### PR TITLE
Add subdomains [WIP]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.4)
-    puma (4.3.5)
+    puma (4.3.6)
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,13 @@ class ApplicationController < ActionController::Base
   def disable_flash_header
     @disable_flash_header = true
   end
+
+  def current_council
+    if request.subdomains.any?
+      Council.find_by! subdomain: request.subdomain
+    else
+      false
+    end
+  end
+  helper_method :current_council
 end

--- a/app/models/council.rb
+++ b/app/models/council.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Council < ApplicationRecord
+end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -3,5 +3,10 @@
     <div class="govuk-header__content">
       <%= link_to "Back-office Planning System", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
     </div>
+
+    <% if current_council != false %>
+      <%= current_council.name %>
+    <% end %>
+
   </div>
 </header>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  config.hosts << ".lvh.me"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # this match is an example on how we could constraint access to subdomain X. It needs to be placed before root.
+  # match '', to: "planning_applications#index", :via => [:get, :post], defaults: { q: "exclude_others" }, constraints: lambda { |r| r.subdomain.present? && r.subdomain != 'www'}
   root to: "planning_applications#index", defaults: { q: "exclude_others" }
 
   devise_for :users

--- a/db/migrate/20201117172619_create_councils.rb
+++ b/db/migrate/20201117172619_create_councils.rb
@@ -1,0 +1,10 @@
+class CreateCouncils < ActiveRecord::Migration[6.0]
+  def change
+    create_table :councils do |t|
+      t.string :name
+      t.string :subdomain
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_112602) do
+ActiveRecord::Schema.define(version: 2020_11_17_172619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,13 @@ ActiveRecord::Schema.define(version: 2020_08_05_112602) do
     t.string "phone_2"
     t.bigint "agent_id"
     t.index ["agent_id"], name: "index_applicants_on_agent_id"
+  end
+
+  create_table "councils", force: :cascade do |t|
+    t.string "name"
+    t.string "subdomain"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "decisions", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,3 +27,6 @@ Applicant.find_or_create_by!(email: "bops-team@unboxedconsulting.com") do |appli
   applicant.phone = Faker::Base.numerify("+44 7### ######")
   applicant.residence_status = true
 end
+
+Council.create! name: "Lambeth", subdomain: "lambeth-council"
+Council.create! name: "Southwark", subdomain: "southwark-council"

--- a/spec/factories/councils.rb
+++ b/spec/factories/councils.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :council do
+    name { "MyString" }
+    subdomain { "MyString" }
+  end
+end

--- a/spec/models/council_spec.rb
+++ b/spec/models/council_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Council, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
### Description of change

![image](https://user-images.githubusercontent.com/9452321/99519438-cb1f0c00-2989-11eb-8fd5-c03c40738de5.png)

![image](https://user-images.githubusercontent.com/9452321/99519993-77f98900-298a-11eb-870c-c7a9184169e5.png)

This WIP plays with the ability to add subdomains using native rails methods, without depending on gems.
To see this locally, start your rails server normally then head to 

```http://lambeth-council.lvh.me:3000/```
```http://southwark-council.lvh.me:3000/```

The idea would be to scope users per council, re-routing users depending on which council they belong to. Still thinking about the best practice to scope this.

Maybe a join table for council users instead of doing the dependency directly users - to - council would be best, to allow for multiple councils per user should the need occur.

### Story Link

https://trello.com/c/5Oujf3pn/6-support-multiple-councils
