### PR TITLE
Change logic for archive document function

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,6 +6,7 @@ class DocumentsController < AuthenticationController
   before_action :set_planning_application
   before_action :set_document, only: %i[archive confirm_archive]
   before_action :disable_flash_header, only: :index
+  before_action :ensure_document_edits_unlocked, only: %i[new edit update archive]
 
   def index
     @documents = @planning_application.documents.order(:created_at)
@@ -71,5 +72,9 @@ private
     @document = @planning_application.documents.find(
       params[:document_id],
     )
+  end
+
+  def ensure_document_edits_unlocked
+    render plain: "forbidden", status: 403 and return unless @planning_application.can_validate?
   end
 end

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -1,34 +1,32 @@
-<% if @planning_application.can_validate? %>
-  <% add_parent_breadcrumb_link "Home", planning_applications_path %>
-  <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-  <% add_parent_breadcrumb_link "Documents", planning_application_documents_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Documents", planning_application_documents_path(@planning_application) %>
 
-  <% content_for :title, "Archive document" %>
+<% content_for :title, "Archive document" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
-        <ol class="govuk-breadcrumbs__list">
-          <li class="govuk-breadcrumbs__list-item" aria-current="page"></li>
-        </ol>
-      </div>
-      <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
-        <%= @planning_application.reference %>
-      </h1>
-      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
-        <%= @planning_application.full_address %>
-      </h2>
-      <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
-        Archive document
-      </h2>
-      <p class="govuk-body  govuk-!-padding-top-1" >
-        File name: <%= @document.name %>
-      </p>
-      <p>
-        <%= link_to image_tag(@document.file.representation(resize: "300x212")),
-                    url_for_document(@document), target: :_blank %>
-      </p>
-      <%= render "archive_form" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
+      <ol class="govuk-breadcrumbs__list">
+        <li class="govuk-breadcrumbs__list-item" aria-current="page"></li>
+      </ol>
     </div>
+    <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
+      <%= @planning_application.reference %>
+    </h1>
+    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+      <%= @planning_application.full_address %>
+    </h2>
+    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
+      Archive document
+    </h2>
+    <p class="govuk-body  govuk-!-padding-top-1" >
+      File name: <%= @document.name %>
+    </p>
+    <p>
+      <%= link_to image_tag(@document.file.representation(resize: "300x212")),
+                  url_for_document(@document), target: :_blank %>
+    </p>
+    <%= render "archive_form" %>
   </div>
-<% end %>
+</div>

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.assessor? %>
+<% if @planning_application.can_validate? %>
   <% add_parent_breadcrumb_link "Home", planning_applications_path %>
   <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
   <% add_parent_breadcrumb_link "Documents", planning_application_documents_path(@planning_application) %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -23,9 +23,9 @@
     </p>
   </div>
   <div class="govuk-grid-column-one-third" style="text-align: right">
-    <% if current_user.assessor? && (@planning_application.in_progress? && !@planning_application.awaiting_determination?) %>
+    <% if @planning_application.can_validate? %>
       <%= link_to "Upload documents", new_planning_application_document_path(@planning_application), role: "button", class: "govuk-button", data: { module: "govuk-button" } %>
-    <% elsif current_user.assessor? %>
+    <% else %>
       <%= tag.button "Upload documents", disabled: "disabled", "aria-disabled": true, class: "govuk-button govuk-button--disabled", data: { module: "govuk-button" } %>
     <% end %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -56,7 +56,7 @@
           <p class="govuk-body govuk-!-margin-bottom-1">
             Date received: <%= document.created_at.strftime("%e %B %Y") %>
           </p>
-          <% unless document.numbers.blank? %>
+          <% if document.numbers.present? %>
             <p class="govuk-body govuk-!-margin-bottom-1">
               Document reference(s): <%= document.numbers %>
             </p>
@@ -68,52 +68,53 @@
               Public: <%= document.publishable? ? "Yes" : "No" %>
             </p>
         </div>
-      <div class="govuk-grid-column-one-quarter">
-        <p style="text-align: right" class="govuk-body">
-          <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br />
-          <%= link_to "Archive document", planning_application_document_archive_path(document_id: document.id) if current_user.assessor? && @planning_application.in_assessment? %>
-        </p>
-      </div>
+      <% if @planning_application.can_validate? %>
+        <div class="govuk-grid-column-one-quarter">
+          <p style="text-align: right" class="govuk-body">
+            <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br />
+            <%= link_to "Archive document", planning_application_document_archive_path(document_id: document.id) %>
+          </p>
+        </div>
+      <% end %>
     </li>
     <% end %>
   <% end %>
 </ul>
 
