### PR TITLE
Add change request email methods

### DIFF
--- a/app/controllers/description_change_requests_controller.rb
+++ b/app/controllers/description_change_requests_controller.rb
@@ -10,6 +10,7 @@ class DescriptionChangeRequestsController < ApplicationController
     @description_change_request.user = current_user
 
     if @description_change_request.save
+      change_request_mail
       flash[:notice] = "Change request for description successfully sent."
       redirect_to validate_documents_form_planning_application_path(@planning_application)
     else
@@ -29,5 +30,13 @@ private
 
   def set_planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
+  end
+
+  def change_request_mail
+    PlanningApplicationMailer.change_request_mail(
+      @planning_application,
+      request.host,
+      @description_change_request,
+    ).deliver_now
   end
 end

--- a/app/controllers/description_change_requests_controller.rb
+++ b/app/controllers/description_change_requests_controller.rb
@@ -8,9 +8,10 @@ class DescriptionChangeRequestsController < ApplicationController
   def create
     @description_change_request = @planning_application.description_change_requests.new(description_change_request_params)
     @description_change_request.user = current_user
+    @current_local_authority = current_local_authority
 
     if @description_change_request.save
-      change_request_mail
+      send_change_request_email
       flash[:notice] = "Change request for description successfully sent."
       redirect_to validate_documents_form_planning_application_path(@planning_application)
     else
@@ -32,10 +33,9 @@ private
     @planning_application = PlanningApplication.find(params[:planning_application_id])
   end
 
-  def change_request_mail
+  def send_change_request_email
     PlanningApplicationMailer.change_request_mail(
       @planning_application,
-      request.host,
       @description_change_request,
     ).deliver_now
   end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -26,8 +26,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
-  def change_request_mail(planning_application, host, change_request)
-    @host = host
+  def change_request_mail(planning_application, change_request)
     @planning_application = planning_application
     @change_request = change_request
 

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -25,4 +25,16 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       to: @planning_application.applicant_email,
     )
   end
+
+  def change_request_mail(planning_application, host, change_request)
+    @host = host
+    @planning_application = planning_application
+    @change_request = change_request
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: "Change requested to your planning application",
+      to: @planning_application.applicant_email,
+    )
+  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -215,6 +215,10 @@ class PlanningApplication < ApplicationRecord
     "#{address_1}, #{town}, #{postcode}"
   end
 
+  def secure_change_url(subdomain, application_id, secure_token)
+    "https://#{subdomain}#{change_url}/planning_applications/#{application_id}/change_requests?change_access_id=#{secure_token}"
+  end
+
 private
 
   def set_target_date
@@ -228,6 +232,16 @@ private
   def documents_validated_at_date
     if in_assessment? && !documents_validated_at.is_a?(Date)
       errors.add(:planning_application, "Please enter a valid date")
+    end
+  end
+
+  def change_url
+    if ENV["RAILS_ENV"] == "production"
+      "bops-applicants.services"
+    elsif ENV["RAILS_ENV"] == "staging"
+      "bops-applicants-staging.services"
+    else
+      ""
     end
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -215,8 +215,12 @@ class PlanningApplication < ApplicationRecord
     "#{address_1}, #{town}, #{postcode}"
   end
 
-  def secure_change_url(subdomain, application_id, secure_token)
-    "https://#{subdomain}#{change_url}/planning_applications/#{application_id}/change_requests?change_access_id=#{secure_token}"
+  def secure_change_url(application_id, secure_token)
+    if ENV["RAILS_ENV"] == "production" || ENV["RAILS_ENV"] == "preview"
+      "https://#{local_authority.subdomain}.#{ENV['applicants_app_host']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+    else
+      "http://#{local_authority.subdomain}.#{ENV['applicants_app_host']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+    end
   end
 
 private
@@ -232,16 +236,6 @@ private
   def documents_validated_at_date
     if in_assessment? && !documents_validated_at.is_a?(Date)
       errors.add(:planning_application, "Please enter a valid date")
-    end
-  end
-
-  def change_url
-    if ENV["RAILS_ENV"] == "production"
-      "bops-applicants.services"
-    elsif ENV["RAILS_ENV"] == "staging"
-      "bops-applicants-staging.services"
-    else
-      ""
     end
   end
 

