### PR TITLE
Assign case officer to planning application

### DIFF
--- a/app/controllers/decisions_controller.rb
+++ b/app/controllers/decisions_controller.rb
@@ -2,7 +2,6 @@
 
 class DecisionsController < AuthenticationController
   before_action :set_planning_application
-  before_action :assign_assessor
 
   def new
     @decision = @planning_application.decisions.build(user: current_user)
@@ -44,12 +43,6 @@ private
     @planning_application = authorize(
       PlanningApplication.find(params[:planning_application_id]),
     )
-  end
-
-  def assign_assessor
-    if current_user.assessor? && @planning_application.user.nil?
-      @planning_application.update!(user_id: current_user[:id])
-    end
   end
 
   def set_awaiting_correction

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -2,6 +2,7 @@
 
 class PlanningApplicationsController < AuthenticationController
   before_action :set_planning_application, only: %i[show
+                                                    assign
                                                     edit
                                                     assess
                                                     determine
@@ -26,6 +27,17 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def show; end
+
+  def assign
+    if request.patch?
+      @planning_application.user = if params[:planning_application][:user_id] == "0"
+                                     nil
+                                   else
+                                     current_local_authority.users.find(params[:planning_application][:user_id])
+                                   end
+      redirect_to @planning_application if @planning_application.save
+    end
+  end
 
   def edit; end
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -60,6 +60,10 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   padding-left: 0.5em;
 }
 
+.assignment_cta {
+  padding-left: 1em;
+}
+
 .moj-banner__assistive {
   @include govuk-visually-hidden;
 }

--- a/app/policies/planning_application_policy.rb
+++ b/app/policies/planning_application_policy.rb
@@ -14,6 +14,7 @@ class PlanningApplicationPolicy < ApplicationPolicy
   alias_method :determine?, :editor?
   alias_method :request_correction?, :editor?
   alias_method :update_numbers?, :editor?
+  alias_method :assign?, :editor?
 
   def show?
     (super || signed_in_viewer?) && record.local_authority_id == user.local_authority_id

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -23,8 +23,10 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds assigned_to">
-    <%= @planning_application.user ? @planning_application.user.name : "Unassigned" %>
-    <%= link_to "Change", assign_planning_application_path(@planning_application) %>
+    <p class="govuk-body">
+    <strong><%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
+      <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application) %></span>
+    </p>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -22,6 +22,12 @@
   </div>
 </div>
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds assigned_to">
+    <%= @planning_application.user ? @planning_application.user.name : "Unassigned" %>
+    <%= link_to "Change", assign_planning_application_path(@planning_application) %>
+  </div>
+</div>
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
     <% if @planning_application.in_progress? %>
       <p class="govuk-body">

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -24,7 +24,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds assigned_to">
     <p class="govuk-body">
-    <strong><%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
+    <strong>Assigned to: <%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
       <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application) %></span>
     </p>
   </div>

--- a/app/views/planning_applications/assign.html.erb
+++ b/app/views/planning_applications/assign.html.erb
@@ -1,22 +1,27 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% content_for :title, "Assign planning application" %>
   <h2 class="govuk-heading-m">Assign application</h2>
-
+  <p class="govuk-body">
+    Please select the officer you wish to assign this application to.
+  </p>
   <%= form_for @planning_application, url: assign_planning_application_path(@planning_application) do |form| %>
-    <div class="govuk-radios govuk-radios--small">
-      <div class="govuk-radios__item">
-        <%= form.radio_button :user_id, 0, class: "govuk-radios__input" %>
-        <%= form.label :user_id, "Unassigned", value: 0, class: "govuk-label govuk-radios__label" %>
-      </div>
-
-      <% current_local_authority.users.each do |user| %>
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-radios govuk-radios--small">
         <div class="govuk-radios__item">
-          <%= form.radio_button :user_id, user.id, class: "govuk-radios__input" %>
-          <%= form.label :user_id, user.name, value: user.id, class: "govuk-label govuk-radios__label" %>
+          <%= form.radio_button :user_id, 0, class: "govuk-radios__input" %>
+          <%= form.label :user_id, "Unassigned", value: 0, class: "govuk-label govuk-radios__label" %>
         </div>
-      <% end %>
-    </div>
 
