### PR TITLE
Feature/pt 172980236/add error message on decision

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -8,11 +8,11 @@ class DecisionsController < AuthenticationController
   before_action :assign_assessor
 
   def new
-    @decision = @planning_application.decisions.create(user: current_user)
+    @decision = @planning_application.decisions.build(user: current_user)
   end
 
   def create
-    @decision = @planning_application.decisions.create(
+    @decision = @planning_application.decisions.build(
       decision_params.merge(user: current_user)
     )
 

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -8,11 +8,11 @@ class DecisionsController < AuthenticationController
   before_action :assign_assessor
 
   def new
-    @decision = @planning_application.decisions.build(user: current_user)
+    @decision = @planning_application.decisions.create(user: current_user)
   end
 
   def create
-    @decision = @planning_application.decisions.build(
+    @decision = @planning_application.decisions.create(
       decision_params.merge(user: current_user)
     )
 

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 class Decision < ApplicationRecord
-  enum status: { pending: 0, granted: 1, refused: 2 }
+  enum status: { granted: 0, refused: 1 }
 
   belongs_to :planning_application
   belongs_to :user
 
   validates :status, inclusion: { in: ["granted", "refused"],
-    message: "Please select Yes or No" }, on: :update
+    message: "Please select Yes or No" }
 
   def comment_made?
     granted? && comment_met.present? || refused? && comment_unmet.present?

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -6,6 +6,9 @@ class Decision < ApplicationRecord
   belongs_to :planning_application
   belongs_to :user
 
+  validates :status, inclusion: { in: ["granted", "refused"],
+    message: "Please select Yes or No" }, on: :update
+
   def comment_made?
     granted? && comment_met.present? || refused? && comment_unmet.present?
   end

--- a/app/views/decisions/_assessor_new.html.erb
+++ b/app/views/decisions/_assessor_new.html.erb
@@ -6,14 +6,16 @@
         The applicant has submitted the following application. Please review each answer to determine whether what they say and their plans align with the policy questions.
       </p>
       <%= render "policy_consideration_list", policy_considerations: @policy_evaluation.policy_considerations %>
-      <div class="govuk-form-group <%= form.object.errors[:status].present? ? 'govuk-form-group--error' : '' %>">
+      <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
         <p class="govuk-body">
           <br>
           <strong>Have permitted development requirements been met?</strong>
         </p>
-        <% if form.object.errors[:status].present? %>
-          <span id="status-error" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span><%= form.object.errors[:status][0] %></span>
+        <% if form.object.errors.any? %>
+          <% form.object.errors.each do |attribute, error| %>
+            <span id="status-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+          <% end %>
         <% end %>
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
           <div class="govuk-radios govuk-radios--small">

--- a/app/views/decisions/_assessor_new.html.erb
+++ b/app/views/decisions/_assessor_new.html.erb
@@ -6,34 +6,40 @@
         The applicant has submitted the following application. Please review each answer to determine whether what they say and their plans align with the policy questions.
       </p>
       <%= render "policy_consideration_list", policy_considerations: @policy_evaluation.policy_considerations %>
-      <p class="govuk-body">
-        <br>
-        <strong>Have permitted development requirements been met?</strong>
-      </p>
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-        <div class="govuk-radios govuk-radios--small">
-          <div class="govuk-radios__item">
-            <%= form.radio_button :status, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
-            <%= form.label :status_granted, "Yes", class: "govuk-label govuk-radios__label",  for: "status-granted-conditional" %>
-          </div>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-granted-conditional">
-            <div class="govuk-form-group">
-              <p class="govuk-body">
-                Please add any comments that can be inserted into the decision notice.
-              </p>
-                <%= form.text_area :comment_met, class: "govuk-textarea", id: "comment_met", rows: "3", "aria-describedby": "comment-met-hint" %>
+      <div class="govuk-form-group <%= form.object.errors[:status].present? ? 'govuk-form-group--error' : '' %>">
+        <p class="govuk-body">
+          <br>
+          <strong>Have permitted development requirements been met?</strong>
+        </p>
+        <% if form.object.errors[:status].present? %>
+          <span id="status-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span><%= form.object.errors[:status][0] %></span>
+        <% end %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+          <div class="govuk-radios govuk-radios--small">
+            <div class="govuk-radios__item">
+              <%= form.radio_button :status, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
+              <%= form.label :status_granted, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
             </div>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :status, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
-            <%= form.label :status_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
-          </div>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
-            <div class="govuk-form-group">
-              <p class="govuk-body">
-                Please add any comments that can be inserted into the decision notice.
-              </p>
-              <%= form.text_area :comment_unmet, class: "govuk-textarea", id: "comment_unmet", rows: "3", "aria-describedby": "comment-unmet-hint" %>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-granted-conditional">
+              <div class="govuk-form-group">
+                <p class="govuk-body">
+                  Please add any comments that can be inserted into the decision notice.
+                </p>
+                <%= form.text_area :comment_met, class: "govuk-textarea", id: "comment_met", rows: "3", "aria-describedby": "comment-met-hint" %>
+              </div>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :status, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
+              <%= form.label :status_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
+            </div>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
+              <div class="govuk-form-group">
+                <p class="govuk-body">
+                  Please add any comments that can be inserted into the decision notice.
+                </p>
+                <%= form.text_area :comment_unmet, class: "govuk-textarea", id: "comment_unmet", rows: "3", "aria-describedby": "comment-unmet-hint" %>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/decisions/_reviewer_new.html.erb
+++ b/app/views/decisions/_reviewer_new.html.erb
@@ -22,34 +22,40 @@
       </div>
     <% end %>
     <br>
-    <p class="govuk-body">
-      <strong>
-        Do you agree with this recommendation?
-      </strong>
-    </p>
-    <% if planning_application.assessor_decision.granted? %>
-      <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-          <%= form.radio_button :status, :granted, class: "govuk-radios__input" %>
-          <%= form.label :status_granted, "Yes", class: "govuk-radios__label" %>
+    <div class="govuk-form-group <%= form.object.errors[:status].present? ? 'govuk-form-group--error' : '' %>">
+      <p class="govuk-body">
+        <strong>
+          Do you agree with this recommendation?
+        </strong>
+      </p>
+      <% if form.object.errors[:status].present? %>
+        <span id="status-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span><%= form.object.errors[:status][0] %></span>
+      <% end %>
+      <% if planning_application.assessor_decision.granted? %>
+        <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button :status, :granted, class: "govuk-radios__input" %>
+            <%= form.label :status_granted, "Yes", class: "govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :status, :refused, class: "govuk-radios__input" %>
+            <%= form.label :status_refused, "No", class: "govuk-radios__label" %>
+          </div>
         </div>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :status, :refused, class: "govuk-radios__input" %>
-          <%= form.label :status_refused, "No", class: "govuk-radios__label" %>
+      <% elsif planning_application.assessor_decision.refused? %>
+        <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button :status, :refused, class: "govuk-radios__input" %>
+            <%= form.label :status_refused, "Yes", class: "govuk-radios__label" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :status, :granted, class: "govuk-radios__input" %>
+            <%= form.label :status_granted, "No", class: "govuk-radios__label" %>
+          </div>
         </div>
-      </div>
-    <% elsif planning_application.assessor_decision.refused? %>
-      <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
-        <div class="govuk-radios__item">
-          <%= form.radio_button :status, :refused, class: "govuk-radios__input" %>
-          <%= form.label :status_refused, "Yes", class: "govuk-radios__label" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :status, :granted, class: "govuk-radios__input" %>
-          <%= form.label :status_granted, "No", class: "govuk-radios__label" %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </fieldset>
   <p>
     <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/decisions/_reviewer_new.html.erb
+++ b/app/views/decisions/_reviewer_new.html.erb
@@ -22,15 +22,17 @@
       </div>
     <% end %>
     <br>
-    <div class="govuk-form-group <%= form.object.errors[:status].present? ? 'govuk-form-group--error' : '' %>">
+    <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
       <p class="govuk-body">
         <strong>
           Do you agree with this recommendation?
         </strong>
       </p>
-      <% if form.object.errors[:status].present? %>
-        <span id="status-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">Error:</span><%= form.object.errors[:status][0] %></span>
+      <% if form.object.errors.any? %>
+        <% form.object.errors.each do |attribute, error| %>
+          <span id="status-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+        <% end %>
       <% end %>
       <% if planning_application.assessor_decision.granted? %>
         <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -23,7 +23,7 @@
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
 
-          <% if @planning_application.assessor_decision %>
+          <% if @planning_application.assessor_decision&.valid? %>
             <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
           <% end %>
         </li>
@@ -70,7 +70,7 @@
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
 
-          <% if @planning_application.reviewer_decision %>
+          <% if @planning_application.reviewer_decision&.valid? %>
             <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
           <% end %>
         </li>

--- a/db/migrate/20200608103746_change_status_on_decision.rb
+++ b/db/migrate/20200608103746_change_status_on_decision.rb
@@ -1,0 +1,9 @@
+class ChangeStatusOnDecision < ActiveRecord::Migration[6.0]
+  def up
+    change_column :decisions, :status, :integer, default: nil, null: true
+  end
+
+  def down
+    change_column :decisions, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_29_073959) do
+ActiveRecord::Schema.define(version: 2020_06_08_103746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_073959) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status", default: 0, null: false
+    t.integer "status"
     t.text "comment_met"
     t.text "comment_unmet"
     t.index ["planning_application_id"], name: "index_decisions_on_planning_application_id"

