### PR TITLE
Fix/valid from date

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -99,8 +99,4 @@ module PlanningApplicationHelper
                                         )}"
     end
   end
-
-  def received_at(planning_application)
-    Time.first_business_day(planning_application.created_at).to_formatted_s(:day_month_year)
-  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -354,6 +354,16 @@ class PlanningApplication < ApplicationRecord
     Time.next_immediate_business_day(created_at)
   end
 
+  def valid_from
+    return nil unless validated?
+
+    if closed_validation_requests.any?
+      Time.next_immediate_business_day(last_validation_request_date)
+    else
+      received_at
+    end
+  end
+
   private
 
   def set_key_dates

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -350,6 +350,10 @@ class PlanningApplication < ApplicationRecord
     documents.for_display
   end
 
+  def received_at
+    Time.next_immediate_business_day(created_at)
+  end
+
   private
 
   def set_key_dates

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -367,8 +367,8 @@ class PlanningApplication < ApplicationRecord
   private
 
   def set_key_dates
-    self.expiry_date = 40.business_days.after(documents_validated_at || created_at)
-    self.target_date = 35.business_days.after(documents_validated_at || created_at)
+    self.expiry_date = 40.business_days.after(documents_validated_at || received_at)
+    self.target_date = 35.business_days.after(documents_validated_at || received_at)
   end
 
   def set_change_access_id

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -51,6 +51,10 @@ module ValidationRequest
           audit_auto_closed!
         end
       end
+
+      event :close! do
+        transitions from: :open, to: :closed
+      end
     end
 
     def response_due

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -26,7 +26,7 @@ module ValidationRequest
       state :closed
       state :cancelled
 
-      event :mark_as_sent! do
+      event :mark_as_sent do
         transitions from: :pending, to: :open
 
         after do
@@ -42,7 +42,7 @@ module ValidationRequest
         end
       end
 
-      event :auto_approve! do
+      event :auto_approve do
         transitions from: :open, to: :closed
 
         after do
@@ -52,7 +52,7 @@ module ValidationRequest
         end
       end
 
-      event :close! do
+      event :close do
         transitions from: :open, to: :closed
       end
     end

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <p class="govuk-body">
       <strong>At:</strong> <%= @planning_application.full_address  %> <br>
-      <strong>Date received:</strong> <%= received_at(@planning_application) %> <br>
+      <strong>Date received:</strong> <%= @planning_application.received_at.to_formatted_s(:day_month_year) %> <br>
       <strong>Application number:</strong> <%= @planning_application.reference  %>
     </p>
     <div class="govuk-form-group">
@@ -41,7 +41,7 @@
         <% if @planning_application.latest_rejected_description_change.present? %>
           <p class="govuk-body">
             <strong>
-              Rejected proposed description 
+              Rejected proposed description
             </strong>
           </p>
           <p class="govuk-body">

--- a/app/views/other_change_validation_requests/new.html.erb
+++ b/app/views/other_change_validation_requests/new.html.erb
@@ -10,7 +10,7 @@
       <strong>At:</strong> <%= @planning_application.full_address  %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= received_at(@planning_application) %>
+      <strong>Date received:</strong> <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-8">
       <strong>Application number:</strong> <%= @planning_application.reference  %>

--- a/app/views/other_change_validation_requests/show.html.erb
+++ b/app/views/other_change_validation_requests/show.html.erb
@@ -10,7 +10,7 @@
       <strong>At:</strong> <%= @planning_application.full_address  %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= received_at(@planning_application) %>
+      <strong>Date received:</strong> <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-8">
       <strong>Application number:</strong> <%= @planning_application.reference  %>

--- a/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
@@ -1,5 +1,5 @@
 Application number: <%= @planning_application.reference %>
-Application received: <%= received_at(@planning_application) %>
+Application received: <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
 At: <%= @planning_application.full_address %>
 
 Hi <%= @planning_application.agent_or_applicant_name %>,

--- a/app/views/planning_application_mailer/description_change_mail.html.erb
+++ b/app/views/planning_application_mailer/description_change_mail.html.erb
@@ -1,5 +1,5 @@
 Application number: <%= @planning_application.reference %>
