### PR TITLE
Prevent requests being added after application has been validated

### DIFF
--- a/app/views/other_change_validation_requests/_form.html.erb
+++ b/app/views/other_change_validation_requests/_form.html.erb
@@ -33,12 +33,14 @@
       <%= form.govuk_text_area :summary,
                                label: { text: 'Tell the applicant another reason why the application is invalid.', size: 's', class: 'govuk-label govuk-label--s'},
                                hint: { text: 'Only add one reason for each request.' },
-                               rows: 5 %>
+                               rows: 5,
+                               readonly: @planning_application.validated? %>
 
       <%= form.govuk_text_area :suggestion,
                                label: { text: 'Explain to the applicant how the application can be made valid.', size: 's', class: 'govuk-label govuk-label--s'},
                                hint: { text: 'Add all information that they will need to complete this action.' },
-                               rows: 5 %>
+                               rows: 5,
+                               readonly: @planning_application.validated? %>
 
       <%= render "shared/validation_request_form_actions", form: form %>
     <% end %>

--- a/app/views/planning_application/validation_tasks/_other_validation_request.html.erb
+++ b/app/views/planning_application/validation_tasks/_other_validation_request.html.erb
@@ -3,11 +3,13 @@
     Other validation issues
   </h2>
   <ul class="app-task-list__items">
-    <li class="app-task-list__item">
-      <span class="app-task-list__task-name">
-        <%= link_to "Add an other validation request", new_planning_application_other_change_validation_request_path, class: "govuk-link" %>
-      </span>
-    </li>
+    <% unless @planning_application.validated? %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= link_to "Add an other validation request", new_planning_application_other_change_validation_request_path, class: "govuk-link" %>
+        </span>
+      </li>
+    <% end %>
     <% @planning_application.other_change_validation_requests.each do |other_change_validation_request| %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -68,8 +68,8 @@
       </h2>
       <p class="govuk-body">
         <%= validation_request_summary(@planning_application.validation_requests, @planning_application) %>
-        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </p>
+      <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -10,7 +10,9 @@
 
 <div class="govuk-button-group">
   <% if action_name.eql?("edit") %>
-    <%= form.govuk_submit "Update" %>
+    <% unless @planning_application.validated? %>
+      <%= form.govuk_submit "Update" %>
+    <% end %>
     <%= link_to "Back", planning_application_validation_requests_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
   <% else %>
     <%= form.govuk_submit "Add" %>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -125,7 +125,9 @@
         </p>
       <% end %>
 
-      <%= link_to "Add new request", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <% unless @planning_application.validated? %>
+        <%= link_to "Add new request", new_planning_application_validation_request_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <% end %>
     </div>
     <% if @planning_application.not_started? %>
       <% if @planning_application.errors.any? %>

--- a/spec/factories/additional_document_validation_requests.rb
+++ b/spec/factories/additional_document_validation_requests.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :additional_document_validation_request do
-    planning_application
+    planning_application { create :planning_application, :invalidated }
     user
     state { "open" }
     document_request_type { "Floor plan" }

--- a/spec/factories/other_change_validation_requests.rb
+++ b/spec/factories/other_change_validation_requests.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :other_change_validation_request do
-    planning_application
+    planning_application { create :planning_application, :invalidated }
     user
     state { "open" }
     summary { "Incorrect fee" }

--- a/spec/factories/red_line_boundary_change_validation_requests.rb
+++ b/spec/factories/red_line_boundary_change_validation_requests.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :red_line_boundary_change_validation_request do
-    planning_application
+    planning_application { create :planning_application, :invalidated }
     user
     state { "open" }
     new_geojson do

--- a/spec/factories/replacement_document_validation_requests.rb
+++ b/spec/factories/replacement_document_validation_requests.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :replacement_document_validation_request do
-    planning_application
+    planning_application { create :planning_application, :invalidated }
     user
     old_document factory: :document
     new_document factory: :document

--- a/spec/helpers/validation_request_helper_spec.rb
+++ b/spec/helpers/validation_request_helper_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ValidationRequestHelper, type: :helper do
-  let(:planning_application) { create(:planning_application) }
+  let(:planning_application) { create(:planning_application, :invalidated) }
   let(:request) { create(:other_change_validation_request, planning_application: planning_application) }
   let(:document) { create(:document, planning_application: planning_application) }
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -25,10 +25,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       decision: "granted"
     )
   end
+  let!(:invalid_planning_application) { create(:planning_application, :invalidated) }
 
   let(:host) { "default.example.com" }
   let!(:validation_request) do
