### PR TITLE
Allow reviewer/managers to edit public comment decision notice text

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -3,7 +3,7 @@
 class PlanningApplicationsController < AuthenticationController
   before_action :set_planning_application, except: %i[new create index]
 
-  before_action :ensure_user_is_reviewer, only: %i[review review_form]
+  before_action :ensure_user_is_reviewer, only: %i[review review_form edit_public_comment]
 
   before_action :set_last_audit, only: %i[show validate_form view_recommendation submit_recommendation publish]
 
@@ -54,6 +54,8 @@ class PlanningApplicationsController < AuthenticationController
       redirect_to planning_application_fee_items_path(@planning_application, validate_fee: "yes"), notice: "Planning application payment amount was successfully updated."
     elsif @planning_application.update(planning_application_params)
       redirect_to @planning_application, notice: "Planning application was successfully updated."
+    elsif params[:edit_action] == "edit_public_comment"
+      render :edit_public_comment
     else
       render :edit
     end
@@ -117,6 +119,12 @@ class PlanningApplicationsController < AuthenticationController
 
   def recommendation_form
     @recommendation = @planning_application.recommendations.last || @planning_application.pending_or_new_recommendation
+  end
+
+  def edit_public_comment
+    respond_to do |format|
+      format.html { render :edit_public_comment }
+    end
   end
 
   def recommend
@@ -301,6 +309,7 @@ class PlanningApplicationsController < AuthenticationController
                         payment_reference
                         payment_amount
                         postcode
+                        public_comment
                         town
                         uprn
                         work_status]

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -69,6 +69,7 @@ class PlanningApplication < ApplicationRecord
                                            payment_reference
                                            payment_amount
                                            postcode
+                                           public_comment
                                            town
                                            uprn
                                            work_status].freeze

--- a/app/views/planning_applications/edit_public_comment.html.erb
+++ b/app/views/planning_applications/edit_public_comment.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, "Edit public comment" %>
+
+<%= render "planning_applications/assessment_dashboard" do %>
+  <h2 class="govuk-heading-m govuk-!-padding-top-3">Edit the information appearing on the decision notice</h2>
+
+  <p class="govuk-body">
+    The planning officer recommends that the application is <strong><%= @planning_application.decision %></strong>
+  </p>
+
+  <%= form_with model: @planning_application, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= hidden_field_tag(:edit_action, "edit_public_comment") %>
+
+    <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+      <% if form.object.errors.any? %>
+        <% form.object.errors.each do |error| %>
+          <span id="status-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span>
+            <%= error.type %>
+          </span>
+        <% end %>
+      <% end %>
+     </div>
+
+    <div class="govuk-form-group">
+      <span class="govuk-body">
+        <%= form.label :public_comment, class: "govuk-label--m" %>
+      </span>
+
+      <%= form.text_area :public_comment, class: "govuk-textarea", rows: "9" %>
+    </div>
+
+    <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+  <% end %>
+<% end %>

--- a/app/views/planning_applications/review_form.html.erb
+++ b/app/views/planning_applications/review_form.html.erb
@@ -19,6 +19,8 @@
     <%= @planning_application.public_comment %>
   </p>
 
+  <%= link_to "Edit this text", edit_public_comment_planning_application_path(@planning_application), class: "govuk-link" %>
+
   <%= render "recommendations", { recommendations: @planning_application.recommendations } %>
 
   <%= form_for @recommendation, url: review_planning_application_path(@planning_application) do |form| %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -201,6 +201,57 @@
       "note": ""
     },
     {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "994ddfe9be5cc79bcc8889a6ecb3da1781fbbaaf13d2a5cc8284c5ad863cd743",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/shared/_supporting_information.html.erb",
+      "line": 124,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"audits/types/#{audit_entry_template(PlanningApplicationPresenter.new(view_context, current_local_authority.planning_applications.find((params[:planning_application_id] or params[:id]))).audits.last)}\", { :locals => ({ :item => PlanningApplicationPresenter.new(view_context, current_local_authority.planning_applications.find((params[:planning_application_id] or params[:id]))).audits.last }) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "PlanningApplicationsController",
+          "method": "show",
+          "line": 27,
+          "file": "app/controllers/planning_applications_controller.rb",
+          "rendered": {
+            "name": "planning_applications/show",
+            "file": "app/views/planning_applications/show.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "planning_applications/show",
+          "line": 1,
+          "file": "app/views/planning_applications/show.html.erb",
+          "rendered": {
+            "name": "planning_applications/_assessment_dashboard",
+            "file": "app/views/planning_applications/_assessment_dashboard.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "planning_applications/_assessment_dashboard",
+          "line": 27,
+          "file": "app/views/planning_applications/_assessment_dashboard.html.erb",
+          "rendered": {
+            "name": "shared/_supporting_information",
+            "file": "app/views/shared/_supporting_information.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "shared/_supporting_information"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "note": ""
+    },
+    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "c94415625c7d2247e3915a74143dfb40f58d8880a171210510866a61f5eb4041",
@@ -321,6 +372,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-10-27 10:54:37 +0000",
+  "updated": "2022-04-20 17:22:00 +0100",
   "brakeman_version": "5.1.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,7 @@ en:
     label:
       planning_application:
         closed_or_cancellation_comment: "Provide a reason"
+        public_comment: "This information will appear on the decision notice:"
       additional_document_validation_request: &cancel_reason
         cancel_reason: "Explain to the applicant why this request is being cancelled"
       description_change_validation_request: *cancel_reason

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
       patch :save_assessment
       patch :assess
       get :review_form
+      get :edit_public_comment
       patch :review
       get :publish
       patch :determine


### PR DESCRIPTION
### Story Link

https://trello.com/c/YjtDWZhm/883-managers-to-edit-the-reasons-section-decision-notice-text-that-has-been-submitted-by-the-officer