### PR TITLE
Use 'master' branch in package-builder

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -159,8 +159,8 @@ class PackageBuilder
     end
   end
 
-  def main_ref?
-    ENV.fetch("GITHUB_REF", "") == "refs/heads/main"
+  def master_ref?
+    ENV.fetch("GITHUB_REF", "") == "refs/heads/master"
   end
 
   def tag_ref?
@@ -168,7 +168,7 @@ class PackageBuilder
   end
 
   def deploy_build?
-    main_ref? || tag_ref?
+    master_ref? || tag_ref?
   end
 
   def deployment_config(deployment_group_name) # rubocop:disable Metrics/MethodLength


### PR DESCRIPTION
I believe the below commit message is accurate, but let me know if I've misunderstood something.

This code was copied from another project, who's production branch was called 'main', whereas ours is 'master'.

This was causing the [deploy to skip in Gtihub actions](https://github.com/unboxed/bops/runs/1557472572?check_suite_focus=true), as it didn't think it was on the correct branch.