### PR TITLE
Feature/pt 173110690/multistep archive form 

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,8 @@ class ApplicationController < ActionController::Base
     response.headers["Pragma"] = "no-cache"
     response.headers["Expires"] = 100.years.ago
   end
+
+  def disable_flash_header
+    @disable_flash_header = true
+  end
 end

--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -12,27 +12,35 @@ class DrawingsController < AuthenticationController
 
   def archive
     @drawing = @planning_application.drawings.find(
-        params[:drawing_id])
+      params[:drawing_id])
     assign_archive_reason_to_form
   end
 
   def confirm
     @drawing = @planning_application.drawings.find(
-        params[:drawing_id])
-    archive_reason = drawing_form_params[:drawing_form]
-    @drawing_form = DrawingWizard::ArchiveForm.new(archive_reason)
+      params[:drawing_id])
+    assign_archive_reason_to_form
+  end
+
+  def validate_archive_reason
+    if @drawing_form.archive_reason
+      render :confirm
+    else
+      flash.now[:alert] = "Please select valid reason for archiving"
+      render :archive
+    end
   end
 
   def validate_step
     @drawing = @planning_application.drawings.find(params[:drawing_id])
     assign_archive_reason_to_form
     if !@drawing_form.updated_at.nil? && params[:current_step] == "confirm"
-      @drawing.archive(@drawing_form.archive_reason)
+      @drawing.archive(params[:archive_reason])
       redirect_to planning_application_drawings_path
     elsif @drawing_form.updated_at.nil? && params[:current_step] == "archive"
-      render :confirm
+      validate_archive_reason
     else
-      render :archive, notice: "Please select valid reason for archiving"
+      render :archive
     end
   end
 
@@ -48,7 +56,7 @@ class DrawingsController < AuthenticationController
 
   def set_planning_application
     @planning_application = authorize(PlanningApplication.find(
-        params[:planning_application_id])
+                                        params[:planning_application_id])
     )
   end
 
@@ -57,4 +65,3 @@ class DrawingsController < AuthenticationController
     @drawing_form = DrawingWizard::ArchiveForm.new(archive_reason)
   end
 end
-

--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -4,21 +4,19 @@ class DrawingsController < AuthenticationController
   include PlanningApplicationDashboardVariables
 
   before_action :set_planning_application
+  before_action :set_drawing, except: :index
   before_action :set_planning_application_dashboard_variables
+  before_action :disable_flash_header, only: :index
 
   def index
     @drawings = policy_scope(@planning_application.drawings)
   end
 
   def archive
-    @drawing = @planning_application.drawings.find(
-      params[:drawing_id])
     assign_archive_reason_to_form
   end
 
   def confirm
-    @drawing = @planning_application.drawings.find(
-      params[:drawing_id])
     assign_archive_reason_to_form
   end
 
@@ -26,21 +24,35 @@ class DrawingsController < AuthenticationController
     if @drawing_form.archive_reason
       render :confirm
     else
-      flash.now[:alert] = "Please select valid reason for archiving"
+      @drawing_form.validate
       render :archive
     end
   end
 
-  def validate_step
-    @drawing = @planning_application.drawings.find(params[:drawing_id])
-    assign_archive_reason_to_form
-    if !@drawing_form.updated_at.nil? && params[:current_step] == "confirm"
-      @drawing.archive(params[:archive_reason])
-      redirect_to planning_application_drawings_path
-    elsif @drawing_form.updated_at.nil? && params[:current_step] == "archive"
-      validate_archive_reason
+  def confirm_archived
+    @drawing.archive(params[:archive_reason])
+    flash[:notice] = "#{@drawing.name} has been archived"
+    redirect_to planning_application_drawings_path
+  end
+
+  def verify_selection
+    if form_params[:confirmation]
+      if form_params[:confirmation][:confirm] == "yes"
+        confirm_archived
+      else
+        render :archive
+      end
     else
       render :archive
+    end
+   end
+
+  def validate_step
+    assign_archive_reason_to_form
+    if params[:current_step] == "confirm"
+        verify_selection
+    elsif params[:current_step] == "archive"
+      validate_archive_reason
     end
   end
 
@@ -54,10 +66,19 @@ class DrawingsController < AuthenticationController
     params.permit drawing_form: [:drawing_id, :archive_reason, :updated_at]
   end
 
+  def form_params
+    params.permit confirmation: [:confirm]
+  end
+
   def set_planning_application
     @planning_application = authorize(PlanningApplication.find(
                                         params[:planning_application_id])
     )
+  end
+
+  def set_drawing
+    @drawing = @planning_application.drawings.find(
+      params[:drawing_id])
   end
 
   def assign_archive_reason_to_form

--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -10,15 +10,51 @@ class DrawingsController < AuthenticationController
     @drawings = policy_scope(@planning_application.drawings)
   end
 
+  def archive
+    @drawing = @planning_application.drawings.find(
+        params[:drawing_id])
+    assign_archive_reason_to_form
+  end
+
+  def confirm
+    @drawing = @planning_application.drawings.find(
+        params[:drawing_id])
+    archive_reason = drawing_form_params[:drawing_form]
+    @drawing_form = DrawingWizard::ArchiveForm.new(archive_reason)
+  end
+
+  def validate_step
+    @drawing = @planning_application.drawings.find(params[:drawing_id])
+    assign_archive_reason_to_form
+    if !@drawing_form.updated_at.nil? && params[:current_step] == "confirm"
+      @drawing.archive(@drawing_form.archive_reason)
+      redirect_to planning_application_drawings_path
+    elsif @drawing_form.updated_at.nil? && params[:current_step] == "archive"
+      render :confirm
+    else
+      render :archive, notice: "Please select valid reason for archiving"
+    end
+  end
+
   private
 
   def drawing_params
-    params.require(:drawing).permit(:name, :plan, :planning_application_id)
+    params.fetch(:drawing, {}).permit(:archive_reason, :name, :archived_at)
+  end
+
+  def drawing_form_params
+    params.permit drawing_form: [:drawing_id, :archive_reason, :updated_at]
   end
 
   def set_planning_application
