### PR TITLE
added reference generator method

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -36,6 +36,10 @@ class PlanningApplication < ApplicationRecord
     update(status: status, "#{status}_at": Time.current)
   end
 
+  def reference
+    @_reference ||= id.to_s.rjust(8, "0")
+  end
+
   private
 
   def set_target_date

--- a/db/migrate/20200708095601_remove_reference_from_planning_application.rb
+++ b/db/migrate/20200708095601_remove_reference_from_planning_application.rb
@@ -1,0 +1,5 @@
+class RemoveReferenceFromPlanningApplication < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :planning_applications, :reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_29_093307) do
+ActiveRecord::Schema.define(version: 2020_07_08_095601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,7 +111,6 @@ ActiveRecord::Schema.define(version: 2020_06_29_093307) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "agent_id"
     t.bigint "applicant_id"
-    t.string "reference"
     t.string "ward"
     t.bigint "user_id"
     t.datetime "awaiting_determination_at"

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -81,7 +81,6 @@ task create_sample_data: :environment do
     applicant: applicant,
     user: assessor
   ) do |pa|
-    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
     pa.description = "Installation of new external insulated render to be added"
   end
 
@@ -102,7 +101,6 @@ task create_sample_data: :environment do
     applicant: applicant
   ) do |pa|
     pa.description = "Construction of a single storey rear extension"
-    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
   end
 
   college_planning_application.update(target_date: 1.week.from_now)
@@ -123,7 +121,6 @@ task create_sample_data: :environment do
     ward: "Rye Lane"
   ) do |pa|
     pa.description = "Construction of a single storey side extension"
-    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
   end
 
   bellenden_planning_application.update(target_date: 3.weeks.from_now)
@@ -143,7 +140,6 @@ task create_sample_data: :environment do
     ward: "South Bermondsey",
     applicant: applicant
   ) do |pa|
-    pa.reference = "AP/#{rand(-4500)}/#{rand(-100)}"
     pa.description = "Single storey rear extension and rear dormer extension"
   end
 

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     site
     agent
     applicant
-    sequence(:reference, 10) { |n| "AP/#{4500 + n * 2}/#{n}" }
     description      { Faker::Lorem.unique.sentence }
     status           { :in_assessment }
     in_assessment_at { Time.current }

--- a/spec/fixtures/planning_applications.yml
+++ b/spec/fixtures/planning_applications.yml
@@ -1,7 +1,6 @@
 planning_application_1:
   description: "Roof extension"
   application_type: "lawfulness_certificate"
-  reference: "AP/453/880"
   status: :in_assessment
   ward: "Dulwich Wood"
   agent: jennifer

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -91,4 +91,12 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  subject { create :planning_application, id: 1000 }
+
+  describe "#reference" do
+    it "pads the ID correctly" do
+      expect(subject.reference).to eq "00001000"
+    end
+  end
 end

--- a/spec/support/shared_examples/assessor_decision_error_examples.rb
+++ b/spec/support/shared_examples/assessor_decision_error_examples.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'assessor decision error message' do
   scenario "shows the error message" do
     within("#in_assessment") do
-      click_link "19/AP/1880"
+      click_link planning_application.reference
     end
 
     expect(page).not_to have_link("Submit the recommendation")

--- a/spec/support/shared_examples/reviewer_assignment_examples.rb
+++ b/spec/support/shared_examples/reviewer_assignment_examples.rb
@@ -2,7 +2,7 @@
 
 RSpec.shared_examples 'reviewer assignment' do
   scenario "reviewer is not assigned to planning application" do
-    click_link "19/AP/1880"
+    click_link planning_application.reference
 
     click_link "Review the recommendation"
 
@@ -11,7 +11,7 @@ RSpec.shared_examples 'reviewer assignment' do
     table_rows = all(".govuk-table__row").map(&:text)
 
     table_rows.each do |row|
-      expect(row).not_to include("Harley Dicki") if row.include? "19/AP/1880"
+      expect(row).not_to include("Harley Dicki") if row.include? "00000001"
     end
   end
 end

--- a/spec/support/shared_examples/reviewer_decision_error_examples.rb
+++ b/spec/support/shared_examples/reviewer_decision_error_examples.rb
@@ -3,7 +3,7 @@
 RSpec.shared_examples 'reviewer decision error message' do
   scenario "shows the error message" do
     within("#awaiting_determination") do
-      click_link "19/AP/1880"
+      click_link planning_application.reference
     end
 
     expect(page).not_to have_link("Publish the recommendation")

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Drawings index page", type: :system do
   let!(:planning_application) do
     create :planning_application,
            :lawfulness_certificate,
-           site: site,
-           reference: "19/AP/1880"
+           site: site
   end
 
   let!(:drawing) do
@@ -68,7 +67,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Archive page contains application reference" do
-      expect(page).to have_text "19/AP/1880"
+      expect(page).to have_text planning_application.reference
     end
 
     scenario "Breadcrumbs are correct on archive page" do

--- a/spec/system/drawings/index_spec.rb
+++ b/spec/system/drawings/index_spec.rb
@@ -10,8 +10,7 @@ RSpec.feature "Drawings index page", type: :system do
   let!(:planning_application) do
     create :planning_application,
            :lawfulness_certificate,
-           site: site,
-           reference: "19/AP/1880"
+           site: site
   end
 
   let!(:drawing) do
@@ -36,7 +35,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Application reference is displayed on page" do
-      expect(page).to have_text "19/AP/1880"
+      expect(page).to have_text planning_application.reference
     end
 
     scenario "Application address is displayed on page" do

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 RSpec.describe "Planning Application Assessment", type: :system do
   let!(:planning_application) do
     create :planning_application,
