### PR TITLE
Add form for withdrawing and returning applications

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -3,7 +3,8 @@
 class PlanningApplicationsController < AuthenticationController
   include PlanningApplicationDashboardVariables
 
-  before_action :set_planning_application, only: [ :show, :edit, :assess, :determine, :request_correction, :cancel_confirmation, :cancel ]
+  before_action :set_planning_application, only: [ :show, :edit, :assess, :determine, :request_correction,
+                                                   :cancel_confirmation, :cancel ]
   before_action :set_planning_application_dashboard_variables,
                 only: [ :show, :edit, :assess, :determine, :request_correction, :cancel_confirmation, :cancel ]
 
@@ -76,21 +77,17 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def cancel
-    status = authorize_user_can_update_status(
-        planning_application_params[:status])
+    status = authorize_user_can_update_status(params[:planning_application][:status])
     apply_cancellation(status)
-    @planning_application.update!(cancellation_comment: planning_application_params[:cancellation_comment])
-    if @planning_application.withdrawn? || @planning_application.returned?
-      flash[:notice] = "Application has been cancelled"
-    end
+    flash[:notice] = "Application has been cancelled"
     redirect_to @planning_application
   end
 
   def apply_cancellation(status)
     if status == "withdrawn"
-      @planning_application.withdraw!
+      @planning_application.withdraw!(:withdrawn, params[:planning_application][:cancellation_comment])
     elsif status == "returned"
-      @planning_application.return!
+      @planning_application.return!(:returned, params[:planning_application][:cancellation_comment])
     end
   end
 
@@ -98,10 +95,6 @@ class PlanningApplicationsController < AuthenticationController
 
   def set_planning_application
     @planning_application = authorize(PlanningApplication.find(params[:id]))
-  end
-
-  def planning_application_params
-    params.require(:planning_application).permit(:status, :cancellation_comment)
   end
 
   def authorize_user_can_update_status(status)

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -3,9 +3,9 @@
 class PlanningApplicationsController < AuthenticationController
   include PlanningApplicationDashboardVariables
 
-  before_action :set_planning_application, only: [ :show, :edit, :assess, :determine, :request_correction ]
+  before_action :set_planning_application, only: [ :show, :edit, :assess, :determine, :request_correction, :cancel_confirmation, :cancel ]
   before_action :set_planning_application_dashboard_variables,
-                only: [ :show, :edit, :assess, :determine, :request_correction ]
+                only: [ :show, :edit, :assess, :determine, :request_correction, :cancel_confirmation, :cancel ]
 
   rescue_from Notifications::Client::NotFoundError,
     with: :decision_notice_mail_error
@@ -71,6 +71,29 @@ class PlanningApplicationsController < AuthenticationController
     redirect_to @planning_application
   end
 
+  def cancel_confirmation
+    render :cancel_confirmation
+  end
+
+  def cancel
+    status = authorize_user_can_update_status(
+        planning_application_params[:status])
+    apply_cancellation(status)
+    @planning_application.update!(cancellation_comment: planning_application_params[:cancellation_comment])
+    if @planning_application.withdrawn? || @planning_application.returned?
+      flash[:notice] = "Application has been cancelled"
+    end
+    redirect_to @planning_application
+  end
+
+  def apply_cancellation(status)
+    if status == "withdrawn"
+      @planning_application.withdraw!
+    elsif status == "returned"
+      @planning_application.return!
+    end
+  end
+
   private
 
   def set_planning_application
@@ -78,7 +101,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def planning_application_params
-    params.require(:planning_application).permit(:status)
+    params.require(:planning_application).permit(:status, :cancellation_comment)
   end
 
   def authorize_user_can_update_status(status)
@@ -90,7 +113,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def unpermitted_status_for_user?(status)
-    policy(@planning_application).unpermitted_statuses.include?(status)
+    status == :awaiting_determination if current_user.assessor?
   end
 
   def decision_notice_mail

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -31,17 +31,17 @@ module PlanningApplicationHelper
     if planning_application.determined? && planning_application.reviewer_decision
       display_decision_status(planning_application)
     elsif planning_application.status == "withdrawn"
-      {color: "grey", decision: "Withdrawn"}
+      { color: "grey", decision: "Withdrawn" }
     else
