### PR TITLE
Add save as draft option to assessments

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -147,15 +147,7 @@ class PlanningApplicationsController < AuthenticationController
 
   def save_assessment
     @planning_application.public_comment = params[:planning_application][:public_comment]
-    @planning_application.save(validate: false)
-
-    recommendation = @planning_application.recommendations.build
-    if current_user.assessor?
-      recommendation.assessor = current_user
-    elsif current_user.reviewer?
-      recommendation.reviewer = current_user
-    end
-
+    recommendation = @planning_application.recommendations.build(assessor: current_user)
     recommendation.assessor_comment = params[:recommendation][:assessor_comment]
     recommendation.save(validate: false)
 

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -42,6 +42,10 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def update
+    if @planning_application.recommendations.last.present? && !@planning_application.recommendations.last.submitted
+      flash.now[:error] = "Please complete in draft assessment before updating application fields."
+    end
+
     if @planning_application.update(planning_application_params)
       planning_application_params.keys.map do |p|
         if @planning_application.saved_change_to_attribute?(p)

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -67,7 +67,7 @@ class PlanningApplication < ApplicationRecord
     end
 
     event :save_assessment do
-      transitions from: %i[assessment_in_progress in_assessment], to: :assessment_in_progress
+      transitions from: %i[in_assessment assessment_in_progress], to: :assessment_in_progress
 
       after do
         save(validate: false)
@@ -198,7 +198,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def assessment_complete?
-    (validation_complete? && pending_review?) || awaiting_determination? || determined?
+    (validation_complete? && pending_review? && recommendations.last.submitted) || awaiting_determination? || determined?
   end
 
   def can_submit_recommendation?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -202,7 +202,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def can_submit_recommendation?
-    assessment_complete? && (in_assessment? || awaiting_correction?)
+    assessment_complete? && (in_assessment? || assessment_in_progress? || awaiting_correction?)
   end
 
   def submit_recommendation_complete?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -44,7 +44,7 @@ class PlanningApplication < ApplicationRecord
   validate :policy_classes_editable
 
   scope :not_started_and_invalid, -> { where("status = 'not_started' OR status = 'invalidated'") }
-  scope :under_assessment, -> { where("status = 'in_assessment' OR status = 'awaiting_correction'") }
+  scope :under_assessment, -> { where("status = 'in_assessment' OR status = 'assessment_in_progress' OR status = 'awaiting_correction'") }
   scope :closed, -> { where("status = 'determined' OR status = 'withdrawn' OR status = 'returned'") }
 
   attribute :policy_classes, :policy_class, array: true

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -21,7 +21,7 @@ class Recommendation < ApplicationRecord
     if current_recommendation? && planning_application.awaiting_determination?
       false
     else
-      reviewer_comment.present?
+      reviewer.present?
     end
   end
 

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -2,11 +2,12 @@
 
 class Recommendation < ApplicationRecord
   belongs_to :planning_application
-  belongs_to :assessor, class_name: "User"
+  belongs_to :assessor, class_name: "User", optional: true
   belongs_to :reviewer, class_name: "User", optional: true
 
   scope :pending_review, -> { where(reviewer_id: nil) }
   scope :reviewed, -> { where.not(reviewer_id: nil) }
+  scope :submitted, -> { where(submitted: true) }
 
   validate :reviewer_comment_is_present?
 
@@ -20,7 +21,7 @@ class Recommendation < ApplicationRecord
     if current_recommendation? && planning_application.awaiting_determination?
       false
     else
-      reviewer.present?
+      reviewer_comment.present?
     end
   end
 

--- a/app/views/planning_applications/_recommendations.html.erb
+++ b/app/views/planning_applications/_recommendations.html.erb
@@ -1,10 +1,10 @@
-<% if recommendations.present? %>
+<% if recommendations.submitted.present? %>
   <div class="recommendations govuk-inset-text">
-    <% recommendations.each do |recommendation| %>
+    <% recommendations.submitted.each do |recommendation| %>
       <div class="recommendation">
         <p class="govuk-body">
           <strong>Submitted recommendation</strong> by <%= recommendation.assessor.name %><br />
-          <%= accessible_time recommendation.created_at %>
+          <%= recommendation.created_at %>
         </p>
 
         <p class="govuk-body comment">
@@ -15,7 +15,7 @@
         <div class="recommendation">
           <p class="govuk-body">
             <strong>Recommendation challenged</strong> by <%= recommendation.reviewer.name %> <br />
