### PR TITLE
Removed background colour from template margins

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -7,3 +7,7 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 .noborder {
   border-bottom: none !important;
 }
+
+.govuk-template {
+  background-color: white;
+}


### PR DESCRIPTION
Before pic:
<img width="568" alt="beforemobile" src="https://user-images.githubusercontent.com/1880450/84141543-3fed3200-aa4b-11ea-84f1-58fd504f553a.png">

After pic:
<img width="630" alt="mobileview" src="https://user-images.githubusercontent.com/1880450/84141122-9148f180-aa4a-11ea-9530-09938ba9d32d.png">


### Description of change

This removes the grey background from the margins to make the page content horizontally scrollable without the page appearing broken when viewing on mobile devices.

### Story Link

pt-173105075

### Decisions [OPTIONAL]

Discussed with Claudia and she feels it is a pragmatic solution that allows the table to be navigated and scrolled on a mobile device, for example on site visits.

