### PR TITLE
Updated copy in decision notice email

### DIFF
--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -1,5 +1,12 @@
-<%= @planning_application.agent_or_applicant_name %>,
+Dear <%= @planning_application.agent_or_applicant_name %>,
 
-Your Certificate of lawful development (<%= @planning_application.work_status %>) has been <%= @planning_application.decision %>.
+Reference: <%= @planning_application.reference %>
+Site address: <%= @planning_application.full_address %>
+Description: <%= @planning_application.description %>
 
-To see the full decision notice visit <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
+Your Lawful Development Certificate (<%= @planning_application.work_status %>) has been <%= @planning_application.decision %>.
+
+To see the full decision notice, please visit <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
+
+Yours faithfully,
+<%= @planning_application.local_authority.name %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(mail.body.encoded).to include("Your Certificate of lawful development (proposed) has been granted.")
+      expect(mail.body.encoded).to include("Your Lawful Development Certificate (proposed) has been granted.")
       expect(mail.body.encoded).to include(decision_notice_api_v1_planning_application_path(planning_application,
                                                                                             format: "pdf"))
     end
@@ -76,7 +76,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
 
       it "includes the status in the body" do
-        expect(mail.body.encoded).to include("Your Certificate of lawful development (proposed) has been refused.")
+        expect(mail.body.encoded).to include("Your Lawful Development Certificate (proposed) has been refused.")
         expect(mail.body.encoded).to include(decision_notice_api_v1_planning_application_path(planning_application,
                                                                                               format: "pdf"))
       end


### PR DESCRIPTION
### Description of change

Update wording of decision notice email.

### Story Link

https://trello.com/c/Rl9azfJm/553-amend-notification-decision-notice-email

