### PR TITLE
Correct order of resolved and unresolved in helper

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -156,7 +156,7 @@ module PlanningApplicationHelper
     elsif planning_application.recommendable? || planning_application.closed?
       "This application has #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'resolved validation request')}"
     else
-      "This application has #{pluralize(validation_requests.select { |req| req.state == 'open' }.count, 'resolved validation request')} and #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'unresolved validation request')}"
+      "This application has #{pluralize(validation_requests.select { |req| req.state == 'open' }.count, 'unresolved validation request')} and #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'resolved validation request')}"
     end
   end
 end

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -304,7 +304,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Validate application"
 
       expect(page).to have_content("The application has not yet been marked as valid or invalid")
-      expect(page).to have_content("This application has 0 resolved validation requests and 1 unresolved validation request")
+      expect(page).to have_content("This application has 0 unresolved validation requests and 1 resolved validation request")
 
       click_link "Start new or view existing validation requests"
 


### PR DESCRIPTION
### Description of change

"Closed" should == resolved and "open" == unresolved, but the helper had those words switched on the last if statement.