### PR TITLE
Add osVectorTilesApiKey to  AWS param store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 APPLICANTS_APP_HOST=bops-care.link:3001
+OS_VECTOR_TILES_API_KEY=xxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ yarn-debug.log*
 
 # Ignore build packages
 /pkg
+
+# Ignore .env
+.env

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ http://lambeth.lambeth.localhost:3000/
 http://buckinghamshire.buckinghamshire.localhost:3000/
 ```
 
+## OS maps
+
+To utilise all the map functionality, you will need to set an `OS_VECTOR_TILES_API_KEY` in `.env`
+You can find this value from the parameter store on AWS
+
 ## BOPS applicants
 
 BOPS allows planning officers to request changes to an application;

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -1,6 +1,6 @@
 <my-map
   style="width: 100%; height: 400px;"
-  osVectorTilesApiKey="VgqyKyGclwrFphAv4fw2MrpNI4CnzATT"
+  osVectorTilesApiKey='<%= ENV['OS_VECTOR_TILES_API_KEY'] %>'
   showScale
   useScaleBarStyle
   <% if locals[:geojson].present? %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       API_USER: api_user
       PORT: 3001
       PROTOCOL: http
+      OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
     ports:
       - "3001:3001"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       DATABASE_URL: postgres://postgres:postgres@db:5432
       APPLICANTS_APP_HOST: southwark.localhost:3001
       GROVER_NO_SANDBOX: "true"
+      OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
     ports:
       - "3000:3000"
       - "3333:3333"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         target: /app
   applicants:
     build: ./bops-applicants
-    entrypoint: ./bops-applicants/docker-entrypoint.sh
+    entrypoint: ./docker-entrypoint.sh
     stdin_open: true
     tty: true
     command: bash -c "bundle exec rails s -p 3001 -b 0.0.0.0"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+echo "Initializing BOPS"
 echo "Bundling gems"
 bundle check || bundle install
 


### PR DESCRIPTION
### Description of change

Not sure why we were exposing this API key publicly but this moves the logic to AWS parameter store

### Story Link

https://trello.com/c/vbc7MVod/741-move-api-keys-to-aws-parameter-store