### PR TITLE
Feature/pt 173960508/decision comments

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -60,6 +60,8 @@ class DecisionsController < AuthenticationController
   end
 
   def decision_params
-    params.fetch(:decision, {}).permit(:status, :public_comment)
+    params.fetch(:decision, {}).permit(
+      :status, :public_comment, :private_comment
+    )
   end
 end

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -60,6 +60,6 @@ class DecisionsController < AuthenticationController
   end
 
   def decision_params
-    params.fetch(:decision, {}).permit(:status, :comment_unmet)
+    params.fetch(:decision, {}).permit(:status, :public_comment)
   end
 end

--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -60,6 +60,6 @@ class DecisionsController < AuthenticationController
   end
 
   def decision_params
-    params.fetch(:decision, {}).permit(:status, :comment_met, :comment_unmet)
+    params.fetch(:decision, {}).permit(:status, :comment_unmet)
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -10,6 +10,6 @@ class Decision < ApplicationRecord
     message: "Please select Yes or No" }
 
   def comment_made?
-    granted? && comment_met.present? || refused? && comment_unmet.present?
+    refused? && comment_unmet.present?
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -9,7 +9,18 @@ class Decision < ApplicationRecord
   validates :status, inclusion: { in: ["granted", "refused"],
     message: "Please select Yes or No" }
 
+  validate :validate_public_comment
+
   def refused_with_public_comment?
     refused? && public_comment.present?
+  end
+
+  def validate_public_comment
+    if refused? && user.assessor? && public_comment.blank?
+      errors.add(
+        :public_comment,
+        "Please provide which GDPO policy (or policies) have not been met."
+      )
+    end
   end
 end

--- a/app/models/decision.rb
+++ b/app/models/decision.rb
@@ -9,7 +9,7 @@ class Decision < ApplicationRecord
   validates :status, inclusion: { in: ["granted", "refused"],
     message: "Please select Yes or No" }
 
-  def comment_made?
-    refused? && comment_unmet.present?
+  def refused_with_public_comment?
+    refused? && public_comment.present?
   end
 end

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -33,7 +33,7 @@
                   Please add any comments for your manager to see.
                   This will <strong>not</strong> appear on the decision notice.
                 </p>
-                <%= form.text_area :comment_unmet, class: "govuk-textarea", id: "comment_unmet", rows: "3", "aria-describedby": "comment-unmet-hint" %>
+                <%= form.text_area :public_comment, class: "govuk-textarea", id: "public_comment", rows: "3", "aria-describedby": "public-comment-hint" %>
               </div>
             </div>
           </div>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -11,6 +11,9 @@
           <br>
           <strong>Have permitted development requirements been met?</strong>
         </p>
+        <p class="govuk-body">
+          You need to check that the applicant's answers and proposal documents meet the permitted development requirements.
+        </p>
         <% if form.object.errors.any? %>
           <% form.object.errors.each do |attribute, error| %>
             <span id="status-error" class="govuk-error-message">
@@ -30,8 +33,17 @@
             <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
               <div class="govuk-form-group">
                 <p class="govuk-body">
-                  Please add any comments for your manager to see.
-                  This will <strong>not</strong> appear on the decision notice.
+                  <br>
+                  <strong>Please provide which GDPO policy (or policies) have not been met. </strong>
+                  If there are multiple, please separate by a comma.
+                </p>
+                <p class="govuk-body">
+                  <span class="govuk-hint">
+                    For example, "GPDO 2015 S.2 P.1 A.1 (f)(i), GPDO 2015 S.2 P.1 A.1 (f)(ii)"
+                  </span>
+                </p>
+                <p class="govuk-body">
+                  This <strong>will</strong> appear on the decision notice.
                 </p>
                 <%= form.text_area :public_comment, class: "govuk-textarea", id: "public_comment", rows: "3", "aria-describedby": "public-comment-hint" %>
               </div>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -51,6 +51,14 @@
           </div>
         </div>
       </div>
