### PR TITLE
[#173794989] Numbered Drawings

### DIFF
--- a/app/javascript/stylesheets/components/_task_list.scss
+++ b/app/javascript/stylesheets/components/_task_list.scss
@@ -53,7 +53,7 @@
   }
 }
 
-.app-task-list__task-completed {
+.app-task-list__task-tag {
   margin-top: govuk-spacing(2);
   margin-bottom: govuk-spacing(1);
   @include govuk-media-query($from: 450px) {

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -7,6 +7,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     @planning_application = planning_application
     @decision = @planning_application.reviewer_decision
     @user = @planning_application.applicant
+    @drawings = @planning_application.drawings.for_publication
 
     view_mail(
       NOTIFY_TEMPLATE_ID,

--- a/app/models/drawing.rb
+++ b/app/models/drawing.rb
@@ -35,6 +35,7 @@ class Drawing < ApplicationRecord
       proposed_tag_array: Drawing::PROPOSED_TAGS)
   }
   scope :has_empty_numbers, -> { where("numbers = '[]'") }
+  scope :numbered, -> { where.not("numbers = '[]'") }
   scope :active, -> { where(archived_at: nil) }
 
   scope :for_publication, -> { active.has_proposed_tag }

--- a/app/models/drawing_numbers_list_form.rb
+++ b/app/models/drawing_numbers_list_form.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+class DrawingNumbersListForm
+  include ActiveModel::Model
+  include ActiveModel::Validations
+
+  attr_reader :drawings
+
+  def initialize(drawings, drawings_numbers_hash = {})
+    @drawings = drawings.map { |drawing| DrawingNumbersUpdateForm.new(drawing) }
+    @drawings_numbers_hash = drawings_numbers_hash
+  end
+
+  def update_all
+    ActiveRecord::Base.transaction do
+      drawings.each do |drawing|
+        drawing.numbers = drawings_numbers_hash.dig(drawing.id.to_s, "numbers")
+        drawing.save
+      end
+
+      raise ActiveRecord::Rollback if any_drawings_errors?
+    end
+
+    !any_drawings_errors?
+  end
+
+  private
+
+    attr_accessor :drawings_numbers_hash
+
+    def any_drawings_errors?
+      drawings.map(&:errors).any?(&:present?)
+    end
+
+    class DrawingNumbersUpdateForm
+      include ActiveModel::Model
+      include ActiveModel::Validations
+
+      attr_accessor :drawing
+
+      validates :numbers, presence: { message: "Provide at least one number" }
+
+      delegate *Drawing.attribute_names, to: :drawing
+
+      def initialize(drawing)
+        @drawing = drawing
+      end
+
+      def plan
+        drawing.plan
+      end
+
+      def name
+        drawing.name
+      end
+
+      def numbers=(value)
+        drawing.numbers = value
+      end
+
+      def numbers
+        drawing.numbers
+      end
+
+      def save
+        if valid?
+          @drawing.update(numbers: numbers)
+        end
+
+        errors.none?
+      end
+    end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -71,6 +71,13 @@ class PlanningApplication < ApplicationRecord
     awaiting_correction? || determined?
   end
 
+  def drawings_ready_for_publication?
+    drawings_for_publication = drawings.for_publication
+
+    drawings_for_publication.present? &&
+      drawings_for_publication.has_empty_numbers.none?
+  end
+
   private
 
   def set_target_date

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -78,6 +78,14 @@ class PlanningApplication < ApplicationRecord
       drawings_for_publication.has_empty_numbers.none?
   end
 
+  def drawing_numbering_partially_completed?
+    numbered_count = drawings.has_proposed_tag.numbered.count
+
+    return false if numbered_count.zero?
+
+    numbered_count < drawings.has_proposed_tag.count
+  end
+
   private
 
   def set_target_date

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -7,6 +7,8 @@ class PlanningApplicationPolicy < ApplicationPolicy
   alias_method :validate_step?, :editor?
   alias_method :archive?, :editor?
   alias_method :confirm_new?, :editor?
+  alias_method :edit_numbers?, :editor?
+  alias_method :update_numbers?, :editor?
 
   def show?
     super || signed_in_viewer?

--- a/app/views/drawings/edit_numbers.html.erb
+++ b/app/views/drawings/edit_numbers.html.erb
@@ -1,0 +1,84 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% content_for :title, "Attach drawing numbers" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+      <%= @planning_application.reference %>
+    </h1>
+    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+      <%= display_address(@site) %>
+    </h2>
+
+    <h2 class="govuk-heading-m">Attach drawing numbers</h2>
+
+    <% if @drawings_list.drawings.none? %>
+      <div class="govuk-form-group govuk-form-group--error">
+        <span id="status-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+            No drawings are available
+        </span>
+
+        <p class="govuk-body">This could be because the proposed plans:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <li>have not been submitted</li>
+          <li>are not tagged with proposed document tags</li>
+          <li>were archived</li>
+        </ul>
+
+        <p class="govuk-body">
+          Please <%= link_to "upload proposal documents", new_planning_application_drawing_path(@planning_application), class: "govuk-link" %> and tag with <span class="govuk-tag govuk-tag--turquoise">PROPOSED</span> to add drawing numbers.
+        </p>
+      </div>
+      <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button", data: { module: "govuk-button" } %>
+    <% else %>
+      <p class="govuk-body">
+        Attach drawing numbers to all proposed documents. These will be published in the decision notice.
+      </p>
+      <%= form_with model: @drawings_list, scope: "drawings_list", url: update_numbers_planning_application_drawings_path, method: :put, local: true do |f| %>
+        <fieldset class="govuk-fieldset">
+          <% @drawings_list.drawings.each do |drawing| %>
+            <%= f.fields_for "drawings[#{drawing.id}]", drawing do |ff| %>
+              <div class="thumbnail">
+                <p class="govuk-body doc-names govuk-!-margin-bottom-1">
+                  <%= drawing.name %>
+                </p>
+                <ul class="govuk-list">
+                  <% drawing.tags.each do |tag| %>
+                    <li><strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong></li>
+                  <% end %>
+                </ul>
+                <p class="govuk-body">
+                  <%= drawing.created_at.strftime("%e %B %Y") %>
+                  <br/>
+                  <%= link_to "View in new window", rails_blob_path(drawing.plan), target: :_blank %>
+                </p>
+                <%= link_to image_tag(drawing.plan.representation(resize: "300x212")),
+                            rails_blob_path(drawing.plan), target: :_blank %>          <br/>
+
+                <div class="govuk-form-group <%= drawing.errors[:numbers].any? ? 'govuk-form-group--error' : '' %>">
+                  <% if drawing.errors[:numbers].any? %>
+                    <% drawing.errors[:numbers].each do |error| %>
+                      <span id="status-error" class="govuk-error-message">
+                        <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+                    <% end %>
+                  <% end %>
+
+                  <%= ff.label :numbers, "Drawing number:", class: "govuk-label", for: "numbers" %>
+                  <%= ff.text_area :numbers, class: "govuk-input govuk-input--width-20", id: "numbers" %>
+                </div>
+                <br/>
+                <br/>
+              </div>
+            <% end %>
+          <% end%>
+        </fieldset>
+        <div class="govuk-form-group">
+          <%= submit_tag "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+        </div>
+      <% end %>
+    <% end%>
+  </div>
+</div>

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -24,8 +24,13 @@ Certificate of lawful development (proposed) for the construction of <%= @planni
   1 The development shall be carried out in accordance with the following approved plans:
 
   Plan reference number	Plan description	Date received
-  [Plan reference number]	[Document name]	[ DD MONTH YYYY ]
-  [Plan reference number]	[Document name]	[ DD MONTH YYYY ]
+  <% @drawings.each do |drawing| %>
+    <% if drawing.numbers.present?  %>
+      <% drawing.numbers.split(",").each do |number| %>
+        <%= number %> <%= drawing.created_at.strftime("%e %B %Y") %>
+      <% end %>
+    <% end %>
+  <% end %>
 <% elsif @decision.refused? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are not lawful for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
   <% if @decision.refused? && @planning_application.assessor_decision&.public_comment.present? %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -42,7 +42,7 @@
               <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>
 
               <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% elsif !@planning_application.drawings.has_proposed_tag.numbered.count.zero? && (@planning_application.drawings.has_proposed_tag.numbered.count < @planning_application.drawings.has_proposed_tag.count) %>
+            <% elsif @planning_application.drawing_numbering_partially_completed? %>
               <% aria_attributes = { describedby: "#{step_name.parameterize}-in-progress" } %>
 
               <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -25,11 +25,29 @@
         <% end %>
       </li>
 
+      <% if (current_user.assessor?) %>
+        <li class="app-task-list__item">
+          <% step_name = "Attach drawing numbers" %>
+
+          <% if !(@planning_application.awaiting_determination? || @planning_application.determined?)  && !@planning_application.drawings_ready_for_publication? %>
+            <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
+
+            <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>
+          <% else %>
+            <span class="app-task-list__task-name"><%= step_name %></span>
+          <% end %>
+
+          <% if @planning_application.drawings_ready_for_publication? %>
+            <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+          <% end %>
+        </li>
+      <% end %>
+
       <li class="app-task-list__item">
         <% step_name = t("#{@planning_application.status}.recommendation_step") %>
         <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
-        <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision %>
+        <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision && @planning_application.drawings_ready_for_publication? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
         <% elsif current_user.reviewer? && @planning_application.reviewer_decision  && !@planning_application.awaiting_correction? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -21,7 +21,7 @@
         <% end %>
 
         <% if proposal_step_mark_completed?(step_name, @planning_application) %>
-          <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+          <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
         <% end %>
       </li>
 
@@ -29,16 +29,28 @@
         <li class="app-task-list__item">
           <% step_name = "Attach drawing numbers" %>
 
-          <% if !(@planning_application.awaiting_determination? || @planning_application.determined?)  && !@planning_application.drawings_ready_for_publication? %>
-            <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
-
-            <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>
-          <% else %>
+          <% if @planning_application.awaiting_determination? || @planning_application.determined? %>
             <span class="app-task-list__task-name"><%= step_name %></span>
-          <% end %>
 
-          <% if @planning_application.drawings_ready_for_publication? %>
-            <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+            <% if @planning_application.drawings_ready_for_publication? %>
+              <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
+            <% end %>
+          <% else %>
+            <% if @planning_application.drawings_ready_for_publication? %>
+              <% aria_attributes = { describedby: "#{step_name.parameterize}-completed" } %>
+
+              <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>
+
+              <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
+            <% elsif !@planning_application.drawings.has_proposed_tag.numbered.count.zero? && (@planning_application.drawings.has_proposed_tag.numbered.count < @planning_application.drawings.has_proposed_tag.count) %>
+              <% aria_attributes = { describedby: "#{step_name.parameterize}-in-progress" } %>
+
+              <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application), aria: aria_attributes %></span>
+
+              <%= tag.strong "In Progress", id: "#{step_name.parameterize}-in-progress", class: "govuk-tag govuk-tag--grey app-task-list__task-tag" %>
+            <% else %>
+              <span class="app-task-list__task-name"><%= link_to step_name, edit_numbers_planning_application_drawings_path(@planning_application) %></span>
+            <% end %>
           <% end %>
         </li>
       <% end %>
@@ -56,7 +68,7 @@
         <% end %>
 
         <% if recommendation_step_mark_completed?(step_name, @planning_application) %>
-          <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-completed" %>
+          <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
         <% end %>
       </li>
     </ul>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -29,27 +29,6 @@
       </strong>
     </p>
     <p class="govuk-body">1 The development shall be carried out in accordance with the following approved plans:</p>
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header app-custom-class">Plan reference number</th>
-          <th scope="col" class="govuk-table__header app-custom-class">Plan description</th>
-          <th scope="col" class="govuk-table__header app-custom-class">Date received</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">[Plan reference number]</td>
-          <td class="govuk-table__cell">[Document name]</td>
-          <td class="govuk-table__cell">[ DD MONTH YYYY ]</td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">[Plan reference number]</td>
-          <td class="govuk-table__cell">[Document name]</td>
-          <td class="govuk-table__cell">[ DD MONTH YYYY ]</td>
-        </tr>
-      </tbody>
-    </table>
   <% elsif decision.refused? %>
     <p class="govuk-body">
       IT IS HEREBY CERTIFIED that the use or operations described below are
@@ -60,7 +39,30 @@
       <p class="govuk-body">The proposal does not comply with:</p>
       <p class="govuk-body"> <%= planning_application.assessor_decision.public_comment %> </p>
     <% end %>
+    <p class="govuk-body">
+    The proposal was refused based on the following plans:
+    </p>
   <% end %>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header app-custom-class">Plan reference number</th>
+          <th scope="col" class="govuk-table__header app-custom-class">Date received</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% planning_application.drawings.for_publication.each do |drawing| %>
+         <% if drawing.numbers.present? %>
+          <% drawing.numbers.split(",").each do |number| %>
+            <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><%= number %></td>
+            <td class="govuk-table__cell"><%= drawing.created_at.strftime("%e %B %Y") %></td>
+          </tr>
+         <% end %>
+        <% end %>
+       <% end %>
+      </tbody>
+    </table>
   <p class="govuk-body">Signed: Simon Bevan
     <br>
     Director of Planning

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,10 @@ Rails.application.routes.draw do
   resources :planning_applications, only: %i[show index edit update] do
     resources :decisions, only: %i[new create edit update show]
 
-
     resources :drawings, only: %i[index new create] do
+      get :edit_numbers, on: :collection
+      put :update_numbers, on: :collection
+
       get :archive
       get :confirm
 

--- a/db/migrate/20200805112602_add_numbers_to_drawings.rb
+++ b/db/migrate/20200805112602_add_numbers_to_drawings.rb
@@ -1,0 +1,5 @@
+class AddNumbersToDrawings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :drawings, :numbers, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_30_113602) do
+ActiveRecord::Schema.define(version: 2020_08_05_112602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 2020_07_30_113602) do
     t.datetime "archived_at"
     t.integer "archive_reason"
     t.jsonb "tags", default: [], null: false
