### PR TITLE
Ripa questions

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -145,4 +145,8 @@ module PlanningApplicationHelper
       planning_application.returned_at
     end
   end
+
+  def display_number(proposal_details, element)
+    proposal_details.find_index(element) + 1
+  end
 end

--- a/app/javascript/stylesheets/planning_applications.scss
+++ b/app/javascript/stylesheets/planning_applications.scss
@@ -9,3 +9,7 @@
     }
   }
 }
+
+.proposal {
+  margin-left: -2em;
+}

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -216,17 +216,17 @@ class PlanningApplication < ApplicationRecord
     proposal_details.present? ? JSON.parse(proposal_details) : []
   end
 
-  def proposals_with_metadata
+  def proposal_details_with_metadata
     parsed_proposal_details.select { |proposal| proposal["metadata"].present? }
   end
 
-  def proposals_with_flags
-    proposals_with_metadata.select { |proposal| proposal["metadata"]["flags"].present? }
+  def proposal_details_with_flags
+    proposal_details_with_metadata.select { |proposal| proposal["metadata"]["flags"].present? }
   end
 
-  def flagged_proposals(flag)
-    proposals_with_flags.select do |proposal|
-      proposal["metadata"]["flags"].select { |element| element == flag }
+  def flagged_proposal_details(flag)
+    proposal_details_with_flags.select do |proposal|
+      proposal["metadata"]["flags"].include?(flag)
     end
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -217,16 +217,16 @@ class PlanningApplication < ApplicationRecord
   end
 
   def proposals_with_metadata
-    parsed_proposal_details.select { |detail| proposal["metadata"].present? }
+    parsed_proposal_details.select { |proposal| proposal["metadata"].present? }
   end
 
   def proposals_with_flags
     proposals_with_metadata.select { |proposal| proposal["metadata"]["flags"].present? }
   end
 
-  def flagged_proposal(flag)
-    proposals_with_flags.select do | proposal|
-        proposal["metadata"]["flags"].any? { |element| element == flag }
+  def flagged_proposals(flag)
+    proposals_with_flags.select do |proposal|
+      proposal["metadata"]["flags"].select { |element| element == flag }
     end
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -216,6 +216,20 @@ class PlanningApplication < ApplicationRecord
     proposal_details.present? ? JSON.parse(proposal_details) : []
   end
 
+  def proposals_with_metadata
+    parsed_proposal_details.select { |detail| proposal["metadata"].present? }
+  end
+
+  def proposals_with_flags
+    proposals_with_metadata.select { |proposal| proposal["metadata"]["flags"].present? }
+  end
+
+  def flagged_proposal(flag)
+    proposals_with_flags.select do | proposal|
+        proposal["metadata"]["flags"].any? { |element| element == flag }
+    end
+  end
+
   def full_address
     "#{address_1}, #{town}, #{postcode}"
   end

--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -1,13 +1,13 @@
 <div class="govuk-accordion__section result_information">
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
-      <button type="button" id="accordion-default-heading-2" aria-controls="accordion-default-heading-3" class="govuk-accordion__section-button" aria-expanded="false">
+      <button type="button" id="accordion-default-heading-5" aria-controls="accordion-default-heading-5" class="govuk-accordion__section-button" aria-expanded="false">
         Result from <%= @planning_application.api_user.present? ? @planning_application.api_user.name : "application" %>
       </button>
       <span class="govuk-accordion__icon" aria-hidden="true"></span>
     </h3>
   </div>
-  <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3">
+  <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-5">
     <% if @planning_application.result_present? %>
       <h3 class="govuk-heading-m">
         <%= @planning_application.result_flag if @planning_application.result_flag.present? %>
@@ -27,20 +27,20 @@
             <%= @planning_application.result_override %>
           </p>
         </div>
-        <% if @planning_application.flagged_proposals(@planning_application.result_flag).present? %>
+        <% if @planning_application.flagged_proposal_details(@planning_application.result_flag).present? %>
           <p class="govuk-body">
             <strong>Details identified <%= @planning_application.api_user.present? ? "by #{@planning_application.api_user.name}" : "" %> as relevant to the result</strong>
           </p>
           <ol class="govuk-body">
-          <% @planning_application.flagged_proposals(@planning_application.result_flag).each do |proposal_detail| %>
-          <p class="govuk-body">
-            <span class="proposal"><strong><%= display_number(@planning_application.parsed_proposal_details, proposal_detail) %>.</strong></span>
-            <strong><%= proposal_detail["question"] %></strong>
-          </p>
-            <% proposal_detail["responses"].each do |response| %>
-                <%= response["value"] %>
-           <% end %>
-          <% end %>
+            <% @planning_application.flagged_proposal_details(@planning_application.result_flag).each do |proposal_detail| %>
+              <p class="govuk-body">
+                <span class="proposal"><strong><%= display_number(@planning_application.parsed_proposal_details, proposal_detail) %>.</strong></span>
+                <strong><%= proposal_detail["question"] %></strong>
+              </p>
+              <% proposal_detail["responses"].each do |response| %>
+                  <%= response["value"] %>
+             <% end %>
+            <% end %>
           </ol>
         <% end %>
       <% end %>

--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-accordion__section">
+<div class="govuk-accordion__section result_information">
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
       <button type="button" id="accordion-default-heading-2" aria-controls="accordion-default-heading-3" class="govuk-accordion__section-button" aria-expanded="false">
@@ -27,6 +27,21 @@
             <%= @planning_application.result_override %>
           </p>
         </div>
