### PR TITLE
Upper-case applicants_app_host env var

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -217,9 +217,9 @@ class PlanningApplication < ApplicationRecord
 
   def secure_change_url(application_id, secure_token)
     if ENV["RAILS_ENV"] == "production" || ENV["RAILS_ENV"] == "preview"
-      "https://#{local_authority.subdomain}.#{ENV['applicants_app_host']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+      "https://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     else
-      "http://#{local_authority.subdomain}.#{ENV['applicants_app_host']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+      "http://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     end
   end
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#validation_notice_mail" do
     let(:validation_mail) { described_class.validation_notice_mail(planning_application, host) }
 
-    ENV["applicants_app_host"] = "example.com"
+    ENV["APPLICANTS_APP_HOST"] = "example.com"
 
     it "renders the headers" do
       expect(validation_mail.subject).to eq("Your planning application has been validated")
@@ -85,7 +85,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#change_request_mail" do
     let(:change_request_mail) { described_class.change_request_mail(planning_application.reload, change_request) }
 
-    ENV["applicants_app_host"] = "localhost"
+    ENV["APPLICANTS_APP_HOST"] = "localhost"
 
     it "renders the headers" do
       expect(change_request_mail.subject).to eq("Change requested to your planning application")


### PR DESCRIPTION
### Description of change

The APPLICANTS_APP_HOST environment variable was lower-case. This fixes it.