### PR TITLE
Add document validation step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "bootsnap", ">= 1.4.2", require: false
 gem "devise"
 gem "faker", require: false
 gem "faraday", require: false
+gem "govuk_design_system_formbuilder"
 gem "image_processing", "~> 1.2"
 gem "jbuilder", "~> 2.7"
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,12 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gov_uk_date_fields (4.1.0)
+      rails (>= 5.0.7.2)
+    govuk_design_system_formbuilder (2.1.5)
+      actionview (>= 5.2)
+      activemodel (>= 5.2)
+      activesupport (>= 5.2)
     hashdiff (1.0.1)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
@@ -352,6 +358,8 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  gov_uk_date_fields
+  govuk_design_system_formbuilder
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,8 +7,6 @@ class ApplicationController < ActionController::Base
   attr_reader :current_local_authority
   helper_method :current_local_authority
 
-  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
-
   private
 
   def find_current_local_authority_from_subdomain

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
   attr_reader :current_local_authority
   helper_method :current_local_authority
 
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   private
 
   def find_current_local_authority_from_subdomain

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -30,10 +30,12 @@ module PlanningApplicationHelper
   def display_status(planning_application)
     if planning_application.determined? && planning_application.reviewer_decision
       display_decision_status(planning_application)
-    elsif planning_application.status == "withdrawn"
-      { color: "grey", decision: "Withdrawn" }
+    elsif planning_application.status == "invalidated"
+      { color: "yellow", decision: "invalidated" }
+    elsif planning_application.status == "not_started"
+      { color: "grey", decision: "Not started" }
     else
-      { color: "grey", decision: "Returned" }
+      { color: "grey", decision: planning_application.status }
     end
   end
 
@@ -48,6 +50,8 @@ module PlanningApplicationHelper
   # rubocop: disable Metrics/MethodLength
   def proposal_step_mark_completed?(step_name, application)
     case step_name
+    when "Check documents"
+      application.not_started? == false
     when "Assess the proposal"
       application.assessor_decision&.valid?
     when "Reassess the proposal"

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -5,6 +5,7 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "components/task_list";
 @import "proposal";
 @import "components/drawings";
