### PR TITLE
Check if document is published before revealing in API

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::DocumentsController < Api::V1::ApplicationController
   skip_before_action :authenticate
 
   def show
-    document = PlanningApplication.find(params[:planning_application_id]).documents.find(params[:id])
+    document = PlanningApplication.find(params[:planning_application_id]).documents.for_publication.find(params[:id])
     redirect_to rails_blob_url(document.file)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def url_for_document(document)
+    if document.published?
+      api_v1_planning_application_document_url(document.planning_application, document)
+    else
+      rails_blob_url(document.file)
+    end
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -58,6 +58,10 @@ class Document < ApplicationRecord
     super.join(", ")
   end
 
+  def published?
+    self.class.for_publication.where(id: id).any?
+  end
+
 private
 
   def tag_values_permitted

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -23,7 +23,7 @@
       </h2>
       <p>
         <%= link_to image_tag(@document.file.representation(resize: "300x212")),
-                    api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
+                    url_for_document(@document), target: :_blank %>
       </p>
       <h2 class="govuk-heading-s">
         Why do you want to archive this document?

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -17,9 +17,9 @@
     <h2 class="govuk-heading-m"><%= @document.name %></h2>
 
     <%= link_to image_tag(@document.file.representation(resize: "500x500")),
-                api_v1_planning_application_document_url(@planning_application, @document), target: :_blank %>
+                url_for_document(@document), target: :_blank %>
     <p class="govuk-body">
-      <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, @document), target: :_new %>
+      <%= link_to "View in new window", url_for_document(@document), target: :_new %>
     </p>
 
     <%= form_with model: [ @planning_application, @document ], local: true do |form| %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -63,9 +63,9 @@
     <li class="app-task-list__item">
       <div class="govuk-grid-column-one-quarter">
         <%= link_to image_tag(document.file.representation(resize: "300x212"), class: "govuk-!-width-full"),
-                    api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
+                    url_for_document(document), target: :_blank %>
         <p class="govuk-body">
-          <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, document), target: :_new %>
+          <%= link_to "View in new window", url_for_document(document), target: :_new %>
         </p>
       </div>
 
@@ -116,7 +116,7 @@
       <tbody class="govuk-table__body">
         <% filter_archived(@documents).each do |document| %>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell archive-data"><%= link_to document.name, api_v1_planning_application_document_url(@planning_application, document), target: :_new %></td>
+            <td class="govuk-table__cell archive-data"><%= link_to document.name, url_for_document(document), target: :_new %></td>
             <td class="govuk-table__cell archive-data tags">
               <p class="govuk-body">
                 <% document.tags.each do |tag| %>

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -20,7 +20,7 @@
             <%= document.created_at.strftime('%d %b %Y') %>
           </p>
           <p class="govuk-body">
-            <%= link_to "View in new window", api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
+            <%= link_to "View in new window", url_for_document(document), target: :_blank %>
           </p>
           <ul class="govuk-list">
             <% document.tags.each do |tag| %>
@@ -28,7 +28,7 @@
             <% end %>
           </ul>
           <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                          api_v1_planning_application_document_url(@planning_application, document), target: :_blank %>
+                          url_for_document(document), target: :_blank %>
           <br>
           <br>
         <% end %>

--- a/spec/requests/document_show_spec.rb
+++ b/spec/requests/document_show_spec.rb
@@ -2,9 +2,9 @@
 
 require "rails_helper"
 
-RSpec.describe "API request to list planning applications", type: :request, show_exceptions: true do
+RSpec.describe "API request to show document file", type: :request, show_exceptions: true do
   let!(:planning_application) { create(:planning_application, :not_started) }
-  let!(:document) { create(:document, :with_file, planning_application: planning_application) }
+  let!(:document) { create(:document, :with_file, :numbered, planning_application: planning_application) }
 
   describe "data" do
     it "returns a 404 if no planning application" do
@@ -17,6 +17,26 @@ RSpec.describe "API request to list planning applications", type: :request, show
       expect {
         get "/api/v1/planning_applications/#{planning_application.id}/documents/xxx"
       }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "with a document that does not contain a number" do
+      let!(:document) { create(:document, :with_file, planning_application: planning_application) }
+
+      it "returns a 404" do
+        expect {
+          get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with a document that has been archived" do
+      let!(:document) { create(:document, :with_file, :numbered, :archived, planning_application: planning_application) }
+
+      it "returns a 404" do
+        expect {
+          get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
 
     it "redirects to blob url" do


### PR DESCRIPTION
Adds a check to the API call to show a document file to ensure it is published before redirecting to temp s3 URL.

Add new helper method for using within the logged in API: if the document is published, then use the public API method, else create a temporary secure s3 URL directly.