### PR TITLE
Close accordion when re-rendering page

### DIFF
--- a/app/views/planning_applications/_policy_consideration_list.html.erb
+++ b/app/views/planning_applications/_policy_consideration_list.html.erb
@@ -1,12 +1,16 @@
 <div class="govuk-accordion__section">
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
-      <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-content-2" class="govuk-accordion__section-button" aria-expanded="false">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+      <button type="button" id="accordion-default-heading-2" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
         Proposal Details
-        <span class="govuk-accordion__icon" aria-hidden="true"></span></button>
+      </button>
+        <span class="govuk-accordion__icon" aria-hidden="true"></span>
     </h3>
   </div>
-  <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+  <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
     <ol class="govuk-body" style="line-height: 2;">
       <% policy_considerations.order(created_at: :asc).each do |policy_consideration| %>
         <%= render "question_answer_pair", policy_consideration: policy_consideration %>

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -2,12 +2,15 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-        <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-content-1" class="govuk-accordion__section-button" aria-expanded="false">
+          <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <button type="button" id="accordion-default-heading-1" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
           Application information
           <span class="govuk-accordion__icon" aria-hidden="true"></span></button>
       </h3>
     </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+    <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
       <table class="govuk-table">
         <tbody class="govuk-table__body">
           <tr class="govuk-table__row">

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -1,12 +1,16 @@
 <div class="govuk-accordion__section">
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
-      <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-content-2" class="govuk-accordion__section-button" aria-expanded="false">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+      <button type="button" id="accordion-default-heading-3" aria-controls="" class="govuk-accordion__section-button" aria-expanded="true">
         Documents
-        <span class="govuk-accordion__icon" aria-hidden="true"></span></button>
+      </button>
+        <span class="govuk-accordion__icon" aria-hidden="true"></span>
     </h3>
   </div>
-  <div id="accordion-default-content-2" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
+  <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
     <div class="scroll-docs">
       <p class="govuk-body govuk-!-margin-bottom-1">
         <%= link_to "Manage documents", planning_application_documents_path(@planning_application) %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -2,13 +2,16 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-        <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-content-2" class="govuk-accordion__section-button" aria-expanded="false">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <button type="button" id="accordion-default-heading-1" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
           Constraints
         </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h3>
     </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+    <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
       <ul class="govuk-list govuk-list--bullet">
         <% if @planning_application.constraints %>
         <% list_constraints(@planning_application.constraints).each do |constraint| %>
@@ -21,13 +24,16 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-        <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-content-3" class="govuk-accordion__section-button" aria-expanded="false">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <button type="button" id="accordion-default-heading-1" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
           Key application dates
         </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h3>
     </div>
-    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+    <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
       <p class="govuk-body">
         <strong>Application status:</strong>
         <%= t("statuses.#{@planning_application.status}") %>
@@ -65,13 +71,16 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
-        <button type="button" id="accordion-default-heading-3" aria-controls="accordion-default-content-4" class="govuk-accordion__section-button" aria-expanded="true">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <button type="button" id="accordion-default-heading-3" aria-controls="" class="govuk-accordion__section-button" aria-expanded="true">
           Contact information
         </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h2>
     </div>
-    <div id="accordion-default-content-3" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+    <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
       <% if @planning_application.agent? %>
         <p class='govuk-body'>
           <strong>Agent: </strong><br>
@@ -95,13 +104,16 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h2 class="govuk-accordion__section-heading">
-        <button type="button" id="accordion-default-heading-4" aria-controls="accordion-default-content-5" class="govuk-accordion__section-button" aria-expanded="true">
+      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <button type="button" id="accordion-default-heading-4" aria-controls="" class="govuk-accordion__section-button" aria-expanded="true">
           Consultation
         </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h2>
     </div>
-    <div id="accordion-default-content-4" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
+    <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
       <p class='govuk-body'>Consultation is not applicable for proposed permitted development.</p>
     </div>
   </div>


### PR DESCRIPTION
-Removing aria controls has the desired effect. This is because accordion-default-content is the class being called to setState in JavaScript, thus using that state in order to maintain the accordion open or closed. 
Without that class, no state is found or stored in the browser and thus the accordions close as they should.
Adding a separate ticket as well to fix the javaScript library in the long term so we can re-add aria controls for accessibility.

### Description of change

Remove aria controls that were storing state for the accordion and forcing it to stay open.

### Story Link


https://trello.com/c/LSGIdnO4/179-accordion-should-not-save-state-between-page-reloads


