### PR TITLE
planning applications: correctly grab/audit requests on invalidation

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -131,7 +131,7 @@ class PlanningApplicationsController < AuthenticationController
 
       invalidation_notice_mail
 
-      request_names = @planning_application.pending_validation_requests.map(&:audit_name)
+      request_names = @planning_application.open_validation_requests.map(&:audit_name)
 
       audit("validation_requests_sent", nil, request_names.join(", "))
 

--- a/features/auditing.feature
+++ b/features/auditing.feature
@@ -8,3 +8,9 @@ Feature: Auditing a planning application
     Given I create a new document validation request for a "Picture of the dog" because "it would be nice"
     When I view the planning application audit
     Then there is an audit entry containing "Added: validation request (new document#1)"
+
+  Scenario: As an assessor I can audit the validation requests are sent when the application is invalid
+    Given I create an additional document validation request with "Picture of the dog"
+    And the planning application is invalidated
+    When I view the planning application audit
+    Then there is an audit entry containing "invalidation requests have been emailed: Additional document validation request #2, Additional document validation request #1"


### PR DESCRIPTION
the `invalidate!` event already turns the requests into open requests,
so remove the wrong assumption that there still are pending requests.

