### PR TITLE
Draw site outline is zoomed in on latitude/longitude when no boundary set

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -138,7 +138,9 @@ module Api
             address_1: params[:site][:address_1],
             address_2: params[:site][:address_2],
             town: params[:site][:town],
-            postcode: params[:site][:postcode] }
+            postcode: params[:site][:postcode],
+            latitude: params[:site][:latitude],
+            longitude: params[:site][:longitude] }
         end
       end
 

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -41,6 +41,8 @@ json.site do
   json.town planning_application.town
   json.postcode planning_application.postcode
   json.uprn planning_application.uprn
+  json.latitude planning_application.latitude
+  json.longitude planning_application.longitude
 end
 json.received_date planning_application.created_at
 json.decision planning_application.decision if planning_application.determined?

--- a/app/views/planning_applications/draw_sitemap.html.erb
+++ b/app/views/planning_applications/draw_sitemap.html.erb
@@ -18,6 +18,8 @@
 <%= form_with model: @planning_application, url: update_sitemap_planning_application_path(@planning_application), local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <%= form.hidden_field :boundary_geojson %>
   <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'planning_application_boundary_geojson' } %>
-  <%= form.govuk_submit "Save" %>
-  <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  <div class="govuk-button-group govuk-!-margin-top-3">
+    <%= form.govuk_submit "Save" %>
+    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
 <% end %>

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -5,6 +5,10 @@
   useScaleBarStyle
   <% if locals[:geojson].present? %>
     geojsonData='<%= locals[:geojson].is_a?(Hash) ? locals[:geojson].to_json : JSON.parse(locals[:geojson]).to_json.html_safe %>'
+  <% elsif @planning_application.latitude && @planning_application.longitude %>
+    zoom="19"
+    latitude='<%= @planning_application.latitude %>'
+    longitude='<%= @planning_application.longitude %>'
   <% end %>
   <% if locals[:geojson_field].present?  %>
     drawMode="true"

