### PR TITLE
Description change updates

### DIFF
--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -57,7 +57,7 @@
       label: { text: 'Please suggest a new application description', class: 'govuk-label govuk-label--s'},
       rows: 5 %>
         <div class="govuk-button-group">
-          <%= form.govuk_submit "Add" %>
+          <%= form.govuk_submit "Send" %>
           <%= link_to "Back", validate_form_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
         </div>
       <% end %>

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -34,7 +34,7 @@ Feature: Creating a description change on the application
     Given I create a description change request with "A yard full of bananas"
     When I visit the new description change request link
     And I fill in "Please suggest a new application description" with "Mambo number 2"
-    And I press "Add"
+    And I press "Send"
     Then the page contains "An open description change already exists for this planning application."
 
   Scenario: I cannot create a description change request on a determined planning application
@@ -43,7 +43,7 @@ Feature: Creating a description change on the application
     When I press "Application information"
     And I press "Propose a change to the description"
     And I fill in "Please suggest a new application description" with "Mambo number 10"
-    And I press "Add"
+    And I press "Send"
     Then the page contains "A description change request cannot be submitted for a determined planning application"
 
   Scenario: I can view a notification banner when a request has been auto-closed

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -22,7 +22,7 @@ Given("I create a description change request with {string}") do |details|
     And I press "Application information"
     And I press "Propose a change to the description"
     And I fill in "Please suggest a new application description" with "#{details}"
-    And I press "Add"
+    And I press "Send"
   )
 end
 

--- a/lib/package_builder/scripts/after_install.sh
+++ b/lib/package_builder/scripts/after_install.sh
@@ -16,4 +16,5 @@ mv -Tf /home/deploy/bops/current_<%= release %> /home/deploy/bops/current
 cd /home/deploy/bops/current && bundle install --without development test --deployment --quiet
 cd /home/deploy/bops/current && bundle exec rake db:migrate
 cd /home/deploy/bops/current && bundle exec rake assets:precompile
+if [ ${SERVER_TYPE} = "worker" ] ; then cd /home/deploy/bops/current && bundle exec whenever -w ; else echo not running whenever ; fi
 EOF

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
     visit new_planning_application_description_change_validation_request_path(planning_application)
 
     fill_in "Please suggest a new application description", with: "New description"
-    click_button "Add"
+    click_button "Send"
 
     expect(page).to have_text("Description change request successfully sent.")
 
@@ -38,7 +38,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
     visit new_planning_application_description_change_validation_request_path(planning_application)
 
     fill_in "Please suggest a new application description", with: " "
-    click_button "Add"
+    click_button "Send"
 
     expect(page).to have_content("Proposed description can't be blank")
   end


### PR DESCRIPTION
### Description of change

- Add amendments from UAT session requests
- Add after_install cron job update to run the close_description_change job

### Story Link
https://trello.com/c/at1G8s6E/561-remove-description-change-as-a-validation-request-and-instead-allow-proposals-for-description-change-outside-of-the-validation-r