### PR TITLE
Update date format in validation mail

### DIFF
--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -14,7 +14,7 @@ Please quote the planning reference number <%= @planning_application.reference %
 
 We may request additional information and/or revisions before deciding whether the application should be recommended for permission or refusal.
 
-We aim to issue a decision by <%= @planning_application.target_date.strftime("%e %B %Y") %>. However, if your application has not been determined by <%= @planning_application.target_date %>, you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate, or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
+We aim to issue a decision by <%= @planning_application.target_date.strftime("%e %B %Y") %>. However, if your application has not been determined by <%= @planning_application.target_date.strftime("%e %B %Y") %>, you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate, or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
 
 An appeal in this situation assumes the refusal of the application, even if it had intended to be granted. It is therefore recommended that you consult your case officer before taking such action.
 


### PR DESCRIPTION
### Description of change

We had mismatching date formats in the validation mailtext. Correct `.strftime` format now applied.

### Story Link

https://trello.com/c/K2RsIONy/434-update-notification-text-in-confirmation-of-validation-to-remove-hard-code-references-to-southwark-council

