### PR TITLE
Show last audit item in validate form

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -6,6 +6,8 @@ class PlanningApplicationsController < AuthenticationController
   before_action :ensure_user_is_reviewer, only: %i[review review_form]
   before_action :ensure_constraint_edits_unlocked, only: %i[edit_constraints_form edit_constraints]
 
+  before_action :set_last_audit, only: %i[show validate_form]
+
   def index
     @planning_applications = if helpers.exclude_others? && current_user.assessor?
                                current_local_authority.planning_applications.where(user_id: current_user.id).order("created_at DESC").or(
@@ -16,9 +18,7 @@ class PlanningApplicationsController < AuthenticationController
                              end
   end
 
-  def show
-    @last_audit = @planning_application.audits.last
-  end
+  def show; end
 
   def new
     @planning_application = PlanningApplication.new
@@ -341,5 +341,9 @@ class PlanningApplicationsController < AuthenticationController
 
   def ensure_constraint_edits_unlocked
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_validate?
+  end
+
+  def set_last_audit
+    @last_audit = @planning_application.audits.last if @planning_application.present?
   end
 end

--- a/features/auditing.feature
+++ b/features/auditing.feature
@@ -9,6 +9,8 @@ Feature: Auditing a planning application
     Given I create a new document validation request for a "Picture of the dog" because "it would be nice"
     When I view the planning application audit
     Then there is an audit entry containing "Added: validation request (new document#1)"
+    And there is an audit log entry in the index accordion with "Added: validation request (new document#1)"
+    And there is an audit log entry in the validate form accordion with "Added: validation request (new document#1)"
 
   Scenario: I can audit the validation requests are sent when the application is invalid
     Given I create an additional document validation request with "Picture of the dog"

--- a/features/step_definitions/auditing_steps.rb
+++ b/features/step_definitions/auditing_steps.rb
@@ -16,6 +16,23 @@ Then("there is an audit entry with") do |content|
   end
 end
 
+Then("there is an audit log entry in the index accordion with {string}") do |content|
+  steps %(
+    When I view the planning application
+    And I press "Audit log"
+    Then the page contains "#{content}"
+  )
+end
+
+Then("there is an audit log entry in the validate form accordion with {string}") do |content|
+  steps %(
+    When I view the planning application
+    And I press "Validate application"
+    And I press "Audit log"
+    Then the page contains "#{content}"
+  )
+end
+
 When("I visit the audit log") do
   steps %(
     When I view the planning application


### PR DESCRIPTION
### Description of change
Needed to set the @last_audit instance variable in two views instead of just one in order to show the latest audit from both show page and from validate_form which is also the show page -.-