+    t.jsonb "numbers", default: [], null: false
     t.index ["planning_application_id"], name: "index_drawings_on_planning_application_id"
   end
 

--- a/spec/factories/drawing.rb
+++ b/spec/factories/drawing.rb
@@ -6,6 +6,18 @@ FactoryBot.define do
   end
 
   trait :with_plan do
-    plan { fixture_file_upload(Rails.root.join("spec/fixtures/images/existing-floorplan.png"), "existing-floorplan/png") }
+    plan { fixture_file_upload(Rails.root.join("spec/fixtures/images/proposed-floorplan.png"), "proposed-floorplan/png") }
+  end
+
+  trait :archived do
+    archived_at { Time.current }
+  end
+
+  trait :proposed_tags do
+    tags { [Drawing::PROPOSED_TAGS.first] }
+  end
+
+  trait :existing_tags do
+    tags { [Drawing::EXISTING_TAGS.first] }
   end
 end

--- a/spec/factories/drawing.rb
+++ b/spec/factories/drawing.rb
@@ -20,4 +20,8 @@ FactoryBot.define do
   trait :existing_tags do
     tags { [Drawing::EXISTING_TAGS.first] }
   end
+
+  trait :numbered do
+    numbers { "drawing_number" }
+  end
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -8,6 +8,24 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     let!(:planning_application) { create(:planning_application, :determined) }
     let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
 
