### PR TITLE
Amend incorrect wording in receipt email

### DIFF
--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -18,7 +18,7 @@ If by <%= @planning_application.target_date.strftime("%e %B %Y") %>:
 
 - you have not been given a decision in writing
 - you have not been told that the application is invalid
-- you not agreed in writing to extend the decision period
+- you have not agreed in writing to extend the decision period
 
 Then you can appeal to the Secretary of State under section 195 of the Town and Country Planning Act 1990. This does not apply if your application has already been referred to the Secretary of State. You can find out how to appeal an application for a Lawful Development Certificate here: https://www.gov.uk/appeal-lawful-development-certificate-decision.
 


### PR DESCRIPTION
### Description of change

We are missing the word 'have' in this email. Note that the copy is under review by stakeholders and will likely change again.

