### PR TITLE
Support uploading multiple documents via additional document validation requests

### DIFF
--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -24,6 +24,10 @@ module Api
       def unauthorized_response
         render json: {}, status: :unauthorized
       end
+
+      def render_failed_request
+        render json: { message: "Validation request could not be updated - please contact support" }, status: :bad_request
+      end
     end
   end
 end

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -58,6 +58,11 @@ module ValidationRequestHelper
          validation_request)
   end
 
+  def document_url(document)
+    link_to(document.name.to_s,
+            edit_planning_application_document_path(document.planning_application, document.id))
+  end
+
   private
 
   def request_type(validation_request)

--- a/app/models/additional_document_validation_request.rb
+++ b/app/models/additional_document_validation_request.rb
@@ -1,12 +1,43 @@
 # frozen_string_literal: true
 
 class AdditionalDocumentValidationRequest < ApplicationRecord
+  class UploadFilesError < RuntimeError; end
+
   include ValidationRequest
 
   belongs_to :planning_application
   belongs_to :user
-  belongs_to :new_document, optional: true, class_name: "Document"
+
+  has_many :documents, dependent: :destroy
 
   validates :document_request_type, presence: { message: "Please fill in the document request type." }
   validates :document_request_reason, presence: { message: "Please fill in the reason for this document request." }
+
+  def upload_files!(files)
+    transaction do
+      files.each do |file|
+        planning_application.documents.create!(file: file, additional_document_validation_request: self)
+      end
+      close!
+      audit_upload_files!
+    end
+  rescue ActiveRecord::ActiveRecordError, AASM::InvalidTransition => e
+    raise UploadFilesError, e.message
+  end
+
+  def can_upload?
+    open? && may_close?
+  end
+
+  private
+
+  def audit_upload_files!
+    Audit.create!(
+      planning_application_id: planning_application.id,
+      audit_comment: documents.map(&:name).join(", "),
+      api_user: Current.api_user,
+      activity_type: "additional_document_validation_request_received",
+      activity_information: sequence
+    )
+  end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,8 +2,12 @@
 
 class Document < ApplicationRecord
   belongs_to :planning_application
-  belongs_to :user, optional: true
-  belongs_to :api_user, optional: true
+
+  with_options optional: true do
+    belongs_to :additional_document_validation_request
+    belongs_to :user
+    belongs_to :api_user
+  end
 
   has_one_attached :file, dependent: :destroy
 

--- a/app/views/api/v1/additional_document_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/additional_document_validation_requests/_show.json.jbuilder
@@ -10,11 +10,8 @@ json.extract! additional_document_validation_request,
               :cancel_reason,
               :cancelled_at
 
-json.new_document do
-  if additional_document_validation_request.new_document
-    json.name additional_document_validation_request.new_document.file.filename
-    json.url additional_document_validation_request.new_document.file.representation(
-      resize_to_limit: [1000, 1000]
-    ).processed.url
-  end
+json.documents additional_document_validation_request.documents do |document|
+  json.name document.file.filename
+  json.url document.file.representation(resize_to_limit: [1000, 1000]).processed.url
+  json.extract! document
 end

--- a/app/views/api/v1/validation_requests/index.json.jbuilder
+++ b/app/views/api/v1/validation_requests/index.json.jbuilder
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 json.data do
   json.description_change_validation_requests @planning_application.description_change_validation_requests do |description_change_validation_request|
     json.extract! description_change_validation_request,
@@ -66,13 +65,12 @@ json.data do
                   :cancel_reason,
                   :cancelled_at
 
-    json.new_document do
-      if additional_document_validation_request.new_document
-        json.name additional_document_validation_request.new_document.file.filename
-        json.url additional_document_validation_request.new_document.file.representation(resize_to_limit: [1000,
-                                                                                                           1000]).processed.url
-      end
+    json.documents additional_document_validation_request.documents do |document|
+      json.name document.file.filename
+      json.url document.file.representation(resize_to_limit: [1000, 1000]).processed.url
+      json.extract! document
     end
+
     json.type "additional_document_validation_request"
   end
 
