### PR TITLE
Add step to before_install to remove node_modules

### DIFF
--- a/lib/package_builder/scripts/before_install.sh
+++ b/lib/package_builder/scripts/before_install.sh
@@ -7,5 +7,6 @@ rm -rf /home/deploy/bops/current/.bundle
 rm -f /home/deploy/bops/current/log
 rm -f /home/deploy/bops/current/tmp
 rm -f /home/deploy/bops/current/vendor/bundle
-rm -f /home/deploy/bops/current/public/assets
+rm -f /home/deploy/bops/current/public/packs
+rm -f /home/deploy/bops/current/node_modules
 EOF


### PR DESCRIPTION
Deployments were failing because disk space was filling up with node_modules. This step in before_install deletes them.