-Application received: <%= received_at(@planning_application) %>
+Application received: <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
 At: <%= @planning_application.full_address %>
 
 Dear <%= @planning_application.agent_or_applicant_name %>,

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -6,7 +6,7 @@ Reference No.: <%= @planning_application.reference %>
 Proposal: <%= @planning_application.description %>
 Site Address: <%= @planning_application.full_address %>
 
-Thank you for your planning application received on <%= @planning_application.created_at.to_formatted_s(:day_month_year) %>. Unfortunately your application is invalid and has not been registered.
+Thank you for your planning application received on <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>. Unfortunately your application is invalid and has not been registered.
 
 To review the reasons for invalidation and make the changes required, please follow the link below:
 

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -2,7 +2,7 @@ Dear <%= @planning_application.agent_or_applicant_name %>,
 
 Reference: <%= @planning_application.reference %>
 Date of application: <%= @planning_application.created_at.strftime("%e %B %Y - %H:%M:%S") %>
-Date received: <%= received_at(@planning_application) %>
+Date received: <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
 
 Site address: <%= @planning_application.full_address %>
 Description: <%= @planning_application.description %>

--- a/app/views/planning_application_mailer/validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_mail.text.erb
@@ -1,5 +1,5 @@
 Application number: <%= @planning_application.reference %>