@@ -90,4 +88,3 @@ json.data do
     json.type "other_change_validation_request"
   end
 end
-# rubocop:enable Metrics/BlockLength

--- a/app/views/audits/types/_additional_document_validation_request_received.html.erb
+++ b/app/views/audits/types/_additional_document_validation_request_received.html.erb
@@ -1,5 +1,4 @@
 <%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
 <p class="govuk-body">
-  New file: <i><%= locals[:item].audit_comment %></i>
+  New file(s): <i><%= locals[:item].audit_comment %></i>
 </p>
-

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -56,8 +56,18 @@
                   <td class="govuk-table__cell limit-column-width">
                     <%= request_closed_at(validation_request)  %>
                   </td>
-                  <td class="govuk-table__cell limit-column-width">
-                    <%= applicant_response(validation_request) %>
+                   <td class="govuk-table__cell limit-column-width">
+                    <% if validation_request.is_a?(AdditionalDocumentValidationRequest) %>
+                      <ul id="additional-documents" class="govuk-list">
+                        <% validation_request.documents.each do |document| %>
+                          <%= tag.li id: dom_id(document) do %>
+                            <%= document_url(document) %>
+                          <% end %>
+                        <% end %>
+                      </ul>
+                    <% else %>
+                      <%= applicant_response(validation_request) %>
+                    <% end %>
                   </td>
                   <td class="govuk-table__cell limit-column-width">
                     <% if !validation_request.closed? && !validation_request.cancelled? %>

--- a/db/migrate/20211201160951_remove_additional_document_validation_request_new_document_foreign_key.rb
+++ b/db/migrate/20211201160951_remove_additional_document_validation_request_new_document_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveAdditionalDocumentValidationRequestNewDocumentForeignKey < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :additional_document_validation_requests, :new_document
+  end
+end

--- a/db/migrate/20211201161025_add_additional_document_validation_request_foreign_key_to_documents.rb
+++ b/db/migrate/20211201161025_add_additional_document_validation_request_foreign_key_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdditionalDocumentValidationRequestForeignKeyToDocuments < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :documents, :additional_document_validation_request, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_29_164248) do
+ActiveRecord::Schema.define(version: 2021_12_01_161025) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 2021_11_29_164248) do
   create_table "additional_document_validation_requests", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
-    t.bigint "new_document_id"
     t.string "state", null: false
     t.string "document_request_type"
     t.string "document_request_reason"
@@ -56,7 +55,6 @@ ActiveRecord::Schema.define(version: 2021_11_29_164248) do
     t.date "notified_at"
     t.text "cancel_reason"
     t.datetime "cancelled_at"
-    t.index ["new_document_id"], name: "index_document_create_requests_on_new_document_id"
     t.index ["planning_application_id"], name: "index_document_create_requests_on_planning_application_id"
     t.index ["user_id"], name: "index_document_create_requests_on_user_id"
   end
@@ -132,6 +130,8 @@ ActiveRecord::Schema.define(version: 2021_11_29_164248) do
     t.bigint "user_id"
     t.bigint "api_user_id"
     t.datetime "received_at"
+    t.bigint "additional_document_validation_request_id"
+    t.index ["additional_document_validation_request_id"], name: "ix_documents_on_additional_document_validation_request_id"
     t.index ["api_user_id"], name: "ix_documents_on_api_user_id"
     t.index ["planning_application_id"], name: "index_documents_on_planning_application_id"
     t.index ["user_id"], name: "ix_documents_on_user_id"
@@ -301,13 +301,13 @@ ActiveRecord::Schema.define(version: 2021_11_29_164248) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "additional_document_validation_requests", "documents", column: "new_document_id"
   add_foreign_key "additional_document_validation_requests", "planning_applications"
   add_foreign_key "additional_document_validation_requests", "users"
   add_foreign_key "audits", "api_users"
   add_foreign_key "audits", "planning_applications"
   add_foreign_key "description_change_validation_requests", "planning_applications"
   add_foreign_key "description_change_validation_requests", "users"
