### PR TITLE
Add notes to planning applications

### DIFF
--- a/app/controllers/planning_application/notes_controller.rb
+++ b/app/controllers/planning_application/notes_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class NotesController < ApplicationController
+    before_action :set_planning_application
+
+    def index
+      @notes = @planning_application.notes
+      @note = Note.new
+
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      @note = @planning_application.notes.new(note_params)
+      @note.user = current_user
+
+      respond_to do |format|
+        if @note.save
+          format.html do
+            redirect_to planning_application_path(@planning_application), notice: "Note was successfully created."
+          end
+        else
+          format.html { render :index }
+        end
+      end
+    end
+
+    private
+
+    def set_planning_application
+      @planning_application = planning_applications_scope.find(planning_application_id)
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications.includes(:notes)
+    end
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+
+    def note_params
+      params.require(:note).permit(:entry)
+    end
+  end
+end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Note < ApplicationRecord
+  belongs_to :planning_application
+  belongs_to :user
+
+  validates :entry, presence: true, length: { maximum: 500 }
+
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -7,13 +7,16 @@ class PlanningApplication < ApplicationRecord
 
   enum application_type: { lawfulness_certificate: 0, full: 1 }
 
-  has_many :documents, dependent: :destroy
-  has_many :recommendations, dependent: :destroy
-  has_many :description_change_validation_requests, dependent: :destroy
-  has_many :replacement_document_validation_requests, dependent: :destroy
-  has_many :other_change_validation_requests, dependent: :destroy
-  has_many :additional_document_validation_requests, dependent: :destroy
-  has_many :red_line_boundary_change_validation_requests, dependent: :destroy
+  with_options dependent: :destroy do
+    has_many :documents
+    has_many :recommendations
+    has_many :description_change_validation_requests
+    has_many :replacement_document_validation_requests
+    has_many :other_change_validation_requests
+    has_many :additional_document_validation_requests
+    has_many :red_line_boundary_change_validation_requests
+    has_many :notes, -> { by_created_at_desc }, inverse_of: :planning_application
+  end
 
   belongs_to :user, optional: true
   belongs_to :api_user, optional: true

--- a/app/views/planning_application/notes/_form.html.erb
+++ b/app/views/planning_application/notes/_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_with model: [@planning_application, @note], url: planning_application_notes_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <% if @note.errors.any? %>
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <% @note.errors.full_messages.each do |error| %>
+            <li><%= error %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form.govuk_text_area :entry, rows: 5, required: true %>
+
+  <div class="govuk-button-group">
+    <%= form.submit "Add new note", class: "govuk-button", data: { module: "govuk-button" } %>
+    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
+<% end %>

--- a/app/views/planning_application/notes/index.html.erb
+++ b/app/views/planning_application/notes/index.html.erb
@@ -1,0 +1,38 @@
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Notes" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Notes
+    </h1>
+
+    <%= render "form" %>
+
+    <% if @notes.empty? %>
+      <p class="govuk-body">There are no notes yet.</p>
+    <% else %>
+      <ul id="notes" class="govuk-list">
+        <% @notes.each_with_index do |note, i| %>
+          <% if i == 0 %>
+            <h2 class="govuk-heading-m">Current note</h2>
+          <% end %>
+          <% if i == 1 %>
+            <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+            <h2 class="govuk-heading-m">Previous notes</h2>
+          <% end %>
+          <%= content_tag(:li, id: dom_id(note), class: "govuk-!-margin-bottom-7") do %>
+            <p class="govuk-body">
+              [<%= note.user.name %>] on <%= note.created_at.to_formatted_s(:day_month_year_time) %>
+            </p>
+            <p class="govuk-body">
+              <%= note.entry %>
+            </p>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -115,6 +115,33 @@
       <p class='govuk-body'>Consultation is not applicable for proposed permitted development.</p>
     </div>
   </div>
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="notes-section">
+          Notes
+        </span>
+        <span class="govuk-accordion__icon" aria-hidden="true"></span>
+      </h2>
+    </div>
+    <div class="govuk-accordion__section-content" aria-labelledby="notes-section">
+      <% if @planning_application.notes.any? %>
+        <p class='govuk-body'>
+          <%= @planning_application.notes.first.entry %>
+        </p>
+        <p class='govuk-body'>
+          <%= @planning_application.notes.first.created_at.to_formatted_s(:day_month_year) %>
+        </p>
+        <p class='govuk-body'>
+          <%= link_to "Add and view all notes", planning_application_notes_path(@planning_application) %>
+        </p>
+      <% else %>
+        <p class='govuk-body'>
+          <%= link_to "Add a note", planning_application_notes_path(@planning_application), class: "govuk-link" %>
+        </p>
+      <% end %>
+    </div>
+  </div>
 </div>
 <% if @planning_application.in_progress? %>
   <div class="govuk-grid-row">

