### PR TITLE
Add new fields to local authority

### DIFF
--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -1,4 +1,4 @@
-# Southwark Council
+# <%= @planning_application.local_authority.name %>
 
 # Town and country planning act 1990 (as amended)
 
@@ -41,12 +41,17 @@ Certificate of lawful development (proposed) for the construction of <%= @planni
   <% end %>
 <% end %>
 
-Signed: Simon Bevan
-Director of Planning
+Signed: <%= @planning_application.local_authority.signatory_name %>
+ <%= @planning_application.local_authority.signatory_job_title %>
 
 Your attention is drawn to the notes accompanying this document
 
-Any enquiries regarding this document should quote the Application Number and be sent to the Director of Planning, Southwark Council, Chief executive's department, Planning division, Development management, PO Box 64529, London SE1 5LX, or by email to planning.applications@southwark.gov.uk
+Any enquiries regarding this document should quote the Application Number and be sent to
+the
+<%= @planning_application.local_authority.signatory_job_title %>,
+<%= @planning_application.local_authority.name %>,
+<%= @planning_application.local_authority.enquiries_paragraph %>
+or by email to <%= @planning_application.local_authority.email_address %>
 
 <% if @decision.refused? %>
   [1] APPEAL TO THE SECRETARY OF STATE. If the applicant is aggrieved by this decision of the council to refuse an application for a Certificate of Lawfulness of Existing Use or Development or to refuse it in part the applicant may appeal to the Secretary of State in accordance with Section 195 of the Town and Country Planning Act 1990 within six months of the receipt of this notice. The Secretary of State can allow a longer period for giving notice of an appeal but will not normally use this power unless there are special circumstances which excuse the delay in giving notice of appeal. If you do decide to appeal you can do so using The Planning Inspectorate’s online appeals service. You can find the service through the appeals area of the Planning Portal at www.planningportal.gov.uk/pcs. You can also appeal by completing the appropriate form which you can get from The Planning Inspectorate, Customer Support Unit, Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN [tel. 0117-3726372]. The form can also be downloaded from the Inspectorate's website at www.planning-inspectorate.gov.uk. The Planning Inspectorate will publish details of your appeal on the internet on the appeals area of the Planning Portal. This may include a copy of the original planning application from and relevant supporting documents supplied to the council by you or your agent, together with the completed appeal form and information you submit to The Planning Inspectorate. Please ensure that you only provide information, including personal information belonging to you, that you are happy will be made available to others in this way. If you supply information belonging to someone else please ensure you have their permission to do so. More detailed information about data protection and privacy matters is available on the Planning Portal.

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -1,5 +1,5 @@
 <div style="background-color: #f3f2f1; border: solid 1px; padding: 30px; clear: both; margin-top: 10px;">
-  <span class="govuk-caption-xl">Southwark Council</span>
+  <span class="govuk-caption-xl"><%= planning_application.local_authority.name %> </span>
   <h2 class="govuk-heading-m">Town and country planning act 1990 (as amended)</h2>
   <p class="govuk-body"> <strong>Decision notice</strong> </p>
   <p class="govuk-body">Certificate of lawfulness of proposed use or development: <strong><%= "#{decision.status}." %></strong></p>
@@ -63,17 +63,21 @@
        <% end %>
       </tbody>
     </table>
-  <p class="govuk-body">Signed: Simon Bevan
+  <p class="govuk-body">Signed: <%= planning_application.local_authority.signatory_name %>
     <br>
-    Director of Planning
+    <%= planning_application.local_authority.signatory_job_title %>
   </p>
   <p class="govuk-body">
     Your attention is drawn to the notes accompanying this document
   </p>
 
   <p class="govuk-body">
-    Any enquiries regarding this document should quote the Application Number and be sent to the Director of Planning, Southwark Council, Chief executive's department, Planning division, Development management, PO Box 64529, London SE1 5LX, or by email
-    to planning.applications@southwark.gov.uk
+    Any enquiries regarding this document should quote the Application Number and be sent to
+    the
+    <%= planning_application.local_authority.signatory_job_title %>,
+    <%= planning_application.local_authority.name %>,
+    <%= planning_application.local_authority.enquiries_paragraph %>
+    or by email to <%= planning_application.local_authority.email_address %>
   </p>
   <% if decision.refused? %>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/db/migrate/20201125150405_add_fields_to_local_authority.rb