--- a/db/migrate/20220112155627_add_latitude_and_longitude_to_planning_applications.rb
+++ b/db/migrate/20220112155627_add_latitude_and_longitude_to_planning_applications.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddLatitudeAndLongitudeToPlanningApplications < ActiveRecord::Migration[6.1]
+  def change
+    change_table :planning_applications, bulk: true do |t|
+      t.string :latitude
+      t.string :longitude
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_05_160435) do
+ActiveRecord::Schema.define(version: 2022_01_12_155627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -231,6 +231,8 @@ ActiveRecord::Schema.define(version: 2022_01_05_160435) do
     t.datetime "assessment_in_progress_at"
     t.string "ward"
     t.string "ward_type"
+    t.string "latitude"
+    t.string "longitude"
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -37,6 +37,8 @@ paths:
                       town: nil
                       county: London
                       postcode: SE16 3RQ
+                      latitude: '51.4842536'
+                      longitude: '-0.0764165'
                       uprn: '100081043511'
                     status: not_started
                     application_type: lawfulness_certificate
@@ -112,6 +114,8 @@ paths:
                           town: nil
                           county: London
                           postcode: SE16 3RQ
+                          latitude: '51.4842536'
+                          longitude: '-0.0764165'
                           uprn: '100081043511'
                         status: not_started
                         application_type: lawfulness_certificate
@@ -211,6 +215,12 @@ paths:
                     postcode:
                       type: string
                       example: SE16 3RQ
+                    latitude:
+                      type: string
+                      example: '51.4842536'
+                    longitude:
+                      type: string
+                      example: '-0.0764165'
                 description:
                   type: string
                   example: Add chimnney stack
@@ -350,6 +360,8 @@ paths:
                     address_2: Southwark
                     town: London
                     postcode: SE16 3RQ
+                    latitude: '51.4842536'
+                    longitude: '-0.0764165'
                   applicant_email: applicant@example.com
               Full:
                 value:
@@ -360,6 +372,8 @@ paths:
                     address_2: Southwark
                     town: London
                     postcode: SE16 3RQ
+                    latitude: '51.4842536'
+                    longitude: '-0.0764165'
                   description: Add a chimney stack
                   payment_reference: PAY1
                   payment_amount: 10300

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -38,6 +38,8 @@ paths:
                       town: nil
                       county: London
                       postcode: SE16 3RQ
+                      latitude: '51.4842536'
+                      longitude: '-0.0764165'
                       uprn: '100081043511'
                     status: not_started
                     application_type: lawfulness_certificate
@@ -146,6 +148,12 @@ paths:
                     postcode:
                       type: string
                       example: SE16 3RQ
+                    latitude:
+                      type: string
+                      example: '51.4842536'
+                    longitude:
+                      type: string
+                      example: '-0.0764165'
                 description:
                   type: string
                   example: Add chimnney stack
@@ -285,6 +293,8 @@ paths:
                     address_2: Southwark
                     town: London
                     postcode: SE16 3RQ
+                    latitude: '51.4842536'
+                    longitude: '-0.0764165'
                   applicant_email: applicant@example.com
               Full:
                 value:
@@ -295,6 +305,8 @@ paths:
                     address_2: Southwark
                     town: London
                     postcode: SE16 3RQ
+                    latitude: '51.4842536'
+                    longitude: '-0.0764165'
                   description: Add a chimney stack
                   payment_reference: PAY1
                   payment_amount: 10300

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -26,6 +26,8 @@ FactoryBot.define do
     town { Faker::Address.city }
     county { Faker::Address.state }
     postcode { Faker::Address.postcode }
+    latitude { Faker::Address.latitude }
+    longitude { Faker::Address.longitude }
     constraints { ["Conservation Area", "Listed Building"] }
     result_flag { "Planning permission / Permission needed" }
     result_heading { Faker::Lorem.unique.sentence }

--- a/spec/requests/api/planning_application_list_spec.rb
+++ b/spec/requests/api/planning_application_list_spec.rb
@@ -72,6 +72,8 @@ RSpec.describe "API request to list planning applications", type: :request, show
         expect(planning_application_json["site"]["county"]).to eq(planning_application.county)
         expect(planning_application_json["site"]["postcode"]).to eq(planning_application.postcode)
         expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
+        expect(planning_application_json["site"]["latitude"]).to eq(planning_application.latitude)
+        expect(planning_application_json["site"]["longitude"]).to eq(planning_application.longitude)
         expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
         expect(planning_application_json["documents"]).to eq([])
       end

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -124,6 +124,8 @@ RSpec.describe "API request to list planning applications", type: :request, show
           expect(planning_application_json["site"]["county"]).to eq(planning_application.county)
           expect(planning_application_json["site"]["postcode"]).to eq(planning_application.postcode)
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
+          expect(planning_application_json["site"]["latitude"]).to eq(planning_application.latitude)
+          expect(planning_application_json["site"]["longitude"]).to eq(planning_application.longitude)
           expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
           expect(planning_application_json["documents"].size).to eq(1)
           expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(

--- a/spec/system/planning_applications/drawing_sitemap_spec.rb
+++ b/spec/system/planning_applications/drawing_sitemap_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
       expect(page).to have_content("No digital sitemap provided")
       click_link "Draw digital sitemap"
 
+      # When no boundary set, map should be displayed zoomed in at latitiude/longitude if fields present
+      map_selector = find("my-map")
+      expect(map_selector["latitude"]).to eq(planning_application.latitude)
+      expect(map_selector["longitude"]).to eq(planning_application.longitude)
+
       # JS to emulate a polygon drawn on the map
       execute_script 'document.getElementById("planning_application_boundary_geojson").setAttribute("value", \'{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}\')'
       click_button "Save"


### PR DESCRIPTION
### Description of change

- If no boundary is set/drawn then planning applications created via RIPA with latitude/longitude fields within the site object is used as a starting point for the site outline

### Story Link

https://trello.com/c/hV8lG0L0/700-draw-site-outline-should-start-on-site-address