### PR TITLE
Update s3 bucket with one which has full public access

### DIFF
--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -335,7 +335,7 @@ paths:
                     properties:
                       filename:
                         type: string
-                        example: 'https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
+                        example: 'https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
                       tags:
                         type: array
                         items:
@@ -491,7 +491,7 @@ paths:
                     conservation_area: true
                     protected_trees: false
                   files:
-                    - filename: 'https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
+                    - filename: 'https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf'
                       applicant_description: This is the side plan
                       tags:
                         - Side

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -268,7 +268,7 @@ paths:
                     properties:
                       filename:
                         type: string
-                        example: https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
+                        example: https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
                       tags:
                         type: array
                         items:
@@ -424,7 +424,7 @@ paths:
                     conservation_area: true
                     protected_trees: false
                   files:
-                    - filename: https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
+                    - filename: https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf
                       applicant_description: 'This is the side plan'
                       tags:
                         - Side

--- a/spec/fixtures/files/minimal_planning_application.json
+++ b/spec/fixtures/files/minimal_planning_application.json
@@ -24,11 +24,11 @@
     "postcode": "SE16 3RQ"
   },
   "files": [{
-    "filename": "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+    "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
     "tags": ["Side", "Elevation", "Proposed", "Plan"]
   },
     {
-      "filename": "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+      "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
       "tags": ["Front", "Section", "Existing"]
     }],
   "constraints": {

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -121,11 +121,11 @@
     "email": "applicant@example.com"
   },
   "files": [{
-    "filename": "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+    "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
     "tags": ["Front", "Section", "Existing"]
   },
     {
-      "filename": "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+      "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
       "tags": ["Side", "Elevation", "Proposed"]
     }],
   "constraints": {

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "The Open API Specification document", type: :request, show_excep
   end
 
   it "successfully creates the Full application as per the oas3 definition" do
-    stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+    stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
       .to_return(
         status: 200,
         body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")),

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
 
   context "with success in downloading document" do
     before do
-      stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+      stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
         .to_return(
           status: 200,
           body: File.read(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf")),
@@ -140,7 +140,7 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
 
   context "with error in downloading document" do
     before do
-      stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+      stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
         .to_return(status: 404, body: "")
     end
 
@@ -156,7 +156,7 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
 
   context "with the wrong type of document" do
     before do
-      stub_request(:get, "https://bops-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+      stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
         .to_return(status: 200, body: "some document", headers: { "Content-Type" => "application/octet-stream" })
     end
 


### PR DESCRIPTION
### Description of change

Update s3 bucket with one which has full public access

The `bops-test` s3 bucket returns 403 `Forbidden` error. I couldn't find it under our AWS account so I've created a new one with public access