### PR TITLE
Add granted comment to recommendation

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -223,7 +223,7 @@ private
   end
 
   def public_comment_present
-    if decision == "refused" && public_comment.blank?
+    if decision_present? && public_comment.blank?
       errors.add(:planning_application, "Please fill in the GDPO policies text box.")
     end
   end

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -2,8 +2,9 @@
   <span class="govuk-caption-xl">
     <%= planning_application.local_authority.name %>
   </span>
-  <h2 class="govuk-heading-m">
-    Town and country planning act 1990 (as amended)
+  <h2 class="govuk-heading-s">
+    Town and country planning act 1990 (as amended) <br><br>
+    Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended)
   </h2>
   <h3 class="govuk-heading-s">
     Decision notice
@@ -19,7 +20,7 @@
         "Applicant" => @planning_application.applicant_name,
         "Date of Issue of this decision" => planning_application.determined_at&.strftime("%e %B %Y") || "TBD",
         "Application received" => planning_application.created_at.strftime("%e %B %Y"),
-        "Address" => planning_application.site.full_address,
+        "Site address" => planning_application.site.full_address,
         "Application number" => planning_application.reference,
       }.each do |key, value|
     %>
@@ -33,37 +34,42 @@
       </div>
     <% end %>
   </dl>
-  <h3 class="govuk-heading-s">
-    <%= @planning_application.work_status.humanize %> use or development:
-  </h3>
-  <p class="govuk-body">
-    <%= planning_application.description %>
-  </p>
   <% if planning_application.granted? %>
     <p class="govuk-body">
       IT IS HEREBY CERTIFIED that the use or operations described below are
-      <strong>lawful</strong> for the purposes of S.192 of the Town and Country Planning Act 1990 in accordance with the valid application received on <%= planning_application.created_at.strftime("%d/%m/%Y") %> and supporting documents listed below. Full application is available on the planning register.
+      <strong>lawful</strong> for the purposes of S.192 of the Town and Country Planning Act 1990
+      in accordance with the valid application received on <%= planning_application.created_at.strftime("%d/%m/%Y") %>
+      and supporting documents listed below. Full application is available on the planning register.
     </p>
-    <h3 class="govuk-heading-s">
-      CONDITIONS<br>
-      Permission is subject to the following Approved Plans Condition:
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+      <%= @planning_application.work_status.humanize %> use or development:
     </h3>
     <p class="govuk-body">
-      The development shall be carried out in accordance with the following approved plans:
+      <%= planning_application.description %>
     </p>
+    <p class="govuk-body govuk-!-margin-bottom-1"><strong>The proposal complies due to the following reason(s):</strong></p>
+    <p class="govuk-body"> <%= planning_application.public_comment %> </p>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+      Permission is subject to the following approved plans:
+    </h3>
   <% elsif planning_application.refused? %>
     <p class="govuk-body">
       IT IS HEREBY CERTIFIED that the use or operations described below are
       <strong>not lawful</strong>
-      for the purposes of S.192 of the Town and Country Planning Act 1990 on the date that the application for this Certificate was received.
+      for the purposes of S.192 of the Town and Country Planning Act 1990
+      on the date that the application for this Certificate was received.
     </p>
-    <% if planning_application.refused_with_public_comment? %>
-      <p class="govuk-body">The proposal does not comply with:</p>
-      <p class="govuk-body"> <%= planning_application.public_comment %> </p>
-    <% end %>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+      <%= @planning_application.work_status.humanize %> use or development:
+    </h3>
     <p class="govuk-body">
-      The proposal was refused based on the following plans:
+      <%= planning_application.description %>
     </p>
+    <p class="govuk-body"> <strong>The proposal does not comply due to the following reason(s):</strong></p>
+    <p class="govuk-body"> <%= planning_application.public_comment %> </p>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-1">
+      The proposal was refused based on the following plans:
+    </h3>
   <% end %>
   <% if planning_application.documents.for_publication.present? %>
     <table class="govuk-table">

--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -20,7 +20,8 @@
           </span>
         <% end %>
       <% end %>
