### PR TITLE
Change "Send" to "Add" when adding a change request to an application that has not yet been invalidated

### DIFF
--- a/app/views/additional_document_validation_requests/new.html.erb
+++ b/app/views/additional_document_validation_requests/new.html.erb
@@ -13,8 +13,7 @@
          label: { text: 'Please specify the reason you have requested this document?', size: 's'},
          rows: 5 %>
       <% end %>
-      <%= form.govuk_submit "Send" %>
+      <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
-    <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
   </div>
 </div>

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -44,8 +44,7 @@
     <%= form.govuk_text_area :proposed_description,
       label: { text: 'Please suggest a new application description', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
       rows: 5 %>
-      <%= form.govuk_submit "Send" %>
-      <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/other_change_validation_requests/new.html.erb
+++ b/app/views/other_change_validation_requests/new.html.erb
@@ -41,8 +41,7 @@
                                label: { text: 'Explain to the applicant how the application can be made valid.', size: 's', class: 'govuk-label govuk-label--s'},
                                hint: { text: 'Add all information that they will need to complete this action.' },
                                rows: 5 %>
-      <%= form.govuk_submit "Send" %>
-      <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/red_line_boundary_change_validation_requests/new.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/new.html.erb
@@ -56,8 +56,7 @@
       <%= form.govuk_text_area :reason,
                                label: { text: 'Explain to the applicant why changes are proposed to the red line boundary', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
                                rows: 5 %>
-      <%= form.govuk_submit "Send" %>
-      <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/replacement_document_validation_requests/new.html.erb
+++ b/app/views/replacement_document_validation_requests/new.html.erb
@@ -37,8 +37,7 @@
       <p class="govuk-body govuk-!-padding-top-6 govuk-!-padding-bottom-8">
         If you want to make any changes to the requests, return to <%= link_to "documents", planning_application_documents_path(@planning_application), class: "govuk-link" %>
       </p>
-      <%= form.govuk_submit "Send" %>
-      <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -1,0 +1,4 @@
+<div class="govuk-button-group">
+  <%= form.govuk_submit "Add" %>
+  <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+</div>

--- a/app/views/validation_requests/new.html.erb
+++ b/app/views/validation_requests/new.html.erb
@@ -2,7 +2,7 @@
 <% add_parent_breadcrumb_link "Application", validate_form_planning_application_path(@planning_application) %>
 <% add_parent_breadcrumb_link "Validation requests", planning_application_validation_requests_path(@planning_application) %>
 
-<% content_for :title, "Send a validation request" %>
+<% content_for :title, "Add a validation request" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -16,7 +16,7 @@
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <h1 class="govuk-fieldset__heading">
-              Send a validation request
+              Add a validation request
             </h1>
           </legend>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">

--- a/features/step_definitions/validation_requests_steps.rb
+++ b/features/step_definitions/validation_requests_steps.rb
@@ -12,7 +12,7 @@ When("I create a new document validation request for a(n) {string} because {stri
     And I press "Next"
     And I fill in "Please specify the new document type:" with "#{type}"
     And I fill in "the reason" with "#{reason}"
-    And I press "Send"
+    And I press "Add"
   )
 end
 
@@ -36,7 +36,7 @@ Given("I create a(n) additional document validation request with {string}") do |
     And I press "Next"
     And I fill in "Please specify the new document type:" with "#{details}"
     And I fill in "the reason" with "a valid reason"
-    And I press "Send"
+    And I press "Add"
   )
 end
 
@@ -46,7 +46,7 @@ Given("I create a description change validation request with {string}") do |deta
     And I choose "Request approval to a description change"
     And I press "Next"
     And I fill in "Please suggest a new application description" with "#{details}"
-    And I press "Send"
+    And I press "Add"
   )
 end
 
@@ -57,7 +57,7 @@ Given("I create a(n) other change validation request with {string}") do |details
     And I press "Next"
     And I fill in "Tell the applicant" with "#{details}"
     And I fill in "Explain to the applicant" with "Please make the change"
-    And I press "Send"
+    And I press "Add"
   )
 end
 

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request a new document"
     end
 
@@ -34,7 +34,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     fill_in "Please specify the new document type:", with: "Backyard plans"
     fill_in "Please specify the reason you have requested this document?", with: "Application is missing a rear view."
 
