### PR TITLE
Amend target date to expiry date

### DIFF
--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -14,7 +14,7 @@ Please quote the planning reference number <%= @planning_application.reference %
 
 We may request additional information and/or revisions before deciding whether the application should be recommended for permission or refusal.
 
-We aim to issue a decision by <%= @planning_application.target_date.to_datetime.to_formatted_s(:day_month_year) %>. However, if your application has not been determined by <%= @planning_application.target_date.to_datetime.to_formatted_s(:day_month_year) %>, you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate, or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
+We aim to issue a decision by <%= @planning_application.expiry_date.to_datetime.to_formatted_s(:day_month_year) %>. However, if your application has not been determined by <%= @planning_application.expiry_date.to_datetime.to_formatted_s(:day_month_year) %>, you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate, or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
 
 An appeal in this situation assumes the refusal of the application, even if it had intended to be granted. It is therefore recommended that you consult your case officer before taking such action.
 

--- a/app/views/planning_applications/_validation_notice.html.erb
+++ b/app/views/planning_applications/_validation_notice.html.erb
@@ -25,8 +25,8 @@
     We may request additional information and/or revisions before deciding whether the application should be recommended for permission or refusal.
   </p>
   <p class="govuk-body">
-    We aim to issue a decision by <%= @planning_application.target_date.to_datetime.to_formatted_s(:day_month_year) %>.
-    However, if your application has not been determined by <%= @planning_application.target_date.to_datetime.to_formatted_s(:day_month_year) %>,
+    We aim to issue a decision by <%= @planning_application.expiry_date.to_datetime.to_formatted_s(:day_month_year) %>.
+    However, if your application has not been determined by <%= @planning_application.expiry_date.to_datetime.to_formatted_s(:day_month_year) %>,
     you have the right to appeal to the Secretary of State, either online at https://www.gov.uk/government/organisations/planning-inspectorate,
     or by post to Temple Quay House, 2 The Square, Temple Quay, Bristol BS1 6PN.
   </p>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -161,8 +161,8 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the body" do
       expect(validation_mail.body.encoded).to match("started from #{planning_application.documents_validated_at.to_formatted_s(:day_month_year)}")
-      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.to_formatted_s(:day_month_year)}")
-      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.target_date.to_formatted_s(:day_month_year)}")
+      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.expiry_date.to_formatted_s(:day_month_year)}")
+      expect(validation_mail.body.encoded).to match("issue a decision by #{planning_application.expiry_date.to_formatted_s(:day_month_year)}")
       expect(validation_mail.body.encoded).to match("Site Address: #{planning_application.full_address}")
       expect(validation_mail.body.encoded).to match("planning reference number #{planning_application.reference}")
       expect(validation_mail.body.encoded).to match("Proposal: #{planning_application.description}")


### PR DESCRIPTION
### Description of change

Bug fix: expiry date should be communicated in validation email, not target date - due to legal target of when an application can be appealed.

### Story Link

https://trello.com/c/kGdQXdX0/672-application-valid-letter-is-showing-the-wrong-date