### PR TITLE
Add receipt email acknowledgement

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -46,6 +46,7 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
         activity_information: current_api_user.name,
       )
       send_success_response
+      receipt_notice_mail if @planning_application.applicant_email.present?
     else
       send_failed_response
     end
@@ -112,5 +113,12 @@ private
         town: params[:site][:town],
         postcode: params[:site][:postcode] }
     end
+  end
+
+  def receipt_notice_mail
+    PlanningApplicationMailer.receipt_notice_mail(
+      @planning_application,
+      request.host,
+    ).deliver_now
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -50,6 +50,7 @@ class PlanningApplicationsController < AuthenticationController
     if @planning_application.save
       audit("created", nil, current_user.name)
       flash[:notice] = "Planning application was successfully created."
+      receipt_notice_mail if @planning_application.applicant_email.present?
       redirect_to planning_application_documents_path(@planning_application)
     else
       render :new
@@ -283,6 +284,13 @@ private
 
   def validation_notice_mail
     PlanningApplicationMailer.validation_notice_mail(
+      @planning_application,
+      request.host,
+    ).deliver_now
+  end
+
+  def receipt_notice_mail
+    PlanningApplicationMailer.receipt_notice_mail(
       @planning_application,
       request.host,
     ).deliver_now

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -32,7 +32,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: "Your planning application has been received",
+      subject: "We have received your application",
       to: @planning_application.applicant_email,
     )
   end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -26,6 +26,17 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
+  def receipt_notice_mail(planning_application, host)
+    @host = host
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: "Your planning application has been received",
+      to: @planning_application.applicant_email,
+    )
+  end
+
   def change_request_mail(planning_application, change_request)
     @planning_application = planning_application
     @change_request = change_request

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -1,34 +1,34 @@
-# <%= @planning_application.local_authority.name %>
+Reference: <%= @planning_application.reference %>
+Date of application: <%= @planning_application.created_at.strftime("%e %B %Y - %H:%M:%S") %>
+Date received: <%= @planning_application.created_at.strftime("%e %B %Y - %H:%M:%S") %>
 
-# Town and country planning act 1990 (as amended)
+Site address: <%= @planning_application.full_address %>
+Description: <%= @planning_application.description %>
+Application type: <%= @planning_application.application_type %>
 
-Dear Sir/Madam,
+What happens next
 
-Reference No.: <%= @planning_application.reference %>
-Proposal: <%= @planning_application.description %>
-Site Address: <%= @planning_application.full_address %>
+We are still checking your application for errors or missing information, and ensuring that all plans and documents comply with all statutory requirements. This is the process for accepting your application and should take less than 14 days. We will contact you during this time if needed.
 
-<%= @planning_application.reference %>
+If your application is valid, then a planning officer may contact you to arrange a site visit.
 
-<%= @planning_application.target_date.strftime("%e %B %Y") %>
+A planning officer will then make a decision on your application.
 
+If you do not hear from us
+
+If by <%= @planning_application.target_date.strftime("%e %B %Y") %>:
+
+you have not been given a decision in writing
+you have not been told that the application is invalid
+you not agreed in writing to extend the decision period
+
+Then you can appeal to the Secretary of State under section 195 of the Town and Country Planning Act 1990. This does not apply if your application has already been referred to the Secretary of State. You can find out how to appeal an application for a Lawful Development Certificate here: https://www.gov.uk/appeal-lawful-development-certificate-decision.
+
+Contact us
+You can contact us at  <%= @planning_application.local_authority.email_address %>.
 
 Signed: <%= @planning_application.local_authority.signatory_name %>
- <%= @planning_application.local_authority.signatory_job_title %>
+<%= @planning_application.local_authority.signatory_job_title %>
 
-Your attention is drawn to the notes accompanying this document
+Disclaimer: This email does not constitute an approval of any application submitted.
 
-Any enquiries regarding this document should quote the Application Number and be sent to
-the
-<%= @planning_application.local_authority.signatory_job_title %>,
-<%= @planning_application.local_authority.name %>,
-<%= @planning_application.local_authority.enquiries_paragraph %>
-or by email to <%= @planning_application.local_authority.email_address %>
-
-Please Note: In light of the COVID-19 situation, Southwark Council is following the current advice from the government to minimise travelling and non-essential contact.
-
-The council is fully committed to helping reduce the spread of the virus by following national guidance, whilst ensuring we continue to provide essential services in our business continuity plans. In accordance with government advice, we have to minimise non-essential contact with service users. Therefore if your application requires a site visit/meeting it may be necessary to delay this to an appropriate time. To avoid/minimise delay you can send us additional information, like site photographs, for us to review together with your application documents.
-
-We apologise for the inconvenience any delays in the determination of your application will cause you.
-
-Thank you for your understanding, support and patience during this period. I will keep you updated if anything changes.

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -1,0 +1,34 @@
+# <%= @planning_application.local_authority.name %>
+
+# Town and country planning act 1990 (as amended)
+
+Dear Sir/Madam,
+
+Reference No.: <%= @planning_application.reference %>
+Proposal: <%= @planning_application.description %>
+Site Address: <%= @planning_application.full_address %>
+
+<%= @planning_application.reference %>
+
+<%= @planning_application.target_date.strftime("%e %B %Y") %>
+
+
+Signed: <%= @planning_application.local_authority.signatory_name %>
+ <%= @planning_application.local_authority.signatory_job_title %>
+
+Your attention is drawn to the notes accompanying this document
+
+Any enquiries regarding this document should quote the Application Number and be sent to
+the
+<%= @planning_application.local_authority.signatory_job_title %>,
+<%= @planning_application.local_authority.name %>,
+<%= @planning_application.local_authority.enquiries_paragraph %>
+or by email to <%= @planning_application.local_authority.email_address %>
+
+Please Note: In light of the COVID-19 situation, Southwark Council is following the current advice from the government to minimise travelling and non-essential contact.
+
+The council is fully committed to helping reduce the spread of the virus by following national guidance, whilst ensuring we continue to provide essential services in our business continuity plans. In accordance with government advice, we have to minimise non-essential contact with service users. Therefore if your application requires a site visit/meeting it may be necessary to delay this to an appropriate time. To avoid/minimise delay you can send us additional information, like site photographs, for us to review together with your application documents.
+
+We apologise for the inconvenience any delays in the determination of your application will cause you.
+
+Thank you for your understanding, support and patience during this period. I will keep you updated if anything changes.

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -103,4 +103,24 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(change_request_mail.body.encoded).to include("Lord of BiscuitTown")
     end
   end
