### PR TITLE
Add business day reference to auto closure email

### DIFF
--- a/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
+++ b/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
@@ -4,7 +4,7 @@ Reference: <%= @planning_application.reference %>
 Site address: <%= @planning_application.full_address %>
 Description: <%= @planning_application.description %>
 
-The proposed description change which you were told about 5 days ago has been automatically accepted. 
+The proposed description change which you were told about 5 business days ago has been automatically accepted. 
 To see the updated description please follow the link below:
 
 <%= @planning_application.secure_change_url %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         expect(description_closure_mail.body.encoded).to match("Reference: #{planning_application.reference}")
         expect(description_closure_mail.body.encoded).to match("Site address: #{planning_application.full_address}")
         expect(description_closure_mail.body.encoded).to match("Description: #{planning_application.description}")
-        expect(description_closure_mail.body.encoded).to match("The proposed description change which you were told about 5 days ago has been automatically accepted.")
+        expect(description_closure_mail.body.encoded).to match("The proposed description change which you were told about 5 business days ago has been automatically accepted.")
         expect(description_closure_mail.body.encoded).to match("To see the updated description please follow the link below:")
       end
     end


### PR DESCRIPTION
### Description of change
We auto close description changes past 5 business days, not pat 5 normal days so we're changing the email language to make that clearer.