-    <%= form.submit "Assign", class: "govuk-button", data: { module: "govuk-button" } %>
+        <% current_local_authority.users.each do |user| %>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :user_id, user.id, class: "govuk-radios__input" %>
+            <%= form.label :user_id, user.name, value: user.id, class: "govuk-label govuk-radios__label" %>
+          </div>
+        <% end %>
+      </div>
+    </fieldset>
+    <p>
+      <%= form.submit "Confirm", class: "govuk-button", data: { module: "govuk-button" } %>
+    </p>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/assign.html.erb
+++ b/app/views/planning_applications/assign.html.erb
@@ -1,0 +1,22 @@
+<%= render "planning_applications/assessment_dashboard" do %>
+  <% content_for :title, "Assign planning application" %>
+  <h2 class="govuk-heading-m">Assign application</h2>
+
+  <%= form_for @planning_application, url: assign_planning_application_path(@planning_application) do |form| %>
+    <div class="govuk-radios govuk-radios--small">
+      <div class="govuk-radios__item">
+        <%= form.radio_button :user_id, 0, class: "govuk-radios__input" %>
+        <%= form.label :user_id, "Unassigned", value: 0, class: "govuk-label govuk-radios__label" %>
+      </div>
+
+      <% current_local_authority.users.each do |user| %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :user_id, user.id, class: "govuk-radios__input" %>
+          <%= form.label :user_id, user.name, value: user.id, class: "govuk-label govuk-radios__label" %>
+        </div>
+      <% end %>
+    </div>
+
+    <%= form.submit "Assign", class: "govuk-button", data: { module: "govuk-button" } %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
 
   resources :planning_applications, only: %i[show index edit] do
     member do
+      get :assign
+      patch :assign
       patch :assess
       patch :determine
       patch :cancel

--- a/spec/system/planning_applications/assessing_spec.rb
+++ b/spec/system/planning_applications/assessing_spec.rb
@@ -72,9 +72,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     expect(page).to have_content("Please review the applicant's answers")
 
-    # Application now associated with assessor
-    expect(page).to have_text("Lorrine Krajcik")
-
     expect(page).to have_content("The property is a semi detached house")
     expect(page).to have_content("The project will not alter the internal floor area of the building")
 
@@ -202,35 +199,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     within("#awaiting_determination") do
       click_link planning_application.reference
-    end
-  end
-
-  it "Assessor is assigned to planning application" do
-    click_link "In assessment"
-    click_link planning_application.reference
-
-    expect(page).to have_content("Make recommendation")
-    expect(page).to have_link("Assess the proposal")
-    expect(page).not_to have_link("Submit the recommendation")
-
-    # Ensure officer name is not displayed on page when accordion is opened
-    within(".govuk-grid-column-two-thirds.application") do
-      first(".govuk-accordion").click_button("Open all")
-    end
-
-    click_link "Assess the proposal"
-
-    # Ensure officer name is now displayed
-    within(".govuk-grid-column-two-thirds.application") do
-      expect(page).to have_text("Lorrine Krajcik")
-    end
-
-    click_link "Home"
-
-    table_rows = all(".govuk-table__row").map(&:text)
-
-    table_rows.each do |row|
-      expect(row).to include("Lorrine Krajcik") if row.include? planning_application.reference
     end
   end
 

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Assigning a planning application", type: :system do
       click_link "Change"
     end
     choose "Assessor 2"
-    click_button "Assign"
+    click_button "Confirm"
     within ".assigned_to" do
       expect(page).to have_text("Assessor 2")
     end
@@ -31,7 +31,7 @@ RSpec.describe "Assigning a planning application", type: :system do
       click_link "Change"
     end
     choose "Unassigned"
-    click_button "Assign"
+    click_button "Confirm"
     within ".assigned_to" do
       expect(page).to have_text("Unassigned")
     end

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assigning a planning application", type: :system do
+  let(:local_authority) { @default_local_authority }
+  let!(:assessor1) { create :user, :assessor, local_authority: local_authority, name: "Assessor 1" }
+  let!(:assessor2) { create :user, :assessor, local_authority: local_authority, name: "Assessor 2" }
+  let!(:planning_application) { create :planning_application, local_authority: local_authority, user: assessor1 }
+
+  before do
+    sign_in assessor1
+    visit planning_application_path(planning_application)
+  end
+
+  it "is possible to assign to a user" do
+    within ".assigned_to" do
+      expect(page).to have_text("Assessor 1")
+      click_link "Change"
+    end
+    choose "Assessor 2"
+    click_button "Assign"
+    within ".assigned_to" do
+      expect(page).to have_text("Assessor 2")
+    end
+  end
+
+  it "is possible to assign to nobody" do
+    within ".assigned_to" do
+      expect(page).to have_text("Assessor 1")
+      click_link "Change"
+    end
+    choose "Unassigned"
+    click_button "Assign"
+    within ".assigned_to" do
+      expect(page).to have_text("Unassigned")
+    end
+  end
+end


### PR DESCRIPTION
<img width="1161" alt="assignment" src="https://user-images.githubusercontent.com/1880450/106782563-32239700-6642-11eb-9bc8-8c2420624282.png">

### Description of change

The old method of auto-assigning a planning officer has been removed from the decision controller and a new form for manually assigning an officer has been created.

### Story Link

https://trello.com/c/YypYDWca/44-assignment-and-reassignment-of-cases-to-officers

