### PR TITLE
Add evidence tags to documents

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -8,4 +8,12 @@ module DocumentHelper
   def filter_current(documents)
     documents.select { |file| file.archived? == false }.sort_by(&:created_at)
   end
+
+  def is_plan_tag(tag)
+    Document::PLAN_TAGS.include?(tag)
+  end
+
+  def is_evidence_tag(tag)
+    Document::EVIDENCE_TAGS.include?(tag)
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,7 +5,7 @@ class Document < ApplicationRecord
 
   has_one_attached :file, dependent: :destroy
 
-  TAGS = %w[
+  PLAN_TAGS = %w[
     Front
     Rear
     Side
@@ -18,6 +18,21 @@ class Document < ApplicationRecord
     Proposed
     Existing
   ].freeze
+
+  EVIDENCE_TAGS = [
+    "Photograph",
+    "Utility Bill",
+    "Building Control Certificate",
+    "Construction Invoice",
+    "Council Tax Document",
+    "Tenancy Agreement",
+    "Tenancy Invoice",
+    "Bank Statement",
+    "Statutory Declaration",
+    "Other",
+  ].freeze
+
+  TAGS = PLAN_TAGS + EVIDENCE_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze
 

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -13,13 +13,35 @@
       <% end %>
     <% end %>
 
-    <div class="govuk-checkboxes govuk-checkboxes--small">
-      <%= form.collection_check_boxes :tags, Document::TAGS, :itself, :itself do |b| %>
-        <div class="govuk-checkboxes__item">
-          <%= b.check_box class: "govuk-checkboxes__input" %>
-          <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-half">
+        <h3 class="govuk-heading-s govuk-!-padding-top-4">
+          PLANS
+        </h3>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <%= form.collection_check_boxes :tags, Document::PLAN_TAGS, :itself, :itself do |b| %>
+            <div class="govuk-checkboxes__item">
+              <%= b.check_box class: "govuk-checkboxes__input" %>
+              <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+            </div>
+          <% end %>
         </div>
-      <% end %>
+      </div>
+
+      <div class="govuk-grid-column-one-half">
+        <h3 class="govuk-heading-s govuk-!-padding-top-5">
+          EVIDENCE
+        </h3>
+        <div class="govuk-checkboxes govuk-checkboxes--small">
+          <%= form.collection_check_boxes :tags, Document::EVIDENCE_TAGS, :itself, :itself do |b| %>
+            <div class="govuk-checkboxes__item">
+              <%= b.check_box class: "govuk-checkboxes__input" %>
+              <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
     </div>
   </fieldset>
 </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -60,9 +60,18 @@
             <% if document.tags.present? %>
               <p class="govuk-body">
                 <% document.tags.each do |tag| %>
-                  <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+                  <% if is_plan_tag(tag) %>
+                    <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+                  <% end %>
                 <% end %>
               </p>
+                <% document.tags.each do |tag| %>
+                  <% if is_evidence_tag(tag) %>
+                    <p class="govuk-body">
+                      <strong class="govuk-tag govuk-tag--turquoise">EVIDENCE</strong> <strong class="govuk-tag govuk-tag--turquoise"><%= tag  %></strong><br/>
+                    </p>
+                  <% end %>
+                <% end %>
             <% end %>
             <% if document.validated == false %>
             <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold">

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -35,9 +35,18 @@
             <% if document.tags.present? %>
               <p class="govuk-body">
                 <% document.tags.each do |tag| %>
-                  <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+                  <% if is_plan_tag(tag) %>
+                    <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+                  <% end %>
                 <% end %>
               </p>
+              <% document.tags.each do |tag| %>
+                <% if is_evidence_tag(tag) %>
+                  <p class="govuk-body">
+                    <strong class="govuk-tag govuk-tag--turquoise">EVIDENCE</strong> <strong class="govuk-tag govuk-tag--turquoise"><%= tag  %></strong><br/>
+                  </p>
+                <% end %>
+              <% end %>
             <% end %>
             <p class="govuk-body govuk-!-margin-bottom-1">
               File name: <%= document.name %>

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
   end
 
   trait :with_tags do
-    tags { %w[Side Elevation Proposed] }
+    tags { %w[Side Elevation Proposed Photograph] }
   end
 
   trait :referenced do

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -49,6 +49,8 @@ RSpec.describe "Edit document numbers page", type: :system do
         expect(page).to have_text("Side")
         expect(page).to have_text("Elevation")
         expect(page).to have_text("Proposed")
+        expect(page).to have_text("Photograph")
+        expect(page).to have_text("EVIDENCE")
         expect(page).to have_text("proposed-floorplan.png")
       end
 

--- a/spec/system/documents/upload_spec.rb
+++ b/spec/system/documents/upload_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "Document uploads", type: :system do
 
         check("Floor")
         check("Side")
+        check("Utility Bill")
 
         within(".display") do
           choose "Yes"
@@ -43,6 +44,8 @@ RSpec.describe "Document uploads", type: :system do
 
         expect(page).to have_css(".govuk-tag", text: "Floor")
         expect(page).to have_css(".govuk-tag", text: "Side")
+        expect(page).to have_css(".govuk-tag", text: "Utility Bill")
+        expect(page).to have_css(".govuk-tag", text: "EVIDENCE")
 
         expect(page).to have_content("Included in decision notice: Yes")
         expect(page).to have_content("Public: Yes")


### PR DESCRIPTION
### Description of change

This PR subcategorizes the TAGS constant into two separate arrays: plan tags and evidence tags. The latter are treated differently in that they are presented in a separate column and, if added, are displayed with the extra tag 'EVIDENCE'. There is otherwise no behavioural difference.

### Story Link

https://trello.com/c/PqRk4Gvc/263-add-evidence-tags-to-documents

