### PR TITLE
Add local authority notify id to emails

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -23,6 +23,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application has been validated",
       to: user,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id,
     )
   end
 
@@ -35,6 +36,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application is invalid",
       to: @application_accountable_email,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id,
     )
   end
 
@@ -46,6 +48,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       NOTIFY_TEMPLATE_ID,
       subject: "We have received your application",
       to: user,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id,
     )
   end
 
@@ -58,6 +61,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       NOTIFY_TEMPLATE_ID,
       subject: "Your planning application at: #{@planning_application.full_address}",
       to: @application_accountable_email,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id,
     )
   end
 end

--- a/db/migrate/20210910145259_add_reply_to_local_authority.rb
+++ b/db/migrate/20210910145259_add_reply_to_local_authority.rb
@@ -1,0 +1,17 @@
+class AddReplyToLocalAuthority < ActiveRecord::Migration[6.1]
+  class LocalAuthority < ApplicationRecord; end
+  
+  def change
+    add_column :local_authorities, :reply_to_notify_id, :string
+  
+    reversible do |dir|
+      dir.up do
+        LocalAuthority.find_each do |authority|
+          authority.update(reply_to_notify_id: "f755c178-b01a-4323-a756-d669e9350c33") if authority.subdomain == "southwark"
+          authority.update(reply_to_notify_id: "5fe1d483-9bbe-4b56-8e71-8ce193fef723") if authority.subdomain == "lambeth"
+          authority.update(reply_to_notify_id: "4896bb50-4f4c-4b4d-ad67-2caddddde125") if authority.subdomain == "buckinghamshire"
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_27_123609) do
+ActiveRecord::Schema.define(version: 2021_09_10_145259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.bigint "record_id", null: false
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "ix_active_storage_attachments_on_blob_id"
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
@@ -35,7 +35,7 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.string "checksum", null: false
     t.datetime "created_at", null: false
     t.string "service_name", null: false
-    t.index ["key"], name: "ix_active_storage_blobs_on_key", unique: true
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
@@ -55,9 +55,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "sequence"
     t.date "notified_at"
-    t.index ["new_document_id"], name: "ix_additional_document_validation_requests_on_new_document_id"
-    t.index ["planning_application_id"], name: "ix_additional_document_validation_requests_on_planning_applicat"
-    t.index ["user_id"], name: "ix_additional_document_validation_requests_on_user_id"
+    t.index ["new_document_id"], name: "index_document_create_requests_on_new_document_id"
+    t.index ["planning_application_id"], name: "index_document_create_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_document_create_requests_on_user_id"
   end
 
   create_table "api_users", force: :cascade do |t|
@@ -76,9 +76,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "api_user_id"
-    t.index ["api_user_id"], name: "ix_audits_on_api_user_id"
-    t.index ["planning_application_id"], name: "ix_audits_on_planning_application_id"
-    t.index ["user_id"], name: "ix_audits_on_user_id"
+    t.index ["api_user_id"], name: "index_audits_on_api_user_id"
+    t.index ["planning_application_id"], name: "index_audits_on_planning_application_id"
+    t.index ["user_id"], name: "index_audits_on_user_id"
   end
 
   create_table "description_change_validation_requests", force: :cascade do |t|
@@ -93,8 +93,8 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.string "previous_description"
     t.integer "sequence"
     t.date "notified_at"
-    t.index ["planning_application_id"], name: "ix_description_change_validation_requests_on_planning_applicati"
-    t.index ["user_id"], name: "ix_description_change_validation_requests_on_user_id"
+    t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_description_change_requests_on_user_id"
   end
 
   create_table "documents", force: :cascade do |t|
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.boolean "validated"
     t.text "invalidated_document_reason"
     t.text "applicant_description"
-    t.index ["planning_application_id"], name: "ix_documents_on_planning_application_id"
+    t.index ["planning_application_id"], name: "index_documents_on_planning_application_id"
   end
 
   create_table "local_authorities", force: :cascade do |t|
@@ -122,7 +122,8 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.string "signatory_job_title"
     t.text "enquiries_paragraph"
     t.string "email_address"
-    t.index ["subdomain"], name: "ix_local_authorities_on_subdomain", unique: true
+    t.string "reply_to_notify_id"
+    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 
   create_table "other_change_validation_requests", force: :cascade do |t|
@@ -192,8 +193,8 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.bigint "boundary_created_by_id"
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
-    t.index ["local_authority_id"], name: "ix_planning_applications_on_local_authority_id"
-    t.index ["user_id"], name: "ix_planning_applications_on_user_id"
+    t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
+    t.index ["user_id"], name: "index_planning_applications_on_user_id"
   end
 
   create_table "recommendations", force: :cascade do |t|
@@ -206,9 +207,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "challenged"
-    t.index ["assessor_id"], name: "ix_recommendations_on_assessor_id"
-    t.index ["planning_application_id"], name: "ix_recommendations_on_planning_application_id"
-    t.index ["reviewer_id"], name: "ix_recommendations_on_reviewer_id"
+    t.index ["assessor_id"], name: "index_recommendations_on_assessor_id"
+    t.index ["planning_application_id"], name: "index_recommendations_on_planning_application_id"
+    t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"
   end
 
   create_table "red_line_boundary_change_validation_requests", force: :cascade do |t|
@@ -218,9 +219,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.string "new_geojson"
     t.string "reason"
     t.string "rejection_reason"
-    t.boolean "approved"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "approved"
     t.integer "sequence"
     t.date "notified_at"
   end
@@ -235,10 +236,10 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "sequence"
     t.date "notified_at"
-    t.index ["new_document_id"], name: "ix_replacement_document_validation_requests_on_new_document_id"
-    t.index ["old_document_id"], name: "ix_replacement_document_validation_requests_on_old_document_id"
-    t.index ["planning_application_id"], name: "ix_replacement_document_validation_requests_on_planning_applica"
-    t.index ["user_id"], name: "ix_replacement_document_validation_requests_on_user_id"
+    t.index ["new_document_id"], name: "index_document_change_requests_on_new_document_id"
+    t.index ["old_document_id"], name: "index_document_change_requests_on_old_document_id"
+    t.index ["planning_application_id"], name: "index_document_change_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_document_change_requests_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -252,9 +253,9 @@ ActiveRecord::Schema.define(version: 2021_07_27_123609) do
     t.integer "role", default: 0
     t.string "name"
     t.bigint "local_authority_id"
-    t.index ["email", "local_authority_id"], name: "ix_users_on_email__local_authority_id", unique: true
-    t.index ["local_authority_id"], name: "ix_users_on_local_authority_id"
-    t.index ["reset_password_token"], name: "ix_users_on_reset_password_token", unique: true
+    t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true
+    t.index ["local_authority_id"], name: "index_users_on_local_authority_id"
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
### Description of change

- Updated the local authority db table with an email id and associated the correct id from notify to each local authority.
This allows us to add the reply-to parameter in planning application mailer, so each email can have a different reply-to address, depending on which local authority the planning application belongs to.

### Story Link

https://trello.com/c/uUqHl2wL/468-set-up-reply-to-email-from-notify