-<% unless @documents.nil? %>
-  <div class="govuk-grid-row">
-  <table class="govuk-table archived-documents">
-    <caption class="govuk-table__caption">Archived documents</caption>
-    <thead class="govuk-table__head">
-      <tr>
-        <% if filter_archived(@documents).present? %>
-          <th scope="col" class="govuk-table__header">Document name</th>
-          <th scope="col" class="govuk-table__header">Tags </th>
-          <th scope="col" class="govuk-table__header">Date uploaded</th>
-          <th scope="col" class="govuk-table__header">Officer's comment</th>
-        <% else %>
-          <th scope="row" class="govuk-table__cell" style="font-weight: 100">No documents archived</th>
-        <% end %>
-      </tr>
-    </thead>
-    <% if filter_archived(@documents).present? %>
-      <tbody class="govuk-table__body">
-        <% filter_archived(@documents).each do |document| %>
-          <tr class="govuk-table__row">
-            <td class="govuk-table__cell archive-data"><%= link_to document.name, url_for_document(document), target: :_new %></td>
-            <td class="govuk-table__cell archive-data tags">
-              <p class="govuk-body">
-                <% document.tags.each do |tag| %>
-                  <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
-                <% end %>
-              </p>
-            </td>
-            <td class="govuk-table__cell archive-data"><%= document.created_at.strftime("%e %b %Y") %></td>
-            <td class="govuk-table__cell archive-data"><%= document.archive_reason %></td>
-          </tr>
-        <% end %>
-      </tbody>
-    <% end %>
-  </table>
+<% if @documents.present? %>
+  <div class="govuk-grid-row govuk-!-padding-left-6">
+    <table class="govuk-table archived-documents">
+      <caption class="govuk-table__caption">Archived documents</caption>
+      <thead class="govuk-table__head">
+        <tr>
+          <% if filter_archived(@documents).present? %>
+            <th scope="col" class="govuk-table__header">Document name</th>
+            <th scope="col" class="govuk-table__header">Tags </th>
+            <th scope="col" class="govuk-table__header">Date uploaded</th>
+            <th scope="col" class="govuk-table__header">Officer's comment</th>
+          <% else %>
+            <th scope="row" class="govuk-table__cell" style="font-weight: 100">No documents archived</th>
+          <% end %>
+        </tr>
+      </thead>
+      <% if filter_archived(@documents).present? %>
+        <tbody class="govuk-table__body">
+          <% filter_archived(@documents).each do |document| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell archive-data"><%= link_to document.name, url_for_document(document), target: :_new %></td>
+              <td class="govuk-table__cell archive-data tags">
+                <p class="govuk-body">
+                  <% document.tags.each do |tag| %>
+                    <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+                  <% end %>
+                </p>
+              </td>
+              <td class="govuk-table__cell archive-data"><%= document.created_at.strftime("%e %b %Y") %></td>
+              <td class="govuk-table__cell archive-data"><%= document.archive_reason %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      <% end %>
+    </table>
   </div>
-</div>
 <% end %>

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -22,6 +22,30 @@ RSpec.describe "Documents index page", type: :system do
            tags: document_tags
   end
 
+  let!(:not_started_planning_application) do
+    create :planning_application, :not_started,
+           local_authority: @default_local_authority,
+           address_1: "Elm Grove"
+  end
+
+  let!(:not_started_document) do
+    create :document, :with_file,
+           planning_application: not_started_planning_application,
+           tags: document_tags
+  end
+
+  let!(:awaiting_determination_planning_application) do
+    create :planning_application, :awaiting_determination,
+           local_authority: @default_local_authority,
+           address_1: "Elm Grove"
+  end
+
+  let!(:awaiting_document) do
+    create :document, :with_file,
+           planning_application: awaiting_determination_planning_application,
+           tags: document_tags
+  end
+
   context "as a user who is not logged in" do
     it "User cannot see archive page" do
       visit planning_application_documents_path(planning_application)
@@ -128,10 +152,50 @@ RSpec.describe "Documents index page", type: :system do
       visit planning_application_path(planning_application)
       click_button "Documents"
       click_link "Manage documents"
+      click_link "Archive document"
     end
 
