### PR TITLE
Add test coverage for edit flash

### DIFF
--- a/features/editing_a_planning_application.feature
+++ b/features/editing_a_planning_application.feature
@@ -54,3 +54,10 @@ Feature: Editing an application's details
     Given I fill in "Payment reference" with "293844848"
     When I press "Save"
     Then the page contains "293844848"
+
+  Scenario: I cannot edit a planning application if it has an assessment in progress
+    Given a draft assessment on the planning application
+    When I edit the planning application's details
+    And I fill in "Address 2" with "Happy Buns"
+    And I press "Save"
+    Then the page contains "Please complete in draft assessment before updating application fields."

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -165,3 +165,14 @@ Then("the assess proposal accordion displays a {string} tag") do |tag|
     expect(page).to have_content tag
   end
 end
+
+Given "a draft assessment on the planning application" do
+  steps %(
+    Given the planning application is validated
+    And I view the planning application
+    And I press "Assess proposal"
+    When I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
+    And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
+    And I press "Save and come back later"
+  )
+end


### PR DESCRIPTION
### Description of change

Small test to check that the "edit" planning application function is disabled when an assessment is in draft

### Story Link
(continuation of)
https://trello.com/c/hZvZPEWC/685-when-using-assess-proposal-provide-a-save-as-draft-option

### Decisions 
We prevent edits on the planning application because the draft assessment functionality skips validation as per ACs, but we don't want to save a planning application with invalid fields, so we simply require the draft assessment to be completed before the planning application can be edited again.