### PR TITLE
Update error message and styling

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -230,7 +230,7 @@ private
 
   def public_comment_present
     if decision_present? && public_comment.blank?
-      errors.add(:planning_application, "Please fill in the GDPO policies text box.")
+      errors.add(:planning_application, "Please state the reasons why this application is, or is not lawful")
     end
   end
 

--- a/app/views/documents/new.html.erb
+++ b/app/views/documents/new.html.erb
@@ -5,7 +5,7 @@
 <% content_for :title, "Upload document" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
       Documents: <%= @planning_application.reference %>
     </h1>

--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -40,22 +40,22 @@
         <span class="govuk-body">
           <%= form.label :public_comment, "State the reasons why this application is, or is not lawful.", class: "govuk-label govuk-!-font-weight-bold" %>
         </span>
-        <span class="govuk-body">
+        <p class="govuk-body">
           Refer to the specific permitted development rights being evoked.
-          </span>
-        <p class="govuk-hint">
+        </p>
+        <p class="govuk-body">
           This information <strong>will</strong> appear on the decision notice.
         </p>
         <%= form.text_area :public_comment, class: "govuk-textarea", rows: "3" %>
       </div>
     </div>
     <div class="govuk-form-group">
-      <span class="govuk-body">
+      <p class="govuk-body">
         <%= label_tag :recommendation_assessor_comment, "Please provide supporting information for your manager.", class: "govuk-label govuk-!-font-weight-bold" %>
-      </span>
-      <span class="govuk-hint">
+      </p>
+      <p class="govuk-body">
         Your comment will <strong>not</strong> appear on the decision notice.
-      </span>
+      </p>
       <%= text_area_tag "recommendation[assessor_comment]", @recommendation.assessor_comment, class: "govuk-textarea", rows: "3" %>
     </div>
     <div class="govuk-!-padding-top-4">

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -74,7 +74,7 @@
         Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
         For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
         <button type="button" id="accordion-default-heading-2" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
-          Site Map
+          Site map
         </button>
           <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h3>

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     fill_in "State the reasons why this application is, or is not lawful.", with: ""
     click_button "Save"
 
-    expect(page).to have_content("Please fill in the GDPO policies text box.")
+    expect(page).to have_content("Please state the reasons why this application is, or is not lawful")
 
     expect(planning_application.status).to eq("in_assessment")
   end


### PR DESCRIPTION
### Description of change

Make final round of design amendments:

- reword error message on recommendation form
- change hint text to body text on recommendation form
- update Site Map heading to lower-case 'm'
- change new document screen to full width to bring it into line with edit document screen