-    create(:other_change_validation_request, planning_application: planning_application, user: assessor)
+    create(:other_change_validation_request, planning_application: invalid_planning_application, user: assessor)
   end
 
   let!(:document_with_tags) do

--- a/spec/models/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/models/red_line_boundary_change_validation_request_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe RedLineBoundaryChangeValidationRequest, type: :model do
 
     describe "::before_create" do
       it "sets the original geojson field using the planning application boundary geojson" do
-        planning_application = create(:planning_application, :with_boundary_geojson)
+        planning_application = create(:planning_application, :invalidated, :with_boundary_geojson)
         red_line_boundary_change_validation_request = create(:red_line_boundary_change_validation_request,
                                                              planning_application: planning_application)
 

--- a/spec/requests/api/additional_document_validation_request_patch_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_patch_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to patch document create requests", type: :request, 
 
   let!(:api_user) { create :api_user }
   let!(:default_local_authority) { build(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
 
   let!(:additional_document_validation_request) do
     create(:additional_document_validation_request,

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Additional document validation requests API", type: :request, show_exceptions: true do
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:additional_document_validation_request) do
     create(:additional_document_validation_request, planning_application: planning_application)
   end

--- a/spec/requests/api/other_change_validation_request_put_spec.rb
+++ b/spec/requests/api/other_change_validation_request_put_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "API request to list change requests", type: :request, show_exceptions: true do
   let!(:api_user) { create :api_user }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:other_change_validation_request) do
     create(:other_change_validation_request,
            planning_application: planning_application)

--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Other change validation requests API", type: :request, show_exceptions: true do
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:other_change_validation_request) do
     create(:other_change_validation_request, planning_application: planning_application)
   end

--- a/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to patch document validation requests", type: :reque
   let!(:default_local_authority) { create(:local_authority, :default) }
 
   let!(:api_user) { create :api_user }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
 
   let!(:red_line_boundary_change_validation_request) do
     create(:red_line_boundary_change_validation_request,

--- a/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Red line boundary change validation requests API", type: :request, show_exceptions: true do
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, :with_boundary_geojson, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, :with_boundary_geojson, local_authority: default_local_authority) }
   let!(:red_line_boundary_change_validation_request) do
     create(:red_line_boundary_change_validation_request, planning_application: planning_application)
   end

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to patch document validation requests", type: :reque
 
   let!(:api_user) { create :api_user }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:document) do
     create(:document, :with_file, :public, planning_application: planning_application, validated: false,
                                            invalidated_document_reason: "Not readable")

--- a/spec/requests/api/replacement_document_validation_request_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Replacement document validation requests API", type: :request, show_exceptions: true do
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:replacement_document_validation_request) do
     create(:replacement_document_validation_request, planning_application: planning_application)
   end

--- a/spec/requests/api/validation_request_list_spec.rb
+++ b/spec/requests/api/validation_request_list_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "API request to list validation requests", type: :request, show_exceptions: true do
   let!(:api_user) { create :api_user }
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:description_change_validation_request) do
     create(:description_change_validation_request, planning_application: planning_application)
   end

--- a/spec/support/validation_request_shared_examples.rb
+++ b/spec/support/validation_request_shared_examples.rb
@@ -2,8 +2,8 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "ValidationRequest" do |_klass, request_type|
-  let(:planning_application) { create(:planning_application) }
+RSpec.shared_examples "ValidationRequest" do |klass, request_type|
+  let(:planning_application) { create(:planning_application, :invalidated) }
   let(:request) { create(request_type, planning_application: planning_application) }
 
   describe "validations" do
@@ -21,6 +21,17 @@ RSpec.shared_examples "ValidationRequest" do |_klass, request_type|
 
         another_request = create(request_type, planning_application: planning_application)
         expect(another_request.sequence).to eq(2)
+      end
+
+      context "when a planning application has been validated" do
+        let(:planning_application) { create(:planning_application, :in_assessment) }
+
+        it "prevents a #{request_type} validation request from being created" do
+          expect do
+            request
+          end.to raise_error(ValidationRequest::ValidationRequestNotCreatableError,
+                             "Cannot create #{klass.name} when planning application has been validated")
+        end
       end
     end
 

--- a/spec/support/validation_requests_shared_examples.rb
+++ b/spec/support/validation_requests_shared_examples.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
   let!(:current_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: current_local_authority) }
+  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: current_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: current_local_authority) }
   let!(:request) { create(request_type, planning_application: planning_application) }
 

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -322,4 +322,23 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).to have_content("The application is marked as invalid. The applicant was notified on #{invalid_planning_application.invalidated_at}")
     end
   end
