### PR TITLE
css: use the correct styling for links

### DIFF
--- a/app/views/application/_create_breadcrumb_navigation.html.erb
+++ b/app/views/application/_create_breadcrumb_navigation.html.erb
@@ -1,6 +1,6 @@
 <% nav.each do |n| %>
   <li class="govuk-breadcrumbs__list-item" aria-current="page">
-    <%= link_to n[:title], n[:path], class: "govuk-button__link" %>
+    <%= link_to n[:title], n[:path], class: "govuk-breadcrumbs__link" %>
   </li>
 <% end %>
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,19 +3,19 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "govuk-link" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "govuk-link" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "govuk-link" %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "govuk-link" %><br />
   <% end %>
 <% end %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -9,7 +9,7 @@
     <%= link_to image_tag(@document.file.representation(resize: "500x500"), style: 'max-width:100%'),
                 url_for_document(@document), target: :_blank %>
     <p class="govuk-body">
-      <%= link_to "View in new window", url_for_document(@document), target: :_new %>
+      <%= link_to "View in new window", url_for_document(@document), target: :_new, class: "govuk-link" %>
     </p>
   </div>
   <div class="govuk-grid-column-one-half">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -53,7 +53,7 @@
             <%= link_to image_tag(document.file.representation(resize: "300x212")),
                         url_for_document(document), target: :_blank %>
             <p class="govuk-body">
-              <%= link_to "View in new window", url_for_document(document), target: :_new %>
+              <%= link_to "View in new window", url_for_document(document), target: :_new, class: "govuk-link" %>
             </p>
           </td>
           <td class="govuk-table__cell govuk-!-width-one-half">
@@ -99,8 +99,8 @@
           <td class="govuk-table__cell">
               <% if @planning_application.can_validate? %>
                 <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
-                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br />
-                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id) %>
+                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br />
+                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %>
                 </p>
               <% end %>
           </td>

--- a/app/views/planning_applications/_proposal_header.html.erb
+++ b/app/views/planning_applications/_proposal_header.html.erb
@@ -24,13 +24,13 @@
     <div class="govuk-grid-column-two-thirds assigned_to">
       <p class="govuk-body">
         Assigned to: <strong><%= @planning_application.user ? @planning_application.user.name : "Unassigned" %></strong>
-        <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application) %></span>
+        <span class="assignment_cta"><%= link_to "Change", assign_planning_application_path(@planning_application), class: "govuk-link" %></span>
       </p>
     </div>
   </div>
 <% elsif @planning_application.determined? %>
   <p class="govuk-body">
-    <%= link_to "View decision notice", decision_notice_planning_application_path(@planning_application)%>
+    <%= link_to "View decision notice", decision_notice_planning_application_path(@planning_application), class: "govuk-link" %>
   </p>
 <% end %>
 

--- a/app/views/planning_applications/decision_notice.html.erb
+++ b/app/views/planning_applications/decision_notice.html.erb
@@ -16,7 +16,7 @@
     <%= render "decision_notice", planning_application: @planning_application %>
 
     <p class="govuk-body">
-      <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf') %>
+      <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
     </p>
   </div>
 </div>

--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -6,7 +6,7 @@
 
   <%= render "decision_notice", planning_application: @planning_application %>
   <p class="govuk-body">
-    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf') %>
+    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
   </p>
   <% if @planning_application.awaiting_determination? %>
     <p class="govuk-body">By determining the application, the applicant will receive this decision notice. The decision notice will also be available publicly. </p>

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -16,7 +16,7 @@
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_validate? %>
-                <%= link_to "Validate application", validate_form_planning_application_path(@planning_application), aria: { describedby: "validation-completed" } %>
+                <%= link_to "Validate application", validate_form_planning_application_path(@planning_application), aria: { describedby: "validation-completed" }, class: "govuk-link" %>
               <% else %>
                 Validate application
               <% end %>
@@ -39,7 +39,7 @@
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_assess? %>
-                <%= link_to "Assess proposal", recommendation_form_planning_application_path(@planning_application), aria: {describedby: "assessment-completed"}%>
+                <%= link_to "Assess proposal", recommendation_form_planning_application_path(@planning_application), aria: { describedby: "assessment-completed" }, class: "govuk-link" %>
               <% else %>
                 Assess proposal
               <% end %>
@@ -51,7 +51,7 @@
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_submit_recommendation? %>
-                <%= link_to "Submit recommendation", submit_recommendation_planning_application_path(@planning_application), aria: {describedby: "submit_recommendation-completed"} %>
+                <%= link_to "Submit recommendation", submit_recommendation_planning_application_path(@planning_application), aria: { describedby: "submit_recommendation-completed" }, class: "govuk-link" %>
               <% else %>
                 Submit recommendation
               <% end %>
@@ -74,9 +74,9 @@
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_review_assessment? && current_user.reviewer? %>
-                <%= link_to "Review assessment", review_form_planning_application_path(@planning_application), aria: {describedby: "review_assessment-completed"} %>
+                <%= link_to "Review assessment", review_form_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
               <% elsif @planning_application.can_review_assessment? && !current_user.reviewer? %>
