### PR TITLE
Connect to docker postgres db from local host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
         source: db
         target: /var/lib/postgresql/data
     environment:
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+    ports:
+      - "5433:5432"
   web:
     build: .
     stdin_open: true


### PR DESCRIPTION
### Description of change

- Map docker container port 5432 to 5433 on host machine
- Add postgres user

Enables connection to docker db via a db gui e.g. Postico

![Screenshot 2021-10-12 at 15 13 08](https://user-images.githubusercontent.com/34001723/136972886-71027760-86f5-4b58-a0b7-f9782f6be6ff.png)
