### PR TITLE
Send email on validation

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -114,7 +114,8 @@ class PlanningApplicationsController < AuthenticationController
       else
         @planning_application.documents_validated_at = date_from_params
         @planning_application.start!
-        flash[:notice] = "Application is ready for assessment"
+        validation_notice_mail
+        flash[:notice] = "Application is ready for assessment and applicant has been notified"
         redirect_to @planning_application
       end
     elsif status == "invalidated"
@@ -126,8 +127,6 @@ class PlanningApplicationsController < AuthenticationController
       render "documents/index"
     end
   end
-
-private
 
   def date_from_params
     Time.zone.parse(
@@ -161,9 +160,15 @@ private
     ).deliver_now
   end
 
+  def validation_notice_mail
+    PlanningApplicationMailer.validation_notice_mail(
+      @planning_application,
+    ).deliver_now
+  end
+
   def decision_notice_mail_error
     flash[:notice] =
-      "The Decision Notice cannot be sent. Please try again later."
-    render :edit
+      "The email cannot be sent. Please try again later."
+    render "documents/index"
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -128,6 +128,8 @@ class PlanningApplicationsController < AuthenticationController
     end
   end
 
+private
+
   def date_from_params
     Time.zone.parse(
       [

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -14,4 +14,14 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       to: @planning_application.applicant_email,
     )
   end
+
+  def validation_notice_mail(planning_application)
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: "Your planning application has been validated",
+      to: @planning_application.applicant_email,
+    )
+  end
 end

--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -1,0 +1,46 @@
+# <%= @planning_application.local_authority.name %>
+
+# Town and country planning act 1990 (as amended)
+
+Dear Sir/Madam,
+
+Reference No.: <%= @planning_application.reference %>
+Proposal: <%= @planning_application.description %>
+Site Address: <%= @planning_application.site.full_address %>
+
+Your application is now valid and has been started from <%= @planning_application.documents_validated_at.strftime("%e %B %Y") %>. The description of your development given in the title block above may be different from the one on your application form. Contact us if you would like the description to be amended.
+
+Please quote the planning reference number <%= @planning_application.reference %> when contacting us. The progress of your application can also be tracked using Southwark Council’s online planning register, accessible from the following link: www.southwark.gov.uk/planningregister.
+
+We may request additional information and/or revisions before deciding whether the application should be recommended for permission or refusal.
+
+Planning law requires your application be determined in accordance with the development plan unless material considerations indicate otherwise. The development plan is accessible from the following link:
+https://www.southwark.gov.uk/planning-and-building-control/planning-policy-and-transport-policy.
+
+All relevant parties are now being consulted regarding your application and the council aims to issue a decision by <%= @planning_application.target_date.strftime("%e %B %Y") %>. However, if your application has not been determined by <%= @planning_application.target_date %>, you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate, or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
+
+An appeal in this situation assumes the refusal of the application, even if it had intended to be granted. It is therefore, recommended that you consult your case officer before taking such action.
+
+If you wish to appeal, use the Planning Inspectorate’s online appeals service. To find out more, follow the link below. The Planning Inspectorate will publish your appeal details on its website, including the documents you submitted as part of your planning application, along with your completed appeal form
+and any other information required. Ensure any personal information provided belongs to you and that its publication is not an issue. If you provide information belonging to someone else make sure you have their permission. Further information about data protection and privacy matters is available on the
+
+
+Signed: <%= @planning_application.local_authority.signatory_name %>
+ <%= @planning_application.local_authority.signatory_job_title %>
+
+Your attention is drawn to the notes accompanying this document
+
+Any enquiries regarding this document should quote the Application Number and be sent to
+the
+<%= @planning_application.local_authority.signatory_job_title %>,
+<%= @planning_application.local_authority.name %>,
+<%= @planning_application.local_authority.enquiries_paragraph %>
+or by email to <%= @planning_application.local_authority.email_address %>
+
+Please Note: In light of the COVID-19 situation, Southwark Council is following the current advice from the government to minimise travelling and non-essential contact.
+
+The council is fully committed to helping reduce the spread of the virus by following national guidance, whilst ensuring we continue to provide essential services in our business continuity plans. In accordance with government advice, we have to minimise non-essential contact with service users. Therefore if your application requires a site visit/meeting it may be necessary to delay this to an appropriate time. To avoid/minimise delay you can send us additional information, like site photographs, for us to review together with your application documents.
+
+We apologise for the inconvenience any delays in the determination of your application will cause you.
+
+Thank you for your understanding, support and patience during this period. I will keep you updated if anything changes.

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -3,38 +3,38 @@
 require "rails_helper"
 
 RSpec.describe PlanningApplicationMailer, type: :mailer do
