### PR TITLE
Feature/pt 173528363/content design changes

### DIFF
--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <h2 class="govuk-heading-m">Permitted development requirements</h2>
+      <h2 class="govuk-heading-m">Assess the proposal</h2>
       <p class="govuk-body">
         The applicant has submitted the following application. Please review each answer to determine whether what they say and their plans align with the policy questions.
       </p>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -3,7 +3,7 @@
     <fieldset class="govuk-fieldset">
       <h2 class="govuk-heading-m">Assess the proposal</h2>
       <p class="govuk-body">
-        The applicant has submitted the following application. Please review each answer to determine whether what they say and their plans align with the policy questions.
+        Please review the applicant's answers:
       </p>
       <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
       <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
@@ -26,7 +26,10 @@
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-granted-conditional">
               <div class="govuk-form-group">
                 <p class="govuk-body">
-                  Please add any comments that can be inserted into the decision notice.
+                  By selecting yes, you are saying that this proposal complies with the GDPO.
+                  <br>
+                  <br>
+                  Please add any comments that you would like to share with your manager.
                 </p>
                 <%= form.text_area :comment_met, class: "govuk-textarea", id: "comment_met", rows: "3", "aria-describedby": "comment-met-hint" %>
               </div>
@@ -38,7 +41,8 @@
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
               <div class="govuk-form-group">
                 <p class="govuk-body">
-                  Please add any comments that can be inserted into the decision notice.
+                  Please add any comments for your manager to see.
+                  This will <strong>not</strong> appear on the decision notice.
                 </p>
                 <%= form.text_area :comment_unmet, class: "govuk-textarea", id: "comment_unmet", rows: "3", "aria-describedby": "comment-unmet-hint" %>
               </div>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -3,9 +3,9 @@
   <fieldset class="govuk-fieldset">
     <h2 class="govuk-heading-m">Review the recommendation</h2>
     <p class="govuk-body">
-      The recommended by the planning officer is
+      The planning officer recommends that the application is
       <strong><%= assessor_decision.status %></strong>
-      <%= "based on the following comment:" if assessor_decision.comment_made? %>
+      <%= "and added this comment:" if assessor_decision.comment_made? %>
     </p>
     <% if assessor_decision.granted? && assessor_decision.comment_made? %>
       <div style="border: 1px solid; padding: 10px;">

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
 <div class="govuk-form-group">
   <fieldset class="govuk-fieldset">
-    <h2 class="govuk-heading-m">Permitted development requirements</h2>
+    <h2 class="govuk-heading-m">Review the recommendation</h2>
     <p class="govuk-body">
       The applicant has submitted the following application
     </p>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -3,29 +3,27 @@
   <fieldset class="govuk-fieldset">
     <h2 class="govuk-heading-m">Review the recommendation</h2>
     <p class="govuk-body">
-      The applicant has submitted the following application
-    </p>
-    <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
-    <p class="govuk-body">
-      Based on the evidence given by applicant, the planning officer recommended that permitted development should be
-      <strong><%= "#{assessor_decision.status}." %></strong>
+      The recommended by the planning officer is
+      <strong><%= assessor_decision.status %></strong>
+      <%= "based on the following comment:" if assessor_decision.comment_made? %>
     </p>
     <% if assessor_decision.granted? && assessor_decision.comment_made? %>
-      <p class="govuk-body">The officer has submitted this comment to the applicant:</p>
       <div style="border: 1px solid; padding: 10px;">
         <p class="govuk-body"><%= assessor_decision.comment_met %></p>
       </div>
+      <br>
     <% elsif assessor_decision.refused? && assessor_decision.comment_made? %>
-      <p class="govuk-body">The officer has submitted this comment to the applicant:</p>
       <div style="border: 1px solid; padding: 10px;">
         <p class="govuk-body"><%= assessor_decision.comment_unmet %></p>
       </div>
+      <br>
     <% end %>
