### PR TITLE
Update application type to reflect work status

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -27,6 +27,14 @@ module PlanningApplicationHelper
     planning_application.work_status == "proposed" ? "No" : "Yes"
   end
 
+  def status_and_type(planning_application)
+    if planning_application.work_status == "proposed" && planning_application.application_type == "lawfulness_certificate"
+      "Lawful ​Development ​Certificate (Proposed)"
+    elsif planning_application.work_status == "existing" && planning_application.application_type == "lawfulness_certificate"
+      "Lawful ​Development ​Certificate (Existing)"
+    end
+  end
+
   def filter_text
     if current_user.assessor?
       "View my applications"

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -27,8 +27,8 @@
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>Application type:</strong></td>
-            <td class="govuk-table__cell">Proposed permitted development:
-              <%= t("application_types.#{@planning_application.application_type}") %>
+            <td class="govuk-table__cell">
+              <%= status_and_type(@planning_application) %>
             </td>
           </tr>
           <tr class="govuk-table__row">

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Creating a planning application", type: :system do
 
       expect(page).to have_text("Site address: Palace Road, Crystal Palace, SE19 2LX")
       expect(page).to have_text("UPRN: 19284783939")
-      expect(page).to have_text("Proposed permitted development: Certificate of Lawfulness")
+      expect(page).to have_text("Application type: Lawful Development Certificate (Proposed)")
       expect(page).to have_text("Work already completed: No")
       expect(page).to have_text("Description: Backyard bird hotel")
       expect(page).to have_text("Payment Reference: 232432544")

--- a/spec/system/planning_applications/requesting_changes_spec.rb
+++ b/spec/system/planning_applications/requesting_changes_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Requesting changes to a planning application", type: :system do
     expect(page).to have_content("Request for approval of changes to description")
     expect(page).to have_content("Application number: #{planning_application.reference}")
     expect(page).to have_content("At: #{planning_application.full_address}")
-    expect(page).to have_content("Request sent:#{description_change_request.created_at.strftime('%e %B %Y')}")
+    expect(page).to have_content("Request sent: #{description_change_request.created_at.strftime('%-e %B %Y')}")
     expect(page).to have_content("Open")
     expect(page).to have_content("Previous description: #{planning_application.description}")
     expect(page).to have_content("Suggested description: #{description_change_request.proposed_description}")

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("Site address: 7 Elm Grove, London, SE15 6UT")
       expect(page).to have_text("UPRN: 00773377")
       expect(page).to have_link("View site on Google Maps")
-      expect(page).to have_text("Application type: Proposed permitted development: Certificate of Lawfulness")
+      expect(page).to have_text("Application type: Lawful Development Certificate (Proposed)")
       expect(page).to have_text("Description: Roof extension")
       expect(page).to have_text("PAY123")
     end
@@ -137,6 +137,18 @@ RSpec.describe "Planning Application show page", type: :system do
 
       expect(page).to have_current_path(/sign_in/)
       expect(page).to have_content("You need to sign in or sign up before continuing.")
+    end
+  end
+
+  context "when work status is existing" do
+    before do
+      sign_in assessor
+      planning_application.update!(work_status: "existing")
+      visit planning_application_path(planning_application.reload.id)
+    end
+
+    it "displays the correct application type" do
+      expect(page).to have_text("Application type: Lawful Development Certificate (Existing)")
     end
   end
 end


### PR DESCRIPTION
### Description of change

This change adds a helper method to derive the application description from application type and work status. It's currently an if statement but can be changed to a case statement when we add further certificate types.

### Story Link

https://trello.com/c/LL56t8jY/282-reflect-work-status-in-planning-application-information

