### PR TITLE
Change subheading from Agent to Applicant

### DIFF
--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -72,7 +72,7 @@
       <% end %>
       <% if @planning_application.applicant? %>
         <p class='govuk-body'>
-          <strong>Agent: </strong><br>
+          <strong>Applicant: </strong><br>
           <%= @planning_application.applicant_first_name %>
           <%= @planning_application.applicant_last_name %><br>
           <%= @planning_application.applicant_phone %><br>


### PR DESCRIPTION
An update to the view introduced an error where the Agent subheading appeared twice. This commit fixes this

