### PR TITLE
Integrate with Mapit API to fetch ward information given a postcode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,7 +275,7 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RAILS_ENV: test
-          SPEC_OPTS: "-f doc -P spec/{helpers,presenters,mailer,jobs}/**/*_spec.rb"
+          SPEC_OPTS: "-f doc -P spec/{helpers,presenters,mailer,jobs,services}/**/*_spec.rb"
         run: |
           bundle exec rake spec
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,3 +49,6 @@ RSpec/InstanceVariable:
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -29,6 +29,10 @@ module PlanningApplicationHelper
     "https://google.co.uk/maps/place/#{CGI.escape(address)}"
   end
 
+  def mapit_link(postcode)
+    "https://mapit.mysociety.org/postcode/#{postcode.gsub(/\s+/, '').upcase}.html"
+  end
+
   def display_number(proposal_details, element)
     proposal_details.find_index(element) + 1
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -28,6 +28,8 @@ class PlanningApplication < ApplicationRecord
 
   before_create :set_key_dates
   before_create :set_change_access_id
+
+  after_create :set_ward_information
   before_update :set_key_dates
 
   WORK_STATUSES = %w[proposed existing].freeze
@@ -424,6 +426,16 @@ class PlanningApplication < ApplicationRecord
 
   def set_change_access_id
     self.change_access_id = SecureRandom.hex(15)
+  end
+
+  def set_ward_information
+    return if postcode.blank?
+
+    ward_type, ward = Apis::Mapit::Query.new.fetch(postcode)
+
+    self.ward_type = ward_type
+    self.ward = ward
+    save!
   end
 
   def documents_validated_at_date

--- a/app/services/apis/mapit/client.rb
+++ b/app/services/apis/mapit/client.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module Apis
+  module Mapit
+    class Client
+      HOST = "https://mapit.mysociety.org"
+      ENDPOINT = "postcode/%s"
+      TIMEOUT = 5
+
+      def call(postcode)
+        faraday.get(path(postcode)) do |request|
+          request.options[:timeout] = TIMEOUT
+        end
+      end
+
+      private
+
+      def faraday
+        @faraday ||= Faraday.new(url: HOST) do |f|
+          f.response :raise_error
+        end
+      end
+
+      def path(postcode)
+        format(ENDPOINT, postcode.gsub(/\s+/, "").upcase)
+      end
+    end
+  end
+end

--- a/app/services/apis/mapit/query.rb
+++ b/app/services/apis/mapit/query.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module Apis
+  module Mapit
+    class Query
+      def fetch(postcode)
+        response = client.call(postcode)
+
+        if response.success?
+          parse(JSON.parse(response.body))
+        else
+          []
+        end
+      rescue Faraday::ResourceNotFound, Faraday::ClientError
+        []
+      rescue Faraday::Error => e
+        Appsignal.send_exception(e)
+        []
+      end
+
+      private
+
+      def parse(body)
+        ward_id = body["shortcuts"]["ward"]
+        ward_object = body["areas"][ward_id.to_s]
+
+        [ward_object["type_name"], ward_object["name"]]
+      end
+
+      def client
+        @client ||= Apis::Mapit::Client.new
+      end
+    end
+  end
+end

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -43,6 +43,28 @@
             <td class="govuk-table__cell"><strong>Location:</strong></td>
             <td class="govuk-table__cell"><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></td>
           </tr>
+          <tr class="govuk-table__row" id="ward">
+            <td class="govuk-table__cell"><strong>Ward:</strong></td>
+            <td class="govuk-table__cell">
+            <% if @planning_application.postcode.present? %>
+              <p class="govuk-body"><%= @planning_application.ward %></p>
+              <%= link_to "View on mapit", mapit_link(@planning_application.postcode), target: '_blank', class: "govuk-link" %>
+            <% else %>
+              <p class="govuk-body">A postcode is required for ward information</p>
+            <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row" id="ward-type">
+            <td class="govuk-table__cell"><strong>Ward type:</strong></td>
+            <td class="govuk-table__cell">
+            <% if @planning_application.postcode.present? %>
+              <p class="govuk-body"><%= @planning_application.ward_type %></p>
+              <%= link_to "View on mapit", mapit_link(@planning_application.postcode), target: '_blank', class: "govuk-link" %>
+            <% else %>
+              <p class="govuk-body">A postcode is required for ward information</p>
+            <% end %>
+            </td>
+          </tr>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell"><strong>UPRN:</strong></td>
             <td class="govuk-table__cell"><%= @planning_application.uprn %></td>

