### PR TITLE
Update Swagger to better reflect structure

### DIFF
--- a/spec/requests/api/planning_applications_spec.rb
+++ b/spec/requests/api/planning_applications_spec.rb
@@ -37,7 +37,18 @@ RSpec.describe 'Planning Applications', swagger_doc: '/v1/swagger_doc.json', typ
                 description: { type: :string },
                 ward: { type: :string },
                 user_id: { type: :integer },
-                questions: { type: :string },
+                questions: { type: :object,
+                             properties: {
+                                 flow: { type: :object,
+                                         properties: {
+                                             id: { type: :string },
+                                             text: { type: :string },
+                                             val: { type: :string },
+                                             options: [{ type: :object }]
+                                         }
+                                 }
+                             }
+                },
                 agent_first_name: { type: :string },
                 agent_last_name: { type: :string },
                 agent_phone: { type: :string },
@@ -46,7 +57,7 @@ RSpec.describe 'Planning Applications', swagger_doc: '/v1/swagger_doc.json', typ
                 applicant_last_name: { type: :string },
                 applicant_phone: { type: :string },
                 applicant_email: { type: :string },
-                constraints: { type: :string },
+                constraints: [{ type: :object }],
                 plans: [{
                             filename: { type: :string },
                             tags: { type: :string },

--- a/swagger/v1/swagger_doc.json
+++ b/swagger/v1/swagger_doc.json
@@ -95,7 +95,28 @@
                     "type": "integer"
                   },
                   "questions": {
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                      "flow": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "val": {
+                            "type": "string"
+                          },
+                          "options": [
+                            {
+                              "type": "object"
+                            }
+                          ]
+                        }
+                      }
+                    }
                   },
                   "agent_first_name": {
                     "type": "string"
@@ -121,9 +142,11 @@
                   "applicant_email": {
                     "type": "string"
                   },
-                  "constraints": {
-                    "type": "string"
-                  },
+                  "constraints": [
+                    {
+                      "type": "object"
+                    }
+                  ],
                   "plans": [
                     {
                       "filename": {


### PR DESCRIPTION
We store the JSON as jsonb so it is not "wrong" to specify this as a string, but it is more accurate to specify the more complex fields (questions and constraints) as objects so we can give potential users a better idea of the structure