### PR TITLE
Display application status

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -38,6 +38,12 @@ module PlanningApplicationHelper
       { color: "yellow", decision: "invalid" }
     elsif planning_application.status == "not_started"
       { color: "grey", decision: "Not started" }
+    elsif planning_application.status == "in_assessment"
+      { color: "turquoise", decision: "In assessment" }
+    elsif planning_application.status == "awaiting_determination"
+      { color: "purple", decision: "Awaiting determination" }
+    elsif planning_application.status == "awaiting_correction"
+      { color: "purple", decision: "Awaiting correction" }
     else
       { color: "grey", decision: planning_application.status }
     end
@@ -48,6 +54,14 @@ module PlanningApplicationHelper
       { color: "green", decision: "Granted" }
     else
       { color: "red", decision: "Refused" }
+    end
+  end
+
+  def cancelled_at(planning_application)
+    if planning_application.withdrawn?
+      planning_application.withdrawn_at
+    elsif planning_application.returned?
+      planning_application.returned_at
     end
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -157,7 +157,7 @@ class PlanningApplication < ApplicationRecord
     true unless determined? || returned? || withdrawn? || invalidated? || not_started?
   end
 
-  def cancellable?
+  def in_progress?
     true unless determined? || returned? || withdrawn?
   end
 

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -18,7 +18,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @planning_application.cancellable? && current_user.assessor? %>
+    <% if @planning_application.in_progress? && current_user.assessor? %>
       <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <fieldset class="govuk-fieldset">
           <% if form.object.errors.any? %>
@@ -49,7 +49,7 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">
-    <% if current_user.assessor? && (@planning_application.cancellable? && !@planning_application.awaiting_determination?) %>
+    <% if current_user.assessor? && (@planning_application.in_progress? && !@planning_application.awaiting_determination?) %>
       <%= link_to "Upload documents", new_planning_application_document_path(@planning_application), role: "button", class: "govuk-button", data: { module: "govuk-button" } %>
     <% elsif current_user.assessor? %>
       <%= tag.button "Upload documents", disabled: "disabled", "aria-disabled": true, class: "govuk-button govuk-button--disabled", data: { module: "govuk-button" } %>

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -19,7 +19,7 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
-    <% if @planning_application.cancellable? %>
+    <% if @planning_application.in_progress? %>
       <p class="govuk-body">
         <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application) %>
       </p>

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -14,6 +14,7 @@
     <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
       <%= @planning_application.site.full_address %>
     </h2>
+    <%= render "shared/status_panel" %>
   </div>
   <div class="govuk-grid-column-one-third">
     <div style="float: right; margin: 20px 0 30px 100px; ">

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -16,17 +16,6 @@
     </h2>
     <%= render "shared/status_panel" %>
   </div>
-  <div class="govuk-grid-column-one-third">
-    <div style="float: right; margin: 20px 0 30px 100px; ">
-      <p class="govuk-body">
-        <strong class="govuk-tag govuk-tag--<%= @planning_application.days_left > 7 ? 'green' : 'red' %>">
-          Due: <%= @planning_application.target_date.strftime("%d %B") %><br> <%= @planning_application.days_left %>
-          days
-          remaining
-        </strong>
-      </p>
-    </div>
-  </div>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -11,7 +11,7 @@
     <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
       Fast track application: <%= @planning_application.reference %>
     </h1>
-    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+    <h2 class="govuk-heading-m">
       <%= @planning_application.site.full_address %>
     </h2>
     <%= render "shared/status_panel" %>

--- a/app/views/shared/_status_panel.html.erb
+++ b/app/views/shared/_status_panel.html.erb
@@ -1,0 +1,15 @@
+<p class="govuk-body">
+<!--  <strong class="govuk-tag govuk-tag--<%#= display_status(@planning_application)["color"] %>">-->
+    <% if @planning_application.cancellable? %>
+      <%= @planning_application.status %>
+      Due: <%= @planning_application.target_date.strftime("%d %B") %> - <%= @planning_application.days_left %>
+      days
+      remaining
+    <% elsif @planning_application.determined?%>
+      <%= @planning_application.status %> <%= @planning_application.determined_at.strftime("%d %B") %>
+    <% else %>
+      <%= @planning_application.status %>
+      <%= @planning_application.cancellation_comment %>
+    <% end %>
+<!--  </strong>-->
+</p>

--- a/app/views/shared/_status_panel.html.erb
+++ b/app/views/shared/_status_panel.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  <% if @planning_application.cancellable? %>
+  <% if @planning_application.in_progress? %>
     <strong class="govuk-tag govuk-tag--<%= display_status(@planning_application)[:color] %>">
     <%= display_status(@planning_application)[:decision] %>
     </strong>

--- a/app/views/shared/_status_panel.html.erb
+++ b/app/views/shared/_status_panel.html.erb
@@ -1,15 +1,19 @@
 <p class="govuk-body">
