### PR TITLE
Email agent and applicant

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -48,7 +48,7 @@ class Api::V1::PlanningApplicationsController < Api::V1::ApplicationController
         activity_information: current_api_user.name,
       )
       send_success_response
-      receipt_notice_mail if @planning_application.applicant_email.present?
+      receipt_notice_mail if @planning_application.agent_email.present? || @planning_application.applicant_email.present?
     else
       send_failed_response
     end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -54,7 +54,7 @@ class PlanningApplicationsController < AuthenticationController
     if @planning_application.save
       audit("created", nil, current_user.name)
       flash[:notice] = "Planning application was successfully created."
-      receipt_notice_mail if @planning_application.applicant_email.present?
+      receipt_notice_mail if @planning_application.agent_email.present? || @planning_application.applicant_email.present?
       redirect_to planning_application_documents_path(@planning_application)
     else
       render :new
@@ -107,7 +107,7 @@ class PlanningApplicationsController < AuthenticationController
       @planning_application.start!
       audit("started")
       validation_notice_mail
-      flash[:notice] = "Application is ready for assessment and applicant has been notified"
+      flash[:notice] = "Application is ready for assessment and an email notification has been sent."
       render :show
     end
   end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -3,6 +3,13 @@
 class PlanningApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
 
+  def applicant_and_agent_email(planning_application)
+    @agent = planning_application.agent_email
+    @applicant = planning_application.applicant_email
+
+    [@agent, @applicant].reject(&:nil?)
+  end
+
   def decision_notice_mail(planning_application, host)
     @planning_application = planning_application
     @documents = @planning_application.documents.for_display
@@ -11,7 +18,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Certificate of Lawfulness: #{@planning_application.decision}",
-      to: @planning_application.applicant_email,
+      to: applicant_and_agent_email(@planning_application),
     )
   end
 
@@ -22,7 +29,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application has been validated",
-      to: @planning_application.applicant_email,
+      to: applicant_and_agent_email(@planning_application),
     )
   end
 
@@ -33,7 +40,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application is invalid",
-      to: @planning_application.applicant_email,
+      to: applicant_and_agent_email(@planning_application),
     )
   end
 
@@ -44,18 +51,19 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "We have received your application",
-      to: @planning_application.applicant_email,
+      to: applicant_and_agent_email(@planning_application),
     )
   end
 
   def validation_request_mail(planning_application, validation_request)
     @planning_application = planning_application
     @validation_request = validation_request
+    @application_accountable_email = @planning_application.agent_email.presence || @planning_application.applicant_email
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application at: #{@planning_application.full_address}",
-      to: @planning_application.applicant_email,
+      to: @application_accountable_email,
     )
   end
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
   let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
   let!(:assessor) { create :user, :assessor, local_authority: local_authority }
-  let!(:planning_application) { create(:planning_application, :determined, local_authority: local_authority, decision: "granted") }
+  let!(:planning_application) { create(:planning_application, :determined, agent_email: "cookie_crackers@example.com", applicant_email: "cookie_crumbs@example.com", local_authority: local_authority, decision: "granted") }
   let(:host) { "default.example.com" }
   let!(:validation_request) { create(:description_change_validation_request, planning_application: planning_application, user: assessor) }
 
@@ -37,7 +37,18 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the headers" do
       expect(mail.subject).to eq("Certificate of Lawfulness: granted")
+    end
+
+    it "emails the applicant when only the applicant is present" do
+      planning_application.update!(agent_email: "")
+      mail = described_class.decision_notice_mail(planning_application.reload, host)
+
       expect(mail.to).to eq([planning_application.applicant_email])
+    end
+
+    it "emails both applicant and agent when both are present" do
+      expect(mail.subject).to eq("Certificate of Lawfulness: granted")
+      expect(mail.to).to eq([planning_application.agent_email, planning_application.applicant_email])
     end
 
     it "renders the body" do
@@ -73,7 +84,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the headers" do
       expect(invalidation_mail.subject).to eq("Your planning application is invalid")
-      expect(invalidation_mail.to).to eq([planning_application.applicant_email])
+      expect(invalidation_mail.to).to eq([planning_application.agent_email, planning_application.applicant_email])
     end
 
     it "renders the body" do
@@ -91,7 +102,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the headers" do
       expect(validation_mail.subject).to eq("Your planning application has been validated")
-      expect(validation_mail.to).to eq([planning_application.applicant_email])
+      expect(validation_mail.to).to eq([planning_application.agent_email, planning_application.applicant_email])
     end
 
     it "renders the body" do
@@ -111,7 +122,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the headers" do
       expect(validation_request_mail.subject).to eq("Your planning application at: #{planning_application.full_address}")
-      expect(validation_request_mail.to).to eq([planning_application.applicant_email])
+      expect(validation_request_mail.to).to eq([planning_application.agent_email])
     end
 
     it "renders the body" do
@@ -133,7 +144,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the headers" do
       expect(receipt_mail.subject).to eq("We have received your application")
-      expect(receipt_mail.to).to eq([planning_application.applicant_email])
+      expect(receipt_mail.to).to eq([planning_application.agent_email, planning_application.applicant_email])
     end
 
     it "renders the body" do


### PR DESCRIPTION
### Description of change

Email both applicant and agent:

- decision notice
- validation notice
- receipt notice

Only validation requests go to:

- if agent, only go to agent
- if applicant, go to agent if agent exists if not got to applicant

### Story Link
https://trello.com/c/x4mQZ5j0/405-all-emails-notifications-decision-notice-to-go-to-either-agent-or-applicant