### PR TITLE
Scope planning applications in API to local authority

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,5 +22,8 @@ RSpec/ContextWording:
 RSpec/LetSetup:
   Enabled: false
 
+RSpec/InstanceVariable:
+  Enabled: false
+
 Naming/VariableNumber:
   Enabled: false

--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -5,13 +5,13 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
   skip_before_action :authenticate, only: %i[index show]
 
   def index
-    @planning_applications = PlanningApplication.all
+    @planning_applications = current_local_authority.planning_applications.all
 
     respond_to(:json)
   end
 
   def show
-    @planning_application = PlanningApplication.where(id: params[:id]).first
+    @planning_application = current_local_authority.planning_applications.where(id: params[:id]).first
     if @planning_application
       respond_to(:json)
     else

--- a/spec/requests/oas3_spec.rb
+++ b/spec/requests/oas3_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
   it "successfullies return the listing of applications as specified" do
     planning_application_hash = example_response_hash_for("/api/v1/planning_applications", "get", 200, "Full")["data"].first
     site = Site.create! planning_application_hash.fetch("site")
-    planning_application = PlanningApplication.create! planning_application_hash.except("application_number", "received_date", "documents").merge(site: site, local_authority: create(:local_authority))
+    planning_application = PlanningApplication.create! planning_application_hash.except("application_number", "received_date", "documents").merge(site: site, local_authority: @default_local_authority)
     planning_application_document = planning_application.documents.create!(planning_application_hash.fetch("documents").first.except("url"))
 
     get "/api/v1/planning_applications"
@@ -75,7 +75,7 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
   it "successfullies return an application as specified" do
     planning_application_hash = example_response_hash_for("/api/v1/planning_applications/{id}", "get", 200, "Full")
     site = Site.create! planning_application_hash.fetch("site")
-    planning_application = PlanningApplication.create! planning_application_hash.except("application_number", "received_date", "documents").merge(site: site, local_authority: create(:local_authority))
+    planning_application = PlanningApplication.create! planning_application_hash.except("application_number", "received_date", "documents").merge(site: site, local_authority: @default_local_authority)
     planning_application_document = planning_application.documents.create!(planning_application_hash.fetch("documents").first.except("url"))
 
     get "/api/v1/planning_applications/#{planning_application_hash['id']}"

--- a/spec/requests/planning_application_list_spec.rb
+++ b/spec/requests/planning_application_list_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe "API request to list planning applications", type: :request, show
     end
 
     context "for a new planning application" do
-      let!(:planning_application) { create(:planning_application, :not_started) }
+      let!(:planning_application) { create(:planning_application, :not_started, local_authority: @default_local_authority) }
+      let(:lambeth) { create :local_authority, subdomain: "lambeth" }
+      let!(:planning_application_lambeth) { create(:planning_application, :not_started, local_authority: lambeth) }
 
       it "returns the accurate data" do
         get "/api/v1/planning_applications.json"
@@ -81,8 +83,13 @@ RSpec.describe "API request to list planning applications", type: :request, show
         expect(planning_application_json["documents"]).to eq([])
       end
 
+      it "does not return applications from another authority" do
+        get "/api/v1/planning_applications.json"
+        expect(data.size).to eq(1)
+      end
+
       context "for a granted planning application" do
-        let!(:planning_application) { create(:planning_application, :determined) }
+        let!(:planning_application) { create(:planning_application, :determined, local_authority: @default_local_authority) }
         let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
         let!(:document) { create(:document, :with_file, planning_application: planning_application) }
 

--- a/spec/system/local_authorities_spec.rb
+++ b/spec/system/local_authorities_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Accessing correct local authority", type: :system do
   let!(:southwark) { create :local_authority, name: "Southwark Council", subdomain: "southwark" }
 
   context "Lambeth council" do
-    # rubocop:disable RSpec/InstanceVariable
     before do
       @previous_host = Capybara.app_host
       host! "http://lambeth.example.com"
@@ -16,7 +15,6 @@ RSpec.describe "Accessing correct local authority", type: :system do
     after do
       host! "http://#{@previous_host}"
     end
-    # rubocop:enable RSpec/InstanceVariable
 
     it "visit namespaced path" do
       visit root_path
@@ -27,7 +25,6 @@ RSpec.describe "Accessing correct local authority", type: :system do
   end
 
   context "Non existent council" do
-    # rubocop:disable RSpec/InstanceVariable
     before do
       @previous_host = Capybara.app_host
       host! "http://biscuits.example.com"
@@ -36,7 +33,6 @@ RSpec.describe "Accessing correct local authority", type: :system do
     after do
       host! "http://#{@previous_host}"
     end
-    # rubocop:enable RSpec/InstanceVariable
 
     it "visit non existing path" do
       visit root_path

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe "Sign in", type: :system do
       let(:lambeth_assessor) { create :user, :assessor, name: "Lambertina Lamb", password: "Lambsrock18!", local_authority: lambeth }
       let(:southwark_assessor) { create :user, :assessor, name: "Southwarkina Sully", password: "Southwark4ever!", local_authority: southwark }
 
-      # rubocop:disable RSpec/InstanceVariable
       before do
         @previous_host = Capybara.app_host
         host! "http://lamb.example.com"
@@ -70,7 +69,6 @@ RSpec.describe "Sign in", type: :system do
       after do
         host! "http://#{@previous_host}"
       end
-      # rubocop:enable RSpec/InstanceVariable
 
       it "is prevented from logging in to a different subdomain" do
         visit root_path


### PR DESCRIPTION
Previously we were showing all planning applications in the system through the API. This was wrong and we only want to show the applications relevant to the current local authority (as specified by subdomain)

I've also disabled the RSpec/InstanceVariable cop, as this is the cleanest way I can think of managing the subdomain for the specs.