-Application received: <%= received_at(@planning_application) %>
+Application received: <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
 At: <%= @planning_application.full_address %>
 
 Hi <%= @planning_application.agent_or_applicant_name %>,

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -17,7 +17,7 @@
       {
         "Applicant" => planning_application.applicant_name,
         "Application number" => planning_application.reference,
-        "Application received" => planning_application.created_at.to_formatted_s(:day_month_year),
+        "Application received" => planning_application.received_at.to_formatted_s(:day_month_year),
         "Decision date" => planning_application.determined_at&.to_formatted_s(:day_month_year) || "TBD",
         "Site address" => planning_application.full_address,
         "Use/development" => planning_application.description,

--- a/app/views/planning_applications/review_form.html.erb
+++ b/app/views/planning_applications/review_form.html.erb
@@ -31,10 +31,14 @@
       <% end %>
     <% end %>
     <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+        <h2 class="govuk-fieldset__heading">
+          Do you agree with the recommendation?
+        </h2>
+      </legend>
       <div class="<%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
         <div class="govuk-form-group">
-          <p class="govuk-body"><strong>Do you agree with the recommendation?</strong></p>
-          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios" style="margin-bottom: 20px;">
+          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios govuk-radios--small">
               <div class="govuk-radios__item">
                 <%= form.radio_button :agree, "Yes", checked: @recommendation.challenged == false, class: "govuk-radios__input" %>

--- a/app/views/red_line_boundary_change_validation_requests/new.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/new.html.erb
@@ -10,7 +10,7 @@
       <strong>At:</strong> <%= @planning_application.full_address  %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= received_at(@planning_application) %>
+      <strong>Date received:</strong> <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-8">
       <strong>Application number:</strong> <%= @planning_application.reference  %>

--- a/app/views/red_line_boundary_change_validation_requests/show.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/show.html.erb
@@ -10,7 +10,7 @@
       <strong>At:</strong> <%= @planning_application.full_address  %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= received_at(@planning_application) %>
+      <strong>Date received:</strong> <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
     </p>
     <p class="govuk-body govuk-!-margin-bottom-8">
       <strong>Application number:</strong> <%= @planning_application.reference  %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -45,7 +45,7 @@
     <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
       <p class="govuk-body">
         <strong>Application received:</strong>
-        <%= @planning_application.created_at.to_formatted_s(:day_month_year) %>
+        <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
       </p>
       <p class="govuk-body">
         <strong>Validation complete:</strong>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -48,11 +48,11 @@
         <%= @planning_application.received_at.to_formatted_s(:day_month_year) %>
       </p>
       <p class="govuk-body">
-        <strong>Validation complete:</strong>
-        <% if @planning_application.in_assessment_at %>
-          <%= @planning_application.in_assessment_at.to_formatted_s(:day_month_year) %>
+        <strong>Valid from:</strong>
+        <% if @planning_application.valid_from.present? %>
+          <%= @planning_application.valid_from.to_formatted_s(:day_month_year) %>
         <% else %>
-          Not yet started
+          Not yet valid
         <% end %>
       </p>
       <p class="govuk-body">

--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -6,3 +6,17 @@ BusinessTime::Config.load(Rails.root.join("config/business_time.yml").to_s)
 #  BusinessTime::Config.beginning_of_workday = "10:00 am"
 #  BusinessTime::Config.end_of_workday = "11:30 am"
 #  BusinessTime::Config.holidays << Date.parse("August 4th, 2010")
+
+module Bops
+  module TimeExtensions
+    module ClassMethods
+      def next_immediate_business_day(time)
+        Time.roll_forward(time).to_date
+      end
+    end
+  end
+end
+
+class Time
+  extend Bops::TimeExtensions::ClassMethods
+end

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -4,7 +4,7 @@ Feature: Creating a description change on the application
     And a new planning application
     And the planning application has a description of "Add a statue of Melissa striking poses"
     And I view the planning application
-  
+
   Scenario: I can add a new description change request
     Given I create a description change request with "Add a backyard cinema"
     Then the page contains "Description change request successfully sent."
@@ -14,7 +14,7 @@ Feature: Creating a description change on the application
     And I cancel the existing description change request
     Then the page contains "Description change request successfully cancelled"
     And there is an audit entry containing "Cancelled: description change request"
-  
+
   Scenario: I can add and view a new description change request after cancelling the previous one
     Given I create a description change request with "Its margarita time ole!"
     When I press "Application information"
@@ -23,7 +23,7 @@ Feature: Creating a description change on the application
     Then the page contains "Add a statue of Melissa striking poses"
     Then the page contains "Proposed description"
     Then the page contains "Its margarita time ole!"
-  
+
   Scenario: When a change request has been accepted I can view the previous description and the new one
     Given I create a description change request with "Bring me the beans"
     And the request has been responded to
@@ -49,9 +49,10 @@ Feature: Creating a description change on the application
     Then the page contains "An open description change already exists for this planning application."
 
   Scenario: I cannot create a description change request on a determined planning application
-    Given a determined planning application
+    Given I am logged in as a reviewer
+    And the planning application is determined
     When I view the planning application
-    When I press "Application information"
+    And I press "Application information"
     And I press "Propose a change to the description"
     And I fill in "Please suggest a new application description" with "Mambo number 10"
     And I press "Send"

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -2,9 +2,17 @@
 
 require "faker"
 
-Given("I am logged in as an assessor") do
+Given("I am logged out") do
+  visit root_path
+
+  click_on "Log out" if page.has_button? "Log out"
+end
+
+Given("I am logged in as a(n) {}") do |role|
+  step("I am logged out")
+
   southwark = LocalAuthority.find_by(subdomain: "southwark")
-  @officer = FactoryBot.create(:user, :assessor, local_authority: southwark)
+  @officer = FactoryBot.create(:user, role.to_sym, local_authority: southwark)
 
   domain = @officer.local_authority.subdomain
 
@@ -28,13 +36,6 @@ Given("a new planning application") do
   @planning_application = FactoryBot.create(
     :planning_application,
     :not_started,
-    local_authority: @officer.local_authority
-  )
-end
-
-Given("a determined planning application") do
-  @planning_application = FactoryBot.create(
-    :determined_planning_application,
     local_authority: @officer.local_authority
   )
 end
@@ -68,6 +69,26 @@ Given("the planning application is assessed") do
     And I fill in "State the reasons why" with "a valid reason"
     And I fill in "supporting information" with "looks legit"
     And I press "Save"
+  )
+end
+
+Given("a recommandation is submitted for the planning application") do
+  steps %(
+    Given the planning application is validated
+    And the planning application is assessed
+    And I press "Submit recommendation"
+    And I press "Submit to manager"
+  )
+end
+
+Given("the planning application is determined") do
+  steps %(
+    Given a recommandation is submitted for the planning application
+    And I press "Review assessment"
+    And I choose "Yes" for "Do you agree with the recommendation?"
+    And I press "Save"
+    And I press "Publish determination"
+    And I press "Determine application"
   )
 end
 

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -5,8 +5,8 @@ require "faker"
 FactoryBot.define do
   factory :planning_application do
     local_authority
