### PR TITLE
Fix host for URLs in emails

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -148,12 +148,14 @@ private
   def decision_notice_mail
     PlanningApplicationMailer.decision_notice_mail(
       @planning_application,
+      request.host,
     ).deliver_now
   end
 
   def validation_notice_mail
     PlanningApplicationMailer.validation_notice_mail(
       @planning_application,
+      request.host,
     ).deliver_now
   end
 

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -3,10 +3,11 @@
 class PlanningApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
 
-  def decision_notice_mail(planning_application)
+  def decision_notice_mail(planning_application, host)
     @planning_application = planning_application
     @decision = @planning_application.reviewer_decision
     @documents = @planning_application.documents.for_publication
+    @host = host
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
@@ -15,7 +16,8 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
-  def validation_notice_mail(planning_application)
+  def validation_notice_mail(planning_application, host)
+    @host = host
     @planning_application = planning_application
 
     view_mail(

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -2,4 +2,4 @@
 
 Your Certificate of lawful development (<%= @planning_application.work_status %>) has been <%= @decision.status %>.
 
-To see the full decision notice visit <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf') %>
+To see the full decision notice visit <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,6 +51,4 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
-
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
   let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority) }
   let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
+  let(:host) { "default.example.com" }
 
   let!(:document_with_proposed_tags) do
     create :document, :proposed_tags,
@@ -35,7 +36,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#decision_notice_mail" do
-    let(:mail) { described_class.decision_notice_mail(planning_application.reload) }
+    let(:mail) { described_class.decision_notice_mail(planning_application.reload, host) }
 
     it "renders the headers" do
       expect(mail.subject).to eq("Certificate of Lawfulness: granted")
@@ -64,7 +65,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#validation_notice_mail" do
-    let(:validation_mail) { described_class.validation_notice_mail(planning_application.reload) }
+    let(:validation_mail) { described_class.validation_notice_mail(planning_application.reload, host) }
 
     it "renders the headers" do
       expect(validation_mail.subject).to eq("Your planning application has been validated")


### PR DESCRIPTION
We can't set the default url host for emails, as we support subdomains. However currently all emails are triggered from a HTTP request, so we can borrow the host domain from that request and pass it into the mailer.