-      <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+     <div class="govuk-form-group">
+      <div class="govuk-radios" data-module="govuk-radios" style="margin-bottom: 20px;">
         <div class="govuk-radios govuk-radios--small">
           <div class="govuk-radios__item">
             <%= form.radio_button :decision, "granted", class: "govuk-radios__input", id:"status-granted-conditional", "aria-controls": "conditional-status-granted-conditional", "aria-expanded": "false" %>
@@ -28,39 +29,30 @@
           </div>
           <div class="govuk-radios__item">
             <%= form.radio_button :decision, "refused", class: "govuk-radios__input", id: "status-refused-conditional", "aria-controls": "conditional-status-refused-conditional", "aria-expanded": "false" %>
-            <%= form.label :decision_refused, "No", class: "govuk-label govuk-radios__label", for: "status-refused-conditional" %>
-          </div>
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-status-refused-conditional">
-            <div class="govuk-form-group">
-              <p class="govuk-body">
-                <br>
-                <strong>Please provide which GDPO policy (or policies) have not been met. </strong>
-                If there are multiple, please separate by a comma.
-              </p>
-              <p class="govuk-body">
-                <span class="govuk-hint">
-                  For example, "GPDO 2015 S.2 P.1 A.1 (f)(i), GPDO 2015 S.2 P.1 A.1 (f)(ii)"
-                </span>
-              </p>
-              <p class="govuk-body">
-                This <strong>will</strong> appear on the decision notice.
-              </p>
-              <%= form.text_area :public_comment, class: "govuk-textarea", id: "public_comment", rows: "3", "aria-describedby": "public-comment-hint" %>
-            </div>
+            <%= form.label :decision_refused, "No", class: "govuk-label govuk-radios__label govuk-!-margin-bottom-8", for: "status-refused-conditional" %>
           </div>
         </div>
+      </div>
+     </div>
+      <div class="govuk-form-group">
+        <p class="govuk-body">
+          <%= form.label :public_comment, "Please provide supporting information to indicate which GDPO policy(s) have or have not been met.", class: "govuk-label govuk-!-font-weight-bold" %>
+        </p>
+        <p class="govuk-body">
+          This information <strong>will</strong> appear on the decision notice.
+        </p>
+        <%= form.text_area :public_comment, class: "govuk-textarea govuk-!-margin-bottom-9", rows: "3" %>
       </div>
     </div>
     <div class="govuk-form-group">
       <p class="govuk-body">
-        <strong>Please provide supporting information for your manager.</strong> For example, you may want to add any details about the width, depth or height of the proposal.
-        <br><br>
+        <%= label_tag :recommendation_assessor_comment, "Please provide supporting information for your manager.", class: "govuk-label govuk-!-font-weight-bold" %>
+      </p>
+      <p class="govuk-body">
         Your comment will <strong>not</strong> appear on the decision notice.
       </p>
-      <%= text_area_tag "recommendation[assessor_comment]", @recommendation.assessor_comment, class: "govuk-textarea", id: "assessor_comment", rows: "3", "aria-describedby": "private-comment-hint" %>
+      <%= text_area_tag "recommendation[assessor_comment]", @recommendation.assessor_comment, class: "govuk-textarea", rows: "3" %>
     </div>
-    <p>
-      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-    </p>
+    <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/review_form.html.erb
+++ b/app/views/planning_applications/review_form.html.erb
@@ -2,7 +2,22 @@
 <%= render "planning_applications/assessment_dashboard" do %>
   <h2 class="govuk-heading-m">Review the recommendation</h2>
 
-  <p class="govuk-body">The planning officer recommends that the application is <strong><%= @planning_application.decision %></strong>.</p>
+  <p class="govuk-body">
+    The planning officer recommends that the application is
+    <strong>
+      <%= @planning_application.decision %>
+    </strong>.
+  </p>
+  <p class="govuk-body">
+    <strong>
+      This information will appear on the decision notice:
+    </strong>
+  </p>
+  <p class="govuk-body">
+    It adheres to the limitations and conditions of Part 1 Class A and F,
+    Schedule 2 of The Town and Country Planning (General Permitted Development)
+    Order 2015 (as amended).
+  </p>
 
   <%= render "recommendations", { recommendations: @planning_application.recommendations } %>
   <%= form_for @recommendation, url: review_planning_application_path(@planning_application) do |form| %>

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     applicant_phone { Faker::Base.numerify("+44 7### ######") }
     applicant_email { Faker::Internet.email }
     application_type { :lawfulness_certificate }
