### PR TITLE
Added link for reviewer to see applications in assessment

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -14,4 +14,12 @@ module PlanningApplicationHelper
   def exclude_others?
     params[:q] == "exclude_others"
   end
+
+  def filter_text
+    if current_user.assessor?
+      "View my applications"
+    else
+      "View assessed applications"
+    end
+  end
 end

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -1,6 +1,6 @@
 <div>
   <ul class="govuk-tabs__list" id="planning_applications_statusTab" role="tablist">
-    <% unless current_user.reviewer?%>
+      <% unless exclude_others? && current_user.reviewer? %>
       <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
         <%= link_to "In assessment", "#in_assessment", class: "govuk-tabs__tab", role: "tab", "aria-controls":"in-assessment", "aria-selected": true, tabindex: 0 %>
       </li>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -9,10 +9,10 @@
       Your fast track applications
     </h1>
     <p class="govuk-body"><%= current_user.name %>, <%= current_user.role.capitalize %></p>
-    <% if exclude_others? && current_user.assessor? %>
+    <% if exclude_others? %>
       <p class="govuk-body"><%= link_to "View all applications", planning_applications_path, class: "govuk-link" %></p>
-    <% elsif !exclude_others? && current_user.assessor? %>
-      <p class="govuk-body"><%= link_to "View my applications", planning_applications_path(q: "exclude_others"), class: "govuk-link" %></p>
+    <% else %>
+      <p class="govuk-body"><%= link_to filter_text, planning_applications_path(q: "exclude_others"), class: "govuk-link" %></p>
     <% end %>
   </div>
 </div>
@@ -23,7 +23,7 @@
         Contents
       </h2>
       <%= render "planning_application_tabs" %>
-      <%= render "planning_application_table", planning_applications: @planning_applications.in_assessment, id: "in_assessment", title: "In assessment" unless current_user.reviewer?%>
+      <%= render "planning_application_table", planning_applications: @planning_applications.in_assessment, id: "in_assessment", title: "In assessment" unless exclude_others? && current_user.reviewer?  %>
       <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination, id: "awaiting_determination", title: "Awaiting manager's determination" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.determined, id: "determined", title: "Determined" %>
     </div>

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -127,10 +127,28 @@ RSpec.feature "Planning Application index page", type: :system do
   context "as an reviewer" do
     before do
       sign_in users(:reviewer)
-      visit planning_applications_path
+      visit root_path
     end
 
-    scenario "Planning Application status bar is present" do
+    scenario "Planning Application status bar is present and does not show In Assessment by default" do
+      within(:planning_applications_status_tab) do
+        expect(page).to have_link "Awaiting manager's determination"
+        expect(page).to have_link "Determined"
+        expect(page).not_to have_link "In assessment"
+      end
+    end
+
+    scenario "Reviewer can see applications in assessment status by toggling link" do
+      click_link "View all applications"
+
+      within(:planning_applications_status_tab) do
+        expect(page).to have_link "Awaiting manager's determination"
+        expect(page).to have_link "Determined"
+        expect(page).to have_link "In assessment"
+      end
+
+      click_link "View assessed applications"
+
       within(:planning_applications_status_tab) do
         expect(page).to have_link "Awaiting manager's determination"
         expect(page).to have_link "Determined"


### PR DESCRIPTION
<img width="1161" alt="reviewer1" src="https://user-images.githubusercontent.com/1880450/89178577-d0e11500-d585-11ea-8512-94f3c00562eb.png">
<img width="1138" alt="reviewer2" src="https://user-images.githubusercontent.com/1880450/89178579-d179ab80-d585-11ea-9686-518535369482.png">

### Description of change

This story allows the reviewer to see the In Assessment tab when they click View All Applications. The link is the same as the View All Applications link that the assessor sees, but the functionality is slightly different as it changes the statuses that are visible to the reviewer, rather than allowing them to see applications that are assigned to different users (the reviewer can already see applications that are assigned to all users).

### Story Link

https://www.pivotaltracker.com/n/projects/2441805/stories/173508551