-    <br>
+    <p class="govuk-body">Please review the applicant's answers:</p>
+    <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
     <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
       <p class="govuk-body">
         <strong>
-          Do you agree with this recommendation?
+          Do you agree with the recommendation?
         </strong>
       </p>
       <% if form.object.errors.any? %>

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Make recommendation', edit_planning_application_decision_path %>
+    <% navigation_add 'Assess the proposal', edit_planning_application_decision_path %>
     <%=
       render "assessor_decision_form",
         planning_application: @planning_application,
@@ -8,7 +8,7 @@
         policy_evaluation: @policy_evaluation
     %>
   <% else %>
-    <% navigation_add 'Approve recommendation', edit_planning_application_decision_path %>
+    <% navigation_add 'Review the recommendation', edit_planning_application_decision_path %>
     <%=
       render "reviewer_decision_form",
         planning_application: @planning_application,

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -1,6 +1,6 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Make recommendation', new_planning_application_decision_path %>
+    <% navigation_add 'Assess the proposal', new_planning_application_decision_path %>
     <%=
       render "assessor_decision_form",
         planning_application: @planning_application,
@@ -8,7 +8,7 @@
         policy_evaluation: @policy_evaluation
     %>
   <% else %>
-    <% navigation_add 'Approve recommendation', new_planning_application_decision_path %>
+    <% navigation_add 'Review the recommendation', new_planning_application_decision_path %>
     <%=
       render "reviewer_decision_form",
         planning_application: @planning_application,

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -2,11 +2,11 @@
   <% if (current_user.assessor? || current_user.admin?)%>
     <li>
       <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number">Assess the proposal</span>
+        <span class="app-task-list__section-number">Make recommendation</span>
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% step_name = "Evaluate permitted development policy requirements" %>
+          <% step_name = "Assess the proposal" %>
 
           <% if (current_user.assessor? || current_user.admin?) && @planning_application.in_assessment? %>
             <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
@@ -29,7 +29,7 @@
         </li>
 
         <li class="app-task-list__item">
-          <% step_name = "Confirm decision notice" %>
+          <% step_name = "Submit the recommendation" %>
 
           <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
@@ -53,7 +53,7 @@
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% step_name = "Review permitted development policy requirements" %>
+          <% step_name = "Review the recommendation" %>
 
           <% if current_user.reviewer? && @planning_application.awaiting_determination? %>
             <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
@@ -76,7 +76,7 @@
         </li>
 
         <li class="app-task-list__item">
-          <% step_name = "Publish and send decision notice" %>
+          <% step_name = "Publish the recommendation" %>
 
           <% if current_user.reviewer? && @planning_application.awaiting_determination? %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -8,7 +8,7 @@
         <li class="app-task-list__item">
           <% step_name = "Assess the proposal" %>
 
-          <% if (current_user.assessor? || current_user.admin?) && @planning_application.in_assessment? %>
+          <% if (current_user.assessor? || current_user.admin?) %>
             <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
             <%# TODO: Make a helper for this %>
@@ -34,7 +34,7 @@
           <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
-            <span class="app-task-list__task-name"><%= link_to_if @planning_application.in_assessment?, step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
+            <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
           <% else %>
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
@@ -55,7 +55,7 @@
         <li class="app-task-list__item">
           <% step_name = "Review the recommendation" %>
 
-          <% if current_user.reviewer? && @planning_application.awaiting_determination? %>
+          <% if current_user.reviewer? %>
             <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
             <%# TODO: Make a helper for this %>
@@ -78,10 +78,10 @@
         <li class="app-task-list__item">
           <% step_name = "Publish the recommendation" %>
 