-    @planning_application = PlanningApplication.find(
-      params[:planning_application_id]
+    @planning_application = authorize(PlanningApplication.find(
+        params[:planning_application_id])
     )
   end
+
+  def assign_archive_reason_to_form
+    archive_reason = drawing_form_params[:drawing_form]
+    @drawing_form = DrawingWizard::ArchiveForm.new(archive_reason)
+  end
 end
+

--- a/app/helpers/drawing_helper.rb
+++ b/app/helpers/drawing_helper.rb
@@ -1,0 +1,12 @@
+
+# frozen_string_literal: true
+
+module DrawingHelper
+  def filter_archived(drawings)
+    drawings.select { |plan| plan.is_archived? == true }
+  end
+
+  def filter_current(drawings)
+    drawings.select { |plan| plan.is_archived? == false }.sort_by(&:archived_at)
+  end
+end

--- a/app/helpers/drawing_helper.rb
+++ b/app/helpers/drawing_helper.rb
@@ -1,12 +1,11 @@
-
 # frozen_string_literal: true
 
 module DrawingHelper
   def filter_archived(drawings)
-    drawings.select { |plan| plan.is_archived? == true }
+    drawings.select { |plan| plan.archived? == true }
   end
 
   def filter_current(drawings)
-    drawings.select { |plan| plan.is_archived? == false }.sort_by(&:archived_at)
+    drawings.select { |plan| plan.archived? == false }.sort_by(&:archived_at)
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -16,10 +16,12 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   float:left;
   padding-bottom: 5%;
   width: 40%;
+  margin-left: 2%;
 }
 
 .thumbnail-right {
   float:right;
   padding-bottom: 5%;
   width: 40%;
+  margin-right: 10%;
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -20,8 +20,71 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 }
 
 .thumbnail-right {
-  float:right;
-  padding-bottom: 5%;
-  width: 40%;
-  margin-right: 10%;
+   float:right;
+   padding-bottom: 5%;
+   width: 40%;
+   margin-right: 10%;
+ }
+
+.flash-archive {
+  border: 5px solid govuk-colour("green");
+  @include govuk-font($size: 19);
+  color: govuk-colour("black");
+  display: block;
+  overflow: hidden;
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(2);
 }
+
+.moj-banner {
+  border-color: green;
+  color: govuk-colour("green");
+  font-size: 0; // Removes white space when using inline-block on child element.
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(2);
+}
+
+
+.moj-banner__icon {
+  fill: currentColor;
+  float: left;
+  margin-right: govuk-spacing(2);
+}
+
+.moj-banner__message {
+  @include govuk-font($size: 19);
+  color: govuk-colour("black");
+  display: block;
+  overflow: hidden;
+}
+
+.moj-banner__message h2 {
+  margin-bottom: govuk-spacing(2);
+}
+
+
+.moj-banner__message h2:last-child,
+.moj-banner__message p:last-child {
+  margin-bottom: 0;
+}
+
+
+.moj-banner__assistive {
+  @include govuk-visually-hidden;
+}
+
+
+/* Style variants
+   ========================================================================== */
+
+.moj-banner--success {
+  border-color: govuk-colour("green");
+  color: govuk-colour("green");
+}
+
+
+.moj-banner--warning {
+  border-color: govuk-colour("red");
+  color: govuk-colour("red");
+}
+

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -11,3 +11,15 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 .govuk-template {
   background-color: white;
 }
+
+.thumbnail-left {
+  float:left;
+  padding-bottom: 5%;
+  width: 40%;
+}
+
+.thumbnail-right {
+  float:right;
+  padding-bottom: 5%;
+  width: 40%;
+}

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -8,11 +8,12 @@ class Drawing < ApplicationRecord
   enum archive_reason: { scale: 0, design: 1,
                          dimensions: 2, other: 3 }
 
-  def is_archived?
-     archived_at == nil ? false : true
+  def archived?
+     archived_at.present?
    end
 
   def archive(archive_reason)
-    self.update(archive_reason: archive_reason, archived_at: Time.zone.now)
+    update(archive_reason: archive_reason,
+           archived_at: Time.current) unless archived?
   end
 end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -4,4 +4,15 @@ class Drawing < ApplicationRecord
   belongs_to :planning_application
 
   has_one_attached :plan
+
+  enum archive_reason: { scale: 0, design: 1,
+                         dimensions: 2, other: 3 }
+
+  def is_archived?
+    archived_at == nil ? false : true
+  end
+
+  def archive(archive_reason)
+    self.update(archive_reason: archive_reason, archived_at: Time.zone.now)
+  end
 end

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -9,8 +9,8 @@ class Drawing < ApplicationRecord
                          dimensions: 2, other: 3 }
 
   def is_archived?
-    archived_at == nil ? false : true
-  end
+     archived_at == nil ? false : true
+   end
 
   def archive(archive_reason)
     self.update(archive_reason: archive_reason, archived_at: Time.zone.now)

--- a/app/models/drawing_wizard/archive_form.rb
+++ b/app/models/drawing_wizard/archive_form.rb
@@ -6,8 +6,8 @@ module DrawingWizard
     validates :updated_at, presence: true
 
     validates :archive_reason,
-              inclusion: {in: %w(scale design dimensions other),
+              inclusion: { in: %w(scale design dimensions other),
                           on: :update,
-                          message: "Please select one of the above reasons"}
+                          message: "Please select one of the above reasons" }
   end
 end

--- a/app/models/drawing_wizard/archive_form.rb
+++ b/app/models/drawing_wizard/archive_form.rb
@@ -4,5 +4,10 @@ module DrawingWizard
   class ArchiveForm < BaseForm
     validates :archive_reason, presence: true
     validates :updated_at, presence: true
+
+    validates :archive_reason,
+              inclusion: {in: %w(scale design dimensions other),
+                          on: :update,
+                          message: "Please select one of the above reasons"}
   end
 end

--- a/app/models/drawing_wizard/archive_form.rb
+++ b/app/models/drawing_wizard/archive_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module DrawingWizard
+  class ArchiveForm < BaseForm
+    validates :archive_reason, presence: true
+    validates :updated_at, presence: true
+  end
+end

--- a/app/models/drawing_wizard/archive_form.rb
+++ b/app/models/drawing_wizard/archive_form.rb
@@ -2,12 +2,8 @@
 
 module DrawingWizard
   class ArchiveForm < BaseForm
-    validates :archive_reason, presence: true
-    validates :updated_at, presence: true
-
     validates :archive_reason,
-              inclusion: { in: %w(scale design dimensions other),
-                          on: :update,
-                          message: "Please select one of the above reasons" }
+              inclusion: { in: Drawing.archive_reasons.keys,
+                          message: "Please select one of the below reasons" }
   end
 end

