### PR TITLE
Add SSH access to fargate web tasks

### DIFF
--- a/.aws/task-definitions/web.json
+++ b/.aws/task-definitions/web.json
@@ -9,6 +9,11 @@
           "containerPort": 3000,
           "protocol": "tcp",
           "hostPort": 3000
+        },
+        {
+          "hostPort": 22,
+          "protocol": "tcp",
+          "containerPort": 22
         }
       ],
       "memory": 300,
@@ -58,6 +63,10 @@
         {
           "name": "DATABASE_URL",
           "valueFrom": "arn:aws:ssm:eu-west-2:735309401039:parameter/bops/preview/DATABASE_URL"
+        },
+        {
+          "name": "SSH_PUBLIC_KEYS",
+          "valueFrom": "arn:aws:ssm:eu-west-2:735309401039:parameter/bops/preview/SSH_PUBLIC_KEYS"
         },
         {
           "name": "NOTIFY_API_KEY",

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -84,14 +84,18 @@ RUN bash -c "bundle exec yarn install"
 # Build image for application
 FROM base_image AS application
 
-# Run security updates, install libpq5 libgeos-c1v5 libproj13 libgdal20
+# Run security updates, install libpq5 libgeos-c1v5 libproj13 libgdal20 openssh-server
 RUN bash -c "export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -qq && \
     apt-get upgrade -y && \
     apt-get install -y libpq5 \
-      libgeos-c1v5 libproj13 libgdal20 && \
+      libgeos-c1v5 libproj13 libgdal20 openssh-server && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*"
+
+# Add public keys to authorized keys, and start SSH daemon
+echo $SSH_PUBLIC_KEYS > ~/.ssh/authorized_keys
+/usr/sbin/sshd -D
 
 # Create a directory for our application
 # and set it as the working directory


### PR DESCRIPTION
This ensures that an SSH deamon is installed and running on the web instances.
We add authorised keys from the AWS secrets.