### PR TITLE
Edit validation requests

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -283,6 +283,7 @@ Style/GuardClause:
     - 'app/models/recommendation.rb'
     - 'app/models/red_line_boundary_change_validation_request.rb'
     - 'db/migrate/20210308183431_add_service_name_to_active_storage_blobs.active_storage.rb'
+    - 'app/helpers/validation_request_helper.rb'
 
 # Offense count: 174
 # Cop supports --auto-correct.

--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -3,6 +3,8 @@
 class AdditionalDocumentValidationRequestsController < ValidationRequestsController
   include ValidationRequests
 
+  before_action :set_additional_document_validation_request, only: %i[edit update]
+
   def new
     @additional_document_validation_request = planning_application.additional_document_validation_requests.new
   end
@@ -27,6 +29,10 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
     end
   end
 
+  def edit; end
+
+  def update; end
+
   private
 
   def additional_document_validation_request_params
@@ -40,5 +46,9 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
   def document_create_audit_item(additional_document_validation_request)
     { document: additional_document_validation_request.document_request_type,
       reason: additional_document_validation_request.document_request_reason }.to_json
+  end
+
+  def set_additional_document_validation_request
+    @additional_document_validation_request = @planning_application.additional_document_validation_requests.find(params[:id])
   end
 end

--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -31,7 +31,13 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
 
   def edit; end
 
-  def update; end
+  def update
+    if @additional_document_validation_request.update(additional_document_validation_request_params)
+      redirect_to planning_application_validation_requests_path(@planning_application), notice: "Additional document request successfully updated"
+    else
+      render :edit
+    end
+  end
 
   private
 

--- a/app/controllers/other_change_validation_requests_controller.rb
+++ b/app/controllers/other_change_validation_requests_controller.rb
@@ -34,7 +34,13 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
 
   def edit; end
 
-  def update; end
+  def update
+    if @other_change_validation_request.update(other_change_validation_request_params)
+      redirect_to planning_application_validation_requests_path(@planning_application), notice: "Other validation request successfully updated"
+    else
+      render :edit
+    end
+  end
 
   private
 

--- a/app/controllers/other_change_validation_requests_controller.rb
+++ b/app/controllers/other_change_validation_requests_controller.rb
@@ -3,13 +3,13 @@
 class OtherChangeValidationRequestsController < ValidationRequestsController
   include ValidationRequests
 
+  before_action :set_other_validation_request, only: %i[show edit update]
+
   def new
     @other_change_validation_request = @planning_application.other_change_validation_requests.new
   end
 
-  def show
-    @other_change_validation_request = @planning_application.other_change_validation_requests.find(params[:id])
-  end
+  def show; end
 
   def create
     @other_change_validation_request = @planning_application.other_change_validation_requests.new(other_change_validation_request_params)
@@ -32,6 +32,10 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
     end
   end
 
+  def edit; end
+
+  def update; end
+
   private
 
   def other_change_validation_request_params
@@ -40,5 +44,9 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
 
   def audit_item(other_change_validation_request)
     { summary: other_change_validation_request.summary, suggestion: other_change_validation_request.suggestion }.to_json
+  end
+
+  def set_other_validation_request
+    @other_change_validation_request = @planning_application.other_change_validation_requests.find(params[:id])
   end
 end

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -3,13 +3,13 @@
 class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsController
   include ValidationRequests
 
+  before_action :set_red_line_boundary_validation_request, only: %i[show edit update]
+
   def new
     @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.new
   end
 
-  def show
-    @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
-  end
+  def show; end
 
   def create
     @red_line_boundary_change_validation_request = RedLineBoundaryChangeValidationRequest.new(red_line_boundary_change_validation_request_params
@@ -33,6 +33,10 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
     end
   end
 
+  def edit; end
+
+  def update; end
+
   private
 
   def red_line_boundary_change_validation_request_params
@@ -41,5 +45,9 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
 
   def red_line_boundary_audit_item(validation_request)
     validation_request.reason
+  end
+
+  def set_red_line_boundary_validation_request
+    @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
   end
 end

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -35,7 +35,13 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
 
   def edit; end
 
-  def update; end
+  def update
+    if @red_line_boundary_change_validation_request.update(red_line_boundary_change_validation_request_params)
+      redirect_to planning_application_validation_requests_path(@planning_application)
+    else
+      render :edit
+    end
+  end
 
   private
 

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -58,6 +58,12 @@ module ValidationRequestHelper
          validation_request)
   end
 
