### PR TITLE
Enforce local authority relationship to user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   has_many :decisions, dependent: :restrict_with_exception
   has_many :planning_applications, through: :decisions
-  belongs_to :local_authority
+  belongs_to :local_authority, optional: false
 
   def self.find_first_by_auth_conditions(conditions)
     local_authority = LocalAuthority.find_by(subdomain: conditions[:subdomains].first)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  enum role: { assessor: 0, reviewer: 1, admin: 2 }
+  enum role: { assessor: 0, reviewer: 1 }
 
   devise :database_authenticatable, :recoverable,
          :rememberable, :validatable, request_keys: [:subdomains]

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,7 +9,7 @@ class ApplicationPolicy
 
   attr_reader :user, :record
 
-  delegate :assessor?, :reviewer?, :admin?, to: :user
+  delegate :assessor?, :reviewer?, to: :user
 
   def initialize(user, record)
     @user = user

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -33,7 +33,7 @@ class PlanningApplicationPolicy < ApplicationPolicy
   def permitted_statuses
     if @user.assessor?
       [ "awaiting_determination" ]
-    elsif @user.reviewer? || @user.admin?
+    elsif @user.reviewer?
       [ "determined" ]
     else
       []

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -7,11 +7,11 @@
       <li class="app-task-list__item">
         <% step_name = t("#{@planning_application.status}.proposal_step") %>
 
-        <% if (current_user.assessor? || current_user.admin?) %>
+        <% if current_user.assessor? %>
           <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
           <% path = assessor_decision_path(@planning_application) %>
           <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
-        <% elsif !@planning_application.in_assessment? && (current_user.reviewer? || current_user.admin?) %>
+        <% elsif !@planning_application.in_assessment? && current_user.reviewer? %>
           <% aria_attributes = @planning_application.reviewer_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
           <% path = reviewer_decision_path(@planning_application) %>
@@ -59,7 +59,7 @@
         <% step_name = t("#{@planning_application.status}.recommendation_step") %>
         <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
-        <% if (current_user.assessor? || current_user.admin?) && @planning_application.assessor_decision && @planning_application.drawings_ready_for_publication? %>
+        <% if current_user.assessor? && @planning_application.assessor_decision && @planning_application.drawings_ready_for_publication? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
         <% elsif current_user.reviewer? && @planning_application.reviewer_decision  && !@planning_application.awaiting_correction? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -56,7 +56,7 @@ task create_sample_data: :environment do
 
   ApiUser.find_or_create_by!(name: "api_user", token: ENV["API_TOKEN"]) if ENV["API_TOKEN"]
 
-  admin_roles = %i[assessor reviewer]
+  admin_roles = %i[assessor reviewer admin]
   local_authorities = [southwark, lambeth, bucks]
 
   # Add lambeth and southwark specific admins

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -56,46 +56,8 @@ task create_sample_data: :environment do
 
   ApiUser.find_or_create_by!(name: "api_user", token: ENV["API_TOKEN"]) if ENV["API_TOKEN"]
 
-  admin_roles = %i[assessor reviewer admin]
+  admin_roles = %i[assessor reviewer]
   local_authorities = [southwark, lambeth, bucks]
-
-  # Add lambeth and southwark specific admins
-  local_authorities.each do |authority|
-    admin_roles.each do |admin_role|
-      User.find_or_create_by!(email: "#{authority.subdomain}_#{admin_role}@example.com") do |user|
-        first_name = Faker::Name.unique.first_name
-        last_name = Faker::Name.unique.last_name
-        user.name = "#{first_name} #{last_name}"
-        user.local_authority = authority
-        if Rails.env.development?
-          user.password = user.password_confirmation = "password"
-        else
-          user.password = user.password_confirmation = SecureRandom.uuid
-          user.encrypted_password =
-            "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
-        end
-
-        user.role = admin_role
-      end
-
-      User.find_or_create_by!(email: "#{authority.subdomain}_#{admin_role}2@example.com") do |user|
-        first_name = Faker::Name.unique.first_name
-        last_name = Faker::Name.unique.last_name
-        user.name = "#{first_name} #{last_name}"
-        user.local_authority = authority
-
-        if Rails.env.development?
-          user.password = user.password_confirmation = "password"
-        else
-          user.password = user.password_confirmation = SecureRandom.uuid
-          user.encrypted_password =
-            "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
-        end
-
-        user.role = admin_role
-      end
-    end
-  end
 
   southwark_assessor = User.find_by!(email: "southwark_assessor@example.com", role: :assessor)
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,8 +15,4 @@ FactoryBot.define do
   trait :reviewer do
     role { :reviewer }
   end