+++ b/db/migrate/20201125150405_add_fields_to_local_authority.rb
@@ -1,0 +1,8 @@
+class AddFieldsToLocalAuthority < ActiveRecord::Migration[6.0]
+  def change
+    add_column :local_authorities, :signatory_name, :string
+    add_column :local_authorities, :signatory_job_title, :string
+    add_column :local_authorities, :enquiries_paragraph, :text
+    add_column :local_authorities, :email_address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_20_161436) do
+ActiveRecord::Schema.define(version: 2020_11_25_150405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,10 @@ ActiveRecord::Schema.define(version: 2020_11_20_161436) do
     t.string "subdomain"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "signatory_name"
+    t.string "signatory_job_title"
+    t.text "enquiries_paragraph"
+    t.string "email_address"
   end
 
   create_table "planning_applications", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,27 @@
 # frozen_string_literal: true
 require "faker"
 
-lambeth = LocalAuthority.find_or_create_by!(name: "Lambeth Council", subdomain: "lambeth")
-southwark = LocalAuthority.find_or_create_by!(name: "Southwark Council", subdomain: "southwark")
+lambeth = LocalAuthority.find_or_create_by!(
+  name: "Lambeth Council",
+  subdomain: "lambeth",
+  signatory_name: "Christina Thompson",
+  signatory_job_title: "Director of Finance & Property",
+  enquiries_paragraph: "Postal address: Planning London Borough of Lambeth PO Box 734 Winchester SO23 5DG.",
+  email_address: "planning@lambeth.gov.uk"
+)
 
-User.find_or_create_by!(email: "admin@example.com") do |user|
+southwark = LocalAuthority.find_or_create_by!(
+  name: "Southwark Council",
+  subdomain: "southwark",
+  signatory_name: "Simon Bevan",
+  signatory_job_title: "Director of Planning",
+  enquiries_paragraph: "Postal address: Planning London Borough of Southwark PO Box 734 Winchester SO23 5DG.",
+  email_address: "planning@lambeth.gov.uk"
+)
+
+User.find_or_create_by!(email: "southwark_admin@example.com") do |user|
   user.name = "#{Faker::Name.unique.first_name} #{Faker::Name.unique.last_name}"
-  user.local_authority = lambeth
+  user.local_authority = southwark
 
   if Rails.env.development?
     user.password = user.password_confirmation = "password"

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -28,49 +28,22 @@ task create_sample_data: :environment do
 
   lambeth = LocalAuthority.find_or_create_by!(
     name: "Lambeth Council",
-    subdomain: "lambeth"
+    subdomain: "lambeth",
+    signatory_name: "Christina Thompson",
+    signatory_job_title: "Director of Finance & Property",
+    enquiries_paragraph: "Postal address: Planning London Borough of Lambeth PO Box 734 Winchester SO23 5DG.",
+    email_address: "planning@lambeth.gov.uk"
   )
   southwark = LocalAuthority.find_or_create_by!(
     name: "Southwark Council",
-    subdomain: "southwark"
+    subdomain: "southwark",
+    signatory_name: "Simon Bevan",
+    signatory_job_title: "Director of Planning",
+    enquiries_paragraph: "Postal address: Planning London Borough of Southwark PO Box 734 Winchester SO23 5DG.",
+    email_address: "planning@lambeth.gov.uk"
   )
 
   admin_roles = %i[assessor reviewer]
-
-  admin_roles.each do |admin_role|
-    User.find_or_create_by!(email: "#{admin_role}@example.com") do |user|
-      first_name = Faker::Name.unique.first_name
-      last_name = Faker::Name.unique.last_name
-      user.name = "#{first_name} #{last_name}"
-      user.local_authority = southwark
-      if Rails.env.development?
-        user.password = user.password_confirmation = "password"
-      else
-        user.password = user.password_confirmation = SecureRandom.uuid
-        user.encrypted_password =
-          "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
-      end
-
-      user.role = admin_role
-    end
-
-    User.find_or_create_by!(email: "#{admin_role}2@example.com") do |user|
-      first_name = Faker::Name.unique.first_name
-      last_name = Faker::Name.unique.last_name
-      user.name = "#{first_name} #{last_name}"
-      user.local_authority = southwark
-      if Rails.env.development?
-        user.password = user.password_confirmation = "password"
-      else
-        user.password = user.password_confirmation = SecureRandom.uuid
-        user.encrypted_password =
-          "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
-      end
-
-      user.role = admin_role
-    end
-  end
-
   local_authorities = [southwark, lambeth]
 
   # Add lambeth and southwark specific admins
@@ -111,8 +84,7 @@ task create_sample_data: :environment do
     end
   end
 
-  assessor = User.find_by!(email: "assessor@example.com", role: :assessor)
-  reviewer = User.find_by!(email: "reviewer@example.com", role: :reviewer)
+  southwark_assessor = User.find_by!(email: "southwark_assessor@example.com", role: :assessor)
 
   # Agent
   agent = Agent.find_or_create_by!(
@@ -151,7 +123,7 @@ task create_sample_data: :environment do
     ward: "Dulwich Wood",
     agent: agent,
     applicant: applicant,
-    user: assessor,
+    user: southwark_assessor,
     local_authority: southwark
   ) do |pa|
     pa.description = "Installation of new external insulated render to be added"
@@ -235,7 +207,7 @@ task create_sample_data: :environment do
     applicant: applicant,
     local_authority: lambeth
   ) do |pa|
