### PR TITLE
Add status column to all tabs on applications index

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -43,7 +43,7 @@ module PlanningApplicationHelper
     elsif planning_application.status == "awaiting_determination"
       { color: "purple", decision: "Awaiting determination" }
     elsif planning_application.status == "awaiting_correction"
-      { color: "purple", decision: "Awaiting correction" }
+      { color: "green", decision: "Awaiting correction" }
     else
       { color: "grey", decision: planning_application.status }
     end

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -7,14 +7,11 @@
       <th scope="col" class="govuk-table__header">Site address</th>
       <th scope="col" class="govuk-table__header">Application type</th>
       <th scope="col" class="govuk-table__header">Target date</th>
-      <% if id == "closed" %>
-        <th scope="col" class="govuk-table__header">Decision</th>
-      <% else %>
+      <% if id != "closed" %>
         <th scope="col" class="govuk-table__header">Days left</th>
       <% end %>
-      <% if (id == "in_assessment" || id == "not_started_and_invalid") %>
-        <th scope="col" class="govuk-table__header">Status</th>
-      <% elsif id == "awaiting_determination" %>
+      <th scope="col" class="govuk-table__header">Status</th>
+      <% if id == "awaiting_determination" %>
         <th scope="col" class="govuk-table__header">Recommendation date</th>
       <% elsif id == "closed" %>
         <th scope="col" class="govuk-table__header">Determination date</th>
@@ -31,26 +28,19 @@
         <td class="govuk-table__cell"><%= planning_application.site.full_address %></td>
         <td class="govuk-table__cell"><%= t(planning_application.application_type) %></td>
         <td class="govuk-table__cell"><%= planning_application.target_date.strftime("%e %b") %></td>
-        <td class="govuk-table__cell">
-          <% if id == "closed" %>
-            <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
-              <%= display_status(planning_application)[:decision] %>
-            </strong>
-          <% else %>
+        <% if id != "closed" %>
+          <td class="govuk-table__cell">
             <strong class="govuk-tag govuk-tag--<%= days_color(planning_application.days_left) %>">
               <%= planning_application.days_left %>
             </strong>
-          <% end %>
+          </td>
+        <% end %>
+        <td class="govuk-table__cell">
+          <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
+            <%= display_status(planning_application)[:decision] %>
+          </strong>
         </td>
-        <% if id == "in_assessment" %>
-          <td class="govuk-table__cell">Not required</td>
-        <% elsif id == "not_started_and_invalid" %>
-            <td class="govuk-table__cell">
-              <strong class="govuk-tag govuk-tag--<%= display_status(planning_application)[:color] %>">
-                <%= display_status(planning_application)[:decision] %>
-              </strong>
-            </td>
-        <% elsif id == "awaiting_determination" %>
+        <% if id == "awaiting_determination" %>
           <td class="govuk-table__cell"><%= planning_application.awaiting_determination_at.strftime("%e %b") %></td>
         <% elsif id == "closed" %>
           <td class="govuk-table__cell"><%= planning_application.determined_at.strftime("%e %b") if planning_application.determined? %></td>

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   it "Assessment completing and editing" do
     click_link "In assessment"
+    expect(page).to have_css(".govuk-tag--turquoise")
     click_link planning_application.reference
 
     expect(page).to have_content("Make recommendation")
@@ -196,6 +197,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     # Check that the application is now in awaiting determination
     click_link "Awaiting determination"
+
+    expect(page).to have_css(".govuk-tag--purple")
 
     within("#awaiting_determination") do
       click_link planning_application.reference

--- a/spec/system/planning_applications/correcting_spec.rb
+++ b/spec/system/planning_applications/correcting_spec.rb
@@ -136,6 +136,7 @@ RSpec.describe "Planning Application correction journey", type: :system do
       expect(page).not_to have_css("corrections-banner")
       click_link "Corrections requested"
       expect(page).to have_text(planning_application_corrected.reference)
+      expect(page).to have_css(".govuk-tag--green")
     end
 
     it "Reviewer is unable to submit correction without reason" do


### PR DESCRIPTION
### Description of change

This commit tidies up the planning applications table so that we have consistent column display and naming and the status tag is always shown

### Story Link

https://trello.com/c/Vs5pjRyw/77-status-field-to-be-added-to-in-assessment-and-awaiting-determination-tables

