### PR TITLE
Hide task list when application is determined

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -15,7 +15,8 @@ class PlanningApplicationsController < AuthenticationController
                                                     validate_documents_form
                                                     validate_documents
                                                     cancel_confirmation
-                                                    cancel]
+                                                    cancel
+                                                    decision_notice]
 
   before_action :ensure_user_is_reviewer, only: %i[review review_form]
 
@@ -109,6 +110,10 @@ class PlanningApplicationsController < AuthenticationController
     flash[:notice] = "Decision Notice sent to applicant"
 
     redirect_to @planning_application
+  end
+
+  def decision_notice
+    render :decision_notice
   end
 
   def request_correction

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -30,8 +30,15 @@
       </p>
     </div>
   </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+<% elsif @planning_application.determined? %>
+  <p class="govuk-body">
+  <%= link_to "View decision notice", decision_notice_planning_application_path(@planning_application)
+  %>
+  </p>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds cancel">
+    <% if @planning_application.in_progress? %>
       <p class="govuk-body">
         <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application) %>
       </p>

--- a/app/views/planning_applications/decision_notice.html.erb
+++ b/app/views/planning_applications/decision_notice.html.erb
@@ -1,0 +1,19 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Decision notice" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+      <%= @planning_application.reference %>
+    </h1>
+
+    <p class="govuk-body">
+      <%= @planning_application.site.full_address %>
+    </p>
+
+    <%= render "decision_notice", planning_application: @planning_application %>
+
+  </div>
+</div>

--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -1,8 +1,8 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <% content_for :title, "Publish the recommendation" %>
 
-  <h2 class="govuk-heading-m">Publish the recommendation</h2>
-  <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.</p>
+    <h2 class="govuk-heading-m">Publish the recommendation</h2>
+    <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.</p>
 
   <%= render "decision_notice", planning_application: @planning_application %>
   <p class="govuk-body">

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -1,5 +1,5 @@
 <%= render "assessment_dashboard" do %>
-  <% unless @planning_application.withdrawn? || @planning_application.returned? %>
+  <% if @planning_application.in_progress? %>
     <h2 class="app-task-list__section">
       <span class="app-task-list__section-number">Process Application</span>
     </h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       patch :determine
       patch :cancel
       get :cancel_confirmation
+      get :decision_notice
     end
 
     resources :documents, only: %i[index new create edit update] do

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(planning_application.recommendations.last.reviewed_at).not_to be_nil
     expect(planning_application.recommendations.last.reviewer_comment).to eq("Reviewer private comment")
     expect(page).not_to have_content("Assigned to:")
+    expect(page).not_to have_content("Process Application")
+    expect(page).not_to have_content("Review Assessment")
     expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
+    click_link("View decision notice")
+    expect(page).to have_content("IT IS HEREBY CERTIFIED")
   end
 
   it "can be rejected" do

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -64,17 +64,6 @@ RSpec.describe "Planning Application show page", type: :system do
       task_item_exists("Publish determination", linked: true, completed: false)
     end
 
-    it "makes valid task list for when it is determined" do
-      planning_application = create(:planning_application, :determined, local_authority: @default_local_authority)
-      create(:recommendation, :reviewed, planning_application: planning_application)
-      visit planning_application_path(planning_application.id)
-      task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess proposal", linked: false, completed: true)
-      task_item_exists("Submit recommendation", linked: false, completed: true)
-      task_item_exists("Review assessment", linked: false, completed: true)
-      task_item_exists("Publish determination", linked: false, completed: true)
-    end
-
     it "makes valid task list for when it is awaiting correction and no re-proposal has been made" do
       planning_application = create(:planning_application, :awaiting_correction, local_authority: @default_local_authority)
       create(:recommendation, :reviewed, planning_application: planning_application)


### PR DESCRIPTION
### Description of change

Once the planning application has moved to Determined status, the task list should be hidden. Assessors and reviewers should be able to view the decision notice via a link near the top of the page

### Story Link

https://trello.com/c/qvB833hO/160-hide-task-list-and-give-link-to-decision-notice-once-determined

### Decisions 

Although it was not in the story, I have also added a conditional for not displaying Publish recommendation heading if the application is closed.