### PR TITLE
Check if active replacement document validation request exists before displaying document invalid message

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -5,7 +5,7 @@
 
 <%= render "planning_applications/proposal_header" %>
 
-<% if @planning_application.invalid_documents.present? %>
+<% if @planning_application.replacement_document_validation_requests.open_or_pending.with_active_document.any? %>
 <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
   <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 25 25" height="25" width="25">

--- a/app/views/planning_application/validation_tasks/index.html.erb
+++ b/app/views/planning_application/validation_tasks/index.html.erb
@@ -20,7 +20,7 @@
       <%= link_to "Check documents", planning_application_documents_path(@planning_application), class: "govuk-link" %>
     </p>
 
-    <% if @planning_application.invalid_documents.present? %>
+    <% if @planning_application.replacement_document_validation_requests.open_or_pending.with_active_document.any? %>
       <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
         <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 25 25" height="25" width="25">


### PR DESCRIPTION
### Story Link

https://trello.com/c/NvXeIDis/723-validation-wizard-5-add-all-documents-to-the-tasklist