--- a/app/models/drawing_wizard/base_form.rb
+++ b/app/models/drawing_wizard/base_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DrawingWizard
+  class BaseForm
+    include ActiveModel::Model
+
+    attr_accessor :drawing
+
+    delegate *Drawing.attribute_names.map { |attr| [attr, "#{attr}="] }.
+        flatten, to: :drawing
+
+    def initialize(drawing_attributes = {})
+      @drawing = Drawing.new(drawing_attributes)
+    end
+  end
+end

--- a/app/models/drawing_wizard/confirm_form.rb
+++ b/app/models/drawing_wizard/confirm_form.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module DrawingWizard
-  class ConfirmForm < BaseForm
-    validates :archive_reason, presence: true
-    validates :complete, presence: true
-  end
-end

--- a/app/models/drawing_wizard/confirm_form.rb
+++ b/app/models/drawing_wizard/confirm_form.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module DrawingWizard
+  class ConfirmForm < BaseForm
+    validates :archive_reason, presence: true
+    validates :complete, presence: true
+  end
+end

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -19,6 +19,18 @@ class PlanningApplicationPolicy < ApplicationPolicy
     super || signed_in_editor?
   end
 
+  def confirm?
+    signed_in_editor?
+  end
+
+  def validate_step?
+    signed_in_editor?
+  end
+
+  def archive?
+    signed_in_editor?
+  end
+
   def unpermitted_statuses
     PlanningApplication.statuses.keys - permitted_statuses
   end

--- a/app/views/application/_success_flash.html.erb
+++ b/app/views/application/_success_flash.html.erb
@@ -1,0 +1,7 @@
+<% flash.each do |name, msg| %>
+  <div class="flash-archive">
+    <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+      <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path></svg>
+    <%= msg.to_s %>
+  </div>
+<% end %>

--- a/app/views/drawings/_archive_form.html.erb
+++ b/app/views/drawings/_archive_form.html.erb
@@ -1,7 +1,8 @@
 <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
-  <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
-  <%= hidden_field_tag :current_step, 'archive' %>
+  <div class="govuk-form-group">
+    <%= hidden_field_tag :current_step, 'archive' %>
     <fieldset class="govuk-fieldset">
+      <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
       <% if form.object.errors.any? %>
         <% form.object.errors.each do |attribute, error| %>
             <span id="status-error" class="govuk-error-message">
@@ -28,6 +29,7 @@
           </div>
         </div>
       </div>
+     </div>
     </fieldset>
     <p>
       <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/drawings/_archive_form.html.erb
+++ b/app/views/drawings/_archive_form.html.erb
@@ -1,28 +1,36 @@
 <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+  <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
   <%= hidden_field_tag :current_step, 'archive' %>
-  <fieldset class="govuk-fieldset">
-    <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-      <div class="govuk-radios govuk-radios--small">
-        <div class="govuk-radios__item">
-          <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale", "aria-controls": "archive-reason-scale" %>
-          <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_scale" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design", "aria-controls": "archive-reason-revise-design" %>
-          <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_design" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions", "aria-controls": "archive-reason-revise-dimensions" %>
-          <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
-        </div>
-        <div class="govuk-radios__item">
-          <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other", "aria-controls": "archive-reason-other" %>
-          <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
+    <fieldset class="govuk-fieldset">
+      <% if form.object.errors.any? %>
+        <% form.object.errors.each do |attribute, error| %>
+            <span id="status-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+        <% end %>
+      <% end %>
+      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <div class="govuk-radios govuk-radios--small">
+          <div class="govuk-radios__item">
+            <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", "aria-controls": "archive-reason-scale" %>
+            <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", value: "scale" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", "aria-controls": "archive-reason-design" %>
+            <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", value: "design" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", "aria-controls": "archive-reason-dimensions" %>
+            <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", value: "dimensions" %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", "aria-controls": "archive-reason-other" %>
+            <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", value: "other" %>
+          </div>
         </div>
       </div>
-    </div>
-  </fieldset>
-  <p>
-    <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-  </p>
+    </fieldset>
+    <p>
+      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+    </p>
+  </div>
 <% end %>

--- a/app/views/drawings/_archive_form.html.erb
+++ b/app/views/drawings/_archive_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+  <%= hidden_field_tag :current_step, 'archive' %>
+  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+    <div class="govuk-radios govuk-radios--small">
+      <div class="govuk-radios__item">
+        <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input" %>
+        <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_missing-scale" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input" %>
+        <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_designs" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input" %>
+        <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input" %>
+        <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
+      </div>
+    </div>
+    <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
+  </div>
+<% end %>

--- a/app/views/drawings/_archive_form.html.erb
+++ b/app/views/drawings/_archive_form.html.erb
@@ -1,24 +1,28 @@
 <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
   <%= hidden_field_tag :current_step, 'archive' %>
-  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-    <div class="govuk-radios govuk-radios--small">
-      <div class="govuk-radios__item">
-        <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input" %>
-        <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_missing-scale" %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input" %>
-        <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_designs" %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input" %>
-        <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
-      </div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input" %>
-        <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
+  <fieldset class="govuk-fieldset">
+    <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+      <div class="govuk-radios govuk-radios--small">
+        <div class="govuk-radios__item">
+          <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale", "aria-controls": "archive-reason-scale" %>
+          <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_scale" %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design", "aria-controls": "archive-reason-revise-design" %>
+          <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_design" %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions", "aria-controls": "archive-reason-revise-dimensions" %>
+          <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
+        </div>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other", "aria-controls": "archive-reason-other" %>
+          <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
+        </div>
       </div>
     </div>
-    <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
-  </div>
+  </fieldset>
+  <p>
+    <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+  </p>
 <% end %>

--- a/app/views/drawings/_confirm_form.html.erb
+++ b/app/views/drawings/_confirm_form.html.erb
@@ -1,16 +1,16 @@
-<%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+<%= form_for(:confirmation, url: planning_application_drawing_validate_step_path) do |form| %>
   <%= hidden_field_tag :current_step, 'confirm' %>
   <fieldset class="govuk-fieldset">
   <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
     <div class="govuk-radios govuk-radios--small">
       <div class="govuk-radios__item">
         <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
-        <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"archive-yes", "aria-controls":"archive-yes" %>
-        <%= form.label :updated_at, "Yes", class: "govuk-label govuk-radios__label", for: "archive-yes" %>
+        <%= form.radio_button :confirm, "yes", class: "govuk-radios__input", id:"archive-yes", "aria-controls":"archive-yes" %>
+        <%= form.label :confirm, "Yes", class: "govuk-label govuk-radios__label", for: "archive-yes" %>
       </div>
       <div class="govuk-radios__item">
