### PR TITLE
Tell rubocop package_builder doesn't use Rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,10 @@ AllCops:
   Exclude:
     - "db/migrate/*"
 
+Rails:
+  Exclude:
+    - "lib/package_builder.rb"
+
 RSpec/ContextWording:
   Enabled: false
 

--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -25,7 +25,7 @@ class PackageBuilder
     @environment = environment.to_s
     @revision    = current_revision
     @tmpdir      = Dir.mktmpdir
-    @timestamp   = Time.zone.now.getutc
+    @timestamp   = Time.now.getutc
     @release     = @timestamp.strftime("%Y%m%d%H%M%S")
     @client      = nil
     @completed   = false
@@ -57,11 +57,11 @@ class PackageBuilder
     release_obj = bucket.object(release_key)
 
     info "Uploading package #{package_name} to S3 ..."
-    start_time = Time.zone.now
+    start_time = Time.now
 
     release_obj.upload_file(package_path)
 
-    duration = Time.zone.now - start_time
+    duration = Time.now - start_time
     info "Upload completed in #{duration} seconds."
   end
 
@@ -400,7 +400,7 @@ private
   def deployment_progress(deployment)
     id         = deployment.deployment_id
     created_at = deployment.create_time
-    duration   = Time.zone.now - created_at
+    duration   = Time.now - created_at
     overview   = deployment.deployment_overview
     progress   = %w[Pending InProgress Succeeded Failed Skipped]
     progress   = progress.map { |status| "#{status}: %d" }.join(", ")


### PR DESCRIPTION
Rubocop assumed that package_builder.rb had Rails loaded, and therefore autocorrected Time.now to Time.zone.now. Undo that, and exclude Rails rules from this file.