### PR TITLE
Monkey patch Accordion state

### DIFF
--- a/app/javascript/packs/govuk.js
+++ b/app/javascript/packs/govuk.js
@@ -8,6 +8,9 @@ govukall.Accordion.prototype.setExpanded = function (expanded, $section) {
   }  
 }
 
+govukall.Accordion.prototype.storeState = function ($section) {}
+govukall.Accordion.prototype.setInitialState = function ($section) {}
+
 govukall.initAll()
 
 require.context('govuk-frontend/govuk/assets/images', true)

--- a/app/views/planning_applications/_policy_consideration_list.html.erb
+++ b/app/views/planning_applications/_policy_consideration_list.html.erb
@@ -1,10 +1,7 @@
 <div class="govuk-accordion__section">
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
-      <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
-      Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
-      For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
-      <button type="button" id="accordion-default-heading-2" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
+      <button type="button" id="accordion-default-heading-2" aria-controls="accordion-default-heading-3" class="govuk-accordion__section-button" aria-expanded="false">
         Proposal details
       </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -2,10 +2,7 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-        <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
-    Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
-    For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
-        <button type="button" id="accordion-default-heading-1" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
+        <button type="button" id="accordion-default-heading-1" aria-controls="accordion-default-heading-1" class="govuk-accordion__section-button" aria-expanded="false">
           Application information
           <span class="govuk-accordion__icon" aria-hidden="true"></span></button>
       </h3>
@@ -70,10 +67,7 @@
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
-        <!-- We have removed aria controls due to a problem with the default npm gov-uk functionality, which forces accordions to stay open by using the aria controls classes to setState in the browser, and force them open.
-        Our research suggests this makes the website harder to use as there is too much information on the screen overwhelming the user.
-        For now we are removing these until we create our own version of the gov-uk library that stops the behaviour of forcing accordions open. -->
-        <button type="button" id="accordion-default-heading-2" aria-controls="" class="govuk-accordion__section-button" aria-expanded="false">
+        <button type="button" id="accordion-default-heading-2" aria-controls="accordion-default-heading-2" class="govuk-accordion__section-button" aria-expanded="false">
           Site map
         </button>
         <span class="govuk-accordion__icon" aria-hidden="true"></span>


### PR DESCRIPTION
We don't want accordions to remember their state on page refresh. Previously we did this by breaking the aria-controls connection, which breaks accessibility requirements, as well as not being very clear on why that is happening.

This approach monkey patches gouk.Accordion methods.