### PR TITLE
Restyle task list on planning application show page

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -61,6 +61,10 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   padding-left: 0.5em;
 }
 
+.task-list-subhead {
+  margin-top: 2em;
+}
+
 .assignment_cta {
   padding-left: 1em;
 }

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -1,101 +1,124 @@
 <%= render "assessment_dashboard" do %>
-  <% unless @planning_application.withdrawn?  ||  @planning_application.returned?  %>
-    <ol class="app-task-list">
-      <li>
-        <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number"><%= t("#{@planning_application.status}.heading") %></span>
-        </h2>
-        <ul class="app-task-list__items">
-          <li class="app-task-list__item">
+  <% unless @planning_application.withdrawn? || @planning_application.returned? %>
+    <h2 class="app-task-list__section">
+      <span class="app-task-list__section-number">Process Application</span>
+    </h2>
+    <div class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <p class="govuk-body task-list-subhead">
+          <strong>1. Validation</strong>
+        <p>
+      </div>
+      <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_validate? %>
                 <%= link_to "Validate documents",
                             validate_documents_form_planning_application_path(@planning_application),
-                            aria: { describedby: "validation-completed" }
+                            aria: {describedby: "validation-completed"}
                 %>
               <% else %>
                 Validate documents
               <% end %>
             </span>
 
-            <% if @planning_application.validation_complete?  %>
-              <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% end %>
-          </li>
+          <% if @planning_application.validation_complete? %>
+            <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
+          <% end %>
+        </div>
+      </div>
 
-          <li class="app-task-list__item">
+      <div class="govuk-summary-list__row">
+        <p class="govuk-body task-list-subhead">
+          <strong>2. Assessment</strong>
+        <p>
+      </div>
+      <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_assess? %>
                 <%= link_to "Assess Proposal",
                             recommendation_form_planning_application_path(@planning_application),
-                            aria: { describedby: "assessment-completed" }
+                            aria: {describedby: "assessment-completed"}
                 %>
               <% else %>
                 Assess Proposal
               <% end %>
             </span>
 
-            <% if @planning_application.assessment_complete?  %>
-              <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% end %>
-          </li>
+          <% if @planning_application.assessment_complete? %>
+            <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
+          <% end %>
+        </div>
+      </div>
 
-          <li class="app-task-list__item">
+      <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_submit_recommendation? %>
                 <%= link_to "Submit Recommendation",
                             submit_recommendation_planning_application_path(@planning_application),
-                            aria: { describedby: "submit_recommendation-completed" }
+                            aria: {describedby: "submit_recommendation-completed"}
                 %>
               <% else %>
                 Submit Recommendation
               <% end %>
             </span>
 
-            <% if @planning_application.submit_recommendation_complete?  %>
-              <%= tag.strong "Completed", id: "submit_recommendation-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% end %>
-          </li>
+          <% if @planning_application.submit_recommendation_complete? %>
+            <%= tag.strong "Completed", id: "submit_recommendation-completed", class: "govuk-tag app-task-list__task-tag" %>
+          <% end %>
+        </div>
+      </div>
 
-          <li class="app-task-list__item">
+
+      <div class="govuk-summary-list__row">
+        <p class="govuk-body task-list-subhead">
+          <strong>3. Review</strong>
+        <p>
+      </div>
+      <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_review_assessment? && current_user.reviewer? %>
                 <%= link_to "Review Assessment",
                             review_form_planning_application_path(@planning_application),
-                            aria: { describedby: "review_assessment-completed" }
+                            aria: {describedby: "review_assessment-completed"}
                 %>
               <% else %>
                 Review Assessment
               <% end %>
             </span>
 
-            <% if @planning_application.review_assessment_complete? %>
-              <%= tag.strong "Completed", id: "review_assessment-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% elsif @planning_application.can_review_assessment? && current_user.assessor? %>
-              <%= tag.strong "Waiting", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag" %>
-            <% end %>
-          </li>
+          <% if @planning_application.review_assessment_complete? %>
+            <%= tag.strong "Completed", id: "review_assessment-completed", class: "govuk-tag app-task-list__task-tag" %>
+          <% elsif @planning_application.can_review_assessment? && current_user.assessor? %>
+            <%= tag.strong "Waiting", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag" %>
+          <% end %>
 
-          <li class="app-task-list__item">
+        </div>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_publish? && current_user.reviewer? %>
-                <%= link_to "Publish",
+                <%= link_to "Publish Determination",
                             publish_planning_application_path(@planning_application),
-                            aria: { describedby: "publish-completed" }
+                            aria: {describedby: "publish-completed"}
                 %>
               <% else %>
                 Publish
               <% end %>
             </span>
 
-            <% if @planning_application.publish_complete?  %>
-              <%= tag.strong "Completed", id: "publish-completed", class: "govuk-tag app-task-list__task-tag" %>
-            <% elsif @planning_application.can_publish? && current_user.assessor? %>
-              <%= tag.strong "Waiting", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag" %>
-            <% end %>
-          </li>
-        </ul>
-      </li>
-    </ol>
+          <% if @planning_application.publish_complete? %>
+            <%= tag.strong "Completed", id: "publish-completed", class: "govuk-tag app-task-list__task-tag" %>
+          <% elsif @planning_application.can_publish? && current_user.assessor? %>
+            <%= tag.strong "Waiting", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag" %>
+          <% end %>
+        </div>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   not_started:
     title: "Not started"
     status: "Not Started"
-    heading: "Validate documents"
+    heading: "Process application"
     proposal_step: "Read the proposal"
     validation_step: "Check the documents"
     recommendation_step: "Submit the recommendation at next stage"
@@ -15,7 +15,7 @@ en:
     recommendation_step: "Submit the recommendation"
   in_assessment:
     title: "In assessment"
-    heading: "Make recommendation"
+    heading: "Process application"
     proposal_step: "Assess the proposal"
     validation_step: "Check the documents"
     recommendation_step: "Submit the recommendation"

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -103,11 +103,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "Assessment tasks are visible" do
-      expect(page).to have_text("Make recommendation")
-    end
-
-    it "Review tasks are not visible" do
-      expect(page).not_to have_text("Determine the proposal")
+      expect(page).to have_text("Submit Recommendation")
     end
   end
 

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe "Planning Application show page", type: :system do
   end
 
   def task_item_exists(text, opts = { linked: false, completed: false })
-    within ".app-task-list__items" do
-      within :xpath, "//*[contains(text(),'#{text}')]/ancestor::li[@class='app-task-list__item']" do
+    within ".govuk-summary-list" do
+      within :xpath, "//*[contains(text(),'#{text}')]/ancestor::div[@class='govuk-summary-list__value']" do
         if opts[:linked]
           expect(page).to have_link(text)
         else


### PR DESCRIPTION
<img width="732" alt="tasklist" src="https://user-images.githubusercontent.com/1880450/107969072-253e6600-6fa7-11eb-973d-245a00711043.png">

### Description of change

This has been styled using divs so it matches the prototype but we will need to have another look at it when we move to full householder to try to make it fit a task list format

### Story Link

https://trello.com/c/YvwZjtK1/153-add-styling-to-new-task-list

### Decisions 

On the prototype, these items were styled as `<dd>` but I thought the markup context would be misleading as they are not listed for this purpose so I have created them as `<div>`s.

