### PR TITLE
Move document validation checks to model

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -107,25 +107,37 @@ class PlanningApplicationsController < AuthenticationController
 
   def validate_documents
     status = authorize_user_can_update_status(params[:planning_application][:status])
-    @planning_application.update(status: status, documents_validated_at: Time.zone.parse(date_string_from_params))
-    if @planning_application.save && @planning_application.in_assessment?
-      flash[:notice] = "Application is ready for assessment"
-      redirect_to @planning_application
-    elsif @planning_application.save && @planning_application.invalidated?
+    if status == "in_assessment"
+      if date_from_params.blank?
+        @planning_application.errors.add(:planning_application, "Please enter a valid date")
+        render "documents/index"
+      else
+        @planning_application.documents_validated_at = date_from_params
+        @planning_application.start!
+        flash[:notice] = "Application is ready for assessment"
+        redirect_to @planning_application
+      end
+    elsif status == "invalidated"
+      @planning_application.invalidate!
       flash[:notice] = "Application has been invalidated"
       redirect_to @planning_application
     else
+      @planning_application.errors.add(:status, "Please select one of the below options")
       render "documents/index"
     end
   end
 
-  def date_string_from_params
-    [params[:planning_application][:"documents_validated_at(3i)"],
-     params[:planning_application][:"documents_validated_at(2i)"],
-     params[:planning_application]["documents_validated_at(1i)"]].join("-")
-  end
-
 private
+
+  def date_from_params
+    Time.zone.parse(
+      [
+        params[:planning_application]["documents_validated_at(3i)"],
+        params[:planning_application]["documents_validated_at(2i)"],
+        params[:planning_application]["documents_validated_at(1i)"],
+      ].join("-"),
+    )
+  end
 
   def set_planning_application
     @planning_application = authorize(PlanningApplication.find(params[:id]))

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -107,47 +107,22 @@ class PlanningApplicationsController < AuthenticationController
 
   def validate_documents
     status = authorize_user_can_update_status(params[:planning_application][:status])
-    apply_validation(status)
-    if @planning_application.in_assessment?
+    @planning_application.update(status: status, documents_validated_at: Time.zone.parse(date_string_from_params))
+    if @planning_application.save && @planning_application.in_assessment?
       flash[:notice] = "Application is ready for assessment"
       redirect_to @planning_application
-    elsif @planning_application.invalidated?
+    elsif @planning_application.save && @planning_application.invalidated?
       flash[:notice] = "Application has been invalidated"
       redirect_to @planning_application
     else
-      render template: "documents/index", planning_application: @planning_application,
-             documents: @planning_application.documents
+      render "documents/index"
     end
   end
 
-  def apply_validation(status)
-    case status
-    when "invalidated"
-      @planning_application.invalidate!
-    when "in_assessment"
-      update_validation_and_start
-    else
-      @planning_application.errors.add(:planning_application, "Please choose Yes or No")
-    end
-  end
-
-  def update_validation_and_start
-    valid_at = date_string_from_params(params[:planning_application][:'documents_validated_at(3i)'],
-                                       params[:planning_application][:'documents_validated_at(2i)'],
-                                       params[:planning_application]["documents_validated_at(1i)"])
-    if date_string_valid?(valid_at) && @planning_application.update!(documents_validated_at: Time.zone.parse(valid_at))
-      @planning_application.start!
-    else
-      @planning_application.errors.add(:planning_application, "A validation date must be present")
-    end
-  end
-
-  def date_string_from_params(year, month, day)
-    [year, month, day].join("-")
-  end
-
-  def date_string_valid?(valid_date)
-    valid_date.match?(/\d{1,2}-\d{1,2}-\d{4}/)
+  def date_string_from_params
+    [params[:planning_application][:"documents_validated_at(3i)"],
+     params[:planning_application][:"documents_validated_at(2i)"],
+     params[:planning_application]["documents_validated_at(1i)"]].join("-")
   end
 
 private

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -49,7 +49,7 @@ class PlanningApplication < ApplicationRecord
             inclusion: { in: WORK_STATUSES,
                          message: "Work Status should be proposed or existing" }
 
-  validate :documents_validated_if_not_started
+  validate :documents_validated_at_date
 
   scope :not_started_and_invalid, -> { where("status = 'not_started' OR status = 'invalidated'") }
   scope :under_assessment, -> { where("status = 'in_assessment' OR status = 'awaiting_correction'") }
@@ -188,8 +188,8 @@ class PlanningApplication < ApplicationRecord
     true if determined? || returned? || withdrawn?
   end
 
-  def documents_validated_if_not_started
-    if in_assessment? && documents_validated_at.blank?
+  def documents_validated_at_date
+    if in_assessment? && !documents_validated_at.is_a?(Date)
       errors.add(:planning_application, "Please enter a valid date")
     end
   end

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -21,10 +21,10 @@
     <% if @planning_application.cancellable? && current_user.assessor? %>
       <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <fieldset class="govuk-fieldset">
-          <% if form.object.errors[:planning_application].any? %>
-            <% form.object.errors[:planning_application].each do |error| %>
-              <span id="status-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
+          <% if form.object.errors.any? %>
+            <% form.object.errors.each do |attribute, error| %>
+          <span id="status-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span><%= error %></span>
             <% end %>
           <% end %>
           <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Are the documents valid?' }) do %>

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       click_button "Save"
 
-      expect(page).to have_content("A validation date must be present")
+      expect(page).to have_content("Please enter a valid date")
 
       choose "Yes"
 
@@ -161,7 +161,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       click_button "Save"
 
-      expect(page).to have_content("Please choose Yes or No")
+      expect(page).to have_content("Please select one of the below options")
     end
 
     it "remains in not_started status if incorrect date is sent" do
@@ -200,7 +200,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       click_button "Save"
 
-      expect(page).to have_content("A validation date must be present")
+      expect(page).to have_content("Please enter a valid date")
 
       expect(planning_application.status).to eql("not_started")
       expect(planning_application.documents_validated_at).to be(nil)


### PR DESCRIPTION
### Description of change

This improves the planning application controller action on the validate_documents route and fixes a bug where users could not see an invalid date message when validating an already invalid application

### Story Link

https://trello.com/c/VxIpHdHx/74-bug-add-error-message-when-planning-officer-enters-blank-date-input-on-planning-application-in-invalid-status

