### PR TITLE
Avoid using N+1 queries in planning applications and audit index

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -4,6 +4,6 @@ class AuditsController < AuthenticationController
   before_action :set_planning_application
 
   def index
-    @audits = @planning_application.audits
+    @audits = @planning_application.audits.with_user_and_api_user
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -18,11 +18,9 @@ class PlanningApplicationsController < AuthenticationController
 
   def index
     @planning_applications = if helpers.exclude_others? && current_user.assessor?
-                               current_local_authority.planning_applications.where(user_id: current_user.id).order("created_at DESC").or(
-                                 current_local_authority.planning_applications.where(user_id: nil).order("created_at DESC")
-                               )
+                               planning_applications_scope.for_user_and_null_users(current_user.id)
                              else
-                               current_local_authority.planning_applications.all.order("created_at DESC")
+                               planning_applications_scope
                              end
   end
 
@@ -292,6 +290,10 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   private
+
+  def planning_applications_scope
+    @planning_applications_scope ||= current_local_authority.planning_applications.with_user.by_created_at_desc
+  end
 
   def planning_application_params
     permitted_keys = %i[address_1

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -5,6 +5,8 @@ class Audit < ApplicationRecord
   belongs_to :user, optional: true
   belongs_to :api_user, optional: true
 
+  scope :with_user_and_api_user, -> { preload(:user, :api_user) }
+
   enum activity_type: {
     approved: "approved",
     assessed: "assessed",

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -32,6 +32,10 @@ class PlanningApplication < ApplicationRecord
   belongs_to :boundary_created_by, class_name: "User", optional: true
   belongs_to :local_authority
 
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+  scope :with_user, -> { preload(:user) }
+  scope :for_user_and_null_users, ->(user_id) { where(user_id: [user_id, nil]) }
+
   before_create :set_key_dates
   before_create :set_change_access_id
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Audit, type: :model do
+  describe "validations" do
+    subject(:audit) { described_class.new }
+
+    describe "#activity_type" do
+      it "validates presence" do
+        expect { audit.valid? }.to change { audit.errors[:activity_type] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { audit.valid? }.to change { audit.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe PlanningApplication, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe ".by_created_at_desc" do
+      let!(:planning_application1) { create(:planning_application, created_at: Time.zone.now - 1.day) }
+      let!(:planning_application2) { create(:planning_application, created_at: Time.zone.now) }
+      let!(:planning_application3) { create(:planning_application, created_at: Time.zone.now - 2.days) }
+
+      it "returns planning applications sorted by created at desc (i.e. most recent first)" do
+        expect(described_class.by_created_at_desc).to eq([planning_application2, planning_application1, planning_application3])
+      end
+    end
+
+    describe ".for_user_and_null_users" do
+      let!(:user1) { create(:user) }
+      let!(:user2) { create(:user) }
+      let!(:planning_application1) { create(:planning_application, user: user1) }
+      let!(:planning_application2) { create(:planning_application, user: user2) }
+      let!(:planning_application3) { create(:planning_application, user: nil) }
+
+      it "returns planning applications for a given user_id and all other null users" do
+        expect(described_class.for_user_and_null_users(user1.id)).to eq(
+          [planning_application1, planning_application3]
+        )
+      end
+    end
+  end
+
   describe "callbacks" do
     describe "::after_create" do
       context "when there is a postcode set" do


### PR DESCRIPTION
- Avoid using N+1 queries in planning applications and audit index
- Use scopes instead of sql queries in the controller
- Add missing model spec for Audit