+    let!(:drawing_with_proposed_tags) do
+      create :drawing, :proposed_tags,
+             planning_application: planning_application,
+             numbers: "proposed_number_1, proposed_number_2"
+    end
+
+    let!(:archived_drawing_with_proposed_tags) do
+      create :drawing, :archived, :proposed_tags,
+             planning_application: planning_application,
+             numbers: "archived_number"
+    end
+
+    let!(:drawing_with_existing_tags) do
+      create :drawing, :existing_tags,
+             planning_application: planning_application,
+             numbers: "existing_number"
+    end
+
     let(:mail) { PlanningApplicationMailer.decision_notice_mail(planning_application.reload) }
 
     it "renders the headers" do
@@ -22,6 +40,19 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(mail.body.encoded).to match("Application received: #{planning_application.created_at.strftime("%e %B %Y")}")
       expect(mail.body.encoded).to match("Address: #{planning_application.site.full_address}")
       expect(mail.body.encoded).to match("Application number: #{planning_application.reference}")
+    end
+
+    it "renders numbers for active drawings with proposed tags" do
+      expect(mail.body.encoded).to match("proposed_number_1")
+      expect(mail.body.encoded).to match("proposed_number_2")
+    end
+
+    it "does not render numbers for archived drawings with proposed tags" do
+      expect(mail.body.encoded).not_to match("archived_number")
+    end
+
+    it "does not render numbers for active drawings that have only existing tags" do
+      expect(mail.body.encoded).not_to match("existing_number")
     end
 
     context "for a rejected application" do