-        <%= form.radio_button :updated_at, nil, checked: false, class: "govuk-radios__input", id: "archive-no", "aria-controls":"archive-no" %>
-        <%= form.label :archive_reason, "No", class: "govuk-label govuk-radios__label", for: "archive-no" %>
+        <%= form.radio_button :confirm, "no", class: "govuk-radios__input", id: "archive-no", "aria-controls":"archive-no" %>
+        <%= form.label :confirm, "No", class: "govuk-label govuk-radios__label", for: "archive-no" %>
       </div>
     </div>
   </div>

--- a/app/views/drawings/_confirm_form.html.erb
+++ b/app/views/drawings/_confirm_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+  <%= hidden_field_tag :current_step, 'confirm' %>
+  <fieldset class="govuk-fieldset">
+  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+    <div class="govuk-radios govuk-radios--small">
+      <div class="govuk-radios__item">
+        <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
+        <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"archive-yes", "aria-controls":"archive-yes" %>
+        <%= form.label :updated_at, "Yes", class: "govuk-label govuk-radios__label", for: "archive-yes" %>
+      </div>
+      <div class="govuk-radios__item">
+        <%= form.radio_button :updated_at, nil, checked: false, class: "govuk-radios__input", id: "archive-no", "aria-controls":"archive-no" %>
+        <%= form.label :archive_reason, "No", class: "govuk-label govuk-radios__label", for: "archive-no" %>
+      </div>
+    </div>
+  </div>
+  </fieldset>
+  <p>
+  <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
+  </p>
+<% end %>

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -28,25 +28,25 @@
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
           <div class="govuk-radios govuk-radios--small">
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale" %>
-              <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_missing-scale" %>
+              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale", "aria-controls": "archive-reason-scale" %>
+              <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_scale" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design" %>
-              <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_designs" %>
+              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design", "aria-controls": "archive-reason-revise-design" %>
+              <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_design" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions" %>
+              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions", "aria-controls": "archive-reason-revise-dimensions" %>
               <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other" %>
+              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other", "aria-controls": "archive-reason-other" %>
               <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
             </div>
           </div>
         </div>
-        </div>
+       </div>
       </div>
-        <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
-   <% end %>
+    <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
+  <% end %>
 <% end %>

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -20,8 +20,6 @@
         <%= link_to image_tag(@drawing.plan.representation(resize: "300x212")),
                     rails_blob_path(@drawing.plan), target: :_blank %>
       </p>
-    </div>
-    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-s">
         Why do you want to archive this document?
       </h2>
@@ -30,28 +28,25 @@
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
           <div class="govuk-radios govuk-radios--small">
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input" %>
+              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale" %>
               <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_missing-scale" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input" %>
+              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design" %>
               <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_designs" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input" %>
+              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions" %>
               <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input" %>
+              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other" %>
               <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
             </div>
           </div>
         </div>
         </div>
-        </div>
-        <p>
-          <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
-        </p>
-      <% end %>
+      </div>
+        <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
+   <% end %>
 <% end %>
-

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -13,6 +13,7 @@
       <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
         <%= display_address(@site) %>
       </h2>
+      </h2>
       <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
         <%= @drawing.name %>
       </h2>
@@ -23,30 +24,7 @@
       <h2 class="govuk-heading-s">
         Why do you want to archive this document?
       </h2>
-      <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
-        <%= hidden_field_tag :current_step, 'archive' %>
-        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-          <div class="govuk-radios govuk-radios--small">
-            <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", id: "scale", "aria-controls": "archive-reason-scale" %>
-              <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_scale" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", id: "revise-design", "aria-controls": "archive-reason-revise-design" %>
-              <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_design" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", id: "revise-dimensions", "aria-controls": "archive-reason-revise-dimensions" %>
-              <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", id: "other", "aria-controls": "archive-reason-other" %>
-              <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
-            </div>
-          </div>
-        </div>
-       </div>
-      </div>
-    <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
-  <% end %>
+      <%= render "archive_form" %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -1,0 +1,57 @@
+<% if current_user.assessor? %>
+  <% navigation_add "Archive document", planning_application_drawings_path(@planning_application) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
+        <ol class="govuk-breadcrumbs__list">
+          <li class="govuk-breadcrumbs__list-item" aria-current="page"></li>
+        </ol>
+      </div>
+      <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+        Documents: <%= @planning_application.reference %>
+      </h1>
+      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+        <%= display_address(@site) %>
+      </h2>
+      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+        <%= @drawing.name %>
+      </h2>
+      <p>
+        <%= link_to image_tag(@drawing.plan.representation(resize: "300x212")),
+                    rails_blob_path(@drawing.plan), target: :_blank %>
+      </p>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-s">
+        Why do you want to archive this document?
+      </h2>
+      <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+        <%= hidden_field_tag :current_step, 'archive' %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+          <div class="govuk-radios govuk-radios--small">
+            <div class="govuk-radios__item">
+              <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input" %>
+              <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", for: "archive_reason_missing-scale" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input" %>
+              <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_designs" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input" %>
+              <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", for: "archive_reason_revise_dimensions" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input" %>
+              <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", for: "archive_reason_other" %>
+            </div>
+          </div>
+        </div>
+        </div>
+        </div>
+        <p>
+          <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
+        </p>
+      <% end %>
+<% end %>
+

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -13,7 +13,6 @@
       <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
         <%= display_address(@site) %>
       </h2>
-      </h2>
       <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
         <%= @drawing.name %>
       </h2>

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -1,0 +1,43 @@
+<% if current_user.assessor? %>
+  <% navigation_add "Archive document", planning_application_drawings_path(@planning_application) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
+        <ol class="govuk-breadcrumbs__list">
+          <li class="govuk-breadcrumbs__list-item" aria-current="page"></li>
+        </ol>
+      </div>
+      <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+        Documents: <%= @planning_application.reference %>
+      </h1>
+      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+        Confirm archiving
+      </h2>
+      <h2 class="govuk-heading-s">
+        You want to archive the document because:
+      </h2>
+      <p class="govuk-body"><%= @drawing_form.archive_reason %></p>
+      <h2 class="govuk-heading-s">
+        Is this correct?
+      </h2>
+      <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
+        <%= hidden_field_tag :current_step, 'confirm' %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+          <div class="govuk-radios govuk-radios--small">
+            <div class="govuk-radios__item">
+              <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
+              <%= form.label :archive_reason, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :updated_at, nil, class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
+              <%= form.label :archive_reason, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
+            </div>
+          </div>
+        </div>
+        </div>
+        </div>
+<!--        <p>-->
+          <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
+<!--        </p>-->
+      <% end %>
+<% end %>

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -11,6 +11,9 @@
         Documents: <%= @planning_application.reference %>
       </h1>
       <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+        <%= display_address(@site) %>
