### PR TITLE
deploy: reapply sysadmins as part of the deploy

### DIFF
--- a/lib/package_builder/scripts/after_install.sh
+++ b/lib/package_builder/scripts/after_install.sh
@@ -4,6 +4,8 @@ set -o pipefail
 
 chown -R deploy:deploy /home/deploy/bops/releases/<%= release %>
 
+reapply-sysadmins
+
 su - deploy <<'EOF'
 ln -nfs /home/deploy/bops/shared/tmp /home/deploy/bops/releases/<%= release %>/tmp
 ln -nfs /home/deploy/bops/shared/log /home/deploy/bops/releases/<%= release %>/log


### PR DESCRIPTION
It's not too much overhead and removes the need to run either:

* an AWS Instance Refresh (which will run through the early Ansible steps
that deals with SSH - normal deploy doesn't);
* have a fellow dev log into the machine and run the
`reapply-sysadmins` command manually.