--- a/spec/models/drawing_numbers_list_form_spec.rb
+++ b/spec/models/drawing_numbers_list_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DrawingNumbersListForm, type: :model do
+  let(:drawings_to_update) { create_list :drawing, 2 }
+
+  subject do
+    described_class.new(drawings_to_update, drawing_numbers_hash)
+  end
+
+  describe "#update_all" do
+    context "when the hash contains blank numbers" do
+      let(:drawing_numbers_hash) do
+        {
+          drawings_to_update.first.id.to_s => {
+            "numbers" => "one, two"
+          },
+          drawings_to_update.last.id.to_s => {
+            "numbers" => ""
+          }
+        }
+      end
+
+      it "returns false" do
+        expect(subject.update_all).to eq false
+      end
+
+      it "assigns errors to drawings" do
+         subject.update_all
+
+         expect(subject.drawings.last.errors).not_to be_empty
+      end
+
+      it "does not persist any drawing numbers to the database" do
+         subject.update_all
+
+         persisted_drawings = Drawing.find(drawings_to_update.map(&:id))
+
+         persisted_drawings.each do |drawing|
+          expect(drawing.numbers).to be_empty
+         end
+      end
+    end
+
+    context "when the hash is missing an id for the supplied drawings" do
+      let(:drawing_numbers_hash) do
+        {
+          drawings_to_update.first.id.to_s => {
+            "numbers" => "one"
+          },
+          # no key for second drawing id
+        }
+      end
+
+      it "returns false" do
+        expect(subject.update_all).to eq false
+      end
+    end
+
+    context "when the hash has keys for all drawings with valid numbers" do
+      let(:drawing_numbers_hash) do
+        {
+          drawings_to_update.first.id.to_s => {
+            "numbers" => "one, two"
+          },
+          drawings_to_update.last.id.to_s => {
+            "numbers" => "three"
+          }
+        }
+      end
+
+      it "returns true" do
+        expect(subject.update_all).to eq true
+      end
+
+      it "assigns the numbers to the relevant drawings" do
+        subject.update_all
+
+        expect(drawings_to_update.first.numbers).to eq "one, two"
+        expect(drawings_to_update.last.numbers).to eq "three"
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -145,4 +145,39 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  describe "#drawing_numbering_partially_completed?" do
+    it "returns false when there are no drawings" do
+      expect(subject.drawing_numbering_partially_completed?).to eq false
+    end
+
+    context "when all relevant drawings are numbered" do
+      let!(:proposed_drawing_1) do
+        create :drawing, :proposed_tags,
+        planning_application: subject,
+        numbers: "number"
+      end
+
+      it "returns false" do
+        expect(subject.drawing_numbering_partially_completed?).to eq false
+      end
+    end
+
+    context "when one relevant drawing has a number and another does not" do
+      let!(:proposed_drawing_1) do
+        create :drawing, :proposed_tags,
+        planning_application: subject,
+        numbers: "number"
+      end
+
+      let!(:proposed_drawing_2) do
+        create :drawing, :proposed_tags,
+        planning_application: subject
+      end
+
+      it "returns true" do
+        expect(subject.drawing_numbering_partially_completed?).to eq true
+      end
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -92,11 +92,57 @@ RSpec.describe PlanningApplication, type: :model do
     end
   end
 