--- a/db/migrate/20220105160435_add_ward_information_to_planning_applications.rb
+++ b/db/migrate/20220105160435_add_ward_information_to_planning_applications.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddWardInformationToPlanningApplications < ActiveRecord::Migration[6.1]
+  # rubocop:disable Rails/BulkChangeTable
+  def change
+    add_column :planning_applications, :ward, :string
+    add_column :planning_applications, :ward_type, :string
+  end
+  # rubocop:enable Rails/BulkChangeTable
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_31_163004) do
+ActiveRecord::Schema.define(version: 2022_01_05_160435) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,8 @@ ActiveRecord::Schema.define(version: 2021_12_31_163004) do
     t.bigint "boundary_created_by_id"
     t.jsonb "policy_classes", default: [], array: true
     t.datetime "assessment_in_progress_at"
+    t.string "ward"
+    t.string "ward_type"
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"

--- a/features/support/stub_requests.rb
+++ b/features/support/stub_requests.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require Rails.root.join "spec/support/api/mapit_helpers"
+
+World(MapitHelper)
+
+Before do
+  stub_any_api_request.to_return(api_response(:ok))
+end

--- a/spec/fixtures/mapit/SE220HW.json
+++ b/spec/fixtures/mapit/SE220HW.json
@@ -1,0 +1,28 @@
+{
+  "wgs84_lat": 51.45392903566775,
+  "shortcuts": {
+    "WMC": 65808,
+    "ward": 151821,
+    "council": 2491
+  },
+  "wgs84_lon": -0.07010828918056362,
+  "postcode": "SE22 0HW",
+  "areas": {
+    "151821": {
+      "parent_area": 2491,
+      "generation_high": 44,
+      "all_names": {},
+      "id": 151821,
+      "codes": {
+        "gss": "E05011099",
+        "unit_id": "44809"
+      },
+      "name": "Dulwich Hill",
+      "country": "E",
+      "type_name": "London borough ward",
+      "generation_low": 33,
+      "country_name": "England",
+      "type": "LBW"
+    }
+  }
+}

--- a/spec/fixtures/mapit/default.json
+++ b/spec/fixtures/mapit/default.json
@@ -1,0 +1,28 @@
+{
+  "wgs84_lat": 51.49215328714048,
+  "shortcuts": {
+    "WMC": 65689,
+    "ward": 151831,
+    "council": 2491
+  },
+  "wgs84_lon": -0.06662168182039398,
+  "postcode": "SE16 3RQ",
+  "areas": {
+    "151831": {
+      "parent_area": 2491,
+      "generation_high": 44,
+      "all_names": {},
+      "id": 151831,
+      "codes": {
+        "gss": "E05011116",
+        "unit_id": "11090"
+      },
+      "name": "South Bermondsey",
+      "country": "E",
+      "type_name": "London borough ward",
+      "generation_low": 33,
+      "country_name": "England",
+      "type": "LBW"
+    }
+  }
+}

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe PlanningApplicationHelper, type: :helper do
     end
   end
 
+  describe "#mapit_link" do
+    it "returns the correct link for a postcode" do
+      expect(mapit_link("se16 3Rq")).to eq("https://mapit.mysociety.org/postcode/SE163RQ.html")
+      expect(mapit_link("s e16 3 rQ")).to eq("https://mapit.mysociety.org/postcode/SE163RQ.html")
+    end
+  end
+
   describe "#display_number" do
     it "returns the right number for an element in an array" do
       expect(display_number([25, 84, "proposal", 165, true], 165)).to eq(4)

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -249,6 +249,32 @@ RSpec.describe PlanningApplication, type: :model do
     end
   end
 
+  describe "callbacks" do
+    describe "::after_create" do
+      context "when there is a postcode set" do
+        let(:planning_application) { create :planning_application, postcode: "SE22 0HW" }
+
+        it "calls the mapit API and sets the ward information" do
+          expect_any_instance_of(Apis::Mapit::Client).to receive(:call).with("SE22 0HW").and_call_original
+
+          expect(planning_application.ward).to eq("South Bermondsey")
+          expect(planning_application.ward_type).to eq("London borough ward")
+        end
+      end
+
+      context "when there is no postcode set" do
+        let(:planning_application) { create :planning_application, postcode: nil }
+
+        it "does not call the mapit API" do
+          expect_any_instance_of(Apis::Mapit::Client).not_to receive(:call)
+
+          expect(planning_application.ward).to eq(nil)
+          expect(planning_application.ward_type).to eq(nil)
+        end
+      end
+    end
+  end
+
   describe "#reference" do
     it "pads the ID correctly" do
       planning_application.update!(id: 1000)

--- a/spec/services/apis/mapit/client_spec.rb
+++ b/spec/services/apis/mapit/client_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Apis::Mapit::Client do
+  let(:client) { described_class.new }
+
+  describe "#call" do
+    let(:faraday_connection) { spy }
+    let(:url) { "https://mapit.mysociety.org" }
+
+    it "makes a Faraday connection" do
+      allow(Faraday).to receive(:new).with(url: url).and_yield(faraday_connection)
+
+      client.call("SE220HW")
+    end
+
+    it "removes whitespace from the postcode" do
+      stub = stub_api_request_for("SE220HW")
+      client.call("s e 22 0h w")
+      expect(stub).to have_been_requested
+    end
+
+    it "upcases the postcode" do
+      stub = stub_api_request_for("SE220HW")
+      client.call("se220hw")
+      expect(stub).to have_been_requested
+    end
+  end
+end