+      <div class="govuk-form-group">
+        <p class="govuk-body">
+          <strong>Please provide supporting information for your manager.</strong> For example, you may want to add any details about the width, depth or height of the proposal.
+          <br><br>
+          Your comment will <strong>not</strong> appear on the decision notice.
+        </p>
+        <%= form.text_area :private_comment, class: "govuk-textarea", id: "private_comment", rows: "3", "aria-describedby": "private-comment-hint" %>
+      </div>
     </fieldset>
     <p>
       <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -23,17 +23,6 @@
               <%= form.radio_button :status, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
               <%= form.label :status_granted, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
             </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-granted-conditional">
-              <div class="govuk-form-group">
-                <p class="govuk-body">
-                  By selecting yes, you are saying that this proposal complies with the GDPO.
-                  <br>
-                  <br>
-                  Please add any comments that you would like to share with your manager.
-                </p>
-                <%= form.text_area :comment_met, class: "govuk-textarea", id: "comment_met", rows: "3", "aria-describedby": "comment-met-hint" %>
-              </div>
-            </div>
             <div class="govuk-radios__item">
               <%= form.radio_button :status, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
               <%= form.label :status_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -5,11 +5,11 @@
     <p class="govuk-body">
       The planning officer recommends that the application is
       <strong><%= assessor_decision.status %></strong>
-      <%= "and added this comment:" if assessor_decision.comment_unmet? %>
+      <%= "and added this comment:" if assessor_decision.public_comment? %>
     </p>
-    <% if assessor_decision.comment_made? %>
+    <% if assessor_decision.refused_with_public_comment? %>
       <div style="border: 1px solid; padding: 10px;">
-        <p class="govuk-body"><%= assessor_decision.comment_unmet %></p>
+        <p class="govuk-body"><%= assessor_decision.public_comment %></p>
       </div>
       <br>
     <% end %>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -4,23 +4,19 @@
     <h2 class="govuk-heading-m">Review the recommendation</h2>
     <p class="govuk-body">
       The planning officer recommends that the application is
-      <strong><%= assessor_decision.status %></strong>
-      <%= "and added this comment:" if assessor_decision.public_comment? %>
+      <strong><%= "#{assessor_decision.status}. " %></strong>
+      <%= "The following policy requirement(s) have not been met:" if assessor_decision.public_comment? %>
     </p>
     <% if assessor_decision.refused_with_public_comment? %>
-      <div style="border: 1px solid; padding: 10px;">
-        <p class="govuk-body"><%= assessor_decision.public_comment %></p>
-      </div>
-      <br>
+      <p class="govuk-body"><%= assessor_decision.public_comment %></p>
     <% end %>
-    <p class="govuk-body">Please review the applicant's answers:</p>
+    <p class="govuk-body">
+      The planning officer has made their recommendation after reviewing the information provided by the applicant and checking the proposal documents against the GDPO
+    </p>
+    <p class="govuk-body"><strong> Information provided by the applicant:</strong></p>
     <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
     <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
-      <p class="govuk-body">
-        <strong>
-          Do you agree with the recommendation?
-        </strong>
-      </p>
+      <p class="govuk-body">Do you agree with the recommendation?</p>
       <% if form.object.errors.any? %>
         <% form.object.errors.each do |attribute, error| %>
           <span id="status-error" class="govuk-error-message">

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -10,6 +10,15 @@
     <% if assessor_decision.refused_with_public_comment? %>
       <p class="govuk-body"><%= assessor_decision.public_comment %></p>
     <% end %>
+
+    <% if assessor_decision.private_comment.present? %>
+      <p class="govuk-body">The officer has submitted the following comment for you:</p>
+      <div style="border: 1px solid; padding: 10px;">
+        <p class="govuk-body"><%= assessor_decision.private_comment %></p>
+      </div>
+      <br>
+    <% end %>
+
     <p class="govuk-body">
       The planning officer has made their recommendation after reviewing the information provided by the applicant and checking the proposal documents against the GDPO
     </p>

