### PR TITLE
Add Leaflet map to decision notice

### DIFF
--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -105,7 +105,12 @@
   <p class="govuk-body">Signed: <%= planning_application.local_authority.signatory_name %>
     <%= planning_application.local_authority.signatory_job_title %>
   </p>
-  <p class="govuk-body">
+  <% if @planning_application.boundary_geojson.present? %>
+    <%= render "shared/location_map", locals: { div_id: "decision_map" } %>
+  <% else %>
+    <p class="govuk-body">No digital sitemap provided</p>
+  <% end %>
+  <p class="govuk-body govuk-!-padding-top-6">
     Your attention is drawn to the notes accompanying this document
   </p>
 

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-          <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
-      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
-      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
+        <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
+    Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
+    For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
         <button type="button" id="accordion-default-heading-1" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
           Application information
           <span class="govuk-accordion__icon" aria-hidden="true"></span></button>
@@ -76,32 +76,18 @@
         <button type="button" id="accordion-default-heading-2" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
           Site map
         </button>
-          <span class="govuk-accordion__icon" aria-hidden="true"></span>
+        <span class="govuk-accordion__icon" aria-hidden="true"></span>
       </h3>
     </div>
     <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-2">
       <% if @planning_application.boundary_geojson.present? %>
-        <div id='map' style="width: 100%; height: 200px"></div>
-        <script>
-          var map = L.map('map', {minZoom: 8, maxZoom: 22});
-          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-            maxZoom: 22,
-            maxNativeZoom: 19
-          }).addTo(map);
-          var boundary = L.geoJSON(<%= JSON.parse(@planning_application.boundary_geojson).to_json.html_safe %>, {"color": "#ff0000", "weight": 2, "opacity": 0.65}).addTo(map);
-          map.fitBounds(boundary.getBounds());
-
-          function accordion_expanded() {
-            map.invalidateSize().fitBounds(boundary.getBounds());
-          }
-        </script>
+        <%= render "shared/location_map", locals: { div_id: "accordion_map" } %>
       <% else %>
         <p class="govuk-body">No digital sitemap provided</p>
       <% end %>
     </div>
   </div>
 
-    <%= render "planning_applications/policy_consideration_list" %>
-    <%= render "shared/proposal_documents" %>
+  <%= render "planning_applications/policy_consideration_list" %>
+  <%= render "shared/proposal_documents" %>
 </div>

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -1,0 +1,32 @@
+<% if locals[:div_id] == "decision_map" %>
+  <div id="decision_map" style="width: 550px; height: 400px"></div>
+<% else %>
+  <div id="accordion_map" style="width: 100%; height: 200px"></div>
+<% end %>
+
+<script>
+    var <%= locals[:div_id] %>Map = L.map(<%= locals[:div_id] %>, {minZoom: 8, maxZoom: 22});
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        maxZoom: 22,
+        maxNativeZoom: 19
+    }).addTo(<%= locals[:div_id] %>Map);
+
+    var boundary = L.geoJSON(<%= JSON.parse(@planning_application.boundary_geojson).to_json.html_safe %>, {
+        "color": "#ff0000",
+        "weight": 2,
+        "opacity": 0.65
+    }).addTo(<%= locals[:div_id] %>Map);
+
+    if (<%= locals[:div_id] %>.parentElement.className == "decision-notice") {
+        <%= locals[:div_id] %>Map.fitBounds(boundary.getBounds(), {padding: [50, 50]});
+    } else {
+        <%= locals[:div_id] %>Map.fitBounds(boundary.getBounds());
+
+        function accordion_expanded() {
+            <%= locals[:div_id] %>Map.invalidateSize().fitBounds(boundary.getBounds());
+        }
+    }
+</script>
+
+


### PR DESCRIPTION
<img width="920" alt="decision" src="https://user-images.githubusercontent.com/1880450/115528826-49aa0d80-a28a-11eb-8853-44ee17e33e29.png">

### Description of change

Created a partial with a script tag in it that accepts locals so the map can be reused between the accordion and decision notice

### Story Link

https://trello.com/c/KhmKy762/278-include-red-line-site-plan-on-decision-notice

### Known issues 
Things you know need further follow on work but aren't in scope of this issue

1. This meets the A/Cs specified on the ticket, but does not meet the verbally discussed aim of allowing the planner to alter the zoom on the map and have this reflected in the PDF
2. The fix for PDFKit to export the Leaflet map is to specify the map dimensions in px instead of percentages. This means that the map is not fully responsive - displaying on a narrow viewport means the map breaks the bounds of the div
3. It's slightly ugly interpolating the locals into the JavaScript but given we need different variable names, different bounds and different div Ids it seemed the best way to do it