### PR TITLE
Add document create requests

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -29,6 +29,15 @@ class Api::V1::ApplicationController < ApplicationController
     response.charset = "utf-8"
   end
 
+  def check_token_and_set_application
+    @planning_application = current_local_authority.planning_applications.find_by(id: params[:planning_application_id])
+    if params[:change_access_id] != @planning_application.change_access_id
+      render json: {}, status: 401
+    else
+      @planning_application
+    end
+  end
+
 private
 
   def authenticate

--- a/app/controllers/api/v1/description_change_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_requests_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::DescriptionChangeRequestsController < Api::V1::ApplicationController
   skip_before_action :verify_authenticity_token, only: :update
-  before_action :check_token_and_set_application, only: :update, if: :json_request?
+  before_action :check_token_and_set_application, only: :update
 
   def update
     @description_change_request = @planning_application.description_change_requests.where(id: params[:id]).first
@@ -20,14 +20,5 @@ private
   def description_change_params
     { approved: params[:data][:approved],
       rejection_reason: params[:data][:rejection_reason] }
-  end
-
-  def check_token_and_set_application
-    @planning_application = current_local_authority.planning_applications.where(id: params[:planning_application_id]).first
-    if params[:change_access_id] != @planning_application.change_access_id
-      render json: {}, status: 401
-    else
-      @planning_application
-    end
   end
 end

--- a/app/controllers/api/v1/document_create_requests_controller.rb
+++ b/app/controllers/api/v1/document_create_requests_controller.rb
@@ -1,17 +1,16 @@
 # frozen_string_literal: true
 
-class Api::V1::DocumentChangeRequestsController < Api::V1::ApplicationController
+class Api::V1::DocumentCreateRequestsController < Api::V1::ApplicationController
   skip_before_action :verify_authenticity_token, only: :update
   before_action :check_token_and_set_application, only: :update
   before_action :check_file_params_are_present, only: :update
 
   def update
-    @document_change_request = @planning_application.document_change_requests.find_by(id: params[:id])
+    @document_create_request = @planning_application.document_create_requests.find_by(id: params[:id])
     new_document = @planning_application.documents.create!(file: params[:new_file])
-    @document_change_request.update!(state: "closed", new_document: new_document)
+    @document_create_request.update!(state: "closed", new_document: new_document)
 
-    if @document_change_request.save
-      archive_old_document
+    if @document_create_request.save
       render json: { "message": "Change request updated" }, status: :ok
     else
       render json: { "message": "Unable to update request" }, status: 400
@@ -24,12 +23,5 @@ private
     if params[:new_file].blank?
       render json: { "message": "A file must be selected to proceed." }, status: 400
     end
-  end
-
-  def archive_old_document
-    @document_change_request.old_document.update!(
-      archive_reason: "Applicant has provived a replacement document.",
-      archived_at: Time.zone.now,
-    )
   end
 end

--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -10,6 +10,8 @@ class ChangeRequestsController < ApplicationController
       redirect_to new_planning_application_description_change_request_path
     elsif params[:change_request] == "replacement_document"
       redirect_to new_planning_application_document_change_request_path
+    elsif params[:change_request] == "create_document"
+      redirect_to new_planning_application_document_create_request_path
     else
       flash[:error] = "You must select a change request type to proceed."
       render "new"

--- a/app/controllers/document_create_requests_controller.rb
+++ b/app/controllers/document_create_requests_controller.rb
@@ -1,0 +1,35 @@
+class DocumentCreateRequestsController < ApplicationController
+  def new
+    @document_create_request = planning_application.document_create_requests.new
+  end
+
+  def create
+    @document_create_request = planning_application.document_create_requests.new(document_create_request_params)
+    @document_create_request.user = current_user
+
+    if @document_create_request.save
+      flash[:notice] = "Document create request successfully sent."
+      send_change_request_email
+      redirect_to validate_documents_form_planning_application_path(@planning_application)
+    else
+      render :new
+    end
+  end
+
+private
+
+  def document_create_request_params
+    params.require(:document_create_request).permit(:document_request_type, :document_request_reason)
+  end
+
+  def planning_application
+    @planning_application = PlanningApplication.find(params[:planning_application_id])
+  end
+
+  def send_change_request_email
+    PlanningApplicationMailer.change_request_mail(
+      @planning_application,
+      @document_create_request,
+    ).deliver_now
+  end
+end

