### PR TITLE
[#173130630] Upload documents - styling updates

### DIFF
--- a/app/javascript/stylesheets/components/_drawings.scss
+++ b/app/javascript/stylesheets/components/_drawings.scss
@@ -12,15 +12,14 @@
 }
 
 .current-drawings {
-  .thumbnail {
-    display: inline-block;
-    padding-bottom: 5%;
-    width: 40%;
-    margin-left: 2%;
+  @include govuk-media-query($from: desktop) {
+    .drawing-card.right {
+      padding-left: 90px;
+    }
   }
 
-  .thumbnail:nth-of-type(2n) {
-    float: right;
+  .govuk-grid-row {
+    margin-bottom: 26px;
   }
 }
 

--- a/app/javascript/stylesheets/components/_drawings.scss
+++ b/app/javascript/stylesheets/components/_drawings.scss
@@ -21,6 +21,10 @@
   .govuk-grid-row {
     margin-bottom: 26px;
   }
+
+  a + .govuk-body {
+    margin-top: 16px;
+  }
 }
 
 .upload-container {

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -30,27 +30,33 @@
   </div>
 </div>
 
-<div class="govuk-grid-row current-drawings">
-  <% filter_current(@drawings).each do |drawing| %>
-    <div class="thumbnail">
-      <p class="govuk-body">
-        <strong><%= drawing.name %></strong><br/>
-        <%= drawing.created_at.strftime("%e %B %Y") %><br/>
-        <%= link_to "View in new window",
-        rails_blob_path(drawing.plan), target: :_new %><br/>
-      </p>
+<div class="current-drawings">
+  <% filter_current(@drawings).each_slice(2) do |drawings| %>
+    <div class="govuk-grid-row">
+      <% drawings.each.with_index do |drawing, index| %>
+        <div class="govuk-grid-column-one-half">
+          <div class="drawing-card<%= " right" if index % 2 == 1 %>">
+            <p class="govuk-body">
+              <strong><%= drawing.name %></strong><br/>
+              <%= drawing.created_at.strftime("%e %B %Y") %><br/>
+              <%= link_to "View in new window",
+              rails_blob_path(drawing.plan), target: :_new %><br/>
+            </p>
 
-      <ul class="govuk-list">
-        <% drawing.tags.each do |tag| %>
-          <li><strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong></li>
-        <% end %>
-      </ul>
+            <ul class="govuk-list">
+              <% drawing.tags.each do |tag| %>
+                <li><strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong></li>
+              <% end %>
+            </ul>
 
-      <%= link_to image_tag(drawing.plan.representation(resize: "300x212")),
-                  rails_blob_path(drawing.plan), target: :_blank %>
-      <p class="govuk-body">
-        <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: drawing.id) if current_user.assessor? && @planning_application.in_assessment? %>
-      </p>
+            <%= link_to image_tag(drawing.plan.representation(resize: "300x212")),
+                        rails_blob_path(drawing.plan), target: :_blank %>
+            <p class="govuk-body">
+              <%= link_to "Archive document", planning_application_drawing_archive_path(drawing_id: drawing.id) if current_user.assessor? && @planning_application.in_assessment? %>
+            </p>
+          </div>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -72,7 +72,13 @@
     <tbody class="govuk-table__body">
       <tr class="govuk-table__row">
         <td class="govuk-table__cell archive-data"><%= link_to drawing.name, rails_blob_path(drawing.plan), target: :_new %></td>
-        <td class="govuk-table__cell archive-data tags"><%= drawing.tags.join(", ") %></td>
+        <td class="govuk-table__cell archive-data tags">
+          <ul class="govuk-list">
+            <% drawing.tags.each do |tag| %>
+              <li><strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong></li>
+            <% end %>
+          </ul>
+        </td>
         <td class="govuk-table__cell archive-data"><%= drawing.created_at.strftime("%e %b %Y") %></td>
         <td class="govuk-table__cell archive-data"><%= t(drawing.archive_reason) %></td>
       </tr>

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Assessor can see table of drawings on overview page" do
-      expect(page).to have_css(".thumbnail", count: 1)
+      expect(page).to have_css(".drawing-card", count: 1)
     end
 
     scenario "Archive table is initially empty" do
@@ -163,7 +163,7 @@ RSpec.feature "Drawings index page", type: :system do
     end
 
     scenario "Archived document does not appear on overview page" do
-      expect(page).not_to have_css(".thumbnail-left")
+      expect(page).not_to have_css(".drawing-card")
     end
   end
 

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Drawings index page", type: :system do
         expect(page).to have_text("existing-floorplan.png")
 
         drawing_tags.each do |tag|
-          expect(page).to have_text tag
+          expect(page).to have_css(".govuk-tag", text: tag)
         end
       end
     end

--- a/spec/system/drawings/upload_spec.rb
+++ b/spec/system/drawings/upload_spec.rb
@@ -58,9 +58,9 @@ RSpec.describe "Document uploads", type: :system do
 
         expect(page).to have_content("proposed-section.pdf has been uploaded.")
 
-        expect(page).to have_css(".current-drawings .thumbnail", count: 2)
+        expect(page).to have_css(".current-drawings .drawing-card", count: 2)
 
-        within(".current-drawings .thumbnail:last-child") do
+        within(all(".current-drawings .drawing-card").last) do
           # The newly added document is last in the list
           expect(page).to have_css("img[src*=\"proposed-section.pdf\"]")
 


### PR DESCRIPTION
### Description of change

A few styling updates to the document management page, following UAT.

Adds styled tags to the archived drawing list, and corrects a layout issue where even numbers of drawings were breaking our grid layout.

### [Story Link](https://www.pivotaltracker.com/n/projects/2441805/stories/173130630)

### UI

![image](https://user-images.githubusercontent.com/1370570/89439081-94f2af00-d741-11ea-820b-3879512eebf6.png)