+@import 'govuk_date_fields';
 
 .noborder {
   border-bottom: none !important;

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -5,7 +5,6 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "components/task_list";
 @import "proposal";
 @import "components/drawings";
-@import 'govuk_date_fields';
 
 .noborder {
   border-bottom: none !important;

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -11,6 +11,7 @@ class PlanningApplicationPolicy < ApplicationPolicy
   alias_method :assess?, :editor?
   alias_method :cancel_confirmation?, :editor?
   alias_method :cancel?, :editor?
+  alias_method :validate_documents?, :editor?
   alias_method :determine?, :editor?
   alias_method :request_correction?, :editor?
   alias_method :update_numbers?, :editor?

--- a/app/views/drawings/index.html.erb
+++ b/app/views/drawings/index.html.erb
@@ -13,9 +13,35 @@
 <%= render "success_flash" %>
 
 <h2 class="govuk-heading-m">
-  Documents
+  Proposal documents
 </h2>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if current_user.assessor? && @planning_application.not_started? %>
+      <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+        <fieldset class="govuk-fieldset">
+          <% if form.object.errors[:planning_application].any? %>
+            <% form.object.errors[:planning_application].each do |error| %>
+              <span id="status-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+            <% end %>
+          <% end %>
+            <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>
+              <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes', size: 's'} do %>
+                <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Documents validated on:', size: 's', hint: 'For example, 31 03 2021', placeholder: true } %>
+                <% end %>
+              <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
+            <% end %>
+          </fieldset>
+              <p>
+                <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+                <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+              </p>
+           </div>
+      <% end%>
+    <% end %>
+  </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body" style="line-height: 1.6;">
@@ -23,7 +49,7 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">
-    <% if current_user.assessor? && @planning_application.in_assessment? %>
+    <% if current_user.assessor? && @planning_application.in_assessment? || @planning_application.not_started? %>
       <%= link_to "Upload documents", new_planning_application_drawing_path(@planning_application), role: "button", class: "govuk-button", data: { module: "govuk-button" } %>
     <% elsif current_user.assessor? %>
       <%= tag.button "Upload documents", disabled: "disabled", "aria-disabled": true, class: "govuk-button govuk-button--disabled", data: { module: "govuk-button" } %>
@@ -32,6 +58,7 @@
 </div>
 
 <ul class="app-task-list current-drawings" style="margin-bottom: 2em;">
+  <% unless @drawings.nil? %>
   <% filter_current(@drawings).each do |drawing| %>
     <li class="app-task-list__item">
       <div class="govuk-grid-column-one-quarter">
@@ -65,10 +92,12 @@
         </p>
       </div>
     </li>
+    <% end %>
   <% end %>
 </ul>
 
-<div class="govuk-grid-row">
+<% unless @drawings.nil? %>
+  <div class="govuk-grid-row">
   <table class="govuk-table archived-drawings">
     <caption class="govuk-table__caption">Archived documents</caption>
     <thead class="govuk-table__head">
@@ -104,3 +133,4 @@
   </table>
   </div>
 </div>
+<% end %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -5,8 +5,18 @@
     </h2>
     <ul class="app-task-list__items">
       <li class="app-task-list__item">
-        <% step_name = t("#{@planning_application.status}.proposal_step") %>
+        <% step_name = t("#{@planning_application.status}.validation_step") %>
+        <% aria_attributes = @planning_application.in_assessment? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
+        <% path = planning_application_drawings_path(@planning_application) %>
+        <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
 
+        <% unless @planning_application.not_started? %>
+          <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
+        <% end %>
+      </li>
+
+      <li class="app-task-list__item">
+        <% step_name = t("#{@planning_application.status}.proposal_step") %>
         <% if current_user.assessor? %>
           <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
           <% path = assessor_decision_path(@planning_application) %>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -12,8 +12,8 @@
       <% else %>
         <th scope="col" class="govuk-table__header">Days left</th>
       <% end %>
-      <% if id == "in_assessment" %>
-        <th scope="col" class="govuk-table__header">Consultation status</th>
+      <% if (id == "in_assessment" || id == "not_started_and_invalid") %>
+        <th scope="col" class="govuk-table__header">Status</th>
       <% elsif id == "awaiting_determination" %>
         <th scope="col" class="govuk-table__header">Recommendation date</th>
       <% elsif id == "closed" %>
@@ -44,6 +44,12 @@
         </td>
         <% if id == "in_assessment" %>
           <td class="govuk-table__cell">Not required</td>
+        <% elsif id == "not_started_and_invalid" %>
+            <td class="govuk-table__cell">
+              <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
+                <%= display_status(planning_application)[:decision] %>
+              </strong>
+            </td>
         <% elsif id == "awaiting_determination" %>
           <td class="govuk-table__cell"><%= planning_application.awaiting_determination_at.strftime("%e %b") %></td>
         <% elsif id == "closed" %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -39,7 +39,19 @@
       </p>
       <p class="govuk-body">
         <strong>Validation complete:</strong>
-        <%= @planning_application.created_at.strftime("%e %B %Y") %>
+        <% if @planning_application.in_assessment_at %>
+          <%= @planning_application.in_assessment_at.strftime("%e %B %Y") %>
+        <% else %>
+          Not yet started
+        <% end %>
+      </p>
+      <p class="govuk-body">
+        <strong>Documents valid from:</strong>
+        <% if @planning_application.documents_validated_at %>
+          <%= @planning_application.documents_validated_at.strftime("%e %B %Y") %>
+        <% else %>
+          Not yet validated
+        <% end %>
       </p>
       <p class="govuk-body">
         <strong>Target date:</strong>

--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "govuk_design_system_formbuilder"
+
+GOVUKDesignSystemFormBuilder.configure do |conf|
+  conf.default_submit_button_text = "Save"
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,23 +1,42 @@
 en:
+  not_started:
+    title: "Not started"
+    status: "Not Started"
+    heading: "Validate documents"
+    proposal_step: "Read the proposal"
+    validation_step: "Check the documents"
+    recommendation_step: "Submit the recommendation at next stage"
+  invalidated:
+    title: "Invalidated"
+    status: "Invalid"
+    heading: "For information only"
+    proposal_step: "Read the proposal"
+    validation_step: "Check the documents"
+    recommendation_step: "Submit the recommendation"
   in_assessment:
     title: "In assessment"
     heading: "Make recommendation"
     proposal_step: "Assess the proposal"
+    validation_step: "Check the documents"
     recommendation_step: "Submit the recommendation"
   awaiting_determination:
     title: "Awaiting manager's determination"
+    status: "Awaiting detemrination"
     heading: "Determine the proposal"
     proposal_step: "Review the recommendation"
+    validation_step: "Check the documents"
     recommendation_step: "Publish the recommendation"
   awaiting_correction:
     title: "Corrections requested"
     heading: "Make corrections"
     proposal_step: "Reassess the proposal"
+    validation_step: "Check the documents"
     recommendation_step: "Resubmit the recommendation"
   determined:
     title: "Determined"
     heading: "View the application"
     proposal_step: "View the assessment"
+    validation_step: "Check the documents"
     recommendation_step: "View the decision notice"
   full: "Full Householder Application"
   lawfulness_certificate: "Certificate of Lawfulness"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       patch :assess
       patch :determine
       patch :cancel
+      patch :validate_documents
       get :cancel_confirmation
     end
     resources :decisions, only: %i[new create edit update show]

--- a/db/migrate/20201223164330_add_documents_validated_column_to_planning_applications.rb
+++ b/db/migrate/20201223164330_add_documents_validated_column_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddDocumentsValidatedColumnToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :documents_validated_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_22_104230) do
+ActiveRecord::Schema.define(version: 2020_12_23_164330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 2020_12_22_104230) do
   end
 
   create_table "api_users", force: :cascade do |t|
-    t.string "name"
-    t.string "token"
+    t.string "name", default: "", null: false
+    t.string "token", default: "", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2020_12_22_104230) do
     t.datetime "returned_at"
     t.string "payment_reference"
     t.text "cancellation_comment"
