### PR TITLE
Prevent validation when invalid documents exist

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -102,6 +102,9 @@ class PlanningApplicationsController < AuthenticationController
     elsif @planning_application.validation_requests_open?
       @planning_application.errors.add(:planning_application, "Planning application cannot be validated if open validation requests exist.")
       render "validate_form"
+    elsif @planning_application.invalid_documents.present?
+      @planning_application.errors.add(:planning_application, "This application has an invalid document. You cannot validate an application with invalid documents.")
+      render "validate_form"
     else
       @planning_application.documents_validated_at = date_from_params
       @planning_application.start!

--- a/app/views/planning_applications/validate_form.html.erb
+++ b/app/views/planning_applications/validate_form.html.erb
@@ -66,8 +66,8 @@
           </h2>
           <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
-              <% @planning_application.errors.full_messages.each do |error| %>
-                <li><%= error %></li>
+              <% @planning_application.errors.each do |error| %>
+                <li><%= error.message %></li>
               <% end %>
             </ul>
           </div>

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -88,7 +88,6 @@ RSpec.shared_examples "validate and invalidate" do
 
   it "allows for the user to input a validation date manually" do
     visit validate_form_planning_application_path(second_planning_application)
-
     fill_in "Day", with: "3"
     fill_in "Month", with: "6"
     fill_in "Year", with: "2022"
@@ -173,6 +172,21 @@ RSpec.describe "Planning Application Assessment", type: :system do
   end
 
   context "Planning application does not transition when expected inputs are not sent" do
+    it "shows an error when invalid documents are present" do
+      create :document, :with_file,
+             planning_application: planning_application,
+             validated: false, invalidated_document_reason: "Missing a lazy Suzan"
+
+      click_link planning_application.reference
+      click_link "Validate application"
+
+      click_button "Validate application"
+      expect(page).to have_content("This application has an invalid document. You cannot validate an application with invalid documents.")
+
+      planning_application.reload
+      expect(planning_application.status).to eql("not_started")
+    end
+
     it "shows error if invalid date is sent" do
       click_link planning_application.reference
       click_link "Validate application"


### PR DESCRIPTION
### Description of change

Prevent an application from being marked as valid if any invalid documents are present.

![image](https://user-images.githubusercontent.com/9452321/133105565-f35a6762-8e9e-4192-908e-9563341db99b.png)

### Story Link
https://trello.com/c/y22SlsbN/379-prevent-a-case-from-being-marked-valid-if-a-live-document-is-marked-as-invalid