### PR TITLE
Reinstate lvh.me for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Back Office Planning System (BOPS)
 
 ## Preflight
 
+Pre-installed dependencies include ImageMagick and Poppler for generating and previewing thumbnails for images and PDFs respectively.
+
 ### Clone the project
 
 ```sh
@@ -67,9 +69,9 @@ $ rails server
 #### Because of the subdomain being enforced, your app will be available on:
 
 ```
-http://southwark.local.abscond.org:3000/
+http://southwark.local.lvh.me:3000/
 or
-http://lambeth.local.abscond.org:3000/
+http://lambeth.local.lvh.me:3000/
 ```
 ##Dependencies
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "local.abscond.org"), port: 3000 }
+  config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "local.lvh.me"), port: 3000 }
 
-  config.hosts << ".local.abscond.org"
+  config.hosts << ".local.lvh.me"
 end


### PR DESCRIPTION
### Description of change

This DNS service became unavailable but has since been restored, so we are reverting to it in order to use subdomains on localhost.

