### PR TITLE
Rework and use docker-entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,5 @@ WORKDIR /app
 
 COPY . .
 
-CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
+# Sets an interactive shell as default command when the container starts
+CMD ["/bin/sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,10 @@ services:
       - "5433:5432"
   web:
     build: .
+    entrypoint: ./docker-entrypoint.sh
+    command: bash -c "bundle exec rails s -b 0.0.0.0"
     stdin_open: true
+    tty: true
     environment:
       DATABASE_URL: postgres://postgres:postgres@db:5432
       APPLICANTS_APP_HOST: southwark.localhost:3001
@@ -33,7 +36,10 @@ services:
         target: /app
   applicants:
     build: ./bops-applicants
-    command: bash -c "bundle install && bundle exec rails s -p 3001 -b 0.0.0.0"
+    entrypoint: ./docker-entrypoint.sh
+    stdin_open: true
+    tty: true
+    command: bash -c "bundle exec rails s -p 3001 -b 0.0.0.0"
     environment:
       API_BEARER: 123
       API_HOST: southwark.localhost:3000

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,22 +2,12 @@
 
 set -e
 
-echo 'Waiting for a connection with postgres...'
-
-until psql -h "postgres" -U "postgres" -c '\q' > /dev/null 2>&1; do
-  sleep 1
-done
-
-echo "Connected to postgres..."
-
 echo "Bundling gems"
 bundle check || bundle install
 
-if [ "$2" == 'server' ]; then
-  if [ -f /app/tmp/pids/server.pid ]; then
-    echo 'Deleting old server pid file ...'
-    rm -f /app/tmp/pids/server.pid
-  fi
+if [ -f /app/tmp/pids/server.pid ]; then
+  echo 'Deleting old server pid file ...'
+  rm -f /app/tmp/pids/server.pid
 fi
 
 # parameters will pass to bundle exec from docker-compose


### PR DESCRIPTION
### Description of change

Rework and use `docker-entrypoint`

Sometimes we were getting an error that a server was already running. So we had to go and manually delete the `server.pid` file. We now use `docker-entrypoint` script to delete `server.pid`.