### PR TITLE
Only set planning application for bops applicant if validation is complete

### DIFF
--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -11,7 +11,7 @@ module Api
 
       def check_token_and_set_application
         @planning_application = current_local_authority.planning_applications.find_by(id: params[:planning_application_id])
-        if params[:change_access_id] == @planning_application.change_access_id
+        if @planning_application.validation_complete? && params[:change_access_id] == @planning_application.change_access_id
           @planning_application
         else
           render json: {}, status: :unauthorized


### PR DESCRIPTION
https://trello.com/c/Sa65u1J5/604-bug-validation-requests-appear-on-bops-applicant-before-the-invalidate-application-is-clicked-from-bops-side