--- a/spec/services/apis/mapit/query_spec.rb
+++ b/spec/services/apis/mapit/query_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Apis::Mapit::Query do
+  let(:query) { described_class.new }
+
+  describe "#fetch" do
+    context "when the request is successful" do
+      context "when a valid postcode is supplied" do
+        before do
+          stub_api_request_for("SE220HW").to_return(api_response(:ok, "SE220HW"))
+        end
+
+        it "returns an array with ward type and ward name" do
+          expect(query.fetch("SE220HW")).to eq(["London borough ward", "Dulwich Hill"])
+        end
+      end
+    end
+
+    context "when the request is unsuccessful" do
+      context "when a postcode is not found" do
+        before do
+          stub_api_request_for("SE110H9").to_return(api_response(:not_found, "no_result"))
+        end
+
+        it "returns an empty array" do
+          expect(query.fetch("SE110H9")).to eq([])
+        end
+      end
+
+      context "when the API does not respond" do
+        before do
+          stub_api_request_for("SE110H9").to_timeout
+        end
+
+        it "returns an empty array" do
+          expect(query.fetch("SE110H9")).to eq([])
+        end
+      end
+
+      context "when the API is returning an internal server error" do
+        before do
+          stub_api_request_for("SE110H9").to_return(api_response(:internal_server_error))
+        end
+
+        it "returns an empty array" do
+          expect(query.fetch("SE110H9")).to eq([])
+        end
+      end
+
+      context "when the API can't find the resource" do
+        before do
+          stub_api_request_for("SE110H9").to_return(api_response(:not_acceptable))
+        end
+
+        it "returns an empty array" do
+          expect(query.fetch("SE110H9")).to eq([])
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api/mapit_helpers.rb
+++ b/spec/support/api/mapit_helpers.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module MapitHelper
+  BASE_URL = "https://mapit.mysociety.org/postcode"
+
+  def stub_api_request_for(postcode)
+    stub_request(:get, "#{BASE_URL}/#{postcode}")
+  end
+
+  def stub_any_api_request
+    stub_request(:get, /#{BASE_URL}.*/)
+  end
+
+  def api_response(status, body = "default", &block)
+    status = Rack::Utils.status_code(status)
+
+    body = if block_given?
+             block.call
+           elsif body == "no_result"
+             []
+           else
+             File.read(Rails.root.join("spec", "fixtures", "mapit", "#{body}.json"))
+           end
+
+    { status: status, body: body }
+  end
+end
+
+if RSpec.respond_to?(:configure)
+  RSpec.configure do |config|
+    config.include(MapitHelper)
+
+    config.before do
+      stub_any_api_request.to_return(api_response(:ok))
+    end
+  end
+end

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -57,6 +57,22 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("Description: Roof extension")
       expect(page).to have_text("PAY123")
       expect(page).to have_text("£103.00")
+
+      within("#ward") do
+        expect(page).to have_text("Ward:")
+        expect(page).to have_text("South Bermondsey")
+        expect(page).to have_link(
+          "View on mapit", href: "https://mapit.mysociety.org/postcode/SE156UT.html"
+        )
+      end
+
+      within("#ward-type") do
+        expect(page).to have_text("Ward type:")
+        expect(page).to have_text("London borough ward")
+        expect(page).to have_link(
+          "View on mapit", href: "https://mapit.mysociety.org/postcode/SE156UT.html"
+        )
+      end
     end
 
     it "Constraints accordion" do
@@ -189,6 +205,27 @@ RSpec.describe "Planning Application show page", type: :system do
 
       expect(page).to have_text("No result")
       expect(page).to have_text("#{api_user.name} did not provide a result for this application")
+    end
+  end
+
+  context "when no postcode has been set" do
+    let!(:planning_application) { create(:planning_application, local_authority: @default_local_authority, postcode: "") }
+
+    before do
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    it "displays no ward information in the application information section" do
+      click_button "Application information"
+
+      within("#ward") do
+        expect(page).to have_text("A postcode is required for ward information")
+      end
+
+      within("#ward-type") do
+        expect(page).to have_text("A postcode is required for ward information")
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

- https://mapit.mysociety.org/
- Currently uses free tier (so no API key required). However this is limited to 50 requests per day
- Use after_create callback on planning application to populate these ward fields and also provide external link to mapit page given a postcode
- Limitations are if a postcode is updated we still need to execute a subsequent query to update the ward information
- Postcodes originating from RIPA are likely to be validated and accurate so this is the main use case for this feature

### Story Link

https://trello.com/c/gYoE98cy/435-display-ward-for-a-given-application