--- a/spec/factories/decision.rb
+++ b/spec/factories/decision.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :decision do
     planning_application
     user
-    status { :pending }
   end
 
   trait :granted do

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Decision, type: :model do
+  subject { build :decision }
+
+  describe "statuses" do
+    it "has a list of statuses" do
+      expect(described_class.statuses).to eq(
+        "granted" => 0, "refused" => 1
+      )
+    end
+  end
+
+  describe "validations" do
+    it "is invalid when status is nil" do
+      expect(subject).to be_invalid
+      expect(subject.errors.messages[:status][0]).to include "Please select Yes or No"
+    end
+
+    it "is valid when status is granted" do
+      subject.status = :granted
+
+      expect(subject).to be_valid
+    end
+
+    it "is valid when status is refused" do
+      subject.status = :refused
+
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe PlanningApplication, type: :model do
     let(:assessor)          { create :user, :assessor }
     let(:reviewer)          { create :user, :reviewer }
 
-    let(:assessor_decision) { create(:decision, user: assessor) }
-    let(:reviewer_decision) { create(:decision, user: reviewer) }
+    let(:assessor_decision) { create(:decision, :granted, user: assessor) }
+    let(:reviewer_decision) { create(:decision, :granted, user: reviewer) }
 
     before do
       subject.decisions << assessor_decision << reviewer_decision

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe PlanningApplication, type: :model do
     let(:assessor)          { build :user, :assessor }
     let(:reviewer)          { build :user, :reviewer }
 