-            <%= accessible_time recommendation.reviewed_at %>
+            <%= recommendation.reviewed_at %>
           </p>
 
           <p class="govuk-body comment">

--- a/app/views/planning_applications/_recommendations.html.erb
+++ b/app/views/planning_applications/_recommendations.html.erb
@@ -4,7 +4,7 @@
       <div class="recommendation">
         <p class="govuk-body">
           <strong>Submitted recommendation</strong> by <%= recommendation.assessor.name %><br />
-          <%= recommendation.created_at %>
+          <%= accessible_time recommendation.created_at %>
         </p>
 
         <p class="govuk-body comment">
@@ -15,7 +15,7 @@
         <div class="recommendation">
           <p class="govuk-body">
             <strong>Recommendation challenged</strong> by <%= recommendation.reviewer.name %> <br />
-            <%= recommendation.reviewed_at %>
+            <%= accessible_time recommendation.reviewed_at %>
           </p>
 
           <p class="govuk-body comment">

--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -59,7 +59,9 @@
       <%= text_area_tag "recommendation[assessor_comment]", @recommendation.assessor_comment, class: "govuk-textarea", rows: "7" %>
     </div>
     <div class="govuk-!-padding-top-4">
-      <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+      <%= form.submit "Save and mark as complete", class: "govuk-button", action: "assess", data: { module: "govuk-button" } %>
+      <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", formaction: "save_assessment", data: { module: "govuk-button" } %>
+      <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -59,9 +59,14 @@
       <%= text_area_tag "recommendation[assessor_comment]", @recommendation.assessor_comment, class: "govuk-textarea", rows: "7" %>
     </div>
     <div class="govuk-!-padding-top-4">
+    <% if @recommendation.present? && @recommendation.submitted? %>
+      <%= form.submit "Update assessment", class: "govuk-button", action: "assess", data: { module: "govuk-button" } %>
+      <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+    <% else %>
       <%= form.submit "Save and mark as complete", class: "govuk-button", action: "assess", data: { module: "govuk-button" } %>
       <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", formaction: "save_assessment", data: { module: "govuk-button" } %>
       <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+    <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/steps/_assessment.html.erb
+++ b/app/views/planning_applications/steps/_assessment.html.erb
@@ -10,6 +10,8 @@
     </span>
     <% if @planning_application.assessment_complete? %>
       <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
+    <% elsif @planning_application.assessment_in_progress? %>
+      <%= tag.strong "In progress", id: "assessment-in-progress", class: "govuk-tag app-task-list__task-tag" %>
     <% end %>
   </li>
   <li class="app-task-list__item">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,6 +68,5 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops-care.link"), port: 3000 }
 
-  config.hosts << ".bops-care.link"
-  config.hosts << "southwark.southwark.web"
+  config.hosts.clear
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -68,5 +68,6 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops-care.link"), port: 3000 }
 
-  config.hosts.clear
+  config.hosts << ".bops-care.link"
+  config.hosts << "southwark.southwark.web"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
       patch :recommend
       get :submit_recommendation
       get :view_recommendation
+      patch :save_assessment
       patch :assess
       get :review_form
       patch :review

--- a/db/migrate/20211231120435_add_time_stamp_to_in_assessment_in_progress.rb
+++ b/db/migrate/20211231120435_add_time_stamp_to_in_assessment_in_progress.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddTimeStampToInAssessmentInProgress < ActiveRecord::Migration[6.1]
+  def change
+    add_column :planning_applications, :assessment_in_progress_at, :timestamp
+  end
+end

--- a/db/migrate/20211231131635_make_assessor_id_optional.rb
+++ b/db/migrate/20211231131635_make_assessor_id_optional.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MakeAssessorIdOptional < ActiveRecord::Migration[6.1]
+  def change
+    change_table :recommendations do |t|
+      t.change_null :assessor_id, true
+    end
+  end
+end

--- a/db/migrate/20211231163004_add_submitted_to_recommendations.rb
+++ b/db/migrate/20211231163004_add_submitted_to_recommendations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSubmittedToRecommendations < ActiveRecord::Migration[6.1]
+  def change
+    add_column :recommendations, :submitted, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_16_140625) do
+ActiveRecord::Schema.define(version: 2021_12_31_163004) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,7 @@ ActiveRecord::Schema.define(version: 2021_12_16_140625) do
     t.bigint "api_user_id"
     t.bigint "boundary_created_by_id"
     t.jsonb "policy_classes", default: [], array: true
