### PR TITLE
Contact email is visible if it exists

### DIFF
--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -94,6 +94,12 @@
           <%= @planning_application.agent_email %>
         </p>
       <% end %>
+      <% if @planning_application.agent_email? && !@planning_application.agent? %>
+        <p class='govuk-body'>
+          <strong>Agent: </strong><br>
+          <%= @planning_application.agent_email %>
+        </p>
+      <% end %>
       <% if @planning_application.applicant? %>
         <p class='govuk-body'>
           <strong>Applicant: </strong><br>
@@ -102,6 +108,12 @@
           <%= @planning_application.applicant_phone %><br>
           <%= @planning_application.applicant_email %>
         </p>
+      <% end %>
+      <% if @planning_application.applicant_email? && !@planning_application.applicant? %>
+      <p class='govuk-body'>
+        <strong>Applicant: </strong><br>
+        <%= @planning_application.applicant_email %>
+      </p>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
### Description of change

Until now, we only displayed contact information if all fields were present for agent or applicant. However, now we started making email a required field - and it is the only required field - so it makes sense to display that email in contact information if it exists, given its the only field we are guaranteed to have.

### Story Link

https://trello.com/c/Z4DqLRhJ/312-chore-ensure-contact-email-is-displayed-if-present

![image](https://user-images.githubusercontent.com/9452321/117652819-8bdcb580-b18b-11eb-90bd-d075df3985a9.png)
