### PR TITLE
Preset documents_validated_at in Documents index

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -18,6 +18,7 @@ class DocumentsController < AuthenticationController
 
   def index
     @documents = policy_scope(@planning_application.documents).order(:created_at)
+    @planning_application.documents_validated_at = @planning_application.created_at
   end
 
   def edit

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -18,7 +18,7 @@ class DocumentsController < AuthenticationController
 
   def index
     @documents = policy_scope(@planning_application.documents).order(:created_at)
-    @planning_application.documents_validated_at = @planning_application.created_at
+    @planning_application.documents_validated_at ||= @planning_application.created_at
   end
 
   def edit

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -135,7 +135,7 @@ class PlanningApplicationsController < AuthenticationController
     valid_at = date_string_from_params(params[:planning_application][:'documents_validated_at(3i)'],
                                        params[:planning_application][:'documents_validated_at(2i)'],
                                        params[:planning_application]["documents_validated_at(1i)"])
-    if date_string_valid?(valid_at) && @planning_application.update!(documents_validated_at: valid_at)
+    if date_string_valid?(valid_at) && @planning_application.update!(documents_validated_at: Time.zone.parse(valid_at))
       @planning_application.start!
     else
       @planning_application.errors.add(:planning_application, "A validation date must be present")
@@ -147,7 +147,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def date_string_valid?(valid_date)
-    valid_date.match?(/\d{2}-\d{2}-\d{4}/)
+    valid_date.match?(/\d{1,2}-\d{1,2}-\d{4}/)
   end
 
 private

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -67,7 +67,7 @@ class PlanningApplication < ApplicationRecord
     state :withdrawn
 
     event :start do
-      transitions from: %i[not_started invalidated], to: :in_assessment, guard: :has_validation_date?
+      transitions from: %i[not_started invalidated in_assessment], to: :in_assessment, guard: :has_validation_date?
     end
 
     event :assess do
@@ -75,7 +75,7 @@ class PlanningApplication < ApplicationRecord
     end
 
     event :invalidate do
-      transitions from: %i[not_started in_assessment awaiting_determination awaiting_correction], to: :invalidated
+      transitions from: %i[not_started invalidated in_assessment awaiting_determination awaiting_correction], to: :invalidated
     end
 
     event :determine do
@@ -182,6 +182,10 @@ class PlanningApplication < ApplicationRecord
 
   def cancellable?
     true unless determined? || returned? || withdrawn?
+  end
+
+  def closed?
+    true if determined? || returned? || withdrawn?
   end
 
   def documents_validated_if_not_started

--- a/app/views/decisions/_assessor_decision_form.html.erb
+++ b/app/views/decisions/_assessor_decision_form.html.erb
@@ -15,62 +15,64 @@
         Please review the applicant's answers:
       </p>
       <%= render "policy_consideration_list", policy_considerations: policy_evaluation.policy_considerations %>
-      <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
-        <p class="govuk-body">
-          <br>
-          <strong>Have permitted development requirements been met?</strong>
-        </p>
-        <p class="govuk-body">
-          You need to check that the applicant's answers and proposal documents meet the permitted development requirements.
-        </p>
-        <% if form.object.errors.any? %>
-          <% form.object.errors.each do |attribute, error| %>
-            <span id="status-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
-          <% end %>
-        <% end %>
-        <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
-          <div class="govuk-radios govuk-radios--small">
-            <div class="govuk-radios__item">
-              <%= form.radio_button :status, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
-              <%= form.label :status_granted, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
-            </div>
-            <div class="govuk-radios__item">
-              <%= form.radio_button :status, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
-              <%= form.label :status_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
-            </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
-              <div class="govuk-form-group">
-                <p class="govuk-body">
-                  <br>
-                  <strong>Please provide which GDPO policy (or policies) have not been met. </strong>
-                  If there are multiple, please separate by a comma.
-                </p>
-                <p class="govuk-body">
-                  <span class="govuk-hint">
-                    For example, "GPDO 2015 S.2 P.1 A.1 (f)(i), GPDO 2015 S.2 P.1 A.1 (f)(ii)"
-                  </span>
-                </p>
-                <p class="govuk-body">
-                  This <strong>will</strong> appear on the decision notice.
-                </p>
-                <%= form.text_area :public_comment, class: "govuk-textarea", id: "public_comment", rows: "3", "aria-describedby": "public-comment-hint" %>
+      <% unless @planning_application.invalidated? || @planning_application.not_started? %>
+        <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+            <p class="govuk-body">
+              <br>
+              <strong>Have permitted development requirements been met?</strong>
+            </p>
+            <p class="govuk-body">
+              You need to check that the applicant's answers and proposal documents meet the permitted development requirements.
+            </p>
+            <% if form.object.errors.any? %>
+              <% form.object.errors.each do |attribute, error| %>
+                <span id="status-error" class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+              <% end %>
+            <% end %>
+            <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+              <div class="govuk-radios govuk-radios--small">
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :status, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
+                  <%= form.label :status_granted, "Yes", class: "govuk-label govuk-radios__label", for: "status-granted-conditional" %>
+                </div>
+                <div class="govuk-radios__item">
+                  <%= form.radio_button :status, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
+                  <%= form.label :status_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
+                </div>
+                <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
+                  <div class="govuk-form-group">
+                    <p class="govuk-body">
+                      <br>
+                      <strong>Please provide which GDPO policy (or policies) have not been met. </strong>
+                      If there are multiple, please separate by a comma.
+                    </p>
+                    <p class="govuk-body">
+                      <span class="govuk-hint">
+                        For example, "GPDO 2015 S.2 P.1 A.1 (f)(i), GPDO 2015 S.2 P.1 A.1 (f)(ii)"
+                      </span>
+                    </p>
+                    <p class="govuk-body">
+                      This <strong>will</strong> appear on the decision notice.
+                    </p>
+                    <%= form.text_area :public_comment, class: "govuk-textarea", id: "public_comment", rows: "3", "aria-describedby": "public-comment-hint" %>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      </div>
-      <div class="govuk-form-group">
-        <p class="govuk-body">
-          <strong>Please provide supporting information for your manager.</strong> For example, you may want to add any details about the width, depth or height of the proposal.
-          <br><br>
-          Your comment will <strong>not</strong> appear on the decision notice.
+          <div class="govuk-form-group">
+            <p class="govuk-body">
+              <strong>Please provide supporting information for your manager.</strong> For example, you may want to add any details about the width, depth or height of the proposal.
+              <br><br>
+              Your comment will <strong>not</strong> appear on the decision notice.
+            </p>
+            <%= form.text_area :private_comment, class: "govuk-textarea", id: "private_comment", rows: "3", "aria-describedby": "private-comment-hint" %>
+          </div>
+        </fieldset>
+        <p>
+          <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
         </p>