+    t.datetime "assessment_in_progress_at"
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
@@ -236,7 +237,7 @@ ActiveRecord::Schema.define(version: 2021_12_16_140625) do
 
   create_table "recommendations", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
-    t.bigint "assessor_id", null: false
+    t.bigint "assessor_id"
     t.bigint "reviewer_id"
     t.text "assessor_comment"
     t.text "reviewer_comment"
@@ -244,6 +245,7 @@ ActiveRecord::Schema.define(version: 2021_12_16_140625) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "challenged"
+    t.boolean "submitted"
     t.index ["assessor_id"], name: "index_recommendations_on_assessor_id"
     t.index ["planning_application_id"], name: "index_recommendations_on_planning_application_id"
     t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"

--- a/features/assessing_proposal.feature
+++ b/features/assessing_proposal.feature
@@ -3,23 +3,24 @@ Feature: Assessing a proposal
     Given I am logged in as an assessor
     And a new planning application
     And I view the planning application
-    And the application is valid
+    And the planning application is validated
 
 Scenario: I can save a draft assessment on the planning application
     When I press "Assess proposal"
-    And I fill in "State the reasons why this applicatin is, or is not lawful." with "Lawful as can be"
+    And I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
     And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
     And I press "Save and come back later"
+    Then print the page
     When I view the planning application
     Then the assess proposal accordion displays a "In progress" tag
-    And when I press "Assess proposal"
+    When I press "Assess proposal"
     Then the page contains "Lawful as can be"
     And the page contains "I'm hoping you feel supported"
 
 Scenario: I can submit an assessment on the planning application
     When I press "Assess proposal"
     And I choose "Yes"
-    And I fill in "State the reasons why this applicatin is, or is not lawful." with "Lawful as can be"
+    And I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
     And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
     And I press "Save and mark as complete"
     Then the assess proposal accordion displays a "Completed" tag

--- a/features/assessing_proposal.feature
+++ b/features/assessing_proposal.feature
@@ -1,0 +1,25 @@
+Feature: Assessing a proposal
+  Background: 
+    Given I am logged in as an assessor
+    And a new planning application
+    And I view the planning application
+    And the application is valid
+
+Scenario: I can save a draft assessment on the planning application
+    When I press "Assess proposal"
+    And I fill in "State the reasons why this applicatin is, or is not lawful." with "Lawful as can be"
+    And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
+    And I press "Save and come back later"
+    When I view the planning application
+    Then the assess proposal accordion displays a "In progress" tag
+    And when I press "Assess proposal"
+    Then the page contains "Lawful as can be"
+    And the page contains "I'm hoping you feel supported"
+
+Scenario: I can submit an assessment on the planning application
+    When I press "Assess proposal"
+    And I choose "Yes"
+    And I fill in "State the reasons why this applicatin is, or is not lawful." with "Lawful as can be"
+    And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
+    And I press "Save and mark as complete"
+    Then the assess proposal accordion displays a "Completed" tag

--- a/features/assessing_proposal.feature
+++ b/features/assessing_proposal.feature
@@ -6,11 +6,10 @@ Feature: Assessing a proposal
     And the planning application is validated
 
 Scenario: I can save a draft assessment on the planning application
-    When I press "Assess proposal"
-    And I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
+    Given I press "Assess proposal"
+    When I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
     And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
     And I press "Save and come back later"
-    Then print the page
     When I view the planning application
     Then the assess proposal accordion displays a "In progress" tag
     When I press "Assess proposal"
@@ -18,8 +17,8 @@ Scenario: I can save a draft assessment on the planning application
     And the page contains "I'm hoping you feel supported"
 
 Scenario: I can submit an assessment on the planning application
-    When I press "Assess proposal"
-    And I choose "Yes"
+    Given I press "Assess proposal"
+    When I choose "Yes"
     And I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
     And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
     And I press "Save and mark as complete"

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -74,7 +74,7 @@ Given("the planning application is assessed") do
     And I choose "Yes"
     And I fill in "State the reasons why" with "a valid reason"
     And I fill in "supporting information" with "looks legit"
-    And I press "Save"
+    And I press "Save and mark as complete"
   )
 end
 
@@ -158,4 +158,10 @@ Given "the application is returned by the applicant" do
     And I fill in "Can you provide more detail?" with "Applicant sent selfies instead of floor plans"
     And I press "Save"
   )
+end
+
+Then("the assess proposal accordion displays a {string} tag") do |tag|
+  within(:xpath, '//*[@id="assess-section"]') do
+    expect(page).to have_content tag
+  end
 end

