### PR TITLE
Update planning application description when CR approved

### DIFF
--- a/app/controllers/api/v1/description_change_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_requests_controller.rb
@@ -7,6 +7,7 @@ class Api::V1::DescriptionChangeRequestsController < Api::V1::ApplicationControl
 
     if @description_change_request.update(description_change_params)
       @description_change_request.update!(state: "closed")
+      @planning_application.update!(description: @description_change_request.proposed_description) if @description_change_request.approved?
       render json: { "message": "Change request updated" }, status: :ok
     else
       render json: { "message": "Unable to update request. Please ensure rejection_reason is present if approved is false." }, status: 400

--- a/spec/requests/api/description_change_request_put_spec.rb
+++ b/spec/requests/api/description_change_request_put_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe "API request to list change requests", type: :request, show_exceptions: true do
   let!(:api_user) { create :api_user }
   let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority) }
-  let!(:description_change_request) { create(:description_change_request, planning_application: planning_application) }
+  let!(:description_change_request) do
+    create(:description_change_request,
+           planning_application: planning_application,
+           proposed_description: "new roof")
+  end
 
   approved_json = '{
     "data": {
@@ -33,8 +37,11 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
     expect(response).to be_successful
 
     description_change_request.reload
+    planning_application.reload
     expect(description_change_request.state).to eq("closed")
     expect(description_change_request.approved).to eq(true)
+    expect(description_change_request.approved).to eq(true)
+    expect(planning_application.description).to eq("new roof")
   end
 
   it "successfully accepts a rejection" do
@@ -47,7 +54,6 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
     description_change_request.reload
     expect(description_change_request.state).to eq("closed")
     expect(description_change_request.approved).to eq(false)
-    expect(description_change_request.rejection_reason).to eq("The description is unclear")
   end
 
   it "returns a 400 if the rejection is missing a rejection reason" do


### PR DESCRIPTION
### Description of change

When an approval is received, we need to update the planning application description with the proposed_description from the change request

A brief description of the change, with enough context for the reviewer to be able to understand why we're making this change.

### Story Link

https://trello.com/c/j4l5sZGz/311-bops-change-requests-chores

