### PR TITLE
WIP control user list display

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -14,6 +14,10 @@ class PlanningApplicationsController < AuthenticationController
     @planning_applications = policy_scope(PlanningApplication.all)
   end
 
+  def show_all
+    @planning_applications = authorize(PlanningApplication.all)
+  end
+
   def show
   end
 

--- a/app/views/planning_applications/show_all.html.erb
+++ b/app/views/planning_applications/show_all.html.erb
@@ -9,9 +9,7 @@
       Your fast track applications
     </h1>
     <p class="govuk-body"><%= current_user.name %>, <%= current_user.role.capitalize %></p>
-    <% if current_user.assessor? %>
-    <%= link_to "View all applications", all_applications_path, class: "govuk-link" %>
-    <% end %>
+    <%= link_to "View my applications", root_path, class: "govuk-link" %>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
 
   devise_for :users
 
+  get :all_applications, to: "planning_applications#show_all"
   resources :planning_applications, only: %i[show index edit update] do
     resources :decisions, only: %i[new create edit update]
     resources :drawings, only: %i[index] do

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -3,8 +3,10 @@
 require "rails_helper"
 
 RSpec.feature "Planning Application index page", type: :system do
+  let!(:second_assessor) { create(:user, :assessor) }
   let!(:planning_application_1) { create(:planning_application) }
   let!(:planning_application_2) { create(:planning_application) }
+  let!(:planning_application_3) { create(:planning_application, user_id: second_assessor.id) }
   let!(:planning_application_started) { create(:planning_application, :awaiting_determination) }
   let!(:planning_application_completed) { create(:planning_application, :determined) }
 
@@ -68,6 +70,26 @@ RSpec.feature "Planning Application index page", type: :system do
 
       expect(page).to have_current_path(/sign_in/)
       expect(page).to have_content("You need to sign in or sign up before continuing.")
+    end
+
+    scenario "On login, assessor gets redirected to a view with its own and unassigned Planning Applications" do
+      within("#in_assessment") do
+        expect(page).to have_text("In assessment")
+        expect(page).to have_link(planning_application_1.reference)
+        expect(page).to have_link(planning_application_2.reference)
+        expect(page).not_to have_link(planning_application_3.reference)
+      end
+    end
+
+    scenario "An assessor can toggle the view to access all applications, including those assigned to others" do
+      click_on "View all applications"
+
+      within("#in_assessment") do
+        expect(page).to have_text("In assessment")
+        expect(page).to have_link(planning_application_1.reference)
+        expect(page).to have_link(planning_application_2.reference)
+        expect(page).to have_link(planning_application_3.reference)
+      end
     end
   end
 


### PR DESCRIPTION
### Description of change

On index, ensure that a user with role of type "assessor" only sees both their own planning applications as well as applications that have not yet been assigned to an assessor.

Also adds a "View all applications" so the assessor can toggle the view to see all existing applications

### Story Link

https://www.pivotaltracker.com/story/show/173508545
