### PR TITLE
Notify Integration part I of II

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -32,6 +32,10 @@ class PlanningApplication < ApplicationRecord
     (target_date - Date.current).to_i
   end
 
+  def update_and_timestamp_status(status)
+    update(status: status, "#{status}_at": Time.current)
+  end
+
   private
 
   def set_target_date

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -18,4 +18,18 @@ class PlanningApplicationPolicy < ApplicationPolicy
   def update?
     super || signed_in_editor?
   end
+
+  def unpermitted_statuses
+    PlanningApplication.statuses.keys - permitted_statuses
+  end
+
+  def permitted_statuses
+    if @user.assessor?
+      [ "awaiting_determination" ]
+    elsif @user.reviewer? || @user.admin?
+      [ "determined" ]
+    else
+      []
+    end
+  end
 end

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -6,5 +6,5 @@ json.site_address planning_application.site.full_address
 json.application_type t(planning_application.application_type)
 json.summary_of_proposal planning_application.description
 json.received_date planning_application.created_at.iso8601
-json.decided_at planning_application.reviewer_decision.decided_at&.iso8601
+json.determined_at planning_application.determined_at.iso8601
 json.status planning_application.reviewer_decision.status

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -15,7 +15,7 @@
   <p class="govuk-body">
     <strong>Applicant:</strong>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application.applicant.full_name %><br>
     <strong>Date of Issue of this decision:</strong>
-    &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application&.reviewer_decision&.decided_at || "TBD" %><br>
+    &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application.determined_at&.strftime("%d/%m/%Y") || "TBD" %><br>
     <strong>Application received:</strong>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application.created_at.strftime("%d/%m/%Y") %>
     <br>
     <strong>Address:</strong>

--- a/db/migrate/20200623100000_rename_completed_at_to_determined_at_on_planning_applications.rb
+++ b/db/migrate/20200623100000_rename_completed_at_to_determined_at_on_planning_applications.rb
@@ -1,0 +1,5 @@
+class RenameCompletedAtToDeterminedAtOnPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :planning_applications, :completed_at, :determined_at
+  end
+end

--- a/db/migrate/20200623130405_add_awaiting_determination_at_to_planning_applications.rb
+++ b/db/migrate/20200623130405_add_awaiting_determination_at_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddAwaitingDeterminationAtToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :awaiting_determination_at, :datetime, null: true
+  end
+end

--- a/db/migrate/20200623131225_add_in_assessment_at_to_planning_applications.rb
+++ b/db/migrate/20200623131225_add_in_assessment_at_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddInAssessmentAtToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :in_assessment_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_130405) do
+ActiveRecord::Schema.define(version: 2020_06_23_131225) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_130405) do
     t.string "ward"
     t.bigint "user_id"
     t.datetime "awaiting_determination_at"
+    t.datetime "in_assessment_at"
     t.index ["agent_id"], name: "index_planning_applications_on_agent_id"
     t.index ["applicant_id"], name: "index_planning_applications_on_applicant_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_091721) do
+ActiveRecord::Schema.define(version: 2020_06_23_100000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,7 +103,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_091721) do
     t.integer "application_type", default: 0, null: false
     t.integer "status", default: 0, null: false
     t.datetime "started_at"
-    t.datetime "completed_at"
+    t.datetime "determined_at"
     t.text "description"
     t.bigint "site_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_100000) do
+ActiveRecord::Schema.define(version: 2020_06_23_130405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_100000) do
     t.string "reference"
     t.string "ward"
     t.bigint "user_id"
+    t.datetime "awaiting_determination_at"
     t.index ["agent_id"], name: "index_planning_applications_on_agent_id"
     t.index ["applicant_id"], name: "index_planning_applications_on_applicant_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :agent do
-    first_name { Faker::Name.unique.first_name }
-    last_name { Faker::Name.unique.last_name }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     phone { Faker::Base.numerify("+44 7### ######") }
     email { Faker::Internet.email }
     postcode { Faker::Address.postcode }

--- a/spec/factories/applicants.rb
+++ b/spec/factories/applicants.rb
@@ -3,8 +3,8 @@
 FactoryBot.define do
   factory :applicant do
     agent
