### PR TITLE
Disable JavaScript source maps in production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -3,3 +3,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 const environment = require('./environment')
 
 module.exports = environment.toWebpackConfig()
+
+config.devtool = 'nosources-source-map'
+
+module.exports = config


### PR DESCRIPTION
### Description of change

Disable JavaScript source maps in production