### PR TITLE
Add Google map link to application information partial

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -27,6 +27,10 @@ module PlanningApplicationHelper
     end
   end
 
+  def map_link(address)
+    "https://google.co.uk/maps/place/#{CGI.escape(address)}"
+  end
+
   def list_constraints(constraints)
     JSON.parse(constraints).select { |_category, value| value == true }.keys unless constraints.empty?
   end

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -18,6 +18,10 @@
             <td class="govuk-table__cell"><%= @planning_application.site.full_address %></td>
           </tr>
           <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><strong>Location:</strong></td>
+            <td class="govuk-table__cell"><%= link_to 'Map link', map_link(@planning_application.site.full_address) %></td>
+          </tr>
+          <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>UPRN:</strong></td>
             <td class="govuk-table__cell"><%= @planning_application.site.uprn %></td>
           </tr>

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
     end
   end
 
+  describe "#map_link" do
+    it "returns the correct link for a valid address" do
+      expect(map_link("11 Abbey Gardens, London, SE16 3RQ")).to eq("https://google.co.uk/maps/place/11+Abbey+Gardens%2C+London%2C+SE16+3RQ")
+    end
+  end
+
   describe "#display_decision_status" do
     context "refused" do
       let(:planning_application) do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("Address: 7 Elm Grove, London, SE15 6UT")
       expect(page).to have_text("UPRN: 00773377")
       expect(page).to have_text("Ward: Dulwich Wood")
+      expect(page).to have_link("Map link")
       expect(page).to have_text("Building type: Residential")
       expect(page).to have_text("Application type: Proposed permitted development: Certificate of Lawfulness")
       expect(page).to have_text("Summary: Roof extension")


### PR DESCRIPTION
### Description of change

Created a helper method that takes a postcode, strips whitespace and creates a Google map link. Will return a not found string if postcode is nil

### Story Link

https://trello.com/c/wBolEDiI/170-link-to-google-maps-based-on-address

### Decisions

May change if a design is provided