### PR TITLE
End if statement in correct line

### DIFF
--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -27,6 +27,7 @@
             <%= @planning_application.result_override %>
           </p>
         </div>
+      <% end %>
         <% if @planning_application.flagged_proposal_details(@planning_application.result_flag).present? %>
           <p class="govuk-body">
             <strong>Details identified <%= @planning_application.api_user.present? ? "by #{@planning_application.api_user.name}" : "" %> as relevant to the result</strong>
@@ -40,7 +41,6 @@
               <% proposal_detail["responses"].each do |response| %>
                   <%= response["value"] %>
              <% end %>
-            <% end %>
           </ol>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Description of change
We were ending an if statement in the wrong line, meaning the result questions got excluded if not all the criteria was present.

Before:
![image](https://user-images.githubusercontent.com/9452321/144245597-c8d74787-38c6-4bc5-8229-39a76067e2a7.png)


After:
![image](https://user-images.githubusercontent.com/9452321/144245506-25c5a113-2867-46b6-933e-97dcc3db5a61.png)

