### PR TITLE
Remove validation form from closed applications

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -18,7 +18,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if current_user.assessor? && (!@planning_application.determined? || !@planning_application.withdrawn? || !@planning_application.returned?) %>
+    <% if @planning_application.cancellable? && current_user.assessor? %>
       <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <fieldset class="govuk-fieldset">
           <% if form.object.errors[:planning_application].any? %>
@@ -27,21 +27,21 @@
               <span class="govuk-visually-hidden">Error:</span><%= error %></span>
             <% end %>
           <% end %>
-            <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>
-              <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
-                <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Valid date', size: 's' }, hint: { text: 'Date application should be considered valid, e.g. 28 12 2021' } %>
-                <% end %>
-              <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
+          <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>
+            <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
+              <%= form.govuk_date_field :documents_validated_at, legend: { text: 'Valid date', size: 's' }, hint: { text: 'Date application should be considered valid, e.g. 28 12 2021' } %>
             <% end %>
-          </fieldset>
-              <p>
-                <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-                <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-              </p>
-           </div>
+            <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
+          <% end %>
+        </fieldset>
+        <p>
+          <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+          <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        </p>
       <% end%>
     <% end %>
   </div>
+</div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body" style="line-height: 1.6;">

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -201,6 +201,10 @@ RSpec.describe "Planning Application Reviewing", type: :system do
         within("#closed") do
           expect(page).to have_link planning_application.reference
         end
+
+        # Check that documents validation form is removed
+        click_link planning_application.reference
+        expect(page).not_to have_content("Are the documents valid?")
       end
 
       it "disagrees with assessor's decision" do
@@ -447,6 +451,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
         expect(page).to have_content("The officer has submitted the following comment for you:")
         expect(page).to have_content("This is a private comment")
+
+        expect(page).not_to have_content("Are the documents valid?")
 
         choose "Yes"
         click_button "Save"

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -113,4 +113,52 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).to have_content("Not started")
     end
   end
+
+  context "Planning application does not show validate documents form when withdrawn or returned" do
+    it "does not show validate form when in withdrawn status" do
+      click_link planning_application.reference
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Withdrawn by applicant"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      click_link planning_application.reference
+
+      expect(page).not_to have_content("Are the documents valid?")
+    end
+
+    it "does not show validate form when in returned status" do
+      click_link planning_application.reference
+      click_link "Cancel application"
+
+      expect(page).to have_content("Why is this application being cancelled?")
+
+      choose "Returned as invalid"
+
+      fill_in "cancellation_comment", with: "This has been cancelled"
+
+      click_button "Save"
+
+      expect(page).to have_content("Application has been cancelled")
+
+      click_link "Home"
+
+      click_link "Closed"
+
+      click_link planning_application.reference
+
+      expect(page).not_to have_content("Are the documents valid?")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

This means the form for validating documents will not display on applications that are determined, returned or withdrawn.

### Story Link

https://trello.com/c/M7nZkxgu/79-when-application-determined-withdrawn-returned-remove-validation-control-in-manage-docs
