### PR TITLE
Allow document upload while awaiting correction

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -49,7 +49,7 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">
-    <% if current_user.assessor? && (@planning_application.in_assessment? || @planning_application.not_started? || @planning_application.invalidated?) %>
+    <% if current_user.assessor? && (@planning_application.cancellable? && !@planning_application.awaiting_determination?) %>
       <%= link_to "Upload documents", new_planning_application_document_path(@planning_application), role: "button", class: "govuk-button", data: { module: "govuk-button" } %>
     <% elsif current_user.assessor? %>
       <%= tag.button "Upload documents", disabled: "disabled", "aria-disabled": true, class: "govuk-button govuk-button--disabled", data: { module: "govuk-button" } %>

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -62,6 +62,10 @@ RSpec.describe "Planning Application correction journey", type: :system do
       click_link("In assessment")
       click_link planning_application_corrected.reference
 
+      click_link("Check the documents")
+      expect(page).to have_link("Upload documents")
+      click_link("Application")
+
       # Verify the task list wording is correct
       expect(page).to have_text("Reassess the proposal")
       expect(page).to have_text("Resubmit the recommendation")


### PR DESCRIPTION
### Description of change

The previous logic did not allow document upload after the application was submitted for review, even if it was sent back for corrections. This fix allows the assessor to upload documents for any status other than Closed or Awaiting Determination

### Story Link

https://trello.com/c/6Qtp3vda/92-application-sent-back-for-reassessment-check-documents-cant-upload-new-documents-is-this-correct