-          <% if current_user.reviewer? && @planning_application.awaiting_determination? %>
+          <% if current_user.reviewer? && @planning_application.reviewer_decision %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
-            <span class="app-task-list__task-name"><%= link_to_if @planning_application.reviewer_decision, step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
+            <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
           <% else %>
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -1,6 +1,3 @@
-<h2 class="govuk-heading-m">
-  Submit Recommendation
-</h2>
 <p class="govuk-body">Based on your answers given with the Permitted Development Policy Requirements, Permited Development should be <%= "#{decision.status}." %>
   <% if (decision.granted? && planning_application.assessor_decision.comment_met.present?) || (decision.refused? && planning_application.assessor_decision.comment_unmet.present?) %>
     <%= "Your comments have been added to the decision notice." %>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -1,8 +1,3 @@
-<p class="govuk-body">Based on your answers given with the Permitted Development Policy Requirements, Permited Development should be <%= "#{decision.status}." %>
-  <% if (decision.granted? && planning_application.assessor_decision.comment_met.present?) || (decision.refused? && planning_application.assessor_decision.comment_unmet.present?) %>
-    <%= "Your comments have been added to the decision notice." %>
-  <% end %>
-</p>
 <div style="background-color: #f3f2f1; border: solid 1px; padding: 30px; clear: both; margin-top: 10px;">
   <span class="govuk-caption-xl">Southwark Council</span>
   <h2 class="govuk-heading-m">Town and country planning act 1990 (as amended)</h2>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -8,8 +8,13 @@
       <th scope="col" class="govuk-table__header">Application type</th>
       <th scope="col" class="govuk-table__header">Target date</th>
       <th scope="col" class="govuk-table__header">Days left</th>
-      <th scope="col" class="govuk-table__header">Consultation end date</th>
-      <th scope="col" class="govuk-table__header">Consultation responses</th>
+      <% if id == "in_assessment" %>
+        <th scope="col" class="govuk-table__header">Consultation status</th>
+      <% elsif id == "awaiting_determination" %>
+        <th scope="col" class="govuk-table__header">Recommendation date</th>
+      <% elsif id == "determined" %>
+        <th scope="col" class="govuk-table__header">Determination date</th>
+      <% end %>
       <th scope="col" class="govuk-table__header">Planning officer</th>
     </tr>
     </thead>
@@ -27,8 +32,13 @@
             <%= planning_application.days_left %>
           </strong>
         </td>
-        <td class="govuk-table__cell"> -</td>
-        <td class="govuk-table__cell"> -</td>
+        <% if id == "in_assessment" %>
+          <td class="govuk-table__cell">Not required</td>
+        <% elsif id == "awaiting_determination" %>
+          <td class="govuk-table__cell"><%= planning_application.awaiting_determination_at.strftime("%B %e") %></td>
+        <% elsif id == "determined" %>
+          <td class="govuk-table__cell"><%= planning_application.determined_at.strftime("%B %e") %></td>
+        <% end %>
         <td class="govuk-table__cell">
           <% if planning_application.user %>
             <%= planning_application.user.name %>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -7,7 +7,7 @@
       <th scope="col" class="govuk-table__header">Site address</th>
       <th scope="col" class="govuk-table__header">Application type</th>
       <th scope="col" class="govuk-table__header">Target date</th>
-      <th scope="col" class="govuk-table__header">Working days left</th>
+      <th scope="col" class="govuk-table__header">Days left</th>
       <th scope="col" class="govuk-table__header">Consultation end date</th>
       <th scope="col" class="govuk-table__header">Consultation responses</th>
       <th scope="col" class="govuk-table__header">Planning officer</th>

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -1,6 +1,7 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Make recommendation', edit_planning_application_path %>
+    <% navigation_add 'Submit the recommendation', edit_planning_application_path %>
+    <h2 class="govuk-heading-m">Submit the recommendation</h2>
 
     <%= render "decision_notice", planning_application: @planning_application, decision: @planning_application.assessor_decision  %>
 
@@ -17,7 +18,9 @@
       <%= form.submit "Submit to manager", class: "govuk-button", data: { module: "govuk-button" } %>
     <% end %>
   <% else %>