--- a/config/initializers/date_formatter.rb
+++ b/config/initializers/date_formatter.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 Time::DATE_FORMATS[:day_month_year] = Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"
+Time::DATE_FORMATS[:day_month_year_time] = "%-d %B %Y %H:%M"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,3 +41,5 @@ en:
       other_change_validation_request: *cancel_reason
       red_line_boundary_change_validation_request: *cancel_reason
       replacement_document_validation_request: *cancel_reason
+      note:
+        entry: "Add a note to this application. This will replace the current note."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,10 @@ Rails.application.routes.draw do
     resources :description_change_validation_requests, only: %i[new create show] do
       patch :cancel
     end
+
+    scope module: :planning_application do
+      resources :notes, only: %i[index create]
+    end
   end
 
   namespace :api do

--- a/db/migrate/20211103111313_create_notes.rb
+++ b/db/migrate/20211103111313_create_notes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateNotes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :notes do |t|
+      t.references :planning_application, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :entry, limit: 500, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_21_152725) do
+ActiveRecord::Schema.define(version: 2021_11_03_111313) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,16 @@ ActiveRecord::Schema.define(version: 2021_10_21_152725) do
     t.string "email_address"
     t.string "reply_to_notify_id"
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
+  end
+
+  create_table "notes", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.string "entry", limit: 500, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "ix_notes_on_planning_application_id"
+    t.index ["user_id"], name: "ix_notes_on_user_id"
   end
 
   create_table "other_change_validation_requests", force: :cascade do |t|
@@ -293,6 +303,8 @@ ActiveRecord::Schema.define(version: 2021_10_21_152725) do
   add_foreign_key "audits", "planning_applications"
   add_foreign_key "description_change_validation_requests", "planning_applications"
   add_foreign_key "description_change_validation_requests", "users"
+  add_foreign_key "notes", "planning_applications"
+  add_foreign_key "notes", "users"
   add_foreign_key "other_change_validation_requests", "planning_applications"
   add_foreign_key "other_change_validation_requests", "users"
   add_foreign_key "planning_applications", "api_users"

--- a/features/adding_note.feature
+++ b/features/adding_note.feature
@@ -1,0 +1,22 @@
+Feature: Adding a note
+  Background:
+    Given I am logged in as an assessor
+    And a new planning application
+    And I view the planning application
+    And the time is 14:00 on the 5-11-2021
+
+Scenario Outline: As an assessor I can add notes
+  When I press "Add a note"
+  Then I see that there are no notes
+  When I add a note with "This is an epic note"
+  Then I see the current note with entry "This is an epic note" at "5 November 2021"
+  When I press "Add and view all notes"
+  Then I see that there is one note
+  And I see that there is a note with entry "This is an epic note" at "5 November 2021 14:00"
+  When the time is 15:25 on the 5-11-2021
+  And I add a note with "This is another epic note"
+  And I view the planning application notes
+  Then I see that there are multiple notes
+  And I see that there is a note with entry "This is another epic note" at "5 November 2021 15:25"
+  When I view the planning application
+  Then I see the current note with entry "This is another epic note" at "5 November 2021"

--- a/features/managing_validation_requests.feature
+++ b/features/managing_validation_requests.feature
@@ -42,7 +42,7 @@ Feature: Managing validation requests
     Then there is no validation request for a "Picture of the dog"
 
   Scenario: As an assessor I can cancel a validation request only after invalidating the planning application
-    Given the date is year: 2021, month: 10, day: 21
+    Given the date is 21-10-2021
     And the planning application is invalidated
     When I view the application's validations requests
     Then there is a validation request for a "Picture of the dog" that has a link "Cancel request"
@@ -53,7 +53,7 @@ Feature: Managing validation requests
     And there is no validation request for a "Picture of the dog"
 
   Scenario Outline: As an assessor I can cancel different validation requests
-    Given the date is year: 2021, month: 10, day: 21
+    Given the date is 21-10-2021
     And the planning application is invalidated
     When I cancel a <type> validation request with "<reason>"
     Then there is a cancelled validation request for a "<reason>" that shows "21 October 2021"

