### PR TITLE
Update notified_at when planning application is invalidated

### DIFF
--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -1,4 +1,4 @@
-class AdditionalDocumentValidationRequestsController < ApplicationController
+class AdditionalDocumentValidationRequestsController < ValidationRequestsController
   def new
     @additional_document_validation_request = planning_application.additional_document_validation_requests.new
   end
@@ -9,7 +9,7 @@ class AdditionalDocumentValidationRequestsController < ApplicationController
 
     if @additional_document_validation_request.save
       flash[:notice] = "Additional document request successfully created."
-      send_validation_request_email if @planning_application.invalidated?
+      email_and_timestamp(@additional_document_validation_request) if @planning_application.invalidated?
       audit("additional_document_validation_request_sent", document_create_audit_item(@additional_document_validation_request),
             @additional_document_validation_request.sequence)
       redirect_to planning_application_validation_requests_path(@planning_application)
@@ -26,13 +26,6 @@ private
 
   def planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
-  end
-
-  def send_validation_request_email
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      @additional_document_validation_request,
-    ).deliver_now
   end
 
   def document_create_audit_item(additional_document_validation_request)

--- a/app/controllers/description_change_validation_requests_controller.rb
+++ b/app/controllers/description_change_validation_requests_controller.rb
@@ -1,4 +1,4 @@
-class DescriptionChangeValidationRequestsController < ApplicationController
+class DescriptionChangeValidationRequestsController < ValidationRequestsController
   before_action :set_planning_application, only: %i[new create]
 
   def new
@@ -11,7 +11,7 @@ class DescriptionChangeValidationRequestsController < ApplicationController
     @current_local_authority = current_local_authority
 
     if @description_change_validation_request.save
-      send_validation_request_email if @planning_application.invalidated?
+      email_and_timestamp(@description_change_validation_request) if @planning_application.invalidated?
 
       flash[:notice] = "Validation request for description successfully created."
       audit("description_change_validation_request_sent", description_audit_item(@description_change_validation_request, @planning_application),
@@ -31,13 +31,6 @@ private
 
   def set_planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
-  end
-
-  def send_validation_request_email
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      @description_change_validation_request,
-    ).deliver_now
   end
 
   def description_audit_item(description_change_validation_request, planning_application)

--- a/app/controllers/other_change_validation_requests_controller.rb
+++ b/app/controllers/other_change_validation_requests_controller.rb
@@ -1,4 +1,4 @@
-class OtherChangeValidationRequestsController < ApplicationController
+class OtherChangeValidationRequestsController < ValidationRequestsController
   before_action :set_planning_application, only: %i[new create show]
 
   def new
@@ -14,7 +14,7 @@ class OtherChangeValidationRequestsController < ApplicationController
     @other_change_validation_request.user = current_user
 
     if @other_change_validation_request.save
-      send_validation_request_email if @planning_application.invalidated?
+      email_and_timestamp(@other_change_validation_request) if @planning_application.invalidated?
 
       flash[:notice] = "Other validation change request successfully created."
       audit("other_change_validation_request_sent", audit_item(@other_change_validation_request),
@@ -33,13 +33,6 @@ private
 
   def set_planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
-  end
-
-  def send_validation_request_email
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      @other_change_validation_request,
-    ).deliver_now
   end
 
   def audit_item(other_change_validation_request)

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -1,4 +1,4 @@
-class RedLineBoundaryChangeValidationRequestsController < ApplicationController
+class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsController
   before_action :set_planning_application, only: %i[new create show]
 
   def new
@@ -15,7 +15,7 @@ class RedLineBoundaryChangeValidationRequestsController < ApplicationController
     @red_line_boundary_change_validation_request.user = current_user
 
     if @red_line_boundary_change_validation_request.save
-      send_validation_request_email if @planning_application.invalidated?
+      email_and_timestamp(@red_line_boundary_change_validation_request) if @planning_application.invalidated?
 
       flash[:notice] = "Validation request for red line boundary successfully created."
       audit("red_line_boundary_change_validation_request_sent", red_line_boundary_audit_item(@red_line_boundary_change_validation_request),
@@ -34,13 +34,6 @@ private
 
   def set_planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
-  end
-
-  def send_validation_request_email
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      @red_line_boundary_change_validation_request,
-    ).deliver_now
   end
 
   def red_line_boundary_audit_item(validation_request)

--- a/app/controllers/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/replacement_document_validation_requests_controller.rb
@@ -1,4 +1,4 @@
-class ReplacementDocumentValidationRequestsController < ApplicationController
+class ReplacementDocumentValidationRequestsController < ValidationRequestsController
   def new
     @replacement_document_validation_request = planning_application.replacement_document_validation_requests.new
   end
@@ -12,7 +12,7 @@ class ReplacementDocumentValidationRequestsController < ApplicationController
     end
 
     flash[:notice] = "Replacement document validation request successfully created."
-    send_validation_request_email if @planning_application.invalidated?
+    email_and_timestamp(@replacement_document_validation_request) if @planning_application.invalidated?
     audit("replacement_document_validation_request_sent", document_change_audit_item(@replacement_document_validation_request),
           @replacement_document_validation_request.sequence)
     redirect_to planning_application_validation_requests_path(@planning_application)
@@ -22,13 +22,6 @@ private
 
   def planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
-  end
-
-  def send_validation_request_email
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      @replacement_document_validation_request,
-    ).deliver_now
   end
 
   def document_change_audit_item(replacement_document_validation_request)

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -28,4 +28,16 @@ private
   def set_planning_application
     @planning_application = PlanningApplication.find(params[:planning_application_id])
   end
+
+  def send_validation_request_email(request)
+    PlanningApplicationMailer.validation_request_mail(
+      @planning_application,
+      request,
+    ).deliver_now
+  end
+
+  def email_and_timestamp(request)
+    send_validation_request_email(request)
+    request.update!(notified_at: Time.zone.now)
+  end
 end


### PR DESCRIPTION
### Description of change

All types of validation request currently get a `notified_at` date when the application is invalidated, while validation requests that are sent when the application is in `invalidated` state do not get this update.

This commit unifies the approach so that all validation requests have the `notified_at` field updated, regardless of the planning application status.

### Story Link

https://trello.com/c/NU4AXeJV/489-update-notifiedat-field-for-all-validation-requests

