### PR TITLE
Address email to agent or applicant names

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -326,6 +326,14 @@ class PlanningApplication < ApplicationRecord
     [agent_email, applicant_email].reject(&:blank?)
   end
 
+  def agent_or_applicant_name
+    if agent_first_name?
+      "#{agent_first_name} #{agent_last_name}"
+    else
+      "#{applicant_first_name} #{applicant_last_name}"
+    end
+  end
+
 private
 
   def set_key_dates

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -1,4 +1,4 @@
-<%= @planning_application.applicant_name %>,
+<%= @planning_application.agent_or_applicant_name %>,
 
 Your Certificate of lawful development (<%= @planning_application.work_status %>) has been <%= @planning_application.decision %>.
 

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -1,6 +1,6 @@
 # <%= @planning_application.local_authority.name %>
 
-Dear <%= @planning_application.applicant_name %>,
+Dear <%= @planning_application.agent_or_applicant_name %>,
 
 Reference No.: <%= @planning_application.reference %>
 Proposal: <%= @planning_application.description %>

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -1,3 +1,5 @@
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
 Reference: <%= @planning_application.reference %>
 Date of application: <%= @planning_application.created_at.strftime("%e %B %Y - %H:%M:%S") %>
 Date received: <%= @planning_application.created_at.strftime("%e %B %Y - %H:%M:%S") %>

--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -2,7 +2,7 @@
 
 # Town and country planning act 1990 (as amended)
 
-Dear Sir/Madam,
+Dear <%= @planning_application.agent_or_applicant_name %>,
 
 Reference No.: <%= @planning_application.reference %>
 Proposal: <%= @planning_application.description %>

--- a/app/views/planning_application_mailer/validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_mail.text.erb
@@ -2,7 +2,7 @@ Application number: <%= @planning_application.reference %>
 Application received: <%= @planning_application.created_at.to_formatted_s(:day_month_year) %>
 At: <%= @planning_application.full_address %>
 
-Hi <%= @planning_application.applicant_first_name %> <%= @planning_application.applicant_last_name %>
+Hi <%= @planning_application.agent_or_applicant_name %>,
 
 <%= @validation_request.user.name %>, the case officer working on your planning application has requested change(s) on your application.
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -70,6 +70,19 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         expect(mail.body.encoded).to include("Your Certificate of lawful development (proposed) has been refused.")
         expect(mail.body.encoded).to include(decision_notice_api_v1_planning_application_path(planning_application, format: "pdf"))
       end
+
+      it "includes the name of the agent in the body if agent is present" do
+        expect(mail.body.encoded).to include(planning_application.agent_first_name)
+        expect(mail.body.encoded).to include(planning_application.agent_last_name)
+      end
+
+      it "includes the name of the applicant in the body if no agent is present" do
+        planning_application.update!(agent_first_name: "")
+        mail = described_class.decision_notice_mail(planning_application.reload, host, [planning_application.agent_email, planning_application.applicant_email])
+
+        expect(mail.body.encoded).to include(planning_application.applicant_first_name)
+        expect(mail.body.encoded).to include(planning_application.applicant_last_name)
+      end
     end
   end
 
@@ -162,6 +175,19 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(validation_request_mail.body.encoded).to include("Mr. Biscuit")
       expect(validation_request_mail.body.encoded).to include("Cookie authority")
       expect(validation_request_mail.body.encoded).to include("Lord of BiscuitTown")
+    end
+
+    it "includes the name of the agent in the body if agent is present" do
+      expect(validation_request_mail.body.encoded).to include(planning_application.agent_first_name)
+      expect(validation_request_mail.body.encoded).to include(planning_application.agent_last_name)
+    end
+
+    it "includes the name of the applicant in the body if no agent is present" do
+      planning_application.update!(agent_first_name: "")
+      mail = described_class.validation_request_mail(planning_application.reload, validation_request)
+
+      expect(mail.body.encoded).to include(planning_application.applicant_first_name)
+      expect(mail.body.encoded).to include(planning_application.applicant_last_name)
     end
   end
 


### PR DESCRIPTION
### Description of change

Addressee defaulted to applicant first / last name, rules in emails changed to the below.


Receipt of notification
CURRENT: No name used
ACTION: Amend copy, use agent name (if agent) otherwise use applicant name

Application invalid
CURRENT: Applicant name
ACTION: Use agent name (if agent) otherwise use applicant name

Application valid
CURRENT: Sir / Madam
ACTION: Amend copy, use agent name (if agent) otherwise use applicant name

Validation request (email)
CURRENT: Applicant name
ACTION: Use agent name (if agent) otherwise use applicant name

Validation request (in-app)
CURRENT: No name used
ACTION: No change

Decision notice (email)
CURRENT: Applicant name
ACTION: Use agent name (if agent) otherwise use applicant name

LDC Decision Notice (current)
CURRENT: Applicant name
ACTION: No change

### Story Link
https://trello.com/c/tfXbYm1I/522-notifications-default-to-using-applicant-name-rather-than-agent-can-a-rule-be-put-on-all-notifications