### PR TITLE
Reveal documents in API

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Api::V1::DocumentsController < Api::V1::ApplicationController
+  skip_before_action :authenticate
+
+  def show
+    document = PlanningApplication.find(params[:planning_application_id]).documents.find(params[:id])
+    redirect_to rails_blob_url(document.file)
+  end
+end

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -33,3 +33,12 @@ json.received_date planning_application.created_at
 json.decision planning_application.reviewer_decision.status if planning_application.reviewer_decision
 json.questions JSON.parse(planning_application.questions) if planning_application.questions
 json.constraints JSON.parse(planning_application.constraints) if planning_application.constraints
+json.documents planning_application.documents do |document|
+  json.url api_v1_planning_application_document_url(planning_application, document)
+  json.extract! document,
+    :created_at,
+    :archived_at,
+    :archive_reason,
+    :tags,
+    :numbers
+end

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -23,7 +23,7 @@
       </h2>
       <p>
         <%= link_to image_tag(@document.file.representation(resize: "300x212")),
-                    rails_blob_path(@document.file), target: :_blank %>
+                    api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
       </p>
       <h2 class="govuk-heading-s">
         Why do you want to archive this document?

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -17,9 +17,9 @@
     <h2 class="govuk-heading-m"><%= @document.name %></h2>
 
     <%= link_to image_tag(@document.file.representation(resize: "500x500")),
-                rails_blob_path(@document.file), target: :_blank %>
+                api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
     <p class="govuk-body">
-      <%= link_to "View in new window", rails_blob_path(@document.file), target: :_new %>
+      <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, @document), target: :_new %>
     </p>
 
     <%= form_with model: [ @planning_application, @document ], local: true do |form| %>

--- a/app/views/documents/edit_numbers.html.erb
+++ b/app/views/documents/edit_numbers.html.erb
@@ -53,10 +53,10 @@
                 <p class="govuk-body">
                   <%= document.created_at.strftime("%e %B %Y") %>
                   <br/>
-                  <%= link_to "View in new window", rails_blob_path(document.file), target: :_blank %>
+                  <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, document.id), target: :_blank %>
                 </p>
                 <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                            rails_blob_path(document.file), target: :_blank %>          <br/>
+                            api_v1_planning_application_document_url(@planning_application, document.id), target: :_blank %>          <br/>
 
                 <div class="govuk-form-group <%= document.errors[:numbers].any? ? 'govuk-form-group--error' : '' %>">
                   <% if document.errors[:numbers].any? %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -63,9 +63,9 @@
     <li class="app-task-list__item">
       <div class="govuk-grid-column-one-quarter">
         <%= link_to image_tag(document.file.representation(resize: "300x212"), class: "govuk-!-width-full"),
-                    rails_blob_path(document.file), target: :_blank %>
+                    api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
         <p class="govuk-body">
-          <%= link_to "View in new window", rails_blob_path(document.file), target: :_new %>
+          <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, document), target: :_new %>
         </p>
       </div>
 
@@ -116,7 +116,7 @@
       <tbody class="govuk-table__body">
         <% filter_archived(@documents).each do |document| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell archive-data"><%= link_to document.name, rails_blob_path(document.file), target: :_new %></td>
+            <td class="govuk-table__cell archive-data"><%= link_to document.name, api_v1_planning_application_document_url(@planning_application, document), target: :_new %></td>
             <td class="govuk-table__cell archive-data tags">
               <ul class="govuk-list">
                 <% document.tags.each do |tag| %>

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -20,7 +20,7 @@
             <%= document.created_at.strftime('%d %b %Y') %>
           </p>
           <p class="govuk-body">
-            <%= link_to "View in new window", rails_blob_path(document.file), target: :_blank %>
+            <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
           </p>
           <ul class="govuk-list">
             <% document.tags.each do |tag| %>
@@ -28,7 +28,7 @@
             <% end %>
           </ul>
           <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                          rails_blob_path(document.file), target: :_blank %>
+                          api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
           <br>
           <br>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      resources :planning_applications, only: %i[index create show]
+      resources :planning_applications, only: %i[index create show] do
+        resources :documents, only: %i[show]
+      end
     end
   end
 

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -60,6 +60,14 @@ paths:
                     agent_last_name: Harper
                     agent_phone: '237878889'
                     agent_email: agent@example.com
+                    documents:
+                      - url: http://example.com/document_path.pdf
+                        created_at: '2020-05-16T05:18:17.540Z'
+                        archived_at: '2020-05-16T05:18:17.540Z'
+                        archive_reason: other
+                        tags:
+                          - front elevation - proposed
+                        numbers: PLAN01
   "/api/v1/planning_applications":
     get:
       summary: Retrieves all determined planning applications