--- a/app/views/decisions/_reviewer_decision_form.html.erb
+++ b/app/views/decisions/_reviewer_decision_form.html.erb
@@ -5,14 +5,9 @@
     <p class="govuk-body">
       The planning officer recommends that the application is
       <strong><%= assessor_decision.status %></strong>
-      <%= "and added this comment:" if assessor_decision.comment_made? %>
+      <%= "and added this comment:" if assessor_decision.comment_unmet? %>
     </p>
-    <% if assessor_decision.granted? && assessor_decision.comment_made? %>
-      <div style="border: 1px solid; padding: 10px;">
-        <p class="govuk-body"><%= assessor_decision.comment_met %></p>
-      </div>
-      <br>
-    <% elsif assessor_decision.refused? && assessor_decision.comment_made? %>
+    <% if assessor_decision.comment_made? %>
       <div style="border: 1px solid; padding: 10px;">
         <p class="govuk-body"><%= assessor_decision.comment_unmet %></p>
       </div>

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -26,11 +26,6 @@ Certificate of lawful development (proposed) for the construction of <%= @planni
   Plan reference number	Plan description	Date received
   [Plan reference number]	[Document name]	[ DD MONTH YYYY ]
   [Plan reference number]	[Document name]	[ DD MONTH YYYY ]
-  <% if @decision.granted? && @planning_application.assessor_decision&.comment_met.present? %>
-    Reason for granting:
-
-    * <%= @planning_application.assessor_decision.comment_met %>
-  <% end %>
 <% elsif @decision.refused? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are not lawful for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
   <% if @decision.refused? && @planning_application.assessor_decision&.comment_unmet.present? %>

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -28,10 +28,10 @@ Certificate of lawful development (proposed) for the construction of <%= @planni
   [Plan reference number]	[Document name]	[ DD MONTH YYYY ]
 <% elsif @decision.refused? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are not lawful for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
-  <% if @decision.refused? && @planning_application.assessor_decision&.comment_unmet.present? %>
+  <% if @decision.refused? && @planning_application.assessor_decision&.public_comment.present? %>
     Reason why use or operations would not have been LAWFUL:
 
-    * <%= @planning_application.assessor_decision.comment_unmet %>
+    * <%= @planning_application.assessor_decision.public_comment %>
   <% end %>
 <% end %>
 

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -29,9 +29,9 @@ Certificate of lawful development (proposed) for the construction of <%= @planni
 <% elsif @decision.refused? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are not lawful for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
   <% if @decision.refused? && @planning_application.assessor_decision&.public_comment.present? %>
-    Reason why use or operations would not have been LAWFUL:
+    The proposal does not comply with:
 
-    * <%= @planning_application.assessor_decision.public_comment %>
+    <%= @planning_application.assessor_decision.public_comment %>
   <% end %>
 <% end %>
 

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -56,6 +56,10 @@
       <strong>not lawful</strong>
       for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
     </p>
+    <% if planning_application.assessor_decision.refused_with_public_comment? %>
+      <p class="govuk-body">The proposal does not comply with:</p>
+      <p class="govuk-body"> <%= planning_application.assessor_decision.public_comment %> </p>
+    <% end %>
   <% end %>
   <p class="govuk-body">Signed: Simon Bevan
     <br>

--- a/db/migrate/20200728150326_drop_comment_met_on_decision.rb
+++ b/db/migrate/20200728150326_drop_comment_met_on_decision.rb
@@ -1,0 +1,5 @@
+class DropCommentMetOnDecision < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :decisions, :comment_met, :text
+  end
+end

--- a/db/migrate/20200728151340_rename_comment_unmet_to_public_comment_on_decision.rb
+++ b/db/migrate/20200728151340_rename_comment_unmet_to_public_comment_on_decision.rb
@@ -1,5 +1,5 @@
 class RenameCommentUnmetToPublicCommentOnDecision < ActiveRecord::Migration[6.0]
   def change
-    rename_column :decisions, :comment_unmet, :private_comment
+    rename_column :decisions, :comment_unmet, :public_comment
   end
 end

