### PR TITLE
Make task list titles consistent

### DIFF
--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -37,12 +37,12 @@
         <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_assess? %>
-                <%= link_to "Assess Proposal",
+                <%= link_to "Assess proposal",
                             recommendation_form_planning_application_path(@planning_application),
                             aria: {describedby: "assessment-completed"}
                 %>
               <% else %>
-                Assess Proposal
+                Assess proposal
               <% end %>
             </span>
 
@@ -56,12 +56,12 @@
         <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_submit_recommendation? %>
-                <%= link_to "Submit Recommendation",
+                <%= link_to "Submit recommendation",
                             submit_recommendation_planning_application_path(@planning_application),
                             aria: {describedby: "submit_recommendation-completed"}
                 %>
               <% else %>
-                Submit Recommendation
+                Submit recommendation
               <% end %>
             </span>
 
@@ -81,12 +81,12 @@
         <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_review_assessment? && current_user.reviewer? %>
-                <%= link_to "Review Assessment",
+                <%= link_to "Review assessment",
                             review_form_planning_application_path(@planning_application),
                             aria: {describedby: "review_assessment-completed"}
                 %>
               <% else %>
-                Review Assessment
+                Review assessment
               <% end %>
             </span>
 
@@ -103,12 +103,12 @@
         <div class="govuk-summary-list__value">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_publish? && current_user.reviewer? %>
-                <%= link_to "Publish Determination",
+                <%= link_to "Publish determination",
                             publish_planning_application_path(@planning_application),
                             aria: {describedby: "publish-completed"}
                 %>
               <% else %>
-                Publish
+                Publish determination
               <% end %>
             </span>
 

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   context "with no previous recommendations" do
     it "can create a new recommendation, edit it, and submit it" do
-      click_link "Assess Proposal"
+      click_link "Assess proposal"
       choose "Yes"
       fill_in "assessor_comment", with: "This is a private assessor comment"
       click_button "Save"
@@ -28,7 +28,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(planning_application.recommendations.first.assessor_comment).to eq("This is a private assessor comment")
       expect(planning_application.decision).to eq("granted")
 
-      click_link "Assess Proposal"
+      click_link "Assess proposal"
       expect(page).to have_checked_field("Yes")
       expect(page).to have_field("assessor_comment", with: "This is a private assessor comment")
       choose "No"
@@ -41,7 +41,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(planning_application.decision).to eq("refused")
       expect(planning_application.public_comment).to eq("This is a new public comment")
 
-      click_link "Submit Recommendation"
+      click_link "Submit recommendation"
       click_button "Submit to manager"
 
       # TODO: add a flash message here?
@@ -61,7 +61,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
 
     it "displays the previous recommendations" do
-      click_link "Assess Proposal"
+      click_link "Assess proposal"
 
       within ".recommendations" do
         expect(page).to have_content("I disagree")
@@ -77,7 +77,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(planning_application.recommendations.last.assessor_comment).to eq("This is a private assessor comment")
       expect(planning_application.decision).to eq("granted")
 
-      click_link "Assess Proposal"
+      click_link "Assess proposal"
 
       within ".recommendations" do
         expect(page).to have_content("I disagree")
@@ -91,7 +91,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
   end
 
   it "errors if no public comment is provided when providing rejection recommendation" do
-    click_link "Assess Proposal"
+    click_link "Assess proposal"
     choose "No"
     fill_in "assessor_comment", with: "This is a private assessor comment"
     fill_in "public_comment", with: ""
@@ -103,7 +103,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
   end
 
   it "errors if no decision given" do
-    click_link "Assess Proposal"
+    click_link "Assess proposal"
     click_button "Save"
 
     expect(page).to have_content("Please select Yes or No")

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   it "can be accepted" do
     delivered_emails = ActionMailer::Base.deliveries.count
-    click_link "Review Assessment"
+    click_link "Review assessment"
 
     within ".recommendations" do
       expect(page).to have_content("First assessor comment")
@@ -33,7 +33,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     choose "Yes"
     fill_in "Review comment", with: "Reviewer private comment"
     click_button "Save"
-    click_link "Publish"
+    click_link "Publish determination"
     click_button "Determine application"
 
     planning_application.reload
@@ -47,11 +47,11 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   it "can be rejected" do
     delivered_emails = ActionMailer::Base.deliveries.count
-    click_link "Review Assessment"
+    click_link "Review assessment"
     choose "No"
     fill_in "Review comment", with: "Reviewer private comment"
     click_button "Save"
-    expect(page).not_to have_link("Publish")
+    expect(page).not_to have_link("Publish determination")
 
     planning_application.reload
     expect(planning_application.status).to eq("awaiting_correction")
@@ -63,7 +63,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   it "can edit an existing review of an assessment" do
     recommendation = create :recommendation, :reviewed, planning_application: planning_application, reviewer_comment: "Reviewer private comment"
-    click_link "Review Assessment"
+    click_link "Review assessment"
 
     within ".recommendations" do
       expect(page).to have_content("First assessor comment")

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "Assessment tasks are visible" do
-      expect(page).to have_text("Submit Recommendation")
+      expect(page).to have_text("Submit recommendation")
     end
   end
 

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -15,20 +15,20 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :not_started, local_authority: @default_local_authority)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: true, completed: false)
-      task_item_exists("Assess Proposal", linked: false, completed: false)
-      task_item_exists("Submit Recommendation", linked: false, completed: false)
-      task_item_exists("Review Assessment", linked: false, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: false, completed: false)
+      task_item_exists("Submit recommendation", linked: false, completed: false)
+      task_item_exists("Review assessment", linked: false, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it has been validated but no proposal has been made" do
       planning_application = create(:planning_application, local_authority: @default_local_authority)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: true, completed: true)
