### PR TITLE
Add subdomains

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,7 +76,7 @@ Layout/LeadingCommentSpace:
   Enabled: true
 
 Layout/LineLength:
-  Max: 80
+  Max: 120
   Exclude:
     - "spec/**/*"
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,4 +14,13 @@ class ApplicationController < ActionController::Base
   def disable_flash_header
     @disable_flash_header = true
   end
+
+  def current_authority
+    if request.subdomains.any?
+      LocalAuthority.find_by! subdomain: request.subdomain
+    else
+      false
+    end
+  end
+  helper_method :current_authority
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :find_current_local_authority_from_subdomain
   before_action :prevent_caching
 
+  attr_reader :current_local_authority
+  helper_method :current_local_authority
+
   private
+
+  def find_current_local_authority_from_subdomain
+    unless @current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomain)
+      render plain: "No Local Authority Found", status: 404
+    end
+  end
 
   def prevent_caching
     response.headers["Cache-Control"] = "no-cache, no-store"
@@ -14,13 +24,4 @@ class ApplicationController < ActionController::Base
   def disable_flash_header
     @disable_flash_header = true
   end
-
-  def current_authority
-    if request.subdomains.any?
-      LocalAuthority.find_by! subdomain: request.subdomain
-    else
-      false
-    end
-  end
-  helper_method :current_authority
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class LocalAuthority < ApplicationRecord
+  has_many :users, dependent: :destroy
+  has_many :planning_applications, dependent: :destroy
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -23,6 +23,7 @@ class PlanningApplication < ApplicationRecord
   belongs_to :agent
   belongs_to :applicant
   belongs_to :user, optional: true
+  belongs_to :local_authority, optional: true
 
   before_create :set_target_date
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -23,7 +23,7 @@ class PlanningApplication < ApplicationRecord
   belongs_to :agent
   belongs_to :applicant
   belongs_to :user, optional: true
-  belongs_to :local_authority, optional: true
+  belongs_to :local_authority
 
   before_create :set_target_date
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,5 +10,5 @@ class User < ApplicationRecord
 
   has_many :decisions, dependent: :restrict_with_exception
   has_many :planning_applications, through: :decisions
-  belongs_to :local_authority, optional: true
+  belongs_to :local_authority
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,5 @@ class User < ApplicationRecord
 
   has_many :decisions, dependent: :restrict_with_exception
   has_many :planning_applications, through: :decisions
+  belongs_to :local_authority, optional: true
 end

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -11,19 +11,19 @@ class PlanningApplicationPolicy < ApplicationPolicy
   alias_method :update_numbers?, :editor?
 
   def show?
-    super || signed_in_viewer?
+    (super || signed_in_viewer?) && record.local_authority_id == user.local_authority_id
   end
 
   def index?
-    super || signed_in_viewer?
+    (super || signed_in_viewer?) && record.local_authority_id == user.local_authority_id
   end
 
   def edit?
-    super || signed_in_editor?
+    (super || signed_in_editor?) && record.local_authority_id == user.local_authority_id
   end
 
   def update?
-    super || signed_in_editor?
+    (super || signed_in_editor?) && record.local_authority_id == user.local_authority_id
   end
 
   def unpermitted_statuses
@@ -37,6 +37,19 @@ class PlanningApplicationPolicy < ApplicationPolicy
       [ "determined" ]
     else
       []
+    end
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.where(local_authority_id: user.local_authority_id)
     end
   end
 end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -4,9 +4,7 @@
       <%= link_to "Back-office Planning System", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
     </div>
 
-    <% if current_authority != false %>
-      <%= current_authority.name %>
-    <% end %>
+    <%= current_local_authority.name %>
 
   </div>
 </header>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,10 +1,7 @@
 <header class="govuk-header  with-proposition " role="banner" data-module="govuk-header">
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__content">
-      <%= link_to "Back-office Planning System", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+      <%= link_to "Back-office Planning System: #{current_local_authority.name}", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
     </div>
-
-    <%= current_local_authority.name %>
-
   </div>
 </header>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -3,5 +3,10 @@
     <div class="govuk-header__content">
       <%= link_to "Back-office Planning System", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
     </div>