-            :lawfulness_certificate,
-            reference: "19/AP/1880"
+            :lawfulness_certificate
   end
 
   let(:policy_consideration_1) do
@@ -33,7 +32,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
   end
 
   scenario "Assessment completing and editing" do
-    click_link "19/AP/1880"
+    click_link planning_application.reference
 
     # Ensure we're starting from a fresh "checklist"
     expect(page).not_to have_css(".app-task-list__task-completed")
@@ -118,14 +117,14 @@ RSpec.describe "Planning Application Assessment", type: :system do
     click_link "In assessment"
 
     within("#in_assessment") do
-      expect(page).not_to have_link "19/AP/1880"
+      expect(page).not_to have_link planning_application.reference
     end
 
     # Check that the application is now in awaiting determination
     click_link "Awaiting manager's determination"
 
     within("#awaiting_determination") do
-      click_link "19/AP/1880"
+      click_link planning_application.reference
     end
 
     # TODO: Continue this spec until the assessor decision has been made and check that policy evaluations can no longer be made
@@ -135,10 +134,10 @@ RSpec.describe "Planning Application Assessment", type: :system do
     table_rows = all(".govuk-table__row").map(&:text)
 
     table_rows.each do |row|
-      expect(row).to include("Not started") if row.include? "19/AP/1880"
+      expect(row).to include("Not started") if row.include? planning_application.reference
     end
 
-    click_link "19/AP/1880"
+    click_link planning_application.reference
 
     # Ensure officer name is not displayed on page when accordion is opened
     within(".govuk-grid-column-two-thirds.application") do
@@ -158,7 +157,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     table_rows = all(".govuk-table__row").map(&:text)
 
     table_rows.each do |row|
-      expect(row).to include("Lorrine Krajcik") if row.include? "19/AP/1880"
+      expect(row).to include("Lorrine Krajcik") if row.include? planning_application.reference
     end
   end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
        :awaiting_determination,
        policy_evaluation: policy_evaluation,
        assessor_decision: assessor_decision,
-       reference: "19/AP/1880",
        applicant: applicant
     end
 
@@ -28,7 +27,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       scenario "agrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -81,18 +80,20 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
+
+        id = planning_application.id
 
         # TODO: Replace this with a check for state in the read-only determined decision
         # notice when we implement it
-        planning_application = PlanningApplication.find_by(reference: "19/AP/1880")
+        planning_application = PlanningApplication.find_by(id: id)
 
         expect(planning_application.determined_at).to be_within(5.seconds).of(Time.current)
       end
@@ -100,7 +101,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       scenario "disagrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -147,13 +148,13 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
@@ -183,7 +184,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           )
 
           within("#awaiting_determination") do
-            click_link "19/AP/1880"
+            click_link planning_application.reference
           end
 
           click_link "Review the recommendation"
@@ -207,7 +208,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       scenario "agrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -250,20 +251,20 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
       scenario "disagrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -304,13 +305,13 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
@@ -324,7 +325,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       scenario "agrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -371,20 +372,20 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
       scenario "disagrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -431,13 +432,13 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
@@ -451,7 +452,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       scenario "agrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -492,20 +493,20 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
       scenario "disagrees with assessor's decision" do
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do
-          click_link "19/AP/1880"
+          click_link planning_application.reference
         end
 
         expect(page).not_to have_link("Publish the recommendation")
@@ -552,13 +553,13 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         # Check that the application is no longer in awaiting determination
         click_link "Awaiting manager's determination"
         within("#awaiting_determination") do
-          expect(page).not_to have_link "19/AP/1880"
+          expect(page).not_to have_link planning_application.reference
         end
 
         # Check that the application is now in determined
         click_link "Determined"
         within("#determined") do
-          expect(page).to have_link "19/AP/1880"
+          expect(page).to have_link planning_application.reference
         end
       end
 
@@ -572,7 +573,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     let(:assessor_decision) { create :decision, :granted, user: assessor }
 
     let!(:planning_application) do
-      create :planning_application, reference: "19/AP/1880", assessor_decision: assessor_decision
+      create :planning_application, assessor_decision: assessor_decision
     end
 
     before do
@@ -584,7 +585,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     scenario "Assessment editing" do
       # TODO: Define admin actions on a planning application further and test them
 
-      click_link "19/AP/1880"
+      click_link planning_application.reference
 
       expect(page).to have_link "Assess the proposal"
 

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Planning Application show page", type: :system do
     end
 
     scenario "Planning application code is correct" do
-      expect(page).to have_text("Fast track application: AP/453/880")
+      expect(page).to have_text("Fast track application: #{planning_application.reference}")
     end
 
     scenario "Target date is correct and label is green" do


### PR DESCRIPTION
<img width="1069" alt="newrefs" src="https://user-images.githubusercontent.com/1880450/86769151-98adeb80-c046-11ea-9502-9663940700a6.png">

### Description of change

This story creates a unique reference generator which means that planning applications are sequentially numbered and padded out to an 8-digit number with leading zeroes. No update was made to the table as this takes the place of the previously hard-coded reference.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173066069

### Decisions 

1. Database field has remained a string rather than an integer. The specs have been updated mostly to use planning_application.reference because the randomized running order means we cannot predict which applications will have which reference number. The exception is the show spec where we need to hardcode the reference to ensure it is displayed correctly and here a fixture has been used.
2. If there is no previous application (eg when we reset the DB, value is set to 00000001