+  add_foreign_key "documents", "additional_document_validation_requests"
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "users"
   add_foreign_key "notes", "planning_applications"

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -577,9 +577,9 @@ paths:
                           state: open
                           response_due: '2020-05-14T05:18:17.540Z'
                           days_until_response_due: 10
-                          new_document:
-                            name: new_document.jpg
-                            url: document.blob./new_document.jpg
+                          documents:
+                            - name: new_document.jpg
+                              url: document.blob./new_document.jpg
                           cancel_reason: null
                           cancelled_at: null
   '/api/v1/planning_applications/{planning_application_id}/other_change_validation_requests':
@@ -1056,9 +1056,9 @@ paths:
                     days_until_response_due: 10
                     document_request_type: floor plan
                     document_request_reason: need to see the floor plan
-                    new_document:
-                      name: new_document.jpg
-                      url: document.blob./new_document.jpg
+                    documents:
+                      - name: new_document.jpg
+                        url: document.blob./new_document.jpg
                     cancel_reason: null
                     cancelled_at: null
                   - id: 2
@@ -1067,6 +1067,7 @@ paths:
                     days_until_response_due: 10
                     document_request_type: floor plan
                     document_request_reason: need to see the floor plan
+                    documents: []
                     cancel_reason: null
                     cancelled_at: null
   '/api/v1/planning_applications/{planning_application_id}/additional_document_validation_requests/{additional_document_validation_request_id}':
@@ -1109,9 +1110,9 @@ paths:
                 days_until_response_due: 10
                 document_request_type: floor plan
                 document_request_reason: need to see the floor plan
-                new_document:
-                  name: new_document.jpg
-                  url: document.blob./new_document.jpg
+                documents:
+                  - name: new_document.jpg
+                    url: document.blob./new_document.jpg
                 cancel_reason: null
                 cancelled_at: null
     patch:

--- a/public/api-docs/v1/additional_document_validation_request/id.yaml
+++ b/public/api-docs/v1/additional_document_validation_request/id.yaml
@@ -24,9 +24,9 @@ get:
             days_until_response_due: 10
             document_request_type: floor plan
             document_request_reason: need to see the floor plan
-            new_document:
-              name: new_document.jpg
-              url: document.blob./new_document.jpg
+            documents:
+              - name: new_document.jpg
+                url: document.blob./new_document.jpg
             cancel_reason: null
             cancelled_at: null
 

--- a/public/api-docs/v1/additional_document_validation_request/index.yaml
+++ b/public/api-docs/v1/additional_document_validation_request/index.yaml
@@ -23,9 +23,9 @@ get:
                 days_until_response_due: 10
                 document_request_type: floor plan
                 document_request_reason: need to see the floor plan
-                new_document:
-                  name: new_document.jpg
-                  url: document.blob./new_document.jpg
+                documents:
+                  - name: new_document.jpg
+                    url: document.blob./new_document.jpg
                 cancel_reason: null
                 cancelled_at: null
               - id: 2
@@ -34,5 +34,6 @@ get:
                 days_until_response_due: 10
                 document_request_type: floor plan
                 document_request_reason: need to see the floor plan
+                documents: []
                 cancel_reason: null
                 cancelled_at: null

--- a/public/api-docs/v1/validation_requests.yaml
+++ b/public/api-docs/v1/validation_requests.yaml
@@ -74,9 +74,9 @@
                         state: open
                         response_due: '2020-05-14T05:18:17.540Z'
                         days_until_response_due: 10
-                        new_document:
-                          name: new_document.jpg
-                          url: document.blob./new_document.jpg
+                        documents:
+                          - name: new_document.jpg
+                            url: document.blob./new_document.jpg
                         cancel_reason: null
                         cancelled_at: null
 

--- a/spec/factories/additional_document_validation_requests.rb
+++ b/spec/factories/additional_document_validation_requests.rb
@@ -4,10 +4,15 @@ FactoryBot.define do
   factory :additional_document_validation_request do
     planning_application
     user
-    new_document factory: :document
     state { "open" }
     document_request_type { "Floor plan" }
     document_request_reason { "Missing floor plan" }
