### PR TITLE
Move other change validation request as part of validation wizard

### DIFF
--- a/app/controllers/planning_application/validation_tasks_controller.rb
+++ b/app/controllers/planning_application/validation_tasks_controller.rb
@@ -9,7 +9,11 @@ class PlanningApplication
     private
 
     def set_planning_application
-      @planning_application = current_local_authority.planning_applications.find(planning_application_id)
+      @planning_application = planning_applications_scope.find(planning_application_id)
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications.includes(:other_change_validation_requests)
     end
 
     def planning_application_id

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -5,7 +5,6 @@ module ValidationRequestHelper
     [
       ["replacement_document", "Request replacement documents"],
       ["create_document", "Request a new document"],
-      ["other_validation", "Request other change to application"],
       ["red_line_boundary", "Request approval to a red line boundary change"]
     ]
   end

--- a/app/views/other_change_validation_requests/_form.html.erb
+++ b/app/views/other_change_validation_requests/_form.html.erb
@@ -39,6 +39,7 @@
                                label: { text: 'Explain to the applicant how the application can be made valid.', size: 's', class: 'govuk-label govuk-label--s'},
                                hint: { text: 'Add all information that they will need to complete this action.' },
                                rows: 5 %>
+
       <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>
   </div>

--- a/app/views/planning_application/validation_tasks/_other_validation_request.html.erb
+++ b/app/views/planning_application/validation_tasks/_other_validation_request.html.erb
@@ -1,0 +1,20 @@
+<li id="other-change-validation-tasks">
+  <h2 class="app-task-list__section">
+    Other validation issues
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        <%= link_to "Add an other validation request", new_planning_application_other_change_validation_request_path, class: "govuk-link" %>
+      </span>
+    </li>
+    <% @planning_application.other_change_validation_requests.each do |other_change_validation_request| %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= link_to "View other validation request ##{other_change_validation_request.sequence}",
+            edit_planning_application_other_change_validation_request_path(@planning_application, other_change_validation_request), class: "govuk-link" %>
+        </span>
+      </li>
+    <% end %>
+  </ul>
+</li>

--- a/app/views/planning_application/validation_tasks/index.html.erb
+++ b/app/views/planning_application/validation_tasks/index.html.erb
@@ -40,7 +40,9 @@
     <% end %>
 
     <ol class="app-task-list">
-      <li>
+      <%= render "other_validation_request" %>
+
+      <li id="review-tasks">
         <h2 class="app-task-list__section">
           Review
         </h2>

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -17,7 +17,7 @@
       </p>
       <div class="govuk-button-group">
         <%= link_to "Mark the application as valid", confirm_validation_planning_application_path(@planning_application), class: "govuk-button" %>
-        <%= link_to "Back", validate_form_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>
     <% elsif @planning_application.not_started? && @planning_application.validation_requests.any? %>
       <p class="govuk-body"><strong>You have marked items as invalid, so you cannot validate this application.</strong></p>
@@ -25,7 +25,7 @@
       <%= form_with model: @planning_application, url: invalidate_planning_application_path(@planning_application), local:true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
         <div class="govuk-button-group">
           <%= form.submit "Mark the application as invalid", class: "govuk-button", data: { module: "govuk-button"} %>
-          <%= link_to "Back", validate_form_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+          <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
         </div>
       <% end%>
     <% elsif @planning_application.invalidated? %>
@@ -51,7 +51,7 @@
       </p>
       <div class="govuk-button-group">
         <%= link_to "Mark the application as valid", confirm_validation_planning_application_path(@planning_application), class: "govuk-button" %>
-        <%= link_to "Back", validate_form_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>
     <% elsif @planning_application.validated? %>
       <p class="govuk-body">
@@ -68,7 +68,7 @@
       </h2>
       <p class="govuk-body">
         <%= validation_request_summary(@planning_application.validation_requests, @planning_application) %>
-        <%= link_to "Back", validate_form_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </p>
     <% end %>
   </div>

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -11,8 +11,9 @@
 <div class="govuk-button-group">
   <% if action_name.eql?("edit") %>
     <%= form.govuk_submit "Update" %>
