### PR TITLE
Use params to amend user views

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -11,7 +11,13 @@ class PlanningApplicationsController < AuthenticationController
     with: :decision_notice_mail_error
 
   def index
-    @planning_applications = policy_scope(PlanningApplication.all)
+    if helpers.exclude_others? && current_user.assessor?
+      @planning_applications = policy_scope(
+        PlanningApplication.where(user_id: current_user.id).or(
+          PlanningApplication.where(user_id: nil)))
+    else
+      @planning_applications = policy_scope(PlanningApplication.all)
+    end
   end
 
   def show

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -10,4 +10,8 @@ module PlanningApplicationHelper
       "red"
     end
   end
+
+  def exclude_others?
+    params[:q] == "exclude_others"
+  end
 end

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -9,6 +9,11 @@
       Your fast track applications
     </h1>
     <p class="govuk-body"><%= current_user.name %>, <%= current_user.role.capitalize %></p>
+    <% if exclude_others? && current_user.assessor? %>
+      <p class="govuk-body"><%= link_to "View all applications", planning_applications_path, class: "govuk-link" %></p>
+    <% elsif !exclude_others? && current_user.assessor? %>
+      <p class="govuk-body"><%= link_to "View my applications", planning_applications_path(q: "exclude_others"), class: "govuk-link" %></p>
+    <% end %>
   </div>
 </div>
 <div class="govuk-grid-row">
@@ -18,7 +23,6 @@
         Contents
       </h2>
       <%= render "planning_application_tabs" %>
-
       <%= render "planning_application_table", planning_applications: @planning_applications.in_assessment, id: "in_assessment", title: "In assessment" unless current_user.reviewer?%>
       <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination, id: "awaiting_determination", title: "Awaiting manager's determination" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.determined, id: "determined", title: "Determined" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root to: redirect("/planning_applications")
+  root to: "planning_applications#index", defaults: { q: "exclude_others" }
 
   devise_for :users
 

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -44,6 +44,21 @@ task create_sample_data: :environment do
 
       user.role = admin_role
     end
+
+    User.find_or_create_by!(email: "#{admin_role}2@example.com") do |user|
+      first_name = Faker::Name.unique.first_name
+      last_name = Faker::Name.unique.last_name
+      user.name = "#{first_name} #{last_name}"
+      if Rails.env.development?
+        user.password = user.password_confirmation = "password"
+      else
+        user.password = user.password_confirmation = SecureRandom.uuid
+        user.encrypted_password =
+          "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
+      end
+
+      user.role = admin_role
+    end
   end
 
   assessor = User.find_by!(email: "assessor@example.com", role: :assessor)

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -11,63 +11,116 @@ RSpec.feature "Planning Application index page", type: :system do
   context "as an assessor" do
     before do
       sign_in users(:assessor)
-      visit planning_applications_path
+      visit root_path
     end
 
-    scenario "Planning Application status bar is present" do
-      within(:planning_applications_status_tab) do
-        expect(page).to have_link "In assessment"
-        expect(page).to have_link "Awaiting manager's determination"
-        expect(page).to have_link "Determined"
+    context "viewing tabs" do
+      scenario "Planning Application status bar is present" do
+        within(:planning_applications_status_tab) do
+          expect(page).to have_link "In assessment"
+          expect(page).to have_link "Awaiting manager's determination"
+          expect(page).to have_link "Determined"
+        end
+      end
+
+      scenario "Only Planning Applications that are in_assessment are present in this tab" do
+        within("#in_assessment") do
+          expect(page).to have_text("In assessment")
+          expect(page).to have_link(planning_application_1.reference)
+          expect(page).to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(planning_application_started.reference)
+          expect(page).not_to have_link(planning_application_completed.reference)
+        end
+      end
+
+      scenario "Only Planning Applications that are awaiting_determination are present in this tab" do
+        click_link "Awaiting manager's determination"
+
+        within("#awaiting_determination") do
+          expect(page).to have_text("Awaiting manager's determination")
+          expect(page).to have_link(planning_application_started.reference)
+          expect(page).not_to have_link(planning_application_1.reference)
+          expect(page).not_to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(planning_application_completed.reference)
+        end
+      end
+
+      scenario "Only Planning Applications that are determined are present in this tab" do
+        click_link "Determined"
+
+        within("#determined") do
+          expect(page).to have_text("Determined")
+          expect(page).to have_link(planning_application_completed.reference)
+          expect(page).not_to have_link(planning_application_1.reference)
+          expect(page).not_to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(planning_application_started.reference)
+        end
+      end
+
+      scenario "Breadcrumbs are not displayed" do
+        within(find(".govuk-breadcrumbs__list", match: :first)) do
+          expect(page).to have_no_text "Home"
+          expect(page).to have_no_text "Application"
+        end
+      end
+
+      scenario "User can log out from index page" do
+        click_button "Log out"
+
+        expect(page).to have_current_path(/sign_in/)
+        expect(page).to have_content("You need to sign in or sign up before continuing.")
       end
     end
 
