### PR TITLE
Default valid date to last change request date

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -82,7 +82,11 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def validate_documents_form
-    @planning_application.documents_validated_at ||= @planning_application.created_at
+    @planning_application.documents_validated_at ||= if @planning_application.closed_change_requests.present?
+                                                       @planning_application.last_change_request_date
+                                                     else
+                                                       @planning_application.created_at
+                                                     end
   end
 
   def validate_documents

--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -11,6 +11,7 @@ class DescriptionChangeRequest < ApplicationRecord
   validate :rejected_reason_is_present?
 
   scope :open, -> { where(state: "open") }
+  scope :closed, -> { where(state: "closed") }
 
   def rejected_reason_is_present?
     if approved == false

--- a/app/models/document_change_request.rb
+++ b/app/models/document_change_request.rb
@@ -7,4 +7,5 @@ class DocumentChangeRequest < ApplicationRecord
   belongs_to :new_document, optional: true, class_name: "Document"
 
   scope :open, -> { where(state: "open") }
+  scope :closed, -> { where(state: "closed") }
 end

--- a/app/models/document_create_request.rb
+++ b/app/models/document_create_request.rb
@@ -7,4 +7,5 @@ class DocumentCreateRequest < ApplicationRecord
 
   validates :document_request_type, presence: { message: "Please fill in the document request type." }
   validates :document_request_reason, presence: { message: "Please fill in the reason for this document request." }
+  scope :closed, -> { where(state: "closed") }
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -239,6 +239,14 @@ class PlanningApplication < ApplicationRecord
     (description_change_requests + document_change_requests + document_create_requests).sort_by(&:created_at).reverse
   end
 
+  def closed_change_requests
+    description_change_requests.closed + document_change_requests.closed + document_create_requests.closed
+  end
+
+  def last_change_request_date
+    closed_change_requests.max_by(&:updated_at).updated_at
+  end
+
 private
 
   def set_key_dates

--- a/app/views/description_change_requests/new.html.erb
+++ b/app/views/description_change_requests/new.html.erb
@@ -1,4 +1,4 @@
-<%= render "change_requests/change_requests_breadcrumbs.html.erb" %>
+<%= render "change_requests/change_requests_breadcrumbs" %>
 
 <% content_for :title, "Description change" %>
 <div class="govuk-grid-row">

--- a/app/views/document_change_requests/new.html.erb
+++ b/app/views/document_change_requests/new.html.erb
@@ -1,4 +1,4 @@
-<%= render "change_requests/change_requests_breadcrumbs.html.erb" %>
+<%= render "change_requests/change_requests_breadcrumbs" %>
 
 <% content_for :title, "Replacement documents" %>
 <div class="govuk-grid-row">

--- a/app/views/document_create_requests/new.html.erb
+++ b/app/views/document_create_requests/new.html.erb
@@ -1,4 +1,4 @@
-<%= render "change_requests/change_requests_breadcrumbs.html.erb" %>
+<%= render "change_requests/change_requests_breadcrumbs" %>
 
 <% content_for :title, "Request a new document" %>
 <div class="govuk-grid-row">

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.shared_examples "validate and invalidate" do
+  let!(:second_planning_application) do
+    create :planning_application, local_authority: @default_local_authority
+  end
+
   it "can be validated" do
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link planning_application.reference
@@ -76,6 +80,53 @@ RSpec.shared_examples "validate and invalidate" do
     click_button "Archive"
 
     expect(page).to have_text("proposed-floorplan.png has been archived")
+  end
+
+  it "displays a validation date of the last closed change request if any closed change requests exist" do
+    create(:description_change_request,
+           planning_application: planning_application,
+           proposed_description: "new roof",
+           state: "closed",
+           updated_at: Time.zone.today - 2.days)
+
+    create(:document_change_request,
+           planning_application: planning_application,
+           state: "closed",
+           updated_at: Time.zone.today - 3.days)
+
+    click_link planning_application.reference
+    click_link "Validate application"
+
+    choose "Yes"
+
+    expect(page).to have_field("Day", with: description_change_request.updated_at.strftime("%-d"))
+    expect(page).to have_field("Month", with: description_change_request.updated_at.strftime("%-m"))
+    expect(page).to have_field("Year", with: description_change_request.updated_at.strftime("%Y"))
+  end
+
+  it "displays a validation date of when the documents where validated if no closed change requests exist" do
+    visit validate_documents_form_planning_application_path(second_planning_application)
+
+    choose "Yes"
+
+    expect(page).to have_field("Day", with: second_planning_application.documents_validated_at.strftime("%-d"))
+    expect(page).to have_field("Month", with: second_planning_application.documents_validated_at.strftime("%-m"))
+    expect(page).to have_field("Year", with: second_planning_application.documents_validated_at.strftime("%Y"))
+  end
+
+  it "allows for the user to input a validation date manually" do
+    visit validate_documents_form_planning_application_path(second_planning_application)
+
+    choose "Yes"
+
+    fill_in "Day", with: "3"
+    fill_in "Month", with: "6"
+    fill_in "Year", with: "2022"
+
+    click_button "Save"
+
+    second_planning_application.reload
+    expect(second_planning_application.documents_validated_at.to_s).to eq("2022-06-03")
   end
 end
 


### PR DESCRIPTION
### Description of change
Change the default application "valid" date from the documents_validated_at to the last updated change request if any change requests exist on the application.

Also take care of deprecation warning about ".html.erb" partials

### Story Link
https://trello.com/c/6vC0codP/317-default-validation-date-based-on-last-change-request