-    pa.description = "Bigger bakery because bigger cakes"
+    pa.description = "Single storey rear extension and rear dormer extension"
   end
 
   bowen_pe = bowen_planning_application.create_policy_evaluation

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
   factory :local_authority do
     name { Faker::Name.name }
     subdomain { Faker::Name.name }
+    signatory_name { Faker::FunnyName.two_word_name }
+    signatory_job_title { "Director" }
+    enquiries_paragraph { Faker::Lorem.unique.sentence }
+    email_address { Faker::Internet.email }
   end
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -4,7 +4,15 @@ require "rails_helper"
 
 RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#decision_notice_mail" do
-    let(:local_authority) { create :local_authority }
+    let(:local_authority) {
+      create :local_authority,
+      name: "Cookie authority",
+      signatory_name: "Mr. Biscuit",
+      signatory_job_title: "Lord of BiscuitTown",
+      enquiries_paragraph: "reach us on postcode SW50",
+      email_address: "biscuit@somuchbiscuit.com"
+      }
+
     let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
     let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority) }
     let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
@@ -47,6 +55,14 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     it "renders numbers for active drawings with proposed tags" do
       expect(mail.body.encoded).to match("proposed_number_1")
       expect(mail.body.encoded).to match("proposed_number_2")
+    end
+
+    it "renders the name of the correct local authority signatory" do
+      expect(mail.body.encoded).to match("Cookie authority")
+      expect(mail.body.encoded).to match("Mr. Biscuit")
+      expect(mail.body.encoded).to match("Lord of BiscuitTown")
+      expect(mail.body.encoded).to match("reach us on postcode SW50")
+      expect(mail.body.encoded).to match("biscuit@somuchbiscuit.com")
     end
 
     it "does not render numbers for archived drawings with proposed tags" do

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -3,7 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application Assessment", type: :system do
-  let(:local_authority) { create :local_authority }
+  let(:local_authority) {
+    create :local_authority,
+    name: "Cookie authority",
+    signatory_name: "Mr. Biscuit",
+    signatory_job_title: "Lord of BiscuitTown",
+    enquiries_paragraph: "reach us on postcode SW50",
+    email_address: "biscuit@somuchbiscuit.com"
+    }
   let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik", local_authority: local_authority }
   let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki", local_authority: local_authority }
 
@@ -128,6 +135,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_content("proposed_drawing_number_1")
     expect(page).to have_content("proposed_drawing_number_2")
     expect(page).to have_content("Certificate of lawful development (proposed) for the construction of #{planning_application.description}")
+
+    # Local authority specific fields
+    expect(page).to have_content("Cookie authority")
+    expect(page).to have_content("Mr. Biscuit")
+    expect(page).to have_content("Lord of BiscuitTown")
+    expect(page).to have_content("reach us on postcode SW50")
+    expect(page).to have_content("biscuit@somuchbiscuit.com")
 
     click_button "Submit to manager"
 


### PR DESCRIPTION
### Description of change

- Adds dynamic text fields to display different summaries for different local authorities. See below, different details being displayed depending as to whether the local authority is lambeth or southwark

- Adds tests to ensure new fields are present in mailer and submission page

![Screenshot 2020-11-25 at 11 57 26](https://user-images.githubusercontent.com/9452321/100230232-59ad0380-2f1d-11eb-9436-0ba418070a3e.png)
![Screenshot 2020-11-25 at 11 57 38](https://user-images.githubusercontent.com/9452321/100230237-5ade3080-2f1d-11eb-89c6-dc7983d77efc.png)
![Screenshot 2020-11-25 at 11 58 08](https://user-images.githubusercontent.com/9452321/100230239-5b76c700-2f1d-11eb-9f87-965e74a4cc97.png)
![Screenshot 2020-11-25 at 11 58 18](https://user-images.githubusercontent.com/9452321/100230243-5b76c700-2f1d-11eb-8334-4f2c1d46a936.png)


### Story Link

https://trello.com/c/gjbjBa54/23-display-relevant-local-authority-details-on-decision-notices-and-email-notification

### Decisions

We have decided to keep a generic branding when it comes to the notify account settings, because we would need to setup a different service for each council. For further info see this thread: 
https://ubxd.slack.com/archives/C010BGD9RNC/p1606306923005700
