### PR TITLE
Remove production default url options for mailer

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,9 +95,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options =
-    { host: ENV["PRODUCTION_HOST"], port: 3000 }
-
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write


### PR DESCRIPTION
In 0879918dc3da9891c6b239a03897e7ea75c06ea1 I ensured that we passed the request host through to any mailers we sent, given that we are multi-tenant, and therefore we don't know the host from the environment.

However, I missed that this default_url_options had been set in production.rb, so the host was being set correctly, but the port was being set as 3000 by default, which is wrong.

I believe that removing it is the best solution: I would rather error than have an incorrect URL silently get sent.

I won't fully know if this will fix the problem until it is on production.