### PR TITLE
Sort api response by id

### DIFF
--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
             headers: { "CONTENT-TYPE": "application/json", Authorization: token }
 
         expect(response).to be_successful
-        expect(json["data"]).to eq(
+        expect(sort_by_id(json["data"])).to eq(
           [
             {
               "id" => additional_document_validation_request.id,

--- a/spec/requests/api/description_change_validation_request_spec.rb
+++ b/spec/requests/api/description_change_validation_request_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe "Description change validation requests API", type: :request, sho
             headers: { "CONTENT-TYPE": "application/json", Authorization: token }
 
         expect(response).to be_successful
-
-        expect(json["data"]).to eq(
+        expect(sort_by_id(json["data"])).to eq(
           [
             {
               "id" => description_change_validation_request.id,

--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Other change validation requests API", type: :request, show_exce
             headers: { "CONTENT-TYPE": "application/json", Authorization: token }
 
         expect(response).to be_successful
-        expect(json["data"]).to eq(
+        expect(sort_by_id(json["data"])).to eq(
           [
             {
               "id" => other_change_validation_request.id,

--- a/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Red line boundary change validation requests API", type: :reques
             headers: { "CONTENT-TYPE": "application/json", Authorization: token }
 
         expect(response).to be_successful
-        expect(json["data"]).to eq(
+        expect(sort_by_id(json["data"])).to eq(
           [
             {
               "id" => red_line_boundary_change_validation_request.id,

--- a/spec/requests/api/replacement_document_validation_request_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Replacement document validation requests API", type: :request, s
             headers: { "CONTENT-TYPE": "application/json", Authorization: token }
 
         expect(response).to be_successful
-        expect(json["data"]).to eq(
+        expect(sort_by_id(json["data"])).to eq(
           [
             {
               "id" => replacement_document_validation_request.id,

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -11,6 +11,10 @@ module Requests
     def json_time_format(time)
       time.iso8601(3) if time.present?
     end
+
+    def sort_by_id(response)
+      response.sort_by! { |k| k["id"] }
+    end
   end
 end
 


### PR DESCRIPTION
- Sometimes the request returns the data in a random order causing flaky specs so this way it doesn't matter how it gets returned