-        <%= form.text_area :private_comment, class: "govuk-textarea", id: "private_comment", rows: "3", "aria-describedby": "private-comment-hint" %>
+      <% end%>
       </div>
-    </fieldset>
-    <p>
-      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-    </p>
-  </div>
 <% end%>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -18,7 +18,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if current_user.assessor? && (@planning_application.not_started? || @planning_application.invalidated?) %>
+    <% if current_user.assessor? && (!@planning_application.determined? || !@planning_application.withdrawn? || !@planning_application.returned?) %>
       <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <fieldset class="govuk-fieldset">
           <% if form.object.errors[:planning_application].any? %>
@@ -28,7 +28,7 @@
             <% end %>
           <% end %>
             <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>
-              <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes', size: 's'} do %>
+              <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
                 <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Valid date', size: 's' }, hint: { text: 'Date application should be considered valid, e.g. 28 12 2021' } %>
                 <% end %>
               <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
@@ -49,7 +49,7 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">
-    <% if current_user.assessor? && @planning_application.in_assessment? || @planning_application.not_started? %>
+    <% if current_user.assessor? && (@planning_application.in_assessment? || @planning_application.not_started? || @planning_application.invalidated?) %>
       <%= link_to "Upload documents", new_planning_application_document_path(@planning_application), role: "button", class: "govuk-button", data: { module: "govuk-button" } %>
     <% elsif current_user.assessor? %>
       <%= tag.button "Upload documents", disabled: "disabled", "aria-disabled": true, class: "govuk-button govuk-button--disabled", data: { module: "govuk-button" } %>

--- a/app/views/planning_applications/_assess_proposal.html.erb
+++ b/app/views/planning_applications/_assess_proposal.html.erb
@@ -17,7 +17,7 @@
 
       <li class="app-task-list__item">
         <% step_name = t("#{@planning_application.status}.proposal_step") %>
-        <% if current_user.assessor? && @planning_application.recommendable? %>
+        <% if current_user.assessor? %>
           <% aria_attributes = @planning_application.assessor_decision ? { describedby: "#{step_name.parameterize}-completed" } : {} %>
           <% path = assessor_decision_path(@planning_application) %>
           <span class="app-task-list__task-name"><%= link_to step_name, path, aria: aria_attributes %></span>

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render "planning_applications/assessment_dashboard" do %>
-  <% if current_user.assessor? %>
+  <% if current_user.assessor? && @planning_application.recommendable? %>
     <% content_for :title, t("#{@planning_application.status}.recommendation_step") %>
 
     <h2 class="govuk-heading-m"><%= t("#{@planning_application.status}.recommendation_step") %></h2>
@@ -33,7 +33,7 @@
     <%= render "decision_notice", planning_application: @planning_application, decision: @planning_application.reviewer_decision %>
     <% if @planning_application.awaiting_determination? %>
       <p class="govuk-body">By determining the application, the applicant will receive this decision notice. The decision notice will also be available publicly. </p>
-      
+
       <%= form_with model: @planning_application, url: determine_planning_application_path(@planning_application), local: true do |form| %>
         <%= form.submit "Determine application", class: "govuk-button", data: { module: "govuk-button" } %>
       <% end %>


### PR DESCRIPTION
This change is to enable the date field in the document validation element to be prefilled with the date the planning application was submitted

### Story Link

https://trello.com/c/wNJMfBnm/5-indicate-documents-are-valid-invalid