### PR TITLE
Disable JavaScript source maps in production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -2,4 +2,7 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'production'
 
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+var config = environment.toWebpackConfig()
+config.devtool = 'nosources-source-map'
+
+module.exports = config


### PR DESCRIPTION
### Description of change

Disable JavaScript source maps in production [reference](https://storck.io/posts/rails-webpack-disable-source-maps-in-production/)