-    description      { Faker::Lorem.unique.sentence }
-    status           { :in_assessment }
+    description { Faker::Lorem.unique.sentence }
+    status { :in_assessment }
     in_assessment_at { Time.zone.now }
     documents_validated_at { Time.zone.today }
     work_status { :proposed }
@@ -132,8 +132,26 @@ FactoryBot.define do
     end
 
     factory :not_started_planning_application do
+      status { :not_started }
+
       factory :invalidated_planning_application do
-        after(:create, &:invalidate!)
+        after(:create) do |p|
+          create(
+            :additional_document_validation_request,
+            :pending,
+            planning_application: p
+          )
+
+          p.invalidate!
+        end
+
+        factory :valid_planning_application do
+          after(:create) do |p|
+            p.validation_requests.each(&:close!)
+
+            p.start!
+          end
+        end
       end
 
       factory :in_assessment_planning_application do

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -151,16 +151,16 @@ FactoryBot.define do
 
             p.start!
           end
-        end
-      end
 
-      factory :in_assessment_planning_application do
-        decision { "granted" }
+          factory :in_assessment_planning_application do
+            decision { "granted" }
 
-        after(:create, &:assess!)
+            after(:create, &:assess!)
 
-        factory :determined_planning_application do
-          after(:create, &:determine!)
+            factory :determined_planning_application do
+              after(:create, &:determine!)
+            end
+          end
         end
       end
     end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "renders the body" do
-      expect(validation_request_mail.body.encoded).to include("Application received: #{planning_application.created_at.to_formatted_s(:day_month_year)}")
+      expect(validation_request_mail.body.encoded).to include("Application received: #{planning_application.received_at.to_formatted_s(:day_month_year)}")
       expect(validation_request_mail.body.encoded).to include(validation_request.user.name)
       expect(validation_request_mail.body.encoded).to include(validation_request.response_due.to_formatted_s(:day_month_year))
       expect(validation_request_mail.body.encoded).to include(planning_application.change_access_id)
@@ -239,7 +239,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     it "renders the body" do
       body = cancelled_validation_request_mail.body.encoded
       expect(body).to include("Application number: #{planning_application.reference}")
-      expect(body).to include("Application received: #{planning_application.created_at.to_formatted_s(:day_month_year)}")
+      expect(body).to include("Application received: #{planning_application.received_at.to_formatted_s(:day_month_year)}")
       expect(body).to include("At: #{planning_application.full_address}")
       expect(body).to include("Hi #{planning_application.agent_or_applicant_name}")
       expect(body).to include("#{validation_request.user.name}, the officer working on your planning application has cancelled one of the validation requests(s) on your application. You no longer need to take action for this request.")
@@ -277,7 +277,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "renders the body" do
       expect(receipt_mail.body.encoded).to match("If by #{planning_application.target_date.to_formatted_s(:day_month_year)}:")
-      expect(receipt_mail.body.encoded).to match("Date received: #{Time.first_business_day(planning_application.created_at).to_formatted_s(:day_month_year)}")
+      expect(receipt_mail.body.encoded).to match("Date received: #{planning_application.received_at.to_formatted_s(:day_month_year)}")
       expect(receipt_mail.body.encoded).to match("Site address: #{planning_application.full_address}")
       expect(receipt_mail.body.encoded).to match("Reference: #{planning_application.reference}")
       expect(receipt_mail.body.encoded).to match("Description: #{planning_application.description}")
@@ -308,7 +308,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "renders the body" do
         expect(description_change_mail.body.encoded).to match("Application number: #{planning_application.reference}")
