### PR TITLE
Only use flash alert and notice for messages

### DIFF
--- a/app/controllers/fee_items_controller.rb
+++ b/app/controllers/fee_items_controller.rb
@@ -18,7 +18,7 @@ class FeeItemsController < ValidationRequestsController
           redirect_to planning_application_validation_tasks_path(@planning_application),
                       notice: "Fee item was marked as valid."
         elsif @planning_application.valid_fee.nil?
-          flash.now[:error] = "You must first select Yes or No to continue."
+          flash.now[:alert] = "You must first select Yes or No to continue."
           render :show
         else
           redirect_to new_planning_application_other_change_validation_request_path(@planning_application,

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -46,7 +46,7 @@ class PlanningApplicationsController < AuthenticationController
 
   def update
     if @planning_application.recommendations.last.present? && !@planning_application.recommendations.last.submitted
-      flash.now[:error] = "Please complete in draft assessment before updating application fields."
+      flash.now[:alert] = "Please complete in draft assessment before updating application fields."
     end
 
     respond_to do |format|
@@ -118,7 +118,7 @@ class PlanningApplicationsController < AuthenticationController
       validation_requests = @planning_application.validation_requests
       @cancelled_validation_requests, @active_validation_requests = validation_requests.partition(&:cancelled?)
 
-      flash.now[:error] = "Please create at least one validation request before invalidating"
+      flash.now[:alert] = "Please create at least one validation request before invalidating"
       render "validation_requests/index"
     end
   end

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -18,7 +18,7 @@ class SitemapsController < AuthenticationController
           redirect_to planning_application_validation_tasks_path(@planning_application),
                       notice: "Red line boundary was marked as valid."
         elsif @planning_application.valid_red_line_boundary.nil?
-          flash.now[:error] = "You must first select Valid or Invalid to continue."
+          flash.now[:alert] = "You must first select Valid or Invalid to continue."
           render :show
         else
           redirect_to new_planning_application_red_line_boundary_change_validation_request_path

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -63,7 +63,7 @@ class ValidationRequestsController < AuthenticationController
   end
 
   def validation_notice_request_error(exception)
-    flash[:error] = "Notify was unable to send applicant email. Please contact the applicant directly."
+    flash[:alert] = "Notify was unable to send applicant email. Please contact the applicant directly."
 
     Appsignal.send_error(exception)
     render "planning_applications/show"

--- a/app/javascript/stylesheets/components/_flashes.scss
+++ b/app/javascript/stylesheets/components/_flashes.scss
@@ -8,14 +8,6 @@
     @include flash;
     color: govuk-colour("green");
   }
-  &.success {
-    @include flash;
-    color: govuk-colour("green");
-  }
-  &.error {
-    @include flash;
-    color: $govuk-error-colour;
-  }
   &.alert {
     @include flash;
     color: $govuk-error-colour;

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,0 +1,7 @@
+<div class="govuk-width-container">
+  <div class="flash <%= type %>">
+    <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
+      <%= message %>
+    </p>
+  </div>
+</div>

--- a/app/views/application/_flashes.html.erb
+++ b/app/views/application/_flashes.html.erb
@@ -1,9 +1,6 @@
-<% flash.each do |name, msg| %>
-  <div class="govuk-width-container">
-    <div class="flash <%= name %>">
-      <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">
-        <%= msg %>
-      </p>
-    </div>
-  </div>
+<% if flash.alert %>
+  <%= render(partial: "flash", locals: { message: flash.alert, type: "alert" }) %>
+<% end %>
+<% if flash.notice %>
+  <%= render(partial: "flash", locals: { message: flash.notice, type: "notice" }) %>
 <% end %>

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -283,7 +283,10 @@ RSpec.describe "Sign in", type: :system do
       travel 7.hours
       visit root_path
       expect(page).not_to have_content(user.name)
-      expect(page).to have_content("Your session expired. Please sign in again to continue.")
+
+      within(".flash") do
+        expect(page).to have_content("Your session expired. Please sign in again to continue.")
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

## What

Only use `alert` and `notice` for storing and rendering messages in `FlashHash`.

## Why

Data other than messages can be stored in the `FlashHash`, and Devise uses it to store the `timedout` boolean (see Devise docs - bottom of [this section](https://github.com/heartcombo/devise#configuring-controllers). This is causing a bug where we render 'true' (the value of `timedout`) on the page when the user session times out.

### Story Link

NA

### Decisions [OPTIONAL]

Alternatively we could just exclude the `timedout` key when we render flash messages, but that would mean that similar issues could arise in future. It seems like fairly standard practise just to use `alert` and `notice.

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA
