### PR TITLE
Add new workplace_status field

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -93,7 +93,7 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
                       :applicant_phone, :applicant_email,
                       :agent_first_name, :agent_last_name,
                       :agent_phone, :agent_email, :questions, :files,
-                      :payment_reference]
+                      :payment_reference, :work_status]
     params.permit permitted_keys
   end
 

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -16,7 +16,7 @@ module PlanningApplicationHelper
   end
 
   def proposed_or_existing(planning_application)
-    planning_application.work_status == "Proposed" ? "No" : "Yes"
+    planning_application.work_status == "proposed" ? "No" : "Yes"
   end
 
   def filter_text

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -15,6 +15,10 @@ module PlanningApplicationHelper
     params[:q] == "exclude_others"
   end
 
+  def proposed_or_existing(planning_application)
+    planning_application.work_status == "Proposed" ? "No" : "Yes"
+  end
+
   def filter_text
     if current_user.assessor?
       "View my applications"

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -37,6 +37,12 @@ class PlanningApplication < ApplicationRecord
             inclusion: { in: STATUSES,
                          message: "Please select one of the below options" }
 
+  WORK_STATUSES = %w[Proposed Existing]
+
+  validates :work_status,
+            inclusion: { in: WORK_STATUSES,
+                         message: "Work Status should be Proposed or Existing" }
+
   validate :documents_validated_if_not_started
 
   scope :not_started_and_invalid, -> { where("status = 'not_started' OR status = 'invalidated'") }

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -37,11 +37,11 @@ class PlanningApplication < ApplicationRecord
             inclusion: { in: STATUSES,
                          message: "Please select one of the below options" }
 
-  WORK_STATUSES = %w[Proposed Existing]
+  WORK_STATUSES = %w[proposed existing]
 
   validates :work_status,
             inclusion: { in: WORK_STATUSES,
-                         message: "Work Status should be Proposed or Existing" }
+                         message: "Work Status should be proposed or existing" }
 
   validate :documents_validated_if_not_started
 

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -4,7 +4,7 @@
 
 # Decision notice
 
-Certificate of lawfulness of proposed use or development: <%= "#{@decision.status}." %>
+Certificate of lawfulness of <%= t(@planning_application.work_status) %> use or development: <%= "#{@decision.status}." %>
 
 Applicant: <%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %>
 Date of Issue of this decision: <%= @planning_application.determined_at.strftime("%e %B %Y") %>
@@ -14,7 +14,7 @@ Application number: <%= @planning_application.reference %>
 Local authority: <%= @planning_application.local_authority.name %>
 
 Proposed use or development:
-Certificate of lawful development (proposed) for the construction of <%= @planning_application.description %>
+Certificate of lawful development (<%= t(@planning_application.work_status) %>) for the construction of <%= @planning_application.description %>
 
 <% if @decision.granted? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are lawful for the purposes of S.192 of the Town and Country Planning Act 1990 in accordance with the valid application received on <%= @planning_application.created_at.strftime("%d/%m/%Y") %> and supporting documents listed below. Full application is available on the planning register.

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -4,7 +4,7 @@
 
 # Decision notice
 
-Certificate of lawfulness of <%= t(@planning_application.work_status) %> use or development: <%= "#{@decision.status}." %>
+Certificate of lawfulness of <%= @planning_application.work_status %> use or development: <%= "#{@decision.status}." %>
 
 Applicant: <%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %>
 Date of Issue of this decision: <%= @planning_application.determined_at.strftime("%e %B %Y") %>
@@ -14,7 +14,7 @@ Application number: <%= @planning_application.reference %>
 Local authority: <%= @planning_application.local_authority.name %>
 
 Proposed use or development:
-Certificate of lawful development (<%= t(@planning_application.work_status) %>) for the construction of <%= @planning_application.description %>
+Certificate of lawful development (<%= @planning_application.work_status %>) for the construction of <%= @planning_application.description %>
 
 <% if @decision.granted? %>
   IT IS HEREBY CERTIFIED that the use or operations described below are lawful for the purposes of S.192 of the Town and Country Planning Act 1990 in accordance with the valid application received on <%= @planning_application.created_at.strftime("%d/%m/%Y") %> and supporting documents listed below. Full application is available on the planning register.

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -2,7 +2,7 @@
   <span class="govuk-caption-xl"><%= planning_application.local_authority.name %> </span>
   <h2 class="govuk-heading-m">Town and country planning act 1990 (as amended)</h2>
   <p class="govuk-body"> <strong>Decision notice</strong> </p>
-  <p class="govuk-body">Certificate of lawfulness of proposed use or development: <strong><%= "#{decision.status}." %></strong></p>
+  <p class="govuk-body">Certificate of lawfulness of <%= t(@planning_application.work_status) %> use or development: <strong><%= "#{decision.status}." %></strong></p>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <p class="govuk-body">
     <strong>Applicant:</strong>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %><br>
@@ -15,8 +15,8 @@
     <strong>Application number:</strong>
     &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application.reference %><br>
   </p>
-  <p class="govuk-body">Proposed use or development:<br>
-    Certificate of lawful development (proposed) for the construction of <%= planning_application.description %>
+  <p class="govuk-body"><%= t(@planning_application.work_status) %> use or development:<br>
+    Certificate of lawful development (<%= t(@planning_application.work_status) %>) for the construction of <%= planning_application.description %>
   </p>
   <% if decision.granted? %>
     <p class="govuk-body">

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -2,7 +2,7 @@
   <span class="govuk-caption-xl"><%= planning_application.local_authority.name %> </span>
   <h2 class="govuk-heading-m">Town and country planning act 1990 (as amended)</h2>
   <p class="govuk-body"> <strong>Decision notice</strong> </p>
-  <p class="govuk-body">Certificate of lawfulness of <%= t(@planning_application.work_status) %> use or development: <strong><%= "#{decision.status}." %></strong></p>
+  <p class="govuk-body">Certificate of lawfulness of <%= @planning_application.work_status %> use or development: <strong><%= "#{decision.status}." %></strong></p>
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <p class="govuk-body">
     <strong>Applicant:</strong>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %><br>
@@ -15,8 +15,8 @@
     <strong>Application number:</strong>
     &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<%= planning_application.reference %><br>
   </p>
-  <p class="govuk-body"><%= t(@planning_application.work_status) %> use or development:<br>
-    Certificate of lawful development (<%= t(@planning_application.work_status) %>) for the construction of <%= planning_application.description %>
+  <p class="govuk-body"><%= @planning_application.work_status.humanize %> use or development:<br>
+    Certificate of lawful development (<%= @planning_application.work_status %>) for the construction of <%= planning_application.description %>
   </p>
   <% if decision.granted? %>
     <p class="govuk-body">

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -29,6 +29,11 @@
             </td>
           </tr>
           <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><strong>Work already completed:</strong></td>
+            <td class="govuk-table__cell"><%= proposed_or_existing(@planning_application) %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>Summary:</strong></td>
             <td class="govuk-table__cell">
               <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,8 +40,6 @@ en:
     recommendation_step: "View the decision notice"
   full: "Full Householder Application"
   lawfulness_certificate: "Certificate of Lawfulness"
-  Proposed: "proposed"
-  Existing: "existing"
   user_not_authorized: "You are not authorized to perform this action."
   scale: "Missing scale bar or north arrow"
   design: "Revise design"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
     recommendation_step: "View the decision notice"
   full: "Full Householder Application"
   lawfulness_certificate: "Certificate of Lawfulness"
+  Proposed: "proposed"
+  Existing: "existing"
   user_not_authorized: "You are not authorized to perform this action."
   scale: "Missing scale bar or north arrow"
   design: "Revise design"

--- a/db/migrate/20201230133548_add_completed_to_planning_applications.rb
+++ b/db/migrate/20201230133548_add_completed_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddCompletedToPlanningApplications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :planning_applications, :work_status, :string, default: "Proposed"
+  end
+end

--- a/db/migrate/20201230133548_add_completed_to_planning_applications.rb
+++ b/db/migrate/20201230133548_add_completed_to_planning_applications.rb
@@ -1,5 +1,5 @@
 class AddCompletedToPlanningApplications < ActiveRecord::Migration[6.0]
   def change
-    add_column :planning_applications, :work_status, :string, default: "Proposed"
+    add_column :planning_applications, :work_status, :string, default: "proposed"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,16 +107,14 @@ ActiveRecord::Schema.define(version: 2020_12_30_150801) do
     t.string "applicant_phone"
     t.bigint "local_authority_id"
     t.jsonb "constraints"
-    t.string "payment_reference"
     t.datetime "invalidated_at"
     t.datetime "withdrawn_at"
     t.datetime "returned_at"
+    t.string "payment_reference"
     t.text "cancellation_comment"
-    t.string "reference"
     t.date "documents_validated_at"
-    t.string "work_status", default: "Proposed"
+    t.string "work_status", default: "proposed"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
-    t.index ["reference"], name: "index_planning_applications_on_reference", unique: true
     t.index ["site_id"], name: "index_planning_applications_on_site_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -114,6 +114,7 @@ ActiveRecord::Schema.define(version: 2020_12_30_150801) do
     t.text "cancellation_comment"
     t.string "reference"
     t.date "documents_validated_at"
+    t.string "work_status", default: "Proposed"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["reference"], name: "index_planning_applications_on_reference", unique: true
     t.index ["site_id"], name: "index_planning_applications_on_site_id"

--- a/lib/tasks/create_sample_data.rake
+++ b/lib/tasks/create_sample_data.rake
@@ -153,6 +153,7 @@ task create_sample_data: :environment do
     ward: "Rye Lane",
     local_authority: southwark,
     ward: "Rye Lane",
+    work_status: "existing",
     constraints: sample_constraints
   ) do |pa|
     pa.description = "Construction of a single storey side extension"
@@ -190,6 +191,7 @@ task create_sample_data: :environment do
     application_type: :lawfulness_certificate,
     site: lambeth_site,
     ward: "Lambeth",
+    work_status: "existing",
     local_authority: lambeth,
     constraints: sample_constraints
   ) do |pa|
@@ -208,6 +210,7 @@ task create_sample_data: :environment do
     application_type: :lawfulness_certificate,
     site: bucks_site,
     ward: "Buckinghamshire",
+    work_status: "existing",
     local_authority: bucks,
     constraints: sample_constraints
   ) do |pa|

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -135,6 +135,9 @@ paths:
                 ward:
                   type: string
                   example: Dulwich Wood
+                work_status:
+                  type: string
+                  example: Proposed
                 questions:
                   type: object
                   properties:
@@ -252,6 +255,7 @@ paths:
                   agent_last_name: Harper
                   agent_phone: '237878889'
                   agent_email: agent@example.com
+                  work_status: 'Proposed'
                   questions:
                     flow:
                       - id: '-LsXty7cOZycK0rqv8B2'

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -137,7 +137,7 @@ paths:
                   example: Dulwich Wood
                 work_status:
                   type: string
-                  example: Proposed
+                  example: proposed
                 questions:
                   type: object
                   properties:
@@ -255,7 +255,7 @@ paths:
                   agent_last_name: Harper
                   agent_phone: '237878889'
                   agent_email: agent@example.com
-                  work_status: 'Proposed'
+                  work_status: 'proposed'
                   questions:
                     flow:
                       - id: '-LsXty7cOZycK0rqv8B2'

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
       }.to_json
     }
     documents_validated_at { Time.zone.today }
-    work_status { "Proposed" }
+    work_status { "proposed" }
   end
 
   trait :lawfulness_certificate do

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -40,6 +40,7 @@ FactoryBot.define do
       }.to_json
     }
     documents_validated_at { Time.zone.today }
+    work_status { "Proposed" }
   end
 
   trait :lawfulness_certificate do

--- a/spec/fixtures/files/minimal_planning_application.json
+++ b/spec/fixtures/files/minimal_planning_application.json
@@ -13,7 +13,7 @@
   "agent_last_name": "Harper",
   "agent_phone": "237878889",
   "agent_email": "agent@example.com",