-
-  trait :admin do
-    role { :admin }
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,19 +13,9 @@ RSpec.describe User, type: :model do
     expect(reviewer).to be_valid
   end
 
-  it "should create user with admin role" do
-    admin = create(:user, :admin)
-    expect(admin).to be_valid
-  end
-
   it "should save reviewer role correctly" do
     reviewer = create(:user, :reviewer)
     expect(reviewer.role).to eq "reviewer"
-  end
-
-  it "should save admin role correctly" do
-    admin = create(:user, :admin)
-    expect(admin.role).to eq "admin"
   end
 
   it "should create user with default assessor role if no role is provided" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe User, type: :model do
     expect(email).to_not be_valid
   end
 
+  it "should not be created without a local authority" do
+    user_without_local_authority = build(:user, local_authority: nil)
+    expect(user_without_local_authority).to_not be_valid
+  end
+
   it "does not allow for duplicate users within the same domain" do
     domain = create(:local_authority)
     user_one = create(:user, email: "pompom@pom.com", local_authority: domain)

--- a/spec/policies/decision_policy_spec.rb
+++ b/spec/policies/decision_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DecisionPolicy, type: :policy do
     let(:record) { nil }
     let(:policy) { described_class.new(user, record) }
 
-    %i[assessor reviewer admin].each do |role|
+    %i[assessor reviewer].each do |role|
       context "when signed in as a #{role}" do
         let(:user) { create :user, role }
 

--- a/spec/policies/drawing_policy_spec.rb
+++ b/spec/policies/drawing_policy_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe DrawingPolicy, type: :policy do
-  describe "Assessor, Reviewer and Admin roles" do
+  describe "Assessor and Reviewer roles" do
     let(:record) { nil }
     let(:policy) { described_class.new(user, record) }
 
-    %i[assessor reviewer admin].each do |role|
+    %i[assessor reviewer].each do |role|
       context "when signed in as a #{role}" do
         let(:user) { create :user, role }
 

--- a/spec/policies/planning_application_policy_spec.rb
+++ b/spec/policies/planning_application_policy_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe PlanningApplicationPolicy, type: :policy do
   let(:policy) { described_class.new(user, record) }
   let(:policy_two) { described_class.new(user_two_forbidden, record) }
 
-  describe "Assessor, Reviewer and Admin roles" do
-    %i[assessor reviewer admin].each do |role|
+  describe "Assessor and Reviewer roles" do
+    %i[assessor reviewer].each do |role|
       context "when signed in to the domain as #{role}" do
         let(:user) { create :user, role, local_authority: local_authority }
 
@@ -44,14 +44,6 @@ RSpec.describe PlanningApplicationPolicy, type: :policy do
 
     context "a reviewer" do
       let(:user) {  create :user, :reviewer, local_authority: local_authority }
-
-      it "returns :determined only" do
-        expect(policy.permitted_statuses).to eq %w[ determined ]
-      end
-    end
-
-    context "an admin" do
-      let(:user) {  create :user, :admin, local_authority: local_authority }
 
       it "returns :determined only" do
         expect(policy.permitted_statuses).to eq %w[ determined ]

--- a/spec/policies/policy_evaluation_policy_spec.rb
+++ b/spec/policies/policy_evaluation_policy_spec.rb
@@ -3,18 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe PolicyEvaluationPolicy, type: :policy do
-  describe "Assessor and Admin roles" do
+  describe "Assessor role" do
     let(:record) { nil }
     let(:policy) { described_class.new(user, record) }
 
-    %i[assessor admin].each do |role|
-      context "when signed in as a #{role}" do
-        let(:user) { create :user, role }
+    context "when signed in as an assessor" do
+      let(:user) { create :user, :assessor }
 
