### PR TITLE
Do not use JSON parse geojson when value is a hash

### DIFF
--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -4,7 +4,7 @@
   showScale
   useScaleBarStyle
   <% if locals[:geojson].present? %>
-    geojsonData='<%= JSON.parse(locals[:geojson]).to_json.html_safe %>'
+    geojsonData='<%= locals[:geojson].is_a?(Hash) ? locals[:geojson].to_json : JSON.parse(locals[:geojson]).to_json.html_safe %>'
   <% end %>
   <% if locals[:geojson_field].present?  %>
     drawMode="true"


### PR DESCRIPTION
### Description of change

- For legacy geojson values, this value may be stored as a hash. This change supports the legacy data before change in https://github.com/unboxed/bops/pull/514

https://appsignal.com/southwark-bops/sites/5fce2dd55ac13f75e2b52bd7/exceptions/incidents/144?timestamp=2021-12-22T09%3A04%3A47Z