### PR TITLE
Ensure map doesn't overlap page break in PDF

### DIFF
--- a/app/javascript/stylesheets/decision_notice.scss
+++ b/app/javascript/stylesheets/decision_notice.scss
@@ -11,4 +11,12 @@
   dd {
     width: 60%;
   }
+
+  .map {
+    padding-top: 1em;
+  }
+}
+
+.map {
+  page-break-inside: avoid;
 }

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -1,8 +1,10 @@
-<% if locals[:div_id] == "decision_map" %>
-  <div id="decision_map" style="width: 550px; height: 400px"></div>
-<% else %>
-  <div id="accordion_map" style="width: 100%; height: 400px"></div>
-<% end %>
+<div class="map">
+    <% if locals[:div_id] == "decision_map" %>
+        <div id="decision_map" style="width: 550px; height: 400px;"></div>
+    <% else %>
+        <div id="accordion_map" style="width: 100%; height: 400px;"></div>
+    <% end %>
+</div>
 
 <script>
     var <%= locals[:div_id] %>Map = L.map(<%= locals[:div_id] %>, {minZoom: 8, maxZoom: 22});


### PR DESCRIPTION
Sometimes in the PDF rendering (which uses print CSS), the map would overlap a page break, causing the map to be split over 2 pages.

I've added `page-break-inside: avoid;` to the map which stops this happening! (new to me).

I have also put a wrapping container on the map and added padding to that, otherwise the map hugs the very top of the page.

Before:

![Screenshot_2021-05-19_at_13 18 33](https://user-images.githubusercontent.com/425/120008640-0fdbcd80-bfd3-11eb-9fd4-5ddca343fdb8.png)

After: 

![Screenshot 2021-05-28 at 16 38 25](https://user-images.githubusercontent.com/425/120008718-2550f780-bfd3-11eb-9d89-8615b9ffa2a1.png)