+        <% if @planning_application.flagged_proposals(@planning_application.result_flag).present? %>
+          <p class="govuk-body">
+            <strong>Details identified <%= @planning_application.api_user.present? ? "by #{@planning_application.api_user.name}" : "" %> as relevant to the result</strong>
+          </p>
+          <% @planning_application.flagged_proposals(@planning_application.result_flag).each do |proposal_detail| %>
+          <p class="govuk-body">
+            <strong><%= proposal_detail["question"] %></strong>
+          </p>
+            <% proposal_detail["responses"].each do |response| %>
+              <p class="govuk-body">
+                <%= response["value"] %>
+              </p>
+           <% end %>
+          <% end %>
+        <% end %>
       <% end %>
     <% else %>
       <p class='govuk-body'>

--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -31,16 +31,17 @@
           <p class="govuk-body">
             <strong>Details identified <%= @planning_application.api_user.present? ? "by #{@planning_application.api_user.name}" : "" %> as relevant to the result</strong>
           </p>
+          <ol class="govuk-body">
           <% @planning_application.flagged_proposals(@planning_application.result_flag).each do |proposal_detail| %>
           <p class="govuk-body">
+            <span class="proposal"><strong><%= display_number(@planning_application.parsed_proposal_details, proposal_detail) %>.</strong></span>
             <strong><%= proposal_detail["question"] %></strong>
           </p>
             <% proposal_detail["responses"].each do |response| %>
-              <p class="govuk-body">
                 <%= response["value"] %>
-              </p>
            <% end %>
           <% end %>
+          </ol>
         <% end %>
       <% end %>
     <% else %>

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -398,9 +398,6 @@ paths:
                     - question: Will any part of the new structure be forward of the front of the original house?
                       responses:
                         - value: 'No'
-                    - question: How many storeys will the new structure have?
-                      responses:
-                        - value: '1'
                     - question: Will any part of the pool be forward of the front of the original house?
                       responses:
                         - value: 'No'
@@ -449,7 +446,7 @@ paths:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                    - question: Will the new addition allow you to do an acitivity that most houses do not provide a dedicated space for?
+                    - question: Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?
                       responses:
                         - value: 'Yes'
                       metadata:

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -454,6 +454,8 @@ paths:
                         - value: 'Yes'
                       metadata:
                         notes: It will allow me to exercise on a regular basis and generate energy
+                        flags:
+                          - Planning permission / Permission needed
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -389,6 +389,8 @@ paths:
                         - value: 'Yes'
                       metadata:
                         notes: It will allow me to exercise on a regular basis and generate energy
+                        flags:
+                          - 'Planning permission / Permission needed'
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -333,9 +333,6 @@ paths:
                     - question: Will any part of the new structure be forward of the front of the original house?
                       responses:
                         - value: 'No'
-                    - question: How many storeys will the new structure have?
-                      responses:
-                        - value: '1'
                     - question: Will any part of the pool be forward of the front of the original house?
                       responses:
                         - value: 'No'
@@ -384,7 +381,7 @@ paths:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                    - question: Will the new addition allow you to do an acitivity that most houses do not provide a dedicated space for?
+                    - question: Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?
                       responses:
                         - value: 'Yes'
                       metadata:

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
                 text: "GPDO 32.2342.223",
               },
             ],
-            flags: [ "Planning permission / Permission needed"]
+            flags: ["Planning permission / Permission needed"],
           },
         },
       ].to_json

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -48,6 +48,7 @@ FactoryBot.define do
                 text: "GPDO 32.2342.223",
               },
             ],
+            flags: [ "Planning permission / Permission needed"]
           },
         },
       ].to_json

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -196,7 +196,7 @@
       "question": "When was the original property built?",
       "metadata": {
         "flags": [
-          "Missing information"
+          "Planning permission / Permission needed"
         ]
       },
       "responses": [

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
     end
   end
 
+  describe "#display_number" do
+    it "returns the right number for an element in an array" do
+      expect(display_number([25, 84, "proposal", 165, true], 165)).to eq(4)
+    end
+  end
+
   describe "#display_decision_status" do
     context "refused" do
       let(:planning_application) do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -74,13 +74,23 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("Expiry date: #{planning_application.expiry_date.strftime('%e %B %Y').strip}")
     end
 
-    it "Result accordion" do
+    it "Result summary" do
       click_button "Result from #{api_user.name}"
 
       expect(page).to have_text("Planning permission / Permission needed")
       expect(page).to have_text(planning_application.result_heading)
       expect(page).to have_text(planning_application.result_description)
       expect(page).to have_text("Override")
+    end
+
+    it "Result question summary" do
+      click_button "Result from #{api_user.name}"
+
+      within(".govuk-accordion__section.result_information") do
+        expect(page).to have_text("what are you planning to do?")
+        expect(page).to have_text("demolish")
+        expect(page).to have_text("Details identified by #{api_user.name} as relevant to the result")
+      end
     end
 
     it "Contact information accordion" do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Planning Application show page", type: :system do
       click_button "Result from #{api_user.name}"
 
       within(".govuk-accordion__section.result_information") do
-        expect(page).to have_text("what are you planning to do?")
+        expect(page).to have_text("1. what are you planning to do?")
         expect(page).to have_text("demolish")
         expect(page).to have_text("Details identified by #{api_user.name} as relevant to the result")
       end


### PR DESCRIPTION
<img width="850" alt="proposal_question" src="https://user-images.githubusercontent.com/1880450/126523922-f2394e98-f7aa-48be-9bba-459040d66a5d.png">

### Description of change

We need to find the question(s) that have a flag that matches the flag that is present in the `result` object that RIPA sends us. These are displayed with a number that matches their number in the ordered list in the proposal details array. 

We derive this from the question's index in the proposal_details array, offset by +1.

### Story Link

https://trello.com/c/I99MPhuL/411-as-an-officer-i-want-to-show-the-questions-that-led-to-ripas-decision