--- a/db/migrate/20200728151340_rename_comment_unmet_to_public_comment_on_decision.rb
+++ b/db/migrate/20200728151340_rename_comment_unmet_to_public_comment_on_decision.rb
@@ -1,0 +1,5 @@
+class RenameCommentUnmetToPublicCommentOnDecision < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :decisions, :comment_unmet, :private_comment
+  end
+end

--- a/db/migrate/20200729091424_add_private_comment_on_decision.rb
+++ b/db/migrate/20200729091424_add_private_comment_on_decision.rb
@@ -1,0 +1,5 @@
+class AddPrivateCommentOnDecision < ActiveRecord::Migration[6.0]
+  def change
+    add_column :decisions, :private_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_150326) do
+ActiveRecord::Schema.define(version: 2020_07_28_151340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_150326) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status"
-    t.text "comment_unmet"
+    t.text "public_comment"
     t.index ["planning_application_id"], name: "index_decisions_on_planning_application_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_151340) do
+ActiveRecord::Schema.define(version: 2020_07_29_091424) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2020_07_28_151340) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status"
     t.text "public_comment"
+    t.text "private_comment"
     t.index ["planning_application_id"], name: "index_decisions_on_planning_application_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_08_095601) do
+ActiveRecord::Schema.define(version: 2020_07_28_150326) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,6 @@ ActiveRecord::Schema.define(version: 2020_07_08_095601) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status"
-    t.text "comment_met"
     t.text "comment_unmet"
     t.index ["planning_application_id"], name: "index_decisions_on_planning_application_id"
     t.index ["user_id"], name: "index_decisions_on_user_id"

--- a/spec/factories/decision.rb
+++ b/spec/factories/decision.rb
@@ -18,4 +18,10 @@ FactoryBot.define do
     status { :refused }
     public_comment { "This has been refused." }
   end
+
+  trait :refused_with_public_and_private_comment do
+    status { :refused }
+    public_comment { "This has been refused." }
+    private_comment { "This is a private comment." }
+  end
 end

--- a/spec/factories/decision.rb
+++ b/spec/factories/decision.rb
@@ -16,6 +16,6 @@ FactoryBot.define do
 
   trait :refused_with_comment do
     status { :refused }
-    comment_unmet { "This has been refused." }
+    public_comment { "This has been refused." }
   end
 end

--- a/spec/factories/decision.rb
+++ b/spec/factories/decision.rb
@@ -10,11 +10,6 @@ FactoryBot.define do
     status { :granted }
   end
 
-  trait :granted_with_comment do
-    status { :granted }
-    comment_met { "This has been granted." }
-  end
-
   trait :refused do
     status { :refused }
   end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -43,7 +43,6 @@ FactoryBot.define do
     after(:create) do |pa|
       create :policy_evaluation,
         status: :unmet,
-        comment_unmet: "this application is recommended for refusal",
         planning_application: pa
     end
   end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -52,7 +52,6 @@ FactoryBot.define do
     after(:create) do |pa|
       create :policy_evaluation,
         status: :met,
-        comment_met: "this application is recommended for grant",
         planning_application: pa
     end
   end

--- a/spec/models/decision_spec.rb
+++ b/spec/models/decision_spec.rb
@@ -25,10 +25,36 @@ RSpec.describe Decision, type: :model do
       expect(subject).to be_valid
     end
 
-    it "is valid when status is refused" do
-      subject.status = :refused
+    context "when user is assessor" do
+      before do
+        subject.user.role = :assessor
+      end
 
-      expect(subject).to be_valid
+      it "is valid when status is refused with public_comment" do
+        subject.status = :refused
+        subject.public_comment = "This is not granted."
+
+        expect(subject).to be_valid
+      end
+
+      it "is invalid when status is refused without public_comment" do
+        subject.status = :refused
+        subject.public_comment = " "
+
+        expect(subject).to be_invalid
+      end
+    end
+
+    context "when user is reviewer" do
+      before do
+        subject.user.role = :reviewer
+      end
+
+      it "is valid when status is refused" do
+        subject.status = :refused
+
+        expect(subject).to be_valid
+      end
     end
   end
 end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -54,15 +54,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     choose "Yes"
 
