### PR TITLE
Add explanatory helper text to document index and edit

### DIFF
--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -16,10 +16,6 @@
 
     <h2 class="govuk-heading-m"><%= @document.name %></h2>
 
-    <p class="govuk-body" style="line-height: 1.6;">
-      If you add one or more numbers to this document, it will be published in the decision notice. Only documents with numbers will appear on the decision notice.
-    </p>
-
     <%= link_to image_tag(@document.file.representation(resize: "500x500")),
                 api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
     <p class="govuk-body">
@@ -37,7 +33,7 @@
         <% end %>
         <%= form.label :numbers, "Document number(s)", class: "govuk-label", for: "numbers" %>
         <div id="event-name-hint" class="govuk-hint">
-          If there are multiple numbers, please provide a comma-separated list.
+          Please enter numbers for all documents you wish to appear on the decision notice. Do not add numbers for documents that should not be publicly available. Where documents contain multiple drawings, enter multiple numbers separated by a comma (e.g. "25A-V2, 25B-V2").
         </div>
         <%= form.text_area :numbers, class: "govuk-input govuk-input--width-20", id: "numbers" %>
       </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -45,7 +45,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body" style="line-height: 1.6;">
-      Check documents and attach document numbers to all proposed documents. These will be published in the decision notice.
+      Check all documents to ensure they support the information provided by the applicant and add tags to indicate the document contents. Please note, only documents with document numbers will be be listed on the decision notice and made publicly available.
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">

--- a/spec/system/documents/number_documents_spec.rb
+++ b/spec/system/documents/number_documents_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Edit document numbers page", type: :system do
       it "Assessor can see content for the right application" do
         expect(page).to have_text(planning_application.reference)
 
-        expect(page).to have_text("These will be published in the decision notice.")
+        expect(page).to have_text("only documents with document numbers will be be listed on the decision notice")
       end
 
       it "Assessor can see information about the document" do


### PR DESCRIPTION
### Description of change

This text addition is to remind planners of their responsibilities around making documents public

### Story Link

https://trello.com/c/RFhPaHcG/105-document-number-helper-text-improvements

