### PR TITLE
Expose file representation, instead of file itself

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Api::V1::ApplicationController < ApplicationController
+  # Make ActiveStorage aware of the current host (used in url helpers)
+  include ActiveStorage::SetCurrent
+
   before_action :authenticate, :set_default_format
   protect_from_forgery with: :null_session
 

--- a/app/views/api/v1/change_requests/index.json.jbuilder
+++ b/app/views/api/v1/change_requests/index.json.jbuilder
@@ -28,7 +28,7 @@ json.data do
     json.new_document do
       if document_change_request.new_document
         json.name document_change_request.new_document.file.filename
-        json.url rails_blob_url(document_change_request.new_document.file)
+        json.url document_change_request.new_document.file.representation(resize_to_limit: [1000, 1000]).processed.url
       end
     end
     json.type "document_change_request"

--- a/spec/requests/api/change_request_list_spec.rb
+++ b/spec/requests/api/change_request_list_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
   it "lists the all document change requests that exist on the planning application" do
     get "/api/v1/planning_applications/#{planning_application.id}/change_requests?change_access_id=#{planning_application.change_access_id}", headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
     expect(response).to be_successful
-    expect(json["data"]["document_change_requests"]).to eq([{
+    expect(json["data"]["document_change_requests"].first).to include({
       "id" => document_change_request.id,
       "state" => "open",
       "response_due" => document_change_request.response_due.strftime("%Y-%m-%d"),
@@ -36,12 +36,10 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
         "name" => document_change_request.old_document.name.to_s,
         "invalid_document_reason" => nil,
       },
-      "new_document" => {
-        "name" => "proposed-floorplan.png",
-        "url" => rails_blob_url(document_change_request.new_document.file),
-      },
       "type" => "document_change_request",
-    }])
+    })
+    expect(json["data"]["document_change_requests"].first["new_document"]["name"]).to eq("proposed-floorplan.png")
+    expect(json["data"]["document_change_requests"].first["new_document"]["url"]).to be_a(String)
   end
 
   it "returns a 401 if API key is wrong" do


### PR DESCRIPTION
The front end needs a picture preview, which cannot be done with a PDF,
so we transform the PDF to an image for the frontend to use.

Co-authored-by: james <james@abscond.org>