-  subject { create :planning_application, id: 1000 }
-
   describe "#reference" do
     it "pads the ID correctly" do
+      subject.update(id: 1000)
+
       expect(subject.reference).to eq "00001000"
+    end
+  end
+
+  describe "#drawings_ready_for_publication?" do
+    let!(:proposed_drawing_1) do
+      create :drawing, :with_plan, :proposed_tags,
+            planning_application: subject,
+            numbers: "number"
+    end
+
+    let!(:existing_drawing) do
+      create :drawing, :with_plan, :existing_tags,
+            planning_application: subject
+    end
+
+    let!(:archived_drawing) do
+      create :drawing, :with_plan, :proposed_tags, :archived,
+            planning_application: subject,
+            numbers: "number"
+    end
+
+    context "when all proposed, non-archived drawings have numbers" do
+      it "returns true" do
+        expect(subject.drawings_ready_for_publication?).to eq true
+      end
+    end
+
+    context "when there is a proposed, non-archived drawing without numbers" do
+      let!(:proposed_drawing_2) do
+        create :drawing, :with_plan, :proposed_tags,
+              planning_application: subject
+      end
+
+      it "returns false" do
+        expect(subject.drawings_ready_for_publication?).to eq false
+      end
+    end
+
+    context "when there are no drawings" do
+      before do
+        subject.drawings.delete_all
+      end
+
+      it "returns false" do
+        expect(subject.drawings_ready_for_publication?).to eq false
+      end
     end
   end
 end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-RSpec::Matchers.define :have_completed_tag do
-  match do |page|
-    page.find(:xpath, "./strong[@class=\"govuk-tag app-task-list__task-completed\"]")
-  end
-end

--- a/spec/support/shared_examples/assessor_decision_error_examples.rb
+++ b/spec/support/shared_examples/assessor_decision_error_examples.rb
@@ -18,6 +18,6 @@ RSpec.shared_examples 'assessor decision error message' do
 
     click_link "Home"
 
-    expect(page).not_to have_css(".app-task-list__task-completed")
+    expect(page).not_to have_content("Completed")
   end
 end

--- a/spec/support/shared_examples/reviewer_decision_error_examples.rb
+++ b/spec/support/shared_examples/reviewer_decision_error_examples.rb
@@ -18,6 +18,6 @@ RSpec.shared_examples 'reviewer decision error message' do
 
     click_link "Home"
 
-    expect(page).not_to have_css(".app-task-list__task-completed")
+    expect(page).not_to have_content ("Completed")
   end
 end

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -135,7 +135,7 @@ RSpec.feature "Drawings index page", type: :system do
       choose "Yes"
       click_button "Save"
 
-      expect(page).to have_text("existing-floorplan.png has been archived")
+      expect(page).to have_text("proposed-floorplan.png has been archived")
     end
 
     scenario "Assessor sees error message if neither Yes nor No is selected" do
@@ -154,7 +154,7 @@ RSpec.feature "Drawings index page", type: :system do
 
       within(find(".archived-drawings")) do
         expect(page).to have_text("Missing scale bar")