-                <%= link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: {describedby: "review_assessment-completed"}%>
+                <%= link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
               <% else %>
                 Review assessment
               <% end %>
@@ -90,7 +90,7 @@
           <li class="app-task-list__item">
             <span class="app-task-list__task-name">
               <% if @planning_application.can_publish? && current_user.reviewer? %>
-                <%= link_to "Publish determination", publish_planning_application_path(@planning_application), aria: {describedby: "publish-completed"} %>
+                <%= link_to "Publish determination", publish_planning_application_path(@planning_application), aria: { describedby: "publish-completed" }, class: "govuk-link" %>
               <% else %>
                 Publish determination
               <% end %>

--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -5,7 +5,7 @@
   <p class="govuk-body">The following decision notice has been created based on your answers.</p>
   <%= render "decision_notice", planning_application: @planning_application %>
   <p class="govuk-body">
-    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf') %>
+    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
   </p>
   <p class="govuk-body">
     <br>

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -9,7 +9,7 @@
     </div>
     <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
       <p class="govuk-body">
-        <%= link_to 'Edit details', edit_planning_application_path(@planning_application) %>
+        <%= link_to 'Edit details', edit_planning_application_path(@planning_application), class: "govuk-link" %>
       </p>
       <hr>
       <table class="govuk-table">
@@ -34,7 +34,7 @@
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>Location:</strong></td>
-            <td class="govuk-table__cell"><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank' %></td>
+            <td class="govuk-table__cell"><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></td>
           </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>UPRN:</strong></td>
@@ -88,7 +88,7 @@
         </p>
         <% if @planning_application.officer_can_draw_boundary? %>
           <p class="govuk-body">
-            <%= link_to "Redraw digital sitemap", draw_sitemap_planning_application_path(@planning_application) %>
+            <%= link_to "Redraw digital sitemap", draw_sitemap_planning_application_path(@planning_application), class: "govuk-link" %>
           </p>
         <% end %>
         <%= render "shared/location_map", locals: { in_accordion: true, geojson: @planning_application.boundary_geojson } %>
@@ -96,7 +96,7 @@
         <p class="govuk-body">No digital sitemap provided</p>
         <% if @planning_application.officer_can_draw_boundary? %>
           <p class="govuk-body">
-            <%= link_to "Draw digital sitemap", draw_sitemap_planning_application_path(@planning_application) %>
+            <%= link_to "Draw digital sitemap", draw_sitemap_planning_application_path(@planning_application), class: "govuk-link" %>
           </p>
         <% end %>
       <% end %>

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -13,7 +13,7 @@
   </div>
   <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-4">
     <p class="govuk-body">
-      <%= link_to "Manage documents", planning_application_documents_path(@planning_application) %>
+      <%= link_to "Manage documents", planning_application_documents_path(@planning_application), class: "govuk-link" %>
     </p>
 
       <div class="scroll-docs">
@@ -27,7 +27,7 @@
               url_for_document(document), target: :_blank %>
             </p>
             <p class="govuk-body">
-              <%= link_to "View in new window", url_for_document(document), target: :_blank %>
+              <%= link_to "View in new window", url_for_document(document), target: :_blank, class: "govuk-link" %>
             </p>
           </div>
 
@@ -73,4 +73,3 @@
 
   </div>
 </div>
-

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -23,9 +23,11 @@
           <% end %>
         </ul>
       <% end %>
-      <p class="govuk-body">
-        <%= link_to "Update", edit_constraints_form_planning_application_path(@planning_application) if @planning_application.can_validate? %>
-      </p>
+      <% if @planning_application.can_validate? %>
+        <p class="govuk-body">
+          <%= link_to "Update", edit_constraints_form_planning_application_path(@planning_application), class: "govuk-link" %>
+        </p>
+      <% end %>
     </div>
   </div>
   <div class="govuk-accordion__section">
@@ -62,7 +64,7 @@
         <%= @planning_application.expiry_date.strftime("%e %B %Y") %>
       </p>
       <p class="govuk-body">
-        <%= link_to "Activity log", planning_application_audits_path(@planning_application) %>
+        <%= link_to "Activity log", planning_application_audits_path(@planning_application), class: "govuk-link" %>
       </p>
     </div>
   </div>
@@ -118,7 +120,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds cancel">
       <p class="govuk-body">
-        <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application) %>
+        <%= link_to "Cancel application", cancel_confirmation_planning_application_path(@planning_application), class: "govuk-link" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
### Description of change

Some links weren't using GOV.UK styling for links.

## Before

![Screen Shot 2021-08-26 at 13 22 17](https://user-images.githubusercontent.com/107635/130961902-66c064cb-3ce0-430f-a9e1-c54083b630a8.png)

## After
![Screen Shot 2021-08-26 at 13 23 58](https://user-images.githubusercontent.com/107635/130962062-4772c67d-5ae5-4918-9aad-d698ddc4ab6d.png)
