### PR TITLE
Get, post and update paths for change requests API

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,29 @@ Once you have the application running, you can submit planning application throu
 
 [1]: https://www.docker.com/products/docker-desktop
 [2]: http://localhost:3000/
+
+## Working with api documentation: aggregate swagger files
+
+We need a single openapi file to exist, but to keep the code easier to maintain we have multiple files that are then compiled into this single file:
+
+```public/api-docs/v1/_build/swagger_doc.yaml```.
+
+So to create a new api endpoint, create your yaml doc inside public/api-docs/v1 and reference it in
+
+``` public/api-docs/v1/swagger_doc.yaml ```
+
+like so:
+
+```
+  $ref: "./your_new_file_name.yaml"
+```
+
+Make changes to your new file, and when you're happy aggregate them into our single file by installing this package in your machine:
+
+``` npm install -g swagger-cli ```
+
+and running:
+
+```
+swagger-cli bundle public/api-docs/v1/swagger_doc.yaml --outfile public/api-docs/v1/_build/swagger_doc.yaml --type yaml
+```

--- a/app/controllers/api/v1/change_requests_controller.rb
+++ b/app/controllers/api/v1/change_requests_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::ChangeRequestsController < Api::V1::ApplicationController
+  before_action :check_token_and_set_application, only: %i[index], if: :json_request?
+
+  def index; end
+
+private
+
+  def check_token_and_set_application
+    @planning_application = current_local_authority.planning_applications.where(id: params[:planning_application_id]).first
+    if params[:change_access_id] != @planning_application.change_access_id
+      render json: {}, status: 401
+    else
+      @planning_application
+    end
+  end
+end

--- a/app/controllers/api/v1/description_change_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_requests_controller.rb
@@ -1,0 +1,31 @@
+class Api::V1::DescriptionChangeRequestsController < Api::V1::ApplicationController
+  skip_before_action :verify_authenticity_token, only: :update
+  before_action :check_token_and_set_application, only: :update, if: :json_request?
+
+  def update
+    @description_change_request = @planning_application.description_change_requests.where(id: params[:id]).first
+
+    if @description_change_request.update(description_change_params)
+      @description_change_request.update!(state: "closed")
+      render json: { "message": "Change request updated" }, status: :ok
+    else
+      render json: { "message": "Unable to update request. Please ensure rejection_reason is present if approved is false." }, status: 400
+    end
+  end
+
+private
+
+  def description_change_params
+    { approved: params[:data][:approved],
+      rejection_reason: params[:data][:rejection_reason] }
+  end
+
+  def check_token_and_set_application
+    @planning_application = current_local_authority.planning_applications.where(id: params[:planning_application_id]).first
+    if params[:change_access_id] != @planning_application.change_access_id
+      render json: {}, status: 401
+    else
+      @planning_application
+    end
+  end
+end

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -5,6 +5,7 @@ class DescriptionChangeRequest < ApplicationRecord
   belongs_to :user
 
   validates :proposed_description, presence: true
+  validate :rejected_reason_is_present?
 
   scope :open, -> { where(state: "open") }
   scope :order_by_latest, -> { order(created_at: :desc) }
@@ -18,6 +19,12 @@ class DescriptionChangeRequest < ApplicationRecord
       Time.zone.today.business_days_until(response_due)
     else
       -response_due.business_days_until(Time.zone.today)
+    end
+  end
+
+  def rejected_reason_is_present?
+    if approved == false
+      errors.add(:base, "Please include a comment for the case officer to indicate why the description change has been rejected.") if rejection_reason.blank?
     end
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -15,6 +15,7 @@ class PlanningApplication < ApplicationRecord
   belongs_to :local_authority
 
   before_create :set_target_date
+  before_create :set_change_access_id
   before_update :set_target_date
 
   WORK_STATUSES = %w[proposed existing].freeze
@@ -218,6 +219,10 @@ private
 
   def set_target_date
     self.target_date = (documents_validated_at || created_at) + 8.weeks
+  end
+
+  def set_change_access_id
+    self.change_access_id = SecureRandom.hex(15)
   end
 
   def documents_validated_at_date