-    let(:decision_associated_with_reviewer) { build :decision, user: reviewer }
-    let(:decision_associated_with_assessor) { build :decision, user: assessor }
+    let(:decision_associated_with_reviewer) { build :decision, :granted, user: reviewer }
+    let(:decision_associated_with_assessor) { build :decision, :granted, user: assessor }
 
     it "is invalid when an assessor_decision is associated with a non-assessor" do
       subject.assessor_decision = decision_associated_with_reviewer

--- a/spec/support/shared_examples/assessor_decision_error_examples.rb
+++ b/spec/support/shared_examples/assessor_decision_error_examples.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'assessor decision error message' do
+  scenario "shows the error message" do
+    within("#in_assessment") do
+      click_link "19/AP/1880"
+    end
+
+    expect(page).not_to have_link("Confirm decision notice")
+
+    click_link "Evaluate permitted development policy requirements"
+
+    click_button "Save"
+
+    within(".govuk-error-message") do
+      expect(page).to have_content("Please select Yes or No")
+    end
+
+    click_link "Home"
+
+    expect(page).not_to have_css(".app-task-list__task-completed")
+  end
+end

--- a/spec/support/shared_examples/reviewer_assignment_examples.rb
+++ b/spec/support/shared_examples/reviewer_assignment_examples.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'reviewer assignment' do
+  scenario "reviewer is not assigned to planning application" do
+    click_link "19/AP/1880"
+
+    click_link "Review permitted development policy requirements"
+
+    click_link "Home"
+
+    table_rows = all(".govuk-table__row").map(&:text)
+
+    table_rows.each do |row|
+      expect(row).not_to include("Harley Dicki") if row.include? "19/AP/1880"
+    end
+  end
+end

--- a/spec/support/shared_examples/reviewer_decision_error_examples.rb
+++ b/spec/support/shared_examples/reviewer_decision_error_examples.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'reviewer decision error message' do
+  scenario "shows the error message" do
+    within("#awaiting_determination") do
+      click_link "19/AP/1880"
+    end
+
+    expect(page).not_to have_link("Publish and send decision notice")
+
+    click_link "Review permitted development policy requirements"
+
+    click_button "Save"
+
+    within(".govuk-error-message") do
+      expect(page).to have_content("Please select Yes or No")
+    end
+
+    click_link "Home"
+
+    expect(page).not_to have_css(".app-task-list__task-completed")
+  end
+end