-    expect(page).to have_content("By selecting yes, you are saying that this proposal complies with the GDPO.")
-    expect(page).to have_content("Please add any comments that you would like to share with your manager.")
-
-    fill_in "comment_met", with: "This has been granted"
-
     click_button "Save"
-
-    # TODO remove this line when we validate the comment_met in the decision notice
-    expect(planning_application.reload.assessor_decision.comment_met).to eq("This has been granted")
 
     # Expect the 'completed' label to be present for the evaluation step
     within(:assessment_step, "Assess the proposal") do

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -153,5 +153,27 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
   end
 
+  scenario "shows the public_comment error message" do
+    within("#in_assessment") do
+      click_link planning_application.reference
+    end
+
+    expect(page).not_to have_link("Submit the recommendation")
+
+    click_link "Assess the proposal"
+
+    choose "No"
+
+    click_button "Save"
+
+    within(".govuk-error-message") do
+      expect(page).to have_content("Please provide which GDPO policy (or policies) have not been met.")
+    end
+
+    click_link "Home"
+
+    expect(page).not_to have_css(".app-task-list__task-completed")
+  end
+
   include_examples "assessor decision error message"
 end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     choose "Yes"
 
+    expect(page).to have_content("Please provide supporting information for your manager. For example, you may want to add any details about the width, depth or height of the proposal. Your comment will not appear on the decision notice.")
+
+    fill_in "private_comment", with: "This is a private comment"
+
     click_button "Save"
 
     # Expect the 'completed' label to be present for the evaluation step
@@ -69,6 +73,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
 
     choose "Yes"
+
+    expect(page).to have_content("This is a private comment")
 
     click_button "Save"
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The planning officer recommends that the application is granted")
-        expect(page).not_to have_content("and added this comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted.")
+        expect(page).not_to have_content("The following policy requirement(s) have not been met:")
         expect(page).not_to have_content("This has been refused.")
 
         choose "Yes"
@@ -105,8 +105,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The planning officer recommends that the application is granted")
-        expect(page).not_to have_content("and added this comment:")
+        expect(page).to have_content("The planning officer recommends that the application is granted.")
+        expect(page).not_to have_content("The following policy requirement(s) have not been met:")
         expect(page).not_to have_content("This has been refused.")
 
         choose "No"
@@ -330,8 +330,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The planning officer recommends that the application is refused")
-        expect(page).to have_content("and added this comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused.")
+        expect(page).to have_content("The following policy requirement(s) have not been met:")
 
         choose "Yes"
         click_button "Save"
@@ -384,8 +384,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_link "Review the recommendation"
 
-        expect(page).to have_content("The planning officer recommends that the application is refused")
-        expect(page).to have_content("and added this comment:")
+        expect(page).to have_content("The planning officer recommends that the application is refused.")
+        expect(page).to have_content("The following policy requirement(s) have not been met:")
         expect(page).to have_content("This has been refused.")
 
         choose "No"

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       visit root_path
     end
 
-    context "with a granted assessor_decision without a comment" do
+    context "with a granted assessor_decision" do
       let(:assessor_decision) { create :decision, :granted, user: assessor }
 
       scenario "agrees with assessor's decision" do
@@ -36,7 +36,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is granted")
         expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
         choose "Yes"
@@ -58,8 +57,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
         expect(page).not_to have_content("This has been refused.")
 
@@ -110,7 +107,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is granted")
         expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
         choose "No"
@@ -132,8 +128,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
         expect(page).not_to have_content("This has been refused.")
 
@@ -202,123 +196,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       include_examples "reviewer decision error message"
     end
 