+    <%= link_to "Back", planning_application_validation_requests_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
   <% else %>
     <%= form.govuk_submit "Add" %>
+    <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
   <% end %>
-  <%= link_to "Back", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
 </div>

--- a/features/step_definitions/validation_requests_steps.rb
+++ b/features/step_definitions/validation_requests_steps.rb
@@ -4,6 +4,14 @@ When("I view the application's validations requests") do
   visit planning_application_validation_requests_path(@planning_application)
 end
 
+When("I start the validation wizard") do
+  visit validate_form_planning_application_path(@planning_application)
+
+  steps %(
+    Given I press "Start now"
+  )
+end
+
 When("I create a new document validation request for a(n) {string} because {string}") do |type, reason|
   steps %(
     Given I view the application's validations requests
@@ -66,9 +74,8 @@ end
 
 Given("I create a(n) other change validation request with {string}") do |details|
   steps %(
-    Given I add a new validation request
-    And I choose "Request other change to application"
-    And I press "Next"
+    Given I start the validation wizard
+    And I press "Add an other validation request"
     And I fill in "Tell the applicant" with "#{details}"
     And I fill in "Explain to the applicant" with "Please make the change"
     And I press "Add"

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -22,21 +22,28 @@ RSpec.describe "Requesting description changes to a planning application", type:
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link "Validate application"
     click_link "Start now"
-    click_link "Send validation decision"
-    click_link "Start new or view existing requests"
-    click_link "Add new request"
-
-    choose "Request other change to application"
-    click_button "Next"
+    click_link "Add an other validation request"
 
     fill_in "Tell the applicant another reason why the application is invalid", with: "The wrong fee has been paid"
     fill_in "Explain to the applicant how the application can be made valid",
             with: "You need to pay £100, which is the correct fee"
-    click_button "Add"
+
+    within(".govuk-button-group") do
+      expect(page).to have_link("Back", href: planning_application_validation_tasks_path(planning_application))
+      click_button "Add"
+    end
 
     within(".change-requests") do
       expect(page).to have_content("Other")
       expect(page).to have_content("15 days")
+    end
+
+    click_link "Back"
+    within("#other-change-validation-tasks") do
+      expect(page).to have_link(
+        "View other validation request #1",
+        href: edit_planning_application_other_change_validation_request_path(planning_application, OtherChangeValidationRequest.last)
+      )
     end
 
     click_link "Application"
@@ -52,12 +59,7 @@ RSpec.describe "Requesting description changes to a planning application", type:
   it "only accepts a request that contains a summary and suggestion" do
     click_link "Validate application"
     click_link "Start now"
-    click_link "Send validation decision"
-    click_link "Start new or view existing requests"
-    click_link "Add new request"
-
-    choose "Request other change to application"
-    click_button "Next"
+    click_link "Add an other validation request"
 
     fill_in "Tell the applicant another reason why the application is invalid", with: ""
     fill_in "Explain to the applicant how the application can be made valid", with: ""

--- a/spec/system/planning_applications/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validation_tasks_index_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Validation tasks", type: :system do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create :user, :assessor, local_authority: default_local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :invalidated, local_authority: default_local_authority
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_validation_tasks_path(planning_application)
+  end
+
+  it "displays all the validation tasks list" do
+    within(".app-task-list") do
+      within("#other-change-validation-tasks") do
+        expect(page).to have_content("Other validation issues")
+        expect(page).to have_link(
+          "Add an other validation request",
+          href: new_planning_application_other_change_validation_request_path(planning_application)
+        )
+      end
+
+      within("#review-tasks") do
+        expect(page).to have_content("Review")
+        expect(page).to have_link(
+          "Send validation decision",
+          href: validation_decision_planning_application_path(planning_application)
+        )
+      end
+    end
+
+    expect(page).to have_link("Back", href: planning_application_path(planning_application))
+  end
+end


### PR DESCRIPTION
### Description of change

This PR handles moving the other change validation requests step as part of the new validation wizard feature

### Story Link

https://trello.com/c/JoUXPR4v/719-validation-wizard-2-add-other-validation-requests-to-the-tasklist