-    click_button "Send"
+    click_button "Add"
     expect(page).to have_content("Additional document request successfully created.")
 
     click_link "Application"
@@ -53,21 +53,21 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request a new document"
     end
 
     click_button "Next"
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Please fill in the document request type.")
     expect(page).to have_content("Please fill in the reason for this document request.")
 
     fill_in "Please specify the reason you have requested this document?", with: "Application is missing a floor plan."
-    click_button "Send"
+    click_button "Add"
     expect(page).to have_content("Please fill in the document request type.")
     fill_in "Please specify the new document type:", with: "Floor plan"
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Additional document request successfully created.")
   end

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -31,13 +31,13 @@ RSpec.describe "Requesting description changes to a planning application", type:
     click_link "Request validation changes"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request approval to a description change"
     end
     click_button "Next"
 
     fill_in "Please suggest a new application description", with: "New description"
-    click_button "Send"
+    click_button "Add"
 
     within(".change-requests") do
       expect(page).to have_content("Description")
@@ -60,14 +60,14 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request approval to a description change"
     end
 
     click_button "Next"
 
     fill_in "Please suggest a new application description", with: " "
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Proposed description can't be blank")
   end
@@ -146,13 +146,13 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
       click_link "Add new request"
 
-      within("fieldset", text: "Send a validation request") do
+      within("fieldset", text: "Add a validation request") do
         choose "Request approval to a description change"
       end
       click_button "Next"
 
       fill_in "Please suggest a new application description", with: "New description"
-      click_button "Send"
+      click_button "Add"
 
       within(".change-requests") do
         expect(page).to have_content("Description")

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
     fill_in "Tell the applicant another reason why the application is invalid", with: "The wrong fee has been paid"
     fill_in "Explain to the applicant how the application can be made valid",
             with: "You need to pay £100, which is the correct fee"
-    click_button "Send"
+    click_button "Add"
 
     within(".change-requests") do
       expect(page).to have_content("Other")
@@ -56,7 +56,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
 
     fill_in "Tell the applicant another reason why the application is invalid", with: ""
     fill_in "Explain to the applicant how the application can be made valid", with: ""
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Summary can't be blank")
     expect(page).to have_content("Suggestion can't be blank")

--- a/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/red_line_boundary_change_validation_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request approval to a red line boundary change"
     end
     click_button "Next"
@@ -27,7 +27,7 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
     find(".govuk-visually-hidden",
          visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'
     fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Coordinates look wrong"
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Validation request for red line boundary successfully created.")
     expect(page).to have_link("View proposed red line boundary")
@@ -53,14 +53,14 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request approval to a red line boundary change"
     end
 
     click_button "Next"
 
     find(".govuk-visually-hidden", visible: false).set ""
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Red line drawing must be complete")
   end
@@ -74,14 +74,14 @@ RSpec.describe "Requesting map changes to a planning application", type: :system
 
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request approval to a red line boundary change"
     end
 
     click_button "Next"
 
     fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: " "
-    click_button "Send"
+    click_button "Add"
 
     expect(page).to have_content("Provide a reason for changes")
   end

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request replacement documents"
     end
 
@@ -49,7 +49,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
     expect(page).to have_content(invalid_document.name.to_s)
     expect(page).not_to have_content(valid_document.name.to_s)
 
-    click_button "Send"
+    click_button "Add"
     expect(page).to have_content("Replacement document validation request successfully created.")
 
     click_link "Application"
@@ -71,7 +71,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
     click_link "Start new or view existing requests"
     click_link "Add new request"
 
-    within("fieldset", text: "Send a validation request") do
+    within("fieldset", text: "Add a validation request") do
       choose "Request replacement documents"
     end
 


### PR DESCRIPTION
### Description of change

Change "Send" to "Add" when adding a change request to an application that has not yet been invalidated

- Move action buttons "Add" and "Back" into its own partial as this is being used multiple times. Easier to stay consistent with just needing a change in one place compared to all files.

### Story Link

https://trello.com/c/umrf5O7j/588-change-send-to-add-whenever-adding-a-change-request-to-an-application-that-has-not-yet-been-invalidated