### PR TITLE
Temporarily update CORS for all REST methods

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::ApplicationController < ApplicationController
 
   def set_cors_headers
     response.set_header("Access-Control-Allow-Origin", "*")
-    response.set_header("Access-Control-Allow-Methods", "GET")
+    response.set_header("Access-Control-Allow-Methods", "*")
     response.set_header(
       "Access-Control-Allow-Headers",
       "Origin, X-Requested-With, Content-Type, Accept"

--- a/spec/requests/planning_application_list_spec.rb
+++ b/spec/requests/planning_application_list_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "API request to list planning applications", type: :request, show
 
       expect(response).to be_successful
       expect(access_control_allow_origin).to eq('*')
-      expect(access_control_allow_methods).to eq('GET')
+      expect(access_control_allow_methods).to eq('*')
       expect(access_control_allow_headers).to eq('Origin, X-Requested-With, Content-Type, Accept')
     end
   end


### PR DESCRIPTION
CORS policy is currently set at * for GET requests only. Temporarily updated to allow all methods from all origins for API testing by third parties

This will be updated, along with the test, once third-party testing is complete and we know which sources to allow.