-        %i[new create edit update].each do |action|
-          it "permits the '#{action}' action" do
-            expect(policy).to permit_action(action)
-          end
+      %i[new create edit update].each do |action|
+        it "permits the '#{action}' action" do
+          expect(policy).to permit_action(action)
         end
       end
     end

--- a/spec/requests/planning_application_request_spec.rb
+++ b/spec/requests/planning_application_request_spec.rb
@@ -99,48 +99,5 @@ RSpec.describe "PlanningApplications", type: :request do
         end
       end
     end
-
-    context "for an admin" do
-      let(:user) { create :user, :admin, local_authority: local_authority }
-
-      context "setting the status to \"determined\"" do
-        let(:status) { :determined }
-
-        let(:mailer) { double }
-
-        before do
-          allow(PlanningApplicationMailer).to receive(:decision_notice_mail).and_return(mailer)
-          allow(mailer).to receive(:deliver_now)
-        end
-
-        it "changes the status and redirects to the planning application"  do
-          expect {
-            subject
-          }.to change {
-            planning_application.reload.status
-          }.to(
-            "determined"
-          )
-
-          expect(response.code).to eq "302"
-          expect(response).to redirect_to planning_application_path(planning_application)
-        end
-      end
-
-      context "setting the status to \"awaiting_determination\"" do
-        let(:status) { :awaiting_determination }
-
-        it "does not change the status and redirects to the root"  do
-          expect {
-            subject
-          }.not_to change {
-            planning_application.reload.status
-          }
-
-          expect(response.code).to eq "302"
-          expect(response).to redirect_to root_path
-        end
-      end
-    end
   end
 end

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -3,7 +3,6 @@
 require "rails_helper"
 
 RSpec.feature "Sign in", type: :system do
-  let(:admin) { create :user, :admin, name: "Adrian Schimmel" }
   let(:assessor) { create :user, :assessor, name: "Lorrine Krajcik" }
   let(:reviewer) { create :user, :reviewer, name: "Harley Dicki" }
 
@@ -23,7 +22,7 @@ RSpec.feature "Sign in", type: :system do
   scenario "User cannot log in with invalid credentials" do
     visit root_path
 
-    fill_in("user[email]", with: admin.email)
+    fill_in("user[email]", with: reviewer.email)
     fill_in("user[password]", with: "invalid_password")
     click_button('Log in')
 
@@ -53,18 +52,6 @@ RSpec.feature "Sign in", type: :system do
       scenario "can see their name and role" do
         expect(page).to have_text("Harley Dicki")
         expect(page).to have_text("Reviewer")
-      end
-    end
-
-    context "as an admin" do
-      before do
-        sign_in admin
-        visit root_path
-      end
-
-      scenario "see can see their name and role" do
-        expect(page).to have_text("Adrian Schimmel")
-        expect(page).to have_text("Admin")
       end
     end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
        assessor_decision: assessor_decision,
        applicant_email: "bigplans@example.com"
     end
-    let(:admin) { create :user, :admin, local_authority: local_authority }
     let(:assessor) { create :user, :assessor, local_authority: local_authority }
     let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
 
@@ -471,37 +470,6 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
       include_examples "reviewer assignment"
       include_examples "reviewer decision error message"
-    end
-  end
-
-  context "as an admin" do
-    let(:local_authority) { create :local_authority }
-    let(:assessor) { create :user, :assessor, local_authority: local_authority }
-    let(:admin) { create :user, :admin, local_authority: local_authority }
-    let(:assessor_decision) { create :decision, :granted, user: assessor }
-
-    let!(:planning_application) do
-      create :planning_application,
-      assessor_decision: assessor_decision,
-      local_authority: local_authority
-    end
-
-    before do
-      sign_in admin
-
-      visit root_path
-    end
-
-    scenario "Assessment editing" do
-      # TODO: Define admin actions on a planning application further and test them
-
-      click_link planning_application.reference
-
-      expect(page).to have_link "Assess the proposal"
-
-      within(:assessment_step, "Assess the proposal") do
-        expect(page).to have_content("Completed")
-      end
     end
   end
 end


### PR DESCRIPTION
We needed to prevent the creation of users who do not belong to a local authority. Spec also added, and so was the creation of admin users when the sample data task is run.