### PR TITLE
Add download PDF link to decision notice view

### DIFF
--- a/app/views/planning_applications/decision_notice.html.erb
+++ b/app/views/planning_applications/decision_notice.html.erb
@@ -15,5 +15,8 @@
 
     <%= render "decision_notice", planning_application: @planning_application %>
 
+    <p class="govuk-body">
+      <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf') %>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
### Description of change

Adding this link so that closed application can be viewed in PDF form

### Story Link

https://trello.com/c/d5OCtk0a/181-allow-planners-managers-to-download-pdf-decision-notice-once-in-determined-status