+
+    <% if current_authority != false %>
+      <%= current_authority.name %>
+    <% end %>
+
   </div>
 </header>

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -11,6 +11,7 @@ Date of Issue of this decision: <%= @planning_application.determined_at.strftime
 Application received: <%= @planning_application.created_at.strftime("%e %B %Y") %>
 Address: <%= @planning_application.site.full_address %>
 Application number: <%= @planning_application.reference %>
+Local authority: <%= @planning_application.local_authority.name %>
 
 Proposed use or development:
 Certificate of lawful development (proposed) for the construction of <%= @planning_application.description %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,4 +68,6 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
+  config.hosts << ".lvh.me"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # this match is an example on how we could constraint access to subdomain X
-  # it needs to be placed before root.
-  # match '', to: "planning_applications#index", :via => [:get, :post],
-  # defaults: { q: "exclude_others" },
-  # constraints: lambda { |r| r.subdomain.present? && r.subdomain != 'www'}
   root to: "planning_applications#index", defaults: { q: "exclude_others" }
 
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  # this match is an example on how we could constraint access to subdomain X
+  # it needs to be placed before root.
+  # match '', to: "planning_applications#index", :via => [:get, :post],
+  # defaults: { q: "exclude_others" },
+  # constraints: lambda { |r| r.subdomain.present? && r.subdomain != 'www'}
   root to: "planning_applications#index", defaults: { q: "exclude_others" }
 
   devise_for :users

--- a/db/migrate/20201119113149_create_local_authorities.rb
+++ b/db/migrate/20201119113149_create_local_authorities.rb
@@ -1,0 +1,10 @@
+class CreateLocalAuthorities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :local_authorities do |t|
+      t.string :name
+      t.string :subdomain
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201119114857_add_local_authority_to_usersand_planning_applications.rb
+++ b/db/migrate/20201119114857_add_local_authority_to_usersand_planning_applications.rb
@@ -1,0 +1,6 @@
+class AddLocalAuthorityToUsersandPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :users, :local_authority
+    add_reference :planning_applications, :local_authority
+  end
+end

