### PR TITLE
Update proposals_with_flags method

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -234,16 +234,20 @@ class PlanningApplication < ApplicationRecord
   end
 
   def proposal_details_with_metadata
-    parsed_proposal_details.select { |proposal| proposal["metadata"].present? }
+    parsed_proposal_details.select do |proposal|
+      proposal["responses"].any? { |element| element["metadata"].present? }
+    end
   end
 
   def proposal_details_with_flags
-    proposal_details_with_metadata.select { |proposal| proposal["metadata"]["flags"].present? }
+    proposal_details_with_metadata.select do |proposal|
+      proposal["responses"].any? { |element| element["metadata"]["flags"].present? }
+    end
   end
 
   def flagged_proposal_details(flag)
     proposal_details_with_flags.select do |proposal|
-      proposal["metadata"]["flags"].include?(flag)
+      proposal["responses"].select { |element| element["metadata"]["flags"].include?(flag) }
     end
   end
 

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -37,6 +37,9 @@ FactoryBot.define do
           responses: [
             {
               value: "demolish",
+              metadata: {
+                flags: ["Planning permission / Permission needed"],
+              },
             },
           ],
           metadata: {
@@ -48,7 +51,6 @@ FactoryBot.define do
                 text: "GPDO 32.2342.223",
               },
             ],
-            flags: ["Planning permission / Permission needed"],
           },
         },
       ].to_json

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -194,14 +194,14 @@
     },
     {
       "question": "When was the original property built?",
-      "metadata": {
-        "flags": [
-          "Planning permission / Permission needed"
-        ]
-      },
       "responses": [
         {
-          "value": "Don't know"
+          "value": "Don't know",
+          "metadata": {
+            "flags": [
+              "Planning permission / Permission needed"
+            ]
+          }
         }
       ]
     },


### PR DESCRIPTION
### Description of change

The data that is being submitted has two metadata fields per response: one inside the responses array and one outside. Our code assumed that the metadata field outside the responses array would contain the `flag` field but this is incorrect. 

This commit selects the relevant questions that are displayed under the RIPA Result content by the metadata in the responses array.

### Story Link

https://trello.com/c/c56aOEkX/472-is-ripa-result-flag-key-qs-supposed-to-be-pulling-through