-        expect(description_change_mail.body.encoded).to match("Application received: #{Time.first_business_day(planning_application.created_at).to_formatted_s(:day_month_year)}")
+        expect(description_change_mail.body.encoded).to match("Application received: #{planning_application.received_at.to_formatted_s(:day_month_year)}")
         expect(description_change_mail.body.encoded).to match("At: #{planning_application.full_address}")
         expect(description_change_mail.body.encoded).to match("the officer working on your planning application has proposed a change to the description of your application.")
         expect(description_change_mail.body.encoded).to match("If your response is not received by #{description_change_request.request_expiry_date.to_formatted_s(:day_month_year)}")

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -317,9 +317,20 @@ RSpec.describe PlanningApplication, type: :model do
 
   describe "deadlines" do
     let(:planning_application) { create :planning_application }
+    let(:date) { Time.zone.local(2021, 9, 23, 10, 10, 44) }
 
     before do
-      travel_to Time.zone.local(2021, 9, 23, 10, 10, 44)
+      travel_to date
+    end
+
+    describe "#received_at" do
+      before do
+        planning_application.update!(created_at: date.change(hour: 23))
+      end
+
+      it "returns the correct business day for the application's created_at" do
+        expect(planning_application.received_at).to eq Date.tomorrow
+      end
     end
 
     describe "#target_date" do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -316,48 +316,60 @@ RSpec.describe PlanningApplication, type: :model do
   end
 
   describe "deadlines" do
-    let(:planning_application) { create :planning_application }
-    let(:date) { Time.zone.local(2021, 9, 23, 10, 10, 44) }
+    let(:planning_application) { create(:not_started_planning_application) }
+    let(:date) { Time.zone.local(2021, 9, 23, 22, 10, 44) }
 
     before do
       travel_to date
     end
 
     describe "#received_at" do
-      before do
-        planning_application.update!(created_at: date.change(hour: 23))
-      end
-
       it "returns the correct business day for the application's created_at" do
         expect(planning_application.received_at).to eq Date.tomorrow
       end
     end
 
     describe "#target_date" do
-      it "is set as created_at + 35 business days when new record created" do
-        expect(planning_application.target_date).to eq(35.business_days.after(planning_application.created_at).to_date)
+      context "when there were no documents validated" do
+        before { planning_application.update!(documents_validated_at: nil) }
+
+        it "is set as received at + 35 business days" do
+          expect(planning_application.target_date).to eq(35.business_days.after(planning_application.received_at).to_date)
+        end
       end
 
-      it "is set to documents_validated_at + 35 business days when documents_validated_at added" do
-        planning_application.update!(documents_validated_at: 1.week.ago)
-        expect(planning_application.target_date).to eq(35.business_days.after(planning_application.documents_validated_at).to_date)
+      context "when there are validated documents" do
+        before { planning_application.update!(documents_validated_at: 1.week.ago) }
+
+        it "is set to documents_validated_at + 35 business days" do
+          expect(planning_application.target_date).to eq(35.business_days.after(planning_application.documents_validated_at).to_date)
+        end
       end
     end
 
     describe "#expiry_date" do
-      it "is set as created_at + 40 business days when new record created" do
-        expect(planning_application.expiry_date).to eq(40.business_days.after(planning_application.created_at).to_date)
+      context "when there were no documents validated" do
+        before { planning_application.update!(documents_validated_at: nil) }
+
+        it "is set as received_at + 40 business days" do
+          expect(planning_application.expiry_date).to eq(40.business_days.after(planning_application.received_at).to_date)
+        end
       end
 
-      it "is set to documents_validated_at + 40 business days when documents_validated_at added" do
-        planning_application.update!(documents_validated_at: 1.week.ago)
-        expect(planning_application.expiry_date).to eq(40.business_days.after(planning_application.documents_validated_at).to_date)
+      context "when there are validated documents" do
+        before { planning_application.update!(documents_validated_at: 1.week.ago) }
+
+        it "is set to documents_validated_at + 40 business days" do
+          planning_application.update!(documents_validated_at: 1.week.ago)
+          expect(planning_application.expiry_date).to eq(40.business_days.after(planning_application.documents_validated_at).to_date)
+        end
       end
     end
   end
 
   describe "#valid_from" do
     let(:planning_application) { create(:not_started_planning_application) }