--- a/app/views/api/v1/change_requests/index.json.jbuilder
+++ b/app/views/api/v1/change_requests/index.json.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.data @planning_application.description_change_requests.each do |description_change_request|
+  json.extract! description_change_request,
+                :id,
+                :state,
+                :response_due,
+                :proposed_description,
+                :rejection_reason,
+                :approved
+  json.type "description_change_request"
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -5,5 +5,5 @@
 require "rswag/ui"
 
 Rswag::Ui.configure do |c|
-  c.swagger_endpoint "/api-docs/v1/swagger_doc.yaml", "Docs"
+  c.swagger_endpoint "/api-docs/v1/_build/swagger_doc.yaml", "Docs"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,8 @@ Rails.application.routes.draw do
         member do
           get :decision_notice
         end
+        resources :change_requests, only: :index
+        resources :description_change_requests, only: :update
         resources :documents, only: %i[show]
       end
     end

--- a/db/migrate/20210422152427_add_change_access_id_to_planning_applications.rb
+++ b/db/migrate/20210422152427_add_change_access_id_to_planning_applications.rb
@@ -1,0 +1,5 @@
+class AddChangeAccessIdToPlanningApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :planning_applications, :change_access_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_160121) do
+ActiveRecord::Schema.define(version: 2021_04_22_152427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,7 @@ ActiveRecord::Schema.define(version: 2021_04_20_160121) do
     t.string "uprn"
     t.json "boundary_geojson"
     t.text "constraints", default: [], null: false, array: true
+    t.string "change_access_id"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"
   end

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -1,4 +1,3 @@
----
 openapi: 3.0.1
 info:
   title: Back-office Planning System
@@ -9,7 +8,7 @@ components:
       type: http
       scheme: bearer
 paths:
-  "/api/v1/planning_applications/{id}":
+  '/api/v1/planning_applications/{id}':
     get:
       summary: Retrieves all determined planning applications
       parameters:
@@ -27,7 +26,7 @@ paths:
             application/json:
               examples:
                 Full:
-                  value: &planning_application
+                  value:
                     id: 10000
                     application_number: '00010000'
                     site:
@@ -69,18 +68,23 @@ paths:
                       geometry:
                         type: Polygon
                         coordinates:
-                          -
-                            - [-0.07716178894042969, 51.50094238217541]
-                            - [-0.07645905017852783, 51.50053497847238]
-                            - [-0.07615327835083008, 51.50115276135022]
-                            - [-0.07716178894042969, 51.50094238217541]
+                          - - - -0.07716178894042969
+                              - 51.50094238217541
+                            - - -0.07645905017852783
+                              - 51.50053497847238
+                            - - -0.07615327835083008
+                              - 51.50115276135022
+                            - - -0.07716178894042969
+                              - 51.50094238217541
                     documents:
-                      - url: http://example.com/document_path.pdf
+                      - url: 'http://example.com/document_path.pdf'
                         created_at: '2020-05-16T05:18:17.540Z'
                         tags:
-                          ["Side", "Elevation", "Proposed"]
+                          - Side
+                          - Elevation
+                          - Proposed
                         numbers: PLAN01
-  "/api/v1/planning_applications":
+  /api/v1/planning_applications:
     get:
       summary: Retrieves all determined planning applications
       responses:
@@ -92,12 +96,67 @@ paths:
                 Full:
                   value:
                     data:
-                      -   <<: *planning_application
-
+                      - id: 10000
+                        application_number: '00010000'
+                        site:
+                          address_1: 11 Abbey Gardens
+                          address_2: Southwark
+                          town: nil
+                          county: London
+                          postcode: SE16 3RQ
+                          uprn: '100081043511'
+                        status: not_started
+                        application_type: lawfulness_certificate
+                        description: Add chimnney stack
+                        created_at: '2020-05-14T05:18:17.540Z'
+                        received_date: '2020-05-14T05:18:17.540Z'
+                        determined_at: '2020-06-14T05:18:17.540Z'
+                        target_date: '2020-07-09'
+                        started_at: '2020-05-15T05:18:17.540Z'
+                        invalidated_at: null
+                        withdrawn_at: null
+                        returned_at: null
+                        work_status: proposed
+                        payment_reference: PAY1
+                        awaiting_determination_at: '2020-05-16T05:18:17.540Z'
+                        in_assessment_at: '2020-05-16T05:18:17.540Z'
+                        awaiting_correction_at: null
+                        applicant_first_name: Albert
+                        applicant_last_name: Manteras
+                        applicant_phone: '23432325435'
+                        applicant_email: applicant@example.com
+                        agent_first_name: Jennifer
+                        agent_last_name: Harper
+                        agent_phone: '237878889'
+                        agent_email: agent@example.com
+                        constraints:
+                          - Conservation Area
+                          - Listed Building
+                        boundary_geojson:
+                          type: Feature
+                          geometry:
+                            type: Polygon
+                            coordinates:
+                              - - - -0.07716178894042969
+                                  - 51.50094238217541
+                                - - -0.07645905017852783
+                                  - 51.50053497847238
+                                - - -0.07615327835083008
+                                  - 51.50115276135022
+                                - - -0.07716178894042969
+                                  - 51.50094238217541
+                        documents:
+                          - url: 'http://example.com/document_path.pdf'
+                            created_at: '2020-05-16T05:18:17.540Z'
+                            tags:
+                              - Side
+                              - Elevation
+                              - Proposed
+                            numbers: PLAN01
     post:
       summary: Create new planning application
       security:
-      - bearerAuth: []
+        - bearerAuth: []
       parameters: []
       responses:
         '200':
@@ -179,10 +238,10 @@ paths:
                               properties:
                                 url:
                                   type: string
-                                  example: http://example.com/planning/policy/1/234/a.html
+                                  example: 'http://example.com/planning/policy/1/234/a.html'
                                 value:
                                   type: string
-                                  example: "GPDO 32.2342.223"
+                                  example: GPDO 32.2342.223
                           flags:
                             type: array
                             items:
@@ -223,18 +282,18 @@ paths:
                     properties:
                       filename:
                         type: string
-                        example: https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
+                        example: 'https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
                       tags:
                         type: array
                         items:
                           type: string
-                          example: "Side"
+                          example: Side
                 boundary_geojson:
                   type: object
               required:
-              - site
-              - application_type
-              - applicant_email
+                - site
+                - application_type
+                - applicant_email
             examples:
               Minimum:
                 value:
@@ -269,102 +328,102 @@ paths:
                   proposal_details:
                     - question: What do you want to do?
                       responses:
-                        - value: "Modify or extend"
+                        - value: Modify or extend
                     - question: What is the dwelling used as?
                       responses:
                         - value: A family home
                     - question: Is the property a house?
                       responses:
-                        - value: "Yes"
+                        - value: 'Yes'
                     - question: How many storeys will the new structure have?
                       responses:
-                        - value: "1"
+                        - value: '1'
                     - question: Was the house always a house?
                       responses:
-                        - value: "Yes"
+                        - value: 'Yes'
                     - question: Will the structure include a satellite dish or antenna?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         policy_refs:
-                        - url: http://example.com/planning/policy/1/234/a.html
-                          text: "GPDO 00.0000.000"
+                          - url: 'http://example.com/planning/policy/1/234/a.html'
+                            text: GPDO 00.0000.000
                     - question: What will be the total footprint of all additions of the available area around the original house?
                       responses:
                         - value: 50% or less
                     - question: How high will the eaves of the new structure be?
                       responses:
-                        - value: "2.5m or lower"
+                        - value: 2.5m or lower
                     - question: What will the height of the new structure be?
                       responses:
-                        - value: "2.5m or lower"
+                        - value: 2.5m or lower
                     - question: How close will the new structure be to the site boundary?
                       responses:
-                        - value: "Within 2m"
+                        - value: Within 2m
                     - question: Will any part of the new structure be forward of the front of the original house?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                     - question: How many storeys will the new structure have?
                       responses:
-                        - value: "1"
+                        - value: '1'
                     - question: Will any part of the pool be forward of the front of the original house?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                     - question: What is the addition to the property?
                       responses:
                         - value: An outdoor pool
                         - value: An outbuilding
                       metadata:
                         policy_refs:
-                          - url: http://example.com/planning/policy/1/234/b.html
-                            text: "GPDO 00.0000.000"
-                          - url: http://example.com/planning/policy/1/234/c.html
-                            text: "GPDO 00.0000.000"
+                          - url: 'http://example.com/planning/policy/1/234/b.html'
+                            text: GPDO 00.0000.000
+                          - url: 'http://example.com/planning/policy/1/234/c.html'
+                            text: GPDO 00.0000.000
                     - question: How many storeys will the new structure have?
                       responses:
-                        - value: "1"
+                        - value: '1'
                     - question: Is the property on designated land?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                           auto_answered: true
                     - question: Is the property in an area of outstanding natural beauty?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         auto_answered: true
                     - question: Is the property in the broads?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         auto_answered: true
                     - question: Is the property in a world heritage site?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         auto_answered: true
                     - question: Is the property in a national park?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         auto_answered: true
                     - question: Is the house listed?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                     - question: Will the works affect a protected tree?
                       responses:
-                        - value: "No"
+                        - value: 'No'
                       metadata:
                         auto_answered: true
                     - question: Will the new addition allow you to do an acitivity that most houses do not provide a dedicated space for?
                       responses:
-                        - value: "Yes"
+                        - value: 'Yes'
                       metadata:
                         notes: It will allow me to exercise on a regular basis and generate energy
                   constraints:
                     conservation_area: true
                     protected_trees: false
                   files:
-                    - filename: https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
+                    - filename: 'https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
                       tags:
                         - Side
                   boundary_geojson:
@@ -372,10 +431,106 @@ paths:
                     geometry:
                       type: Polygon
                       coordinates:
-                        -
-                          - [-0.07716178894042969, 51.50094238217541]
-                          - [-0.07645905017852783, 51.50053497847238]
-                          - [-0.07615327835083008, 51.50115276135022]
-                          - [-0.07716178894042969, 51.50094238217541]
-
-  $ref: "./change_requests.yaml"
+                        - - - -0.07716178894042969
+                            - 51.50094238217541
+                          - - -0.07645905017852783
+                            - 51.50053497847238
+                          - - -0.07615327835083008
+                            - 51.50115276135022
+                          - - -0.07716178894042969
+                            - 51.50094238217541
+  '/api/v1/planning_applications/{planning_application_id}/change_requests':
+    get:
+      summary: Retrieves all determined planning applications
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: planning_application_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The planning application ID
+        - in: query
+          name: change_access_id
+          schema:
+            type: string
+          required: true
+          description: A unique access code for this planning application
+      responses:
+        '200':
+          description: All change requests
+          content:
+            application/json:
+              examples:
+                Full:
+                  value:
+                    data:
+                      - id: 1
+                        type: description_change_request
+                        proposed_description: A proposed new description
+                        state: open
+                        response_due: '2020-05-14T05:18:17.540Z'
+                        approved: true
+                        rejection_reason: nil
+  '/api/v1/planning_applications/{planning_application_id}/description_change_requests/{description_change_request_id}':
+    patch:
+      summary: Saves the response for a description change request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: planning_application_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The planning application ID
+        - in: path
+          name: description_change_request_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The change request ID
+        - in: query
+          name: change_access_id
+          schema:
+            type: string
+          required: true
+          description: A unique access code for this planning application
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approved:
+                  type: boolean
+                  example: true
+                rejection_reason:
+                  type: string
+                  example: Refusal reason
+              required:
+                - approved
+            examples:
+              Accept:
+                value:
+                  data:
+                    approved: true
+              Reject:
+                value:
+                  data:
+                    approved: false
+                    rejection_reason: Refusal reason
+      responses:
+        '200':
+          description: Update change request
+          content:
+            application/json:
+              examples:
+                Accept:
+                  value:
+                    message:
+                      - Change request updated

--- a/public/api-docs/v1/change_requests.yaml
+++ b/public/api-docs/v1/change_requests.yaml
@@ -1,0 +1,99 @@
+"/api/v1/planning_applications/{planning_application_id}/change_requests":
+  get:
+    summary: Retrieves all determined planning applications
+    security:
+      - bearerAuth: []
+    parameters:
+      - in: path
+        name: planning_application_id
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The planning application ID
+      - in: query
+        name: change_access_id
+        schema:
+          type: string
+        required: true
+        description: A unique access code for this planning application
+
+    responses:
+      "200":
+        description: All change requests
+        content:
+          application/json:
+            examples:
+              Full:
+                value:
+                  data:
+                    - id: 1
+                      type: description_change_request
+                      proposed_description: A proposed new description
+                      state: open
+                      response_due: "2020-05-14T05:18:17.540Z"
+                      approved: true
+                      rejection_reason: nil
+
+
+"/api/v1/planning_applications/{planning_application_id}/description_change_requests/{description_change_request_id}":
+  patch:
+    summary: Saves the response for a description change request
+    security:
+    - bearerAuth: []
+    parameters:
+      - in: path
+        name: planning_application_id
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The planning application ID
+      - in: path
+        name: description_change_request_id
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The change request ID
+      - in: query
+        name: change_access_id
+        schema:
+          type: string
+        required: true
+        description: A unique access code for this planning application
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              approved:
+                type: boolean
+                example: true
+              rejection_reason:
+                type: string
+                example: "Refusal reason"
+            required:
+              - approved
+          examples:
+            Accept:
+              value:
+                data:
+                  approved: true
+            Reject:
+              value:
+                data:
+                  approved: false
+                  rejection_reason: "Refusal reason"
+
+    responses:
+      "200":
+        description: Update change request
+        content:
+          application/json:
+            examples:
+              Accept:
+                value:
+                  message:
+                    - Change request updated

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -377,3 +377,87 @@ paths:
                           - [-0.07645905017852783, 51.50053497847238]
                           - [-0.07615327835083008, 51.50115276135022]
                           - [-0.07716178894042969, 51.50094238217541]
+
+  "/api/v1/planning_applications/{planning_application_id}/change_requests":
+    get:
+      summary: Retrieves all determined planning applications
+      parameters:
+        - in: path
+          name: planning_application_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The planning application ID
+        - in: query
+          name: change_access_id
+          schema:
+            type: string
+          required: true
+          description: A unique access code for this planning application
+
+      responses:
+        '200':
+          description: All change requests
+          content:
+            application/json:
+              examples:
+                Full:
+                  value:
+                    data:
+                      - id: 1
+                        type: description_change_request
+                        proposed_description: A proposed new description
+                        state: open
+                        response_due: '2020-05-14T05:18:17.540Z'
+                        approved: true
+                        rejection_reason: nil
+
+  "/api/v1/planning_applications/{planning_application_id}/description_change_requests/{id}":
+    put:
+      summary: Saves the response for a description change request
+      parameters:
+        - in: path
+          name: planning_application_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The planning application ID
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The change request ID
+        - in: query
+          name: change_access_id
+          schema:
+            type: string
+          required: true
+          description: A unique access code for this planning application
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                approved:
+                  type: boolean
+                  example: true
+                rejection_reason:
+                  type: string
+                  example: "Refusal reason"
+              required:
+              - approved
+            examples:
+              Accept:
+                value:
+                  data:
+                    approved: true
+              Reject:
+                value:
+                  data:
+                    approved: false
+                    rejection_reason: "Refusal reason"

--- a/spec/requests/api/change_request_list_spec.rb
+++ b/spec/requests/api/change_request_list_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API request to list change requests", type: :request, show_exceptions: true do
+  let!(:api_user) { create :api_user }
+  let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority) }
+  let!(:description_change_request) { create(:description_change_request, planning_application: planning_application) }
+
+  it "lists the description_change_requests that exist on the planning application" do
+    get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+    expect(response).to be_successful
+    expect(json["data"]).to eq([{
+      "id" => description_change_request.id,
+      "type" => "description_change_request",
+      "state" => "open",
+      "response_due" => description_change_request.response_due.to_s,
+      "proposed_description" => description_change_request.proposed_description,
+      "approved" => nil,
+      "rejection_reason" => nil,
+    }])
+  end
+
+  it "returns a 401 if API key is wrong" do
+    get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer bipbopboop" }
+    expect(response.status).to eq(401)
+  end
+
+  it "returns a 401 if change_access_id is wrong" do
+    get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=fffffff", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+    expect(response.status).to eq(401)
+  end
+end

