### PR TITLE
Move closing div to correct place in accordion

### DIFF
--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -58,9 +58,9 @@
         </tbody>
       </table>
     </div>
+  </div>
     <% if @planning_application.policy_evaluation %>
       <%= render "planning_applications/policy_consideration_list", policy_considerations: @planning_application.policy_evaluation.policy_considerations %>
     <% end %>
     <%= render "shared/proposal_documents" %>
-  </div>
 </div>


### PR DESCRIPTION
- This ensures the accordion behaves as it should, only opening the selected section instead of the 3 sections this div was encompassing.

### Story

https://trello.com/c/faRnFF6i/156-bug-main-accordion-opening-and-closing-behaviour


![image](https://user-images.githubusercontent.com/9452321/108392710-e3155e80-720a-11eb-97b7-f564e3ee7337.png)