-        expect(page).to have_text("existing-floorplan.png")
+        expect(page).to have_text("proposed-floorplan.png")
 
         drawing_tags.each do |tag|
           expect(page).to have_css(".govuk-tag", text: tag)

--- a/spec/system/drawings/edit_numbers_spec.rb
+++ b/spec/system/drawings/edit_numbers_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Edit drawing numbers page", type: :system do
+  let!(:planning_application) do
+    create :planning_application,
+           :lawfulness_certificate
+  end
+
+  context "as a user who is not logged in" do
+    scenario "User cannot see edit_numbers page" do
+      visit edit_numbers_planning_application_drawings_path(planning_application)
+      expect(page).to have_current_path(/sign_in/)
+      expect(page).to have_content("You need to sign in or sign up before continuing.")
+    end
+  end
+
+  context "as an assessor" do
+    before do
+      sign_in users(:assessor)
+      visit planning_application_path(planning_application)
+    end
+
+    context "when there are no drawings that require numbers" do
+      scenario "shows a message and links to the document upload page" do
+        click_link "Attach drawing numbers"
+
+        expect(page).to have_content("No drawings are available")
+        expect(page).to have_link("upload proposal documents", href: /drawings\/new/)
+        expect(page).to have_link("Back", href: /planning_applications\//)
+      end
+    end
+
+    context "when there are drawings that require numbers" do
+      let!(:proposed_tag) { Drawing::PROPOSED_TAGS.first }
+
+      let!(:proposed_drawing_1) do
+        create :drawing, :with_plan, tags: [ proposed_tag ],
+              planning_application: planning_application
+      end
+
+      let!(:proposed_drawing_2) do
+        create :drawing, :with_plan, tags: [ proposed_tag ],
+              planning_application: planning_application
+      end
+
+      let!(:existing_drawing) do
+        create :drawing, :with_plan, :existing_tags,
+              planning_application: planning_application
+      end
+
+      let!(:archived_drawing) do
+        create :drawing, :with_plan, :proposed_tags, :archived,
+              planning_application: planning_application
+      end
+
+      before do
+        click_link "Attach drawing numbers"
+      end
+
+      scenario "Assessor can see content for the right application" do
+        expect(page).to have_text(planning_application.reference)
+        expect(page).to have_text(planning_application.site.full_address)
+        expect(page).to have_text("Attach drawing numbers")
+        expect(page).to have_text("These will be published in the decision notice.")
+      end
+
+      scenario "Assessor can see information about the drawing" do
+        within(all(".thumbnail").first) do
+          expect(page).to have_text(proposed_tag)
+          expect(page).to have_text("proposed-floorplan.png")
+        end
+      end
+
+      scenario "Assessor is able to add drawing numbers and save them" do
+        within(all(".thumbnail").first) do
+          fill_in "numbers", with: "new_number_1, new_number_2"
+        end
+
+        click_button "Save"
+
+        expect(page).to have_content "Attach drawing numbers"
+
+        within(all(".thumbnail").first) do
+          # the submitted values are re-presented in the form
+          expect(find_field("numbers")).to have_content "new_number_1, new_number_2"
+        end
+
+        within(all(".thumbnail").last) do
+          expect(page).to have_content("Provide at least one number")
+          fill_in "numbers", with: "other_new_number_1"
+        end
+
+        click_button "Save"
+
+        # redirected to the application assessment page
+        expect(page).to have_text("Make recommendation")
+        expect(page).to have_text("Updated 2 drawings with numbers")
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_link("Assess the proposal")
 
     # No steps have been completed
-    expect(page).not_to have_css(".app-task-list__task-completed")
+    expect(page).not_to have_content("Completed")
 
     # Cannot submit until preparation steps have been completed
     expect(page).not_to have_link("Submit the recommendation")
@@ -71,7 +71,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     click_button "Save"
 
     within(:assessment_step, "Assess the proposal") do
-      expect(page).to have_css(".app-task-list__task-completed")
+      expect(page).to have_content("Completed")
     end
 
     click_link "Assess the proposal"
@@ -89,7 +89,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     # Expect the 'completed' label to still be present for the evaluation step
     within(:assessment_step, "Assess the proposal") do
-      expect(page).to have_css(".app-task-list__task-completed")
+      expect(page).to have_content("Completed")
     end
 
     # Unable to submit yet because not all steps are complete
@@ -102,7 +102,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     click_button "Save"
 
     within(:assessment_step, "Attach drawing numbers") do
-      expect(page).to have_css(".app-task-list__task-completed")
+      expect(page).to have_content("Completed")
     end
 
     click_link "Submit the recommendation"
@@ -131,7 +131,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_link("Publish the recommendation")
 
     within(:assessment_step, "Review the recommendation") do
-      expect(page).not_to have_css(".app-task-list__task-completed")
+      expect(page).not_to have_content("Completed")
     end
 
     expect(page).not_to have_link "Attach drawing numbers"
@@ -194,6 +194,46 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
   end
 
+  context "when a drawing for publication is added after initial numbering" do
+    # Simulate a completed decision step
+    let!(:assessor_decision) { create :decision, :granted, user: users(:assessor), planning_application: planning_application }
+
+    # Number the current drawing
+    before { drawing.update(numbers: "a number") }
+
+    # Add a new drawing for publication which will require numbering
+    let!(:new_drawing_to_number) { create :drawing, :with_plan, :proposed_tags, planning_application: planning_application }
+
+    scenario "numbering needs to completed before submission" do
+      click_link planning_application.reference
+
+      expect(page).not_to have_link "Submit the recommendation"
+
+      within(:assessment_step, "Attach drawing numbers") do
+        expect(page).to have_content("In Progress")
+      end
+
+      click_link("Attach drawing numbers")
+
+      expect(page).to have_css(".thumbnail", count: 2)
+
+      within(all(".thumbnail").last) do
+        fill_in "Drawing number:", with: "new_drawing_number_1"
+      end
+
+      click_button "Save"
+
+      within(:assessment_step, "Attach drawing numbers") do
+        expect(page).to have_content("Completed")
+      end
+
+      click_link "Submit the recommendation"
+
+      expect(page).to have_content "a number"
+      expect(page).to have_content "new_drawing_number_1"
+    end
+  end
+
   scenario "shows the public_comment error message" do
     within("#in_assessment") do
       click_link planning_application.reference
@@ -213,7 +253,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     click_link "Home"
 
-    expect(page).not_to have_css(".app-task-list__task-completed")
+    expect(page).not_to have_content("Completed")
   end
 
   include_examples "assessor decision error message"

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe "Planning Application Assessment", type: :system do
             policy_considerations: [policy_consideration_1, policy_consideration_2]
   end
 
+  let!(:drawing) do
+    create :drawing, :with_plan, :proposed_tags,
+           planning_application: planning_application
+  end
+
   before do
     sign_in users(:assessor)
     visit root_path
@@ -37,12 +42,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_content("Make recommendation")
     expect(page).to have_link("Assess the proposal")
 
-    # The second step is not yet a link
-    expect(page).not_to have_link("Submit the recommendation")
-
-    # Ensure we're starting from a fresh "checklist"
+    # No steps have been completed
     expect(page).not_to have_css(".app-task-list__task-completed")
 
+    # Cannot submit until preparation steps have been completed
+    expect(page).not_to have_link("Submit the recommendation")
+
+    # Application not yet associated with the assessor
     within(".govuk-grid-column-two-thirds.application") do
       first('.govuk-accordion').click_button('Open all')
       expect(page).not_to have_text("Lorrine Krajcik")
@@ -50,25 +56,23 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     click_link "Assess the proposal"
 
+    expect(page).to have_content("Please review the applicant's answers")
+
+    # Application now associated with assessor
+    expect(page).to have_text("Lorrine Krajcik")
+
     expect(page).to have_content("The property is a semi detached house")
     expect(page).to have_content("The project will not alter the internal floor area of the building")
 
-    expect(page).to have_text("Lorrine Krajcik")
-
     choose "Yes"
-
-    expect(page).to have_content("Please provide supporting information for your manager. For example, you may want to add any details about the width, depth or height of the proposal. Your comment will not appear on the decision notice.")
 
     fill_in "private_comment", with: "This is a private comment"
 
     click_button "Save"
 
-    # Expect the 'completed' label to be present for the evaluation step
     within(:assessment_step, "Assess the proposal") do
-      expect(page).to have_completed_tag
+      expect(page).to have_css(".app-task-list__task-completed")
     end
-
-    expect(page).to have_link("Submit the recommendation")
 
     click_link "Assess the proposal"
 
@@ -85,7 +89,20 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     # Expect the 'completed' label to still be present for the evaluation step
     within(:assessment_step, "Assess the proposal") do
-      expect(page).to have_completed_tag
+      expect(page).to have_css(".app-task-list__task-completed")
+    end
+
+    # Unable to submit yet because not all steps are complete
+    expect(page).not_to have_link("Submit the recommendation")
+
+    click_link "Attach drawing numbers"
+
+    fill_in("Drawing number:", with: "proposed_drawing_number_1, proposed_drawing_number_2")
+
+    click_button "Save"
+
+    within(:assessment_step, "Attach drawing numbers") do
+      expect(page).to have_css(".app-task-list__task-completed")
     end
 
     click_link "Submit the recommendation"
@@ -97,16 +114,15 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     # Applicant
     expect(page).to have_content("#{planning_application.applicant.full_name}")
-    expect(page).to have_content("TBD")
     # Application received
     expect(page).to have_content("#{planning_application.created_at.strftime("%d/%m/%Y")}")
     # Address, TODO: add a fixture test for this
     # Application number
     expect(page).to have_content("#{planning_application.reference}")
-
+    # Drawings
+    expect(page).to have_content("proposed_drawing_number_1")
+    expect(page).to have_content("proposed_drawing_number_2")
     expect(page).to have_content("Certificate of lawful development (proposed) for the construction of #{planning_application.description}")
-
-    expect(page).to have_content("If you agree with the decision notice, please submit it to your manager. If your manager disagrees with your recommendation they will send it back to you to make changes.")
 
     click_button "Submit to manager"
 
@@ -114,7 +130,11 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_link("Review the recommendation")
     expect(page).to have_link("Publish the recommendation")
 
-    expect(page).not_to have_css(".app-task-list__task-completed")
+    within(:assessment_step, "Review the recommendation") do
+      expect(page).not_to have_css(".app-task-list__task-completed")
+    end
+
+    expect(page).not_to have_link "Attach drawing numbers"
 
     click_link "Review the recommendation"
     click_link "Back"
@@ -137,8 +157,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
     within("#awaiting_determination") do
       click_link planning_application.reference
     end
-
-    # TODO: Continue this spec until the assessor decision has been made and check that policy evaluations can no longer be made
   end
 
   scenario "Assessor is assigned to planning application" do

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
         click_button "Save"
 
         within(:assessment_step, "Reassess the proposal") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "Resubmit the recommendation"
@@ -183,7 +183,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
         click_button "Save"
 
         within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "Publish the recommendation"
@@ -194,7 +194,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
         click_button "Determine application"
 
         within(:assessment_step, "View the decision notice") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         expect(page).to have_link("View the assessment")

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_button "Save"
 
         within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "Review the recommendation"
@@ -82,7 +82,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         expect(page).to have_link("View the decision notice")
 
         within(:assessment_step, "View the decision notice") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "View the assessment"
@@ -136,7 +136,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_css(".app-task-list__task-completed")
+        expect(page).not_to have_content("Completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")
@@ -236,7 +236,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_button "Save"
 
         within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "Review the recommendation"
@@ -258,7 +258,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_button "Determine application"
 
         within(:assessment_step, "View the decision notice") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         expect(page).to have_link("View the assessment")
@@ -304,7 +304,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_css(".app-task-list__task-completed")
+        expect(page).not_to have_content("Completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")
@@ -363,7 +363,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_button "Save"
 
         within(:assessment_step, "Review the recommendation") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         click_link "Review the recommendation"
@@ -387,7 +387,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         click_button "Determine application"
 
         within(:assessment_step, "View the decision notice") do
-          expect(page).to have_completed_tag
+          expect(page).to have_content("Completed")
         end
 
         expect(page).to have_link("View the assessment")
@@ -433,7 +433,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_css(".app-task-list__task-completed")
+        expect(page).not_to have_content("Completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")
@@ -492,7 +492,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       expect(page).to have_link "Assess the proposal"
 
       within(:assessment_step, "Assess the proposal") do
-        expect(page).to have_completed_tag
+        expect(page).to have_content("Completed")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Co-Authored with @Rhian

Adds a drawing numbering step to assessments. Each proposed drawing requires one or more numbers to be suitable for publication. Numbers then appear in the decision notice page and email.

### [Story Link](https://www.pivotaltracker.com/n/projects/2441805/stories/173794989)

### Known issues

We do not block submissions of decisions or access to the drawing numbering page in our access control layer. We plan to address access control at several points in the application in another chore.

### UI

<img width="528" alt="Screenshot 2020-08-09 at 14 49 33" src="https://user-images.githubusercontent.com/1370570/89733870-5a925600-da50-11ea-90e7-680ffa7eae4f.png">
<img width="528" alt="Screenshot 2020-08-09 at 14 50 13" src="https://user-images.githubusercontent.com/1370570/89733869-5a925600-da50-11ea-9599-bbe9e6878c7f.png">
<img width="529" alt="Screenshot 2020-08-09 at 14 50 36" src="https://user-images.githubusercontent.com/1370570/89733868-59f9bf80-da50-11ea-9c75-97a09adf742c.png">
<img width="529" alt="Screenshot 2020-08-09 at 14 51 09" src="https://user-images.githubusercontent.com/1370570/89733864-56663880-da50-11ea-8da2-5a6bfa9068a1.png">