-    context "with a granted assessor_decision with a comment" do
-      let(:assessor_decision) { create :decision, :granted_with_comment, user: assessor }
-
-      scenario "agrees with assessor's decision" do
-        # Check that the application is no longer in awaiting determination
-        within("#awaiting_determination") do
-          click_link planning_application.reference
-        end
-
-        expect(page).not_to have_link("Publish the recommendation")
-
-        click_link "Review the recommendation"
-
-        expect(page).to have_content("The planning officer recommends that the application is granted")
-        expect(page).to have_content("and added this comment:")
-        expect(page).to have_content("This has been granted.")
-        expect(page).not_to have_content("This has been refused.")
-
-        choose "Yes"
-        click_button "Save"
-
-        within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
-        click_button "Save"
-
-        click_link "Publish the recommendation"
-
-        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        expect(page).to have_content("granted")
-
-        click_button "Determine application"
-
-        within(:assessment_step, "Publish the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Home"
-
-        # Check that the application is no longer in awaiting determination
-        click_link "Awaiting manager's determination"
-        within("#awaiting_determination") do
-          expect(page).not_to have_link planning_application.reference
-        end
-
-        # Check that the application is now in determined
-        click_link "Determined"
-        within("#determined") do
-          expect(page).to have_link planning_application.reference
-        end
-      end
-
-      scenario "disagrees with assessor's decision" do
-        # Check that the application is no longer in awaiting determination
-        within("#awaiting_determination") do
-          click_link planning_application.reference
-        end
-
-        expect(page).not_to have_link("Publish the recommendation")
-
-        click_link "Review the recommendation"
-
-        expect(page).to have_content("The planning officer recommends that the application is granted")
-        expect(page).to have_content("and added this comment:")
-
-        choose "No"
-        click_button "Save"
-
-        within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
-
-        click_link "Publish the recommendation"
-
-        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        expect(page).to have_content("refused")
-
-        click_button "Determine application"
-
-        within(:assessment_step, "Publish the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Home"
-
-        # Check that the application is no longer in awaiting determination
-        click_link "Awaiting manager's determination"
-        within("#awaiting_determination") do
-          expect(page).not_to have_link planning_application.reference
-        end
-
-        # Check that the application is now in determined
-        click_link "Determined"
-        within("#determined") do
-          expect(page).to have_link planning_application.reference
-        end
-      end
-
-      include_examples "reviewer assignment"
-      include_examples "reviewer decision error message"
-    end
-
     context "with a refused assessor_decision without a comment" do
       let(:assessor_decision) { create :decision, :refused, user: assessor }
 
@@ -334,7 +211,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is refused")
         expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
         choose "Yes"
@@ -356,8 +232,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
         expect(page).not_to have_content("This has been refused.")
 
@@ -394,7 +268,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is refused")
         expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("This has been refused.")
 
         choose "No"
@@ -416,8 +289,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
         expect(page).not_to have_content("This has been refused.")
 
@@ -515,7 +386,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is refused")
         expect(page).to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).to have_content("This has been refused.")
 
         choose "No"
@@ -537,8 +407,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason for granting:")
-        expect(page).not_to have_content("This has been granted.")
         expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
         expect(page).not_to have_content("This has been refused.")
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -196,128 +196,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       include_examples "reviewer decision error message"
     end
 
-    context "with a refused assessor_decision without a comment" do
-      let(:assessor_decision) { create :decision, :refused, user: assessor }
-
-      scenario "agrees with assessor's decision" do
-        # Check that the application is no longer in awaiting determination
-        within("#awaiting_determination") do
-          click_link planning_application.reference
-        end
-
-        expect(page).not_to have_link("Publish the recommendation")
-
-        click_link "Review the recommendation"
-
-        expect(page).to have_content("The planning officer recommends that the application is refused")
-        expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been refused.")
-
-        choose "Yes"
-        click_button "Save"
-
-        within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("Yes")).to be_checked
-        end
-        click_button "Save"
-
-        click_link "Publish the recommendation"
-
-        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
-        expect(page).not_to have_content("This has been refused.")
-
-        click_button "Determine application"
-
-        within(:assessment_step, "Publish the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Home"
-
-        # Check that the application is no longer in awaiting determination
-        click_link "Awaiting manager's determination"
-        within("#awaiting_determination") do
-          expect(page).not_to have_link planning_application.reference
-        end
-
-        # Check that the application is now in determined
-        click_link "Determined"
-        within("#determined") do
-          expect(page).to have_link planning_application.reference
-        end
-      end
-
-      scenario "disagrees with assessor's decision" do
-        # Check that the application is no longer in awaiting determination
-        within("#awaiting_determination") do
-          click_link planning_application.reference
-        end
-
-        expect(page).not_to have_link("Publish the recommendation")
-
-        click_link "Review the recommendation"
-
-        expect(page).to have_content("The planning officer recommends that the application is refused")
-        expect(page).not_to have_content("and added this comment:")
-        expect(page).not_to have_content("This has been refused.")
-
-        choose "No"
-        click_button "Save"
-
-        within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Review the recommendation"
-
-        # Expect the saved state to be shown in the form
-        within(find("form.decision")) do
-          expect(page.find_field("No")).to be_checked
-        end
-        click_button "Save"
-
-        click_link "Publish the recommendation"
-
-        expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
-        expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
-        expect(page).not_to have_content("This has been refused.")
-
-        click_button "Determine application"
-
-        within(:assessment_step, "Publish the recommendation") do
-          expect(page).to have_completed_tag
-        end
-
-        click_link "Home"
-
-        # Check that the application is no longer in awaiting determination
-        click_link "Awaiting manager's determination"
-        within("#awaiting_determination") do
-          expect(page).not_to have_link planning_application.reference
-        end
-
-        # Check that the application is now in determined
-        click_link "Determined"
-        within("#determined") do
-          expect(page).to have_link planning_application.reference
-        end
-      end
-
-      include_examples "reviewer assignment"
-      include_examples "reviewer decision error message"
-    end
-
-    context "with a refused assessor_decision with a comment" do
+    context "with a refused assessor_decision" do
       let(:assessor_decision) { create :decision, :refused_with_comment, user: assessor }
 
       scenario "agrees with assessor's decision" do
@@ -332,6 +211,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The planning officer recommends that the application is refused.")
         expect(page).to have_content("The following policy requirement(s) have not been met:")
+        expect(page).to have_content("This has been refused.")
 
         choose "Yes"
         click_button "Save"

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
+        expect(page).not_to have_content("The proposal does not comply with:")
         expect(page).not_to have_content("This has been refused.")
 
         click_button "Determine application"
@@ -128,7 +128,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
+        expect(page).not_to have_content("The proposal does not comply with:")
         expect(page).not_to have_content("This has been refused.")
 
         click_button "Determine application"
@@ -352,6 +352,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("refused")
+        expect(page).to have_content("The proposal does not comply with:")
+        expect(page).to have_content("This has been refused.")
 
         click_button "Determine application"
 
@@ -407,7 +409,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.")
         expect(page).to have_content("granted")
-        expect(page).not_to have_content("Reason why use or operations would not have been LAWFUL:")
+        expect(page).not_to have_content("The proposal does not comply with:")
         expect(page).not_to have_content("This has been refused.")
 
         click_button "Determine application"


### PR DESCRIPTION
### Description of change

- Drop `comment_met` from decisions
- Rename `comment_unmet` to `public_comment` in decisions
- Show `public_comment` to decision_notice
- Add validation on `public_comment` when assessor user choose no to write a comment
- Add `private_comment` on decision table
- Update with latest content design changes

### Story Link

https://www.pivotaltracker.com/story/show/173960508

### Screenshots

![Screenshot 2020-07-29 at 13 21 03](https://user-images.githubusercontent.com/7561969/88799640-b03c4800-d19e-11ea-8fe2-5993cdc9e07b.jpg)
![Screenshot 2020-07-29 at 13 21 38](https://user-images.githubusercontent.com/7561969/88799642-b0d4de80-d19e-11ea-85b5-8e2593699b24.jpg)
![Screenshot 2020-07-29 at 13 22 20](https://user-images.githubusercontent.com/7561969/88799643-b0d4de80-d19e-11ea-8190-d8f46dcb77b8.jpg)
