### PR TITLE
reworded button on archive confirm form

### DIFF
--- a/app/views/drawings/_confirm_form.html.erb
+++ b/app/views/drawings/_confirm_form.html.erb
@@ -24,7 +24,7 @@
       </div>
     </fieldset>
     <p>
-      <%= form.submit "Archive document", class: "govuk-button", data: { module: "govuk-button" } %>
+      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
     </p>
   </div>
 <% end %>

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "Drawings index page", type: :system do
       choose "scale"
       click_button "Save"
       choose "No"
-      click_button "Archive document"
+      click_button "Save"
 
       expect(page).to have_text("Why do you want to archive this document?")
     end
@@ -118,7 +118,7 @@ RSpec.feature "Drawings index page", type: :system do
       click_button "Save"
 
       choose "Yes"
-      click_button "Archive document"
+      click_button "Save"
 
       expect(page).to have_current_path(/drawings/)
     end
@@ -128,7 +128,7 @@ RSpec.feature "Drawings index page", type: :system do
       click_button "Save"
 
       choose "Yes"
-      click_button "Archive document"
+      click_button "Save"
 
       expect(page).to have_text("Side elevation has been archived")
     end
@@ -136,7 +136,7 @@ RSpec.feature "Drawings index page", type: :system do
     scenario "Assessor sees error message if neither Yes nor No is selected" do
       choose "scale"
       click_button "Save"
-      click_button "Archive document"
+      click_button "Save"
 
       expect(page).to have_text("Please select one of the below options")
     end
@@ -145,7 +145,7 @@ RSpec.feature "Drawings index page", type: :system do
       choose "scale"
       click_button "Save"
       choose "Yes"
-      click_button "Archive document"
+      click_button "Save"
 
       within(find(".archived-drawings")) do
         expect(page).to have_text("Missing scale bar")


### PR DESCRIPTION
### Description of change

Reworded call to action on second step of archive form from "Archive Document" to "Save".

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173110690

