### PR TITLE
Style changes to notify errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,6 @@ private
     flash[:error] = "Notify was unable to send applicant email. Please contact the applicant directly."
     flash[:notice] = "Document validation successful. Application is ready for assessment."
     Appsignal.send_error(exception)
-    render "documents/index"
+    render "planning_applications/show"
   end
 end

--- a/app/views/application/_flash_content.html.erb
+++ b/app/views/application/_flash_content.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |name, msg| %>
   <% if msg.include?("unable") %>
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+  <div class="govuk-error-summary govuk-!-margin-top-6 govuk-!-margin-bottom-6" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
     <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 25 25" height="25" width="25">
       <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path>
@@ -14,7 +14,7 @@
     </div>
   </div>
   <% else %>
-  <div class="flash-archive">
+  <div class="flash-archive govuk-!-margin-top-6 govuk-!-margin-bottom-8">
     <div class="govuk-error-summary__body govuk-!-padding-2">
       <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 25 25" height="25" width="25">

--- a/app/views/planning_applications/_proposal_header.html.erb
+++ b/app/views/planning_applications/_proposal_header.html.erb
@@ -34,3 +34,5 @@
     <%= link_to "View decision notice", decision_notice_planning_application_path(@planning_application)%>
   </p>
 <% end %>
+
+<%= render "flash_content" %>


### PR DESCRIPTION
### Description of change
https://trello.com/c/r5RkfC1F/265-after-notify-error-redirect-to-planning-application-page-and-show-flash-error-under-top-header-of-address

![image](https://user-images.githubusercontent.com/9452321/112837553-f0d4c400-9093-11eb-870d-62e393a51452.png)
