### PR TITLE
Add helper text to document edit view

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -19,9 +19,6 @@
     <p class="govuk-body" style="line-height: 1.6;">
       If you add one or more numbers to this document, it will be published in the decision notice. Only documents with numbers will appear on the decision notice.
     </p>
-    <p class="govuk-body" style="line-height: 1.6;">
-      If there are multiple numbers, please provide a comma-separated list.
-    </p>
 
     <%= link_to image_tag(@document.file.representation(resize: "500x500")),
                 api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
@@ -38,8 +35,10 @@
               <span class="govuk-visually-hidden">Error:</span><%= error %></span>
           <% end %>
         <% end %>
-
         <%= form.label :numbers, "Document number(s)", class: "govuk-label", for: "numbers" %>
+        <div id="event-name-hint" class="govuk-hint">
+          If there are multiple numbers, please provide a comma-separated list.
+        </div>
         <%= form.text_area :numbers, class: "govuk-input govuk-input--width-20", id: "numbers" %>
       </div>
 

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -17,7 +17,10 @@
     <h2 class="govuk-heading-m"><%= @document.name %></h2>
 
     <p class="govuk-body" style="line-height: 1.6;">
-      If you add one or more numbers to this document, it will be published in the decision notice.
+      If you add one or more numbers to this document, it will be published in the decision notice. Only documents with numbers will appear on the decision notice.
+    </p>
+    <p class="govuk-body" style="line-height: 1.6;">
+      If there are multiple numbers, please provide a comma-separated list.
     </p>
 
     <%= link_to image_tag(@document.file.representation(resize: "500x500")),


### PR DESCRIPTION
### Description of change

This addition is to replace the helper text in the  document numbers view, which was deleted.

<img width="916" alt="doc_numbers" src="https://user-images.githubusercontent.com/1880450/105021202-2fb91e80-5a40-11eb-81ca-ef8a6d485101.png">

### Story Link

https://trello.com/c/NZ2sMxgm/89-helper-text-for-document-numbers
