### PR TITLE
Show warning text even when constraints/proposal details aren't defined

### DIFF
--- a/app/views/planning_applications/_policy_consideration_list.html.erb
+++ b/app/views/planning_applications/_policy_consideration_list.html.erb
@@ -8,12 +8,12 @@
     </h3>
   </div>
   <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-3" id="proposal-details-section">
-    <% if @planning_application.proposal_details.any? %>
-      <% if @planning_application.updated_address_or_boundary_geojson %>
-        <%= render "shared/warning_text",
-          message: "This application has been updated. The proposal details may no longer be accurate. Please check all relevant details have been provided." %>
-      <% end %>
+    <% if @planning_application.updated_address_or_boundary_geojson %>
+      <%= render "shared/warning_text",
+        message: "This application has been updated. The proposal details may no longer be accurate. Please check all relevant details have been provided." %>
+    <% end %>
 
+    <% if @planning_application.proposal_details.any? %>
       <ol class="govuk-list govuk-list--number">
         <% @planning_application.proposal_details.each do |proposal_detail| %>
           <li><%= @planning_application.proposal_detail_item(proposal_detail) %></li>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -12,16 +12,16 @@
       </h3>
     </div>
     <div class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1" id="constraints-section">
+      <% if @planning_application.updated_address_or_boundary_geojson %>
+        <%= render "shared/warning_text",
+          message: "This application has been updated. Please check the constraints are correct." %>
+      <% end %>
+
       <% if @planning_application.constraints.empty? %>
         <p class="govuk-body audit_details">
           No constraints identified by RIPA
         </p>
       <% else %>
-        <% if @planning_application.updated_address_or_boundary_geojson %>
-          <%= render "shared/warning_text",
-            message: "This application has been updated. Please check the constraints are correct." %>
-        <% end %>
-
         <ul class="govuk-list govuk-list--bullet">
           <% @planning_application.constraints.each do |constraint| %>
             <li><%= constraint %></li>


### PR DESCRIPTION
### Description of change

- From UAT feedback we want to still show the warning text in these situations where constraints / proposal details may be empty

https://trello.com/c/OpJtIGV9/765-include-a-prompt-when-address-or-polygons-are-updated-to-check-constraints-and-proposal-details