+    public_comment { "All GDPO compliant" }
     questions do
       {
         flow: [

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -20,20 +20,22 @@ RSpec.describe "Planning Application Assessment", type: :system do
     it "can create a new recommendation, edit it, and submit it" do
       click_link "Assess proposal"
       choose "Yes"
-      fill_in "assessor_comment", with: "This is a private assessor comment"
+      fill_in "Please provide supporting information to indicate which GDPO policy(s) have or have not been met.", with: "This is a public comment"
+      fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
       click_button "Save"
 
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(1)
+      expect(planning_application.public_comment).to eq("This is a public comment")
       expect(planning_application.recommendations.first.assessor_comment).to eq("This is a private assessor comment")
       expect(planning_application.decision).to eq("granted")
 
       click_link "Assess proposal"
       expect(page).to have_checked_field("Yes")
-      expect(page).to have_field("assessor_comment", with: "This is a private assessor comment")
+      expect(page).to have_field("Please provide supporting information for your manager.", with: "This is a private assessor comment")
       choose "No"
-      fill_in "public_comment", with: "This is a new public comment"
-      fill_in "assessor_comment", with: "Edited private assessor comment"
+      fill_in "Please provide supporting information to indicate which GDPO policy(s) have or have not been met.", with: "This is a new public comment"
+      fill_in "Please provide supporting information for your manager.", with: "Edited private assessor comment"
       click_button "Save"
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(1)
@@ -69,11 +71,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       choose "Yes"
-      fill_in "assessor_comment", with: "This is a private assessor comment"
+      fill_in "Please provide supporting information to indicate which GDPO policy(s) have or have not been met.", with: "This is so granted and GDPO everything"
+      fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
       click_button "Save"
 
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(2)
+      expect(planning_application.public_comment).to eq("This is so granted and GDPO everything")
       expect(planning_application.recommendations.last.assessor_comment).to eq("This is a private assessor comment")
       expect(planning_application.decision).to eq("granted")
 
@@ -86,15 +90,15 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       expect(page).to have_checked_field("Yes")
-      expect(page).to have_field("assessor_comment", with: "This is a private assessor comment")
+      expect(page).to have_field("Please provide supporting information for your manager.", with: "This is a private assessor comment")
     end
   end
 
   it "errors if no public comment is provided when providing rejection recommendation" do
     click_link "Assess proposal"
     choose "No"
-    fill_in "assessor_comment", with: "This is a private assessor comment"
-    fill_in "public_comment", with: ""
+    fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
+    fill_in "Please provide supporting information to indicate which GDPO policy(s) have or have not been met.", with: ""
     click_button "Save"
 
     expect(page).to have_content("Please fill in the GDPO policies text box.")


### PR DESCRIPTION
### Description of change

Make the public comment field compulsory to all decisions regardless of granted or not, and display it on decision notice. 
After aligning with design it seems we no longer want different conditional comments meaning there is no need for a db change, we can just use the "public comment" for all instances.
Also aligned regarding the comment that should show up on the review screen - we still want the "comment to your manager" to show, not the "granted comment" (public comment) so the functionality doesn't change there, its just a text change.

![image](https://user-images.githubusercontent.com/9452321/108709084-28d36f00-750a-11eb-8ed3-02392b33c65b.png)

![image](https://user-images.githubusercontent.com/9452321/108709151-3f79c600-750a-11eb-81c0-98b83af71f30.png)

![image](https://user-images.githubusercontent.com/9452321/108709256-58827700-750a-11eb-9383-64c1273426fa.png)

### Story Link

https://trello.com/c/x35QLpFq/139-add-planning-officers-note-for-granted-decisions-to-the-notice