+
+  describe "#receipt_notice_mail" do
+    let(:receipt_mail) { described_class.receipt_notice_mail(planning_application, host) }
+
+    ENV["APPLICANTS_APP_HOST"] = "example.com"
+
+    it "renders the headers" do
+      expect(receipt_mail.subject).to eq("Your planning application has been received")
+      expect(receipt_mail.to).to eq([planning_application.applicant_email])
+    end
+
+    it "renders the body" do
+      # expect(receipt_mail.body.encoded).to match("started from #{planning_application.documents_validated_at.strftime('%e %B %Y')}")
+      # expect(receipt_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
+      # expect(receipt_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
+      # expect(receipt_mail.body.encoded).to match("Site Address: #{planning_application.full_address}")
+      # expect(receipt_mail.body.encoded).to match("planning reference number #{planning_application.reference}")
+      # expect(receipt_mail.body.encoded).to match("Proposal: #{planning_application.description}")
+    end
+  end
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(change_request_mail.body.encoded).to include(change_request.user.name)
       expect(change_request_mail.body.encoded).to include(change_request.response_due.strftime("%e %B %Y"))
       expect(change_request_mail.body.encoded).to include(planning_application.change_access_id)
-      expect(change_request_mail.body.encoded).to include("http://cookies.localhost/change_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}")
+      expect(change_request_mail.body.encoded).to include("http://cookies.example.com/change_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}")
       expect(change_request_mail.body.encoded).to include("Mr. Biscuit")
       expect(change_request_mail.body.encoded).to include("Cookie authority")
       expect(change_request_mail.body.encoded).to include("Lord of BiscuitTown")
@@ -110,17 +110,16 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     ENV["APPLICANTS_APP_HOST"] = "example.com"
 
     it "renders the headers" do
-      expect(receipt_mail.subject).to eq("Your planning application has been received")
+      expect(receipt_mail.subject).to eq("We have received your application")
       expect(receipt_mail.to).to eq([planning_application.applicant_email])
     end
 
     it "renders the body" do
-      # expect(receipt_mail.body.encoded).to match("started from #{planning_application.documents_validated_at.strftime('%e %B %Y')}")
-      # expect(receipt_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
-      # expect(receipt_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.strftime('%e %B %Y')}")
-      # expect(receipt_mail.body.encoded).to match("Site Address: #{planning_application.full_address}")
-      # expect(receipt_mail.body.encoded).to match("planning reference number #{planning_application.reference}")
-      # expect(receipt_mail.body.encoded).to match("Proposal: #{planning_application.description}")
+      expect(receipt_mail.body.encoded).to match("If by #{planning_application.target_date.strftime('%e %B %Y')}:")
+      expect(receipt_mail.body.encoded).to match("Date received: #{planning_application.created_at.strftime('%e %B %Y - %H:%M:%S')}")
+      expect(receipt_mail.body.encoded).to match("Site address: #{planning_application.full_address}")
+      expect(receipt_mail.body.encoded).to match("Reference: #{planning_application.reference}")
+      expect(receipt_mail.body.encoded).to match("Description: #{planning_application.description}")
     end
   end
 end

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -46,6 +46,14 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
         expect(PlanningApplication.all[0]).to be_valid
       end
 
+      it "sends the receipt email" do
+        post "/api/v1/planning_applications", params: permitted_development_json,
+                                              headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }
+
+        email = ActionMailer::Base.deliveries.last
+        expect(email.body).to include(PlanningApplication.all[0].reference)
+      end
+
       it "downloads and saves the plan against the planning application" do
         post "/api/v1/planning_applications", params: permitted_development_json,
                                               headers: { "CONTENT-TYPE": "application/json", "Authorization": "Bearer #{api_user.token}" }

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -153,6 +153,9 @@ RSpec.describe "Creating a planning application", type: :system do
       click_link "Activity log"
 
       expect(page).to have_text("Application created by Assessor 1")
+
+      email = ActionMailer::Base.deliveries.last
+      expect(email.body).to have_content("Palace Road, Crystal Palace, SE19 2LX")
     end
   end
 end


### PR DESCRIPTION
### Description of change

We now send a receipt email as soon as the application is created. We are calling the Notify integration when an application is either created via the form or via the API.

### Story Link

https://trello.com/c/PxpL2KoR/390-notify-applicant-that-their-application-has-been-received

### Known issues [OPTIONAL]

Things you know need further follow on work:

- Payment amount is TBA until the dependent story has been done
- Phone number has been removed pending product owner decision on whether we need to store these