--- a/app/views/planning_application_mailer/change_request_mail.text.erb
+++ b/app/views/planning_application_mailer/change_request_mail.text.erb
@@ -1,0 +1,21 @@
+Application number: <%= @planning_application.reference %>
+Application received: <%= @planning_application.created_at.strftime("%e %B %Y") %>
+At: <%= @planning_application.full_address %>
+
+Dear <%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %>
+
+<%= @change_request.user.name %>, the case officer working on your planning application has requested change(s) on your application.
+
+To review the requested change please follow the link below:
+
+Review requested actions: <%= @planning_application.secure_change_url(@host, @planning_application.id,  @planning_application.change_access_id) %>
+
+If we don't hear from you:
+
+We will take no further action on your application until you submit the following change(s).
+
+If these change(s) are not received by <%= @change_request.response_due.strftime("%e %B %Y") %>, your application will be returned to you and your payment refunded.
+
+Yours faithfully,
+<%= @planning_application.local_authority.signatory_name %>, <%= @planning_application.local_authority.signatory_job_title %>,
+<%= @planning_application.local_authority.name %>

--- a/app/views/planning_application_mailer/change_request_mail.text.erb
+++ b/app/views/planning_application_mailer/change_request_mail.text.erb
@@ -8,7 +8,7 @@ Dear <%= @planning_application.applicant_first_name %> <%= @planning_application
 
 To review the requested change please follow the link below:
 
-Review requested actions: <%= @planning_application.secure_change_url(@host, @planning_application.id,  @planning_application.change_access_id) %>
+Review requested actions: <%= @planning_application.secure_change_url(@planning_application.id, @planning_application.change_access_id) %>
 
 If we don't hear from you:
 

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -70,9 +70,6 @@
   <% end %>
 
   <%= form.govuk_radio_buttons_fieldset(:status, legend: {size: 's', text: 'Is the application valid?' }) do %>
-    <span class="govuk-hint">
-      If the application is invalid, please contact the applicant via email.
-    </span>
       <%= form.govuk_radio_button :status, 'in_assessment', label: { text: 'Yes'} do %>
         <%= form.govuk_date_field :documents_validated_at, legend: { text: '', size: 's' }, hint: { text: 'Enter valid date, e.g. 28 12 2021' } %>
       <% end %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   let(:local_authority) do
     create :local_authority,
            name: "Cookie authority",
+           subdomain: "cookies",
            signatory_name: "Mr. Biscuit",
            signatory_job_title: "Lord of BiscuitTown",
            enquiries_paragraph: "reach us on postcode SW50",
@@ -64,6 +65,8 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#validation_notice_mail" do
     let(:validation_mail) { described_class.validation_notice_mail(planning_application, host) }
 
+    ENV["applicants_app_host"] = "example.com"
+
     it "renders the headers" do
       expect(validation_mail.subject).to eq("Your planning application has been validated")
       expect(validation_mail.to).to eq([planning_application.applicant_email])
@@ -80,7 +83,9 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#change_request_mail" do
-    let(:change_request_mail) { described_class.change_request_mail(planning_application.reload, host, change_request) }
+    let(:change_request_mail) { described_class.change_request_mail(planning_application.reload, change_request) }
+
+    ENV["applicants_app_host"] = "localhost"
 
     it "renders the headers" do
       expect(change_request_mail.subject).to eq("Change requested to your planning application")
@@ -92,7 +97,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(change_request_mail.body.encoded).to include(change_request.user.name)
       expect(change_request_mail.body.encoded).to include(change_request.response_due.strftime("%e %B %Y"))
       expect(change_request_mail.body.encoded).to include(planning_application.change_access_id)
-      expect(change_request_mail.body.encoded).to include("https://default.example.com/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}")
+      expect(change_request_mail.body.encoded).to include("http://cookies.localhost/change_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}")
       expect(change_request_mail.body.encoded).to include("Mr. Biscuit")
       expect(change_request_mail.body.encoded).to include("Cookie authority")
       expect(change_request_mail.body.encoded).to include("Lord of BiscuitTown")


### PR DESCRIPTION
### Description of change

This creates the secure url parameterised with the change_id token and sends out the email to the applicant. Note that it forms only a small part of the story linked below.

### Story Link

https://trello.com/c/g4SHx8aA/292-as-an-applicant-i-can-accept-or-reject-a-request-to-change-a-description-part-2