--- a/db/migrate/20201120161436_reindex_users_by_email_and_subdomain.rb
+++ b/db/migrate/20201120161436_reindex_users_by_email_and_subdomain.rb
@@ -1,0 +1,11 @@
+class ReindexUsersByEmailAndSubdomain < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :users, :email
+    add_index :users, [:email, :local_authority_id], :unique => true
+  end
+
+  def down
+    remove_index :users, [:email, :local_authority_id]
+    add_index :users, :email, :unique => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_19_114857) do
+ActiveRecord::Schema.define(version: 2020_11_20_161436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,7 +170,7 @@ ActiveRecord::Schema.define(version: 2020_11_19_114857) do
     t.integer "role", default: 0
     t.string "name"
     t.bigint "local_authority_id"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true
     t.index ["local_authority_id"], name: "index_users_on_local_authority_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_05_112602) do
+ActiveRecord::Schema.define(version: 2020_11_19_114857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,13 @@ ActiveRecord::Schema.define(version: 2020_08_05_112602) do
     t.index ["planning_application_id"], name: "index_drawings_on_planning_application_id"
   end
 
+  create_table "local_authorities", force: :cascade do |t|
+    t.string "name"
+    t.string "subdomain"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "planning_applications", force: :cascade do |t|
     t.date "target_date", null: false
     t.integer "application_type", default: 0, null: false
@@ -117,8 +124,10 @@ ActiveRecord::Schema.define(version: 2020_08_05_112602) do
     t.datetime "awaiting_determination_at"
     t.datetime "in_assessment_at"
     t.datetime "awaiting_correction_at"
+    t.bigint "local_authority_id"
     t.index ["agent_id"], name: "index_planning_applications_on_agent_id"
     t.index ["applicant_id"], name: "index_planning_applications_on_applicant_id"
+    t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"
   end
@@ -160,7 +169,9 @@ ActiveRecord::Schema.define(version: 2020_08_05_112602) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "role", default: 0
     t.string "name"
+    t.bigint "local_authority_id"
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["local_authority_id"], name: "index_users_on_local_authority_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 require "faker"
 
+lambeth = LocalAuthority.find_or_create_by!(name: "Lambeth Council", subdomain: "lambeth")
+
 User.find_or_create_by!(email: "admin@example.com") do |user|
   user.name = "#{Faker::Name.unique.first_name} #{Faker::Name.unique.last_name}"
+  user.local_authority = lambeth
 
   if Rails.env.development?
     user.password = user.password_confirmation = "password"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,6 +2,7 @@
 require "faker"
 
 lambeth = LocalAuthority.find_or_create_by!(name: "Lambeth Council", subdomain: "lambeth")
+southwark = LocalAuthority.find_or_create_by!(name: "Southwark Council", subdomain: "southwark")
 
 User.find_or_create_by!(email: "admin@example.com") do |user|
   user.name = "#{Faker::Name.unique.first_name} #{Faker::Name.unique.last_name}"

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -42,7 +42,7 @@ task create_sample_data: :environment do
       first_name = Faker::Name.unique.first_name
       last_name = Faker::Name.unique.last_name
       user.name = "#{first_name} #{last_name}"
-
+      user.local_authority = southwark
       if Rails.env.development?
         user.password = user.password_confirmation = "password"
       else
@@ -58,6 +58,7 @@ task create_sample_data: :environment do
       first_name = Faker::Name.unique.first_name
       last_name = Faker::Name.unique.last_name
       user.name = "#{first_name} #{last_name}"
+      user.local_authority = southwark
       if Rails.env.development?
         user.password = user.password_confirmation = "password"
       else
@@ -150,7 +151,8 @@ task create_sample_data: :environment do
     ward: "Dulwich Wood",
     agent: agent,
     applicant: applicant,
-    user: assessor
+    user: assessor,
+    local_authority: southwark
   ) do |pa|
     pa.description = "Installation of new external insulated render to be added"
   end

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -27,11 +27,11 @@ task create_sample_data: :environment do
   plan_4 = Rails.root.join("#{image_path}proposed-floorplan.png")
 
   lambeth = LocalAuthority.find_or_create_by!(
-    name: "Lambeth",
+    name: "Lambeth Council",
     subdomain: "lambeth"
   )
   southwark = LocalAuthority.find_or_create_by!(
-    name: "Southwark",
+    name: "Southwark Council",
     subdomain: "southwark"
   )
 

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :local_authority do
+    name { Faker::Name.name }
+    subdomain { Faker::Name.name }
+  end
+end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     site
     agent
     applicant
+    local_authority
     description      { Faker::Lorem.unique.sentence }
     status           { :in_assessment }
     in_assessment_at { Time.current }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :user do
+    local_authority
     name { Faker::Name.name }
     email { Faker::Internet.email }
     password  { "password123" }

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#decision_notice_mail" do
-    let!(:reviewer) { create :user, :reviewer }
-    let!(:planning_application) { create(:planning_application, :determined) }
+    let(:local_authority) { create :local_authority }
+    let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
+    let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority) }
     let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
 
     let!(:drawing_with_proposed_tags) do
@@ -40,6 +41,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(mail.body.encoded).to match("Application received: #{planning_application.created_at.strftime("%e %B %Y")}")
       expect(mail.body.encoded).to match("Address: #{planning_application.site.full_address}")
       expect(mail.body.encoded).to match("Application number: #{planning_application.reference}")
+      expect(mail.body.encoded).to match("Local authority: #{planning_application.local_authority.name}")
     end
 
     it "renders numbers for active drawings with proposed tags" do

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LocalAuthority, type: :model do
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,4 +34,13 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.include Devise::Test::IntegrationHelpers, type: :request
+
+  config.before(:each) do |example|
+    @default_local_authority = LocalAuthority.find_or_create_by!(name: 'Default Authority', subdomain: 'default')
+    if example.metadata[:type] == :request
+      host! "default.example.com"
+    elsif example.metadata[:type] == :system
+      host! "http://default.example.com"
+    end
+  end
 end

--- a/spec/requests/planning_application_request_spec.rb
+++ b/spec/requests/planning_application_request_spec.rb
@@ -11,7 +11,8 @@ RSpec.describe "PlanningApplications", type: :request do
   end
 
   describe "PATCH #update" do
