### PR TITLE
Prevent login from different subdomain

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,9 +6,14 @@ class User < ApplicationRecord
   enum role: { assessor: 0, reviewer: 1, admin: 2 }
 
   devise :database_authenticatable, :recoverable,
-         :rememberable, :validatable
+         :rememberable, :validatable, request_keys: [:subdomains]
 
   has_many :decisions, dependent: :restrict_with_exception
   has_many :planning_applications, through: :decisions
   belongs_to :local_authority
+
+  def self.find_first_by_auth_conditions(conditions)
+    local_authority = LocalAuthority.find_by(subdomain: conditions[:subdomains].first)
+    find_by(email: conditions[:email], local_authority: local_authority.id)
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe User, type: :model do
     email = build(:user, email: nil)
     expect(email).to_not be_valid
   end
+
+  it "does not allow for duplicate users within the same domain" do
+    domain = create(:local_authority)
+    user_one = create(:user, email: "pompom@pom.com", local_authority: domain)
+    user_two = build(:user, email: "pompom@pom.com", local_authority: domain)
+
+    expect(user_two.save).to be false
+    expect(user_two.errors.messages[:email]).to include("has already been taken")
+  end
+
+  it "does not allow for duplicate users in separate domains" do
+    domain_one = create(:local_authority)
+    domain_two = create(:local_authority)
+
+    user_one = create(:user, email: "gali@galileo.com", local_authority: domain_one)
+    user_two = build(:user, email: "gali@galileo.com", local_authority: domain_two)
+
+    expect(user_two.save).to be false
+    expect(user_two.errors.messages[:email]).to include("has already been taken")
+  end
 end


### PR DESCRIPTION
### Description of change
- Prevent users that belong to subdomain southwark from logging in to lambeth subdomain and vice versa
- This is achieved by using the routes file to pass the subdomain to the params used by the devise authentication method "find_for_authentication"


### Story Link

https://trello.com/c/04CvzZFU/18-prevent-login-to-users-belonging-to-a-different-council-then-the-subdomain
