### PR TITLE
Notification banners

### DIFF
--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -38,8 +38,4 @@ module ValidationRequestHelper
       "green"
     end
   end
-
-  def overdue_requests(validation_requests)
-    validation_requests.select { |req| req.overdue? && req.state == "open" }
-  end
 end

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -38,4 +38,8 @@ module ValidationRequestHelper
       "green"
     end
   end
+
+  def overdue_requests(validation_requests)
+    validation_requests.select { |req| req.overdue? && req.state == "open" }
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -36,8 +36,34 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
   padding: govuk-spacing(2);
 }
 
+.validations-banner {
+  border: 5px solid govuk-colour("red");
+  @include govuk-font($size: 19);
+  color: govuk-colour("black");
+  display: block;
+  overflow: hidden;
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(2);
+}
+
+.response-banner {
+  border: 5px solid govuk-colour("blue");
+  @include govuk-font($size: 19);
+  color: govuk-colour("black");
+  display: block;
+  overflow: hidden;
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(2);
+}
+
 .alert__icon {
   fill: govuk-colour("red");
+  float: left;
+  margin-right: govuk-spacing(2);
+}
+
+.info__icon {
+  fill: govuk-colour("blue");
   float: left;
   margin-right: govuk-spacing(2);
 }

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -251,6 +251,14 @@ class PlanningApplication < ApplicationRecord
     payment_amount.to_i / 100
   end
 
+  def overdue_requests
+    validation_requests.select { |req| req.overdue? && req.state == "open" }
+  end
+
+  def closed_requests
+    validation_requests.select { |req| req.state == "closed" }
+  end
+
 private
 
   def set_key_dates

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -8,6 +8,12 @@
 
 <%= render "proposal_header" %>
 
+<div class="govuk-grid-column-two-thirds">
+  <% if @planning_application.validation_requests %>
+    <%= render "response_banner" unless overdue_requests(@planning_application.validation_requests).empty? %>
+  <% end %>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds application">
     <%= render "shared/application_information" %>

--- a/app/views/planning_applications/_assessment_dashboard.html.erb
+++ b/app/views/planning_applications/_assessment_dashboard.html.erb
@@ -10,7 +10,8 @@
 
 <div class="govuk-grid-column-two-thirds">
   <% if @planning_application.validation_requests %>
-    <%= render "response_banner" unless overdue_requests(@planning_application.validation_requests).empty? %>
+    <%= render "overdue_banner" if @planning_application.overdue_requests.present? %>
+    <%= render "response_banner" if @planning_application.closed_requests.present? %>
   <% end %>
 </div>
 

--- a/app/views/planning_applications/_overdue_banner.html.erb
+++ b/app/views/planning_applications/_overdue_banner.html.erb
@@ -1,0 +1,9 @@
+<div class=validations-banner>
+  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path></svg>
+  <div class="moj-banner__message">
+    <span class="moj-banner__assistive">
+      Warning</span><strong><%= pluralize(@planning_application.overdue_requests.count, "validation request") %></strong> now overdue.<br/>
+    <%= link_to "View all validation requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %>
+  </div>
+</div>

--- a/app/views/planning_applications/_response_banner.html.erb
+++ b/app/views/planning_applications/_response_banner.html.erb
@@ -1,8 +1,10 @@
-<div class=corrections-banner>
-  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path></svg>
+<div class=response-banner>
+    <svg class="info__icon" fill="#1d70b8" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+      <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+    C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
   <div class="moj-banner__message">
     <span class="moj-banner__assistive">
-      Warning</span><strong><%= overdue_requests(@planning_application.validation_requests).count %></strong> validation request is now overdue.
+      Warning</span><strong><%= pluralize(@planning_application.closed_requests.count, "new response") %></strong> to a validation request.<br/>
+      <%= link_to "View all validation requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %></span>
   </div>
 </div>

--- a/app/views/planning_applications/_response_banner.html.erb
+++ b/app/views/planning_applications/_response_banner.html.erb
@@ -1,0 +1,8 @@
+<div class=corrections-banner>
+  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path></svg>
+  <div class="moj-banner__message">
+    <span class="moj-banner__assistive">
+      Warning</span><strong><%= overdue_requests(@planning_application.validation_requests).count %></strong> validation request is now overdue.
+  </div>
+</div>

--- a/spec/system/planning_applications/validation_banner_display_spec.rb
+++ b/spec/system/planning_applications/validation_banner_display_spec.rb
@@ -1,0 +1,67 @@
+RSpec.describe "Validation banners", type: :system do
+  context "Validation request banners are displayed correctly when open request is overdue" do
+    let!(:assessor) { create :user, :assessor, local_authority: @default_local_authority }
+
+    let!(:planning_application) { create :planning_application, local_authority: @default_local_authority }
+
+    let!(:description_change_validation_request) do
+      create :description_change_validation_request, planning_application: planning_application, state: "open"
+    end
+
+    before do
+      sign_in assessor
+    end
+
+    after do
+      travel_back
+    end
+
+    it "shows the correct count for 1 overdue request validation" do
+      travel 2.months
+      visit planning_application_path(planning_application)
+      expect(page).to have_content("1 validation request now overdue")
+    end
+
+    it "shows the correct count for 2 overdue request validations" do
+      create(:replacement_document_validation_request,
+             planning_application: planning_application,
+             state: "open")
+
+      travel 2.months
+      visit planning_application_path(planning_application)
+      expect(page).to have_content("2 validation requests now overdue")
+    end
+  end
+
+  context "Validation warning banner is not displayed when request is closed" do
+    let!(:assessor) { create :user, :assessor, local_authority: @default_local_authority }
+
+    let!(:planning_application) { create :planning_application, local_authority: @default_local_authority }
+
+    let!(:description_change_validation_request) do
+      create :description_change_validation_request, planning_application: planning_application, state: "closed"
+    end
+
+    let!(:replacement_document_validation_request) do
+      create :replacement_document_validation_request, planning_application: planning_application, state: "closed"
+    end
+
+    before do
+      travel 2.months
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    after do
+      travel_back
+    end
+
+    it "does not display the overdue validation request banner" do
+      expect(page).not_to have_content("now overdue.")
+    end
+
+    it "displays the resolved validation request banner" do
+      expect(page).to have_content("2 new responses to a validation request.")
+    end
+  end
+end


### PR DESCRIPTION
<img width="993" alt="validation" src="https://user-images.githubusercontent.com/1880450/125269927-144d1300-e301-11eb-8951-cffad4265943.png">

### Description of change

We are adding two notification banners to the Planning Application Show view. One is a warning banner that displays if there are overdue validation requests that have not been responded to, and the other one is an information banner that shows validation requests that have been responded to.

### Story Link

https://trello.com/c/DKaQY1c7/346-add-notification-banner-when-change-requests-are-updated

