### PR TITLE
policy class: restore a hint to save the policy classes

### DIFF
--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -43,6 +43,8 @@ class PolicyClassesController < PlanningApplicationsController
       policy["status"] = value if value.present?
     end
 
+    @planning_application.policy_classes_will_change!
+
     if @planning_application.save
       redirect_to @planning_application, notice: "Successfully updated policy class"
     end


### PR DESCRIPTION
I thought this could go away with the inclusion of ActiveModel::Dirty
in a previous commit but it definitely cannot; the policy classes must
be marked as changed in the controller otherwise Rails doesn't notice
the difference and won't save the record.

