### PR TITLE
Remove character limit from notes

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -4,7 +4,7 @@ class Note < ApplicationRecord
   belongs_to :planning_application
   belongs_to :user
 
-  validates :entry, presence: true, length: { maximum: 500 }
+  validates :entry, presence: true
 
   scope :by_created_at_desc, -> { order(created_at: :desc) }
 end

--- a/app/views/planning_application/notes/index.html.erb
+++ b/app/views/planning_application/notes/index.html.erb
@@ -17,7 +17,7 @@
       <ul id="notes" class="govuk-list">
         <% @notes.each_with_index do |note, i| %>
           <% if i == 0 %>
-            <h2 class="govuk-heading-m">Current note</h2>
+            <h2 class="govuk-heading-m">Latest note</h2>
           <% end %>
           <% if i == 1 %>
             <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -25,7 +25,7 @@
           <% end %>
           <%= content_tag(:li, id: dom_id(note), class: "govuk-!-margin-bottom-7") do %>
             <p class="govuk-body">
-              [<%= note.user.name %>] on <%= note.created_at.to_formatted_s(:day_month_year_time) %>
+              <%= note.user.name %> on <%= note.created_at.to_formatted_s(:day_month_year_time) %>
             </p>
             <p class="govuk-body">
               <%= note.entry %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -127,7 +127,7 @@
     <div class="govuk-accordion__section-content" aria-labelledby="notes-section">
       <% if @planning_application.notes.any? %>
         <p class='govuk-body'>
-          <%= @planning_application.notes.first.entry %>
+          <%= truncate @planning_application.notes.first.entry, length: 200 %>
         </p>
         <p class='govuk-body'>
           <%= @planning_application.notes.first.created_at.to_formatted_s(:day_month_year) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,4 +42,4 @@ en:
       red_line_boundary_change_validation_request: *cancel_reason
       replacement_document_validation_request: *cancel_reason
       note:
-        entry: "Add a note to this application. This will replace the current note."
+        entry: "Add a note to this application."

--- a/db/migrate/20211109132114_remove_character_limit_from_notes_entry.rb
+++ b/db/migrate/20211109132114_remove_character_limit_from_notes_entry.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class RemoveCharacterLimitFromNotesEntry < ActiveRecord::Migration[6.1]
+  # rubocop:disable Rails/BulkChangeTable
+  def change
+    change_column :notes, :entry, :string, limit: nil
+    change_column :notes, :entry, :text
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_111313) do
+ActiveRecord::Schema.define(version: 2021_11_09_132114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,7 +148,7 @@ ActiveRecord::Schema.define(version: 2021_11_03_111313) do
   create_table "notes", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
-    t.string "entry", limit: 500, null: false
+    t.text "entry", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["planning_application_id"], name: "ix_notes_on_planning_application_id"

--- a/features/adding_note.feature
+++ b/features/adding_note.feature
@@ -9,7 +9,7 @@ Scenario Outline: As an assessor I can add notes
   When I press "Add a note"
   Then I see that there are no notes
   When I add a note with "This is an epic note"
-  Then I see the current note with entry "This is an epic note" at "5 November 2021"
+  Then I see the latest note with entry "This is an epic note" at "5 November 2021"
   When I press "Add and view all notes"
   Then I see that there is one note
   And I see that there is a note with entry "This is an epic note" at "5 November 2021 14:00"
@@ -19,4 +19,4 @@ Scenario Outline: As an assessor I can add notes
   Then I see that there are multiple notes
   And I see that there is a note with entry "This is another epic note" at "5 November 2021 15:25"
   When I view the planning application
-  Then I see the current note with entry "This is another epic note" at "5 November 2021"
+  Then I see the latest note with entry "This is another epic note" at "5 November 2021"

--- a/features/step_definitions/note_steps.rb
+++ b/features/step_definitions/note_steps.rb
@@ -16,7 +16,7 @@ end
 Then("I see that there are no notes") do
   steps %(
     And the page contains "There are no notes yet."
-    And the page does not contain "Current note"
+    And the page does not contain "Latest note"
     And the page does not contain "Previous notes"
   )
 end
@@ -24,7 +24,7 @@ end
 Then("I see that there is one note") do
   steps %(
     And the page does not contain "There are no notes yet."
-    And the page contains "Current note"
+    And the page contains "Latest note"
     And the page does not contain "Previous notes"
   )
 end
@@ -46,7 +46,7 @@ end
 Then("I see that there are multiple notes") do
   within("#notes") do
     steps %(
-      And the page contains "Current note"
+      And the page contains "Latest note"
       And the page contains "Previous notes"
     )
   end
@@ -54,14 +54,14 @@ end
 
 Given("I add a note with {string}") do |entry|
   steps %(
-    Given I fill in "Add a note to this application. This will replace the current note." with "#{entry}"
+    Given I fill in "Add a note to this application." with "#{entry}"
     And I see the note form actions
     And I press "Add new note"
     Then the page contains "Note was successfully created."
   )
 end
 
-When("I see the current note with entry {string} at {string}") do |entry, day_month_year|
+When("I see the latest note with entry {string} at {string}") do |entry, day_month_year|
   steps %(
     Then the page contains "#{entry}"
     And the page contains "#{day_month_year}"

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Note, type: :model do
       it "validates presence" do
         expect { note.valid? }.to change { note.errors[:entry] }.to ["can't be blank"]
       end
-
-      it "validates max length of 500 characters" do
-        note = described_class.new(entry: "x" * 501)
-
-        expect { note.valid? }.to change { note.errors[:entry] }.to ["is too long (maximum is 500 characters)"]
-      end
     end
 
     describe "#user" do


### PR DESCRIPTION
- Update to use Latest note
- Truncate text after 200 characters for latest note preview on planning applications index