### PR TITLE
Allow policy classes to be updated when planning application is assessable

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -331,7 +331,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def policy_classes_editable
-    errors.add(:policy_classes, "cannot be added at this stage") if policy_classes_changed? && !in_assessment?
+    errors.add(:policy_classes, "cannot be added at this stage") if policy_classes_changed? && !can_assess?
   end
 
   def documents_for_decision_notice


### PR DESCRIPTION
https://trello.com/c/wDFiT5lk/825-cannot-add-a-new-class-to-an-application-once-it-has-been-submitted-to-manager-and-then-returned