### PR TITLE
Add validation to require applicant or agent email

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -23,6 +23,7 @@ class PlanningApplication < ApplicationRecord
                          message: "Work Status should be proposed or existing" }
   validates :application_type, presence: true
 
+  validate :applicant_or_agent_email
   validate :documents_validated_at_date
   validate :public_comment_present
   validate :decision_with_recommendations
@@ -241,6 +242,12 @@ private
   def decision_with_recommendations
     if decision.nil? && recommendations.any?
       errors.add(:planning_application, "Please select Yes or No")
+    end
+  end
+
+  def applicant_or_agent_email
+    unless applicant_email? || agent_email?
+      errors.add(:base, "An applicant or agent email is required.")
     end
   end
 end

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -8,8 +8,8 @@
         </h2>
       </span>
       <ul>
-        <% @planning_application.errors.messages.each do |error| %>
-          <li><%= error %></li>
+        <% @planning_application.errors.map do |error| %>
+          <li><%= error.type %></li>
         <% end %>
       </ul>
     </span>

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -64,7 +64,7 @@ paths:
                     constraints:
                       - Conservation Area
                       - Listed Building
-                    boundary_geojson: 
+                    boundary_geojson:
                       type: Feature
                       geometry:
                         type: Polygon
@@ -229,11 +229,12 @@ paths:
                         items:
                           type: string
                           example: "Side"
-                boundary_geojson: 
+                boundary_geojson:
                   type: object
               required:
               - site
               - application_type
+              - applicant_email
             examples:
               Minimum:
                 value:
@@ -244,6 +245,7 @@ paths:
                     address_2: Southwark
                     town: London
                     postcode: SE16 3RQ
+                  applicant_email: applicant@example.com
               Full:
                 value:
                   application_type: lawfulness_certificate
@@ -365,7 +367,7 @@ paths:
                     - filename: https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
                       tags:
                         - Side
-                  boundary_geojson: 
+                  boundary_geojson:
                     type: Feature
                     geometry:
                       type: Polygon

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -24,11 +24,35 @@ RSpec.describe "Creating a planning application", type: :system do
     expect(page).to have_text("New Application: Residential Lawful Development Certificate")
 
     fill_in "Description", with: "Back shack"
+
+    within ".applicant-information" do
+      fill_in "Email address", with: "thesebeans@thesebeans.com"
+    end
+
     click_button "Save"
     expect(page).to have_text("Planning application was successfully created.")
 
     visit planning_application_path(PlanningApplication.last.id)
     expect(page).to have_text("Description: Back shack")
+  end
+
+  it "displays an error when both agent and applicant emails are missing" do
+    click_link "Add new application"
+
+    expect(page).to have_text("New Application: Residential Lawful Development Certificate")
+
+    fill_in "Description", with: "Bad bad application"
+
+    click_button "Save"
+    expect(page).to have_text("An applicant or agent email is required.")
+
+    within ".agent-information" do
+      fill_in "Email address", with: "agentina@agentino.com"
+    end
+    click_button "Save"
+
+    visit planning_application_path(PlanningApplication.last.id)
+    expect(page).to have_text("Description: Bad bad application")
   end
 
   it "allows for an application to be created by a reviewer, using minimum details" do
@@ -39,6 +63,10 @@ RSpec.describe "Creating a planning application", type: :system do
     click_link "Add new application"
 
     fill_in "Description", with: "Bird house"
+    within ".applicant-information" do
+      fill_in "Email address", with: "mah@mah.com"
+    end
+
     click_button "Save"
     expect(page).to have_text("Planning application was successfully created.")
 


### PR DESCRIPTION
### Story Link

https://trello.com/c/0UTd9mJu/294-reject-applications-that-do-not-have-an-agent-or-applicant-email-address