-    it "Reviewer cannot see Archive links" do
-      expect(page).not_to have_link("Archive document")
+    it "Reviewer can archive document" do
+      choose "scale"
+      click_button "Save"
+
+      choose "Yes"
+      click_button "Save"
+
+      expect(page).to have_text("proposed-floorplan.png has been archived")
+    end
+  end
+
+  context "Application that has not been started" do
+    before do
+      sign_in assessor
+      visit planning_application_path(not_started_planning_application)
+      click_button "Documents"
+      click_link "Manage documents"
+    end
+
+    it "Document can be archived" do
+      click_link "Archive document"
+      choose "scale"
+      click_button "Save"
+
+      choose "Yes"
+      click_button "Save"
+
+      expect(page).to have_text("proposed-floorplan.png has been archived")
+    end
+  end
+
+  context "Application that is awaiting determination" do
+    before do
+      sign_in assessor
+      visit planning_application_path(awaiting_determination_planning_application)
+      click_button "Documents"
+      click_link "Manage documents"
+    end
+
+    it "Archive button is not visible" do
+      expect(page).to have_no_link("Archive document")
     end
   end
 end

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -85,10 +85,6 @@ RSpec.describe "Documents index page", type: :system do
       click_link "Archive document"
     end
 
-    it "Archive page contains expected text" do
-      expect(page).to have_text "Why do you want to archive this document?"
-    end
-
     it "Archive page contains site info" do
       expect(page).to have_text "Elm Grove"
     end
@@ -156,11 +152,8 @@ RSpec.describe "Documents index page", type: :system do
     end
 
     it "Reviewer can archive document" do
-      choose "scale"
-      click_button "Save"
-
-      choose "Yes"
-      click_button "Save"
+      fill_in "Why do you want to archive this document?", with: "Scale was wrong"
+      click_button "Archive"
 
       expect(page).to have_text("proposed-floorplan.png has been archived")
     end
@@ -172,15 +165,12 @@ RSpec.describe "Documents index page", type: :system do
       visit planning_application_path(not_started_planning_application)
       click_button "Documents"
       click_link "Manage documents"
+      click_link "Archive document"
     end
 
     it "Document can be archived" do
-      click_link "Archive document"
-      choose "scale"
-      click_button "Save"
-
-      choose "Yes"
-      click_button "Save"
+      fill_in "Why do you want to archive this document?", with: "Scale was wrong"
+      click_button "Archive"
 
       expect(page).to have_text("proposed-floorplan.png has been archived")
     end

--- a/spec/system/documents/upload_spec.rb
+++ b/spec/system/documents/upload_spec.rb
@@ -150,17 +150,4 @@ RSpec.describe "Document uploads", type: :system do
       end
     end
   end
-
-  context "for a reviewer" do
-    before { sign_in reviewer }
-
-    it "no upload actions are visible at all" do
-      visit planning_application_documents_path(planning_application)
-
-      # Neither the enabled call-to-action or its disabled, button
-      # equivalent are visible.
-      expect(page).not_to have_link("Upload documents")
-      expect(page).not_to have_button("Upload documents", disabled: true)
-    end
-  end
 end

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -67,6 +67,15 @@ RSpec.shared_examples "validate and invalidate" do
     expect(page).to have_content("Application has been invalidated")
 
     planning_application.reload
+
+    click_button "Documents"
+    click_link "Manage documents"
+    click_link "Archive document"
+
+    fill_in "Why do you want to archive this document?", with: "Scale was wrong"
+    click_button "Archive"
+
+    expect(page).to have_text("proposed-floorplan.png has been archived")
   end
 end
 

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -55,6 +55,19 @@ RSpec.shared_examples "validate and invalidate" do
     expect(page).to have_text(assessor.name)
     expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
   end
+
+  it "allows document edit, archive and upload after invalidation" do
+    click_link planning_application.reference
+    click_link "Validate documents"
+
+    choose "No"
+
+    click_button "Save"
+
+    expect(page).to have_content("Application has been invalidated")
+
+    planning_application.reload
+  end
 end
 
 RSpec.describe "Planning Application Assessment", type: :system do
@@ -129,6 +142,16 @@ RSpec.describe "Planning Application Assessment", type: :system do
       planning_application.reload
       expect(planning_application.status).to eql("not_started")
       expect(page).to have_content("Please enter a valid date")
+    end
+
+    it "shows edit, upload and archive links for documents" do
+      click_link planning_application.reference
+      click_button "Documents"
+      click_link "Manage documents"
+
+      expect(page).to have_link("Edit")
+      expect(page).to have_link("Upload documents")
+      expect(page).to have_link("Archive")
     end
   end
 


### PR DESCRIPTION
### Description of change

We need to allow access to archive, edit, upload in all states except when application is closed or awaiting determination. Access to the routes has been restricted and the buttons and links hidden when the planning application is in any state other than: awaiting determination, determined, withdrawn or returned. We can reuse the `can_validate?` method for this.

### Story Link

https://trello.com/c/joo32duV/86-archive-documents-function-currently-only-visible-once-documents-have-been-validated-should-always-be-visible