-      {color: "grey", decision: "Returned"}
+      { color: "grey", decision: "Returned" }
     end
   end
 
   def display_decision_status(planning_application)
     if planning_application.reviewer_decision.granted?
-      {color: "green", decision: "Granted"}
+      { color: "green", decision: "Granted" }
     else
-      {color: "red", decision: "Refused"}
+      { color: "red", decision: "Refused" }
     end
   end
 

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -27,6 +27,24 @@ module PlanningApplicationHelper
     JSON.parse(constraints).select { |category, value| value == true }.keys unless constraints.empty?
   end
 
+  def display_status(planning_application)
+    if planning_application.determined? && planning_application.reviewer_decision
+      display_decision_status(planning_application)
+    elsif planning_application.status == "withdrawn"
+      {color: "grey", decision: "Withdrawn"}
+    else
+      {color: "grey", decision: "Returned"}
+    end
+  end
+
+  def display_decision_status(planning_application)
+    if planning_application.reviewer_decision.granted?
+      {color: "green", decision: "Granted"}
+    else
+      {color: "red", decision: "Refused"}
+    end
+  end
+
   # rubocop: disable Metrics/MethodLength
   def proposal_step_mark_completed?(step_name, application)
     case step_name

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -72,7 +72,8 @@ class PlanningApplication < ApplicationRecord
     end
 
     event :return do
-      transitions from: :invalidated, to: :returned
+      transitions from: [:not_started, :in_assessment, :invalidated, :awaiting_determination, :awaiting_correction,
+                         :returned], to: :returned
     end
 
     event :withdraw do

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -27,6 +27,7 @@ class ApplicationPolicy
   alias_method :update?, :editor?
   alias_method :edit?, :editor?
   alias_method :destroy?, :editor?
+  alias_method :cancel?, :editor?
 
   class Scope
     attr_reader :user, :scope

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -9,6 +9,8 @@ class PlanningApplicationPolicy < ApplicationPolicy
   alias_method :confirm_new?, :editor?
   alias_method :edit_numbers?, :editor?
   alias_method :assess?, :editor?
+  alias_method :cancel_confirmation?, :editor?
+  alias_method :cancel?, :editor?
   alias_method :determine?, :editor?
   alias_method :request_correction?, :editor?
   alias_method :update_numbers?, :editor?

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -29,7 +29,7 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
-    <% unless @planning_application.determined? || @planning_application.returned? || @planning_application.withdrawn? %>
+    <% if @planning_application.cancellable? %>
       <p class="govuk-body">
         <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application) %>
       </p>

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -29,6 +29,11 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
+    <% unless @planning_application.determined? || @planning_application.returned? || @planning_application.withdrawn? %>
+      <p class="govuk-body">
+        <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application) %>
+      </p>
+    <% end %>
     <%= render "shared/application_information" %>
 
     <%= yield %>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -7,7 +7,11 @@
       <th scope="col" class="govuk-table__header">Site address</th>
       <th scope="col" class="govuk-table__header">Application type</th>
       <th scope="col" class="govuk-table__header">Target date</th>
-      <th scope="col" class="govuk-table__header">Days left</th>
+      <% if id == "closed" %>
+        <th scope="col" class="govuk-table__header">Decision</th>
+      <% else %>
+        <th scope="col" class="govuk-table__header">Days left</th>
+      <% end %>
       <% if id == "in_assessment" %>
         <th scope="col" class="govuk-table__header">Consultation status</th>
       <% elsif id == "awaiting_determination" %>
@@ -28,16 +32,22 @@
         <td class="govuk-table__cell"><%= t(planning_application.application_type) %></td>
         <td class="govuk-table__cell"><%= planning_application.target_date.strftime("%e %b") %></td>
         <td class="govuk-table__cell">
-          <strong class="govuk-tag govuk-tag--<%= days_color(planning_application.days_left) %>">
-            <%= planning_application.days_left %>
-          </strong>
+          <% if id == "closed" %>
+            <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
+              <%= display_status(planning_application)[:decision] %>
+            </strong>
+            <% else %>
+              <strong class="govuk-tag govuk-tag--<%= days_color(planning_application.days_left) %>">
+                <%= planning_application.days_left %>
+              </strong>
+            <% end %>
         </td>
         <% if id == "in_assessment" %>
           <td class="govuk-table__cell">Not required</td>
         <% elsif id == "awaiting_determination" %>
           <td class="govuk-table__cell"><%= planning_application.awaiting_determination_at.strftime("%e %b") %></td>
         <% elsif id == "closed" %>
