### PR TITLE
[WIP] Notify errors

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PlanningApplicationsController < AuthenticationController
+  include ActiveSupport::Rescuable
+
   before_action :set_planning_application, only: %i[show
                                                     edit
                                                     update
@@ -20,9 +22,6 @@ class PlanningApplicationsController < AuthenticationController
                                                     decision_notice]
 
   before_action :ensure_user_is_reviewer, only: %i[review review_form]
-
-  rescue_from Notifications::Client::NotFoundError,
-              with: :decision_notice_mail_error
 
   def index
     @planning_applications = if helpers.exclude_others? && current_user.assessor?
@@ -252,12 +251,6 @@ private
       @planning_application,
       request.host,
     ).deliver_now
-  end
-
-  def decision_notice_mail_error
-    flash[:notice] =
-      "The email cannot be sent. Please try again later."
-    render "documents/index"
   end
 
   def ensure_user_is_reviewer

--- a/app/views/application/_success_flash.html.erb
+++ b/app/views/application/_success_flash.html.erb
@@ -1,7 +1,0 @@
-<% flash.each do |name, msg| %>
-  <div class="flash-archive">
-    <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-      <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path></svg>
-    <%= msg.to_s %>
-  </div>
-<% end %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -10,7 +10,7 @@
   <%= @planning_application.full_address %>
 </p>
 
-<%= render "success_flash" %>
+<%= render "flashes" %>
 
 <h2 class="govuk-heading-m">
   Proposal documents

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,8 +40,9 @@ Rails.application.configure do
                                   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
+  config.action_mailer.perform_deliveries = true
 
   if ENV["NOTIFY_API_KEY"].present?
     config.action_mailer.delivery_method = :notify

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to
   # raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,6 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
-    mocks.allow_message_expectations_on_nil = true
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
+    mocks.allow_message_expectations_on_nil = true
   end
 
   config.shared_context_metadata_behavior = :apply_to_host_groups


### PR DESCRIPTION
### Description of change

Catching errors that notify provides to us so we can rescue these instead of hitting a 500 page on the front end. Right now we seem to be catching a single error but its not tested anywhere and it doesn't seem to be doing anything

### Story Link

https://trello.com/c/0k4XVeKD/98-catch-more-notify-errors

### Decisions

- Moved the rescue clauses to the application controller which should by default inherit from ActiveSupport::Rescuable, and because we didn't seem to be hitting the single rescue_from on the planning application controller.
- Changed deliver_now to deliver_now! to ensure errors are raised
- Changed config.action_mailer.raise_delivery_errors = true so we can raise errors for failed emails