### PR TITLE
Updated secure_change_url method to use https on both staging and pro…

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -252,7 +252,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def secure_change_url(application_id, secure_token)
-    if ENV["DOMAIN"] == "bops-services"
+    if ENV["AWS_PROFILE"].present?
       "https://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/validation_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"
     else
       "http://#{local_authority.subdomain}.#{ENV['APPLICANTS_APP_HOST']}/validation_requests?planning_application_id=#{application_id}&change_access_id=#{secure_token}"


### PR DESCRIPTION
### Description of change

We were previously using https for `bops-applicants` on production for legacy reasons. Now we have a certificate on `bops-applicants` in the preview/staging environment, we want to use https everywhere other than our local.

### Story Link

https://trello.com/c/AKfU3h8O/481-ensure-email-links-on-prod-for-bops-applicants-are-sent-with-https-instead-of-http

