### PR TITLE
Disable 3D in leaflet JS

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,6 +8,7 @@ import "stylesheets"
 require("@rails/ujs").start()
 require("@rails/activestorage").start()
 
+L_DISABLE_3D = true;
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-defaulticon-compatibility/dist/leaflet-defaulticon-compatibility.webpack.css'; // Re-uses images from ~leaflet package
 import * as L from 'leaflet';


### PR DESCRIPTION
This is an attempt to fix a bug in the rendering of the leaflet map in the PDF.

As I am unable to reproduce this bug locally, and it only happens on staging, I am basing this fix on https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1648

