### PR TITLE
Include RIPA test json in docker directory

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -136,6 +136,7 @@ COPY --chown=app:app ./yarn.lock /app/yarn.lock
 COPY --chown=app:app ./babel.config.js /app/babel.config.js
 COPY --chown=app:app ./postcss.config.js /app/postcss.config.js
 COPY --chown=app:app ./startup.sh /app/startup.sh
+COPY --chown=app:app ./spec/fixtures/files/permitted_development.json /app/spec/fixtures/files/permitted_development.json
 
 RUN chmod +x /app/startup.sh
 


### PR DESCRIPTION
### Description of change

We needed to set this Docker directory to copy the test file to allow our `create_sample_data` task to read this test file.