+
+    trait :with_documents do
+      before(:create) do |additional_document_validation_request|
+        additional_document_validation_request.documents << create(:document)
+      end
+    end
 
     trait :pending do
       state { "pending" }

--- a/spec/helpers/validation_request_helper_spec.rb
+++ b/spec/helpers/validation_request_helper_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe ValidationRequestHelper, type: :helper do
   let(:planning_application) { create(:planning_application) }
   let(:request) { create(:other_change_validation_request, planning_application: planning_application) }
+  let(:document) { create(:document, planning_application: planning_application) }
 
   describe "#cancel_confirmation_request_url" do
     it "returns the link text and url to the cancel confirmation page for a validation request" do
@@ -19,6 +20,15 @@ RSpec.describe ValidationRequestHelper, type: :helper do
     it "returns the url to the cancel action for a validation request" do
       url = "/planning_applications/#{planning_application.id}/other_change_validation_requests/#{request.id}/cancel"
       expect(cancel_request_url(planning_application, request)).to eq(url)
+    end
+  end
+
+  describe "#document_url" do
+    it "returns the url to the relevant document for an additional document validation request" do
+      # rubocop:disable Layout/LineLength
+      url = "<a href=\"/planning_applications/#{planning_application.id}/documents/#{document.id}/edit\">proposed-floorplan.png</a>"
+      # rubocop:enable Layout/LineLength
+      expect(document_url(document)).to eq(url)
     end
   end
 end

--- a/spec/models/additional_document_validation_request_spec.rb
+++ b/spec/models/additional_document_validation_request_spec.rb
@@ -3,5 +3,63 @@
 require "rails_helper"
 
 RSpec.describe AdditionalDocumentValidationRequest, type: :model do
+  include ActionDispatch::TestProcess::FixtureFile
+
+  let(:additional_document_validation_request) { create(:additional_document_validation_request, :open) }
+  let(:api_user) { create(:api_user) }
+  let(:files) do
+    [
+      fixture_file_upload(Rails.root.join("spec/fixtures/images/proposed-floorplan.png"), "proposed-floorplan/png"),
+      fixture_file_upload(Rails.root.join("spec/fixtures/images/proposed-roofplan.pdf"), "proposed-roofplan/pdf")
+    ]
+  end
+
   it_behaves_like "ValidationRequest", described_class, "additional_document_validation_request"
+
+  describe "instance methods" do
+    describe "#upload_files!" do
+      before { Current.api_user = api_user }
+
+      describe "when successful" do
+        it "uploads the files, saves them as documents and creates an audit record" do
+          expect { additional_document_validation_request.upload_files!(files) }
+            .to change(additional_document_validation_request, :state).from("open").to("closed")
+
+          additional_document_validation_request.reload
+
+          expect(Audit.last).to have_attributes(
+            planning_application_id: additional_document_validation_request.planning_application.id,
+            activity_type: "additional_document_validation_request_received",
+            activity_information: "1",
+            audit_comment: "proposed-floorplan.png, proposed-roofplan.pdf",
+            api_user_id: api_user.id
+          )
+
+          documents = additional_document_validation_request.documents
+          expect(documents.length).to eq(2)
+          expect(documents.map(&:name).map(&:to_s)).to include("proposed-floorplan.png", "proposed-roofplan.pdf")
+          expect(documents.pluck(:additional_document_validation_request_id)).to eq(
+            [
+              additional_document_validation_request.id, additional_document_validation_request.id
+            ]
+          )
+        end
+      end
+
+      describe "when there is an error" do
+        it "when request is in closed state it raises AdditionalDocumentValidationRequest::UploadFilesError" do
+          additional_document_validation_request.update(state: "closed")
+
+          expect { additional_document_validation_request.upload_files!(files) }
+            .to raise_error(AdditionalDocumentValidationRequest::UploadFilesError,
+                            "Event 'close' cannot transition from 'closed'.")
+            .and change(Audit, :count).by(0)
+
+          additional_document_validation_request.reload
+          expect(additional_document_validation_request).to be_closed
+          expect(additional_document_validation_request.documents).to eq([])
+        end
+      end
+    end
+  end
 end

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
   describe "#index" do
     let(:path) { "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests" }
     let!(:additional_document_validation_request2) do
