### PR TITLE
Remove assignment option from closed applications

### DIFF
--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -21,14 +21,16 @@
     <%= render "shared/status_panel" %>
   </div>
 </div>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds assigned_to">
-    <p class="govuk-body">
-    <strong>Assigned to: <%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
-      <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application) %></span>
-    </p>
+<% if @planning_application.in_progress? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds assigned_to">
+      <p class="govuk-body">
+      <strong>Assigned to: <%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
+        <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application) %></span>
+      </p>
+    </div>
   </div>
-</div>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
     <% if @planning_application.in_progress? %>

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       planning_application.reload
       expect(planning_application.status).to eq("withdrawn")
       expect(planning_application.cancellation_comment).to eq("Withdrawn reason")
+      expect(page).not_to have_content("Assigned to:")
     end
 
     it "can return an application" do
@@ -37,6 +38,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       planning_application.reload
       expect(planning_application.status).to eq("returned")
       expect(planning_application.cancellation_comment).to eq("Returned reason")
+      expect(page).not_to have_content("Assigned to:")
     end
 
     it "errors if no option chosen" do

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(planning_application.recommendations.last.reviewer).to eq(reviewer)
     expect(planning_application.recommendations.last.reviewed_at).not_to be_nil
     expect(planning_application.recommendations.last.reviewer_comment).to eq("Reviewer private comment")
+    expect(page).not_to have_content("Assigned to:")
     expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
   end
 


### PR DESCRIPTION
### Description of change

We do not want to be able to assign planning applications if they have been returned, withdrawn or determined

### Story Link

https://trello.com/c/HlOSnGOz/159-hide-assignment-if-the-application-is-determined-returned-or-withdrawn

