### PR TITLE
Add payment_reference to planning applications

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -78,7 +78,8 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
                       :applicant_first_name, :applicant_last_name,
                       :applicant_phone, :applicant_email,
                       :agent_first_name, :agent_last_name,
-                      :agent_phone, :agent_email, :questions, :plans]
+                      :agent_phone, :agent_email, :questions, :plans,
+                      :payment_reference]
     params.permit permitted_keys
   end
 

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -37,6 +37,14 @@
             </td>
           </tr>
           <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><strong>Payment Reference:</strong></td>
+            <td class="govuk-table__cell">
+              <p class="govuk-body">
+                <%= @planning_application.payment_reference %>
+              </p>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
             <td class="govuk-table__cell noborder"><strong>Case officer:</strong></td>
             <td class="govuk-table__cell noborder">
               <p class="govuk-body"><%= @planning_application.user ? @planning_application.user.name : "Not started" %></p>
@@ -47,4 +55,3 @@
     </div>
   </div>
 </div>
-  

--- a/db/migrate/20201218151758_add_payment_reference_to_planning_applications.rb
+++ b/db/migrate/20201218151758_add_payment_reference_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddPaymentReferenceToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :payment_reference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_30_153208) do
+ActiveRecord::Schema.define(version: 2020_12_18_151758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 2020_11_30_153208) do
     t.string "applicant_phone"
     t.bigint "local_authority_id"
     t.jsonb "constraints"
+    t.string "payment_reference"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"

--- a/spec/requests/api/planning_applications_spec.rb
+++ b/spec/requests/api/planning_applications_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe 'Planning Applications', swagger_doc: '/v1/swagger_doc.json', typ
                           }
                         },
                 description: { type: :string },
+                payment_reference: { type: :string },
                 ward: { type: :string },
                 user_id: { type: :integer },
                 questions: { type: :object,
@@ -68,7 +69,7 @@ RSpec.describe 'Planning Applications', swagger_doc: '/v1/swagger_doc.json', typ
 
         response '200', :valid_request do
           let(:planning_application) { { application_type: 1, status: 0, site: { uprn: "12343243" },
-                                         description: 'Add chimnney stack',
+                                         payment_reference: 'PAY1', description: 'Add chimnney stack',
                                          questions: JSON.parse(File.read(Rails.root.join("spec/fixtures/files/permitted_development.json"))) }}
           let(:api_user) { create(:api_user) }
           let(:Authorization) { "Bearer #{api_user.token}" }

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature "Planning Application show page", type: :system do
                                        application_type: "lawfulness_certificate", status: :in_assessment,
                                        ward: "Dulwich Wood", site: site,
                                        target_date: Date.current + 14.days, local_authority: local_authority,
+                                       payment_reference: 'PAY123',
                                        constraints:  '{"conservation_area": true, "article4_area": false, "scheduled_monument": false }'}
   let(:assessor) { create :user, :assessor, local_authority: local_authority }
   let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
@@ -41,6 +42,7 @@ RSpec.feature "Planning Application show page", type: :system do
       expect(page).to have_text("Building type: Residential")
       expect(page).to have_text("Application type: Proposed permitted development: Certificate of Lawfulness")
       expect(page).to have_text("Summary: Roof extension")
+      expect(page).to have_text("PAY123")
       expect(page).to have_text("Case officer: Not started")
     end
 


### PR DESCRIPTION
New attribute on PlanningApplication for payment_references
Show this value in information accordion
Accept this value via the API

Note: there isn't really a good spec for the API part of this, as there are currently no good specs for the API.