-    let(:planning_application) { create :planning_application }
+    let(:local_authority) { create :local_authority }
+    let(:planning_application) { create :planning_application, local_authority: local_authority }
 
     subject {
       patch "/planning_applications/#{planning_application.id}",
@@ -23,7 +24,7 @@ RSpec.describe "PlanningApplications", type: :request do
     end
 
     context "for an assessor" do
-      let(:user) { create :user, :assessor }
+      let(:user) { create :user, :assessor, local_authority: local_authority }
 
       context "setting the status to \"awaiting_determination\"" do
         let(:status) { :awaiting_determination }
@@ -57,7 +58,7 @@ RSpec.describe "PlanningApplications", type: :request do
     end
 
     context "for a reviewer" do
-      let(:user) { create :user, :reviewer }
+      let(:user) { create :user, :reviewer, local_authority: local_authority }
 
       context "setting the status to \"determined\"" do
         let(:status) { :determined }
@@ -100,7 +101,7 @@ RSpec.describe "PlanningApplications", type: :request do
     end
 
     context "for an admin" do
-      let(:user) { create :user, :admin }
+      let(:user) { create :user, :admin, local_authority: local_authority }
 
       context "setting the status to \"determined\"" do
         let(:status) { :determined }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -34,7 +34,5 @@ RSpec.configure do |config|
 
   config.before type: :system do
     driven_by(ENV.fetch("JS_DRIVER", "chrome_headless").to_sym)
-
-    host! "http://localhost"
   end
 end

--- a/spec/system/drawings/archive_spec.rb
+++ b/spec/system/drawings/archive_spec.rb
@@ -3,14 +3,16 @@
 require "rails_helper"
 
 RSpec.feature "Drawings index page", type: :system do
+  let(:local_authority) { create :local_authority }
   let(:site) { create :site, address_1: "Elm Grove" }
-  let(:assessor) { create :user, :assessor }
-  let(:reviewer) { create :user, :reviewer }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
   let!(:planning_application) do
     create :planning_application,
            :lawfulness_certificate,
-           site: site
+           site: site,
+           local_authority: local_authority
   end
 
   let(:drawing_tags) {

--- a/spec/system/drawings/edit_numbers_spec.rb
+++ b/spec/system/drawings/edit_numbers_spec.rb
@@ -3,13 +3,14 @@
 require "rails_helper"
 
 RSpec.feature "Edit drawing numbers page", type: :system do
+  let(:local_authority) { create :local_authority }
   let!(:planning_application) do
     create :planning_application,
-           :lawfulness_certificate
+           :lawfulness_certificate,
+           local_authority: local_authority
   end
-
-  let!(:assessor) { create :user, :assessor }
-  let!(:reviewer) { create :user, :reviewer }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
   context "as a user who is not logged in" do
     scenario "User cannot see edit_numbers page" do

--- a/spec/system/drawings/index_spec.rb
+++ b/spec/system/drawings/index_spec.rb
@@ -4,13 +4,15 @@ require "rails_helper"
 
 RSpec.feature "Drawings index page", type: :system do
   let!(:site) { create :site, address_1: "7 Elm Grove" }
-  let(:assessor) { create :user, :assessor }
-  let(:reviewer) { create :user, :reviewer }
+  let(:local_authority) { create :local_authority }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
   let!(:planning_application) do
     create :planning_application,
            :lawfulness_certificate,
-           site: site
+           site: site,
+           local_authority: local_authority
   end
 
   let!(:drawing) do

--- a/spec/system/drawings/upload_spec.rb
+++ b/spec/system/drawings/upload_spec.rb
@@ -3,14 +3,16 @@
 require "rails_helper"
 
 RSpec.describe "Document uploads", type: :system do
+  let(:local_authority) { create :local_authority }
   let!(:planning_application) do
     create :planning_application,
-           :lawfulness_certificate
+           :lawfulness_certificate,
+           local_authority: local_authority
   end
 
   let!(:drawing) { create :drawing, :with_plan, planning_application: planning_application }
-  let(:assessor) { create :user, :assessor }
-  let(:reviewer) { create :user, :reviewer }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
   context "for an assessor" do
     before { sign_in assessor }

--- a/spec/system/local_authorities_spec.rb
+++ b/spec/system/local_authorities_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.feature "Accessing correct local authority", type: :system do
+
+ let!(:lambeth) { create :local_authority, name: "Lambeth Council", subdomain: "lambeth" }
+ let!(:southwark) { create :local_authority, name: "Southwark Council", subdomain: "southwark" }
+
+  before do
+    @previous_host = Capybara.app_host
+    host! "http://lambeth.example.com"
+  end
+
+  after do
+    host! "http://#{@previous_host}"
+  end
+
+  scenario "visit namespaced path" do
+    visit root_path
+
+    expect(page.body).to have_content("Lambeth Council")
+    expect(page.body).to_not have_content("Southwark Council")
+  end
+end

--- a/spec/system/local_authorities_spec.rb
+++ b/spec/system/local_authorities_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature "Accessing correct local authority", type: :system do
 
     scenario "visit non existing path" do
       visit root_path
-
       expect(page).to have_content("No Local Authority Found")
     end
   end

--- a/spec/system/local_authorities_spec.rb
+++ b/spec/system/local_authorities_spec.rb
@@ -3,23 +3,40 @@
 require "rails_helper"
 
 RSpec.feature "Accessing correct local authority", type: :system do
+  let!(:lambeth) { create :local_authority, name: "Lambeth Council", subdomain: "lambeth" }
+  let!(:southwark) { create :local_authority, name: "Southwark Council", subdomain: "southwark" }
+  context "Lambeth council" do
+    before do
+      @previous_host = Capybara.app_host
+      host! "http://lambeth.example.com"
+    end
 
- let!(:lambeth) { create :local_authority, name: "Lambeth Council", subdomain: "lambeth" }
- let!(:southwark) { create :local_authority, name: "Southwark Council", subdomain: "southwark" }
+    after do
+      host! "http://#{@previous_host}"
+    end
 
-  before do
-    @previous_host = Capybara.app_host
-    host! "http://lambeth.example.com"
+    scenario "visit namespaced path" do
+      visit root_path
+
+      expect(page.body).to have_content("Lambeth Council")
+      expect(page.body).to_not have_content("Southwark Council")
+    end
   end
 
-  after do
-    host! "http://#{@previous_host}"
-  end
+  context "Non existent council" do
+    before do
+      @previous_host = Capybara.app_host
+      host! "http://biscuits.example.com"
+    end
 
-  scenario "visit namespaced path" do
-    visit root_path
+    after do
+      host! "http://#{@previous_host}"
+    end
 
-    expect(page.body).to have_content("Lambeth Council")
-    expect(page.body).to_not have_content("Southwark Council")
+    scenario "visit non existing path" do
+      visit root_path
+
+      expect(page).to have_content("No Local Authority Found")
+    end
   end
 end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -3,12 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application Assessment", type: :system do
-  let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik" }
-  let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki" }
+  let(:local_authority) { create :local_authority }
+  let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik", local_authority: local_authority }
+  let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki", local_authority: local_authority }
 
   let!(:planning_application) do
     create :planning_application,
-            :lawfulness_certificate
+            :lawfulness_certificate,
+            local_authority: local_authority
   end
 
   let(:policy_consideration_1) do

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application correction journey", type: :system do
-    let(:assessor) { create :user, :assessor }
-    let(:reviewer) { create :user, :reviewer }
+    let(:local_authority) { create :local_authority }
+    let(:assessor) { create :user, :assessor, local_authority: local_authority }
+    let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
     let!(:planning_application_corrected) do
       create :planning_application,
       :lawfulness_certificate,
-      :awaiting_correction
+      :awaiting_correction,
+      local_authority: local_authority
     end
 
     let!(:assessor_decision) do

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -3,12 +3,13 @@
 require "rails_helper"
 
 RSpec.feature "Planning Application index page", type: :system do
-  let!(:planning_application_1) { create(:planning_application) }
-  let!(:planning_application_2) { create(:planning_application) }
-  let!(:planning_application_started) { create(:planning_application, :awaiting_determination) }
-  let!(:planning_application_completed) { create(:planning_application, :determined) }
-  let(:assessor) { create :user, :assessor }
-  let(:reviewer) { create :user, :reviewer }
+  let(:local_authority) { create :local_authority }
+  let!(:planning_application_1) { create :planning_application, local_authority: local_authority }
+  let!(:planning_application_2) { create :planning_application, local_authority: local_authority }
+  let!(:planning_application_started) { create :planning_application, :awaiting_determination, local_authority: local_authority }
+  let!(:planning_application_completed) { create :planning_application, :determined, local_authority: local_authority }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
 
   context "as an assessor" do
@@ -73,8 +74,8 @@ RSpec.feature "Planning Application index page", type: :system do
     end
 
     context "restricted views" do
-      let!(:second_assessor) { create(:user, :assessor) }
-      let!(:other_assessor_planning_application) { create(:planning_application, user_id: second_assessor.id) }
+      let!(:second_assessor) { create :user, :assessor, local_authority: local_authority }
+      let!(:other_assessor_planning_application) { create :planning_application, user_id: second_assessor.id, local_authority: local_authority }
 
       scenario "On login, assessor gets redirected to a view with its own and unassigned Planning Applications" do
         within("#in_assessment") do

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Planning Application Reviewing", type: :system do
   context "as a reviewer" do
     # Look at an application that has had some assessment work done by the assessor
+    let(:local_authority) { create :local_authority }
     let(:policy_evaluation) { create(:policy_evaluation, :met) }
     let(:assessor) { create :user, :assessor }
     let(:applicant) { create :applicant, email: "bigplans@example.com" }
@@ -13,11 +14,12 @@ RSpec.describe "Planning Application Reviewing", type: :system do
        :awaiting_determination,
        policy_evaluation: policy_evaluation,
        assessor_decision: assessor_decision,
-       applicant: applicant
+       applicant: applicant,
+       local_authority: local_authority
     end
-    let(:admin) { create :user, :admin }
-    let(:assessor) { create :user, :assessor }
-    let(:reviewer) { create :user, :reviewer }
+    let(:admin) { create :user, :admin, local_authority: local_authority }
+    let(:assessor) { create :user, :assessor, local_authority: local_authority }
+    let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
     before do
       sign_in reviewer
@@ -474,12 +476,15 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   end
 
   context "as an admin" do
-    let(:assessor) { create :user, :assessor }
-    let(:admin) { create :user, :admin }
+    let(:local_authority) { create :local_authority }
+    let(:assessor) { create :user, :assessor, local_authority: local_authority }
+    let(:admin) { create :user, :admin, local_authority: local_authority }
     let(:assessor_decision) { create :decision, :granted, user: assessor }
 
     let!(:planning_application) do
-      create :planning_application, assessor_decision: assessor_decision
+      create :planning_application,
+      assessor_decision: assessor_decision,
+      local_authority: local_authority
     end
 
     before do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -3,12 +3,13 @@
 require "rails_helper"
 
 RSpec.feature "Planning Application show page", type: :system do
+  let(:local_authority) { create :local_authority }
   let!(:site) { create :site, address_1: "7 Elm Grove", town: "London", postcode: "SE15 6UT" }
   let!(:applicant) { create :applicant, first_name: "Jason", last_name: "Collins", phone: "07814 222222", email: "applicant@example.com" }
   let!(:agent) { create :agent, first_name: "Jennifer", last_name: "Harper", phone: "07532 1133333", email: "agent@example.com" }
-  let!(:planning_application) { create :planning_application, description: "Roof extension", application_type: "lawfulness_certificate", status: :in_assessment, ward: "Dulwich Wood", agent: agent, applicant: applicant, site: site, target_date: Date.current + 14.days }
-  let(:assessor) { create :user, :assessor }
-  let(:reviewer) { create :user, :reviewer }
+  let!(:planning_application) { create :planning_application, description: "Roof extension", application_type: "lawfulness_certificate", status: :in_assessment, ward: "Dulwich Wood", agent: agent, applicant: applicant, site: site, target_date: Date.current + 14.days, local_authority: local_authority }
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+  let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
   context "as an assessor" do
     before do
@@ -95,7 +96,7 @@ RSpec.feature "Planning Application show page", type: :system do
 
   context "as an assessor" do
     let(:target_date) { 1.week.from_now }
-    let!(:planning_application) { create(:planning_application, :determined) }
+    let!(:planning_application) { create :planning_application, :determined, local_authority: local_authority }
 
     before do
       sign_in assessor


### PR DESCRIPTION
### Description of change

- Allows for different subdomains to be used on the application. It seeds the database with the two first ones, Lambeth and Southwark.
- Removes all fixtures in favour of factories, to standardise testing and also because fixtures caused issues when testing subdomains
- Modifies pundit policies to scope views by subdomain
- Increases overtly restrictive rubocop line limit


### Story Link

https://trello.com/c/5Oujf3pn/6-support-multiple-councils
