### PR TITLE
Fix/pt 173110690/add confirmation error

### DIFF
--- a/app/controllers/drawings_controller.rb
+++ b/app/controllers/drawings_controller.rb
@@ -36,16 +36,23 @@ class DrawingsController < AuthenticationController
   end
 
   def verify_selection
+    reason = params["archive_reason"]
     if form_params[:confirmation]
-      if form_params[:confirmation][:confirm] == "yes"
-        confirm_archived
-      else
-        render :archive
-      end
+      validate_confirmation
     else
+      @drawing_form.validate
+      @drawing_form.archive_reason = reason
+      render :confirm
+    end
+  end
+
+  def validate_confirmation
+    if form_params[:confirmation][:confirm] == "yes"
+      confirm_archived
+    elsif form_params[:confirmation][:confirm] == "no"
       render :archive
     end
-   end
+  end
 
   def validate_step
     assign_archive_reason_to_form

--- a/app/models/drawing_wizard/archive_form.rb
+++ b/app/models/drawing_wizard/archive_form.rb
@@ -4,6 +4,6 @@ module DrawingWizard
   class ArchiveForm < BaseForm
     validates :archive_reason,
               inclusion: { in: Drawing.archive_reasons.keys,
-                          message: "Please select one of the below reasons" }
+                          message: "Please select one of the below options" }
   end
 end

--- a/app/views/drawings/_confirm_form.html.erb
+++ b/app/views/drawings/_confirm_form.html.erb
@@ -1,21 +1,30 @@
 <%= form_for(:confirmation, url: planning_application_drawing_validate_step_path) do |form| %>
-  <%= hidden_field_tag :current_step, 'confirm' %>
-  <fieldset class="govuk-fieldset">
-  <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-    <div class="govuk-radios govuk-radios--small">
-      <div class="govuk-radios__item">
-        <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
-        <%= form.radio_button :confirm, "yes", class: "govuk-radios__input", id:"archive-yes", "aria-controls":"archive-yes" %>
-        <%= form.label :confirm, "Yes", class: "govuk-label govuk-radios__label", for: "archive-yes" %>
+  <div class="govuk-form-group">
+    <%= hidden_field_tag :current_step, 'confirm' %>
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-form-group <%= @drawing_form.errors.any? ? 'govuk-form-group--error' : '' %>">
+        <% @drawing_form.errors.each do |attribute, error| %>
+          <span id="status-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span><%= error %>
+          </span>
+         <% end %>
+        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+          <div class="govuk-radios govuk-radios--small">
+            <div class="govuk-radios__item">
+              <%= hidden_field_tag :archive_reason, @drawing_form.archive_reason %>
+              <%= form.radio_button :confirm, "yes", class: "govuk-radios__input", id:"archive-yes", "aria-controls":"archive-yes" %>
+              <%= form.label :confirm, "Yes", class: "govuk-label govuk-radios__label", for: "archive-yes" %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button :confirm, "no", class: "govuk-radios__input", id: "archive-no", "aria-controls":"archive-no" %>
+              <%= form.label :confirm, "No", class: "govuk-label govuk-radios__label", for: "archive-no" %>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="govuk-radios__item">
-        <%= form.radio_button :confirm, "no", class: "govuk-radios__input", id: "archive-no", "aria-controls":"archive-no" %>
-        <%= form.label :confirm, "No", class: "govuk-label govuk-radios__label", for: "archive-no" %>
-      </div>
-    </div>
+    </fieldset>
+    <p>
+      <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
+    </p>
   </div>
-  </fieldset>
-  <p>
-  <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
-  </p>
 <% end %>

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -98,18 +98,10 @@ RSpec.feature "Drawings index page", type: :system do
       expect(page).to have_text("Missing scale bar or north arrow")
     end
 
-    scenario "Assessor is returned to archive page if radio button not selected" do
-      choose "scale"
-      click_button "Save"
-      click_button "Archive document"
-
-      expect(page).to have_text("Why do you want to archive this document?")
-    end
-
     scenario "Assessor sees error message if radio button not selected" do
       click_button "Save"
 
-      expect(page).to have_text("Please select one of the below reasons")
+      expect(page).to have_text("Please select one of the below options")
      end
 
     scenario "Assessor is returned to archive page if 'No' is selected" do
@@ -139,6 +131,14 @@ RSpec.feature "Drawings index page", type: :system do
       click_button "Archive document"
 
       expect(page).to have_text("Side elevation has been archived")
+    end
+
+    scenario "Assessor sees error message if neither Yes nor No is selected" do
+      choose "scale"
+      click_button "Save"
+      click_button "Archive document"
+
+      expect(page).to have_text("Please select one of the below options")
     end
 
     scenario "Archived document appears in correct place on DMS page" do


### PR DESCRIPTION
<img width="789" alt="confirm_error" src="https://user-images.githubusercontent.com/1880450/87300690-32bdda00-c506-11ea-978f-f57a62ff07cf.png">

### Description of change

This adds the missing error message when neither of the radio buttons is clicked on the second step of the document archiving story.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173110690

### Decisions 

This is a quick fix to add error messaging. In the longer term, we should add a separate form controller, as previously discussed.

