### PR TITLE
Update secure_change_url method to force http on non-prod

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -219,7 +219,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def secure_change_url(application_id, secure_token)
-    if Rails.env.production?
+    if ENV["DOMAIN"] == "bops-services"
       "https://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     else
       "http://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/change_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"


### PR DESCRIPTION
### Description of change

Both environments other than Prod are currently http. rails.env.production? incorrectly sets staging to https - this commit corrects it