+  let(:local_authority) do
+    create :local_authority,
+           name: "Cookie authority",
+           signatory_name: "Mr. Biscuit",
+           signatory_job_title: "Lord of BiscuitTown",
+           enquiries_paragraph: "reach us on postcode SW50",
+           email_address: "biscuit@somuchbiscuit.com"
+  end
+
+  let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
+  let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority) }
+  let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
+
+  let!(:document_with_proposed_tags) do
+    create :document, :proposed_tags,
+           planning_application: planning_application,
+           numbers: "proposed_number_1, proposed_number_2"
+  end
+
+  let!(:archived_document_with_proposed_tags) do
+    create :document, :archived, :proposed_tags,
+           planning_application: planning_application,
+           numbers: "archived_number"
+  end
+
+  let!(:document_with_existing_tags) do
+    create :document, :existing_tags,
+           planning_application: planning_application,
+           numbers: "existing_number"
+  end
+
   describe "#decision_notice_mail" do
-    let(:local_authority) do
-      create :local_authority,
-             name: "Cookie authority",
-             signatory_name: "Mr. Biscuit",
-             signatory_job_title: "Lord of BiscuitTown",
-             enquiries_paragraph: "reach us on postcode SW50",
-             email_address: "biscuit@somuchbiscuit.com"
-    end
-
-    let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
-    let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority) }
-    let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
-
-    let!(:document_with_proposed_tags) do
-      create :document, :proposed_tags,
-             planning_application: planning_application,
-             numbers: "proposed_number_1, proposed_number_2"
-    end
-
-    let!(:archived_document_with_proposed_tags) do
-      create :document, :archived, :proposed_tags,
-             planning_application: planning_application,
-             numbers: "archived_number"
-    end
-
-    let!(:document_with_existing_tags) do
-      create :document, :existing_tags,
-             planning_application: planning_application,
-             numbers: "existing_number"
-    end
-
     let(:mail) { described_class.decision_notice_mail(planning_application.reload) }
 
     it "renders the headers" do
@@ -82,6 +82,24 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       it "includes the status in the body" do
         expect(mail.body.encoded).to match("Certificate of lawfulness of proposed use or development: refused.")
       end
+    end
+  end
+
+  describe "#validation_notice_mail" do
+    let(:validation_mail) { described_class.validation_notice_mail(planning_application.reload) }
+
+    it "renders the headers" do
+      expect(validation_mail.subject).to eq("Your planning application has been validated")
+      expect(validation_mail.to).to eq([planning_application.applicant_email])
+    end
+
+    it "renders the body" do
+      expect(validation_mail.body.encoded).to match("started from #{planning_application.documents_validated_at.strftime('%e %B %Y')}")
+      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
+      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
+      expect(validation_mail.body.encoded).to match("Site Address: #{planning_application.site.full_address}")
+      expect(validation_mail.body.encoded).to match("planning reference number #{planning_application.reference}")
+      expect(validation_mail.body.encoded).to match("Proposal: #{planning_application.description}")
     end
   end
 end

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -297,7 +297,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
           click_link "Publish the recommendation"
           click_button "Determine application"
 
-          expect(page).to have_content("The Decision Notice cannot be sent. Please try again later.")
+          expect(page).to have_content("The email cannot be sent. Please try again later.")
         end
       end
 

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   context "Checking documents from Not Started status" do
     it "can be validated from Not Started" do
+      delivered_emails = ActionMailer::Base.deliveries.count
       click_link planning_application.reference
       click_link "Check the documents"
 
@@ -46,6 +47,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_button "Save"
 
       expect(page).to have_content("Application is ready for assessment")
+
+      expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
 
       click_link "Home"
 


### PR DESCRIPTION
### Description of change

This sends a notification via Notify to the applicant's email once their application has been validated and makes the "email not sent" error message for Determination more generic

### Story Link

https://trello.com/c/VK9OMXtT/32-notify-applicant-when-application-is-marked-as-valid

