### PR TITLE
Display UK timezone on audit log

### DIFF
--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -17,7 +17,7 @@
   <tbody class="govuk-table__body">
     <% @audits.each do |audit_item| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= audit_item.created_at.strftime("%d-%m-%Y %H:%M") %></td>
+        <td class="govuk-table__cell"><%= audit_item.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M") %></td>
         <% if audit_item.user %>
           <td class="govuk-table__cell"><%= audit_item.user.name %></td>
         <% elsif audit_item.api_user %>

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe "Documents index page", type: :system do
       expect(page).to have_text("Document archived")
       expect(page).to have_text("proposed-floorplan.png")
       expect(page).to have_text(assessor.name)
-      expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
     end
 
     it "User can log out from archive page" do

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe "Assigning a planning application", type: :system do
     click_link "Activity log"
 
     expect(page).to have_text("Application assigned to Assessor 2")
-    expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
 
     expect(page).to have_text("Application unassigned")
-    expect(page).to have_text(Audit.second_to_last.created_at.strftime("%d-%m-%Y %H:%M"))
+    expect(page).to have_text(Audit.second_to_last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
   end
 end

--- a/spec/system/planning_applications/cancelling_spec.rb
+++ b/spec/system/planning_applications/cancelling_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       expect(page).to have_text("Application withdrawn")
       expect(page).to have_text(assessor.name)
-      expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
     end
 
     it "can return an application" do
@@ -52,7 +52,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       expect(page).to have_text("Application returned")
       expect(page).to have_text(assessor.name)
-      expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
     end
 
     it "errors if no option chosen" do

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).to have_text("Recommendation submitted")
       expect(page).to have_text(assessor.name)
       expect(page).to have_text("Edited private assessor comment")
-      expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
     end
   end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     expect(page).to have_text("Recommendation challenged")
     expect(page).to have_text("Reviewer private comment")
-    expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
   end
 
   it "cannot be rejected without a review comment" do

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -29,7 +29,7 @@ RSpec.shared_examples "validate and invalidate" do
 
     expect(page).to have_text("Application validated")
     expect(page).to have_text(assessor.name)
-    expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
   end
 
   it "can be invalidated" do
@@ -53,7 +53,7 @@ RSpec.shared_examples "validate and invalidate" do
 
     expect(page).to have_text("Application invalidated")
     expect(page).to have_text(assessor.name)
-    expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    expect(page).to have_text(Audit.last.created_at.in_time_zone("London").strftime("%d-%m-%Y %H:%M"))
   end
 
   it "allows document edit, archive and upload after invalidation" do


### PR DESCRIPTION
### Description of change

Time displayed was previously UTC. This update forces the app to use London, regardless of server timezone or user's timezone

### Story Link

https://trello.com/c/q7YTMdcA/272-time-in-bops-is-all-gmt-never-got-updated-to-bst

### Decisions 

I decided to go down the route of simply displaying London timezone times in the audit log instead of UTC because this way it avoids messing with what is stored in the DB and also avoids a dependency on server time. Following the "principle of least surprise", I reckon that simply updating the display to UK current time in this way would be what a planner might expect, even if they were temporarily in another timezone.