--- a/spec/requests/api/description_change_request_put_spec.rb
+++ b/spec/requests/api/description_change_request_put_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe "API request to list change requests", type: :request, show_exceptions: true do
+  let!(:api_user) { create :api_user }
+  let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority) }
+  let!(:description_change_request) { create(:description_change_request, planning_application: planning_application) }
+
+  approved_json = '{
+    "data": {
+      "approved": true
+    }
+  }'
+
+  rejected_json = '{
+    "data": {
+      "approved": false,
+      "rejection_reason": "The description is unclear"
+    }
+  }'
+
+  rejected_json_missing_reason = '{
+    "data": {
+      "approved": false,
+      "rejection_reason": ""
+    }
+  }'
+
+  it "successfully accepts an approval" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_requests/#{description_change_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: approved_json,
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response).to be_successful
+
+    description_change_request.reload
+    expect(description_change_request.state).to eq("closed")
+    expect(description_change_request.approved).to eq(true)
+  end
+
+  it "successfully accepts a rejection" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_requests/#{description_change_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: rejected_json,
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response).to be_successful
+
+    description_change_request.reload
+    expect(description_change_request.state).to eq("closed")
+    expect(description_change_request.approved).to eq(false)
+    expect(description_change_request.rejection_reason).to eq("The description is unclear")
+  end
+
+  it "returns a 400 if the rejection is missing a rejection reason" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_requests/#{description_change_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: rejected_json_missing_reason,
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response.status).to eq(400)
+  end
+
+  it "returns a 401 if API key is wrong" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_requests/#{description_change_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: approved_json,
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer BEAR_THE_BEARER" }
+
+    expect(response.status).to eq(401)
+  end
+
+  it "returns a 401 if change_access_id is wrong" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_requests/#{description_change_request.id}?change_access_id=CHANGEISGOOD",
+          params: approved_json,
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response.status).to eq(401)
+  end
+end

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "The Open API Specification document", type: :request, show_exceptions: true do
-  let(:document) { Openapi3Parser.load_file(Rails.root.join("public/api-docs/v1/swagger_doc.yaml")) }
+  let(:document) { Openapi3Parser.load_file(Rails.root.join("public/api-docs/v1/_build/swagger_doc.yaml")) }
   let(:api_user) { create :api_user }
 
   def example_request_json_for(path, http_method, example_name)