-          <td class="govuk-table__cell"><%= planning_application.determined_at.strftime("%e %b") %></td>
+          <td class="govuk-table__cell"><%= planning_application.determined_at.strftime("%e %b") if planning_application.determined? %></td>
         <% end %>
         <td class="govuk-table__cell">
           <% if planning_application.user %>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -36,11 +36,11 @@
             <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
               <%= display_status(planning_application)[:decision] %>
             </strong>
-            <% else %>
-              <strong class="govuk-tag govuk-tag--<%= days_color(planning_application.days_left) %>">
-                <%= planning_application.days_left %>
-              </strong>
-            <% end %>
+          <% else %>
+            <strong class="govuk-tag govuk-tag--<%= days_color(planning_application.days_left) %>">
+              <%= planning_application.days_left %>
+            </strong>
+          <% end %>
         </td>
         <% if id == "in_assessment" %>
           <td class="govuk-table__cell">Not required</td>

--- a/app/views/planning_applications/cancel_confirmation.html.erb
+++ b/app/views/planning_applications/cancel_confirmation.html.erb
@@ -1,0 +1,63 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Cancel application" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+      <%= @planning_application.reference %>
+    </h1>
+
+    <p class="govuk-body">
+      <%= display_address(@site) %>
+    </p>
+
+    <%= form_with model: @planning_application, url: cancel_planning_application_path(@planning_application), local: true do |form| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <h2 class="govuk-heading-m">Cancel application</h2>
+          <% if @planning_application.determined? %>
+            <p class="govuk-body">
+              This application has been determined and cannot be cancelled.
+            </p>
+          <% else %>
+            <p class="govuk-body">
+              <strong>Why is this application being cancelled?</strong>
+            </p>
+          <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+            <% if form.object.errors.any? %>
+              <% form.object.errors.each do |attribute, error| %>
+              <span id="status-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+              <% end %>
+            <% end %>
+            <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+              <div class="govuk-radios govuk-radios--small">
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :status, "withdrawn", class: "govuk-radios__input", id:"withdrawn", "aria-controls": "conditional-status-withdrawn-conditional", "aria-expanded": "false" %>
+                  <%= form.label :withdrawn, "Withdrawn by applicant", class: "govuk-label govuk-radios__label", for: "withdrawn" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :status, "returned", class: "govuk-radios__input", id: "returned", "aria-controls": "conditional-status-returned-conditional", "aria-expanded": "false" %>
+                  <%= form.label :returned, "Returned as invalid", class: "govuk-label govuk-radios__label", for: "returned" %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="govuk-form-group">
+            <p class="govuk-body">
+              <strong>Can you provide more detail?</strong>
+            </p>
+            <%= form.text_area :cancellation_comment, class: "govuk-textarea", id: "cancellation_comment", rows: "3", "aria-describedby": "cancellation-comment-hint" %>
+          </div>
+        </fieldset>
+        <p>
+          <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+          <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        </p>
+      </div>
+    <% end%>
+  <% end%>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
     member do
       patch :assess
       patch :determine
+      patch :cancel
+      get :cancel_confirmation
     end
     resources :decisions, only: %i[new create edit update show]
 

--- a/db/migrate/20201222104230_add_cancellation_comment_to_planning_applications.rb
+++ b/db/migrate/20201222104230_add_cancellation_comment_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddCancellationCommentToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :cancellation_comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_18_151758) do
+ActiveRecord::Schema.define(version: 2020_12_22_104230) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,7 @@ ActiveRecord::Schema.define(version: 2020_12_18_151758) do
     t.datetime "withdrawn_at"
     t.datetime "returned_at"
     t.string "payment_reference"
+    t.text "cancellation_comment"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -72,7 +72,7 @@ task create_sample_data: :environment do
         else
           user.password = user.password_confirmation = SecureRandom.uuid
           user.encrypted_password =
