### PR TITLE
Add feedback email to local authorities

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
             beta
           </strong>
           <span class="govuk-phase-banner__text">
-            This is a new service – your <a class="govuk-link" href="mailto:peter.forest@southwark.gov.uk">feedback</a> will help us to improve it.
+            This is a new service – your
+            <%= mail_to current_local_authority.feedback_email, "feedback", class: "govuk-link"  %>
+            will help us to improve it.
           </span>
         </p>
       </div>

--- a/db/migrate/20220127164323_add_feedback_email_to_local_authorities.rb
+++ b/db/migrate/20220127164323_add_feedback_email_to_local_authorities.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddFeedbackEmailToLocalAuthorities < ActiveRecord::Migration[6.1]
+  def up
+    add_column :local_authorities, :feedback_email, :string
+
+    LocalAuthority.find_each do |authority|
+      authority.subdomain == "lambeth" && authority.update(feedback_email: "digitalplanning@lambeth.gov.uk")
+      authority.subdomain == "southwark" && authority.update(feedback_email: "digital.projects@southwark.gov.uk")
+      if authority.subdomain == "buckinghamshire"
+        authority.update(feedback_email: "planning.digital@buckinghamshire.gov.uk")
+      end
+    end
+  end
+
+  def down
+    remove_column :local_authorities, :feedback_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_18_103809) do
+ActiveRecord::Schema.define(version: 2022_01_27_164323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 2022_01_18_103809) do
     t.text "enquiries_paragraph"
     t.string "email_address"
     t.string "reply_to_notify_id"
+    t.string "feedback_email"
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,8 @@ lambeth = LocalAuthority.find_or_create_by!(
   signatory_name: "Christina Thompson",
   signatory_job_title: "Director of Finance & Property",
   enquiries_paragraph: "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG",
-  email_address: "planning@lambeth.gov.uk"
+  email_address: "planning@lambeth.gov.uk",
+  feedback_email: "digitalplanning@lambeth.gov.uk"
 )
 southwark = LocalAuthority.find_or_create_by!(
   name: "Southwark Council",
@@ -16,7 +17,8 @@ southwark = LocalAuthority.find_or_create_by!(
   signatory_name: "Stephen Platts",
   signatory_job_title: "Director of Planning and Growth",
   enquiries_paragraph: "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG",
-  email_address: "planning@southwark.gov.uk"
+  email_address: "planning@southwark.gov.uk",
+  feedback_email: "digital.projects@southwark.gov.uk"
 )
 
 buckinghamshire = LocalAuthority.find_or_create_by!(
@@ -25,7 +27,8 @@ buckinghamshire = LocalAuthority.find_or_create_by!(
   signatory_name: "Steve Bambick",
   signatory_job_title: "Director of Planning",
   enquiries_paragraph: "Planning, Buckinghamshire Council, Gatehouse Rd, Aylesbury HP19 8FF",
-  email_address: "planning@buckinghamshire.gov.uk"
+  email_address: "planning@buckinghamshire.gov.uk",
+  feedback_email: "planning.digital@buckinghamshire.gov.uk"
 )
 
 ApiUser.find_or_create_by!(name: "api_user", token: (ENV["API_TOKEN"] || "123"))

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
       signatory_job_title { "Director of Finance & Property" }
       enquiries_paragraph { "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG" }
       email_address { "planning@lambeth.gov.uk" }
+      feedback_email { "feedback_email@lambeth.gov.uk" }
     end
 
     trait :southwark do
@@ -30,6 +31,7 @@ FactoryBot.define do
       signatory_job_title { "Director of Planning and Growth" }
       enquiries_paragraph { "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG" }
       email_address { "planning@southwark.gov.uk" }
+      feedback_email { "feedback_email@southwark.gov.uk" }
     end
   end
 end

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe "Sign in", type: :system do
     end
 
     context "a user belonging to a given subdomain" do
-      let!(:lambeth) { create :local_authority, subdomain: "lamb" }
-      let!(:southwark) { create :local_authority, subdomain: "south" }
+      let!(:lambeth) { create :local_authority, :lambeth }
+      let!(:southwark) { create :local_authority, :southwark }
       let(:lambeth_assessor) do
         create :user, :assessor, name: "Lambertina Lamb", password: "Lambsrock18!", local_authority: lambeth
       end
@@ -68,7 +68,7 @@ RSpec.describe "Sign in", type: :system do
 
       before do
         @previous_host = Capybara.app_host
-        Capybara.app_host = "http://lamb.example.com"
+        Capybara.app_host = "http://lambeth_authority.example.com"
       end
 
       after do
@@ -93,6 +93,12 @@ RSpec.describe "Sign in", type: :system do
         click_button("Log in")
 
         expect(page).to have_text("Signed in successfully.")
+      end
+
+      it "has the feedback email" do
+        visit root_path
+
+        expect(page).to have_link("feedback", href: "mailto:feedback_email@lambeth.gov.uk")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Add feedback email to local authorities, so the top banner feedback link will link to that

### Story Link

https://trello.com/c/eiRvkqwa