-<!--  <strong class="govuk-tag govuk-tag--<%#= display_status(@planning_application)["color"] %>">-->
-    <% if @planning_application.cancellable? %>
-      <%= @planning_application.status %>
-      Due: <%= @planning_application.target_date.strftime("%d %B") %> - <%= @planning_application.days_left %>
-      days
-      remaining
-    <% elsif @planning_application.determined?%>
-      <%= @planning_application.status %> <%= @planning_application.determined_at.strftime("%d %B") %>
-    <% else %>
-      <%= @planning_application.status %>
-      <%= @planning_application.cancellation_comment %>
-    <% end %>
-<!--  </strong>-->
+  <% if @planning_application.cancellable? %>
+    <strong class="govuk-tag govuk-tag--<%= display_status(@planning_application)[:color] %>">
+    <%= display_status(@planning_application)[:decision] %>
+    </strong>
+    Due: <%= @planning_application.target_date.strftime("%d %B") %> - <%= @planning_application.days_left %>
+    days
+    remaining
+  <% elsif @planning_application.determined?%>
+    <strong class="govuk-tag govuk-tag--<%= display_status(@planning_application)[:color] %>">
+      <%= display_status(@planning_application)[:decision] %>
+    </strong> <%= @planning_application.determined_at.strftime("%d %B") %>
+  <% else %>
+    <strong class="govuk-tag govuk-tag--<%= display_status(@planning_application)[:color] %>">
+      <%= display_status(@planning_application)[:decision] %>
+    </strong>  <%= cancelled_at(@planning_application).strftime("%d %B") %><br/><br/>
+    <%= @planning_application.cancellation_comment %>
+  <% end %>
 </p>

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
 
   describe "#display_status" do
     let(:planning_application) { create :planning_application }
+    let(:awaiting_planning_application) { create :planning_application, :awaiting_determination }
 
     it "returns correct values when application is withdrawn" do
       planning_application.withdraw!
@@ -194,6 +195,17 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
       planning_application.return!
       expect(display_status(planning_application)[:decision]).to eql("returned")
       expect(display_status(planning_application)[:color]).to eql("grey")
+    end
+
+    it "returns correct values when application is in assessment" do
+      planning_application.start!
+      expect(display_status(planning_application)[:decision]).to eql("In assessment")
+      expect(display_status(planning_application)[:color]).to eql("turquoise")
+    end
+
+    it "returns correct values when application is awaiting determination" do
+      expect(display_status(awaiting_planning_application)[:decision]).to eql("Awaiting determination")
+      expect(display_status(awaiting_planning_application)[:color]).to eql("purple")
     end
   end
 end

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -176,6 +176,9 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).not_to have_content("Completed")
     end
 
+    expect(page).to have_css(".govuk-tag--purple")
+    expect(page).to have_content("Awaiting determination")
+
     click_link "Review the recommendation"
     click_link "Back"
 

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       expect(page).not_to have_content("Cancel application")
+      expect(page).to have_content("This has been cancelled")
+      expect(page).to have_css(".govuk-tag--grey")
     end
 
     it "Return from Not Started" do
@@ -75,6 +77,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       expect(page).not_to have_content("Cancel application")
+      expect(page).to have_content("This has been cancelled")
+      expect(page).to have_css(".govuk-tag--grey")
     end
   end
 
@@ -135,6 +139,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       expect(page).not_to have_content("Cancel application")
+      expect(page).to have_content("This has been cancelled")
     end
   end
 

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -37,10 +37,11 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("Fast track application: #{planning_application.reference}")
     end
 
-    it "Target date is correct and label is green" do
+    it "Target date is correct and label is turquoise" do
       expect(page).to have_text("Due: #{planning_application.target_date.strftime('%d %B')}")
       expect(page).to have_text("#{planning_application.days_left} days remaining")
-      expect(page).to have_css(".govuk-tag--green")
+      expect(page).to have_css(".govuk-tag--turquoise")
+      expect(page).to have_content("In assessment")
     end
 
     it "Applicant information accordion" do
@@ -119,10 +120,9 @@ RSpec.describe "Planning Application show page", type: :system do
       visit planning_application_path(planning_application.id)
     end
 
-    it "Target date is correct and label is red" do
+    it "Target date is correct" do
       expect(page).to have_text("Due: #{planning_application.target_date.strftime('%d %B')}")
       expect(page).to have_text("#{planning_application.days_left} days remaining")
-      expect(page).to have_css(".govuk-tag--red")
     end
 
     it "Breadcrumbs contain reference to Application overview which is not linked" do


### PR DESCRIPTION
### Description of change

This commit extends the existing planning application helper method which creates coloured tags according to status. Status, together with due date (if not closed) is now displayed on the assessment dashboard and target date tag is removed from the application page.

### Story Link

https://trello.com/c/r13g3U0c/103-display-an-applications-status-on-application-detail-page

### Decisions [OPTIONAL]

I used multiple elsifs in the helper rather than a case statement as I think the logic isn't straightforward enough for the latter, but there may be a better way to do it.

