### PR TITLE
Update timeout for appspec hooks

### DIFF
--- a/lib/package_builder/config/appspec.yml
+++ b/lib/package_builder/config/appspec.yml
@@ -8,12 +8,16 @@ hooks:
   ApplicationStop:
     - location: scripts/application_stop
       runas: root
+      timeout: 60
   BeforeInstall:
     - location: scripts/before_install
       runas: root
+      timeout: 60
   AfterInstall:
     - location: scripts/after_install
       runas: root
+      timeout: 900
   ApplicationStart:
     - location: scripts/application_start
       runas: root
+      timeout: 60


### PR DESCRIPTION
### Description of change

- AWS has some defaults for this i.e. 1 hour for AfterInstall but we don't want to wait an hour for a failed deployment