+    t.date "documents_validated_at"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["site_id"], name: "index_planning_applications_on_site_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,8 +38,8 @@ ActiveRecord::Schema.define(version: 2020_12_23_164330) do
   end
 
   create_table "api_users", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.string "token", default: "", null: false
+    t.string "name"
+    t.string "token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
         protected_trees: false
       }.to_json
     }
+    documents_validated_at { Time.zone.today }
   end
 
   trait :lawfulness_certificate do
@@ -61,6 +62,7 @@ FactoryBot.define do
 
   trait :not_started do
     status                    { :not_started }
+    documents_validated_at    { nil }
 
     after(:create) do |pa|
       pa.target_date = Date.current + 7.weeks

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -175,13 +175,13 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
 
     it "returns correct values when application is withdrawn" do
       subject.withdraw!
-      expect(display_status(subject)[:decision]).to eql("Withdrawn")
+      expect(display_status(subject)[:decision]).to eql("withdrawn")
       expect(display_status(subject)[:color]).to eql("grey")
     end
 
     it "returns correct values when application is withdrawn" do
       subject.return!
-      expect(display_status(subject)[:decision]).to eql("Returned")
+      expect(display_status(subject)[:decision]).to eql("returned")
       expect(display_status(subject)[:color]).to eql("grey")
     end
   end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -55,12 +55,14 @@ RSpec.describe PlanningApplication, type: :model do
       end
 
       it "sets the status to in_assessment" do
+        subject.update!(documents_validated_at: Time.zone.today)
         subject.start
         expect(subject.status).to eq "in_assessment"
       end
 
       it "sets the timestamp for in_assessment_at to now" do
         freeze_time do
+          subject.update!(documents_validated_at: Time.zone.today)
           subject.start
           expect(subject.send("in_assessment_at")).to eql(Time.current)
         end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -55,8 +55,9 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(page).to have_content("Make recommendation")
     expect(page).to have_link("Assess the proposal")
 
-    # No steps have been completed
-    expect(page).not_to have_content("Completed")
+    # No steps have been completed except for Check documents
+    expect(page).to have_css("#check-the-documents-completed")
+    expect(page).not_to have_css("#assess-the-proposal-completed")
 
     # Cannot submit until preparation steps have been completed
     expect(page).not_to have_link("Submit the recommendation")

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Withdrawn")
+        expect(page).to have_content("withdrawn")
         click_link planning_application.reference
       end
 
@@ -71,7 +71,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Returned")
+        expect(page).to have_content("returned")
         click_link planning_application.reference
       end
 
@@ -81,6 +81,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   context "Cancelling from In Assessment" do
     before do
+      planning_application.update!(documents_validated_at: Time.zone.today)
       planning_application.start!
     end
 
@@ -103,7 +104,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Withdrawn")
+        expect(page).to have_content("withdrawn")
         click_link planning_application.reference
       end
 
@@ -130,7 +131,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Returned")
+        expect(page).to have_content("returned")
         click_link planning_application.reference
       end
 
@@ -163,7 +164,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Withdrawn")
+        expect(page).to have_content("withdrawn")
         click_link planning_application.reference
       end
 
@@ -190,7 +191,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Returned")
+        expect(page).to have_content("returned")
         click_link planning_application.reference
       end
 
@@ -200,6 +201,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   context "Cancelling from Awaiting Determination" do
     before do
+      planning_application.update!(documents_validated_at: Time.zone.today)
       planning_application.start!
       planning_application.assess!
     end
@@ -224,7 +226,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Withdrawn")
+        expect(page).to have_content("withdrawn")
         click_link planning_application.reference
       end
 
@@ -251,7 +253,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Closed"
 
       within("#closed") do
-        expect(page).to have_content("Returned")
+        expect(page).to have_content("returned")
         click_link planning_application.reference
       end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_content("Completed")
+        expect(page).not_to have_css("#determine-the-application-completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")
@@ -307,7 +307,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_content("Completed")
+        expect(page).not_to have_css("#determine-the-application-completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")
@@ -436,7 +436,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         click_button "Save"
 
