### PR TITLE
Add description change requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "appsignal"
 gem "aws-sdk-codedeploy", require: false
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.4.2", require: false
+gem "business_time"
 gem "devise"
 gem "faker", require: false
 gem "faraday", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
     bundler-audit (0.8.0)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    business_time (0.10.0)
+      activesupport (>= 3.2.0)
+      sorted_set
+      tzinfo
     byebug (11.1.3)
     capybara (3.35.3)
       addressable
@@ -255,6 +259,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rbtree (0.4.4)
     regexp_parser (2.1.1)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -321,12 +326,16 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
+    set (1.0.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -377,6 +386,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   brakeman
   bundler-audit
+  business_time
   byebug
   capybara
   devise

--- a/app/controllers/description_change_requests_controller.rb
+++ b/app/controllers/description_change_requests_controller.rb
@@ -1,11 +1,11 @@
 class DescriptionChangeRequestsController < ApplicationController
+  before_action :set_planning_application, only: %i[new create show]
+
   def new
-    @planning_application = PlanningApplication.find(params[:planning_application_id])
     @description_change_request = @planning_application.description_change_requests.new
   end
 
   def create
-    @planning_application = PlanningApplication.find(params[:planning_application_id])
     @description_change_request = @planning_application.description_change_requests.new(description_change_request_params)
     @description_change_request.user = current_user
 
@@ -17,9 +17,17 @@ class DescriptionChangeRequestsController < ApplicationController
     end
   end
 
+  def show
+    @description_change_request = DescriptionChangeRequest.find(params[:id])
+  end
+
 private
 
   def description_change_request_params
     params.require(:description_change_request).permit(:proposed_description)
+  end
+
+  def set_planning_application
+    @planning_application = PlanningApplication.find(params[:planning_application_id])
   end
 end

--- a/app/controllers/description_change_requests_controller.rb
+++ b/app/controllers/description_change_requests_controller.rb
@@ -1,0 +1,25 @@
+class DescriptionChangeRequestsController < ApplicationController
+  def new
+    @planning_application = PlanningApplication.find(params[:planning_application_id])
+    @description_change_request = @planning_application.description_change_requests.new
+  end
+
+  def create
+    @planning_application = PlanningApplication.find(params[:planning_application_id])
+    @description_change_request = @planning_application.description_change_requests.new(description_change_request_params)
+    @description_change_request.user = current_user
+
+    if @description_change_request.save
+      flash[:notice] = "Change request for description successfully sent."
+      redirect_to validate_documents_form_planning_application_path(@planning_application)
+    else
+      render :new
+    end
+  end
+
+private
+
+  def description_change_request_params
+    params.require(:description_change_request).permit(:proposed_description)
+  end
+end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -92,6 +92,9 @@ class PlanningApplicationsController < AuthenticationController
         @planning_application.errors.add(:date, "Please enter a valid date")
         @planning_application.status = "in_assessment"
         render "validate_documents_form"
+      elsif @planning_application.description_change_requests.open.present?
+        @planning_application.errors.add(:status, "Planning application cannot be validated if open change requests exist.")
+        render "validate_documents_form"
       else
         @planning_application.documents_validated_at = date_from_params
         @planning_application.start!
@@ -104,7 +107,7 @@ class PlanningApplicationsController < AuthenticationController
       @planning_application.invalidate!
       audit("invalidated")
       flash[:notice] = "Application has been invalidated"
-      redirect_to @planning_application
+      render "validate_documents_form"
     else
       @planning_application.errors.add(:status, "Please select one of the below options")
       render "validate_documents_form"

--- a/app/helpers/description_change_request_helper.rb
+++ b/app/helpers/description_change_request_helper.rb
@@ -1,0 +1,21 @@
+module DescriptionChangeRequestHelper
+  def display_request_date_state(description_change_request)
+    if description_change_request.state == "closed"
+      "grey"
+    elsif description_change_request.days_until_response_due.positive?
+      "green"
+    else
+      "red"
+    end
+  end
+
+  def display_request_status(description_change_request)
+    if description_change_request.state == "open"
+      "grey"
+    elsif description_change_request.approved == false
+      "red"
+    else
+      "green"
+    end
+  end
+end

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -1,0 +1,14 @@
+class DescriptionChangeRequest < ApplicationRecord
+  belongs_to :planning_application
+  belongs_to :user
+
+  validates :proposed_description, presence: true
+
+  def response_due
+    created_at + 15.days
+  end
+
+  def days_until_response_due
+    (response_due.to_date - Time.zone.today).to_i
+  end
+end

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DescriptionChangeRequest < ApplicationRecord
   belongs_to :planning_application
   belongs_to :user
@@ -5,12 +7,17 @@ class DescriptionChangeRequest < ApplicationRecord
   validates :proposed_description, presence: true
 
   scope :open, -> { where(state: "open") }
+  scope :order_by_latest, -> { order(created_at: :desc) }
 
   def response_due
-    created_at + 15.days
+    15.business_days.after(created_at.to_date)
   end
 
   def days_until_response_due
-    (response_due.to_date - Time.zone.today).to_i
+    if response_due > Time.zone.today
+      Time.zone.today.business_days_until(response_due)
+    else
+      -response_due.business_days_until(Time.zone.today)
+    end
   end
 end

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -4,6 +4,8 @@ class DescriptionChangeRequest < ApplicationRecord
 
   validates :proposed_description, presence: true
 
+  scope :open, -> { where(state: "open") }
+
   def response_due
     created_at + 15.days
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -9,6 +9,7 @@ class PlanningApplication < ApplicationRecord
 
   has_many :documents, dependent: :destroy
   has_many :recommendations, dependent: :destroy
+  has_many :description_change_requests, dependent: :destroy
 
   belongs_to :user, optional: true
   belongs_to :local_authority

--- a/app/views/description_change_requests/new.html.erb
+++ b/app/views/description_change_requests/new.html.erb
@@ -1,0 +1,53 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Request for change" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-l">Request for change</h2>
+
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>At:</strong> <%= @planning_application.full_address  %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>Date received:</strong> <%= @planning_application.created_at.strftime("%e %B %Y") %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-8">
+      <strong>Application number:</strong> <%= @planning_application.reference  %>
+    </p>
+
+    <p class="govuk-heading-m govuk-!-padding-top-6">
+      Description of work
+    </p>
+
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">
+      Previous description
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-6">
+      <%= @planning_application.description  %>
+    </p>
+
+    <%= form_with model: [@planning_application, @description_change_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <% if @description_change_request.errors.any? %>
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <% @description_change_request.errors.full_messages.each do |error| %>
+                <li><%= error %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+
+    <%= form.govuk_text_area :proposed_description,
+      label: { text: 'Please suggest a new application description', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
+      rows: 5 %>
+      <%= form.govuk_submit "Send" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/description_change_requests/new.html.erb
+++ b/app/views/description_change_requests/new.html.erb
@@ -4,9 +4,9 @@
 <% content_for :title, "Request for change" %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
-    <h2 class="govuk-heading-l">Request for change</h2>
-
+    <h2 class="govuk-heading-l">
+      Request for change
+    </h2>
     <p class="govuk-body govuk-!-margin-bottom-1">
       <strong>At:</strong> <%= @planning_application.full_address  %>
     </p>
@@ -16,11 +16,9 @@
     <p class="govuk-body govuk-!-margin-bottom-8">
       <strong>Application number:</strong> <%= @planning_application.reference  %>
     </p>
-
     <p class="govuk-heading-m govuk-!-padding-top-6">
       Description of work
     </p>
-
     <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-1">
       Previous description
     </p>

--- a/app/views/description_change_requests/show.html.erb
+++ b/app/views/description_change_requests/show.html.erb
@@ -1,0 +1,52 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", validate_documents_form_planning_application_path(@planning_application) %>
+
+<% content_for :title, "Request changes to description" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-bottom-4">
+      Request for approval of changes to description
+    </h2>
+
+    <div class="govuk-!-margin-top-8">
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <strong>Application number:</strong> <%= @planning_application.reference  %>
+      </p>
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <strong>At:</strong> <%= @planning_application.full_address  %>
+      </p>
+      <p class="govuk-body govuk-!-margin-bottom-1">
+        <strong>Request sent:</strong> <%= @description_change_request.created_at.strftime("%e %B %Y") %>
+      </p>
+
+      <strong class="govuk-!-margin-top-4 govuk-tag govuk-tag--<%=display_request_status(@description_change_request) %>">
+        <% if @description_change_request.state == "open" %>
+          Open
+        <% else %>
+          <%= @description_change_request.approved? ? 'Approved' : 'Rejected' %>
+        <% end %>
+      </strong>
+
+      <div class="govuk-!-margin-top-6">
+        <p class="govuk-body"> <strong> Previous description:</strong><br>
+          <%= @planning_application.description  %>
+        </p>
+        <p class="govuk-body"> <strong> Suggested description:</strong><br>
+          <%= @description_change_request.proposed_description  %>
+        </p>
+      </div>
+    </div>
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <% if @description_change_request.rejection_reason.present? %>
+      <p class="govuk-body">
+        <strong>Applicant objection to suggested changes:</strong><br>
+        <%= @description_change_request.rejection_reason %>
+      </p>
+    <% end %>
+
+    <%= link_to "Back", validate_documents_form_planning_application_path(@planning_application), class: "govuk-!-margin-top-8 govuk-button" %>
+  </div>
+</div>

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -1,32 +1,82 @@
 <% content_for :title, "Validate documents" %>
-
 <%= render "planning_applications/assessment_dashboard" do %>
 
-  <h2 class="govuk-heading-m govuk-!-padding-top-3">Validate application</h2>
+<h2 class="govuk-heading-m govuk-!-padding-top-3">Validate application</h2>
 
-  <p class="govuk-body"><%= link_to "Check documents", planning_application_documents_path(@planning_application) %></p>
+<p class="govuk-body">
+  <%= link_to "Check documents", planning_application_documents_path(@planning_application) %>
+</p>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+        Request
+      </th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+        Time remaining
+      </th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+        Status
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @planning_application.description_change_requests.each do |description_change_request| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <a class="govuk-link">Description</a>
+      </td>
+      <td class="govuk-table__cell">
+        <strong class="govuk-tag govuk-tag--<%=display_request_date_state(description_change_request) %>">
+          <% if description_change_request.state == "open" %>
+            <%= description_change_request.days_until_response_due %> days
+          <% else %>
+            Closed
+          <% end %>
+        </strong>
+      </td>
+      <td class="govuk-table__cell">
+        <strong class="govuk-tag govuk-tag--<%=display_request_status(description_change_request) %>">
+          <% if description_change_request.state == "open" %>
+            Open
+          <% else %>
+            <%= description_change_request.approved? ? 'Approved' : 'Rejected' %>
+          <% end %>
+        </strong>
+      </td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
 
-  <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-    <fieldset class="govuk-fieldset">
-      <% if form.object.errors.any? %>
-        <% form.object.errors.each do |error| %>
-      <span id="status-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span><%= error.message %></span>
-        <% end %>
-      <% end %>
-      <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Is the application valid?' }) do %>
-        <span class="govuk-hint">
-          If the application is invalid, please contact the applicant via email.
-        </span>
-        <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
-          <%= form.govuk_date_field :documents_validated_at, legend: { text: '', size: 's' }, hint: { text: 'Enter valid date, e.g. 28 12 2021' } %>
-        <% end %>
-        <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
-      <% end %>
-    </fieldset>
-    <p>
-      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-      <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-    </p>
-  <% end%>
+<p class="govuk-body govuk-!-font-weight-bold">
+  Submit new change request(s) to applicant
+</p>
+<%= link_to "New request(s)", new_planning_application_description_change_request_path(@planning_application), class: 'govuk-button govuk-button--secondary' %>
+
+<%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local:true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+<fieldset class="govuk-fieldset">
+  <% if form.object.errors.any? %>
+    <% form.object.errors.each do |error| %>
+    <span id="status-error" class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span><%= error.message %>
+    </span>
+    <% end %>
+  <% end %>
+
+  <%= form.govuk_radio_buttons_fieldset(:status, legend: {size: 's', text: 'Is the application valid?' }) do %>
+  <span class="govuk-hint">
+    If the application is invalid, please contact the applicant via email.
+  </span>
+    <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
+      <%= form.govuk_date_field :documents_validated_at, legend: { text: '', size: 's' }, hint: { text: 'Enter valid date, e.g. 28 12 2021' } %>
+    <% end %>
+    <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
+  <% end %>
+</fieldset>
+<p>
+  <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button"} %>
+  <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+</p>
+<% end%>
 <% end %>

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -6,53 +6,58 @@
 <p class="govuk-body">
   <%= link_to "Check documents", planning_application_documents_path(@planning_application) %>
 </p>
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
-        Request
-      </th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
-        Time remaining
-      </th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
-        Status
-      </th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <% @planning_application.description_change_requests.each do |description_change_request| %>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell">
-        <a class="govuk-link">Description</a>
-      </td>
-      <td class="govuk-table__cell">
-        <strong class="govuk-tag govuk-tag--<%=display_request_date_state(description_change_request) %>">
-          <% if description_change_request.state == "open" %>
-            <%= description_change_request.days_until_response_due %> days
-          <% else %>
-            Closed
-          <% end %>
-        </strong>
-      </td>
-      <td class="govuk-table__cell">
-        <strong class="govuk-tag govuk-tag--<%=display_request_status(description_change_request) %>">
-          <% if description_change_request.state == "open" %>
-            Open
-          <% else %>
-            <%= description_change_request.approved? ? 'Approved' : 'Rejected' %>
-          <% end %>
-        </strong>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
 
-<p class="govuk-body govuk-!-font-weight-bold">
-  Submit new change request(s) to applicant
-</p>
-<%= link_to "New request(s)", new_planning_application_description_change_request_path(@planning_application), class: 'govuk-button govuk-button--secondary' %>
+<% if @planning_application.description_change_requests.present? %>
+  <table class="govuk-table change-requests">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+          Request
+        </th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+          Time remaining
+        </th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">
+          Status
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @planning_application.description_change_requests.each do |description_change_request| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= link_to "Description", planning_application_description_change_request_path(@planning_application, description_change_request), class: "govuk-link" %>
+        </td>
+        <td class="govuk-table__cell">
+          <strong class="govuk-tag govuk-tag--<%=display_request_date_state(description_change_request) %>">
+            <% if description_change_request.state == "open" %>
+              <%= description_change_request.days_until_response_due %> days
+            <% else %>
+              Closed
+            <% end %>
+          </strong>
+        </td>
+        <td class="govuk-table__cell">
+          <strong class="govuk-tag govuk-tag--<%=display_request_status(description_change_request) %>">
+            <% if description_change_request.state == "open" %>
+              Open
+            <% else %>
+              <%= description_change_request.approved? ? 'Approved' : 'Rejected' %>
+            <% end %>
+          </strong>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% if @planning_application.invalidated? %>
+  <p class="govuk-body govuk-!-font-weight-bold">
+    Submit new change request to applicant
+  </p>
+  <%= link_to "New request", new_planning_application_description_change_request_path(@planning_application), class: 'govuk-button govuk-button--secondary' %>
+<% end %>
 
 <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), local:true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
 <fieldset class="govuk-fieldset">
@@ -65,18 +70,18 @@
   <% end %>
 
   <%= form.govuk_radio_buttons_fieldset(:status, legend: {size: 's', text: 'Is the application valid?' }) do %>
-  <span class="govuk-hint">
-    If the application is invalid, please contact the applicant via email.
-  </span>
-    <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
-      <%= form.govuk_date_field :documents_validated_at, legend: { text: '', size: 's' }, hint: { text: 'Enter valid date, e.g. 28 12 2021' } %>
+    <span class="govuk-hint">
+      If the application is invalid, please contact the applicant via email.
+    </span>
+      <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
+        <%= form.govuk_date_field :documents_validated_at, legend: { text: '', size: 's' }, hint: { text: 'Enter valid date, e.g. 28 12 2021' } %>
+      <% end %>
+      <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
     <% end %>
-    <%= form.govuk_radio_button :status, 'invalidated', label: { text: 'No' } %>
-  <% end %>
-</fieldset>
-<p>
-  <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button"} %>
-  <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-</p>
-<% end%>
+  </fieldset>
+  <p>
+    <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button"} %>
+    <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </p>
+  <% end%>
 <% end %>

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -23,7 +23,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @planning_application.description_change_requests.each do |description_change_request| %>
+      <% @planning_application.description_change_requests.order_by_latest.each do |description_change_request| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= link_to "Description", planning_application_description_change_request_path(@planning_application, description_change_request), class: "govuk-link" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Rails.application.routes.draw do
 
     resources :audits, only: :index
 
-    resources :description_change_requests, only: %i[new create]
+    resources :description_change_requests, only: %i[new create show]
   end
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
     end
 
     resources :audits, only: :index
+
+    resources :description_change_requests, only: %i[new create]
   end
 
   namespace :api do

--- a/db/migrate/20210420160121_create_description_change_requests.rb
+++ b/db/migrate/20210420160121_create_description_change_requests.rb
@@ -1,0 +1,14 @@
+class CreateDescriptionChangeRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :description_change_requests do |t|
+      t.references :planning_application, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :state, default: "open", null: false
+      t.text :proposed_description
+      t.boolean :approved
+      t.string :rejection_reason
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_16_094652) do
+ActiveRecord::Schema.define(version: 2021_04_20_160121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -63,6 +63,19 @@ ActiveRecord::Schema.define(version: 2021_04_16_094652) do
     t.index ["api_user_id"], name: "index_audits_on_api_user_id"
     t.index ["planning_application_id"], name: "index_audits_on_planning_application_id"
     t.index ["user_id"], name: "index_audits_on_user_id"
+  end
+
+  create_table "description_change_requests", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.string "state", default: "open", null: false
+    t.text "proposed_description"
+    t.boolean "approved"
+    t.string "rejection_reason"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_description_change_requests_on_user_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -172,6 +185,8 @@ ActiveRecord::Schema.define(version: 2021_04_16_094652) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "audits", "api_users"
   add_foreign_key "audits", "planning_applications"
+  add_foreign_key "description_change_requests", "planning_applications"
+  add_foreign_key "description_change_requests", "users"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"

--- a/spec/factories/description_change_requests.rb
+++ b/spec/factories/description_change_requests.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :description_change_request do
+    planning_application
+    user
+    state { "open" }
+    proposed_description { "New description" }
+    approved { nil }
+    rejection_reason { nil }
+  end
+end

--- a/spec/models/description_change_request_spec.rb
+++ b/spec/models/description_change_request_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DescriptionChangeRequest, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/description_change_request_spec.rb
+++ b/spec/models/description_change_request_spec.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-require "rails_helper"
-
-RSpec.describe DescriptionChangeRequest, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/system/planning_applications/requesting_changes_spec.rb
+++ b/spec/system/planning_applications/requesting_changes_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
     create :planning_application, :invalidated, local_authority: @default_local_authority
   end
 
+  let!(:description_change_request) do
+    create :description_change_request, planning_application: planning_application, state: "open", created_at: 12.days.ago
+  end
+
   before do
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -16,10 +20,10 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
 
   it "is possible to create a request to update description" do
     click_link "Validate application"
-    click_link "New request(s)"
+    click_link "New request"
     fill_in "Please suggest a new application description", with: "New description"
     click_button "Send"
-    within(".change_requests") do
+    within(".change-requests") do
       expect(page).to have_content("Description")
       expect(page).to have_content("15 days")
       expect(page).to have_content("Open")
@@ -28,7 +32,7 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
 
   it "only accepts a request that contains a proposed description" do
     click_link "Validate application"
-    click_link "New request(s)"
+    click_link "New request"
     fill_in "Please suggest a new application description", with: " "
     click_button "Send"
 
@@ -42,7 +46,7 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
     create :description_change_request, planning_application: planning_application, state: "open", created_at: 30.days.ago
 
     click_link "Validate application"
-    within(".change_requests") do
+    within(".change-requests") do
       expect(page).to have_content("3 days")
       expect(page).to have_content("Open")
 
@@ -55,5 +59,26 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
       expect(page).to have_content("-15 days")
       expect(page).to have_content("Open")
     end
+  end
+
+  it "only displays a new change request option if application is invalid" do
+    planning_application.update!(status: "in_assessment")
+
+    click_link "Validate application"
+
+    expect(page).not_to have_content("New request")
+  end
+
+  it "allows the user to access the request after its been created" do
+    click_link "Validate application"
+    click_link "Description"
+
+    expect(page).to have_content("Request for approval of changes to description")
+    expect(page).to have_content("Application number: #{planning_application.reference}")
+    expect(page).to have_content("At: #{planning_application.full_address}")
+    expect(page).to have_content("Request sent: #{description_change_request.created_at.strftime('%e %B %Y')}")
+    expect(page).to have_content("Open")
+    expect(page).to have_content("Previous description: #{planning_application.description}")
+    expect(page).to have_content("Suggested description: #{description_change_request.proposed_description}")
   end
 end

--- a/spec/system/planning_applications/requesting_changes_spec.rb
+++ b/spec/system/planning_applications/requesting_changes_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Requesting changes to a planning application", type: :system do
+  let!(:assessor) { create :user, :assessor, local_authority: @default_local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :invalidated, local_authority: @default_local_authority
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  it "is possible to create a request to update description" do
+    click_link "Validate application"
+    click_link "New request(s)"
+    fill_in "Please suggest a new application description", with: "New description"
+    click_button "Send"
+    within(".change_requests") do
+      expect(page).to have_content("Description")
+      expect(page).to have_content("15 days")
+      expect(page).to have_content("Open")
+    end
+  end
+
+  it "only accepts a request that contains a proposed description" do
+    click_link "Validate application"
+    click_link "New request(s)"
+    fill_in "Please suggest a new application description", with: " "
+    click_button "Send"
+
+    expect(page).to have_content("Proposed description can't be blank")
+  end
+
+  it "lists the current change requests and their statuses" do
+    create :description_change_request, planning_application: planning_application, state: "open", created_at: 12.days.ago
+    create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: true
+    create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false
+    create :description_change_request, planning_application: planning_application, state: "open", created_at: 30.days.ago
+
+    click_link "Validate application"
+    within(".change_requests") do
+      expect(page).to have_content("3 days")
+      expect(page).to have_content("Open")
+
+      expect(page).to have_content("Closed")
+      expect(page).to have_content("Approved")
+
+      expect(page).to have_content("Closed")
+      expect(page).to have_content("Rejected")
+
+      expect(page).to have_content("-15 days")
+      expect(page).to have_content("Open")
+    end
+  end
+end

--- a/spec/system/planning_applications/requesting_changes_spec.rb
+++ b/spec/system/planning_applications/requesting_changes_spec.rb
@@ -43,20 +43,20 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
     create :description_change_request, planning_application: planning_application, state: "open", created_at: 12.days.ago
     create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: true
     create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false
-    create :description_change_request, planning_application: planning_application, state: "open", created_at: 30.days.ago
+    create :description_change_request, planning_application: planning_application, state: "open", created_at: 35.days.ago
 
     click_link "Validate application"
     within(".change-requests") do
-      expect(page).to have_content("3 days")
-      expect(page).to have_content("Open")
+      expect(page).to have_content("Closed")
+      expect(page).to have_content("Rejected")
 
       expect(page).to have_content("Closed")
       expect(page).to have_content("Approved")
 
-      expect(page).to have_content("Closed")
-      expect(page).to have_content("Rejected")
+      expect(page).to have_content("7 days")
+      expect(page).to have_content("Open")
 
-      expect(page).to have_content("-15 days")
+      expect(page).to have_content("-10 days")
       expect(page).to have_content("Open")
     end
   end

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe "Planning Application Assessment", type: :system do
     create :planning_application, :not_started, local_authority: @default_local_authority
   end
 
+  let!(:description_change_request) do
+    create :description_change_request, planning_application: planning_application, state: "closed"
+  end
+
   let!(:document) do
     create :document, :with_file, :with_tags, planning_application: planning_application
   end
@@ -105,6 +109,22 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
 
     include_examples "validate and invalidate"
+
+    it "shows error if trying to mark as valid when open change request exists on planning application" do
+      create :description_change_request, planning_application: planning_application, state: "open"
+      click_link planning_application.reference
+      click_link "Validate application"
+
+      choose "Yes"
+
+      fill_in "Day", with: "03"
+      fill_in "Month", with: "12"
+      fill_in "Year", with: "2021"
+
+      click_button "Save"
+
+      expect(page).to have_content("Planning application cannot be validated if open change requests exist")
+    end
   end
 
   context "Planning application does not transition when expected inputs are not sent" do

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -116,11 +116,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Validate application"
 
       choose "Yes"
-
-      fill_in "Day", with: "03"
-      fill_in "Month", with: "12"
-      fill_in "Year", with: "2021"
-
       click_button "Save"
 
       expect(page).to have_content("Planning application cannot be validated if open change requests exist")


### PR DESCRIPTION
### Description of change

Allow for the creation of description change requests
Only allow for invalid applications types to have description change requests created on them
Add a validation to ensure the new application description is present
Display change requests in the application validation step
Redirect to the application validation step when an application is marked as invalid,
so the user can create change requests from there
Add helpers to change tag colours depending on set conditions of time and status (state)
Ensure that an application can only be marked as valid if no open change requests exist
Add show pages for each change request and link the show pages to each description
Add business time gem and calculate response due
Add a scope to order change description requests per date, latest request displayed at the top

### Story Link

https://trello.com/c/tJ4uzfrb/290-as-an-officer-i-can-create-a-request-for-change-to-a-description

### Decisions

- Have a separate db table, model and controller for each type of description change request so we can keep things RESTFUL and clean
- We will consider how to group decision change requests on the next stage of development, when we will start supporting multiple types of CR