+      </h2>
+      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
         Confirm archiving
       </h2>
       <h2 class="govuk-heading-s">

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -20,23 +20,7 @@
       <h2 class="govuk-heading-s">
         Is this correct?
       </h2>
-      <%= form_for(@drawing_form, as: :drawing_form, url: planning_application_drawing_validate_step_path) do |form| %>
-        <%= hidden_field_tag :current_step, 'confirm' %>
-        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-          <div class="govuk-radios govuk-radios--small">
-            <div class="govuk-radios__item">
-              <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
-              <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"archive-yes" %>
-              <%= form.label :updated_at, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :updated_at, nil, checked: false, class: "govuk-radios__input", id: "archive-no" %>
-              <%= form.label :archive_reason, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
-            </div>
-          </div>
-        </div>
-      </div>
-     </div>
-    <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
-   <% end %>
+        <%= render "confirm_form" %>
+    </div>
+  </div>
 <% end %>

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -25,19 +25,18 @@
         <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
           <div class="govuk-radios govuk-radios--small">
             <div class="govuk-radios__item">
-              <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
-              <%= form.label :archive_reason, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
+              <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
+              <%= form.radio_button :updated_at, Time.zone.now, class: "govuk-radios__input", id:"archive-yes" %>
+              <%= form.label :updated_at, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
             </div>
             <div class="govuk-radios__item">
-              <%= form.radio_button :updated_at, nil, class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
+              <%= form.radio_button :updated_at, nil, checked: false, class: "govuk-radios__input", id: "archive-no" %>
               <%= form.label :archive_reason, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
             </div>
           </div>
         </div>
-        </div>
-        </div>
-<!--        <p>-->
-          <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
-<!--        </p>-->
-      <% end %>
+      </div>
+     </div>
+    <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
+   <% end %>
 <% end %>

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -16,7 +16,7 @@
       <h2 class="govuk-heading-s">
         You want to archive the document because:
       </h2>
-      <p class="govuk-body"><%= @drawing_form.archive_reason %></p>
+      <p class="govuk-body"><%= I18n.t(@drawing_form.archive_reason) %></p>
       <h2 class="govuk-heading-s">
         Is this correct?
       </h2>

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -1,5 +1,4 @@
 <% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
@@ -18,12 +17,12 @@
     </h2>
   </div>
 </div>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row current-drawings">
   <% filter_current(@drawings).each_with_index do |doc, index| %>
     <%  if index.odd? %>
         <div class="thumbnail-right">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.plan.id) %>
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? %>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
@@ -31,7 +30,7 @@
     <% else %>
         <div class="thumbnail-left">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.plan.id) %>
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? %>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
@@ -39,26 +38,31 @@
     <% end %>
   <% end %>
 </div>
-<div class="govuk-grid-column-two-thirds">
-  <h2 class="govuk-heading-m">
-    Archived documents
-  </h2>
-  <% if filter_archived(@drawings).count > 0 %>
-    <% filter_archived(@drawings).each_with_index do |doc, index| %>
-      <%  if index % 2 == 1 %>
-        <span class="thumbnail-right">
-          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
-                      rails_blob_path(doc.plan), target: :_blank %>
-        </span>
+<div class="govuk-grid-row">
+
+  <table class="govuk-table archived-drawings">
+    <caption class="govuk-table__caption">Archived documents</caption>
+    <thead class="govuk-table__head">
+      <% if filter_archived(@drawings).count < 1 %>
+        <th scope="row" class="govuk-table__cell" style="font-weight: 100">No documents archived</th>
       <% else %>
-        <span class="thumbnail-left">
-          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
-                      rails_blob_path(doc.plan), target: :_blank %>
-        </span><br/>
+        <th scope="col" class="govuk-table__header">Document name</th>
+        <th scope="col" class="govuk-table__header">Tags </th>
+        <th scope="col" class="govuk-table__header">Date uploaded</th>
+        <th scope="col" class="govuk-table__header">Officer's comment</th>
+      </tr>
+    </thead>
+        <% filter_archived(@drawings).each do |doc| %>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell archive-data"><%= doc.name %></td>
+        <td class="govuk-table__cell archive-data">Placeholder</td>
+        <td class="govuk-table__cell archive-data"><%= doc.created_at.strftime("%B %e %Y") %></td>
+        <td class="govuk-table__cell archive-data"><%= I18n.t(doc.archive_reason) %></td>
+      </tr>
+        <% end %>
       <% end %>
-    <% end %>
-  <%else %>
-    <p class="govuk-body">No documents archived</p>
-  <% end %>
+    </tbody>
+  </table>
   </div>
 </div>

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -19,21 +19,46 @@
   </div>
 </div>
 <div class="govuk-grid-row">
-  <table class="govuk-table">
-    <tbody class="govuk-table__body">
-      <% @drawings.each_slice(2) do |drawing| %>
-        <tr class="govuk-table__row noborder">
-          <td class="govuk-table__cell noborder">
-            <%= link_to image_tag(drawing[0].plan.representation(resize: "300x212")),
-                        rails_blob_path(drawing[0].plan), target: :_blank %>
-          </td>
-          <td class="govuk-table__cell noborder">
-            <%= link_to image_tag(drawing[1].plan.representation(resize: "300x212")),
-                        rails_blob_path(drawing[1].plan), target: :_blank if drawing[1] %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <% filter_current(@drawings).each_with_index do |doc, index| %>
+    <%  if index.odd? %>
+        <div class="thumbnail-right">
+          <p class="govuk-body">
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.plan.id) %>
+          </p>
+          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                      rails_blob_path(doc.plan), target: :_blank %>
+        </div>
+    <% else %>
+        <div class="thumbnail-left">
+          <p class="govuk-body">
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.plan.id) %>
+          </p>
+          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                      rails_blob_path(doc.plan), target: :_blank %>
+        </div>
+    <% end %>
+  <% end %>
 </div>
