### PR TITLE
Fix audit log deleted user bug

### DIFF
--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -13,7 +13,7 @@ class Api::V1::AdditionalDocumentValidationRequestsController < Api::V1::Applica
     if @additional_document_validation_request.save
 
       audit("additional_document_validation_request_received", document_audit_item(new_document),
-            @additional_document_validation_request.sequence)
+            @additional_document_validation_request.sequence, current_api_user)
 
       render json: { "message": "Validation request updated" }, status: :ok
     else

--- a/app/controllers/api/v1/description_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_validation_requests_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::DescriptionChangeValidationRequestsController < Api::V1::Applicat
       @planning_application.update!(description: @description_change_validation_request.proposed_description) if @description_change_validation_request.approved?
 
       audit("description_change_validation_request_received", description_audit_item(@description_change_validation_request),
-            @description_change_validation_request.sequence)
+            @description_change_validation_request.sequence, current_api_user)
 
       render json: { "message": "Validation request updated" }, status: :ok
     else

--- a/app/controllers/api/v1/other_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/other_change_validation_requests_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::OtherChangeValidationRequestsController < Api::V1::ApplicationCon
       @other_change_validation_request.update!(state: "closed")
 
       audit("other_change_validation_request_received", audit_item(@other_change_validation_request),
-            @other_change_validation_request.sequence)
+            @other_change_validation_request.sequence, current_api_user)
 
       render json: { "message": "Change request updated" }, status: :ok
     else

--- a/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
@@ -10,7 +10,7 @@ class Api::V1::RedLineBoundaryChangeValidationRequestsController < Api::V1::Appl
       @planning_application.update!(boundary_geojson: @red_line_boundary_change_validation_request.new_geojson) if @red_line_boundary_change_validation_request.approved?
 
       audit("red_line_boundary_change_validation_request_received", red_line_boundary_audit_item(@red_line_boundary_change_validation_request),
-            @red_line_boundary_change_validation_request.sequence)
+            @red_line_boundary_change_validation_request.sequence, current_api_user)
 
       render json: { "message": "Validation request updated" }, status: :ok
     else

--- a/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::ReplacementDocumentValidationRequestsController < Api::V1::Applic
       archive_old_document
 
       audit("replacement_document_validation_request_received", document_audit_item(new_document),
-            @replacement_document_validation_request.sequence)
+            @replacement_document_validation_request.sequence, current_api_user)
 
       render json: { "message": "Validation request updated" }, status: :ok
     else

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -18,10 +18,10 @@
     <% @audits.each do |audit_item| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= audit_item.created_at.strftime("%d-%m-%Y %H:%M") %></td>
-        <% if audit_item.user %>
-          <td class="govuk-table__cell"><%= audit_item.user.name %></td>
-        <% elsif audit_item.api_user %>
+        <% if audit_item.api_user %>
           <td class="govuk-table__cell"><%= define_user(audit_item) %></td>
+        <% elsif audit_item.user %>
+          <td class="govuk-table__cell"><%= audit_item.user.name %></td>
         <% else %>
           <td class="govuk-table__cell"> User deleted </td>
         <% end %>

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     create :planning_application, :invalidated, local_authority: @default_local_authority
   end
 
+  let!(:api_user) { create :api_user, name: "Api Wizard" }
+
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
@@ -73,7 +75,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
   end
 
   it "displays the details of the received request in the audit log" do
-    create :audit, planning_application_id: planning_application.id, activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf"
+    create :audit, planning_application_id: planning_application.id, activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf", api_user: api_user
 
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -83,5 +85,6 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
 
     expect(page).to have_text("Received: request for change (new document#1)")
     expect(page).to have_text("roof_plan.pdf")
+    expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
 end

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe "Requesting description changes to a planning application", type:
     create :description_change_validation_request, planning_application: planning_application, state: "open", created_at: 12.days.ago
   end
 
+  let!(:api_user) { create :api_user, name: "Api Wizard" }
+
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
@@ -73,7 +75,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
     create :description_change_validation_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: true
     create :description_change_validation_request, planning_application: planning_application, state: "closed", created_at: 12.days.ago, approved: false, rejection_reason: "No good"
     create :description_change_validation_request, planning_application: planning_application, state: "open", created_at: 35.days.ago
-    create :audit, planning_application_id: planning_application.id, activity_type: "description_change_validation_request_received", activity_information: 1, audit_comment: { response: "approved" }.to_json
+    create :audit, planning_application_id: planning_application.id, activity_type: "description_change_validation_request_received", activity_information: 1, audit_comment: { response: "approved" }.to_json, api_user: api_user
 
     click_link "Validate application"
     click_link "Start new or view existing validation requests"
@@ -95,6 +97,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
     expect(page).to have_text("Received: request for change (description#1)")
     expect(page).to have_text("approved")
+    expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
 
   it "only displays a new validation request option if application is invalid" do

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Requesting description changes to a planning application", type:
     create :planning_application, :invalidated, local_authority: @default_local_authority
   end
 
+  let!(:api_user) { create :api_user, name: "Api Wizard" }
+
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
@@ -88,7 +90,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
   end
 
   it "displays the details of the received request in the audit log" do
-    create :audit, planning_application_id: planning_application.id, activity_type: "other_change_validation_request_received", activity_information: 1, audit_comment: { response: "I have sent the fee" }.to_json
+    create :audit, planning_application_id: planning_application.id, activity_type: "other_change_validation_request_received", activity_information: 1, audit_comment: { response: "I have sent the fee" }.to_json, api_user: api_user
 
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -98,5 +100,6 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
     expect(page).to have_text("Received: request for change (other validation#1)")
     expect(page).to have_text("I have sent the fee")
+    expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
 end

--- a/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
     create :planning_application, :invalidated, local_authority: @default_local_authority
   end
 
+  let!(:api_user) { create :api_user, name: "Api Wizard" }
+
   it "is possible to create a request to update map boundary" do
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -83,7 +85,7 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
   end
 
   it "displays the details of the received request in the audit log" do
-    create :audit, planning_application_id: planning_application.id, activity_type: "red_line_boundary_change_validation_request_received", activity_information: 1, audit_comment: { response: "rejected", reason: "The boundary was too small" }.to_json
+    create :audit, planning_application_id: planning_application.id, activity_type: "red_line_boundary_change_validation_request_received", activity_information: 1, audit_comment: { response: "rejected", reason: "The boundary was too small" }.to_json, api_user: api_user
 
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -94,5 +96,6 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
     expect(page).to have_text("Received: request for change (red line boundary#1)")
     expect(page).to have_text("The boundary was too small")
     expect(page).to have_text("rejected")
+    expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
 end

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
 
   let!(:valid_document) { create :document }
 
+  let!(:api_user) { create :api_user, name: "Api Wizard" }
+
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
@@ -79,7 +81,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
   end
 
   it "displays the details of the received request in the audit log" do
-    create :audit, planning_application_id: planning_application.id, activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf"
+    create :audit, planning_application_id: planning_application.id, activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf", api_user: api_user
 
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -89,5 +91,6 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
 
     expect(page).to have_text("Received: request for change (replacement document#1)")
     expect(page).to have_text("floor_plan.pdf")
+    expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
 end


### PR DESCRIPTION
### Description of change

Solves the issue where the API user was not displaying for received validation requests. We were not capturing the API user at the point of audit. Specs have also been added to make sure we don't miss this in future. Helper method has been updated to a more logical sequence (and also because the factory adds the association with the user by default).

