### PR TITLE
Enforce date ordering on planning applications index

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -29,11 +29,11 @@ class PlanningApplicationsController < AuthenticationController
 
   def index
     @planning_applications = if helpers.exclude_others? && current_user.assessor?
-                               current_local_authority.planning_applications.where(user_id: current_user.id).or(
-                                 current_local_authority.planning_applications.where(user_id: nil),
+                               current_local_authority.planning_applications.where(user_id: current_user.id).order("created_at DESC").or(
+                                 current_local_authority.planning_applications.where(user_id: nil).order("created_at DESC"),
                                )
                              else
-                               current_local_authority.planning_applications.all
+                               current_local_authority.planning_applications.all.order("created_at DESC")
                              end
   end
 


### PR DESCRIPTION
### Description of change

We now enforce ordering by most recent creation date on the planning applications index.

### Story Link

https://trello.com/c/cM56uL5k/429-rearrange-the-order-of-the-submitted-applications-in-the-homepage-by-received-date-with-newest-at-the-top