-    <% navigation_add 'Approve recommendation', edit_planning_application_path %>
+    <% navigation_add 'Publish the recommendation', edit_planning_application_path %>
+    <h2 class="govuk-heading-m">Publish the recommendation</h2>
+
     <%= render "decision_notice", planning_application: @planning_application, decision: @planning_application.reviewer_decision %>
 
     <p class="govuk-body">By determining the application, the applicant will receive this decision notice. The decision notice will also be available publicly. </p>

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -2,6 +2,7 @@
   <% if current_user.assessor? %>
     <% navigation_add 'Submit the recommendation', edit_planning_application_path %>
     <h2 class="govuk-heading-m">Submit the recommendation</h2>
+    <p class="govuk-body">The following decision notice has been created based on your answers.</p>
 
     <%= render "decision_notice", planning_application: @planning_application, decision: @planning_application.assessor_decision  %>
 
@@ -10,7 +11,7 @@
       <strong>
         If you agree with the decision notice, please submit it to your manager.
       </strong>
-      Once submitted, you will not be able to change your recommendation, or decision.
+      If your manager disagrees with your recommendation they will send it back to you to make changes.
     </p>
 
     <%= form_with model: @planning_application, local: true do |form| %>
@@ -20,6 +21,7 @@
   <% else %>
     <% navigation_add 'Publish the recommendation', edit_planning_application_path %>
     <h2 class="govuk-heading-m">Publish the recommendation</h2>
+    <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.</p>
 
     <%= render "decision_notice", planning_application: @planning_application, decision: @planning_application.reviewer_decision %>
 

--- a/spec/support/shared_examples/assessor_decision_error_examples.rb
+++ b/spec/support/shared_examples/assessor_decision_error_examples.rb
@@ -6,9 +6,9 @@ RSpec.shared_examples 'assessor decision error message' do
       click_link "19/AP/1880"
     end
 
-    expect(page).not_to have_link("Confirm decision notice")
+    expect(page).not_to have_link("Submit the recommendation")
 
-    click_link "Evaluate permitted development policy requirements"
+    click_link "Assess the proposal"
 
     click_button "Save"
 

--- a/spec/support/shared_examples/reviewer_assignment_examples.rb
+++ b/spec/support/shared_examples/reviewer_assignment_examples.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'reviewer assignment' do
   scenario "reviewer is not assigned to planning application" do
     click_link "19/AP/1880"
 
-    click_link "Review permitted development policy requirements"
+    click_link "Review the recommendation"
 
     click_link "Home"
 

--- a/spec/support/shared_examples/reviewer_decision_error_examples.rb
+++ b/spec/support/shared_examples/reviewer_decision_error_examples.rb
@@ -6,9 +6,9 @@ RSpec.shared_examples 'reviewer decision error message' do
       click_link "19/AP/1880"
     end
 
-    expect(page).not_to have_link("Publish and send decision notice")
+    expect(page).not_to have_link("Publish the recommendation")
 
-    click_link "Review permitted development policy requirements"
+    click_link "Review the recommendation"
 
     click_button "Save"
 

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_text("Lorrine Krajcik")
 
     choose "Yes"
+
+    expect(page).to have_content("By selecting yes, you are saying that this proposal complies with the GDPO.")
+    expect(page).to have_content("Please add any comments that you would like to share with your manager.")
+
     fill_in "comment_met", with: "This has been granted"
 
     click_button "Save"
@@ -85,10 +89,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     click_link "Submit the recommendation"
 
     expect(page).to have_content("Submit the recommendation")
-    expect(page).to have_content("Based on your answers given with the Permitted Development Policy Requirements, Permited Development should be #{planning_application.reload.assessor_decision.status}")
-
-    expect(planning_application.reload.assessor_decision.comment_made?).to be(true)
-    expect(page).to have_content("Your comments have been added to the decision notice.")
+    expect(page).to have_content("The following decision notice has been created based on your answers.")
 
     expect(page).to have_content("Certificate of lawfulness of proposed use or development: #{planning_application.reload.assessor_decision.status}")
 