-        expect(page).not_to have_content("Completed")
+        expect(page).not_to have_css("#determine-the-application-completed")
 
         expect(page).not_to have_link("Review the recommendation")
         expect(page).not_to have_text("Review the recommendation")

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -3,14 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application Assessment", type: :system do
-  let(:local_authority) {
-    create :local_authority,
-    name: "Cookie authority",
-    signatory_name: "Mr. Biscuit",
-    signatory_job_title: "Lord of BiscuitTown",
-    enquiries_paragraph: "reach us on postcode SW50",
-    email_address: "biscuit@somuchbiscuit.com"
-    }
+  let(:local_authority) do
+      create :local_authority,
+      name: "Cookie authority",
+      signatory_name: "Mr. Biscuit",
+      signatory_job_title: "Lord of BiscuitTown",
+      enquiries_paragraph: "reach us on postcode SW50",
+      email_address: "biscuit@somuchbiscuit.com"
+    end
   let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik", local_authority: local_authority }
   let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki", local_authority: local_authority }
 

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application Assessment", type: :system do
+  let(:local_authority) {
+    create :local_authority,
+    name: "Cookie authority",
+    signatory_name: "Mr. Biscuit",
+    signatory_job_title: "Lord of BiscuitTown",
+    enquiries_paragraph: "reach us on postcode SW50",
+    email_address: "biscuit@somuchbiscuit.com"
+    }
+  let!(:assessor) { create :user, :assessor, name: "Lorrine Krajcik", local_authority: local_authority }
+  let!(:reviewer) { create :user, :reviewer, name: "Harley Dicki", local_authority: local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :not_started,
+            :lawfulness_certificate,
+            local_authority: local_authority
+  end
+
+  let!(:drawing) do
+    create :drawing, :with_plan, :proposed_tags,
+           planning_application: planning_application
+  end
+
+  before do
+    sign_in assessor
+    visit root_path
+  end
+
+  context "Checking documents from Not Started status" do
+    scenario "Validate from Not Started" do
+      click_link planning_application.reference
+      click_link "Check the documents"
+
+      expect(page).to have_content("Are the documents valid?")
+
+      choose "Yes"
+
+      fill_in "Day", with: "03"
+      fill_in "Month", with: "12"
+      fill_in "Year", with: "2021"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application is ready for assessment")
+
+      click_link "Home"
+
+      click_link "In assessment"
+
+      within("#under_assessment") do
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_link("Check documents")
+    end
+
+    scenario "Invalidate from Not Started" do
+      click_link planning_application.reference
+      click_link "Check the documents"
+
+      expect(page).to have_content("Are the documents valid?")
+
+      choose "No"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been invalidated")
+
+      click_link "Home"
+
+      within("#not_started_and_invalid") do
+        expect(page).to have_content("invalidated")
+        click_link planning_application.reference
+      end
+
+      expect(page).not_to have_link("Check documents")
+    end
+  end
+
+  context "Planning application does not transition when expected inputs are not sent" do
+    scenario "Error is shown when no radio button is selected" do
+      click_link planning_application.reference
+      click_link "Check the documents"
+
+      click_button "Save"
+
+      expect(page).to have_content("Please choose Yes or No")
+    end
+
+    scenario "Application remains in not_started status if incorrect date is sent" do
+      click_link planning_application.reference
+      click_link "Check the documents"
+
+      expect(page).to have_content("Are the documents valid?")
+
+      choose "Yes"
+
+      fill_in "Day", with: "3"
+      fill_in "Month", with: "&&£$£$"
+      fill_in "Year", with: "2022"
+
+      click_button "Save"
+
+      expect(planning_application.status).to eql("not_started")
+      expect(planning_application.documents_validated_at).to be(nil)
+
+      click_link "Home"
+      expect(page).to have_content(planning_application.reference)
+      expect(page).to have_content("Not started")
+    end
+  end
+end


### PR DESCRIPTION
<img width="1080" alt="validate3" src="https://user-images.githubusercontent.com/1880450/103342734-3c220b00-4a82-11eb-8939-1aef7e3764b5.png">
<img width="1066" alt="validate2" src="https://user-images.githubusercontent.com/1880450/103342741-3d533800-4a82-11eb-9fa6-1d88ae285297.png">
<img width="1087" alt="validate1" src="https://user-images.githubusercontent.com/1880450/103342746-3e846500-4a82-11eb-9a22-68e0c25d82ad.png">

This adds a form for the assessor to validate the documents. The application cannot transition to in_assessment without the documents_validated_at field being populated. The assessor also has the option to invalidate the application, and in each case the planning application appears correctly flagged in the index table.

### Story Link

https://trello.com/c/wNJMfBnm/5-indicate-documents-are-valid-invalid

### Decisions 

We made a decision to use the GovUK Formbuilder gem. An initial attempt to use the Ministry of Justice `gov_uk_date_fields` gem was abandoned after discovering that its date fields do not work when nested under Formbuilder fields.