-
+<div class="govuk-grid-column-two-thirds">
+  <h2 class="govuk-heading-m">
+    Archived documents
+  </h2>
+  <% if filter_archived(@drawings).count > 0 %>
+    <% filter_archived(@drawings).each_with_index do |doc, index| %>
+      <%  if index % 2 == 1 %>
+        <span class="thumbnail-right">
+          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                      rails_blob_path(doc.plan), target: :_blank %>
+        </span>
+      <% else %>
+        <span class="thumbnail-left">
+          <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                      rails_blob_path(doc.plan), target: :_blank %>
+        </span><br/>
+      <% end %>
+    <% end %>
+  <%else %>
+    <p class="govuk-body">No documents archived</p>
+  <% end %>
+  </div>
+</div>

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -12,6 +12,7 @@
     <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
       <%= display_address(@site) %>
     </h2>
+    <%= render "success_flash" %>
     <%  if filter_current(@drawings).count > 0 %>
     <h2 class="govuk-heading-m">
       Proposal documents
@@ -24,18 +25,30 @@
     <%  if index.odd? %>
         <div class="thumbnail-right">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
+            <strong><%= doc.name %></strong><br/>
+            <%= doc.created_at.strftime("%B %e %Y") %><br/>
+            <%= link_to "View in new window",
+            rails_blob_path(doc.plan), target: :_new %><br/>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
+          <p class="govuk-body">
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
+          </p>
         </div>
     <% else %>
         <div class="thumbnail-left">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
+            <strong><%= doc.name %></strong><br/>
+            <%= doc.created_at.strftime("%B %e %Y") %><br/>
+            <%= link_to "View in new window",
+                        rails_blob_path(doc.plan), target: :_new %><br/>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
+          <p class="govuk-body">
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
+          </p>
         </div>
     <% end %>
   <% end %>

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -12,9 +12,11 @@
     <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
       <%= display_address(@site) %>
     </h2>
+    <%  if filter_current(@drawings).count > 0 %>
     <h2 class="govuk-heading-m">
       Proposal documents
     </h2>
+    <% end %>
   </div>
 </div>
 <div class="govuk-grid-row current-drawings">
@@ -22,7 +24,7 @@
     <%  if index.odd? %>
         <div class="thumbnail-right">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? %>
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
@@ -30,7 +32,7 @@
     <% else %>
         <div class="thumbnail-left">
           <p class="govuk-body">
-            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? %>
+            <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: doc.id) if current_user.assessor? && @planning_application.in_assessment? %>
           </p>
           <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
                       rails_blob_path(doc.plan), target: :_blank %>
@@ -55,7 +57,7 @@
         <% filter_archived(@drawings).each do |doc| %>
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell archive-data"><%= doc.name %></td>
+        <td class="govuk-table__cell archive-data"><%= link_to doc.name, rails_blob_path(doc.plan), target: :_new %></td>
         <td class="govuk-table__cell archive-data">Placeholder</td>
         <td class="govuk-table__cell archive-data"><%= doc.created_at.strftime("%B %e %Y") %></td>
         <td class="govuk-table__cell archive-data"><%= I18n.t(doc.archive_reason) %></td>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     </script>
 
     <%= link_to "Skip to main content", "#main-content", class: "govuk-skip-link" %>
-    <%= render "flashes" %>
+    <%= render "flashes" unless @disable_flash_header %>
     <%= render "header" %>
 
     <div class="govuk-width-container app-width-container--wide">

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -59,7 +59,7 @@
           <%= link_to "Manage documents", planning_application_drawings_path(@planning_application) %>
         </p>
       <div class="govuk-grid-row">
-        <% @planning_application.drawings.each_with_index do |doc, index| %>
+        <% filter_current(@planning_application.drawings).each_with_index do |doc, index| %>
           <% if index.odd? %>
             <div class="thumbnail-right">
               <p class="govuk-body">

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -55,12 +55,12 @@
       </h3>
     </div>
     <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <div class="govuk-accordion__section-row">
         <p class="govuk-body">
           <%= link_to "Manage documents", planning_application_drawings_path(@planning_application) %>
         </p>
+      <div class="govuk-grid-row">
         <% @planning_application.drawings.each_with_index do |doc, index| %>
-          <% if index.odd? == 1 %>
+          <% if index.odd? %>
             <div class="thumbnail-right">
               <p class="govuk-body">
                 <%= link_to "View in new window", rails_blob_path(doc.plan), target: :_blank %>
@@ -82,4 +82,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -55,39 +55,31 @@
       </h3>
     </div>
     <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
-      <p class="govuk-body">
-        <%= link_to "Manage documents", planning_application_drawings_path(@planning_application) %>
-      </p>
-      <table class="govuk-table">
-        <% @planning_application.drawings.each_slice(2) do |drawing| %>
-          <tr class="govuk-table__row">
-            <% drawing.each do |doc_1, doc_2| %>
-              <td class="govuk-table__cell">
-                <p class='govuk-body'>
-                  <%= doc_1.name %>
-                </p>
-                <p class='govuk-body'>
-                  <%= link_to "View in new window", rails_blob_path(doc_1.plan) %>
-                </p>
-                <%= link_to image_tag(doc_1.plan.representation(resize: "300x212")),
-                      rails_blob_path(doc_1.plan), target: :_blank %>
-              </td>
-              <td class="govuk-table__cell">
-                <p class='govuk-body'>
-                  <%= doc_2.name if doc_2 %>
-                </p>
-                <p class='govuk-body'>
-                  <%= link_to "View in new window", rails_blob_path(doc_2.plan) if doc_2 %>
-                </p>
-                <%  if doc_2  %>
-                  <%= link_to image_tag(doc_2.plan.representation(resize: "300x212")),
-                    rails_blob_path(doc_2.plan), target: :_blank %>
-                <% end %>
-              </td>
-            <% end %>
-          </tr>
+      <div class="govuk-accordion__section-row">
+        <p class="govuk-body">
+          <%= link_to "Manage documents", planning_application_drawings_path(@planning_application) %>
+        </p>
+        <% @planning_application.drawings.each_with_index do |doc, index| %>
+          <% if index.odd? == 1 %>
+            <div class="thumbnail-right">
+              <p class="govuk-body">
+                <%= link_to "View in new window", rails_blob_path(doc.plan), target: :_blank %>
+              </p>
+              <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                          rails_blob_path(doc.plan), target: :_blank %>
+            </div>
+          <% else %>
+            <div class="thumbnail-left">
+              <p class="govuk-body">
+                <%= link_to "View in new window", rails_blob_path(doc.plan, target: :_blank) %>
+              </p>
+              <%= link_to image_tag(doc.plan.representation(resize: "300x212")),
+                          rails_blob_path(doc.plan), target: :_blank %>
+            </div>
+          <% end %>
         <% end %>