--- a/features/step_definitions/datetime_steps.rb
+++ b/features/step_definitions/datetime_steps.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-Given("the date is year: {int}, month: {int}, day: {int}") do |year, month, day|
+Given("the date is {int}-{int}-{int}") do |day, month, year|
   travel_to Time.zone.local(year, month, day)
+end
+
+Given("the time is {int}:{int} on the {int}-{int}-{int}") do |hour, minutes, day, month, year|
+  travel_to Time.zone.local(year, month, day, hour, minutes)
 end

--- a/features/step_definitions/note_steps.rb
+++ b/features/step_definitions/note_steps.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+When("I view the planning application notes") do
+  visit planning_application_notes_path(@planning_application)
+end
+
+When("I see the note form actions") do
+  within(".govuk-button-group") do
+    steps %(
+      Then the page has button "Add new note"
+      And the page has a "Back" link with href "#{planning_application_path(@planning_application)}"
+    )
+  end
+end
+
+Then("I see that there are no notes") do
+  steps %(
+    And the page contains "There are no notes yet."
+    And the page does not contain "Current note"
+    And the page does not contain "Previous notes"
+  )
+end
+
+Then("I see that there is one note") do
+  steps %(
+    And the page does not contain "There are no notes yet."
+    And the page contains "Current note"
+    And the page does not contain "Previous notes"
+  )
+end
+
+Then("I see that there is a note with entry {string} at {string}") do |entry, day_month_year_time|
+  note = @planning_application.notes.find_by(entry: entry)
+
+  within("#notes") do
+    within("#note_#{note.id}") do
+      steps %(
+        And the page contains "#{note.user.name}"
+        And the page contains "#{day_month_year_time}"
+        And the page contains "#{entry}"
+      )
+    end
+  end
+end
+
+Then("I see that there are multiple notes") do
+  within("#notes") do
+    steps %(
+      And the page contains "Current note"
+      And the page contains "Previous notes"
+    )
+  end
+end
+
+Given("I add a note with {string}") do |entry|
+  steps %(
+    Given I fill in "Add a note to this application. This will replace the current note." with "#{entry}"
+    And I see the note form actions
+    And I press "Add new note"
+    Then the page contains "Note was successfully created."
+  )
+end
+
+When("I see the current note with entry {string} at {string}") do |entry, day_month_year|
+  steps %(
+    Then the page contains "#{entry}"
+    And the page contains "#{day_month_year}"
+  )
+end

--- a/spec/factories/note.rb
+++ b/spec/factories/note.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :note do
+    planning_application
+    user
+
+    entry { "I am a note" }
+  end
+end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+  describe "validations" do
+    subject(:note) { described_class.new }
+
+    describe "#entry" do
+      it "validates presence" do
+        expect { note.valid? }.to change { note.errors[:entry] }.to ["can't be blank"]
+      end
+
+      it "validates max length of 500 characters" do
+        note = described_class.new(entry: "x" * 501)
+
+        expect { note.valid? }.to change { note.errors[:entry] }.to ["is too long (maximum is 500 characters)"]
+      end
+    end
+
+    describe "#user" do
+      it "validates presence" do
+        expect { note.valid? }.to change { note.errors[:user] }.to ["must exist"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { note.valid? }.to change { note.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".by_created_at_desc" do
+      let!(:notes1) { create(:note, created_at: Time.zone.now - 1.day) }
+      let!(:notes2) { create(:note, created_at: Time.zone.now) }
+      let!(:notes3) { create(:note, created_at: Time.zone.now - 2.days) }
+
+      it "returns notes sorted by created at desc (i.e. most recent first)" do
+        expect(described_class.by_created_at_desc).to eq([notes2, notes1, notes3])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Create notes table with belongs to relation with planning application
- Add ability to create notes and list in created_at descending order
- Display current note as the latest note

### Story Link

https://trello.com/c/p8rukRaF/465-officer-notes

### **When there are no notes**
![Screenshot 2021-11-05 at 11 31 19](https://user-images.githubusercontent.com/34001723/140504497-db212437-4a05-4a00-88c6-f6cb841e1154.png)

### **When there are multiple notes**
![Screenshot 2021-11-05 at 11 31 58](https://user-images.githubusercontent.com/34001723/140504499-715316ec-36ba-42af-bf7f-02b78afa8ecd.png)

### **Current note preview on planning application index**
![Screenshot 2021-11-05 at 11 34 45](https://user-images.githubusercontent.com/34001723/140504583-b3735c17-7037-4449-b9cb-0e0b5d6615c2.png)
