### PR TITLE
Add migration to update existing applications

### DIFF
--- a/db/migrate/20210913155856_update_notified_at.rb
+++ b/db/migrate/20210913155856_update_notified_at.rb
@@ -1,0 +1,13 @@
+class UpdateNotifiedAt < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        PlanningApplication.find_each do |planning_application|
+          planning_application.validation_requests.each do |request|
+            request.update(notified_at: request.created_at)
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_145259) do
+ActiveRecord::Schema.define(version: 2021_09_13_155856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
### Description of change

Due to the change in implementation of when notifications for change requests get sent, we need to make sure previous change requests also have a notified_at field to inform officers of when the email notification was sent to the user

### Story Link
https://trello.com/c/rL7CZA0b/363-add-created-and-received-dates-on-to-validation-request-table