-      </table>
+      </div>
     </div>
   </div>
 </div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,3 +5,7 @@ en:
   full: "Full Householder Application"
   lawfulness_certificate: "Certificate of Lawfulness"
   user_not_authorized: "You are not authorized to perform this action."
+  scale: "Missing scale bar or north arrow"
+  design: "Revise design"
+  dimensions: "Revise dimensions"
+  other: "Other"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,12 @@ Rails.application.routes.draw do
 
   resources :planning_applications, only: %i[show index edit update] do
     resources :decisions, only: %i[new create edit update]
-    resources :drawings, only: %i[index]
+    resources :drawings, only: %i[index] do
+      get :archive
+      get :confirm
+
+      post :validate_step
+    end
   end
 
   namespace :api do

--- a/db/migrate/20200629093307_add_archive_reason_to_drawings.rb
+++ b/db/migrate/20200629093307_add_archive_reason_to_drawings.rb
@@ -1,0 +1,5 @@
+class AddArchiveReasonToDrawings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :drawings, :archive_reason, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_23_131225) do
+ActiveRecord::Schema.define(version: 2020_06_29_093307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2020_06_23_131225) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.datetime "archived_at"
+    t.integer "archive_reason"
     t.index ["planning_application_id"], name: "index_drawings_on_planning_application_id"
   end
 

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe Drawing, type: :model do
     expect(subject).to be_valid
   end
 
+  it "archive reason should be correcly returned when assigned" do
+    subject.archive("scale")
+    expect(subject.archive_reason).to eql("scale")
+  end
+
   it "should be able to be archived with valid reason" do
     subject.archive("scale")
     expect(subject.archived_at).not_to be(nil)
@@ -20,6 +25,6 @@ RSpec.describe Drawing, type: :model do
 
   it "should return true when archived? method called" do
     subject.archive("scale")
-    expect(subject.is_archived?).to be true
+    expect(subject.archived?).to be true
   end
 end

--- a/spec/models/drawing_spec.rb
+++ b/spec/models/drawing_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe Drawing, type: :model do
   it "should create attached plan successfully" do
     expect(subject).to be_valid
   end
+
+  it "should create attached plan successfully" do
+    expect(subject).to be_valid
+  end
+
+  it "should be able to be archived with valid reason" do
+    subject.archive("scale")
+    expect(subject.archived_at).not_to be(nil)
+  end
+
+  it "should return true when archived? method called" do
+    subject.archive("scale")
+    expect(subject.is_archived?).to be true
+  end
 end

--- a/spec/models/drawing_wizard_spec.rb
+++ b/spec/models/drawing_wizard_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe DrawingWizard, type: :model do
   subject { FactoryBot.create :drawing, :with_plan }
 
   it "should be valid when created" do
-    form = DrawingWizard::ArchiveForm.new({ id: subject.id, archive_reason: "scale", updated_at: Time.zone.now })
+    form = DrawingWizard::ArchiveForm.new({ id: subject.id, archive_reason: "scale", updated_at: Time.current })
     expect(form).to be_valid
   end
 
   it "should be invalid when archive reason is blank" do
-    form = DrawingWizard::ArchiveForm.new({ id: subject.id, updated_at: Time.zone.now })
+    form = DrawingWizard::ArchiveForm.new({ id: subject.id, updated_at: Time.current })
     expect(form).to be_invalid
   end
 end

--- a/spec/models/drawing_wizard_spec.rb
+++ b/spec/models/drawing_wizard_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DrawingWizard, type: :model do
+  subject { FactoryBot.create :drawing, :with_plan }
+
+  it "should be valid when created" do
+    form = DrawingWizard::ArchiveForm.new({ id: subject.id, archive_reason: "scale", updated_at: Time.zone.now })
+    expect(form).to be_valid
+  end
+
+  it "should be invalid when archive reason is blank" do
+    form = DrawingWizard::ArchiveForm.new({ id: subject.id, updated_at: Time.zone.now })
+    expect(form).to be_invalid
+  end
+end

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Drawings index page", type: :system do
+  fixtures :sites
+
+  let!(:site) { sites(:elm_grove) }
+
+  let!(:planning_application) do
+    create :planning_application,
+           :lawfulness_certificate,
+           site: site,
+           reference: "19/AP/1880"
+  end
+
+  let!(:drawing) do
+    create :drawing, :with_plan,
+           planning_application: planning_application
+  end
+
+  context "as a user who is not logged in" do
+    scenario "User cannot see archive page" do
+      visit planning_application_drawings_path(planning_application)
+      expect(page).to have_current_path(/sign_in/)
+      expect(page).to have_content("You need to sign in or sign up before continuing.")
+    end
+  end
+
+  context "as an assessor" do
+    before do
+      sign_in users(:assessor)
+      visit planning_application_path(planning_application)
+      click_button "Proposal documents"
+      click_link "Manage documents"
+    end
+
+    scenario "Assessor can see Archive links when application is in determination" do
+      expect(page).to have_css(".thumbnail-left")
+    end
+
+    scenario "Archive table is initially empty" do
+      expect(page).to have_text "No documents archived"
+      expect(page).not_to have_css(".archive-data")
+    end
+  end
+
+  context "archiving journey" do
+    before do
+      sign_in users(:assessor)
+      visit planning_application_path(planning_application)
+      click_button "Proposal documents"
+      click_link "Manage documents"
+      click_link "Archive document"
+    end
+
+    scenario "Archive page contains radio buttons and image" do
+      expect(page).to have_text "Missing scale bar/north arrow"
+      expect(page).to have_css(".govuk-radios__item")
+    end
+
+    scenario "Archive page contains site info" do
+      expect(page).to have_text "Elm Grove"
+    end
+
+    scenario "Archive page contains application reference" do
+      expect(page).to have_text "19/AP/1880"
+    end
+
+    scenario "Breadcrumbs are correct on archive page" do
+      within(find(".govuk-breadcrumbs__list", match: :first)) do
+        expect(page).to have_link "Application"
+        expect(page).to have_link "Home"
+        expect(page).to have_text "Archive document"
+        expect(page).to have_no_link "Archive document"
+      end
+    end
+
+    scenario "User can log out from archive page" do
+      click_button "Log out"
+
+      expect(page).to have_current_path(/sign_in/)
+      expect(page).to have_content("You need to sign in or sign up before continuing.")
+    end
+
+    scenario "Assessor sees flash warning if no radio button selected" do
+      click_button "Save"
+      expect(page).to have_text("Please select valid reason for archiving")
+    end
+
+    scenario "Assessor can proceed to confirmation page" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+      expect(page).to have_current_path(/validate_step/)
+    end
+
+    scenario "Correct reason is shown on confirmation page" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+      expect(page).to have_text("Revise dimensions")
+    end
+
+    scenario "Assessor is returned to archive page if radio button not selected" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+      click_button "Archive document"
+
+      expect(page).to have_text("Why do you want to archive this document?")
+    end
+
+    scenario "Assessor is returned to archive page if 'No' is selected" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+      page.find(id: "archive-no").click
+      click_button "Archive document"
+
+      expect(page).to have_text("Why do you want to archive this document?")
+    end
+
+    scenario "Assessor can archive a document" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+
+      page.find(id: "archive-yes").click
+      click_button "Archive document"
+
+      expect(page).to have_current_path(/drawings/)
+    end
+
+    scenario "Archived document appears in correct place on DMS page" do
+      page.find(id: "revise-dimensions").click
+      click_button "Save"
+      page.find(id: "archive-yes").click
+      click_button "Archive document"
+
+      within(find(".archived-drawings")) do
+        expect(page).to have_text("Revise dimensions")
+        expect(page).to have_text("Side elevation")
+      end
+    end
+
+    scenario "Archived document does not appear on overview page" do
+      expect(page).not_to have_css(".thumbnail-left")
+    end
+  end
+end

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -35,7 +35,11 @@ RSpec.feature "Drawings index page", type: :system do
       click_link "Manage documents"
     end
 
