### PR TITLE
Modify validation requests index messages

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -152,8 +152,8 @@ module PlanningApplicationHelper
 
   def validation_request_summary(validation_requests, planning_application)
     if planning_application.invalidated?
-      "This application has #{pluralize(validation_requests.select { |req| req.state == 'open' }.count, 'unresolved validation request')}"
-    elsif planning_application.recommendable? || planning_application.closed?
+      "This application has #{pluralize(validation_requests.select { |req| req.state == 'open' }.count, 'unresolved validation request')} and #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'resolved validation request')}"
+    elsif planning_application.recommendable? || planning_application.closed? && planning_application.validation_requests.present?
       "This application has #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'resolved validation request')}"
     else
       "This application has #{pluralize(validation_requests.select { |req| req.state == 'open' }.count, 'unresolved validation request')} and #{pluralize(validation_requests.select { |req| req.state == 'closed' }.count, 'resolved validation request')}"

--- a/app/views/planning_applications/validate_form.html.erb
+++ b/app/views/planning_applications/validate_form.html.erb
@@ -41,21 +41,21 @@
     <p class="govuk-body">
       <%= link_to "View notification", validation_notice_planning_application_path(@planning_application), class: "govuk-link" %>
     </p>
+  <% else %>
+    <h2 class="govuk-heading-m">
+      Validation requests
+    </h2>
+    <p class="govuk-body govuk-!-margin-top-2">
+      <%= validation_request_summary(@planning_application.validation_requests, @planning_application) %>
+    </p>
+    <p class="govuk-body govuk-!-padding-bottom-6">
+      <% if @planning_application.can_invalidate? %>
+        <%= link_to "Start new or view existing validation requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %>
+      <% else %>
+        <%= link_to "View requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %>
+      <% end %>
+    </p>
   <% end %>
-
-  <h2 class="govuk-heading-m">
-    Validation requests
-  </h2>
-  <p class="govuk-body govuk-!-margin-top-2">
-    <%= validation_request_summary(@planning_application.validation_requests, @planning_application) %>
-  </p>
-  <p class="govuk-body govuk-!-padding-bottom-6">
-    <% if @planning_application.can_invalidate? %>
-      <%= link_to "Start new or view existing validation requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %>
-    <% else %>
-      <%= link_to "View requests", planning_application_validation_requests_path(@planning_application), class: "govuk-link" %>
-    <% end %>
-  </p>
 
   <% if @planning_application.can_validate? %>
     <%= form_with model: @planning_application, url: validate_planning_application_path(@planning_application), local:true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>


### PR DESCRIPTION
- This ensures we hide the validation requests table when an application has been marked valid and no validation requests were ever opened on it.
- This also makes sure we display the full message of "There are x open and x closed validation requests" anytime there are validation requests and the application is invalid, inline with the required design.

### Description of change
https://trello.com/c/8ngUjY0t/497-validation-flow-in-staging-copy-doesnt-make-sense