@@ -102,6 +103,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_content("#{planning_application.reference}")
 
     expect(page).to have_content("Certificate of lawful development (proposed) for the construction of #{planning_application.description}")
+
+    expect(page).to have_content("If you agree with the decision notice, please submit it to your manager. If your manager disagrees with your recommendation they will send it back to you to make changes.")
 
     click_button "Submit to manager"
 

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).not_to have_css(".app-task-list__task-completed")
 
     # The second step is not yet a link
-    expect(page).not_to have_link("Confirm decision notice")
+    expect(page).not_to have_link("Submit the recommendation")
 
     within(".govuk-grid-column-two-thirds.application") do
       first('.govuk-accordion').click_button('Open all')
       expect(page).not_to have_text("Lorrine Krajcik")
     end
 
-    click_link "Evaluate permitted development policy requirements"
+    click_link "Assess the proposal"
 
     expect(page).to have_content("The property is a semi detached house")
     expect(page).to have_content("The project will not alter the internal floor area of the building")
@@ -62,11 +62,11 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(planning_application.reload.assessor_decision.comment_met).to eq("This has been granted")
 
     # Expect the 'completed' label to be present for the evaluation step
-    within(:assessment_step, "Evaluate permitted development policy requirements") do
+    within(:assessment_step, "Assess the proposal") do
       expect(page).to have_completed_tag
     end
 
-    click_link "Evaluate permitted development policy requirements"
+    click_link "Assess the proposal"
 
     # Expect the saved state to be shown in the form
     within(find("form.decision")) do
@@ -78,13 +78,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
     click_button "Save"
 
     # Expect the 'completed' label to still be present for the evaluation step
-    within(:assessment_step, "Evaluate permitted development policy requirements") do
+    within(:assessment_step, "Assess the proposal") do
       expect(page).to have_completed_tag
     end
 
-    click_link "Confirm decision notice"
+    click_link "Submit the recommendation"
 
-    expect(page).to have_content("Submit Recommendation")
+    expect(page).to have_content("Submit the recommendation")
     expect(page).to have_content("Based on your answers given with the Permitted Development Policy Requirements, Permited Development should be #{planning_application.reload.assessor_decision.status}")
 
     expect(planning_application.reload.assessor_decision.comment_made?).to be(true)
@@ -105,7 +105,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     click_button "Submit to manager"
 
-    within(:assessment_step, "Confirm decision notice") do
+    within(:assessment_step, "Submit the recommendation") do
       expect(page).to have_completed_tag
     end
 
@@ -125,8 +125,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "19/AP/1880"
     end
 
-    expect(page).not_to have_link("Evaluate permitted development policy requirements")
-    expect(page).not_to have_link("Confirm decision notice")
+    expect(page).not_to have_link("Assess the proposal")
+    expect(page).not_to have_link("Submit the recommendation")
     # TODO: Continue this spec until the assessor decision has been made and check that policy evaluations can no longer be made
   end
 
@@ -145,7 +145,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).to have_text("Not started")
     end
 
-    click_link "Evaluate permitted development policy requirements"
+    click_link "Assess the proposal"
 
     # Ensure officer name is now displayed
     within(".govuk-grid-column-two-thirds.application") do

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -128,8 +128,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "19/AP/1880"
     end
 
-    expect(page).not_to have_link("Assess the proposal")
-    expect(page).not_to have_link("Submit the recommendation")
     # TODO: Continue this spec until the assessor decision has been made and check that policy evaluations can no longer be made
   end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -42,11 +42,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "Yes"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -54,7 +54,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("granted")
@@ -71,7 +71,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(mail.subject).to eq("Certificate of Lawfulness: granted")
         expect(mail.body.encoded).to match("Certificate of lawfulness of proposed use or development: granted.")
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -102,9 +102,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -113,11 +113,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "No"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -125,7 +125,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("refused")
@@ -136,7 +136,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -184,11 +184,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
             click_link "19/AP/1880"
           end
 
-          click_link "Review permitted development policy requirements"
+          click_link "Review the recommendation"
           choose "Yes"
           click_button "Save"
 
