### PR TITLE
refactored archive form to use radio button collection

### DIFF
--- a/app/helpers/drawing_helper.rb
+++ b/app/helpers/drawing_helper.rb
@@ -8,4 +8,8 @@ module DrawingHelper
   def filter_current(drawings)
     drawings.select { |plan| plan.archived? == false }.sort_by(&:archived_at)
   end
+
+  def archive_reason_collection_for_radio_buttons
+    Drawing.archive_reasons.keys.map { |k| [k, I18n.t(k)] }
+  end
 end

--- a/app/views/drawings/_archive_form.html.erb
+++ b/app/views/drawings/_archive_form.html.erb
@@ -3,33 +3,25 @@
     <%= hidden_field_tag :current_step, 'archive' %>
     <fieldset class="govuk-fieldset">
       <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
-      <% if form.object.errors.any? %>
-        <% form.object.errors.each do |attribute, error| %>
-            <span id="status-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
-        <% end %>
-      <% end %>
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
-        <div class="govuk-radios govuk-radios--small">
-          <div class="govuk-radios__item">
-            <%= form.radio_button :archive_reason, "scale", class: "govuk-radios__input", "aria-controls": "archive-reason-scale" %>
-            <%= form.label :archive_reason, "Missing scale bar/north arrow", class: "govuk-label govuk-radios__label", value: "scale" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :archive_reason, "design", class: "govuk-radios__input", "aria-controls": "archive-reason-design" %>
-            <%= form.label :archive_reason, "Revise design", class: "govuk-label govuk-radios__label", value: "design" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :archive_reason, "dimensions", class: "govuk-radios__input", "aria-controls": "archive-reason-dimensions" %>
-            <%= form.label :archive_reason, "Revise dimensions", class: "govuk-label govuk-radios__label", value: "dimensions" %>
-          </div>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :archive_reason, "other", class: "govuk-radios__input", "aria-controls": "archive-reason-other" %>
-            <%= form.label :archive_reason, "Other", class: "govuk-label govuk-radios__label", value: "other" %>
-          </div>
+       <% if form.object.errors.any? %>
+         <% form.object.errors.each do |attribute, error| %>
+           <span id="status-error" class="govuk-error-message">
+             <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+         <% end %>
+       <% end %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+          <%= form.collection_radio_buttons :archive_reason, archive_reason_collection_for_radio_buttons, :first, :last do |button| %>
+            <div class='govuk-radios govuk-radios--conditional'>
+              <div class="govuk-radios govuk-radios--small">
+                <div class="govuk-radios__item">
+                  <%= button.radio_button(class: "govuk-radios__input", "aria-controls": "archive-reason-#{button}") %>
+                  <%= button.label(class: "govuk-label govuk-radios__label") %>
+                </div>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
-     </div>
     </fieldset>
     <p>
       <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/spec/helpers/drawing_helper_spec.rb
+++ b/spec/helpers/drawing_helper_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DrawingHelper, type: :helper do
+  describe "#archive_reason_collection_for_radio_buttons" do
+    it "maps the reasons correctly" do
+      expect(archive_reason_collection_for_radio_buttons[2]).
+          to eq(["dimensions", "Revise dimensions"])
+    end
+  end
+end

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Archive page contains radio buttons and image" do
-      expect(page).to have_text "Missing scale bar/north arrow"
+      expect(page).to have_text "Missing scale bar or north arrow"
       expect(page).to have_css(".govuk-radios__item")
     end
 
@@ -115,7 +115,7 @@ RSpec.feature "Drawings index page", type: :system do
     scenario "Assessor is returned to archive page if 'No' is selected" do
       choose "scale"
       click_button "Save"
-      page.find(id: "archive-no").click
+      choose "No"
       click_button "Archive document"
 
       expect(page).to have_text("Why do you want to archive this document?")
@@ -125,7 +125,7 @@ RSpec.feature "Drawings index page", type: :system do
       choose "scale"
       click_button "Save"
 
-      page.find(id: "archive-yes").click
+      choose "Yes"
       click_button "Archive document"
 
       expect(page).to have_current_path(/drawings/)
@@ -135,7 +135,7 @@ RSpec.feature "Drawings index page", type: :system do
       choose "scale"
       click_button "Save"
 
-      page.find(id: "archive-yes").click
+      choose "Yes"
       click_button "Archive document"
 
       expect(page).to have_text("Side elevation has been archived")
@@ -144,7 +144,7 @@ RSpec.feature "Drawings index page", type: :system do
     scenario "Archived document appears in correct place on DMS page" do
       choose "scale"
       click_button "Save"
-      page.find(id: "archive-yes").click
+      choose "Yes"
       click_button "Archive document"
 
       within(find(".archived-drawings")) do


### PR DESCRIPTION
### Description of change

Radio buttons in Archive form have been refactored to generate automatically using the native Rails collection_radio_buttons syntax.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173110690

### Decisions 

The Confirm form was not refactored in the same way as it has only two buttons which behave differently, so it was more straightforward and readable to leave it as HTML.