--- a/app/helpers/change_request_helper.rb
+++ b/app/helpers/change_request_helper.rb
@@ -2,19 +2,19 @@ module ChangeRequestHelper
   def request_state(change_request)
     if change_request.class.name == "DescriptionChangeRequest"
       change_request.approved? ? "Accepted" : "Rejected"
-    elsif change_request.class.name == "DocumentChangeRequest"
+    else
       "Responded"
     end
   end
 
-  def description_approved_or_rejected(change_request)
+  def applicant_response(change_request)
     if change_request.class.name == "DescriptionChangeRequest"
       if change_request.approved?
         "Description change has been approved by the applicant"
       elsif change_request.approved == false
         change_request.rejection_reason.to_s
       end
-    elsif change_request.class.name == "DocumentChangeRequest" && change_request.state == "closed"
+    elsif change_request.state == "closed"
       link_to(change_request.new_document.name.to_s, edit_planning_application_document_path(change_request.planning_application, change_request.new_document.id.to_s))
     end
   end

--- a/app/models/document_create_request.rb
+++ b/app/models/document_create_request.rb
@@ -1,0 +1,10 @@
+class DocumentCreateRequest < ApplicationRecord
+  include ChangeRequest
+
+  belongs_to :planning_application
+  belongs_to :user
+  belongs_to :new_document, optional: true, class_name: "Document"
+
+  validates :document_request_type, presence: { message: "Please fill in the document request type." }
+  validates :document_request_reason, presence: { message: "Please fill in the reason for this document request." }
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -11,6 +11,7 @@ class PlanningApplication < ApplicationRecord
   has_many :recommendations, dependent: :destroy
   has_many :description_change_requests, dependent: :destroy
   has_many :document_change_requests, dependent: :destroy
+  has_many :document_create_requests, dependent: :destroy
 
   belongs_to :user, optional: true
   belongs_to :local_authority
@@ -235,7 +236,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def change_requests
-    (description_change_requests + document_change_requests).sort_by(&:created_at).reverse
+    (description_change_requests + document_change_requests + document_create_requests).sort_by(&:created_at).reverse
   end
 
 private

--- a/app/views/api/v1/change_requests/index.json.jbuilder
+++ b/app/views/api/v1/change_requests/index.json.jbuilder
@@ -33,4 +33,22 @@ json.data do
     end
     json.type "document_change_request"
   end
+
+  json.document_create_requests @planning_application.document_create_requests do |document_create_request|
+    json.extract! document_create_request,
+                  :id,
+                  :state,
+                  :response_due,
+                  :days_until_response_due,
+                  :document_request_type,
+                  :document_request_reason
+
+    json.new_document do
+      if document_create_request.new_document
+        json.name document_create_request.new_document.file.filename
+        json.url document_create_request.new_document.file.representation(resize_to_limit: [1000, 1000]).processed.url
+      end
+    end
+    json.type "document_create_request"
+  end
 end

--- a/app/views/change_requests/index.html.erb
+++ b/app/views/change_requests/index.html.erb
@@ -42,7 +42,7 @@
                     <td class="govuk-table__cell change-request-list">
                       Description change
                     </td>
-                  <% else %>
+                  <% elsif change_request.class.name == "DocumentChangeRequest" %>
                     <td class="govuk-table__cell change-request-list">
                       Replacement document
                     </td>
@@ -51,6 +51,16 @@
                     </td>
                     <td class="govuk-table__cell change-request-list">
                       <%= change_request.old_document.invalidated_document_reason %>
