### PR TITLE
api: intercept wrong file type uploads

### DIFF
--- a/app/controllers/api/v1/errors.rb
+++ b/app/controllers/api/v1/errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Errors
+      class WrongFileTypeError < ArgumentError
+        def initialize(msg, uri)
+          @filename = Pathname.new(uri).basename
+
+          super(msg)
+        end
+
+        def message
+          "The document \"#{@filename}\" doesn't match our accepted file types"
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
 
   it "successfully creates the Full application as per the oas3 definition" do
     stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
-      .to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")))
+      .to_return(
+        status: 200,
+        body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")),
+        headers: { "Content-Type" => "application/pdf" }
+      )
     expect do
       post "/api/v1/planning_applications",
            params: example_request_json_for("/api/v1/planning_applications", "post", "Full"),

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -5,10 +5,25 @@ require "rails_helper"
 RSpec.describe "Creating a planning application via the API", type: :request, show_exceptions: true do
   let(:api_user) { create :api_user }
 
+  def post_with(params:, headers: {})
+    post(
+      "/api/v1/planning_applications",
+      params: params,
+      headers: {
+        "CONTENT-TYPE": "application/json",
+        Authorization: "Bearer #{api_user.token}"
+      }.merge(headers)
+    )
+  end
+
   context "with success in downloading document" do
     before do
       stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
-        .to_return(status: 200, body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")))
+        .to_return(
+          status: 200,
+          body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")),
+          headers: { "Content-Type" => "application/pdf" }
+        )
     end
 
     context "when passed a request with invalid parameters" do
@@ -18,14 +33,14 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
              "related_cases": "20/AP/0135"}'
 
       it "returns a 400 response" do
-        post "/api/v1/planning_applications", params: json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+        post_with(params: json)
+
         expect(response.status).to eq(400)
       end
 
       it "returns 401 if user is not authenticated" do
-        post "/api/v1/planning_applications", params: json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer dasfdsafdsaf" }
+        post_with(params: json, headers: { Authorization: "Bearer dasfdsafdsaf" })
+
         expect(response.status).to eq(401)
       end
 
@@ -41,14 +56,14 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
       permitted_development_json = File.read(valid_json)
 
       it "saves a valid planning application" do
-        post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
-        expect(PlanningApplication.all[0]).to be_valid
+        post_with(params: permitted_development_json)
+
+        expect(response.status).to eq 200
+        expect(PlanningApplication.last).to be_valid
       end
 
       it "sends the receipt email" do
-        post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+        post_with(params: permitted_development_json)
 
         email = ActionMailer::Base.deliveries.last
         expect(email.body).to include(PlanningApplication.all[0].reference)
@@ -129,10 +144,30 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
       minimal_development_json = File.read(valid_json)
 
       it "raises an error" do
-        expect do
-          post "/api/v1/planning_applications", params: minimal_development_json,
-                                                headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
-        end.to raise_error(OpenURI::HTTPError)
+        expect { post_with(params: minimal_development_json) }.to raise_error(OpenURI::HTTPError)
+      end
+    end
+  end
+
+  context "with the wrong type of document" do
+    before do
+      stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+        .to_return(status: 200, body: "some document", headers: { "Content-Type" => "application/octet-stream" })
+    end
+
+    context "when passed a request with the minimal parameters" do
+      valid_json = Rails.root.join("spec/fixtures/files/valid_planning_application.json")
+      minimal_development_json = File.read(valid_json)
+
+      it "rejects the application" do
+        post_with(params: minimal_development_json)
+
+        expect(response.status).to eq 400
+        expect(response.body).to eq('{"message":"The document \"proposed-first-floor-plan.pdf\" doesn\'t match our accepted file types"}')
+      end
+
+      it "does not persist the application" do
+        expect { post_with(params: minimal_development_json) }.not_to change(PlanningApplication, :count)
       end
     end
   end


### PR DESCRIPTION
Check the file type during `upload_documents` and use an ActiveRecord
transaction to roll back the planning application creation if it
doesn't look valid.