--- a/spec/system/api_index_spec.rb
+++ b/spec/system/api_index_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Swagger index file", type: :system do
+  before do
+    visit "/api-docs/index.html"
+  end
+
+  it "Lists all available API options for planning applications" do
+    expect(page).to have_text("GET/api/v1/planning_applications/{id}")
+    expect(page).to have_text("GET/api/v1/planning_applications")
+    expect(page).to have_text("POST/api/v1/planning_applications")
+  end
+
+  it "Lists all available API options for change requests" do
+    expect(page).to have_text("GET/api/v1/planning_applications/{planning_application_id}/change_requests")
+    expect(page).to have_text("PATCH/api/v1/planning_applications/{planning_application_id}/description_change_requests")
+  end
+end

--- a/spec/system/planning_applications/requesting_changes_spec.rb
+++ b/spec/system/planning_applications/requesting_changes_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
   it "lists the current change requests and their statuses" do
     create :description_change_request, planning_application: planning_application, state: "open", created_at: 12.days.ago
     create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: true
-    create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false
+    create :description_change_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false, rejection_reason: "No good"
     create :description_change_request, planning_application: planning_application, state: "open", created_at: 35.days.ago
 
     click_link "Validate application"


### PR DESCRIPTION
### Description of change

- Separate change requests and description  change requests into their own controllers
- Add separate change requests yaml file and README instructions on how to have separate yaml files
- Updates state of change request to close upon successful PUT
- Add swagger index spec to ensure all the requests are being listed on swagger page
- Add validation to prevent rejecting a description change request without a comment

### Story Link

https://trello.com/c/g4SHx8aA/292-as-an-applicant-i-can-accept-or-reject-a-request-to-change-a-description

### Decisions

- Separated yaml files to make the code more maintainable
- Created separate controller for change requests which inherits from the planning applications controller