### PR TITLE
Update target_date when documents validated

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -25,6 +25,7 @@ class PlanningApplication < ApplicationRecord
   belongs_to :local_authority
 
   before_create :set_target_date
+  before_update :set_target_date
 
   validate :assessor_decision_associated_with_assessor
   validate :reviewer_decision_associated_with_reviewer
@@ -201,7 +202,7 @@ class PlanningApplication < ApplicationRecord
 private
 
   def set_target_date
-    self.target_date = created_at + 8.weeks
+    self.target_date = (documents_validated_at || created_at) + 8.weeks
   end
 
   def assessor_decision_associated_with_assessor

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -453,6 +453,19 @@ RSpec.describe PlanningApplication, type: :model do
     end
   end
 
+  describe "#target_date" do
+    it "is set as created_at + 8 weeks when new record created" do
+      planning_application = create(:planning_application)
+      expect(planning_application.target_date).to eq((planning_application.created_at + 8.weeks).to_date)
+    end
+
+    it "is set to documents_validated_at + 8 weeks when documents_validated_at added" do
+      planning_application = create(:planning_application)
+      planning_application.update!(documents_validated_at: 1.week.ago)
+      expect(planning_application.target_date).to eq((planning_application.documents_validated_at + 8.weeks).to_date)
+    end
+  end
+
   describe "#document_numbering_partially_completed?" do
     it "returns false when there are no documents" do
       expect(planning_application.document_numbering_partially_completed?).to eq false

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -5,11 +5,14 @@ require "rails_helper"
 RSpec.describe "Planning Application show page", type: :system do
   let(:local_authority) { create :local_authority }
   let!(:site) { create :site, address_1: "7 Elm Grove", town: "London", postcode: "SE15 6UT" }
+  let(:documents_validated_at) { Date.current - 2.weeks }
   let!(:planning_application) do
     create :planning_application, description: "Roof extension",
-                                  application_type: "lawfulness_certificate", status: :in_assessment,
+                                  application_type: "lawfulness_certificate",
+                                  status: :in_assessment,
                                   ward: "Dulwich Wood", site: site,
-                                  target_date: Date.current + 14.days, local_authority: local_authority,
+                                  documents_validated_at: documents_validated_at,
+                                  local_authority: local_authority,
                                   payment_reference: "PAY123",
                                   work_status: "proposed",
                                   constraints: '{"conservation_area": true, "article4_area": false, "scheduled_monument": false }'
@@ -110,8 +113,7 @@ RSpec.describe "Planning Application show page", type: :system do
   end
 
   context "as an assessor when target date is within a week" do
-    let(:target_date) { 1.week.from_now }
-    let!(:planning_application) { create :planning_application, :determined, local_authority: local_authority }
+    let(:documents_validated_at) { Date.current - (7.weeks + 5.days) }
 
     before do
       sign_in assessor


### PR DESCRIPTION
Before validation, the target date is 8 week from the creation of the application, but this might change when the documents are validated. This updates the target_date.

Implementation note: I am using both `before_create` and `before_update` here, as `before_save`, in the current version of Rails, happens before the created_at timestamp is created, which results in trying to do maths on nil.