+  def edit_validation_request_url(validation_request)
+    link_to "Edit",
+            send("edit_planning_application_#{request_type(validation_request)}_path", validation_request.planning_application,
+                 validation_request)
+  end
+
   def document_url(document)
     link_to(document.name.to_s,
             edit_planning_application_document_path(document.planning_application, document.id))

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -58,10 +58,12 @@ module ValidationRequestHelper
          validation_request)
   end
 
-  def edit_validation_request_url(validation_request)
-    link_to "Edit",
-            send("edit_planning_application_#{request_type(validation_request)}_path", validation_request.planning_application,
-                 validation_request)
+  def edit_validation_request_url(planning_application, validation_request)
+    type = request_type(validation_request)
+
+    unless type.eql?("replacement_document_validation_request")
+      link_to "Edit", [:edit, planning_application, validation_request]
+    end
   end
 
   def document_url(document)

--- a/app/views/additional_document_validation_requests/_form.html.erb
+++ b/app/views/additional_document_validation_requests/_form.html.erb
@@ -1,0 +1,18 @@
+<%= render "validation_requests/validation_requests_breadcrumbs" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: [@planning_application, @additional_document_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <%= form.govuk_fieldset legend: { text: "Request a new document", size: 'l' } do %>
+        <%= form.govuk_text_field :document_request_type,
+         label: { text: 'Please specify the new document type:', size: 's' },
+         hint: { text: 'Eg. Existing floor plans' } %>
+
+        <%= form.govuk_text_area :document_request_reason,
+         label: { text: 'Please specify the reason you have requested this document?', size: 's'},
+         rows: 5 %>
+      <% end %>
+      <%= render "shared/validation_request_form_actions", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/additional_document_validation_requests/_form.html.erb
+++ b/app/views/additional_document_validation_requests/_form.html.erb
@@ -1,5 +1,3 @@
-<%= render "validation_requests/validation_requests_breadcrumbs" %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@planning_application, @additional_document_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>

--- a/app/views/additional_document_validation_requests/edit.html.erb
+++ b/app/views/additional_document_validation_requests/edit.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, "Edit validation request" %>
+
+<%= render "form" %>

--- a/app/views/additional_document_validation_requests/new.html.erb
+++ b/app/views/additional_document_validation_requests/new.html.erb
@@ -1,19 +1,5 @@
 <%= render "validation_requests/validation_requests_breadcrumbs" %>
 
 <% content_for :title, "Request a new document" %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: [@planning_application, @additional_document_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <%= form.govuk_fieldset legend: { text: "Request a new document", size: 'l' } do %>
-        <%= form.govuk_text_field :document_request_type,
-         label: { text: 'Please specify the new document type:', size: 's' },
-         hint: { text: 'Eg. Existing floor plans' } %>
 
-        <%= form.govuk_text_area :document_request_reason,
-         label: { text: 'Please specify the reason you have requested this document?', size: 's'},
-         rows: 5 %>
-      <% end %>
-      <%= render "shared/validation_request_form_actions", form: form %>
-    <% end %>
-  </div>
-</div>
+<%= render "form" %>

--- a/app/views/other_change_validation_requests/_form.html.erb
+++ b/app/views/other_change_validation_requests/_form.html.erb
@@ -1,0 +1,45 @@
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-6">
+      Request other validation change
+    </h2>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>At:</strong> <%= @planning_application.full_address  %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>Date received:</strong> <%= @planning_application.received_at %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-8">
+      <strong>Application number:</strong> <%= @planning_application.reference  %>
+    </p>
+
+    <%= form_with model: [@planning_application, @other_change_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <% if @other_change_validation_request.errors.any? %>
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <% @other_change_validation_request.errors.full_messages.each do |error| %>
+                <li><%= error %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+
+      <%= form.govuk_text_area :summary,
+                               label: { text: 'Tell the applicant another reason why the application is invalid.', size: 's', class: 'govuk-label govuk-label--s'},
+                               hint: { text: 'Only add one reason for each request.' },
+                               rows: 5 %>
+
+      <%= form.govuk_text_area :suggestion,
+                               label: { text: 'Explain to the applicant how the application can be made valid.', size: 's', class: 'govuk-label govuk-label--s'},
+                               hint: { text: 'Add all information that they will need to complete this action.' },
+                               rows: 5 %>
+      <%= render "shared/validation_request_form_actions", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/other_change_validation_requests/edit.html.erb
+++ b/app/views/other_change_validation_requests/edit.html.erb
@@ -1,1 +1,4 @@
-<%= render "other_change_validation_requests/_other_change_validation_request" %>
+<%= render "validation_requests/validation_requests_breadcrumbs" %>
+<% content_for :title, "Update other validation request" %>
+
+<%= render "form" %>

--- a/app/views/other_change_validation_requests/edit.html.erb
+++ b/app/views/other_change_validation_requests/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "other_change_validation_requests/_other_change_validation_request" %>

--- a/app/views/other_change_validation_requests/new.html.erb
+++ b/app/views/other_change_validation_requests/new.html.erb
@@ -1,47 +1,4 @@
 <%= render "validation_requests/validation_requests_breadcrumbs" %>
 <% content_for :title, "Other validation request" %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-6">
-      Request other validation change
-    </h2>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>At:</strong> <%= @planning_application.full_address  %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= @planning_application.received_at %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <strong>Application number:</strong> <%= @planning_application.reference  %>
-    </p>
-
-    <%= form_with model: [@planning_application, @other_change_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <% if @other_change_validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @other_change_validation_request.errors.full_messages.each do |error| %>
-                <li><%= error %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
-
-      <%= form.govuk_text_area :summary,
-                               label: { text: 'Tell the applicant another reason why the application is invalid.', size: 's', class: 'govuk-label govuk-label--s'},
-                               hint: { text: 'Only add one reason for each request.' },
-                               rows: 5 %>
-
-      <%= form.govuk_text_area :suggestion,
-                               label: { text: 'Explain to the applicant how the application can be made valid.', size: 's', class: 'govuk-label govuk-label--s'},
-                               hint: { text: 'Add all information that they will need to complete this action.' },
-                               rows: 5 %>
-      <%= render "shared/validation_request_form_actions", form: form %>
-    <% end %>
-  </div>
-</div>
+<%= render "form" %>

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -28,7 +28,9 @@
         </div>
       <% end %>
       <%= form.govuk_text_area :new_geojson,
-                               label: { text: "Applicant's original red line boundary", size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
+                               label: { text: @planning_application.boundary_geojson ? "Applicant's existing red line boundary" : "No digital red line boundary has been previously set",
+                                        size: 's',
+                                        class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4' },
                                class: "govuk-visually-hidden" %>
       <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
       

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -1,0 +1,63 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-6">
+      Proposed red line boundary change
+    </h2>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>At:</strong> <%= @planning_application.full_address  %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      <strong>Date received:</strong> <%= @planning_application.received_at %>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-8">
+      <strong>Application number:</strong> <%= @planning_application.reference  %>
+    </p>
+    <%= form_with model: [@planning_application, @red_line_boundary_change_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+      <% if @red_line_boundary_change_validation_request.errors.any? %>
+        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+          <h2 class="govuk-error-summary__title" id="error-summary-title">
+            There is a problem
+          </h2>
+          <div class="govuk-error-summary__body">
+            <ul class="govuk-list govuk-error-summary__list">
+              <% @red_line_boundary_change_validation_request.errors.each do |error| %>
+                <li><%= error.message %></li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+      <%= form.govuk_text_area :new_geojson,
+                               label: { text: "Applicant's original red line boundary", size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
+                               class: "govuk-visually-hidden" %>
+      <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
+      
+      <% if action_name.eql?("edit") %>
+        <h2 class="govuk-heading-m govuk-!-padding-top-6">
+          Proposed red line boundary
+        </h2>
+        <%= render "shared/location_map", locals: { geojson: @red_line_boundary_change_validation_request.new_geojson } %>
+      <% end %>
+      
+      <h2 class="govuk-heading-s govuk-!-padding-top-6">
+        Red line drawings shown on map
+      </h2>
+      <div class="govuk-grid-row govuk-!-padding-bottom-2">
+        <p class="govuk-body govuk-!-margin-left-3">
+          <img src="/images/solid_square.png" alt-text="red solid line square" width="60px" style="float:left; padding-right:20px" />
+          Applicant submitted red line boundary
+        </p>
+      </div>
+      <div class="govuk-grid-row govuk-!-padding-bottom-4">
+        <p class="govuk-body govuk-!-margin-left-3">
+          <img src="/images/filled_square.png" alt-text="filled square with dotted border" width="60px" style="float:left; padding-right:20px" />
+          Proposed red line boundary
+        </p>
+      </div>
+      <%= form.govuk_text_area :reason,
+                               label: { text: 'Explain to the applicant why changes are proposed to the red line boundary', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
+                               rows: 5 %>
+      <%= render "shared/validation_request_form_actions", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/red_line_boundary_change_validation_requests/edit.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "red_line_boundary_change_validation_request" %>

--- a/app/views/red_line_boundary_change_validation_requests/edit.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/edit.html.erb
@@ -1,1 +1,4 @@
-<%= render "red_line_boundary_change_validation_request" %>
+<%= render "validation_requests/validation_requests_breadcrumbs" %>
+<% content_for :title, "Update red line boundary change" %>
+
+<%= render "form" %>

--- a/app/views/red_line_boundary_change_validation_requests/new.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/new.html.erb
@@ -1,36 +1,7 @@
 <%= render "validation_requests/validation_requests_breadcrumbs" %>
-
 <% content_for :title, "Red line boundary change" %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-l govuk-!-padding-top-6">
-      Proposed red line boundary change
-    </h2>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>At:</strong> <%= @planning_application.full_address  %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= @planning_application.received_at %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <strong>Application number:</strong> <%= @planning_application.reference  %>
-    </p>
 
-    <%= form_with model: [@planning_application, @red_line_boundary_change_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-      <% if @red_line_boundary_change_validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @red_line_boundary_change_validation_request.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+<%= render "form" %>
 
       <%= form.govuk_text_area :new_geojson,
                                label: { text: @planning_application.boundary_geojson ? "Applicant's existing red line boundary" : "No digital red line boundary has been previously set",
@@ -38,27 +9,3 @@
                                         class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4' },
                                class: "govuk-visually-hidden" %>
 
-      <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
-      <h2 class="govuk-heading-s govuk-!-padding-top-6">
-        Red line drawings shown on map
-      </h2>
-      <div class="govuk-grid-row govuk-!-padding-bottom-2">
-        <p class="govuk-body govuk-!-margin-left-3">
-          <img src="/images/solid_square.png" alt-text="red solid line square" width="60px" style="float:left; padding-right:20px" />
-          Applicant submitted red line boundary
-      </p>
-      </div>
-      <div class="govuk-grid-row govuk-!-padding-bottom-4">
-        <p class="govuk-body govuk-!-margin-left-3">
-          <img src="/images/filled_square.png" alt-text="filled square with dotted border" width="60px" style="float:left; padding-right:20px" />
-          Proposed red line boundary
-      </p>
-      </div>
-
-      <%= form.govuk_text_area :reason,
-                               label: { text: 'Explain to the applicant why changes are proposed to the red line boundary', size: 's', class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4'},
-                               rows: 5 %>
-      <%= render "shared/validation_request_form_actions", form: form %>
-    <% end %>
-  </div>
-</div>

--- a/app/views/red_line_boundary_change_validation_requests/new.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/new.html.erb
@@ -3,9 +3,4 @@
 
 <%= render "form" %>
 
-      <%= form.govuk_text_area :new_geojson,
-                               label: { text: @planning_application.boundary_geojson ? "Applicant's existing red line boundary" : "No digital red line boundary has been previously set",
-                                        size: 's',
-                                        class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4' },
-                               class: "govuk-visually-hidden" %>
 

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -1,8 +1,8 @@
 <div class="govuk-button-group">
-  <% if action_name.eql?("new") %>
-    <%= form.govuk_submit "Add" %>
-  <% else %>
+  <% if action_name.eql?("edit") %>
     <%= form.govuk_submit "Update" %>
+  <% else %>
+    <%= form.govuk_submit "Add" %>
   <% end %>
   <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
 </div>

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -1,4 +1,8 @@
 <div class="govuk-button-group">
-  <%= form.govuk_submit "Add" %>
+  <% if action_name.eql?("new") %>
+    <%= form.govuk_submit "Add" %>
+  <% else %>
+    <%= form.govuk_submit "Update" %>
+  <% end %>
   <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
 </div>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -21,12 +21,18 @@
               <th scope="col" class="govuk-table__header">
                 Status
               </th>
-              <th scope="col" class="govuk-table__header">
-                Response received
-              </th>
-              <th scope="col" class="govuk-table__header">
-                Response
-              </th>
+              <% if @planning_application.invalidated? %>
+                <th scope="col" class="govuk-table__header">
+                  Response received
+                </th>
+                <th scope="col" class="govuk-table__header">
+                  Response
+                </th>
+              <% else %>
+                <th scope="col" class="govuk-table__header">
+                  Edit
+                </th>
+              <% end %>
               <th scope="col" class="govuk-table__header">
                 Actions
               </th>
@@ -53,10 +59,12 @@
                       </strong>
                     <% end %>
                   </td>
-                  <td class="govuk-table__cell limit-column-width">
-                    <%= request_closed_at(validation_request)  %>
-                  </td>
-                   <td class="govuk-table__cell limit-column-width">
+                  <% if @planning_application.invalidated? %>
+                    <td class="govuk-table__cell limit-column-width">
+                      <%= request_closed_at(validation_request)  %>
+                    </td>
+
+                    <td class="govuk-table__cell limit-column-width">
                     <% if validation_request.is_a?(AdditionalDocumentValidationRequest) %>
                       <ul id="additional-documents" class="govuk-list">
                         <% validation_request.documents.each do |document| %>
@@ -69,6 +77,11 @@
                       <%= applicant_response(validation_request) %>
                     <% end %>
                   </td>
+                  <% else %>
+                  <td class="govuk-table__cell limit-column-width"> 
+                    <%= edit_validation_request_url(validation_request) %>
+                  </td>
+                  <% end %>
                   <td class="govuk-table__cell limit-column-width">
                     <% if !validation_request.closed? && !validation_request.cancelled? %>
                       <% if @planning_application.invalidated? %>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -79,7 +79,7 @@
                   </td>
                   <% else %>
                   <td class="govuk-table__cell limit-column-width"> 
-                    <%= edit_validation_request_url(validation_request) %>
+                    <%= edit_validation_request_url(@planning_application, validation_request) %>
                   </td>
                   <% end %>
                   <td class="govuk-table__cell limit-column-width">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,6 +68,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops-care.link"), port: 3000 }
 
-  config.hosts << ".bops-care.link"
-  config.hosts << "southwark.southwark.web"
+  config.hosts.clear
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,5 +68,6 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops-care.link"), port: 3000 }
 
-  config.hosts.clear
+  config.hosts << ".bops-care.link"
+  config.hosts << "southwark.southwark.web"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,9 +58,9 @@ Rails.application.routes.draw do
     end
 
     with_options concerns: :cancel_validation_requests do
-      resources :additional_document_validation_requests, only: %i[new create destroy]
-      resources :other_change_validation_requests, only: %i[new create show destroy]
-      resources :red_line_boundary_change_validation_requests, only: %i[new create show destroy]
+      resources :additional_document_validation_requests, only: %i[new create edit update destroy]
+      resources :other_change_validation_requests, only: %i[new create show edit update destroy]
+      resources :red_line_boundary_change_validation_requests, only: %i[new create show edit update destroy]
       resources :replacement_document_validation_requests, only: %i[new create destroy]
     end
 

--- a/features/editing_validation_requests.feature
+++ b/features/editing_validation_requests.feature
@@ -6,17 +6,38 @@ Feature: Editing validation requests
     When I press "Validate application"
     And I press "Request validation changes"
     And I create a new document validation request for a "Picture of the dog" because "it would be nice"
-    And I create a new document validation request for a "Picture of the cat" because "it would also be nice"
+    And I create a other change validation request with "Time for some changes up in here"
+    And I create a red line boundary change validation request with "We shall update some boundaries"
 
 Scenario: I can edit a document validation request before its been sent
   When I view the application's validations requests
-  And I press "Edit" on "Picture of the dog"
-  And fill in "Reason for requesting this document" with "cats instead"
+  And I click link "Edit" in table row for "Picture of the dog"
+  And I fill in "Please specify the new document type:" with "cats instead"
+  And I fill in "Please specify the reason you have requested this document?" with "I love me some cats"
   When I press "Update"
-  And I view all validation requests
-  Then the table contains "cats instead"
+  And I view the application's validations requests
+  Then the page contains "cats instead"
+  And the page contains "I love me some cats"
 
-Scenario: I cannot edit a document validation request after its been sent
+Scenario: I can edit an other type of validation request before its been sent
   When I view the application's validations requests
-  And the planning application is invalidated
-  Then there is no "Edit" option in the validation requests table
+  And I click link "Edit" in table row for "Time for some changes"
+  And I fill in "Tell the applicant another reason why the application is invalid." with "change those manners"
+  When I press "Update"
+  And I view the application's validations requests
+  Then the page contains "change those manners"
+
+Scenario: I can edit a red line boundary request before its been sent
+  When I view the application's validations requests
+  And I click link "Edit" in table row for "We shall update some boundaries"
+  And I fill in "Explain to the applicant why changes are proposed to the red line boundary" with "bound to be changes"
+  When I press "Update"
+  And I view the application's validations requests
+  Then the page contains "bound to be changes"
+
+Scenario: I cannot edit a validation request after its been sent
+  When the planning application is invalidated
+  And I view the application's validations requests
+  Then the page does not contain "Edit" in table row for "Picture of the dog"
+  And the page does not contain "Edit" in table row for "Time for some changes"
+  And the page does not contain "Edit" in table row for "We shall update some boundaries"

--- a/features/editing_validation_requests.feature
+++ b/features/editing_validation_requests.feature
@@ -12,7 +12,7 @@ Scenario: I can edit a document validation request before its been sent
   When I view the application's validations requests
   And I press "Edit" on "Picture of the dog"
   And fill in "Reason for requesting this document" with "cats instead"
-  When I press "Update request"
+  When I press "Update"
   And I view all validation requests
   Then the table contains "cats instead"
 

--- a/features/editing_validation_requests.feature
+++ b/features/editing_validation_requests.feature
@@ -1,0 +1,22 @@
+Feature: Editing validation requests
+  Background:
+    Given I am logged in as an assessor
+    And a new planning application
+    And I view the planning application
+    When I press "Validate application"
+    And I press "Request validation changes"
+    And I create a new document validation request for a "Picture of the dog" because "it would be nice"
+    And I create a new document validation request for a "Picture of the cat" because "it would also be nice"
+
+Scenario: I can edit a document validation request before its been sent
+  When I view the application's validations requests
+  And I press "Edit" on "Picture of the dog"
+  And fill in "Reason for requesting this document" with "cats instead"
+  When I press "Update request"
+  And I view all validation requests
+  Then the table contains "cats instead"
+
+Scenario: I cannot edit a document validation request after its been sent
+  When I view the application's validations requests
+  And the planning application is invalidated
+  Then there is no "Edit" option in the validation requests table

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -119,6 +119,12 @@ Then "I click link {string} in table row for {string}" do |link, value|
   end
 end
 
+Then "the page does not contain {string} in table row for {string}" do |link, value|
+  within(:xpath, "//tr[contains(.,'#{value}')]") do
+    expect(page).not_to have_content(link)
+  end
+end
+
 When("I upload {string} for the {string} input") do |path, name|
   attach_file(name, path)
 end


### PR DESCRIPTION
### Description of change

Edit red line, other validations and new document requests.

Doesn't edit "replacement document validation requests" since those are always to replace an existing invalid document and don't have any amendable features, so they need to be cancelled and the invalid document changed if amendments were needed.

### Story Link

https://trello.com/c/bYbWqYxC/684-edit-function-when-writing-validation-request