--- a/spec/factories/recommendations.rb
+++ b/spec/factories/recommendations.rb
@@ -7,9 +7,11 @@ FactoryBot.define do
     assessor_comment { "Assessor Comment" }
     reviewer_comment { nil }
     reviewed_at { nil }
+    submitted { nil }
   end
 
   trait :reviewed do
+    submitted { true }
     reviewer { association :user, :reviewer }
     reviewer_comment { "Reviewer Comment" }
     reviewed_at { Time.zone.now }

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -37,8 +37,9 @@ RSpec.describe "Planning Application Assessment", type: :system do
       choose "No"
       fill_in "State the reasons why this application is, or is not lawful.", with: "This is a new public comment"
       fill_in "Please provide supporting information for your manager.", with: "Edited private assessor comment"
-      click_button "Save and mark as complete"
+      click_button "Update assessment"
       planning_application.reload
+
       expect(planning_application.recommendations.count).to eq(1)
       expect(planning_application.recommendations.first.assessor_comment).to eq("Edited private assessor comment")
       expect(planning_application.decision).to eq("refused")
@@ -92,7 +93,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       fill_in "State the reasons why this application is, or is not lawful.",
               with: "This is so granted and GDPO everything"
       fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
-      click_button "Save and mark as complete"
+      click_button "Update assessment"
 
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(2)

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       choose "Yes"
       fill_in "State the reasons why this application is, or is not lawful.", with: "This is a public comment"
       fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
-      click_button "Save"
+      click_button "Save and mark as complete"
 
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(1)
@@ -37,7 +37,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       choose "No"
       fill_in "State the reasons why this application is, or is not lawful.", with: "This is a new public comment"
       fill_in "Please provide supporting information for your manager.", with: "Edited private assessor comment"
-      click_button "Save"
+      click_button "Save and mark as complete"
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(1)
       expect(planning_application.recommendations.first.assessor_comment).to eq("Edited private assessor comment")
@@ -92,7 +92,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       fill_in "State the reasons why this application is, or is not lawful.",
               with: "This is so granted and GDPO everything"
       fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
-      click_button "Save"
+      click_button "Save and mark as complete"
 
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(2)
@@ -119,7 +119,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     choose "No"
     fill_in "Please provide supporting information for your manager.", with: "This is a private assessor comment"
     fill_in "State the reasons why this application is, or is not lawful.", with: ""
-    click_button "Save"
+    click_button "Save and mark as complete"
 
     expect(page).to have_content("Please state the reasons why this application is, or is not lawful")
 
@@ -128,7 +128,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   it "errors if no decision given" do
     click_link "Assess proposal"
-    click_button "Save"
+    click_button "Save and mark as complete"
 
     expect(page).to have_content("Please select Yes or No")
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -15,7 +15,10 @@ RSpec.describe "Planning Application Reviewing", type: :system do
            reviewer_comment: "First reviewer comment"
   end
   let!(:recommendation) do
-    create :recommendation, planning_application: planning_application, assessor_comment: "New assessor comment"
+    create :recommendation,
+           planning_application: planning_application,
+           assessor_comment: "New assessor comment",
+           submitted: true
   end
 
   before do

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Planning Application show page", type: :system do
 
     it "makes valid task list for when it in assessment and a proposal has been created" do
       planning_application = create(:planning_application, local_authority: @default_local_authority)
-      create(:recommendation, planning_application: planning_application)
+      create(:recommendation, planning_application: planning_application, submitted: true)
       visit planning_application_path(planning_application)
 
       within "#assess-section" do
@@ -117,7 +117,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_correction,
                                     local_authority: @default_local_authority)
       create(:recommendation, :reviewed, planning_application: planning_application)
-      create(:recommendation, planning_application: planning_application)
+      create(:recommendation, planning_application: planning_application, submitted: true)
       visit planning_application_path(planning_application)
 
       within "#validation-section" do


### PR DESCRIPTION
### Description of change

- Add a save and come back to later option to the Assessment flow
- Adds a "submitted" column to each review so we can scope recommendations to submitted and not for show purposes.
- Allows for the recommendation to be saved without enforcing validation as required by ACs

### Story Link
https://trello.com/c/hZvZPEWC/685-when-using-assess-proposal-provide-a-save-as-draft-option

### Design Links
https://beta-bops-prototypes.herokuapp.com/v20/pd-summary
https://beta-bops-prototypes.herokuapp.com/v20/assessment-pd