-  "work_status": "Proposed",
+  "work_status": "proposed",
   "site": {
     "uprn": "100081043511",
     "property_name": null,

--- a/spec/fixtures/files/minimal_planning_application.json
+++ b/spec/fixtures/files/minimal_planning_application.json
@@ -13,6 +13,7 @@
   "agent_last_name": "Harper",
   "agent_phone": "237878889",
   "agent_email": "agent@example.com",
+  "work_status": "Proposed",
   "site": {
     "uprn": "100081043511",
     "property_name": null,

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -17,6 +17,7 @@
   "owner_shares": 100,
   "owner_types": 0,
   "owners_notified": 0,
+  "work_status": "Proposed",
   "nonnotification_reason": "Unaware of responsibility to notify",
   "visit_contact_name": "Mantas Prikockas",
   "visit_contact_phone": 7971111111,

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -17,7 +17,7 @@
   "owner_shares": 100,
   "owner_types": 0,
   "owners_notified": 0,
-  "work_status": "Proposed",
+  "work_status": "proposed",
   "nonnotification_reason": "Unaware of responsibility to notify",
   "visit_contact_name": "Mantas Prikockas",
   "visit_contact_phone": 7971111111,

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -78,13 +78,13 @@ RSpec.describe PlanningApplication, type: :model do
 
       subject { create :planning_application, :not_started }
 
-      it "sets work_status to Proposed" do
-        expect(subject.work_status).to eq "Proposed"
+      it "sets work_status to proposed" do
+        expect(subject.work_status).to eq "proposed"
       end
 
       it "allows the work status to be updated" do
-        subject.update!(work_status: "Existing")
-        expect(subject.send("work_status")).to eql("Existing")
+        subject.update!(work_status: "existing")
+        expect(subject.send("work_status")).to eql("existing")
       end
     end
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -69,6 +69,25 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
 
+    describe "work_status" do
+      let!(:proposed_drawing_1) do
+        create :document, :with_file, :proposed_tags,
+               planning_application: subject,
+               numbers: "number"
+      end
+
+      subject { create :planning_application, :not_started }
+
+      it "sets work_status to Proposed" do
+        expect(subject.work_status).to eq "Proposed"
+      end
+
+      it "allows the work status to be updated" do
+        subject.update!(work_status: "Existing")
+        expect(subject.send("work_status")).to eql("Existing")
+      end
+    end
+
     context "return the application from invalidated" do
       subject { create :planning_application, :invalidated }
 

--- a/spec/requests/oas3_spec.rb
+++ b/spec/requests/oas3_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
     expect(PlanningApplication.last.agent_last_name).to eq('Harper')
     expect(PlanningApplication.last.agent_phone).to eq('237878889')
     expect(PlanningApplication.last.agent_email).to eq('agent@example.com')
-    expect(PlanningApplication.last.work_status).to eq('Proposed')
+    expect(PlanningApplication.last.work_status).to eq('proposed')
     expect(JSON.parse(PlanningApplication.last.questions)['flow'].first['text']).to eq('The property is')
     expect(JSON.parse(PlanningApplication.last.constraints)['conservation_area']).to eq(true)
     expect(PlanningApplication.last.documents.first.file).to be_present

--- a/spec/requests/oas3_spec.rb
+++ b/spec/requests/oas3_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
     expect(PlanningApplication.last.agent_last_name).to eq('Harper')
     expect(PlanningApplication.last.agent_phone).to eq('237878889')
     expect(PlanningApplication.last.agent_email).to eq('agent@example.com')
+    expect(PlanningApplication.last.work_status).to eq('Proposed')
     expect(JSON.parse(PlanningApplication.last.questions)['flow'].first['text']).to eq('The property is')
     expect(JSON.parse(PlanningApplication.last.constraints)['conservation_area']).to eq(true)
     expect(PlanningApplication.last.documents.first.file).to be_present

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       end
 
       scenario "agrees with assessor's decision when proposed work has been completed" do
-        planning_application.update!(work_status: "Existing")
+        planning_application.update!(work_status: "existing")
 
         # Check that the application is no longer in awaiting determination
         within("#awaiting_determination") do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature "Planning Application show page", type: :system do
                                        ward: "Dulwich Wood", site: site,
                                        target_date: Date.current + 14.days, local_authority: local_authority,
                                        payment_reference: 'PAY123',
-                                       work_status: "Proposed",
+                                       work_status: "proposed",
                                        constraints:  '{"conservation_area": true, "article4_area": false, "scheduled_monument": false }'}
   let(:assessor) { create :user, :assessor, local_authority: local_authority }
   let(:reviewer) { create :user, :reviewer, local_authority: local_authority }

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -10,6 +10,7 @@ RSpec.feature "Planning Application show page", type: :system do
                                        ward: "Dulwich Wood", site: site,
                                        target_date: Date.current + 14.days, local_authority: local_authority,
                                        payment_reference: 'PAY123',
+                                       work_status: "Proposed",
                                        constraints:  '{"conservation_area": true, "article4_area": false, "scheduled_monument": false }'}
   let(:assessor) { create :user, :assessor, local_authority: local_authority }
   let(:reviewer) { create :user, :reviewer, local_authority: local_authority }
@@ -22,6 +23,10 @@ RSpec.feature "Planning Application show page", type: :system do
 
     scenario "Site address is present" do
       expect(page).to have_text("7 Elm Grove, London, SE15 6UT")
+    end
+
+    scenario "Completed status is correct" do
+      expect(page).to have_text("Work already completed: No")
     end
 
     scenario "Planning application code is correct" do


### PR DESCRIPTION
### Description of change

We need a new field to indicate whether the works for which permission is being applied for are Proposed or Existing. I've renamed this field `work_status` as I felt that `completed` could be too easily confused with application overall status. In addition to displaying this as a Yes/No field on the application information template, we also need to display Proposed/Existing status interpolated into the text in the Decision Notice and mail template.

### Story Link

https://trello.com/c/1Yucb479/1-proposed-or-existing-development

