### PR TITLE
Remove 'Sitemap' tag

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -30,7 +30,6 @@ class Document < ApplicationRecord
     "Bank Statement",
     "Statutory Declaration",
     "Other",
-    "Sitemap",
   ].freeze
 
   TAGS = PLAN_TAGS + EVIDENCE_TAGS

--- a/app/views/planning_applications/draw_sitemap.html.erb
+++ b/app/views/planning_applications/draw_sitemap.html.erb
@@ -2,7 +2,7 @@
 <h3 class="govuk-heading-s">Red line site boundary on submission</h3>
 <p class="govuk-body">Site address: <%= @planning_application.full_address %></p>
 
-<%- sitemap_documents = @planning_application.documents.with_tag("Sitemap") %>
+<%- sitemap_documents = @planning_application.documents.with_tag("Site") %>
 <% if sitemap_documents.size == 0 %>
   <p class="govuk-body">No document has been tagged as a sitemap for this application</p>
   <p class="govuk-body"><%= link_to "View all documents", planning_application_documents_path(@planning_application) %></p>

--- a/spec/system/planning_applications/drawing_sitemap_spec.rb
+++ b/spec/system/planning_applications/drawing_sitemap_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
     end
 
     context "with 1 document tagged with sitemap" do
-      let!(:document1) { create :document, tags: %w[Sitemap], planning_application: planning_application }
+      let!(:document1) { create :document, tags: %w[Site], planning_application: planning_application }
 
       it "links to that documents" do
         click_button "Site map"
@@ -94,8 +94,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
     end
 
     context "with 2 document tagged with sitemap" do
-      let!(:document1) { create :document, tags: %w[Sitemap], planning_application: planning_application }
-      let!(:document2) { create :document, tags: %w[Sitemap], planning_application: planning_application }
+      let!(:document1) { create :document, tags: %w[Site], planning_application: planning_application }
+      let!(:document2) { create :document, tags: %w[Site], planning_application: planning_application }
 
       it "links to all documents" do
         click_button "Site map"


### PR DESCRIPTION
I previously added a 'Sitemap' tag, when actually we want people to use the existing 'Site' tag for sitemaps.