### PR TITLE
Upgrade is-svg package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,14 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "5.2.1",
     "govuk-frontend": "^3.6.0",
+    "is-svg": "^4.2.2",
     "stimulus": "^1.1.1",
     "toastr": "^2.1.4",
     "webpack": "^4.0.0",
     "webpack-merge": "^5.4.0"
+  },
+  "resolutions": {
+    "is-svg": "^4.2.2"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,6 +3032,11 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-xml-parser@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz#cb637ec3f3999f51406dd8ff0e6fc4d83e520d01"
+  integrity sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg==
+
 faye-websocket@^0.11.3:
   version "0.11.3"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.3.tgz#5c0e9a8968e8912c286639fde977a8b209f2508e"
@@ -4081,6 +4086,13 @@ is-svg@^3.0.0:
   integrity sha512-gi4iHK53LR2ujhLVVj+37Ykh9GLqYHX6JOVXbLAucaG/Cqw9xwdFOjDM2qeifLs1sF1npXXFvDu0r5HNgCMrzQ==
   dependencies:
     html-comment-regex "^1.1.0"
+
+is-svg@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/is-svg/-/is-svg-4.3.1.tgz#8c63ec8c67c8c7f0a8de0a71c8c7d58eccf4406b"
+  integrity sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==
+  dependencies:
+    fast-xml-parser "^3.19.0"
 
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
### Description of change
Stop security dependabot alert

### Decisions

This was meant to have been fixed by the webpacker upgrade but it seems webpacker is still dependent on the bad version. The fix, suggested below, is to add the patched package and set "resolutions" to use it 
![image](https://user-images.githubusercontent.com/9452321/112148040-4fea9280-8bd5-11eb-8714-848bf89944cc.png)

https://stackoverflow.com/questions/57092041/yarn-upgrade-does-not-remove-old-version-of-js-yaml-package-in-yarn-lock-file