### PR TITLE
Improve validation for documents valid date

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -135,22 +135,19 @@ class PlanningApplicationsController < AuthenticationController
     valid_at = date_string_from_params(params[:planning_application][:'documents_validated_at(3i)'],
                                        params[:planning_application][:'documents_validated_at(2i)'],
                                        params[:planning_application]["documents_validated_at(1i)"])
-    @planning_application.update!(documents_validated_at: valid_at)
-    if @planning_application.save
+    if date_string_valid?(valid_at) && @planning_application.update!(documents_validated_at: valid_at)
       @planning_application.start!
     else
-      render template: "documents/index", planning_application: @planning_application,
-             documents: @planning_application.documents
+      @planning_application.errors.add(:planning_application, "A validation date must be present")
     end
   end
 
   def date_string_from_params(year, month, day)
-    valid_date = [year, month, day].join("-")
-    if valid_date.match?(/\d{2}-\d{2}-\d{4}/)
-      valid_date
-    else
-      @planning_application.errors.add(:planning_application, "Please enter a valid date")
-    end
+    [year, month, day].join("-")
+  end
+
+  def date_string_valid?(valid_date)
+    valid_date.match?(/\d{2}-\d{2}-\d{4}/)
   end
 
 private

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -35,7 +35,7 @@ module PlanningApplicationHelper
     if planning_application.determined? && planning_application.reviewer_decision
       display_decision_status(planning_application)
     elsif planning_application.status == "invalidated"
-      { color: "yellow", decision: "invalidated" }
+      { color: "yellow", decision: "invalid" }
     elsif planning_application.status == "not_started"
       { color: "grey", decision: "Not started" }
     else

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -176,6 +176,10 @@ class PlanningApplication < ApplicationRecord
     numbered_count < documents.has_proposed_tag.count
   end
 
+  def recommendable?
+    true unless determined? || returned? || withdrawn? || invalidated?
+  end
+
   def cancellable?
     true unless determined? || returned? || withdrawn?
   end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -18,7 +18,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if current_user.assessor? && @planning_application.not_started? %>
+    <% if current_user.assessor? && (@planning_application.not_started? || @planning_application.invalidated?) %>
       <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <fieldset class="govuk-fieldset">
           <% if form.object.errors[:planning_application].any? %>
@@ -29,7 +29,7 @@
           <% end %>
             <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>
               <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes', size: 's'} do %>
-                <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Documents validated on:', size: 's', hint: 'For example, 31 03 2021', placeholder: true } %>
+                <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Valid date', size: 's' }, hint: { text: 'Date application should be considered valid, e.g. 28 12 2021' } %>
                 <% end %>
               <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
             <% end %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -10,14 +10,14 @@
         <% path = planning_application_documents_path(@planning_application) %>
         <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
 
-        <% unless @planning_application.not_started? %>
+        <% unless (@planning_application.not_started? || @planning_application.invalidated?)  %>
           <%= tag.strong "Completed", id: "#{step_name.parameterize}-completed", class: "govuk-tag app-task-list__task-tag" %>
         <% end %>
       </li>
 
       <li class="app-task-list__item">
         <% step_name = t("#{@planning_application.status}.proposal_step") %>
-        <% if current_user.assessor? %>
+        <% if current_user.assessor? && @planning_application.recommendable? %>
           <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
           <% path = assessor_decision_path(@planning_application) %>
           <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>
@@ -69,7 +69,7 @@
         <% step_name = t("#{@planning_application.status}.recommendation_step") %>
         <% aria_attributes = @planning_application.awaiting_determination? ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
 
-        <% if current_user.assessor? && @planning_application.assessor_decision && @planning_application.documents_ready_for_publication? %>
+        <% if current_user.assessor? && @planning_application.assessor_decision && @planning_application.documents_ready_for_publication? && @planning_application.recommendable? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>
         <% elsif current_user.reviewer? && @planning_application.reviewer_decision  && !@planning_application.awaiting_correction? %>
           <span class="app-task-list__task-name"><%= link_to step_name, edit_planning_application_path(@planning_application), aria: aria_attributes %></span>

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Home"
 
       within("#not_started_and_invalid") do
-        expect(page).to have_content("invalidated")
+        expect(page).to have_content("invalid")
         click_link planning_application.reference
       end
 


### PR DESCRIPTION
Also added some bug fixes/improvements around invalid applications and ability to submit a recommendation:

- we want the 'invalidated' status to be displayed as 'invalid'
- hint text added to documents_validated_at field
- more robust validation to avoid error message if date field saved as nil

### Story Link

https://trello.com/c/wNJMfBnm/5-indicate-documents-are-valid-invalid