+
+  context "Application validated" do
+    before do
+      planning_application = create(:planning_application, :in_assessment, local_authority: default_local_authority)
+
+      visit planning_application_path(planning_application)
+    end
+
+    it "does not allow you to add requests if application has been validated" do
+      click_link "Validate application"
+      click_link "Start now"
+      click_link "Send validation decision"
+      expect(page).to have_content("The application is marked as valid and cannot be marked as invalid.")
+
+      click_link "Back"
+      click_link "Review validation requests"
+      expect(page).not_to have_link("Add new request")
+    end
+  end
 end

--- a/spec/system/planning_applications/validation_banner_display_spec.rb
+++ b/spec/system/planning_applications/validation_banner_display_spec.rb
@@ -4,12 +4,10 @@ require "rails_helper"
 
 RSpec.describe "Validation banners", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:planning_application) { create :planning_application, :invalidated, local_authority: default_local_authority }
 
   context "Validation request banners are displayed correctly when open request is overdue" do
     let!(:assessor) { create :user, :assessor, local_authority: default_local_authority }
-
-    let!(:planning_application) { create :planning_application, local_authority: default_local_authority }
-
     let!(:replacement_document_validation_request) do
       create :replacement_document_validation_request, planning_application: planning_application, state: "open"
     end
@@ -37,13 +35,9 @@ RSpec.describe "Validation banners", type: :system do
 
   context "Validation warning banner is not displayed when request is closed" do
     let!(:assessor) { create :user, :assessor, local_authority: default_local_authority }
-
-    let!(:planning_application) { create :planning_application, local_authority: default_local_authority }
-
     let!(:replacement_document_validation_request) do
       create :replacement_document_validation_request, planning_application: planning_application, state: "closed"
     end
-
     let!(:additional_document_validation_request) do
       create :additional_document_validation_request, planning_application: planning_application, state: "closed"
     end

--- a/spec/system/planning_applications/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validation_tasks_index_spec.rb
@@ -15,25 +15,56 @@ RSpec.describe "Validation tasks", type: :system do
     visit planning_application_validation_tasks_path(planning_application)
   end
 
-  it "displays all the validation tasks list" do
-    within(".app-task-list") do
-      within("#other-change-validation-tasks") do
-        expect(page).to have_content("Other validation issues")
-        expect(page).to have_link(
-          "Add an other validation request",
-          href: new_planning_application_other_change_validation_request_path(planning_application)
-        )
-      end
-
-      within("#review-tasks") do
-        expect(page).to have_content("Review")
-        expect(page).to have_link(
-          "Send validation decision",
-          href: validation_decision_planning_application_path(planning_application)
-        )
-      end
+  context "when application is not started or invalidated" do
+    let!(:planning_application) do
+      create :planning_application, :invalidated, local_authority: default_local_authority
     end
 
-    expect(page).to have_link("Back", href: planning_application_path(planning_application))
+    it "displays the validation tasks list" do
+      within(".app-task-list") do
+        within("#other-change-validation-tasks") do
+          expect(page).to have_content("Other validation issues")
+          expect(page).to have_link(
+            "Add an other validation request",
+            href: new_planning_application_other_change_validation_request_path(planning_application)
+          )
+        end
+
+        within("#review-tasks") do
+          expect(page).to have_content("Review")
+          expect(page).to have_link(
+            "Send validation decision",
+            href: validation_decision_planning_application_path(planning_application)
+          )
+        end
+      end
+
+      expect(page).to have_link("Back", href: planning_application_path(planning_application))
+    end
+  end
+
+  context "when application has been validated" do
+    let!(:planning_application) do
+      create :planning_application, :in_assessment, local_authority: default_local_authority
+    end
+
+    it "displays the validation tasks list but no actions to create new requests can be taken" do
+      within(".app-task-list") do
+        within("#other-change-validation-tasks") do
+          expect(page).to have_content("Other validation issues")
+          expect(page).not_to have_link("Add an other validation request")
+        end
+
+        within("#review-tasks") do
+          expect(page).to have_content("Review")
+          expect(page).to have_link(
+            "Send validation decision",
+            href: validation_decision_planning_application_path(planning_application)
+          )
+        end
+      end
+
+      expect(page).to have_link("Back", href: planning_application_path(planning_application))
+    end
   end
 end


### PR DESCRIPTION
### Description of change

- Prevent requests being added after application has been validated
- Raise error if validation requests (apart from description change) are created when a planning application is validated
