### PR TITLE
Remove unnecessary route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,7 @@
 Rails.application.routes.draw do
   root to: redirect("/planning_applications")
 
-  devise_for :users do
-    get "/users/sign_out", to: "devise/sessions#destroy"
-  end
+  devise_for :users
 
   resources :planning_applications, only: [:show, :index, :edit, :update] do
     resources :decisions, only: [:new, :create, :edit, :update]


### PR DESCRIPTION
### Description of change

This has been added in this [commit][1] part of #36.

We had a [failing spec on CI][2] a few days ago saying that it couldn't find `sign_out` route. We added this temporary to test whether it was because it couldn't find the route. Finally, we found that this error was due to the fact we had the Log out as `link_to` method and not `button_to`

[1]: https://github.com/unboxed/bops/pull/36/commits/a485186426d9f7aaa17a77c9e4a33db5c80127f7
[2]: https://github.com/unboxed/bops/runs/689771142?check_suite_focus=true