-          click_link "Publish and send decision notice"
+          click_link "Publish the recommendation"
           click_button "Determine application"
 
           expect(page).to have_content("The Decision Notice cannot be sent. Please try again later.")
@@ -208,9 +208,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).to have_content("The officer has submitted this comment to the applicant:")
         expect(page).to have_content("This has been granted.")
@@ -219,11 +219,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "Yes"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -231,7 +231,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("granted")
@@ -242,7 +242,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -267,9 +267,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).to have_content("The officer has submitted this comment to the applicant:")
         expect(page).to have_content("This has been granted.")
@@ -278,11 +278,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "No"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -290,7 +290,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("refused")
@@ -301,7 +301,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -333,9 +333,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -344,11 +344,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "Yes"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -356,7 +356,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("refused")
@@ -367,7 +367,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -392,9 +392,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -403,11 +403,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "No"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -415,7 +415,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("granted")
@@ -426,7 +426,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -458,9 +458,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -469,11 +469,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "Yes"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -481,7 +481,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("refused")
@@ -492,7 +492,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -517,9 +517,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "19/AP/1880"
         end
 
-        expect(page).not_to have_link("Publish and send decision notice")
+        expect(page).not_to have_link("Publish the recommendation")
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         expect(page).to have_content("The officer has submitted this comment to the applicant:")
         expect(page).not_to have_content("This has been granted.")
@@ -528,11 +528,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         choose "No"
         click_button "Save"
 
-        within(:assessment_step, "Review permitted development policy requirements") do
+        within(:assessment_step, "Review the recommendation") do
           expect(page).to have_completed_tag
         end
 
-        click_link "Review permitted development policy requirements"
+        click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
         within(find("form.decision")) do
@@ -540,7 +540,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         end
         click_button "Save"
 
-        click_link "Publish and send decision notice"
+        click_link "Publish the recommendation"
 
         expect(page).not_to have_content("Your comments have been added to the decision notice.")
         expect(page).to have_content("granted")
@@ -551,7 +551,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Determine application"
 
-        within(:assessment_step, "Publish and send decision notice") do
+        within(:assessment_step, "Publish the recommendation") do
           expect(page).to have_completed_tag
         end
 
@@ -594,9 +594,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
       click_link "19/AP/1880"
 
-      expect(page).to have_link "Evaluate permitted development policy requirements"
+      expect(page).to have_link "Assess the proposal"
 
-      within(:assessment_step, "Evaluate permitted development policy requirements") do
+      within(:assessment_step, "Assess the proposal") do
         expect(page).to have_completed_tag
       end
     end

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is granted")
-        expect(page).not_to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted")
+        expect(page).not_to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -107,8 +107,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is granted")
-        expect(page).not_to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted")
+        expect(page).not_to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -214,8 +214,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is granted")
-        expect(page).to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted")
+        expect(page).to have_content("and added this comment:")
         expect(page).to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -274,8 +274,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is granted")
-        expect(page).to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted")
+        expect(page).to have_content("and added this comment:")
         expect(page).to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -341,8 +341,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is refused")
-        expect(page).not_to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused")
+        expect(page).not_to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -401,8 +401,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is refused")
-        expect(page).not_to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused")
+        expect(page).not_to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -468,8 +468,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is refused")
-        expect(page).to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused")
+        expect(page).to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).to have_content("This has been refused.")
 
@@ -528,8 +528,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The recommended by the planning officer is refused")
-        expect(page).to have_content("based on the following comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused")
+        expect(page).to have_content("and added this comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).to have_content("This has been refused.")
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is granted")
+        expect(page).not_to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -56,7 +57,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -106,7 +107,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is granted")
+        expect(page).not_to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -127,7 +129,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -212,7 +214,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is granted")
+        expect(page).to have_content("based on the following comment:")
         expect(page).to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -233,7 +236,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
         expect(page).to have_content("Reason for granting:")
         expect(page).to have_content("This has been granted.")
@@ -271,7 +274,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is granted")
+        expect(page).to have_content("based on the following comment:")
         expect(page).to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -292,7 +296,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -337,7 +341,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is refused")
+        expect(page).not_to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -358,7 +363,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -396,7 +401,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).not_to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is refused")
+        expect(page).not_to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
@@ -417,7 +423,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -462,7 +468,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is refused")
+        expect(page).to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).to have_content("This has been refused.")
 
