### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 /public/assets
 .byebug_history
+.DS_Store
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key


### PR DESCRIPTION
Stops OS X Finder adding noise to `git status` in development