### PR TITLE
Rescue notify errors and send them to AppSignal

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  rescue_from Notifications::Client::NotFoundError, with: :validation_notice_request_error
+  rescue_from Notifications::Client::ServerError, with: :validation_notice_request_error
+  rescue_from Notifications::Client::RequestError, with: :validation_notice_request_error
+  rescue_from Notifications::Client::ClientError, with: :validation_notice_request_error
+  rescue_from Notifications::Client::BadRequestError, with: :validation_notice_request_error
+
   before_action :find_current_local_authority_from_subdomain
   before_action :prevent_caching
 
@@ -34,5 +40,12 @@ private
 
   def disable_flash_header
     @disable_flash_header = true
+  end
+
+  def validation_notice_request_error(exception)
+    flash[:error] = "Notify was unable to send applicant email. Please contact the applicant directly."
+    flash[:notice] = "Document validation successful. Application is ready for assessment."
+    Appsignal.send_error(exception)
+    render "documents/index"
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -21,9 +21,6 @@ class PlanningApplicationsController < AuthenticationController
 
   before_action :ensure_user_is_reviewer, only: %i[review review_form]
 
-  rescue_from Notifications::Client::NotFoundError,
-              with: :decision_notice_mail_error
-
   def index
     @planning_applications = if helpers.exclude_others? && current_user.assessor?
                                current_local_authority.planning_applications.where(user_id: current_user.id).or(
@@ -242,12 +239,6 @@ private
       @planning_application,
       request.host,
     ).deliver_now
-  end
-
-  def decision_notice_mail_error
-    flash[:notice] =
-      "The email cannot be sent. Please try again later."
-    render "documents/index"
   end
 
   def ensure_user_is_reviewer

--- a/app/views/application/_flash_content.html.erb
+++ b/app/views/application/_flash_content.html.erb
@@ -1,0 +1,27 @@
+<% flash.each do |name, msg| %>
+  <% if msg.include?("success") %>
+  <div class="flash-archive">
+    <div class="govuk-error-summary__body govuk-!-padding-2">
+      <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 25 25" height="25" width="25">
+        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path>
+      </svg>
+      <%= msg %>
+    </div>
+  </div>
+  <% else %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25" height="25" width="25">
+      <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path>
+    </svg>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <%= msg %>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <% end %>
+<% end %>

--- a/app/views/application/_success_flash.html.erb
+++ b/app/views/application/_success_flash.html.erb
@@ -1,7 +1,0 @@
-<% flash.each do |name, msg| %>
-  <div class="flash-archive">
-    <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-      <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path></svg>
-    <%= msg.to_s %>
-  </div>
-<% end %>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -10,7 +10,7 @@
   <%= @planning_application.full_address %>
 </p>
 
-<%= render "success_flash" %>
+<%= render "flash_content" %>
 
 <h2 class="govuk-heading-m">
   Proposal documents

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
                                   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
 
   if ENV["NOTIFY_API_KEY"].present?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to
   # raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
### Description of change

Catching errors that notify provides to us so we can rescue these instead of hitting a 500 page on the front end.

### Story Link

https://trello.com/c/0k4XVeKD/98-catch-more-notify-errors

### Decisions 

Moved the rescue clauses to the application controller which should by default inherit from ActiveSupport::Rescuable, and because we didn't seem to be hitting the single rescue_from on the planning application controller
Consolidated flashes success with the flashes erb file we already had
Changed config.action_mailer.raise_delivery_errors = true so we can raise errors for failed emails