+                    </td>
+                  <% elsif change_request.class.name == "DocumentCreateRequest" %>
+                    <td class="govuk-table__cell change-request-list">
+                      New document
+                    </td>
+                    <td class="govuk-table__cell change-request-list">
+                      <%= change_request.document_request_type %>
+                    </td>
+                    <td class="govuk-table__cell change-request-list">
+                      <%= change_request.document_request_reason %>
                     </td>
                   <% end %>
                   <td class="govuk-table__cell">
@@ -65,7 +75,7 @@
                     <% end %>
                   </td>
                   <td class="govuk-table__cell">
-                    <%= description_approved_or_rejected(change_request) %>
+                    <%= applicant_response(change_request) %>
                   </td>
                 </tr>
               <% end %>

--- a/app/views/change_requests/new.html.erb
+++ b/app/views/change_requests/new.html.erb
@@ -19,6 +19,7 @@
           <%= form.govuk_radio_buttons_fieldset(:planning_application, legend: { size: 's', text: '' }) do %>
             <%= form.govuk_radio_button :change_request, 'description_change', label: { text: 'Request approval to a description change'} %>
             <%= form.govuk_radio_button :change_request, 'replacement_document', label: { text: 'Request replacement documents' } %>
+            <%= form.govuk_radio_button :change_request, 'create_document', label: { text: 'Request a new document' } %>
           <% end %>
         </div>
       </fieldset>

