### PR TITLE
[#173744456] Breadcrumb Navigation

### DIFF
--- a/app/helpers/breadcrumb_navigation_helper.rb
+++ b/app/helpers/breadcrumb_navigation_helper.rb
@@ -1,37 +1,19 @@
 # frozen_string_literal: true
 
 module BreadcrumbNavigationHelper
-  PLANNING_APPLICATION_REGEX = /planning_applications\/[0-9]+\//
-
   def navigation_add(title, path)
-    if path.match?(PLANNING_APPLICATION_REGEX)
-      id = params[:planning_application_id] || params[:id]
-
-      ensure_navigation <<
-          ensure_planning_application_path(id) <<
-          { title: title, path: path }
-    else
-      ensure_navigation << { title: "Application", path: nil }
-    end
+    navigation << { title: title, path: path }
   end
 
   def render_navigation
-    render partial: "breadcrumb_navigation", locals: { nav: ensure_navigation }
+    render partial: "breadcrumb_navigation", locals: { nav: navigation }
   end
 
   private
 
   # rubocop:disable Rails/HelperInstanceVariable
-  def ensure_navigation
-    @navigation ||= home_navigation_path
+  def navigation
+    @_navigation ||= []
   end
   # rubocop:enable Rails/HelperInstanceVariable
-
-  def home_navigation_path
-    [ { title: "Home", path: root_path } ]
-  end
-
-  def ensure_planning_application_path(id)
-    { title: "Application", path: planning_application_path(id) }
-  end
 end

--- a/app/helpers/breadcrumb_navigation_helper.rb
+++ b/app/helpers/breadcrumb_navigation_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module BreadcrumbNavigationHelper
-  def navigation_add(title, path)
+  def add_parent_breadcrumb_link(title, path)
     navigation << { title: title, path: path }
   end
 

--- a/app/views/application/_breadcrumb_navigation.html.erb
+++ b/app/views/application/_breadcrumb_navigation.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <% unless nav.length > 1 %>
+  <% if current_page?(planning_applications_path(@planning_application)) %>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <%= button_to 'Log out', destroy_user_session_path, method: :delete, class: "govuk-button_link", dataModule:"govuk-button" %>

--- a/app/views/application/_create_breadcrumb_navigation.html.erb
+++ b/app/views/application/_create_breadcrumb_navigation.html.erb
@@ -1,11 +1,9 @@
 <% nav.each do |n| %>
-  <% unless n.equal? nav.last %>
-    <div class="govuk-breadcrumbs__list-item" aria-current="page">
-      <%= link_to n[:title], n[:path], class: "govuk-button__link" %>
-    </div>
-  <% else %>
-    <div class="govuk-breadcrumbs__list-item" aria-current="page">
-      <%= n[:title] %>
-    </div>
-  <% end %>
+  <div class="govuk-breadcrumbs__list-item" aria-current="page">
+    <%= link_to n[:title], n[:path], class: "govuk-button__link" %>
+  </div>
 <% end %>
+
+<div class="govuk-breadcrumbs__list-item" aria-current="page">
+  <%= yield :title %>
+</div>

--- a/app/views/decisions/edit.html.erb
+++ b/app/views/decisions/edit.html.erb
@@ -1,6 +1,6 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Assess the proposal', edit_planning_application_decision_path %>
+    <% content_for :title, "Assess the proposal" %>
     <%=
       render "assessor_decision_form",
         planning_application: @planning_application,
@@ -8,7 +8,7 @@
         policy_evaluation: @policy_evaluation
     %>
   <% else %>
-    <% navigation_add 'Review the recommendation', edit_planning_application_decision_path %>
+    <% content_for :title, "Review the recommendation" %>
     <%=
       render "reviewer_decision_form",
         planning_application: @planning_application,

--- a/app/views/decisions/new.html.erb
+++ b/app/views/decisions/new.html.erb
@@ -1,6 +1,6 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Assess the proposal', new_planning_application_decision_path %>
+    <% content_for :title, "Assess the proposal" %>
     <%=
       render "assessor_decision_form",
         planning_application: @planning_application,
@@ -8,7 +8,7 @@
         policy_evaluation: @policy_evaluation
     %>
   <% else %>
-    <% navigation_add 'Review the recommendation', new_planning_application_decision_path %>
+    <% content_for :title, "Review the recommendation" %>
     <%=
       render "reviewer_decision_form",
         planning_application: @planning_application,

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.assessor? %>
-  <% navigation_add "Home", planning_applications_path %>
-  <% navigation_add "Application", planning_application_path(@planning_application) %>
-  <% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Home", planning_applications_path %>
+  <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Documents", planning_application_drawings_path(@planning_application) %>
 
   <% content_for :title, "Archive document" %>
 

--- a/app/views/drawings/archive.html.erb
+++ b/app/views/drawings/archive.html.erb
@@ -1,5 +1,10 @@
 <% if current_user.assessor? %>
-  <% navigation_add "Archive document", planning_application_drawings_path(@planning_application) %>
+  <% navigation_add "Home", planning_applications_path %>
+  <% navigation_add "Application", planning_application_path(@planning_application) %>
+  <% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
+
+  <% content_for :title, "Archive document" %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -1,7 +1,7 @@
 <% if current_user.assessor? %>
-  <% navigation_add "Home", planning_applications_path %>
-  <% navigation_add "Application", planning_application_path(@planning_application) %>
-  <% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Home", planning_applications_path %>
+  <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Documents", planning_application_drawings_path(@planning_application) %>
 
   <% content_for :title, "Archive document" %>
 

--- a/app/views/drawings/confirm.html.erb
+++ b/app/views/drawings/confirm.html.erb
@@ -1,5 +1,10 @@
 <% if current_user.assessor? %>
-  <% navigation_add "Archive document", planning_application_drawings_path(@planning_application) %>
+  <% navigation_add "Home", planning_applications_path %>
+  <% navigation_add "Application", planning_application_path(@planning_application) %>
+  <% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
+
+  <% content_for :title, "Archive document" %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -1,4 +1,8 @@
-<% navigation_add "Documents", planning_application_drawings_path(@planning_application) %>
+<% navigation_add "Home", planning_applications_path %>
+<% navigation_add "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Documents" %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -1,5 +1,5 @@
-<% navigation_add "Home", planning_applications_path %>
-<% navigation_add "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
 
 <% content_for :title, "Documents" %>
 

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -1,9 +1,9 @@
-<% navigation_add "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
 
 <% if current_page?(planning_application_path(@planning_application)) %>
   <% content_for :title, "Application" %>
 <% else %>
-  <% navigation_add "Application", planning_application_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -1,3 +1,11 @@
+<% navigation_add "Home", planning_applications_path %>
+
+<% if current_page?(planning_application_path(@planning_application)) %>
+  <% content_for :title, "Application" %>
+<% else %>
+  <% navigation_add "Application", planning_application_path(@planning_application) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l" style="margin-bottom: 7px;">

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -1,6 +1,7 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% navigation_add 'Submit the recommendation', edit_planning_application_path %>
+    <% content_for :title, "Submit the recommendation" %>
+
     <h2 class="govuk-heading-m">Submit the recommendation</h2>
     <p class="govuk-body">The following decision notice has been created based on your answers.</p>
 
@@ -19,7 +20,8 @@
       <%= form.submit "Submit to manager", class: "govuk-button", data: { module: "govuk-button" } %>
     <% end %>
   <% else %>
-    <% navigation_add 'Publish the recommendation', edit_planning_application_path %>
+    <% content_for :title, "Publish the recommendation" %>
+
     <h2 class="govuk-heading-m">Publish the recommendation</h2>
     <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.</p>
 

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -1,5 +1,3 @@
-<% navigation_add "Application", planning_application_path %>
-
 <%= render "assessment_dashboard" do %>
   <%= render "assess_proposal" %>
 <% end %>


### PR DESCRIPTION
### Description of change

Small change to how we manage breadcrumbs, to allow us to nest pages with more than two parent pages, such as those for document archiving, which require the following breadcrumbs, all linked except for the last:

Home > Application > Documents > Archive Document

The downside of this approach is that it means that some views make multiple calls to add parent pages, with some duplication. I wasn't sure how to address this. One option could be to add a nested layout for drawings, which makes the relevant parent breadcrumbs.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173744456