-    scenario "Only Planning Applications that are in_assessment are present in this tab" do
-      within("#in_assessment") do
-        expect(page).to have_text("In assessment")
-        expect(page).to have_link(planning_application_1.reference)
-        expect(page).to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_started.reference)
-        expect(page).not_to have_link(planning_application_completed.reference)
+    context "restricted views" do
+      let!(:second_assessor) { create(:user, :assessor) }
+      let!(:other_assessor_planning_application) { create(:planning_application, user_id: second_assessor.id) }
+
+      scenario "On login, assessor gets redirected to a view with its own and unassigned Planning Applications" do
+        within("#in_assessment") do
+          expect(page).to have_link(planning_application_1.reference)
+          expect(page).to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(other_assessor_planning_application.reference)
+        end
       end
-    end
 
-    scenario "Only Planning Applications that are awaiting_determination are present in this tab" do
-      click_link "Awaiting manager's determination"
+      scenario "An assessor can click a button to view all applications" do
+        click_on "View all applications"
 
-      within("#awaiting_determination") do
-        expect(page).to have_text("Awaiting manager's determination")
-        expect(page).to have_link(planning_application_started.reference)
-        expect(page).not_to have_link(planning_application_1.reference)
-        expect(page).not_to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_completed.reference)
+        within("#in_assessment") do
+          expect(page).to have_link(planning_application_1.reference)
+          expect(page).to have_link(planning_application_2.reference)
+          expect(page).to have_link(other_assessor_planning_application.reference)
+        end
       end
-    end
 
-    scenario "Only Planning Applications that are determined are present in this tab" do
-      click_link "Determined"
+      scenario "An aassessor can click back to view only its own applications" do
+        click_on "View all applications"
 
-      within("#determined") do
-        expect(page).to have_text("Determined")
-        expect(page).to have_link(planning_application_completed.reference)
-        expect(page).not_to have_link(planning_application_1.reference)
-        expect(page).not_to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_started.reference)
+        click_on "View my applications"
+
+        within("#in_assessment") do
+          expect(page).to have_link(planning_application_1.reference)
+          expect(page).to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(other_assessor_planning_application.reference)
+        end
       end
-    end
 
-    scenario "Breadcrumbs are not displayed" do
-      within(find(".govuk-breadcrumbs__list", match: :first)) do
-        expect(page).to have_no_text "Home"
-        expect(page).to have_no_text "Application"
+      scenario "Applications in a determined state belonging to other assessors are also not visible on login" do
+        other_assessor_planning_application.update(status: "determined", determined_at: Time.current)
+        click_link "Determined"
+
+        within("#determined") do
+          expect(page).not_to have_link(other_assessor_planning_application.reference)
+        end
+
+        click_on "View all applications"
+        click_link "Determined"
+
+        within("#determined") do
+          expect(page).to have_link(other_assessor_planning_application.reference)
+        end
       end
-    end
-
-    scenario "User can log out from index page" do
-      click_button "Log out"
-
-      expect(page).to have_current_path(/sign_in/)
-      expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
   end
 


### PR DESCRIPTION
### Description of change
Display different views to an assessor - upon login assessor only views its own and unassigned applications. Adds option to toggle that view.

### Story Link

https://www.pivotaltracker.com/story/show/173508545