### PR TITLE
Amend valid date to use all change requests

### DIFF
--- a/app/models/description_change_request.rb
+++ b/app/models/description_change_request.rb
@@ -11,7 +11,6 @@ class DescriptionChangeRequest < ApplicationRecord
   validate :rejected_reason_is_present?
 
   scope :open, -> { where(state: "open") }
-  scope :closed, -> { where(state: "closed") }
 
   def rejected_reason_is_present?
     if approved == false

--- a/app/models/document_change_request.rb
+++ b/app/models/document_change_request.rb
@@ -7,5 +7,4 @@ class DocumentChangeRequest < ApplicationRecord
   belongs_to :new_document, optional: true, class_name: "Document"
 
   scope :open, -> { where(state: "open") }
-  scope :closed, -> { where(state: "closed") }
 end

--- a/app/models/document_create_request.rb
+++ b/app/models/document_create_request.rb
@@ -7,5 +7,4 @@ class DocumentCreateRequest < ApplicationRecord
 
   validates :document_request_type, presence: { message: "Please fill in the document request type." }
   validates :document_request_reason, presence: { message: "Please fill in the reason for this document request." }
-  scope :closed, -> { where(state: "closed") }
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -241,7 +241,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def closed_change_requests
-    description_change_requests.closed + document_change_requests.closed + document_create_requests.closed
+    change_requests.each { |cr| cr.state.eql?("closed") }
   end
 
   def last_change_request_date


### PR DESCRIPTION
- Previous implementation created a new collection of change requests based on weather these were in a closed state.
This meant that when the new type of change request for red line boundary was added, the method was not doing what it needed to do, because it did not account for it. Instead, now we rely on a method that will always consider existing change requests.