-    first_name { Faker::Name.unique.first_name }
-    last_name { Faker::Name.unique.last_name }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
     phone { Faker::Base.numerify("+44 7### ######") }
     email { Faker::Internet.email }
     postcode { Faker::Address.postcode }

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -6,9 +6,10 @@ FactoryBot.define do
     agent
     applicant
     sequence(:reference, 10) { |n| "AP/#{4500 + n * 2}/#{n}" }
-    description { Faker::Lorem.unique.sentence }
-    status { :in_assessment }
-    ward { Faker::Address.city }
+    description      { Faker::Lorem.unique.sentence }
+    status           { :in_assessment }
+    in_assessment_at { Time.current }
+    ward             { Faker::Address.city }
   end
 
   trait :lawfulness_certificate do
@@ -20,7 +21,8 @@ FactoryBot.define do
   end
 
   trait :awaiting_determination do
-    status { :awaiting_determination }
+    status                    { :awaiting_determination }
+    awaiting_determination_at { Time.current }
 
     after(:create) do |pa|
       pa.target_date = Date.current + 7.weeks
@@ -29,7 +31,8 @@ FactoryBot.define do
   end
 
   trait :determined do
-    status { :determined }
+    status        { :determined }
+    determined_at { Time.current }
 
     after(:create) do |pa|
       pa.target_date = Date.current + 1.week

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -47,6 +47,27 @@ RSpec.describe PlanningApplication, type: :model do
     end
   end
 
+  describe "update_and_timestamp_status" do
+    described_class.statuses.keys.each do |status|
+      context "for the #{status} status" do
+        before do
+          # Set timestamp to differentiate from now
+          subject.update("#{status}_at": 1.hour.ago)
+
+          subject.update_and_timestamp_status(status)
+        end
+
+        it "sets the status to #{status}" do
+          expect(subject.status).to eq status
+        end
+
+        it "sets the timestamp for #{status}_at to now" do
+          expect(subject.send("#{status}_at")).to be_within(1.second).of(Time.current)
+        end
+      end
+    end
+  end
+
   describe "decisions" do
     let(:assessor)          { create :user, :assessor }
     let(:reviewer)          { create :user, :reviewer }

--- a/spec/policies/planning_application_policy_spec.rb
+++ b/spec/policies/planning_application_policy_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe PlanningApplicationPolicy, type: :policy do
-  describe "Assessor, Reviewer and Admin roles" do
-    let(:record) { nil }
-    let(:policy) { described_class.new(user, record) }
+  let(:record) { nil }
+  let(:policy) { described_class.new(user, record) }
 
+  describe "Assessor, Reviewer and Admin roles" do
     %i[assessor reviewer admin].each do |role|
       context "when signed in as a #{role}" do
         let(:user) { users(role) }
@@ -16,6 +16,32 @@ RSpec.describe PlanningApplicationPolicy, type: :policy do
             expect(policy).to permit_action(action)
           end
         end
+      end
+    end
+  end
+
+  describe "#permitted_statuses" do
+    context "an assessor" do
+      let(:user) { users(:assessor) }
+
+      it "returns :awaiting_determination only" do
+        expect(policy.permitted_statuses).to eq %w[ awaiting_determination ]
+      end
+    end
+
+    context "a reviewer" do
+      let(:user) { users(:reviewer) }
+
+      it "returns :determined only" do
+        expect(policy.permitted_statuses).to eq %w[ determined ]
+      end
+    end
+
+    context "an admin" do
+      let(:user) { users(:admin) }
+
+      it "returns :determined only" do
+        expect(policy.permitted_statuses).to eq %w[ determined ]
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,4 +32,6 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.filter_rails_from_backtrace!
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/planning_application_list_spec.rb
+++ b/spec/requests/planning_application_list_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "API request to list planning applications", type: :request, show
             "application_type" => "Certificate of Lawfulness",
             "summary_of_proposal" => planning_application_1.description,
             "received_date" => planning_application_1.created_at.getutc.iso8601,
-            "decided_at" => nil,
+            "determined_at" => planning_application_1.determined_at.getutc.iso8601,
             "status" => "granted"
           ),
           a_hash_including(
@@ -68,7 +68,7 @@ RSpec.describe "API request to list planning applications", type: :request, show
             "application_type" => "Certificate of Lawfulness",
             "summary_of_proposal" => planning_application_2.description,
             "received_date" => planning_application_2.created_at.getutc.iso8601,
-            "decided_at" => nil,
+            "determined_at" => planning_application_1.determined_at.getutc.iso8601,
             "status" => "refused"
           )
         )

