### PR TITLE
Send two emails on receipt, validation & decision

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -128,9 +128,12 @@ private
   end
 
   def receipt_notice_mail
-    PlanningApplicationMailer.receipt_notice_mail(
-      @planning_application,
-      request.host,
-    ).deliver_now
+    @planning_application.applicant_and_agent_email.each do |user|
+      PlanningApplicationMailer.receipt_notice_mail(
+        @planning_application,
+        request.host,
+        user,
+      ).deliver_now
+    end
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -306,17 +306,23 @@ private
   end
 
   def decision_notice_mail
-    PlanningApplicationMailer.decision_notice_mail(
-      @planning_application,
-      request.host,
-    ).deliver_now
+    @planning_application.applicant_and_agent_email.each do |user|
+      PlanningApplicationMailer.decision_notice_mail(
+        @planning_application,
+        request.host,
+        user,
+      ).deliver_now
+    end
   end
 
   def validation_notice_mail
-    PlanningApplicationMailer.validation_notice_mail(
-      @planning_application,
-      request.host,
-    ).deliver_now
+    @planning_application.applicant_and_agent_email.each do |user|
+      PlanningApplicationMailer.validation_notice_mail(
+        @planning_application,
+        request.host,
+        user,
+      ).deliver_now
+    end
   end
 
   def invalidation_notice_mail
@@ -327,10 +333,13 @@ private
   end
 
   def receipt_notice_mail
-    PlanningApplicationMailer.receipt_notice_mail(
-      @planning_application,
-      request.host,
-    ).deliver_now
+    @planning_application.applicant_and_agent_email.each do |user|
+      PlanningApplicationMailer.receipt_notice_mail(
+        @planning_application,
+        request.host,
+        user,
+      ).deliver_now
+    end
   end
 
   def ensure_user_is_reviewer

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -3,14 +3,7 @@
 class PlanningApplicationMailer < Mail::Notify::Mailer
   NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
 
-  def applicant_and_agent_email(planning_application)
-    @agent = planning_application.agent_email
-    @applicant = planning_application.applicant_email
-
-    [@agent, @applicant].reject(&:nil?)
-  end
-
-  def decision_notice_mail(planning_application, host)
+  def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application
     @documents = @planning_application.documents.for_display
     @host = host
@@ -18,47 +11,48 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Certificate of Lawfulness: #{@planning_application.decision}",
-      to: applicant_and_agent_email(@planning_application),
+      to: user,
     )
   end
 
-  def validation_notice_mail(planning_application, host)
+  def validation_notice_mail(planning_application, host, user)
     @host = host
     @planning_application = planning_application
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application has been validated",
-      to: applicant_and_agent_email(@planning_application),
+      to: user,
     )
   end
 
   def invalidation_notice_mail(planning_application, host)
     @host = host
     @planning_application = planning_application
+    @application_accountable_email = @planning_application.applicant_and_agent_email.first
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application is invalid",
-      to: applicant_and_agent_email(@planning_application),
+      to: @application_accountable_email,
     )
   end
 
-  def receipt_notice_mail(planning_application, host)
+  def receipt_notice_mail(planning_application, host, user)
     @host = host
     @planning_application = planning_application
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "We have received your application",
-      to: applicant_and_agent_email(@planning_application),
+      to: user,
     )
   end
 
   def validation_request_mail(planning_application, validation_request)
     @planning_application = planning_application
     @validation_request = validation_request
-    @application_accountable_email = @planning_application.agent_email.presence || @planning_application.applicant_email
+    @application_accountable_email = @planning_application.applicant_and_agent_email.first
 
     view_mail(
       NOTIFY_TEMPLATE_ID,

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -322,6 +322,10 @@ class PlanningApplication < ApplicationRecord
     end
   end
 
+  def applicant_and_agent_email
+    [agent_email, applicant_email].reject(&:blank?)
+  end
+
 private
 
   def set_key_dates

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(page).not_to have_content("Assigned to:")
     expect(page).not_to have_content("Process Application")
     expect(page).not_to have_content("Review Assessment")
-    expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
+    expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 2)
     click_link("View decision notice")
     expect(page).to have_content("IT IS HEREBY CERTIFIED")
   end

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -24,7 +24,7 @@ RSpec.shared_examples "validate and invalidate" do
     expect(planning_application.status).to eq("in_assessment")
     expect(planning_application.documents_validated_at).to eq(Date.new(2021, 12, 3))
 
-    expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
+    expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 2)
 
     click_button "Key application dates"
     click_link "Activity log"


### PR DESCRIPTION
### Description of change
- Since notify does not support sending the same email to different to addresses, we iterate through the applicant and agent addresses and send multiple emails to fulfill the acs on this
https://trello.com/c/x4mQZ5j0/405-all-emails-notifications-decision-notice-to-go-to-either-agent-or-applicant

