### PR TITLE
Remove seeds and add unique index to subdomain

### DIFF
--- a/db/migrate/20201130135434_add_unique_index_to_subdomain.rb
+++ b/db/migrate/20201130135434_add_unique_index_to_subdomain.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToSubdomain < ActiveRecord::Migration[6.0]
+  def change
+    add_index :local_authorities, :subdomain, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_25_150405) do
+ActiveRecord::Schema.define(version: 2020_11_30_135434) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,7 @@ ActiveRecord::Schema.define(version: 2020_11_25_150405) do
     t.string "signatory_job_title"
     t.text "enquiries_paragraph"
     t.string "email_address"
+    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 
   create_table "planning_applications", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,48 +1,6 @@
 # frozen_string_literal: true
 require "faker"
 
-lambeth = LocalAuthority.find_or_create_by!(
-  name: "Lambeth Council",
-  subdomain: "lambeth",
-  signatory_name: "Christina Thompson",
-  signatory_job_title: "Director of Finance & Property",
-  enquiries_paragraph: "Postal address: Planning London Borough of Lambeth PO Box 734 Winchester SO23 5DG",
-  email_address: "planning@lambeth.gov.uk"
-)
-
-southwark = LocalAuthority.find_or_create_by!(
-  name: "Southwark Council",
-  subdomain: "southwark",
-  signatory_name: "Simon Bevan",
-  signatory_job_title: "Director of Planning",
-  enquiries_paragraph: "Postal address: Planning London Borough of Southwark PO Box 734 Winchester SO23 5DG",
-  email_address: "planning@southwark.gov.uk"
-)
-
-bucks = LocalAuthority.find_or_create_by!(
-  name: "Buckinghamshire",
-  subdomain: "bucks",
-  signatory_name: "Steve Bambick",
-  signatory_job_title: "Director of Planning",
-  enquiries_paragraph: "Postal address: Planning Buckinghamshire Council, The Gateway, Gatehouse Rd, Aylesbury HP19 8FF",
-  email_address: "planning@buckinghamshire.gov.uk"
-)
-
-User.find_or_create_by!(email: "southwark_admin@example.com") do |user|
-  user.name = "#{Faker::Name.unique.first_name} #{Faker::Name.unique.last_name}"
-  user.local_authority = southwark
-
-  if Rails.env.development?
-    user.password = user.password_confirmation = "password"
-  else
-    user.password = user.password_confirmation = SecureRandom.uuid
-    user.encrypted_password =
-      "$2a$11$.ymnkBkdw1/qPlKPWXa5WujF/Ry/R0nUjZVvo4lEvwc3HL3drZ12W"
-  end
-
-  user.role = :admin
-end
-
 Agent.find_or_create_by!(email: "agent@example.com") do |agent|
   agent.first_name = Faker::Name.unique.first_name,
   agent.last_name = Faker::Name.unique.last_name,


### PR DESCRIPTION
- Currently our deployment runs db:reset, meaning the seeds file runs before create_sample_data. This would not be a problem if find_or_create_by was working properly but instead, duplicate subdomains are being created, and users cannot be found on login because two subdomains with the same name exist in the db
