### PR TITLE
Update content of invalidation notice mail

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -365,10 +365,9 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def invalidation_notice_mail
-    PlanningApplicationMailer.invalidation_notice_mail(
-      @planning_application,
-      request.host
-    ).deliver_now
+    PlanningApplicationMailer
+      .invalidation_notice_mail(@planning_application)
+      .deliver_now
   end
 
   def receipt_notice_mail

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -27,13 +27,12 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
-  def invalidation_notice_mail(planning_application, host)
-    @host = host
+  def invalidation_notice_mail(planning_application)
     @planning_application = planning_application
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: "Your planning application is invalid",
+      subject: "Lawful Development Certificate application - changes needed",
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -1,27 +1,19 @@
-# <%= @planning_application.local_authority.name %>
-
 Dear <%= @planning_application.agent_or_applicant_name %>,
 
-Reference No.: <%= @planning_application.reference_in_full %>
-Proposal: <%= @planning_application.description %>
-Site Address: <%= @planning_application.full_address %>
+Application reference number: <%= @planning_application.reference_in_full %>
 
-Thank you for your planning application received on <%= @planning_application.received_at %>. Unfortunately your application is invalid and has not been registered.
+Address: <%= @planning_application.full_address.upcase %>
 
-To review the reasons for invalidation and make the changes required, please follow the link below:
+Your application for a Lawful Development Certificate contains errors or missing information. We cannot continue with your application until you make the necessary changes.
+
+To make changes, go to:
 
 <%= @planning_application.secure_change_url %>
 
-If your amendments contain further errors, we may request further changes to your application.
+If no changes are made by 16 September 2021, we may close your application and send you a refund.
 
-If we don’t hear from you:
+If you need help with your application, contact us at  <%= @planning_application.local_authority.email_address %>.
 
-We will take no further action on your application until you make the necessary change(s).
-
-If these change(s) are not received by <%= @planning_application.invalidation_response_due %>, your application will be returned to you and your payment refunded.
-
-Yours faithfully,
+Regards,
 
 <%= @planning_application.local_authority.name %>
-
-If you have any questions relating to your application, please contact us by email at  <%= @planning_application.local_authority.email_address %> with your application reference.

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -56,4 +56,8 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
       PlanningApplication.last
     )
   end
+
+  def invalidation_notice_mail
+    PlanningApplicationMailer.invalidation_notice_mail(PlanningApplication.last)
+  end
 end


### PR DESCRIPTION
### Description of change

- Update content of invalidation notice mail.
- Remove redundant host argument from `PlanningApplicationMailer.invalidation_notice_mail`.
- Add to `PlanningApplicationMailer.invalidation_notice_mail` to mailer previews.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Decisions [OPTIONAL]

NA

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA

<img width="531" alt="Screenshot 2022-05-23 at 08 21 36" src="https://user-images.githubusercontent.com/25392162/169765341-99995ca9-9baf-40f7-84a0-ceb525506756.png">