-              "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
+            "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
         end
 
         user.role = admin_role
@@ -89,7 +89,7 @@ task create_sample_data: :environment do
         else
           user.password = user.password_confirmation = SecureRandom.uuid
           user.encrypted_password =
-              "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
+            "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
         end
 
         user.role = admin_role

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -59,6 +59,44 @@ task create_sample_data: :environment do
   admin_roles = %i[assessor reviewer]
   local_authorities = [southwark, lambeth, bucks]
 
+  # Add lambeth and southwark specific admins
+  local_authorities.each do |authority|
+    admin_roles.each do |admin_role|
+      User.find_or_create_by!(email: "#{authority.subdomain}_#{admin_role}@example.com") do |user|
+        first_name = Faker::Name.unique.first_name
+        last_name = Faker::Name.unique.last_name
+        user.name = "#{first_name} #{last_name}"
+        user.local_authority = authority
+        if Rails.env.development?
+          user.password = user.password_confirmation = "password"
+        else
+          user.password = user.password_confirmation = SecureRandom.uuid
+          user.encrypted_password =
+              "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
+        end
+
+        user.role = admin_role
+      end
+
+      User.find_or_create_by!(email: "#{authority.subdomain}_#{admin_role}2@example.com") do |user|
+        first_name = Faker::Name.unique.first_name
+        last_name = Faker::Name.unique.last_name
+        user.name = "#{first_name} #{last_name}"
+        user.local_authority = authority
+
+        if Rails.env.development?
+          user.password = user.password_confirmation = "password"
+        else
+          user.password = user.password_confirmation = SecureRandom.uuid
+          user.encrypted_password =
+              "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
+        end
+
+        user.role = admin_role
+      end
+    end
+  end
+
   southwark_assessor = User.find_by!(email: "southwark_assessor@example.com", role: :assessor)
 
   # A planning application with application_type lawfulness_certificate

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -131,4 +131,58 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#display_decision_status" do
+    subject { create :planning_application }
+
+    context "refused" do
+      let(:reviewer) { create :user, :reviewer }
+      let(:reviewer_decision) { create(:decision, :refused_private_comment, user: reviewer) }
+
+      before do
+        subject.decisions << reviewer_decision
+        subject.assess!
+        subject.reload
+        subject.determine!
+      end
+
+      it "returns correct values when application is refused" do
+        expect(display_status(subject)[:decision]).to eql("Refused")
+        expect(display_status(subject)[:color]).to eql("red")
+      end
+    end
+
+    context "granted" do
+      let(:reviewer) { create :user, :reviewer }
+      let(:reviewer_decision) { create(:decision, :granted, user: reviewer) }
+
+      before do
+        subject.decisions << reviewer_decision
+        subject.assess!
+        subject.reload
+        subject.determine!
+      end
+
+      it "returns correct values when application is granted" do
+        expect(display_status(subject)[:decision]).to eql("Granted")
+        expect(display_status(subject)[:color]).to eql("green")
+      end
+    end
+  end
+
+  describe "#display_status" do
+    subject { create :planning_application }
+
+    it "returns correct values when application is withdrawn" do
+      subject.withdraw!
+      expect(display_status(subject)[:decision]).to eql("Withdrawn")
+      expect(display_status(subject)[:color]).to eql("grey")
+    end
+
+    it "returns correct values when application is withdrawn" do
+      subject.return!
+      expect(display_status(subject)[:decision]).to eql("Returned")
+      expect(display_status(subject)[:color]).to eql("grey")
+    end
+  end
 end

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -20,36 +20,12 @@ RSpec.describe "Planning Application Assessment", type: :system do
             local_authority: local_authority
   end
 
-  let(:policy_consideration_1) do
-    create :policy_consideration,
-            policy_question: "The property is",
-            applicant_answer: "a semi detached house"
-  end
-
-  let(:policy_consideration_2) do
-    create :policy_consideration,
-            policy_question: "The project will ___ the internal floor area of the building",
-            applicant_answer: "not alter"
-  end
-
-  let!(:policy_evaluation) do
-    create :policy_evaluation,
-            planning_application: planning_application,
-            policy_considerations: [policy_consideration_1, policy_consideration_2]
-  end
-
-  let!(:drawing) do
-    create :drawing, :with_plan, :proposed_tags,
-           planning_application: planning_application
-  end
-
   before do
     sign_in assessor
     visit root_path
   end
 
   context "Cancelling from Not Started status" do
