### PR TITLE
Restored missing planning application reference in create_sample_data…

### DIFF
--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -63,6 +63,7 @@ task create_sample_data: :environment do
   ) do |pa|
     pa.status = :awaiting_determination
     pa.description = "Installation of new external insulated render to be added"
+    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
   end
 
   bowen_planning_application.update(target_date: 2.weeks.from_now)


### PR DESCRIPTION
### Description of change

Restored the line in the create_sample_data rake task which was mistakenly deleted on the last commit.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/172793340

