### PR TITLE
Only show documents that are for publication in the API

### DIFF
--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -34,12 +34,10 @@ json.received_date planning_application.created_at
 json.decision planning_application.reviewer_decision.status if planning_application.reviewer_decision
 json.questions JSON.parse(planning_application.questions) if planning_application.questions
 json.constraints JSON.parse(planning_application.constraints) if planning_application.constraints
-json.documents planning_application.documents do |document|
+json.documents planning_application.documents.for_publication do |document|
   json.url api_v1_planning_application_document_url(planning_application, document)
   json.extract! document,
                 :created_at,
-                :archived_at,
-                :archive_reason,
                 :tags,
                 :numbers
 end

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -64,8 +64,6 @@ paths:
                     documents:
                       - url: http://example.com/document_path.pdf
                         created_at: '2020-05-16T05:18:17.540Z'
-                        archived_at: '2020-05-16T05:18:17.540Z'
-                        archive_reason: other
                         tags:
                           ["Side", "Elevation", "Proposed"]
                         numbers: PLAN01

--- a/spec/requests/planning_application_list_spec.rb
+++ b/spec/requests/planning_application_list_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe "API request to list planning applications", type: :request, show
       context "for a granted planning application" do
         let!(:planning_application) { create(:planning_application, :determined, local_authority: @default_local_authority) }
         let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
-        let!(:document) { create(:document, planning_application: planning_application) }
+        let!(:document_with_number) { create(:document, :numbered, planning_application: planning_application) }
+        let!(:document_without_number) { create(:document, planning_application: planning_application) }
+        let!(:document_archived) { create(:document, :numbered, :archived, planning_application: planning_application) }
 
         it "returns the accurate data" do
           get "/api/v1/planning_applications.json"
@@ -127,12 +129,13 @@ RSpec.describe "API request to list planning applications", type: :request, show
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
           expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
           expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
-          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document))
-          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document.created_at))
-          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document.archived_at))
-          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document.archive_reason)
-          expect(planning_application_json["documents"].first["tags"]).to eq(document.tags)
-          expect(planning_application_json["documents"].first["numbers"]).to eq(document.numbers)
+          expect(planning_application_json["documents"].size).to eq(1)
+          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document_with_number))
+          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document_with_number.created_at))
+          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document_with_number.archived_at))
+          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document_with_number.archive_reason)
+          expect(planning_application_json["documents"].first["tags"]).to eq(document_with_number.tags)
+          expect(planning_application_json["documents"].first["numbers"]).to eq(document_with_number.numbers)
         end
       end
     end

--- a/spec/requests/planning_application_show_spec.rb
+++ b/spec/requests/planning_application_show_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe "API request to list planning applications", type: :request, show
       context "for a granted planning application" do
         let!(:planning_application) { create(:planning_application, :determined, local_authority: @default_local_authority) }
         let!(:decision) { create(:decision, :granted, user: reviewer, planning_application: planning_application) }
-        let!(:document) { create(:document, planning_application: planning_application) }
+        let!(:document_with_number) { create(:document, :numbered, planning_application: planning_application) }
+        let!(:document_without_number) { create(:document, planning_application: planning_application) }
+        let!(:document_archived) { create(:document, :numbered, :archived, planning_application: planning_application) }
 
         it "returns the accurate data" do
           get "/api/v1/planning_applications/#{planning_application.id}"
@@ -128,12 +130,13 @@ RSpec.describe "API request to list planning applications", type: :request, show
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.site.uprn)
           expect(planning_application_json["questions"]).to eq(JSON.parse(planning_application.questions))
           expect(planning_application_json["constraints"]).to eq(JSON.parse(planning_application.constraints))
-          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document))
-          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document.created_at))
-          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document.archived_at))
-          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document.archive_reason)
-          expect(planning_application_json["documents"].first["tags"]).to eq(document.tags)
-          expect(planning_application_json["documents"].first["numbers"]).to eq(document.numbers)
+          expect(planning_application_json["documents"].size).to eq(1)
+          expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(planning_application, document_with_number))
+          expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document_with_number.created_at))
+          expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document_with_number.archived_at))
+          expect(planning_application_json["documents"].first["archive_reason"]).to eq(document_with_number.archive_reason)
+          expect(planning_application_json["documents"].first["tags"]).to eq(document_with_number.tags)
+          expect(planning_application_json["documents"].first["numbers"]).to eq(document_with_number.numbers)
         end
       end
     end


### PR DESCRIPTION
Previously we were revealing all documents through the API. We only want to show documents that are "for publication" (i.e. have been given a number and have not been archived). We are removing the archived_at and archive_reason from the API too, as they will never not be nil now.