### PR TITLE
Allow cancellation of document archive

### DIFF
--- a/app/views/documents/_archive_form.html.erb
+++ b/app/views/documents/_archive_form.html.erb
@@ -18,7 +18,7 @@
       </div>
     </fieldset>
     <p>
-      <%= form.submit "Archive", class: "govuk-button", data: { module: "govuk-button" } %> <%= link_to 'Cancel', planning_application_document_archive_path, class: "govuk-button govuk-button--secondary" %>
+      <%= form.submit "Archive", class: "govuk-button", data: { module: "govuk-button" } %> <%= link_to 'Cancel', planning_application_documents_path, class: "govuk-button govuk-button--secondary" %>
     </p>
   </div>
 <% end %>

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -176,6 +176,13 @@ RSpec.describe "Documents index page", type: :system do
 
       expect(page).to have_text("proposed-floorplan.png has been archived")
     end
+
+    it "User can cancel archiving journey" do
+      click_link "Cancel"
+
+      expect(page).to have_current_path(/documents/)
+      expect(page).to have_content("Check all documents to ensure they support the information")
+    end
   end
 
   context "Application that is awaiting determination" do


### PR DESCRIPTION
### Description of change

Update the path of the Cancel link on the archive view to return to the Documents view

### Story Link

https://trello.com/c/hwcFIULv/338-cancel-from-archive-a-document-it-doesnt-seem-to-work