### PR TITLE
Display previous description & http email endpoint 

### DIFF
--- a/app/controllers/api/v1/description_change_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_requests_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::DescriptionChangeRequestsController < Api::V1::ApplicationControl
     if @description_change_request.update(description_change_params)
       @description_change_request.update!(state: "closed")
       @planning_application.update!(description: @description_change_request.proposed_description) if @description_change_request.approved?
+
       render json: { "message": "Change request updated" }, status: :ok
     else
       render json: { "message": "Unable to update request. Please ensure rejection_reason is present if approved is false." }, status: 400

--- a/app/helpers/description_change_request_helper.rb
+++ b/app/helpers/description_change_request_helper.rb
@@ -18,4 +18,8 @@ module DescriptionChangeRequestHelper
       "green"
     end
   end
+
+  def change_rejected?(description_change_request)
+    description_change_request.state == "closed" && description_change_request.approved == false
+  end
 end

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class DescriptionChangeRequest < ApplicationRecord
+  before_create :set_previous_application_description
+
   belongs_to :planning_application
   belongs_to :user
 
@@ -26,5 +28,9 @@ class DescriptionChangeRequest < ApplicationRecord
     if approved == false
       errors.add(:base, "Please include a comment for the case officer to indicate why the description change has been rejected.") if rejection_reason.blank?
     end
+  end
+
+  def set_previous_application_description
+    self.previous_description = planning_application.description
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -217,9 +217,9 @@ class PlanningApplication < ApplicationRecord
 
   def secure_change_url(application_id, secure_token)
     if ENV["DOMAIN"] == "bops-staging.services"
-      "https://#{local_authority.subdomain}.bops-applicants-staging.services/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+      "http://#{local_authority.subdomain}.bops-applicants-staging.services/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     elsif ENV["DOMAIN"] == "bops.services"
-      "https://#{local_authority.subdomain}.bops-applicants.services/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
+      "http://#{local_authority.subdomain}.bops-applicants.services/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     else
       "http://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     end

--- a/app/views/api/v1/change_requests/index.json.jbuilder
+++ b/app/views/api/v1/change_requests/index.json.jbuilder
@@ -6,6 +6,7 @@ json.data @planning_application.description_change_requests.each do |description
                 :state,
                 :response_due,
                 :proposed_description,
+                :previous_description,
                 :rejection_reason,
                 :approved,
                 :days_until_response_due

--- a/app/views/description_change_requests/show.html.erb
+++ b/app/views/description_change_requests/show.html.erb
@@ -1,14 +1,11 @@
 <% add_parent_breadcrumb_link "Home", planning_applications_path %>
 <% add_parent_breadcrumb_link "Application", validate_documents_form_planning_application_path(@planning_application) %>
-
 <% content_for :title, "Request changes to description" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-padding-bottom-4">
       Request for approval of changes to description
     </h2>
-
     <div class="govuk-!-margin-top-8">
       <p class="govuk-body govuk-!-margin-bottom-1">
         <strong>Application number:</strong> <%= @planning_application.reference  %>
@@ -19,7 +16,6 @@
       <p class="govuk-body govuk-!-margin-bottom-1">
         <strong>Request sent:</strong> <%= @description_change_request.created_at.strftime("%e %B %Y") %>
       </p>
-
       <strong class="govuk-!-margin-top-4 govuk-tag govuk-tag--<%=display_request_status(@description_change_request) %>">
         <% if @description_change_request.state == "open" %>
           Open
@@ -27,26 +23,22 @@
           <%= @description_change_request.approved? ? 'Approved' : 'Rejected' %>
         <% end %>
       </strong>
-
       <div class="govuk-!-margin-top-6">
         <p class="govuk-body"> <strong> Previous description:</strong><br>
-          <%= @planning_application.description  %>
+          <%= @description_change_request.previous_description  %>
         </p>
         <p class="govuk-body"> <strong> Suggested description:</strong><br>
           <%= @description_change_request.proposed_description  %>
         </p>
       </div>
     </div>
-
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <% if @description_change_request.rejection_reason.present? %>
       <p class="govuk-body">
         <strong>Applicant objection to suggested changes:</strong><br>
         <%= @description_change_request.rejection_reason %>
       </p>
     <% end %>
-
     <%= link_to "Back", validate_documents_form_planning_application_path(@planning_application), class: "govuk-!-margin-top-8 govuk-button" %>
   </div>
 </div>

--- a/app/views/planning_applications/validate_documents_form.html.erb
+++ b/app/views/planning_applications/validate_documents_form.html.erb
@@ -25,7 +25,7 @@
     <tbody class="govuk-table__body">
       <% @planning_application.description_change_requests.order_by_latest.each do |description_change_request| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell change-request-list">
           <%= link_to "Description", planning_application_description_change_request_path(@planning_application, description_change_request), class: "govuk-link" %>
         </td>
         <td class="govuk-table__cell">

--- a/db/migrate/20210512164502_add_previous_description_to_change_requests.rb
+++ b/db/migrate/20210512164502_add_previous_description_to_change_requests.rb
@@ -1,0 +1,5 @@
+class AddPreviousDescriptionToChangeRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :description_change_requests, :previous_description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_22_152427) do
+ActiveRecord::Schema.define(version: 2021_05_12_164502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_152427) do
     t.string "rejection_reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "previous_description"
     t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
     t.index ["user_id"], name: "index_description_change_requests_on_user_id"
   end
@@ -147,6 +148,7 @@ ActiveRecord::Schema.define(version: 2021_04_22_152427) do
     t.json "boundary_geojson"
     t.text "constraints", default: [], null: false, array: true
     t.string "change_access_id"
+    t.string "previous_description"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"
   end

--- a/spec/requests/api/change_request_list_spec.rb
+++ b/spec/requests/api/change_request_list_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
       "state" => "open",
       "response_due" => description_change_request.response_due.to_s,
       "proposed_description" => description_change_request.proposed_description,
+      "previous_description" => description_change_request.previous_description,
       "approved" => nil,
       "rejection_reason" => nil,
       "days_until_response_due" => description_change_request.days_until_response_due,


### PR DESCRIPTION
### Description of change

Keep track of new and current descriptions within each description change request. 

- Change requests keep track of previous descriptions of the applications
- We have decided that bops-applicants will be served over http as it is only a proof of concept,
so the email sent to the applicant should contain the http app link instead of https

![image](https://user-images.githubusercontent.com/9452321/118144063-ec762780-b403-11eb-8132-02bd2f42e03b.png)
