### PR TITLE
Fix/policy class id parsed as number

### DIFF
--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -38,7 +38,7 @@ class PolicyClassesController < PlanningApplicationsController
     new_policies = policies_params[:policies]
 
     @policy_class.policies.each do |policy|
-      value = new_policies[policy["id"]]
+      value = new_policies[policy["id"].to_s]
 
       policy["status"] = value if value.present?
     end

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -1,25 +1,25 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if exclude_others? %>
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+      <h1 class="govuk-heading-l">
         Your planning applications
       </h1>
-      <p class="govuk-body-m govuk-!-padding-top-2">
+      <p class="govuk-body-m">
         <strong><%= current_user.name %>,</strong> <%= role_name %>
       </p>
-      <p class="govuk-body govuk-!-padding-bottom-2">
+      <p class="govuk-body">
         <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
       <p class="govuk-body"><%= link_to "View all applications", planning_applications_path, class: "govuk-button" %></p>
     <% else %>
-      <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+      <h1 class="govuk-heading-l">
         All planning applications
       </h1>
-      <p class="govuk-body-m govuk-!-padding-top-2">
+      <p class="govuk-body-m">
         <strong><%= current_user.name %>,</strong> <%= role_name %>
       </p>
-      <p class="govuk-body govuk-!-padding-bottom-2">
-        <%= link_to "Add new application", new_planning_application_path %>
+      <p class="govuk-body">
+        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
       <p class="govuk-body"><%= link_to filter_text, planning_applications_path(q: "exclude_others"), class: "govuk-button" %></p>
     <% end %>

--- a/app/views/replacement_document_validation_requests/new.html.erb
+++ b/app/views/replacement_document_validation_requests/new.html.erb
@@ -35,7 +35,7 @@
         </tbody>
       </table>
       <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-8">
-        If you want to make any changes to the requests, return to <%= link_to "documents", planning_application_documents_path(@planning_application) %>
+        If you want to make any changes to the requests, return to <%= link_to "documents", planning_application_documents_path(@planning_application), class: "govuk-link" %>
       </p>
       <%= form.govuk_submit "Send" %>
       <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -103,7 +103,7 @@
                       <%= request_sent_at(validation_request) %>
                     </td>
                     <td class="govuk-table__cell change-request-list">
-                      <%= link_to "View proposed red line boundary", planning_application_red_line_boundary_change_validation_request_path(@planning_application, validation_request) %>
+                      <%= link_to "View proposed red line boundary", planning_application_red_line_boundary_change_validation_request_path(@planning_application, validation_request), class: "govuk-link" %>
                     </td>
                     <td class="govuk-table__cell change-request-list">
                       <%= validation_request.reason %>

--- a/app/views/validation_requests/new.html.erb
+++ b/app/views/validation_requests/new.html.erb
@@ -25,7 +25,7 @@
           <% end %>
         </div>
       </fieldset>
-      <div class="govuk-!-padding-top-4">
+      <div class="govuk-button-group">
         <%= form.submit "Next", class: "govuk-button", data: { module: "govuk-button" } %>
         <%= link_to "Back", planning_application_validation_requests_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>


### PR DESCRIPTION
One of our policies looks like this (class E):

```
-
  id: 3
  description: |
  In the case of any land within the curtilage of [...]
```

So far so good but YAML will parse one or more digits as
numbers, which in hindsight makes sense.

```
irb(main):026:0> YAML.load('id: 3')
=> {"id"=>3}

irb(main):027:0> YAML.load('id: 3b')
=> {"id"=>"3b"}
```

This means that when a reviewer is trying to assess the class
policies and Rails send string params over:

```
{"policies"=>{"1a"=>"complies", "3"=>"complies"}, ... }
```

there's a mismatch in trying to find the corresponding values in the
params. Work around it by always casting the policy ID to a string
when digging into the params.
