### PR TITLE
Feature/pt 173125684/add reviewer comment

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -60,6 +60,6 @@ class DecisionsController < AuthenticationController
   end
 
   def decision_params
-    params.fetch(:decision, {}).permit(:status, :comment_met, :comment_unmet)
+    params.fetch(:decision, {}).permit(:status, :comment_met, :comment_unmet, :correction)
   end
 end

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -60,6 +60,7 @@ class DecisionsController < AuthenticationController
   end
 
   def decision_params
-    params.fetch(:decision, {}).permit(:status, :comment_met, :comment_unmet, :correction)
+    params.fetch(:decision, {}).permit(:status, :comment_met,
+                                       :comment_unmet, :correction)
   end
 end

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -14,4 +14,16 @@ module PlanningApplicationHelper
   def exclude_others?
     params[:q] == "exclude_others"
   end
+
+  def mark_completed?(step_name, application)
+    if step_name == "Assess the proposal" || "Submit the recommendation"
+      true if application.assessor_decision&.valid?
+    elsif step_name == "Reassess the proposal"
+      true unless application.correction_requested?
+    elsif step_name == "Resubmit the recommendation"
+      true if application.correction_provided?
+    elsif step_name == "Review the recommendation" || "Review the corrections"
+      true if application.reviewer_decision&.valid?
+    end
+  end
 end

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -26,4 +26,28 @@ module PlanningApplicationHelper
       true if application.reviewer_decision&.valid?
     end
   end
+
+  def assess_proposal_step_name(planning_application)
+    if planning_application.correction?
+      step_name = "Reassess the proposal"
+    else
+      step_name = "Assess the proposal"
+    end
+  end
+
+  def submit_proposal_step_name(planning_application)
+    if planning_application.correction?
+      step_name = "Resubmit the recommendation"
+    else
+      step_name = "Submit the recommendation"
+    end
+  end
+
+  def review_proposal_step_name(planning_application)
+    if planning_application.correction?
+      step_name = "Review the corrections"
+    else
+      step_name = "Review the recommendation"
+    end
+  end
 end

--- a/app/javascript/controllers/correction_controller.js
+++ b/app/javascript/controllers/correction_controller.js
@@ -1,0 +1,13 @@
+import {Controller} from "stimulus"
+
+export default class extends Controller {
+    static targets = ["textArea", "correctionDiv"]
+
+    addCorrection(event) {
+        this.correctionDivTarget.style.display = "block";
+        if (event.target.id === "status-granted-conditional") {
+            this.textAreaTarget.id = "correction";
+            this.textAreaTarget.name = "decision[correction]";
+        }
+    }
+}

