### PR TITLE
Use real gem name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "webpacker", "~> 4.0"
 
 group :development, :test do
   gem "brakeman", require: false
-  gem "bundle-audit", require: false
+  gem "bundler-audit", require: false
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "capybara"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,6 @@ GEM
       msgpack (~> 1.0)
     brakeman (4.8.1)
     builder (3.2.4)
-    bundle-audit (0.1.0)
-      bundler-audit
     bundler-audit (0.6.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
@@ -273,7 +271,7 @@ DEPENDENCIES
   activerecord-postgis-adapter
   bootsnap (>= 1.4.2)
   brakeman
-  bundle-audit
+  bundler-audit
   byebug
   capybara
   devise


### PR DESCRIPTION
### Description of change

- Use real gem name for `bundler-audit`.
`bundle-audit` is a wrapper of `bundler-audit` gem, so let's use the real one.