### PR TITLE
Fix/time format dash

### DIFF
--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -23,7 +23,7 @@
     <% planning_applications.each do |planning_application| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
-          <%= link_to planning_application.reference, planning_application %>
+          <%= link_to planning_application.reference, planning_application, class: "govuk-link" %>
         </td>
         <td class="govuk-table__cell"><%= planning_application.full_address %></td>
         <td class="govuk-table__cell"><%= t("application_types.#{planning_application.application_type}") %></td>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -8,7 +8,7 @@
         <strong><%= current_user.name %>,</strong> <%= role_name %>
       </p>
       <p class="govuk-body govuk-!-padding-bottom-2">
-        <%= link_to "Add new application", new_planning_application_path %>
+        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
       <p class="govuk-body"><%= link_to "View all applications", planning_applications_path, class: "govuk-button" %></p>
     <% else %>

--- a/config/initializers/date_formatter.rb
+++ b/config/initializers/date_formatter.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Time::DATE_FORMATS[:day_month_year] = Date::DATE_FORMATS[:day_month_year] = "-%d %B %Y"
+Time::DATE_FORMATS[:day_month_year] = Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"


### PR DESCRIPTION
### Description of change

Fix a typo in the date format that was causing an extra dash to appear in front of dates.