--- a/spec/system/planning_applications/assessment_spec.rb
+++ b/spec/system/planning_applications/assessment_spec.rb
@@ -2,22 +2,6 @@
 
 require "rails_helper"
 
-RSpec.shared_examples 'Reviewer assignment' do
-  scenario "Reviewer is not assigned to planning application" do
-    click_link "19/AP/1880"
-
-    click_link "Review permitted development policy requirements"
-
-    click_link "Home"
-
-    table_rows = all(".govuk-table__row").map(&:text)
-
-    table_rows.each do |row|
-      expect(row).not_to include("Harley Dicki") if row.include? "19/AP/1880"
-    end
-    end
-end
-
 RSpec.describe "Planning Application Assessment", type: :system do
   context "as an assessor" do
     let!(:planning_application) do
@@ -317,7 +301,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_link "19/AP/1880"
         end
       end
-      include_examples("Reviewer assignment")
+
+      include_examples "reviewer assignment"
     end
 
     context "with a granted assessor_decision with a comment" do
@@ -440,7 +425,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_link "19/AP/1880"
         end
       end
-      include_examples("Reviewer assignment")
+
+      include_examples "reviewer assignment"
     end
 
     context "with a refused assessor_decision without a comment" do
@@ -563,7 +549,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_link "19/AP/1880"
         end
       end
-      include_examples("Reviewer assignment")
+
+      include_examples "reviewer assignment"
     end
 
     context "with a refused assessor_decision with a comment" do
@@ -686,7 +673,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_link "19/AP/1880"
         end
       end
-      include_examples("Reviewer assignment")
+
+      include_examples "reviewer assignment"
     end
   end
 

--- a/spec/system/planning_applications/assessment_spec.rb
+++ b/spec/system/planning_applications/assessment_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -251,7 +251,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -317,7 +317,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -376,7 +376,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -442,7 +442,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -501,7 +501,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -567,7 +567,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 
@@ -626,7 +626,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Confirm decision notice")
+        expect(page).not_to have_link("Publish and send decision notice")
 
         click_link "Review permitted development policy requirements"
 

--- a/spec/system/planning_applications/assessment_spec.rb
+++ b/spec/system/planning_applications/assessment_spec.rb
@@ -162,6 +162,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
         expect(row).to include("Lorrine Krajcik") if row.include? "19/AP/1880"
       end
     end
+
+    include_examples "assessor decision error message"
   end
 
   context "as a reviewer" do
@@ -303,6 +305,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       include_examples "reviewer assignment"
+      include_examples "reviewer decision error message"
     end
 
     context "with a granted assessor_decision with a comment" do
@@ -427,6 +430,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       include_examples "reviewer assignment"
+      include_examples "reviewer decision error message"
     end
 
     context "with a refused assessor_decision without a comment" do
@@ -551,6 +555,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       include_examples "reviewer assignment"
+      include_examples "reviewer decision error message"
     end
 
     context "with a refused assessor_decision with a comment" do
@@ -675,12 +680,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       include_examples "reviewer assignment"
+      include_examples "reviewer decision error message"
     end
   end
 
   context "as an admin" do
     let(:assessor) { create :user, :assessor }
-    let(:assessor_decision) { create :decision, user: assessor }
+    let(:assessor_decision) { create :decision, :granted, user: assessor }
 
     let!(:planning_application) do
       create :planning_application, reference: "19/AP/1880", assessor_decision: assessor_decision


### PR DESCRIPTION
### Description of change

- Move reviewer assignment shared_example to new file
- Add error message on decision when they click save without choice
- Replace `Confirm decision notice` with the correct link `Publish and send decision notice`

### Story Link

https://www.pivotaltracker.com/story/show/172980236

### Screenshot

#### Assessor's

![Screenshot 2020-06-09 at 15 52 28](https://user-images.githubusercontent.com/7561969/84163628-9c5f4a00-aa69-11ea-82a5-c9c68ab19feb.jpg)

#### Reviewer's

![Screenshot 2020-06-09 at 15 53 01](https://user-images.githubusercontent.com/7561969/84163671-a7b27580-aa69-11ea-9f90-fcbc232bd274.jpg)