--- a/spec/requests/document_show_spec.rb
+++ b/spec/requests/document_show_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "API request to list planning applications", type: :request, show_exceptions: true do
+  let!(:planning_application) { create(:planning_application, :not_started) }
+  let!(:document) { create(:document, :with_file, planning_application: planning_application) }
+
+  describe "data" do
+    it "returns a 404 if no planning application" do
+      expect {
+        get "/api/v1/planning_applications/xxx/documents/#{document.id}"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "returns a 404 if no document" do
+      expect {
+        get "/api/v1/planning_applications/#{planning_application.id}/documents/xxx"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it "redirects to blob url" do
+      get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+      expect(response).to redirect_to(rails_blob_path(document.file))
+    end
+  end
+end

--- a/spec/requests/oas3_spec.rb
+++ b/spec/requests/oas3_spec.rb
@@ -61,20 +61,26 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
   it "should successfully return the listing of applications as specified" do
     planning_application_hash = example_response_hash_for('/api/v1/planning_applications', 'get', 200, 'Full')['data'].first
     site = Site.create! planning_application_hash.fetch('site')
-    PlanningApplication.create! planning_application_hash.except('application_number', 'received_date').merge(site: site, local_authority: create(:local_authority))
+    planning_application = PlanningApplication.create! planning_application_hash.except('application_number', 'received_date', 'documents').merge(site: site, local_authority: create(:local_authority))
+    planning_application_document = planning_application.documents.create!(planning_application_hash.fetch('documents').first.except('url'))
 
     get '/api/v1/planning_applications'
 
-    expect(JSON.parse(response.body)).to eq(example_response_hash_for('/api/v1/planning_applications', 'get', 200, 'Full'))
+    expected_reponse = example_response_hash_for('/api/v1/planning_applications', 'get', 200, 'Full')
+    expected_reponse["data"].first["documents"].first['url'] = api_v1_planning_application_document_url(planning_application, planning_application_document)
+    expect(JSON.parse(response.body)).to eq(expected_reponse)
   end
 
   it "should successfully return an application as specified" do
     planning_application_hash = example_response_hash_for('/api/v1/planning_applications/{id}', 'get', 200, 'Full')
     site = Site.create! planning_application_hash.fetch('site')
-    PlanningApplication.create! planning_application_hash.except('application_number', 'received_date').merge(site: site, local_authority: create(:local_authority))
+    planning_application = PlanningApplication.create! planning_application_hash.except('application_number', 'received_date', 'documents').merge(site: site, local_authority: create(:local_authority))
+    planning_application_document = planning_application.documents.create!(planning_application_hash.fetch('documents').first.except('url'))
 
     get "/api/v1/planning_applications/#{planning_application_hash['id']}"
 
-    expect(JSON.parse(response.body)).to eq(planning_application_hash)
+    expected_reponse = example_response_hash_for('/api/v1/planning_applications/{id}', 'get', 200, 'Full')
+    expected_reponse["documents"].first['url'] = api_v1_planning_application_document_url(planning_application, planning_application_document)
+    expect(JSON.parse(response.body)).to eq(expected_reponse)
   end
 end

--- a/spec/requests/planning_application_list_spec.rb
+++ b/spec/requests/planning_application_list_spec.rb
@@ -78,11 +78,13 @@ RSpec.describe "API request to list planning applications", type: :request, show
         expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
         expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
         expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
+        expect(planning_application_json["documents"]).to eq([])
       end
 
       context "for a granted planning application" do
         let!(:planning_application) { create(:planning_application, :determined) }
         let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
+        let!(:document) { create(:document, :with_file, planning_application: planning_application) }
 
         it "returns the accurate data" do
           get "/api/v1/planning_applications.json"
@@ -119,6 +121,12 @@ RSpec.describe "API request to list planning applications", type: :request, show
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
           expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
           expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
+          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document))
+          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document.created_at))
+          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document.archived_at))
+          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document.archive_reason)
+          expect(planning_application_json["documents"].first["tags"]).to eq(document.tags)
+          expect(planning_application_json["documents"].first["numbers"]).to eq(document.numbers)
         end
       end
     end

--- a/spec/requests/planning_application_show_spec.rb
+++ b/spec/requests/planning_application_show_spec.rb
@@ -76,11 +76,13 @@ RSpec.describe "API request to list planning applications", type: :request, show
         expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
         expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
         expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
+        expect(planning_application_json["documents"]).to eq([])
       end
 
       context "for a granted planning application" do
         let!(:planning_application) { create(:planning_application, :determined) }
         let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
+        let!(:document) { create(:document, :with_file, planning_application: planning_application) }
 
         it "returns the accurate data" do
           get "/api/v1/planning_applications/#{planning_application.id}"
@@ -117,6 +119,12 @@ RSpec.describe "API request to list planning applications", type: :request, show
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
           expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
           expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
+          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document))
+          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document.created_at))
+          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document.archived_at))
+          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document.archive_reason)
+          expect(planning_application_json["documents"].first["tags"]).to eq(document.tags)
+          expect(planning_application_json["documents"].first["numbers"]).to eq(document.numbers)
         end
       end
     end

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Documents index page", type: :system do
     end
 
     scenario "File image opens in new tab" do
-      first(:css, 'a[href*="active"]').click
+      click_link 'View in new window'
       page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 
       expect(current_url).to include("/rails/active_storage/")


### PR DESCRIPTION
Adds documents array to show and index actions of the API. This means that all documents are revealed to the public.

We probably want to be able to limit access to some documents in the future, so rather than changing the storage configuration to make all files public, I have created a new action that redirects to the temporary URLs that ActiveStorage creates. This will make it easier to add conditionals to it later.