### PR TITLE
Add missing specs and update audit partials

### DIFF
--- a/app/views/audits/types/_additional_document_validation_request_received.html.erb
+++ b/app/views/audits/types/_additional_document_validation_request_received.html.erb
@@ -1,4 +1,5 @@
+<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
 <p>
-  New file: <i><%= locals[:comment] %></i>
+  New file: <i><%= locals[:item].audit_comment %></i>
 </p>
 

--- a/app/views/audits/types/_description_change_validation_request_received.html.erb
+++ b/app/views/audits/types/_description_change_validation_request_received.html.erb
@@ -1,7 +1,8 @@
+<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
 <p>
-  Applicant: <i><%= JSON.parse(locals[:comment])["response"] %></i>
+  Applicant: <i><%= JSON.parse(locals[:item].audit_comment)["response"] %></i>
 <br/>
-  <% if JSON.parse(locals[:comment]).include?("reason") %>
-    Reason: <i><%= JSON.parse(locals[:comment])["reason"] %></i>
+  <% if JSON.parse(locals[:item].audit_comment).include?("reason") %>
+    Reason: <i><%= JSON.parse(locals[:item].audit_comment)["reason"] %></i>
   <% end %>
 </p>

--- a/app/views/audits/types/_red_line_boundary_change_validation_request_received.html.erb
+++ b/app/views/audits/types/_red_line_boundary_change_validation_request_received.html.erb
@@ -1,7 +1,8 @@
+<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
 <p>
-  Applicant: <i><%= JSON.parse(locals[:comment])["response"] %></i>
+  Applicant: <i><%= JSON.parse(locals[:item].audit_comment)["response"] %></i>
 <br/>
-  <% if JSON.parse(locals[:comment]).include?("reason") %>
-    Reason: <i><%= JSON.parse(locals[:comment])["reason"] %></i>
+  <% if JSON.parse(locals[:item].audit_comment).include?("reason") %>
+    Reason: <i><%= JSON.parse(locals[:item].audit_comment)["reason"] %></i>
     <% end %>
 </p>

--- a/app/views/audits/types/_replacement_document_validation_request_received.html.erb
+++ b/app/views/audits/types/_replacement_document_validation_request_received.html.erb
@@ -1,3 +1,4 @@
+<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
 <p>
-  New file: <i><%= locals[:comment] %></i>
+  New file: <i><%= locals[:item].audit_comment %></i>
 </p>

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -71,4 +71,17 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
 
     expect(page).to have_content("Document create request successfully sent.")
   end
+
+  it "displays the details of the received request in the audit log" do
+    create :audit, planning_application_id: planning_application.id, activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf"
+
+    sign_in assessor
+    visit planning_application_path(planning_application)
+
+    click_button "Key application dates"
+    click_link "Activity log"
+
+    expect(page).to have_text("Received: request for change (new document#1)")
+    expect(page).to have_text("roof_plan.pdf")
+  end
 end

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
     create :description_change_validation_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: true
     create :description_change_validation_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false, rejection_reason: "No good"
     create :description_change_validation_request, planning_application: planning_application, state: "open", created_at: 35.days.ago
+    create :audit, planning_application_id: planning_application.id, activity_type: "description_change_validation_request_received", activity_information: 1, audit_comment: { response: "approved" }.to_json
 
     click_link "Validate application"
     click_link "Start new or view existing validation requests"
@@ -87,6 +88,13 @@ RSpec.describe "Requesting description changes to a planning application", type:
       expect(page).to have_content("6 days")
       expect(page).to have_content("-10 days")
     end
+
+    click_link "Application"
+    click_button "Key application dates"
+    click_link "Activity log"
+
+    expect(page).to have_text("Received: request for change (description#1)")
+    expect(page).to have_text("approved")
   end
 
   it "only displays a new validation request option if application is invalid" do

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -86,4 +86,17 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
     expect(page).not_to have_content("Start new or view existing validation requests")
   end
+
+  it "displays the details of the received request in the audit log" do
+    create :audit, planning_application_id: planning_application.id, activity_type: "other_change_validation_request_received", activity_information: 1, audit_comment: { response: "I have sent the fee" }.to_json
+
+    sign_in assessor
+    visit planning_application_path(planning_application)
+
+    click_button "Key application dates"
+    click_link "Activity log"
+
+    expect(page).to have_text("Received: request for change (other validation#1)")
+    expect(page).to have_text("I have sent the fee")
+  end
 end

--- a/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
@@ -81,4 +81,18 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
 
     expect(page).to have_content("Provide a reason for changes")
   end
+
+  it "displays the details of the received request in the audit log" do
+    create :audit, planning_application_id: planning_application.id, activity_type: "red_line_boundary_change_validation_request_received", activity_information: 1, audit_comment: { response: "rejected", reason: "The boundary was too small" }.to_json
+
+    sign_in assessor
+    visit planning_application_path(planning_application)
+
+    click_button "Key application dates"
+    click_link "Activity log"
+
+    expect(page).to have_text("Received: request for change (red line boundary#1)")
+    expect(page).to have_text("The boundary was too small")
+    expect(page).to have_text("rejected")
+  end
 end

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -77,4 +77,17 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
     click_button "Next"
     expect(page).not_to have_content(invalid_document.name.to_s)
   end
+
+  it "displays the details of the received request in the audit log" do
+    create :audit, planning_application_id: planning_application.id, activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf"
+
+    sign_in assessor
+    visit planning_application_path(planning_application)
+
+    click_button "Key application dates"
+    click_link "Activity log"
+
+    expect(page).to have_text("Received: request for change (replacement document#1)")
+    expect(page).to have_text("floor_plan.pdf")
+  end
 end


### PR DESCRIPTION
### Description of change

A commit for updating the audit partials for received validations was missed on the last deployment. This also adds the missing specs

### Story Link

https://trello.com/c/EhLn4tmq/302-create-audit-logs-for-change-requests

