### PR TITLE
Feature/pt 173509804/add officer comment to review

### DIFF
--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -50,26 +50,12 @@
         </tr>
       </tbody>
     </table>
-    <% if decision.granted? && planning_application.assessor_decision.comment_met.present? %>
-      <p class="govuk-body">
-        <strong>Reason for granting:</strong>
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= planning_application.assessor_decision.comment_met %></li>
-      </ul>
-    <% end %>
   <% elsif decision.refused? %>
     <p class="govuk-body">
       IT IS HEREBY CERTIFIED that the use or operations described below are
       <strong>not lawful</strong>
       for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
     </p>
-    <% if decision.refused? && planning_application.assessor_decision.comment_unmet.present? %>
-      <p class="govuk-body">Reason why use or operations would <strong>not</strong> have been LAWFUL:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><%= planning_application.assessor_decision.comment_unmet %></li>
-      </ul>
-    <% end %>
   <% end %>
   <p class="govuk-body">Signed: Simon Bevan
     <br>

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -238,10 +238,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).to have_content("Reason for granting:")
-        expect(page).to have_content("This has been granted.")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
-        expect(page).not_to have_content("This has been refused.")
 
         click_button "Determine application"
 
@@ -276,8 +272,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is granted")
         expect(page).to have_content("and added this comment:")
-        expect(page).to have_content("This has been granted.")
-        expect(page).not_to have_content("This has been refused.")
 
         choose "No"
         click_button "Save"
@@ -298,10 +292,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
-        expect(page).not_to have_content("This has been refused.")
 
         click_button "Determine application"
 
@@ -470,8 +460,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is refused")
         expect(page).to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
-        expect(page).to have_content("This has been refused.")
 
         choose "Yes"
         click_button "Save"
@@ -492,10 +480,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
-        expect(page).to have_content("Reason why use or operations would not have been LAWFUL:")
-        expect(page).to have_content("This has been refused.")
 
         click_button "Determine application"
 


### PR DESCRIPTION
### Description of change

Removes officer comment from decision notice and updates the specs accordingly. Displaying the officer comment on the review page (which was also part of this story) was done as part of an earlier story (https://www.pivotaltracker.com/n/projects/2441805/stories/173528363).

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173509804

