### PR TITLE
Added data from genuine planning applications

### DIFF
--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -62,8 +62,7 @@ task create_sample_data: :environment do
     user: assessor
   ) do |pa|
     pa.status = :awaiting_determination
-    pa.description = "Installation of new external insulated render to be added to existing walls"
-    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
+    pa.description = "Installation of new external insulated render to be added"
   end
 
   bowen_planning_application.update(target_date: 2.weeks.from_now)
@@ -84,7 +83,7 @@ task create_sample_data: :environment do
     user: assessor
   ) do |pa|
     pa.status = :determined
-    pa.description = "Construction of a single storey rear extension with 2 x rooflights"
+    pa.description = "Construction of a single storey rear extension"
     pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
   end
 
@@ -145,7 +144,7 @@ task create_sample_data: :environment do
     ward: "South Bermondsey",
     applicant: jason_applicant
   ) do |pa|
-    pa.description = "Single storey rear extension and rear dormer extension with juliette balcony and the addition of three roof lights to the front roof slope"
+    pa.description = "Single storey rear extension and rear dormer extension"
     pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
   end
 


### PR DESCRIPTION
### Description of change

Updates the sample data to use data from genuine Southwark planning applications.

### Story Link

Partially completes https://www.pivotaltracker.com/n/projects/2441805/stories/172792272

###Decisions

People's names (applicants, case officers, etc) are still generated by Faker, for confidentiality reasons