--- a/app/javascript/controllers/correction_controller.js
+++ b/app/javascript/controllers/correction_controller.js
@@ -3,11 +3,11 @@ import {Controller} from "stimulus"
 export default class extends Controller {
     static targets = ["textArea", "correctionDiv"]
 
-    addCorrection(event) {
-        this.correctionDivTarget.style.display = "block";
-        if (event.target.id === "status-granted-conditional") {
-            this.textAreaTarget.id = "correction";
-            this.textAreaTarget.name = "decision[correction]";
+    toggleCorrection(event) {
+        if (event.target.id === "reviewer-disagrees-conditional") {
+            this.correctionDivTarget.style.display = "block";
+        } else {
+            this.correctionDivTarget.style.display = "none";
         }
     }
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -41,17 +41,19 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   padding: govuk-spacing(2);
 }
 
-.moj-banner {
-  border-color: green;
-  color: govuk-colour("green");
-  font-size: 0; // Removes white space when using inline-block on child element.
+.corrections-banner {
+  border: 5px solid govuk-colour("red");
+  @include govuk-font($size: 19);
+  color: govuk-colour("black");
+  display: block;
+  overflow: hidden;
   margin-bottom: govuk-spacing(6);
   padding: govuk-spacing(2);
 }
 
 
-.moj-banner__icon {
-  fill: currentColor;
+.alert__icon {
+  fill: govuk-colour("red");
   float: left;
   margin-right: govuk-spacing(2);
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -27,6 +27,10 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
    margin-right: 10%;
  }
 
+.add-correction {
+  display: none;
+}
+
 .flash-archive {
   border: 5px solid govuk-colour("green");
   @include govuk-font($size: 19);

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -20,8 +20,7 @@ class Decision < ApplicationRecord
   def ensure_correction
     return unless planning_application.awaiting_determination?
     return unless user.reviewer?
-    return if planning_application.reviewer_decision.status ==
-        planning_application.assessor_decision.status
+    return unless planning_application.reviewer_disagreed_with_assessor?
 
     if correction.blank?
       errors.add(:correction, "Please enter a reason in the box")

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -9,7 +9,22 @@ class Decision < ApplicationRecord
   validates :status, inclusion: { in: ["granted", "refused"],
     message: "Please select Yes or No" }
 
+  # validate :ensure_correction, on: :update
+
   def comment_made?
     granted? && comment_met.present? || refused? && comment_unmet.present?
+  end
+
+  private
+
+  def ensure_correction
+    return unless planning_application.correction?
+    return unless user.reviewer?
+    return if planning_application.reviewer_decision.status ==
+        planning_application.assessor_decision.status
+
+    if decision_params[correction].blank?
+      errors.add(:correction, "Please enter a reason into the box")
+    end
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -9,7 +9,7 @@ class Decision < ApplicationRecord
   validates :status, inclusion: { in: ["granted", "refused"],
     message: "Please select Yes or No" }
 
-  # validate :ensure_correction, on: :update
+  validate :ensure_correction, on: :update
 
   def comment_made?
     granted? && comment_met.present? || refused? && comment_unmet.present?
@@ -18,13 +18,13 @@ class Decision < ApplicationRecord
   private
 
   def ensure_correction
-    return unless planning_application.correction?
+    return unless planning_application.awaiting_determination?
     return unless user.reviewer?
     return if planning_application.reviewer_decision.status ==
         planning_application.assessor_decision.status
 
-    if decision_params[correction].blank?
-      errors.add(:correction, "Please enter a reason into the box")
+    if correction.blank?
+      errors.add(:correction, "Please enter a reason in the box")
     end
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -40,6 +40,18 @@ class PlanningApplication < ApplicationRecord
     @_reference ||= id.to_s.rjust(8, "0")
   end
 
+  def correction_requested?
+    awaiting_determination? && reviewer_decision.correction.present? &&
+        reviewer_decision.updated_at > assessor_decision.updated_at if
+        reviewer_decision.present?
+  end
+
+  def correction_provided?
+    awaiting_determination? && reviewer_decision.correction.present? &&
+        assessor_decision.updated_at > reviewer_decision.updated_at if
+        reviewer_decision.present?
+  end
+
   private
 
   def set_target_date

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -52,6 +52,12 @@ class PlanningApplication < ApplicationRecord
         reviewer_decision.present?
   end
 
+  def reviewer_disagreed_with_assessor?
+    return false unless reviewer_decision && assessor_decision
+
+    reviewer_decision.status != assessor_decision.status
+  end
+
   def correction?
     correction_provided? || correction_requested?
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -52,6 +52,10 @@ class PlanningApplication < ApplicationRecord
         reviewer_decision.present?
   end
 
+  def correction?
+    correction_provided? || correction_requested?
+  end
+
   private
 
   def set_target_date

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -1,14 +1,13 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <% if @planning_application.awaiting_determination? && @planning_application.reviewer_decision.present? %>
+      <% if @planning_application.correction_provided? %>
         <h2 class="govuk-heading-m">Reassess the proposal</h2>
         <p class="govuk-body">
           <br>
           Your manager sent the following comment about your recommendation below. Please take action based on their comment.
         </p>
         <div style="border: 1px solid; padding: 10px;">
-          <%# if @planning_application.reviewer_decision.present? %>
           <p class="govuk-body"><%= @planning_application.reviewer_decision.correction %></p>
           <br>
         </div>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <% if @planning_application.correction_provided? %>
+      <% if @planning_application.correction_requested? %>
         <h2 class="govuk-heading-m">Reassess the proposal</h2>
         <p class="govuk-body">
           <br>
@@ -11,7 +11,6 @@
           <p class="govuk-body"><%= @planning_application.reviewer_decision.correction %></p>
           <br>
         </div>
-          <%# end %>
       <% else %>
         <h2 class="govuk-heading-m">Assess the proposal</h2>
       <% end %>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -1,7 +1,21 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <h2 class="govuk-heading-m">Assess the proposal</h2>
+      <% if @planning_application.awaiting_determination? && @planning_application.reviewer_decision.present? %>
+        <h2 class="govuk-heading-m">Reassess the proposal</h2>
+        <p class="govuk-body">
+          <br>
+          Your manager sent the following comment about your recommendation below. Please take action based on their comment.
+        </p>
+        <div style="border: 1px solid; padding: 10px;">
+          <%# if @planning_application.reviewer_decision.present? %>
+          <p class="govuk-body"><%= @planning_application.reviewer_decision.correction %></p>
+          <br>
+        </div>
+          <%# end %>
+      <% else %>
+        <h2 class="govuk-heading-m">Assess the proposal</h2>
+      <% end %>
       <p class="govuk-body">
         Please review the applicant's answers:
       </p>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -1,7 +1,21 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
 <div class="govuk-form-group" data-controller="correction">
   <fieldset class="govuk-fieldset">
-    <h2 class="govuk-heading-m">Review the recommendation</h2>
+    <% if @planning_application.correction_provided? %>
+      <h2 class="govuk-heading-m">Review the corrections</h2>
+      <p class="govuk-body">
+        <br>
+        You sent the following comment about the officer's recommendation.
+      </p>
+      <div style="border: 1px solid; padding: 10px;">
+        <p class="govuk-body"><%= @planning_application.reviewer_decision.correction %></p>
+        <br>
+      </div>
+      <br>
+      <p class="govuk-body">The planning officer has responded to your comment</p>
+    <% else %>
+      <h2 class="govuk-heading-m">Review the proposal</h2>
+    <% end %>
     <p class="govuk-body">
       The planning officer recommends that the application is
       <strong><%= assessor_decision.status %></strong>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [planning_application, decision], local: true, class: "decision" do |form| %>
-<div class="govuk-form-group">
+<div class="govuk-form-group" data-controller="correction">
   <fieldset class="govuk-fieldset">
     <h2 class="govuk-heading-m">Review the recommendation</h2>
     <p class="govuk-body">
@@ -20,7 +20,7 @@
     <% end %>
     <p class="govuk-body">Please review the applicant's answers:</p>
     <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
-    <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+    <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %> ">
       <p class="govuk-body">
         <strong>
           Do you agree with the recommendation?
@@ -42,12 +42,19 @@
           <%= form.label :"status_#{reviewer_agrees_status}", "Yes", class: "govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input" %>
-          <%= form.label :"status_#{reviewer_disagrees_status}", "No", class: "govuk-radios__label" %>
+          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input", id: "reviewer-disagrees-conditional", "data-action":"click->correction#addCorrection", "aria-controls": "conditional-reviewer-disagrees-conditional", "aria-expanded": "false" %>
+          <%= form.label :"status_#{reviewer_disagrees_status}", "No", class: "govuk-radios__label", for: "reviewer-disagrees-conditional" %>
+        </div>
         </div>
       </div>
-    </div>
   </fieldset>
+  <div class="add-correction"  data-target="correction.correctionDiv">
+    <p class="govuk-body">
+      <br />
+      Please add any comments that can be inserted into the decision notice.
+    </p>
+    <%= form.text_area :correction, class: "govuk-textarea", "data-target":"correction.textArea", rows: "3" %>
+  </div>
   <p>
     <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
   </p>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -52,11 +52,11 @@
 
       <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <%= form.radio_button :status, reviewer_agrees_status, class: "govuk-radios__input" %>
+          <%= form.radio_button :status, reviewer_agrees_status, class: "govuk-radios__input", checked: false %>
           <%= form.label :"status_#{reviewer_agrees_status}", "Yes", class: "govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input", id: "reviewer-disagrees-conditional", "data-action":"click->correction#addCorrection", "aria-controls": "conditional-reviewer-disagrees-conditional", "aria-expanded": "false" %>
+          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input", checked: false, id: "reviewer-disagrees-conditional", "data-action":"click->correction#addCorrection", "aria-controls": "conditional-reviewer-disagrees-conditional", "aria-expanded": "false" %>
           <%= form.label :"status_#{reviewer_disagrees_status}", "No", class: "govuk-radios__label", for: "reviewer-disagrees-conditional" %>
         </div>
         </div>
@@ -65,9 +65,9 @@
   <div class="add-correction"  data-target="correction.correctionDiv">
     <p class="govuk-body">
       <br />
-      Please add any comments that can be inserted into the decision notice.
+      Please provide comments on why you don't agree.
     </p>
-    <%= form.text_area :correction, class: "govuk-textarea", "data-target":"correction.textArea", rows: "3" %>
+    <%= form.text_area :correction, id: "correction", class: "govuk-textarea", "data-target":"correction.textArea", rows: "3" %>
   </div>
   <p>
     <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -52,11 +52,11 @@
 
       <div class="govuk-radios govuk-radios--small govuk-radios--conditional" data-module="govuk-radios">
         <div class="govuk-radios__item">
-          <%= form.radio_button :status, reviewer_agrees_status, class: "govuk-radios__input", checked: false %>
+          <%= form.radio_button :status, reviewer_agrees_status, class: "govuk-radios__input", "data-action":"click->correction#toggleCorrection", checked: false %>
           <%= form.label :"status_#{reviewer_agrees_status}", "Yes", class: "govuk-radios__label" %>
         </div>
         <div class="govuk-radios__item">
-          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input", checked: false, id: "reviewer-disagrees-conditional", "data-action":"click->correction#addCorrection", "aria-controls": "conditional-reviewer-disagrees-conditional", "aria-expanded": "false" %>
+          <%= form.radio_button :status, reviewer_disagrees_status, class: "govuk-radios__input", checked: false, id: "reviewer-disagrees-conditional", "data-action":"click->correction#toggleCorrection", "aria-controls": "conditional-reviewer-disagrees-conditional", "aria-expanded": "false" %>
           <%= form.label :"status_#{reviewer_disagrees_status}", "No", class: "govuk-radios__label", for: "reviewer-disagrees-conditional" %>
         </div>
         </div>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -6,7 +6,15 @@
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% step_name = "Assess the proposal" %>
+          <% if @planning_application.awaiting_determination? && @planning_application.reviewer_decision.present? %>
+            <% if @planning_application.reviewer_decision.correction.present? %>
+            <% step_name = "Reassess the proposal" %>
+            <% else %>
+              <% step_name = "Assess the proposal" %>
+              <% end %>
+          <% else %>
+            <% step_name = "Assess the proposal" %>
+          <% end %>
 
           <% if (current_user.assessor? || current_user.admin?) %>
             <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -2,16 +2,17 @@
   <% if (current_user.assessor? || current_user.admin?)%>
     <li>
       <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number">Make recommendation</span>
+        <% if @planning_application.correction_requested? %>
+        <span class="app-task-list__section-number">Make corrections</span>
+          <% step_name = "Reassess the proposal" %>
+        <% else %>
+          <span class="app-task-list__section-number">Make recommendation</span>
+        <% end %>
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% if @planning_application.awaiting_determination? && @planning_application.reviewer_decision.present? %>
-            <% if @planning_application.reviewer_decision.correction.present? %>
+          <% if @planning_application.correction_requested? %>
             <% step_name = "Reassess the proposal" %>
-            <% else %>
-              <% step_name = "Assess the proposal" %>
-              <% end %>
           <% else %>
             <% step_name = "Assess the proposal" %>
           <% end %>
@@ -37,7 +38,11 @@
         </li>
 
         <li class="app-task-list__item">
-          <% step_name = "Submit the recommendation" %>
+          <% if @planning_application.correction_requested? %>
+            <% step_name = "Resubmit the recommendation" %>
+          <% else %>
+            <% step_name = "Submit the recommendation" %>
+          <% end %>
 
           <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -3,15 +3,14 @@
     <li>
       <h2 class="app-task-list__section">
         <% if @planning_application.correction_requested? %>
-        <span class="app-task-list__section-number">Make corrections</span>
-          <% step_name = "Reassess the proposal" %>
+          <span class="app-task-list__section-number">Make corrections</span>
         <% else %>
           <span class="app-task-list__section-number">Make recommendation</span>
         <% end %>
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% if @planning_application.correction_requested? %>
+          <% if @planning_application.correction?  %>
             <% step_name = "Reassess the proposal" %>
           <% else %>
             <% step_name = "Assess the proposal" %>
@@ -23,8 +22,8 @@
             <%# TODO: Make a helper for this %>
             <%
               path = @planning_application.assessor_decision ?
-                edit_planning_application_decision_path(@planning_application) :
-                  new_planning_application_decision_path(@planning_application)
+                         edit_planning_application_decision_path(@planning_application) :
+                         new_planning_application_decision_path(@planning_application)
             %>
 
             <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
@@ -32,7 +31,7 @@
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
 
-          <% if @planning_application.assessor_decision&.valid? %>
+          <% if (@planning_application.assessor_decision&.valid? && mark_completed?(step_name, @planning_application)) %>
             <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
           <% end %>
         </li>
@@ -52,7 +51,7 @@
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
 
-          <% if @planning_application.awaiting_determination? %>
+          <% if @planning_application.awaiting_determination? && mark_completed?(step_name, @planning_application) %>
             <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
           <% end %>
         </li>
@@ -77,8 +76,8 @@
             <%# TODO: Make a helper for this %>
             <%
               path = @planning_application.reviewer_decision ?
-                edit_planning_application_decision_path(@planning_application) :
-                  new_planning_application_decision_path(@planning_application)
+                         edit_planning_application_decision_path(@planning_application) :
+                         new_planning_application_decision_path(@planning_application)
             %>
 
             <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
@@ -86,8 +85,8 @@
             <span class="app-task-list__task-name"><%= step_name %></span>
           <% end %>
 
-          <% if @planning_application.reviewer_decision&.valid? %>
-              <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+          <% if @planning_application.reviewer_decision&.valid? && mark_completed?(step_name, @planning_application) %>
+            <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
           <% end %>
         </li>
 

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -59,7 +59,7 @@
       </ul>
     </li>
   <% end %>
-  <% if (current_user.reviewer? || current_user.admin?)%>
+  <% if (current_user.reviewer? || current_user.admin?) %>
     <li>
       <h2 class="app-task-list__section">
         <span class="app-task-list__section-number">Determine the proposal</span>
@@ -71,7 +71,7 @@
           <% else %>
             <% step_name = "Review the recommendation" %>
           <% end %>
-          <% if current_user.reviewer? %>
+          <% if current_user.reviewer? && !@planning_application.correction_requested? %>
             <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
             <%# TODO: Make a helper for this %>
@@ -87,11 +87,7 @@
           <% end %>
 
           <% if @planning_application.reviewer_decision&.valid? %>
-            <% if @planning_application.correction_requested? %>
-              <%= tag.strong "Pending", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
-            <% else %>
               <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
-            <% end %>
           <% end %>
         </li>
 

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -38,7 +38,7 @@
         </li>
 
         <li class="app-task-list__item">
-          <% if @planning_application.correction_requested? %>
+          <% if @planning_application.correction? %>
             <% step_name = "Resubmit the recommendation" %>
           <% else %>
             <% step_name = "Submit the recommendation" %>
@@ -66,8 +66,11 @@
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% step_name = "Review the recommendation" %>
-
+          <% if @planning_application.correction? %>
+            <% step_name = "Review the corrections" %>
+          <% else %>
+            <% step_name = "Review the recommendation" %>
+          <% end %>
           <% if current_user.reviewer? %>
             <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
@@ -84,7 +87,11 @@
           <% end %>
 
           <% if @planning_application.reviewer_decision&.valid? %>
-            <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+            <% if @planning_application.correction_requested? %>
+              <%= tag.strong "Pending", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+            <% else %>
+              <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+            <% end %>
           <% end %>
         </li>
 

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -10,11 +10,7 @@
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% if @planning_application.correction?  %>
-            <% step_name = "Reassess the proposal" %>
-          <% else %>
-            <% step_name = "Assess the proposal" %>
-          <% end %>
+          <% step_name = assess_proposal_step_name(@planning_application) %>
 
           <% if (current_user.assessor? || current_user.admin?) %>
             <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
@@ -37,11 +33,7 @@
         </li>
 
         <li class="app-task-list__item">
-          <% if @planning_application.correction? %>
-            <% step_name = "Resubmit the recommendation" %>
-          <% else %>
-            <% step_name = "Submit the recommendation" %>
-          <% end %>
+          <% step_name = submit_proposal_step_name(@planning_application) %>
 
           <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision %>
             <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
@@ -65,11 +57,8 @@
       </h2>
       <ul class="app-task-list__items">
         <li class="app-task-list__item">
-          <% if @planning_application.correction? %>
-            <% step_name = "Review the corrections" %>
-          <% else %>
-            <% step_name = "Review the recommendation" %>
-          <% end %>
+          <% step_name = review_proposal_step_name(@planning_application) %>
+
           <% if current_user.reviewer? && !@planning_application.correction_requested? %>
             <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 

--- a/app/views/planning_applications/_assessor_corrections_banner.erb
+++ b/app/views/planning_applications/_assessor_corrections_banner.erb
@@ -1,0 +1,8 @@
+<div class=corrections-banner>
+  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path></svg>
+  <div class="moj-banner__message">
+    <span class="moj-banner__assistive">
+      Warning</span>Your manager has requested corrections on <strong><%= pluralize(@planning_applications.select { |pa| pa.correction_requested? }.count, 'application') %>.</strong>
+  </div>
+</div>

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -9,7 +9,11 @@
       <%= link_to "Awaiting manager's determination", "#awaiting_determination", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 1 %>
     </li>
     <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to "Corrections requested", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
+      <% if current_user.assessor?%>
+        <%= link_to "Corrections requested (#{@planning_applications.select { |pa| pa.correction_requested? }.count})", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
+      <% else %>
+        <%= link_to "Corrections requested", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
+      <% end %>
     </li>
     <li class="govuk-tabs__list-item" role="presentation">
       <%= link_to "Determined", "#determined", class: "govuk-tabs__tab", role: "tab", "aria-controls":"determined", "aria-selected": false, tabindex: 3 %>

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -9,7 +9,10 @@
       <%= link_to "Awaiting manager's determination", "#awaiting_determination", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 1 %>
     </li>
     <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to "Determined", "#determined", class: "govuk-tabs__tab", role: "tab", "aria-controls":"determined", "aria-selected": false, tabindex: 2 %>
+      <%= link_to "Corrections requested", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
+    </li>
+    <li class="govuk-tabs__list-item" role="presentation">
+      <%= link_to "Determined", "#determined", class: "govuk-tabs__tab", role: "tab", "aria-controls":"determined", "aria-selected": false, tabindex: 3 %>
     </li>
   </ul>
 </div>

--- a/app/views/planning_applications/_reviewer_corrections_banner.erb
+++ b/app/views/planning_applications/_reviewer_corrections_banner.erb
@@ -1,0 +1,8 @@
+<div class=corrections-banner>
+  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path></svg>
+  <div class="moj-banner__message">
+    <span class="moj-banner__assistive">
+      Warning</span>You have <strong><%= pluralize(@planning_applications.select { |pa| pa.correction_provided? }.count, 'application') %> </strong>returned to you with corrections.
+  </div>
+</div>

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -1,7 +1,10 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% if current_user.assessor? %>
-    <% content_for :title, "Submit the recommendation" %>
-
+    <% if @planning_application.correction_provided? %>
+    <% content_for :title, "Resubmit the recommendation" %>
+  <% else %>
+      <% content_for :title, "Submit the recommendation" %>
+  <% end %>
     <h2 class="govuk-heading-m">Submit the recommendation</h2>
     <p class="govuk-body">The following decision notice has been created based on your answers.</p>
 

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -16,6 +16,11 @@
     <% end %>
   </div>
 </div>
+<% if @planning_applications.select { |pa| pa.correction_requested? }.any? && current_user.assessor?  %>
+  <%= render "assessor_corrections_banner" %>
+<% elsif @planning_applications.select { |pa| pa.correction_provided? }.any? && current_user.reviewer?  %>
+    <%= render "reviewer_corrections_banner" %>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-tabs" data-module="govuk-tabs">
@@ -25,7 +30,7 @@
       <%= render "planning_application_tabs" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.in_assessment, id: "in_assessment", title: "In assessment" unless current_user.reviewer?%>
       <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination.reject { |pa| pa.correction_requested? }, id: "awaiting_determination", title: "Awaiting manager's determination" %>
-      <%= render "planning_application_table", planning_applications: @planning_applications.select { |pa| pa.correction_requested? }, id: "awaiting_correction", title: "Awaiting correction" %>
+      <%= render "planning_application_table", planning_applications: @planning_applications.select { |pa| pa.correction_requested? }, id: "awaiting_correction", title: "Corrections requested" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.determined, id: "determined", title: "Determined" %>
     </div>
   </div>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -24,7 +24,8 @@
       </h2>
       <%= render "planning_application_tabs" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.in_assessment, id: "in_assessment", title: "In assessment" unless current_user.reviewer?%>
-      <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination, id: "awaiting_determination", title: "Awaiting manager's determination" %>
+      <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination.reject { |pa| pa.correction_requested? }, id: "awaiting_determination", title: "Awaiting manager's determination" %>
+      <%= render "planning_application_table", planning_applications: @planning_applications.select { |pa| pa.correction_requested? }, id: "awaiting_correction", title: "Awaiting correction" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.determined, id: "determined", title: "Determined" %>
     </div>
   </div>

--- a/db/migrate/20200714144908_add_correction_to_decisions.rb
+++ b/db/migrate/20200714144908_add_correction_to_decisions.rb
@@ -1,0 +1,5 @@
+class AddCorrectionToDecisions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decisions, :correction, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_095601) do
+ActiveRecord::Schema.define(version: 2020_07_14_144908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_07_08_095601) do
     t.integer "status"
     t.text "comment_met"
     t.text "comment_unmet"
+    t.text "correction"
     t.index ["planning_application_id"], name: "index_decisions_on_planning_application_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"
   end

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -17,4 +17,55 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
       expect(days_color(14)).to eq("green")
     end
   end
-end
+
+  describe "#mark_completed?" do
+    subject { create :planning_application }
+
+    let(:assessor)          { create :user, :assessor }
+    let(:reviewer)          { create :user, :reviewer }
+
+    let(:assessor_decision) { create(:decision, :granted, user: assessor) }
+    let(:reviewer_decision) { create(:decision, :refused, user: reviewer) }
+
+    before do
+      subject.decisions << assessor_decision << reviewer_decision
+      subject.reload.reviewer_decision.update(correction: "I do not agree")
+    end
+
+    it "returns true for Assess the proposal" do
+      step_name = "Assess the proposal"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+
+    it "returns true for Submit the recommendation" do
+      step_name = "Submit the recommendation"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+
+    it "returns true for Reassess the proposal" do
+      step_name = "Reassess the proposal"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+
+    it "returns true for Resubmit the recommendation" do
+      step_name = "Resubmit the recommendation"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+
+    it "returns true for Review the recommendation" do
+      step_name = "Review the recommendation"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+
+    it "returns true for Review the corrections" do
+      step_name = "Review the corrections"
+
+      expect(mark_completed?(step_name, subject)).to eq(true)
+    end
+  end
+  end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -99,4 +99,45 @@ RSpec.describe PlanningApplication, type: :model do
       expect(subject.reference).to eq "00001000"
     end
   end
+
+  describe "corrections" do
+    let(:assessor)          { create :user, :assessor }
+    let(:reviewer)          { create :user, :reviewer }
+
+    let(:assessor_decision) { create(:decision, :granted, user: assessor) }
+    let(:reviewer_decision) { create(:decision, :granted, user: reviewer) }
+
+    before do
+      subject.decisions << assessor_decision << reviewer_decision
+      subject.update_and_timestamp_status("awaiting_determination")
+    end
+
+  describe "#correction_requested?" do
+    it "sets the correct state when reviewer adds correction" do
+      subject.reload.reviewer_decision.update(correction: "I don't agree")
+      expect(subject.correction_requested?).to be true
+    end
+  end
+
+  describe "#correction_provided?" do
+    it "sets the correct state when assessor responds" do
+      subject.reload.reviewer_decision.update(correction: "I don't agree")
+      subject.reload.assessor_decision.update!(comment_met: "returned for review")
+      expect(subject.correction_provided?).to be true
+    end
+  end
+
+    describe "#correction?" do
+      it "sets the correct state when assessor responds" do
+        subject.reload.reviewer_decision.update(correction: "I don't agree")
+        expect(subject.correction?).to be true
+      end
+    end
+  end
+
+  describe "#reference" do
+    it "pads the ID correctly" do
+      expect(subject.reference).to eq "00001000"
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -112,20 +112,26 @@ RSpec.describe PlanningApplication, type: :model do
       subject.update_and_timestamp_status("awaiting_determination")
     end
 
-  describe "#correction_requested?" do
-    it "sets the correct state when reviewer adds correction" do
+    it "expects the correction to be valid" do
       subject.reload.reviewer_decision.update(correction: "I don't agree")
-      expect(subject.correction_requested?).to be true
-    end
-  end
 
-  describe "#correction_provided?" do
-    it "sets the correct state when assessor responds" do
-      subject.reload.reviewer_decision.update(correction: "I don't agree")
-      subject.reload.assessor_decision.update!(comment_met: "returned for review")
-      expect(subject.correction_provided?).to be true
+      expect(subject.reload.reviewer_decision).to be_valid
     end
-  end
+
+    describe "#correction_requested?" do
+      it "sets the correct state when reviewer adds correction" do
+        subject.reload.reviewer_decision.update(correction: "I don't agree")
+        expect(subject.correction_requested?).to be true
+      end
+    end
+
+    describe "#correction_provided?" do
+      it "sets the correct state when assessor responds" do
+        subject.reload.reviewer_decision.update(correction: "I don't agree")
+        subject.reload.assessor_decision.update!(comment_met: "returned for review")
+        expect(subject.correction_provided?).to be true
+      end
+    end
 
     describe "#correction?" do
       it "sets the correct state when assessor responds" do

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application correction journey", type: :system do
+    let(:assessor) { create :user, :assessor }
+    let(:reviewer) { create :user, :reviewer }
+
+    let(:assessor_decision) { create(:decision, :granted, user: assessor) }
+    let(:reviewer_decision) { create(:decision, :granted, user: reviewer) }
+
+    let!(:planning_application_corrected) do
+      create :planning_application,
+             :lawfulness_certificate,
+             :awaiting_determination,
+             assessor_decision: assessor_decision,
+             reviewer_decision: reviewer_decision
+    end
+
+    let(:policy_consideration_1) do
+      create :policy_consideration,
+             policy_question: "The property is",
+             applicant_answer: "a semi detached house"
+    end
+
+    let(:policy_consideration_2) do
+      create :policy_consideration,
+             policy_question: "The project will ___ the internal floor area of the building",
+             applicant_answer: "not alter"
+    end
+
+    let!(:policy_evaluation) do
+      create :policy_evaluation,
+             planning_application: planning_application_corrected,
+             policy_considerations: [policy_consideration_1, policy_consideration_2]
+    end
+
+    context "Assessor responding to reviewer" do
+      before do
+        planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted ")
+        planning_application_corrected.reviewer_decision.update!(correction: "please amend this information")
+      end
+
+      scenario "Assessment can be corrected and resubmitted" do
+        sign_in assessor
+        visit root_path
+
+        expect(page).to have_text("Your manager has requested corrections on 1 application")
+        expect(page).to have_css(".corrections-banner")
+
+        click_link("Corrections requested (1)")
+        click_link planning_application_corrected.reference
+
+        # Verify the task list wording is correct
+        expect(page).to have_text("Reassess the proposal")
+        expect(page).to have_text("Resubmit the recommendation")
+
+        click_link "Reassess the proposal"
+
+        expect(page).to have_text("please amend this information")
+
+        within(find("form.decision")) do
+          expect(page.find_field("Yes")).to be_checked
+        end
+
+        choose "Yes"
+
+        expect(page).to have_text("application should be granted")
+
+        # The next step appends the extra comment to the existing one instead of overwriting
+        find_field("comment_met").native.send_keys(". This is the second assessor comment")
+
+        click_button "Save"
+        expect(page).to have_css(".app-task-list__task-completed")
+
+        click_link "Resubmit the recommendation"
+
+        click_button "Submit to manager"
+
+        expect(page).to have_css(".app-task-list__task-completed")
+
+        click_link "Home"
+
+        expect(page).not_to have_text("Your manager has requested corrections")
+        expect(page).to have_text("Corrections requested (0)")
+        expect(page).not_to have_css(".corrections-banner")
+      end
+    end
+
+    context "Reviewer first stage" do
+      before do
+        planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted ")
+      end
+
+      scenario "Reviewer can leave comment for assessor", js: true do
+        sign_in reviewer
+        visit root_path
+
+        click_link planning_application_corrected.reference
+
+        click_link "Review the recommendation"
+
+        expect(page).to have_text("application should be granted ")
+
+        choose "No"
+
+        expect(page).to have_text("Please provide comments on why you don't agree.")
+
+        fill_in "correction", with: "I don't agree"
+
+        click_on "commit"
+
+        expect(page).to have_css(".app-task-list__task-completed")
+
+        click_link "Home"
+        expect(page).not_to have_css("corrections-banner")
+        click_link "Corrections requested"
+        expect(page).to have_text(planning_application_corrected.reference)
+      end
+    end
+
+    context "Reviewer second stage" do
+      before do
+        planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted ")
+        planning_application_corrected.reviewer_decision.update!(correction: "please amend this information")
+        planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted. This is the second assessor comment")
+      end
+
+      scenario "Reviewer can see corrections and publish recommendation" do
+        sign_in reviewer
+        visit root_path
+
+        expect(page).to have_text("You have 1 application returned to you with corrections")
+
+        click_link planning_application_corrected.reference
+
+        # Verify the task list wording is correct
+        expect(page).to have_text("Review the corrections")
+        expect(page).to have_text("Publish the recommendation")
+
+        click_link "Review the corrections"
+
+        expect(page).to have_text("application should be granted. This is the second assessor comment")
+        expect(page).to have_text("please amend this information")
+        expect(page).to have_text("You sent the following comment about the officer's recommendation")
+        expect(page).to have_text("The planning officer has responded to your comment")
+
+        choose "Yes"
+
+        click_button "Save"
+
+        expect(page).to have_css(".app-task-list__task-completed")
+
+        click_link "Publish the recommendation"
+
+        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
+        expect(page).to have_content("granted")
+
+        click_button "Determine application"
+
+        within(:assessment_step, "Publish the recommendation") do
+          expect(page).to have_completed_tag
+        end
+
+        click_link "Home"
+
+        expect(page).not_to have_text("You have 1 application returned to you with corrections")
+        expect(page).not_to have_css(".corrections-banner")
+      end
+    end
+  end

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
         planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted ")
       end
 
-      scenario "Reviewer can leave comment for assessor", js: true do
+      scenario "Reviewer can leave comment for assessor" do
         sign_in reviewer
         visit root_path
 
@@ -117,6 +117,25 @@ RSpec.describe "Planning Application correction journey", type: :system do
         click_link "Corrections requested"
         expect(page).to have_text(planning_application_corrected.reference)
       end
+
+      scenario "Reviewer is unable to submit correction without reason" do
+        sign_in reviewer
+        visit root_path
+
+        click_link planning_application_corrected.reference
+
+        click_link "Review the recommendation"
+
+        expect(page).to have_text("application should be granted ")
+
+        choose "No"
+
+        expect(page).to have_text("Please provide comments on why you don't agree.")
+
+        click_on "commit"
+
+        expect(page).to have_text("Please enter a reason in the box")
+      end
     end
 
     context "Reviewer second stage" do
@@ -126,7 +145,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
         planning_application_corrected.assessor_decision.update!(comment_met: "application should be granted. This is the second assessor comment")
       end
 
-      scenario "Reviewer can see corrections and publish recommendation" do
+      scenario "Reviewer can see corrections alert which disappears after determination" do
         sign_in reviewer
         visit root_path
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -278,39 +278,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         within(:assessment_step, "Review the corrections") do
           expect(page).to have_completed_tag
         end
-        #
-        # click_link "Review the recommendation"
-        #
-        # # Expect the saved state to be shown in the form
-        # # within(find("form.decision")) do
-        # #   expect(page.find_field("No")).to be_checked
-        # # end
-        # click_button "Save"
-        #
-        # click_link "Publish the recommendation"
-        #
-        # expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        # expect(page).to have_content("refused")
-        #
-        # click_button "Determine application"
-        #
-        # within(:assessment_step, "Publish the recommendation") do
-        #   expect(page).to have_completed_tag
-        # end
-        #
-        # click_link "Home"
-        #
-        # # Check that the application is no longer in awaiting determination
-        # click_link "Awaiting manager's determination"
-        # within("#awaiting_determination") do
-        #   expect(page).not_to have_link planning_application.reference
-        # end
-        #
-        # # Check that the application is now in determined
-        # click_link "Determined"
-        # within("#determined") do
-        #   expect(page).to have_link planning_application.reference
-        # end
       end
 
       include_examples "reviewer assignment"
@@ -344,10 +311,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        # Expect the saved state to be shown in the form
-        # within(find("form.decision")) do
-        #   expect(page.find_field("Yes")).to be_checked
-        # end
         click_button "Save"
 
         click_link "Publish the recommendation"

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -48,10 +48,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
+        choose "Yes"
         click_button "Save"
 
         click_link "Publish the recommendation"
@@ -114,19 +111,19 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(page).not_to have_content("This has been refused.")
 
         choose "No"
-        click_button "Save"
 
-        within(:assessment_step, "Review the recommendation") do
+        expect(page).to have_text("Please provide comments on why you don't agree.")
+
+        fill_in "correction", with: "I don't agree"
+
+        click_on "commit"
+
+        expect(page).not_to have_link("Review the corrections")
+        expect(page).not_to have_text("Review the recommendation")
+
+        within(:assessment_step, "Review the corrections") do
           expect(page).to have_completed_tag
         end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
 
         click_link "Publish the recommendation"
 
@@ -229,10 +226,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
         click_button "Save"
 
         click_link "Publish the recommendation"
@@ -275,44 +268,49 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(page).to have_content("and added this comment:")
 
         choose "No"
-        click_button "Save"
 
-        within(:assessment_step, "Review the recommendation") do
+        expect(page).to have_text("Please provide comments on why you don't agree.")
+
+        fill_in "correction", with: "I don't agree"
+
+        click_on "commit"
+
+        within(:assessment_step, "Review the corrections") do
           expect(page).to have_completed_tag
         end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
-
-        click_link "Publish the recommendation"
-
-        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        expect(page).to have_content("refused")
-
-        click_button "Determine application"
-
-        within(:assessment_step, "Publish the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Home"
-
-        # Check that the application is no longer in awaiting determination
-        click_link "Awaiting manager's determination"
-        within("#awaiting_determination") do
-          expect(page).not_to have_link planning_application.reference
-        end
-
-        # Check that the application is now in determined
-        click_link "Determined"
-        within("#determined") do
-          expect(page).to have_link planning_application.reference
-        end
+        #
+        # click_link "Review the recommendation"
+        #
+        # # Expect the saved state to be shown in the form
+        # # within(find("form.decision")) do
+        # #   expect(page.find_field("No")).to be_checked
+        # # end
+        # click_button "Save"
+        #
+        # click_link "Publish the recommendation"
+        #
+        # expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
+        # expect(page).to have_content("refused")
+        #
+        # click_button "Determine application"
+        #
+        # within(:assessment_step, "Publish the recommendation") do
+        #   expect(page).to have_completed_tag
+        # end
+        #
+        # click_link "Home"
+        #
+        # # Check that the application is no longer in awaiting determination
+        # click_link "Awaiting manager's determination"
+        # within("#awaiting_determination") do
+        #   expect(page).not_to have_link planning_application.reference
+        # end
+        #
+        # # Check that the application is now in determined
+        # click_link "Determined"
+        # within("#determined") do
+        #   expect(page).to have_link planning_application.reference
+        # end
       end
 
       include_examples "reviewer assignment"
@@ -347,9 +345,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_link "Review the recommendation"
 
         # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
+        # within(find("form.decision")) do
+        #   expect(page.find_field("Yes")).to be_checked
+        # end
         click_button "Save"
 
         click_link "Publish the recommendation"
@@ -398,19 +396,12 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(page).not_to have_content("This has been refused.")
 
         choose "No"
-        click_button "Save"
+        fill_in "correction", with: "I don't agree"
+        click_on "commit"
 
-        within(:assessment_step, "Review the recommendation") do
+        within(:assessment_step, "Review the corrections") do
           expect(page).to have_completed_tag
         end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
 
         click_link "Publish the recommendation"
 
@@ -471,10 +462,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
         click_button "Save"
 
         click_link "Publish the recommendation"
@@ -519,19 +506,16 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(page).to have_content("This has been refused.")
 
         choose "No"
-        click_button "Save"
 
-        within(:assessment_step, "Review the recommendation") do
+        expect(page).to have_text("Please provide comments on why you don't agree.")
+
+        fill_in "correction", with: "I don't agree"
+
+        click_on "commit"
+
+        within(:assessment_step, "Review the corrections") do
           expect(page).to have_completed_tag
         end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
 
         click_link "Publish the recommendation"
 


### PR DESCRIPTION
<img width="1278" alt="officer1" src="https://user-images.githubusercontent.com/1880450/88268542-8a103700-ccca-11ea-8989-e9760ea1d8ee.png">
<img width="1177" alt="officer2" src="https://user-images.githubusercontent.com/1880450/88268560-90061800-ccca-11ea-90e7-4fea140d65ca.png">
<img width="1178" alt="officer3" src="https://user-images.githubusercontent.com/1880450/88268618-a2805180-ccca-11ea-865c-9c4b89c3e745.png">
<img width="1209" alt="officer4" src="https://user-images.githubusercontent.com/1880450/88268616-a1e7bb00-ccca-11ea-9ea6-c52e2a761248.png">
<img width="1258" alt="officer5" src="https://user-images.githubusercontent.com/1880450/88268613-a14f2480-ccca-11ea-94d0-ff5bbdfb0d21.png">
<img width="1359" alt="officer6" src="https://user-images.githubusercontent.com/1880450/88268603-9eecca80-ccca-11ea-8d4a-cd7d8e48c442.png">

### Description of change

This changes the journey where the manager disagrees with the officer's decision. Once the manager has clicked 'No' and provided the mandatory correction, the application moves to a new tab on the index (Corrections Requested) and an alert is shown to the officer. Once the application returns to the manager, they are shown an alert and are able to view the officer's comments and their own correction before determining the application.

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173338338
https://www.pivotaltracker.com/story/show/173125684

### Decisions 

I decided against setting entirely new statuses for the applications where corrections were requested and provided, and instead use two methods that look for the presence of a correction and the role that last updated. In my opinion, the correction statuses are subsets of the awaiting_determination status rather than statuses in themselves. I have also removed the specs for the saved state when the reviewer sees the review corrections/review recommendation layout, as the new journey means that the reviewer is now no longer allowed to access the story once they have reviewed it - the link becomes non-clickable.
