### PR TITLE
Yield title only when content for title is present 

### DIFF
--- a/app/views/application/_create_breadcrumb_navigation.html.erb
+++ b/app/views/application/_create_breadcrumb_navigation.html.erb
@@ -4,6 +4,8 @@
   </li>
 <% end %>
 
-<li class="govuk-breadcrumbs__list-item" aria-current="page">
-  <%= yield :title %>
-</li>
+<% if content_for?(:title) %>
+  <li class="govuk-breadcrumbs__list-item" aria-current="page">
+    <%= yield :title  %>
+  </li>
+<% end %>


### PR DESCRIPTION
### Description of change

Yield was generating an extra > if no title exists for a partial, but the code works the same without yielding - except it doesn't create an empty list item unnecessarily

Before:
![image](https://user-images.githubusercontent.com/9452321/133434386-c736bace-2385-4e76-a50b-48f613da9139.png)

After:
![image](https://user-images.githubusercontent.com/9452321/133434463-312867a1-8b1c-490a-9c3a-616153483c64.png)