--- a/spec/requests/planning_application_request_spec.rb
+++ b/spec/requests/planning_application_request_spec.rb
@@ -9,4 +9,123 @@ RSpec.describe "PlanningApplications", type: :request do
       expect(response).to redirect_to("/users/sign_in")
     end
   end
+
+  describe "PATCH #update" do
+    let(:planning_application) { create :planning_application }
+
+    subject {
+      patch "/planning_applications/#{planning_application.id}",
+        params: { planning_application: { status: status } }
+    }
+
+    before do
+      sign_in user
+    end
+
+    context "for an assessor" do
+      let(:user) { users(:assessor) }
+
+      context "setting the status to \"awaiting_determination\"" do
+        let(:status) { :awaiting_determination }
+
+        it "changes the status and redirects to the planning application"  do
+          expect {
+            subject
+          }.to change {
+            planning_application.reload.status
+          }.to("awaiting_determination")
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to planning_application_path(planning_application)
+        end
+      end
+
+      context "setting the status to \"determined\"" do
+        let(:status) { :determined }
+
+        it "does not change the status and redirects to the root"  do
+          expect {
+            subject
+          }.not_to change {
+            planning_application.reload.status
+          }
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+
+    context "for a reviewer" do
+      let(:user) { users(:reviewer) }
+
+      context "setting the status to \"determined\"" do
+        let(:status) { :determined }
+
+        it "changes the status and redirects to the planning application"  do
+          expect {
+            subject
+          }.to change {
+            planning_application.reload.status
+          }.to(
+            "determined"
+          )
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to planning_application_path(planning_application)
+        end
+      end
+
+      context "setting the status to \"awaiting_determination\"" do
+        let(:status) { :awaiting_determination }
+
+        it "does not change the status and redirects to the root"  do
+          expect {
+            subject
+          }.not_to change {
+            planning_application.reload.status
+          }
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+
+    context "for an admin" do
+      let(:user) { users(:admin) }
+
+      context "setting the status to \"determined\"" do
+        let(:status) { :determined }
+
+        it "changes the status and redirects to the planning application"  do
+          expect {
+            subject
+          }.to change {
+            planning_application.reload.status
+          }.to(
+            "determined"
+          )
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to planning_application_path(planning_application)
+        end
+      end
+
+      context "setting the status to \"awaiting_determination\"" do
+        let(:status) { :awaiting_determination }
+
+        it "does not change the status and redirects to the root"  do
+          expect {
+            subject
+          }.not_to change {
+            planning_application.reload.status
+          }
+
+          expect(response.code).to eq "302"
+          expect(response).to redirect_to root_path
+        end
+      end
+    end
+  end
 end

--- a/spec/system/planning_applications/assessment_spec.rb
+++ b/spec/system/planning_applications/assessment_spec.rb
@@ -95,7 +95,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       # Applicant
       expect(page).to have_content("#{planning_application.applicant.full_name}")
-      # Date of Issue of this decision, TODO: implement to hold the decided_at
       expect(page).to have_content("TBD")
       # Application received
       expect(page).to have_content("#{planning_application.created_at.strftime("%d/%m/%Y")}")
@@ -243,6 +242,12 @@ RSpec.describe "Planning Application Assessment", type: :system do
         within("#determined") do
           expect(page).to have_link "19/AP/1880"
         end
+
+        # TODO: Replace this with a check for state in the read-only determined decision
+        # notice when we implement it
+        planning_application = PlanningApplication.find_by(reference: "19/AP/1880")
+
+        expect(planning_application.determined_at).to be_within(5.seconds).of(Time.current)
       end
 
       scenario "disagrees with assessor's decision" do


### PR DESCRIPTION
### Description of change

This PR adds authorisation for users being able to set application statuses.

This is a bit of a detour from the main point of the story, which is to integrate with Notify. But since that story involves changing how we detect determined status from using the decision to the planning application, and the user submitting a 'Determined' application, this felt like a reasonable time to do this.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/172451136