--- a/app/views/document_create_requests/new.html.erb
+++ b/app/views/document_create_requests/new.html.erb
@@ -1,0 +1,32 @@
+<%= render "change_requests/change_requests_breadcrumbs.html.erb" %>
+
+<% content_for :title, "Request a new document" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-6">
+      Request a new document
+    </h2>
+    <%= form_with model: [@planning_application, @document_create_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+        <fieldset class="govuk-fieldset">
+          <div class="govuk-!-padding-bottom-8">
+            <%= form.govuk_text_field :document_request_type,
+            label: { text: 'Please specify the new document type:', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-2' },
+            hint: { text: 'Eg. Existing floor plans' } %>
+          </div>
+        </fieldset>
+        <div>
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-!-padding-bottom-4">
+              <%= form.govuk_text_area :document_request_reason,
+              label: { text: 'Please specify the reason you have requested this document?',
+              size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-2'},
+              rows: 5 %>
+            </div>
+          </fieldset>
+        </div>
+        <%= form.govuk_submit "Send" %>
+        <%= link_to "Back", new_planning_application_change_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+    </div>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
     resources :change_requests, only: %i[index new create]
     resources :description_change_requests, only: %i[new create]
     resources :document_change_requests, only: %i[new create]
+    resources :document_create_requests, only: %i[new create]
   end
 
   namespace :api do
@@ -50,6 +51,7 @@ Rails.application.routes.draw do
         resources :change_requests, only: :index
         resources :description_change_requests, only: :update
         resources :document_change_requests, only: :update
+        resources :document_create_requests, only: :update
         resources :documents, only: %i[show]
       end
     end

--- a/db/migrate/20210524165604_create_document_create_requests.rb
+++ b/db/migrate/20210524165604_create_document_create_requests.rb
@@ -1,0 +1,14 @@
+class CreateDocumentCreateRequests < ActiveRecord::Migration[6.1]
+  def change
+    create_table :document_create_requests do |t|
+      t.references :planning_application, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.references :new_document, foreign_key: { to_table: :documents }
+      t.string :state, default: "open", null: false
+      t.string :document_request_type
+      t.string :document_request_reason
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_22_255806) do
+ActiveRecord::Schema.define(version: 2021_05_24_165604) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,6 +91,20 @@ ActiveRecord::Schema.define(version: 2021_05_22_255806) do
     t.index ["old_document_id"], name: "index_document_change_requests_on_old_document_id"
     t.index ["planning_application_id"], name: "index_document_change_requests_on_planning_application_id"
     t.index ["user_id"], name: "index_document_change_requests_on_user_id"
+  end
+
+  create_table "document_create_requests", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "new_document_id"
+    t.string "state", default: "open", null: false
+    t.string "document_request_type"
+    t.string "document_request_reason"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["new_document_id"], name: "index_document_create_requests_on_new_document_id"
+    t.index ["planning_application_id"], name: "index_document_create_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_document_create_requests_on_user_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -208,6 +222,9 @@ ActiveRecord::Schema.define(version: 2021_05_22_255806) do
   add_foreign_key "document_change_requests", "documents", column: "old_document_id"
   add_foreign_key "document_change_requests", "planning_applications"
   add_foreign_key "document_change_requests", "users"
+  add_foreign_key "document_create_requests", "documents", column: "new_document_id"
+  add_foreign_key "document_create_requests", "planning_applications"
+  add_foreign_key "document_create_requests", "users"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -540,7 +540,7 @@ paths:
                     rejection_reason: Refusal reason
       responses:
         '200':
-          description: Update change request
+          description: Update description change request
           content:
             application/json:
               examples:
@@ -585,7 +585,52 @@ paths:
                   format: binary
       responses:
         '200':
-          description: Update change request
+          description: Update document change request
+          content:
+            application/json:
+              examples:
+                Accept:
+                  value:
+                    message:
+                      - Change request updated
+  '/api/v1/planning_applications/{planning_application_id}/document_create_requests/{document_create_request_id}':
+    patch:
+      summary: Update a document create request
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: planning_application_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The planning application ID
+        - in: path
+          name: document_create_request_id
+          required: true
+          schema:
+            type: integer
+            minimum: 1
+          description: The change request ID
+        - in: query
+          name: change_access_id
+          schema:
+            type: string
+          required: true
+          description: A unique access code for this planning application
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                new_file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Update document create change request
           content:
             application/json:
               examples:

--- a/public/api-docs/v1/change_requests.yaml
+++ b/public/api-docs/v1/change_requests.yaml
@@ -102,7 +102,7 @@
 
     responses:
       "200":
-        description: Update change request
+        description: Update description change request
         content:
           application/json:
             examples:
@@ -148,7 +148,53 @@
                 format: binary
     responses:
       "200":
-        description: Update change request
+        description: Update document change request
+        content:
+          application/json:
+            examples:
+              Accept:
+                value:
+                  message:
+                    - Change request updated
+
+? "/api/v1/planning_applications/{planning_application_id}/document_create_requests/{document_create_request_id}"
+: patch:
+    summary: Update a document create request
+    security:
+      - bearerAuth: []
+    parameters:
+      - in: path
+        name: planning_application_id
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The planning application ID
+      - in: path
+        name: document_create_request_id
+        required: true
+        schema:
+          type: integer
+          minimum: 1
+        description: The change request ID
+      - in: query
+        name: change_access_id
+        schema:
+          type: string
+        required: true
+        description: A unique access code for this planning application
+    requestBody:
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              new_file:
+                type: string
+                format: binary
+    responses:
+      "200":
+        description: Update document create change request
         content:
           application/json:
             examples:

--- a/spec/factories/document_create_requests.rb
+++ b/spec/factories/document_create_requests.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :document_create_request do
+    planning_application
+    user
+    new_document factory: :document
+    state { "open" }
+    document_request_type { "Floor plan" }
+    document_request_reason { "Missing floor plan" }
+  end
+end

--- a/spec/requests/api/change_request_list_spec.rb
+++ b/spec/requests/api/change_request_list_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
   let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority) }
   let!(:description_change_request) { create(:description_change_request, planning_application: planning_application) }
   let!(:document_change_request) { create(:document_change_request, planning_application: planning_application) }
+  let!(:document_create_request) { create(:document_create_request, planning_application: planning_application) }
 
   it "lists the all description change requests that exist on the planning application" do
     get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
@@ -40,6 +41,22 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
     })
     expect(json["data"]["document_change_requests"].first["new_document"]["name"]).to eq("proposed-floorplan.png")
     expect(json["data"]["document_change_requests"].first["new_document"]["url"]).to be_a(String)
