### PR TITLE
Update planning application example in Swagger

### DIFF
--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -263,9 +263,14 @@ paths:
                       - id: '-LsXty7cOZycK0rqv8B2'
                         text: The property is
                         val: property.buildingType
+                        options:
+                          - id: '-LsXty7cOZycK0rqv8B3'
+                            text: a detached house
+                            val: residential.dwelling.house.detached
                         choice:
-                          id: '-LsXty7cOZycK0rqv8B7'
-                          idx: 3
+                          id: '-LsXty7cOZycK0rqv8B3'
+                          idx: 0
+                          text: a detached house
                           recorded_at: '2020-05-14T05:18:17.540Z'
                           auto: true
                   constraints:


### PR DESCRIPTION
### Description of change

The existing example was missing the options array which meant that the proposal details did not show

### Story Link

https://trello.com/c/cjbBsnGS/151-bug-fix-swagger-yml-to-display-proposal-details