-
     scenario "Withdraw from Not Started" do
       click_link planning_application.reference
       click_link "Cancel application"
@@ -110,7 +86,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     scenario "Withdraw from In Assessment" do
       click_link planning_application.reference
-      expect(planning_application.status).to eql("in_assessment")
       click_link "Cancel application"
 
       expect(page).to have_content("Why is this application being cancelled?")

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application Assessment", type: :system do
+  let(:local_authority) {
+    create :local_authority,
+    name: "Cookie authority",
+    signatory_name: "Mr. Biscuit",
+    signatory_job_title: "Lord of BiscuitTown",
+    enquiries_paragraph: "reach us on postcode SW50",
+    email_address: "biscuit@somuchbiscuit.com"
+    }
+  let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik", local_authority: local_authority }
+  let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki", local_authority: local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :not_started,
+            :lawfulness_certificate,
+            local_authority: local_authority
+  end
+
+  let(:policy_consideration_1) do
+    create :policy_consideration,
+            policy_question: "The property is",
+            applicant_answer: "a semi detached house"
+  end
+
+  let(:policy_consideration_2) do
+    create :policy_consideration,
+            policy_question: "The project will ___ the internal floor area of the building",
+            applicant_answer: "not alter"
+  end
+
+  let!(:policy_evaluation) do
+    create :policy_evaluation,
+            planning_application: planning_application,
+            policy_considerations: [policy_consideration_1, policy_consideration_2]
+  end
+
+  let!(:drawing) do
+    create :drawing, :with_plan, :proposed_tags,
+           planning_application: planning_application
+  end
+
+  before do
+    sign_in assessor
+    visit root_path
+  end
+
+  context "Cancelling from Not Started status" do
+
+    scenario "Withdraw from Not Started" do
+      click_link planning_application.reference
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Withdrawn by applicant"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Withdrawn")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+
+    scenario "Return from Not Started" do
+      click_link planning_application.reference
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Returned as invalid"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Returned")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+  end
+
+  context "Cancelling from In Assessment" do
+    before do
+      planning_application.start!
+    end
+
+    scenario "Withdraw from In Assessment" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("in_assessment")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Withdrawn by applicant"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Withdrawn")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+
+    scenario "Return from In Assessment" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("in_assessment")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Returned as invalid"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Returned")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+  end
+
+  context "Cancelling from Invalidated" do
+    before do
+      planning_application.invalidate!
+    end
+
+    scenario "Withdraw from Invalidated" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("invalidated")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Withdrawn by applicant"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Withdrawn")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+
+    scenario "Return from Invalidated" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("invalidated")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Returned as invalid"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Returned")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+  end
+
+  context "Cancelling from Awaiting Determination" do
+    before do
+      planning_application.start!
+      planning_application.assess!
+    end
+
+    scenario "Withdraw from Awaiting Determination" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("awaiting_determination")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Withdrawn by applicant"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Withdrawn")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+
+    scenario "Return from Awaiting Determination" do
+      click_link planning_application.reference
+      expect(planning_application.status).to eql("awaiting_determination")
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Returned as invalid"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      within("#closed") do
+        expect(page).to have_content("Returned")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_content("Cancel application")
+    end
+  end
+end


### PR DESCRIPTION

<img width="1073" alt="cancel_index" src="https://user-images.githubusercontent.com/1880450/102901588-b7bdff80-4465-11eb-8a17-ac9efdc5eb54.png">
<img width="1049" alt="cancel" src="https://user-images.githubusercontent.com/1880450/102901600-ba205980-4465-11eb-9961-a1bce56d51fd.png">



### Description of change

Created cancel and cancel_confirmation routes which allow all types of user to withdraw or return an application and add a comment. Also added logic for displaying status on the index UI and reinstated user creation to create_sample_data rake task, which was removed earlier in error
### Story Link

https://trello.com/c/Md5k7OGz/2-withdraw-return-applications

### Known issues [OPTIONAL]

We will need to add a ticket for showing on the application page that it has been cancelled, and possibly for displaying the comment.