+  end
+
+  it "lists the all document create requests that exist on the planning application" do
+    get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+    expect(response).to be_successful
+    expect(json["data"]["document_create_requests"].first).to include({
+      "id" => document_create_request.id,
+      "state" => "open",
+      "response_due" => document_create_request.response_due.strftime("%Y-%m-%d"),
+      "days_until_response_due" => document_create_request.days_until_response_due,
+      "document_request_type" => document_create_request.document_request_type,
+      "document_request_reason" => document_create_request.document_request_reason,
+      "type" => "document_create_request",
+    })
+    expect(json["data"]["document_create_requests"].first["new_document"]["name"]).to eq("proposed-floorplan.png")
+    expect(json["data"]["document_create_requests"].first["new_document"]["url"]).to be_a(String)
   end
 
   it "returns a 401 if API key is wrong" do

--- a/spec/requests/api/document_create_request_put_spec.rb
+++ b/spec/requests/api/document_create_request_put_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe "API request to patch document create requests", type: :request, show_exceptions: true do
+  include ActionDispatch::TestProcess::FixtureFile
+
+  let!(:api_user) { create :api_user }
+  let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority) }
+
+  let!(:document_create_request) do
+    create(:document_create_request,
+           planning_application: planning_application)
+  end
+
+  it "successfully accepts a new document" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/document_create_requests/#{document_create_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: { new_file: fixture_file_upload("../images/proposed-floorplan.png") },
+          headers: { "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response).to be_successful
+
+    document_create_request.reload
+    planning_application.reload
+
+    expect(document_create_request.state).to eq("closed")
+    expect(document_create_request.new_document).to be_a(Document)
+  end
+
+  it "returns a 400 if the new document is missing" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/document_create_requests/#{document_create_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: "{}",
+          headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+    expect(response.status).to eq(400)
+  end
+end

--- a/spec/system/planning_applications/document_create_request_spec.rb
+++ b/spec/system/planning_applications/document_create_request_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Requesting a new document for a planning application", type: :system do
+  let!(:assessor) { create :user, :assessor, local_authority: @default_local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :invalidated, local_authority: @default_local_authority
+  end
+
+  before do
+    travel_to Time.zone.local(2021, 1, 1)
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  after do
+    travel_back
+  end
+
+  it "allows for a document creation request to be created and sent to the applicant" do
+    click_link "Validate application"
+    click_link "Start new or view existing requests"
+    click_link "Add new request"
+
+    within("fieldset", text: "Send a change request") do
+      choose "Request a new document"
+    end
+
+    click_button "Next"
+
+    expect(page).to have_content("Request a new document")
+
+    fill_in "Please specify the new document type:", with: "Backyard plans"
+    fill_in "Please specify the reason you have requested this document?", with: "Application is missing a rear view."
+
+    click_button "Send"
+    expect(page).to have_content("Document create request successfully sent.")
+  end
+
+  it "does not allow for a creation request without a document request reason and type" do
+    click_link "Validate application"
+    click_link "Start new or view existing requests"
+    click_link "Add new request"
+
+    within("fieldset", text: "Send a change request") do
+      choose "Request a new document"
+    end
+
+    click_button "Next"
+    click_button "Send"
+
+    expect(page).to have_content("Please fill in the document request type.")
+    expect(page).to have_content("Please fill in the reason for this document request.")
+
+    fill_in "Please specify the reason you have requested this document?", with: "Application is missing a floor plan."
+    click_button "Send"
+    expect(page).to have_content("Please fill in the document request type.")
+    fill_in "Please specify the new document type:", with: "Floor plan"
+    click_button "Send"
+
+    expect(page).to have_content("Document create request successfully sent.")
+  end
+end


### PR DESCRIPTION
- Document create requests can be made and are displayed in the requests index
- Adds api support for PUT requests for documents
- Small refactor of a few common methods to all change requests
- Designs reviewed and checked with Ali throughout the ticket since copy was inaccurate in designs

### Story Link
https://trello.com/c/epOc8Wlk/307-request-for-change-new-documents

![image](https://user-images.githubusercontent.com/9452321/119969561-a34ad980-bfa6-11eb-9b00-c05d51bf82d5.png)
