### PR TITLE
Fix subheadings on recommend and validate forms

### DIFF
--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, "Assess proposal" %>
 
 <%= render "planning_applications/assessment_dashboard" do %>
+  <h2 class="govuk-heading-m">Assess proposal</h2>
   <%= render "recommendations", { recommendations: @planning_application.recommendations.reviewed } %>
   <%= form_for @planning_application, url: recommend_planning_application_path(@planning_application) do |form| %>
     <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= render "planning_applications/assessment_dashboard" do %>
 
-  <h2 class="govuk-heading-m">1. Validate documents</h2>
+  <h2 class="govuk-heading-m">Validate documents</h2>
 
   <p class="govuk-body">Please check all the applicant's documents before proceeding</p>
 


### PR DESCRIPTION
### Description of change

Validate documents had acquired the number 1 and the subheading for Assess proposal had disappeared. Both are now reinstated

### Story Link

https://trello.com/b/KQqYJd7W/bops-private-beta-mvp-permitted-development

