### PR TITLE
Add AppSignal

### DIFF
--- a/.aws/task-definitions/web.json
+++ b/.aws/task-definitions/web.json
@@ -62,6 +62,10 @@
         {
           "name": "NOTIFY_API_KEY",
           "valueFrom": "arn:aws:ssm:eu-west-2:735309401039:parameter/bops/preview/NOTIFY_API_KEY"
+        },
+        {
+          "name": "APPSIGNAL_PUSH_API_KEY",
+          "valueFrom": "arn:aws:ssm:eu-west-2:735309401039:parameter/bops/preview/APPSIGNAL_PUSH_API_KEY"
         }
       ]
     }

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem "puma", "~> 4.1"
 gem "pundit"
 gem "rails", "~> 6.0.3"
 gem "webpacker", "~> 4.0"
+gem "appsignal"
 
 group :development, :test do
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    appsignal (2.11.0)
+      rack
     ast (2.4.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.326.0)
@@ -308,6 +310,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-postgis-adapter
+  appsignal
   aws-sdk-s3
   bootsnap (>= 1.4.2)
   brakeman

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,8 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_PUSH_API_KEY'] %>"
+  name: "BOPS"
+  active: false
+
+production:
+  <<: *defaults
+  active: true


### PR DESCRIPTION
- Adds the appsignal gem
- Configure to be active on production, and inactive on all other environments
- Update Fargate task for the production web server to pull the `APPSIGNAL_PUSH_API_KEY` variable from AWS Parameter Store (which I have added manually)