@@ -483,7 +490,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")
@@ -521,7 +528,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The officer has submitted this comment to the applicant:")
+        expect(page).to have_content("The recommended by the planning officer is refused")
+        expect(page).to have_content("based on the following comment:")
         expect(page).not_to have_content("This has been granted.")
         expect(page).to have_content("This has been refused.")
 
@@ -542,7 +550,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Publish the recommendation"
 
-        expect(page).not_to have_content("Your comments have been added to the decision notice.")
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
         expect(page).not_to have_content("Reason for granting:")
         expect(page).not_to have_content("This has been granted.")

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Planning Application show page", type: :system do
     end
 
     scenario "Assessment tasks are visible" do
-      expect(page).to have_text("Assess the proposal")
+      expect(page).to have_text("Make recommendation")
     end
 
     scenario "Review tasks are not visible" do


### PR DESCRIPTION
### Description of change

Here are the changes:

In assessment tab:
- Change "Working Days left" to "Days Left"
- Replace "Consultation end date" and "Consultation responses" with "Consultation status" 
       - For PD, it should say "Not required"

Awaiting determination tab:
- Change "Working Days left" to "Days Left"
- Remove "Consultation end date" and "Consultation responses"
- Add column with "Recommendation date" - this date is the day that the officer submits the recommendation to the manager

Determined
- Change "Working Days left" to "Days Left"
- Remove "Consultation end date" and "Consultation responses"
- Add column with "Determination date" - this date is the day that the manager publishes the decision notice publically/via email

**Task Lists**

Each subtask on the list should be the heading on the following page and in the breadcrumb. 

Task list when an application is in the In Assessment tab
- Change Heading "Assess the proposal" to "Make recommendation"
- Change Subtask "Evaluate permitted development policy requirements" to "Assess the proposal"
- Change Subtask "Confirm decision notice" to "Submit the recommendation"

Task list when an application is in the Awaiting determination tab
- Change Subtask "Review permitted development policy requirements" to "Review the recommendation"
- Change Subtask "Publish and send decision notice" to "Publish the recommendation"

**Content on pages**

Assess the proposal
- Breadcrumb and header say "Assess the proposal"
- Remove h3 and have paragraph text saying "Please review the applicant's answers:"
- When selecting the radio button "yes", it says "By selecting yes, you are saying that this proposal complies with the GDPO. <br><br>Please add any comments that you would like to share with your manager."

Submit the recommendation
- Breadcrumb and header say "Submit the recommendation"
- The paragraph text says "The following decision notice has been created based on your answers."
- Underneath the decision notice, it says "If you agree with the decision notice, please submit it to your manager. If your manager disagrees with your recommendation they will send it back to you to make changes." The first sentence is bold.

Review recommendation
- Breadcrumb and header say "Review the recommendation"
- Under header, there is a paragraph saying "The recommended by the planning officer is refused based on the following comment:". Refused is bold
- Under the officer's comment in a box, there is a paragraph text saying "Please review the applicant's answers:"
- The question is "Do you agree with the recommendation?" - Right now this is not bold but it should be and consistent with Assess the proposal pages
- When selecting the radio button "yes"
- When selecting the radio button "no"

Publish recommendation
- Breadcrumb and header say "Publish recommendation"
- The paragraph under "Publish recommendation" says "The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it."
- Under the decision notice it says "By determining the application, the applicant will receive this decision notice. The decision notice will also be available publicly."

### Story Link

https://www.pivotaltracker.com/story/show/173528363