### PR TITLE
Apply size limitation to document upload

### DIFF
--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class Api::V1::AdditionalDocumentValidationRequestsController < Api::V1::ApplicationController
+class Api::V1::AdditionalDocumentValidationRequestsController < Api::V1::ValidationRequestsController
   skip_before_action :verify_authenticity_token, only: :update
   before_action :check_token_and_set_application, only: :update
   before_action :check_file_params_are_present, only: :update
+  before_action :check_file_size, only: :update
 
   def update
     @additional_document_validation_request = @planning_application.additional_document_validation_requests.find_by(id: params[:id])
@@ -17,7 +18,7 @@ class Api::V1::AdditionalDocumentValidationRequestsController < Api::V1::Applica
 
       render json: { "message": "Validation request updated" }, status: :ok
     else
-      render json: { "message": "Unable to update request" }, status: :bad_request
+      render json: { "message": "Validation request could not be updated" }, status: :bad_request
     end
   end
 

--- a/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class Api::V1::ReplacementDocumentValidationRequestsController < Api::V1::ApplicationController
+class Api::V1::ReplacementDocumentValidationRequestsController < Api::V1::ValidationRequestsController
   skip_before_action :verify_authenticity_token, only: :update
   before_action :check_token_and_set_application, only: :update
   before_action :check_file_params_are_present, only: :update
+  before_action :check_file_size, only: :update
 
   def update
     @replacement_document_validation_request = @planning_application.replacement_document_validation_requests.find_by(id: params[:id])

--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -13,4 +13,10 @@ private
       @planning_application
     end
   end
+
+  def check_file_size
+    if params[:new_file].size > 30.megabytes
+      render json: { "message": "The file must be 30MB or less" }, status: :bad_request
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Documents greater than 2MB were failing because of the nginx config default. Now files up to 30MB are permitted. Those above need to be disallowed on the controller rather than the model

### Story Link

https://trello.com/c/RjtWp2rB/97-bug-unsupported-filetype-for-a-document-submitted-through-api-breaks

