### PR TITLE
Remove task list for cancelled applications

### DIFF
--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -1,3 +1,5 @@
 <%= render "assessment_dashboard" do %>
-  <%= render "assess_proposal" %>
+  <% unless @planning_application.withdrawn?  ||  @planning_application.returned?  %>
+    <%= render "assess_proposal" %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
### Description of change

Added a conditional to not display the assess_proposal partial if the application is cancelled (returned or withdrawn).

### Story Link

https://trello.com/c/c7AOZNwz/90-application-page-for-returned-withdrawn-application-looks-broken

<img width="1252" alt="removed" src="https://user-images.githubusercontent.com/1880450/105058434-1cbd4300-5a6e-11eb-864e-6480282add35.png">
