### PR TITLE
Remove redraw sitemap link if applicant created map

### DIFF
--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -88,7 +88,7 @@
         </p>
         <% if @planning_application.officer_can_draw_boundary? %>
           <p class="govuk-body">
-            <%= link_to "Redraw digital sitemap", draw_sitemap_planning_application_path(@planning_application) %>
+            <%= link_to "Redraw digital sitemap", draw_sitemap_planning_application_path(@planning_application) if @planning_application.boundary_created_by.present? %>
           </p>
         <% end %>
         <%= render "shared/location_map", locals: { div_id: "accordion_map", geojson: @planning_application.boundary_geojson } %>

--- a/spec/system/planning_applications/drawing_sitemap_spec.rb
+++ b/spec/system/planning_applications/drawing_sitemap_spec.rb
@@ -55,6 +55,18 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
     end
   end
 
+  context "when application has a boundary created by the applicant" do
+    let!(:planning_application) do
+      create :planning_application, :with_boundary_geojson, local_authority: @default_local_authority
+    end
+
+    it "is not possible to redraw a sitemap" do
+      click_button "Site map"
+      expect(page).to have_content("Sitemap drawn by Applicant")
+      expect(page).not_to have_link("Redraw digital sitemap")
+    end
+  end
+
   context "when application is already validated and has a boundary" do
     let!(:planning_application) do
       create :planning_application, :with_boundary_geojson, local_authority: @default_local_authority


### PR DESCRIPTION
### Description of change

Display the ability to redraw the site map only if the map was originally created by the planning officer

### Story Link

https://trello.com/c/m8GLB6hG/444-remove-the-possibility-for-a-planning-officer-to-edit-a-red-line-drawn-by-an-applicant-via-the-link-to-redraw-red-line-they-shou