+
     context "when the application is not valid" do
       it "is nil" do
         expect(planning_application.valid_from).to be_nil
@@ -369,7 +381,7 @@ RSpec.describe PlanningApplication, type: :model do
         before do
           [
             [3.days.ago, :closed],
-            [2.day.ago, :cancelled],
+            [2.days.ago, :cancelled],
             [12.days.ago, :closed],
             [1.day.ago, :closed]
           ].each do |at, state|

--- a/spec/models/validation_request_spec.rb
+++ b/spec/models/validation_request_spec.rb
@@ -19,16 +19,16 @@ RSpec.describe ValidationRequest, type: :model do
       it_behaves_like "StateMachineTransitions", request_type, "cancelled", %i[]
       it_behaves_like "StateMachineTransitions", request_type, "closed", %i[]
 
-      it_behaves_like "StateMachineEvents", request_type, "pending", %i[mark_as_sent! cancel]
-      it_behaves_like "StateMachineEvents", request_type, "open", %i[cancel auto_approve!]
+      it_behaves_like "StateMachineEvents", request_type, "pending", %i[mark_as_sent cancel]
+      it_behaves_like "StateMachineEvents", request_type, "open", %i[cancel auto_approve]
       it_behaves_like "StateMachineEvents", request_type, "cancelled", %i[]
       it_behaves_like "StateMachineEvents", request_type, "closed", %i[]
     end
 
     describe "events" do
-      describe "mark_as_sent!" do
+      describe "mark_as_sent" do
         it "updates the notified timestamp" do
-          expect { request.mark_as_sent! }.to change(request, :notified_at).from(nil).to(Time.zone.now.to_date)
+          expect { request.mark_as_sent }.to change(request, :notified_at).from(nil).to(Time.zone.now.to_date)
         end
       end
 

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
   subject(:presenter) { described_class.new(view, planning_application) }
 
   let(:context) { ActionView::Base.new }
-  let!(:planning_application) { create(:planning_application) }
+  let!(:planning_application) { create(:not_started_planning_application) }
 
   it "delegates missing methods to its application" do
     expect(presenter.id).to eq planning_application.id

--- a/spec/support/state_machine_shared_examples.rb
+++ b/spec/support/state_machine_shared_examples.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "StateMachineTransitions" do |request_type, state, valid_s
 end
 
 RSpec.shared_examples "StateMachineEvents" do |request_type, state, valid_events|
-  let(:events) { %i[mark_as_sent! cancel auto_approve!] }
+  let(:events) { %i[mark_as_sent cancel auto_approve] }
   let(:invalid_events) { events - valid_events }
   let(:validation_request) { create("#{request_type}_validation_request", :"#{state}") }
 

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -68,8 +68,8 @@ RSpec.describe "Planning Application show page", type: :system do
     it "Key application dates accordion" do
       click_button "Key application dates"
 
-      expect(page).to have_text("Application received: #{Time.zone.now.to_formatted_s(:day_month_year).strip}")
-      expect(page).to have_text("Validation complete: #{Time.zone.now.to_formatted_s(:day_month_year).strip}")
+      expect(page).to have_text("Application received: #{planning_application.received_at.to_formatted_s(:day_month_year).strip}")
+      expect(page).to have_text("Valid from: #{planning_application.valid_from.to_formatted_s(:day_month_year).strip}")
       expect(page).to have_text("Target date: #{planning_application.target_date.to_formatted_s(:day_month_year).strip}")
       expect(page).to have_text("Expiry date: #{planning_application.expiry_date.to_formatted_s(:day_month_year).strip}")
     end


### PR DESCRIPTION
* Add `PlanningApplication#received_at` to reflect the fact that if an application is received on a Saturday, it's legally received on Monday;
* Add `PlanningApplication#valid_from` which designates the last business-day-friendly update to the application _before_ it was made valid.