-      task_item_exists("Assess Proposal", linked: true, completed: false)
-      task_item_exists("Submit Recommendation", linked: false, completed: false)
-      task_item_exists("Review Assessment", linked: false, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: true, completed: false)
+      task_item_exists("Submit recommendation", linked: false, completed: false)
+      task_item_exists("Review assessment", linked: false, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it in assessment and a proposal has been created" do
@@ -36,10 +36,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: true, completed: true)
-      task_item_exists("Assess Proposal", linked: true, completed: true)
-      task_item_exists("Submit Recommendation", linked: true, completed: false)
-      task_item_exists("Review Assessment", linked: false, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: true, completed: true)
+      task_item_exists("Submit recommendation", linked: true, completed: false)
+      task_item_exists("Review assessment", linked: false, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it is awaiting determination" do
@@ -47,10 +47,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess Proposal", linked: false, completed: true)
-      task_item_exists("Submit Recommendation", linked: false, completed: true)
-      task_item_exists("Review Assessment", linked: true, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: false, completed: true)
+      task_item_exists("Submit recommendation", linked: false, completed: true)
+      task_item_exists("Review assessment", linked: true, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
@@ -58,10 +58,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess Proposal", linked: false, completed: true)
-      task_item_exists("Submit Recommendation", linked: false, completed: true)
-      task_item_exists("Review Assessment", linked: true, completed: true)
-      task_item_exists("Publish", linked: true, completed: false)
+      task_item_exists("Assess proposal", linked: false, completed: true)
+      task_item_exists("Submit recommendation", linked: false, completed: true)
+      task_item_exists("Review assessment", linked: true, completed: true)
+      task_item_exists("Publish determination", linked: true, completed: false)
     end
 
     it "makes valid task list for when it is determined" do
@@ -69,10 +69,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess Proposal", linked: false, completed: true)
-      task_item_exists("Submit Recommendation", linked: false, completed: true)
-      task_item_exists("Review Assessment", linked: false, completed: true)
-      task_item_exists("Publish", linked: false, completed: true)
+      task_item_exists("Assess proposal", linked: false, completed: true)
+      task_item_exists("Submit recommendation", linked: false, completed: true)
+      task_item_exists("Review assessment", linked: false, completed: true)
+      task_item_exists("Publish determination", linked: false, completed: true)
     end
 
     it "makes valid task list for when it is awaiting correction and no re-proposal has been made" do
@@ -80,10 +80,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: true, completed: true)
-      task_item_exists("Assess Proposal", linked: true, completed: false)
-      task_item_exists("Submit Recommendation", linked: false, completed: false)
-      task_item_exists("Review Assessment", linked: false, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: true, completed: false)
+      task_item_exists("Submit recommendation", linked: false, completed: false)
+      task_item_exists("Review assessment", linked: false, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it is awaiting correction and a re-proposal has been made" do
@@ -92,10 +92,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: true, completed: true)
-      task_item_exists("Assess Proposal", linked: true, completed: true)
-      task_item_exists("Submit Recommendation", linked: true, completed: false)
-      task_item_exists("Review Assessment", linked: false, completed: false)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: true, completed: true)
+      task_item_exists("Submit recommendation", linked: true, completed: false)
+      task_item_exists("Review assessment", linked: false, completed: false)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
   end
 
@@ -109,10 +109,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess Proposal", linked: false, completed: true)
-      task_item_exists("Submit Recommendation", linked: false, completed: true)
-      task_item_exists("Review Assessment", linked: false, completed: false, waiting: true)
-      task_item_exists("Publish", linked: false, completed: false)
+      task_item_exists("Assess proposal", linked: false, completed: true)
+      task_item_exists("Submit recommendation", linked: false, completed: true)
+      task_item_exists("Review assessment", linked: false, completed: false, waiting: true)
+      task_item_exists("Publish determination", linked: false, completed: false)
     end
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
@@ -120,10 +120,10 @@ RSpec.describe "Planning Application show page", type: :system do
       create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application.id)
       task_item_exists("Validate documents", linked: false, completed: true)
-      task_item_exists("Assess Proposal", linked: false, completed: true)
-      task_item_exists("Submit Recommendation", linked: false, completed: true)
-      task_item_exists("Review Assessment", linked: false, completed: true)
-      task_item_exists("Publish", linked: false, completed: false, waiting: true)
+      task_item_exists("Assess proposal", linked: false, completed: true)
+      task_item_exists("Submit recommendation", linked: false, completed: true)
+      task_item_exists("Review assessment", linked: false, completed: true)
+      task_item_exists("Publish determination", linked: false, completed: false, waiting: true)
     end
   end
 


### PR DESCRIPTION
### Description of change

Updated Publish to Publish determination, regardless of whether it is linked, and also changed some casing to make titles consistent with each other. Specs consequently needed changing

### Story Link

https://trello.com/c/OjOcJ7E2/175-make-wording-of-task-links-consistent

