### PR TITLE
fixed failing spec by removing padded date

### DIFF
--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -61,8 +61,8 @@ RSpec.feature "Planning Application show page", type: :system do
       expect(page).to have_text("Application status: In assessment")
       expect(page).to have_text("Application received: #{Time.current.strftime("%e %B %Y").strip}")
       expect(page).to have_text("Validation complete: #{Time.current.strftime("%e %B %Y").strip}")
-      expect(page).to have_text("Target date: #{planning_application.target_date.strftime("%d %B %Y")}")
-      expect(page).to have_text("Statutory date: #{planning_application.target_date.strftime("%d %B %Y")}")
+      expect(page).to have_text("Target date: #{planning_application.target_date.strftime("%e %B %Y").strip}")
+      expect(page).to have_text("Statutory date: #{planning_application.target_date.strftime("%e %B %Y").strip}")
     end
 
     scenario "Contact information accordion" do


### PR DESCRIPTION
### Description of change

This fixes a spec that is failing for the first time because the target date falls in the first week of the month. Time.current.strftime("%e %B %Y") adds a leading space in the spec if the date is a single digit. This is handled in the view, but in the spec we need to add a .strip to enable consistency. This has been done elsewhere in the specs but was missed in the target date because it is a date in the future.