-      create(:additional_document_validation_request, :closed, planning_application: planning_application)
+      create(:additional_document_validation_request, :closed, :with_documents, planning_application: planning_application)
     end
     let!(:additional_document_validation_request3) do
       create(:additional_document_validation_request, :cancelled, planning_application: planning_application)
@@ -36,10 +36,7 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
               "document_request_reason" => "Missing floor plan",
               "cancel_reason" => nil,
               "cancelled_at" => nil,
-              "new_document" => {
-                "name" => "proposed-floorplan.png",
-                "url" => json["data"][0]["new_document"]["url"]
-              }
+              "documents" => []
             },
             {
               "id" => additional_document_validation_request2.id,
@@ -50,10 +47,12 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
               "document_request_reason" => "Missing floor plan",
               "cancel_reason" => nil,
               "cancelled_at" => nil,
-              "new_document" => {
-                "name" => "proposed-floorplan.png",
-                "url" => json["data"][1]["new_document"]["url"]
-              }
+              "documents" => [
+                {
+                  "name" => "proposed-floorplan.png",
+                  "url" => json["data"][1]["documents"][0]["url"]
+                }
+              ]
             },
             {
               "id" => additional_document_validation_request3.id,
@@ -64,10 +63,7 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
               "document_request_reason" => "Missing floor plan",
               "cancel_reason" => "Made by mistake!",
               "cancelled_at" => json_time_format(additional_document_validation_request3.cancelled_at),
-              "new_document" => {
-                "name" => "proposed-floorplan.png",
-                "url" => json["data"][2]["new_document"]["url"]
-              }
+              "documents" => []
             }
           ]
         )
@@ -108,10 +104,7 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
             "document_request_reason" => "Missing floor plan",
             "cancel_reason" => nil,
             "cancelled_at" => nil,
-            "new_document" => {
-              "name" => "proposed-floorplan.png",
-              "url" => json["new_document"]["url"]
-            }
+            "documents" => []
           }
         )
       end

--- a/spec/requests/api/validation_request_list_spec.rb
+++ b/spec/requests/api/validation_request_list_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "API request to list validation requests", type: :request, show_e
     create(:replacement_document_validation_request, planning_application: planning_application)
   end
   let!(:additional_document_validation_request) do
-    create(:additional_document_validation_request, planning_application: planning_application)
+    create(:additional_document_validation_request, :with_documents, planning_application: planning_application)
   end
 
   it "lists the all description validation requests that exist on the planning application" do
@@ -66,8 +66,9 @@ RSpec.describe "API request to list validation requests", type: :request, show_e
                                                                                        "document_request_reason" => additional_document_validation_request.document_request_reason,
                                                                                        "type" => "additional_document_validation_request"
                                                                                      })
-    expect(json["data"]["additional_document_validation_requests"].first["new_document"]["name"]).to eq("proposed-floorplan.png")
-    expect(json["data"]["additional_document_validation_requests"].first["new_document"]["url"]).to be_a(String)
+
+    expect(json["data"]["additional_document_validation_requests"].first["documents"][0]["name"]).to eq("proposed-floorplan.png")
+    expect(json["data"]["additional_document_validation_requests"].first["documents"][0]["url"]).to be_a(String)
   end
 
   it "returns a 401 if API key is wrong" do

--- a/spec/support/current.rb
+++ b/spec/support/current.rb
@@ -3,5 +3,6 @@
 RSpec.configure do |config|
   config.after do
     Current.user = nil
+    Current.api_user = nil
   end
 end


### PR DESCRIPTION
### Description of change

- Update association so that AdditionalDocumentValidationRequest has many documents
- Document (optionally) belongs to AdditionalDocumentValidationRequest
- Wrap documents creation process in transaction, change state from open to closed and audit the request

### Story Link

https://trello.com/c/rs1kJhqb/487-allow-multiple-file-uploads-for-a-new-document-request-on-bops-applicant