### PR TITLE
Configure PDFKit to use XVFB

### DIFF
--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,6 +1,6 @@
-require "mkmf"
+# frozen_string_literal: true
 
-if find_executable("xvfb-run")
+if system("which xvfb-run > /dev/null 2>&1")
   PDFKit.configure do |config|
     config.use_xvfb = true
   end

--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,0 +1,7 @@
+require "mkmf"
+
+if find_executable("xvfb-run")
+  PDFKit.configure do |config|
+    config.use_xvfb = true
+  end
+end


### PR DESCRIPTION
### Description of change

wkhtmltopdf does not work out of the box on Ubuntu because it needs a display. We are adding XVFB as a dependency separately in our Terraform  but we also need to tell PDFKit to use xvfb-run to execute wkhtmltopdf if this executable is present