-    scenario "Assessor can see Archive links when application is in determination" do
+    scenario "Assessor can see Archive document links when application is in assessment" do
+      expect(page).to have_text("Archive document")
+    end
+
+    scenario "Assessor can see table of drawings on overview page" do
       expect(page).to have_css(".thumbnail-left")
     end
 
@@ -45,7 +49,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
   end
 
-  context "archiving journey" do
+  context "Archiving journey" do
     before do
       sign_in users(:assessor)
       visit planning_application_path(planning_application)
@@ -83,33 +87,34 @@ RSpec.feature "Drawings index page", type: :system do
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
 
-    scenario "Assessor sees flash warning if no radio button selected" do
-      click_button "Save"
-      expect(page).to have_text("Please select valid reason for archiving")
-    end
-
     scenario "Assessor can proceed to confirmation page" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
       expect(page).to have_current_path(/validate_step/)
     end
 
     scenario "Correct reason is shown on confirmation page" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
-      expect(page).to have_text("Revise dimensions")
+      expect(page).to have_text("Missing scale bar or north arrow")
     end
 
     scenario "Assessor is returned to archive page if radio button not selected" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
       click_button "Archive document"
 
       expect(page).to have_text("Why do you want to archive this document?")
     end
 
+    scenario "Assessor sees error message if radio button not selected" do
+      click_button "Save"
+
+      expect(page).to have_text("Please select one of the below reasons")
+     end
+
     scenario "Assessor is returned to archive page if 'No' is selected" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
       page.find(id: "archive-no").click
       click_button "Archive document"
@@ -118,7 +123,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Assessor can archive a document" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
 
       page.find(id: "archive-yes").click
@@ -127,20 +132,43 @@ RSpec.feature "Drawings index page", type: :system do
       expect(page).to have_current_path(/drawings/)
     end
 
+    scenario "Assessor can archive a document and sees message" do
+      choose "scale"
+      click_button "Save"
+
+      page.find(id: "archive-yes").click
+      click_button "Archive document"
+
+      expect(page).to have_text("Side elevation has been archived")
+    end
+
     scenario "Archived document appears in correct place on DMS page" do
-      page.find(id: "revise-dimensions").click
+      choose "scale"
       click_button "Save"
       page.find(id: "archive-yes").click
       click_button "Archive document"
 
       within(find(".archived-drawings")) do
-        expect(page).to have_text("Revise dimensions")
+        expect(page).to have_text("Missing scale bar")
         expect(page).to have_text("Side elevation")
       end
     end
 
     scenario "Archived document does not appear on overview page" do
       expect(page).not_to have_css(".thumbnail-left")
+    end
+  end
+
+  context "as a reviewer" do
+    before do
+      sign_in users(:reviewer)
+      visit planning_application_path(planning_application)
+      click_button "Proposal documents"
+      click_link "Manage documents"
+    end
+
+    scenario "Reviewer cannot see Archive links" do
+      expect(page).not_to have_link("Archive document")
     end
   end
 end

--- a/spec/system/drawings/index_spec.rb
+++ b/spec/system/drawings/index_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Plan image opens in new tab" do
-      find(:css, 'a[href*="active"]').click
+      first(:css, 'a[href*="active"]').click
       page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 
       expect(current_url).to include("/rails/active_storage/")


### PR DESCRIPTION
<img width="1111" alt="archive" src="https://user-images.githubusercontent.com/1880450/86330587-c7d7ed80-bc3f-11ea-98ca-bc3910d48652.png">
<img width="960" alt="confirm" src="https://user-images.githubusercontent.com/1880450/86330380-847d7f00-bc3f-11ea-9b7e-02de1d1a0936.png">
0-144b31f9c2b0.png">
<img width="1016" alt="index" src="https://user-images.githubusercontent.com/1880450/86330397-8b0bf680-bc3f-11ea-8804-6caa9c547114.png">


### Description of change

This implements the document archive journey.

1. A filter is applied to the Planning Application overview page to show only documents that are not archived
2. The document display has been updated to use divs instead of a table
3. The filter is applied to the Drawings index page and an archive table has been added to display archived documents
4. An Archive page has been added which uses a new model (DrawingWizard) that temporarily stores the reason for archive
5. A Confirm page has been added which adds the new attribute to the Drawing model on saving
6. Flash messages have been suppressed on the drawing page to allow the display of a single-use custom flash message confirming the document has been archived

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173110690

### Known issues 

Things you know need further follow on work 
1. Tags are displayed as a placeholder until the migration has been added


