### PR TITLE
Enforce email to agent when present

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -48,7 +48,7 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
         activity_information: current_api_user.name,
       )
       send_success_response
-      receipt_notice_mail if @planning_application.applicant_email.present?
+      receipt_notice_mail if @planning_application.agent_email.present? || @planning_application.applicant_email.present?
     else
       send_failed_response
     end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -54,7 +54,7 @@ class PlanningApplicationsController < AuthenticationController
     if @planning_application.save
       audit("created", nil, current_user.name)
       flash[:notice] = "Planning application was successfully created."
-      receipt_notice_mail if @planning_application.applicant_email.present?
+      receipt_notice_mail if @planning_application.agent_email.present? || @planning_application.applicant_email.present?
       redirect_to planning_application_documents_path(@planning_application)
     else
       render :new
@@ -107,7 +107,7 @@ class PlanningApplicationsController < AuthenticationController
       @planning_application.start!
       audit("started")
       validation_notice_mail
-      flash[:notice] = "Application is ready for assessment and applicant has been notified"
+      flash[:notice] = "Application is ready for assessment and an email notification has been sent."
       render :show
     end
   end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -3,6 +3,14 @@
 class PlanningApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
 
+  def email_applicant_or_agent(planning_application)
+    planning_application.agent_email.presence || planning_application.applicant_email
+  end
+
+  def bcc_email(planning_application)
+    planning_application.applicant_email if planning_application.agent_email.present?
+  end
+
   def decision_notice_mail(planning_application, host)
     @planning_application = planning_application
     @documents = @planning_application.documents.for_display
@@ -11,7 +19,8 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Certificate of Lawfulness: #{@planning_application.decision}",
-      to: @planning_application.applicant_email,
+      to: email_applicant_or_agent(@planning_application),
+      bcc: bcc_email(@planning_application),
     )
   end
 
@@ -22,7 +31,8 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application has been validated",
-      to: @planning_application.applicant_email,
+      to: email_applicant_or_agent(@planning_application),
+      bcc: bcc_email(@planning_application),
     )
   end
 
@@ -33,7 +43,8 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application is invalid",
-      to: @planning_application.applicant_email,
+      to: email_applicant_or_agent(@planning_application),
+      bcc: bcc_email(@planning_application),
     )
   end
 
@@ -44,18 +55,20 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "We have received your application",
-      to: @planning_application.applicant_email,
+      to: email_applicant_or_agent(@planning_application),
+      bcc: bcc_email(@planning_application),
     )
   end
 
   def validation_request_mail(planning_application, validation_request)
     @planning_application = planning_application
     @validation_request = validation_request
+    @application_accountable_email = @planning_application.agent_email.presence || @planning_application.applicant_email
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application at: #{@planning_application.full_address}",
-      to: @planning_application.applicant_email,
+      to: @application_accountable_email,
     )
   end
 end


### PR DESCRIPTION
### Description of change
agreed approach:

- Email both applicant and agent:
  decision notice
  validation notice
  receipt notice

- Only validation requests go to:
 if agent, only go to agent
 if applicant, go to agent if agent exists if not got to applicant



### Story Link
https://trello.com/c/x4mQZ5j0/405-all-emails-notifications-decision-notice-to-go-to-either-agent-or-applicant