### PR TITLE
Add council code to RIPA test local authority

### DIFF
--- a/db/migrate/20220510091300_add_council_code_to_local_authorities.rb
+++ b/db/migrate/20220510091300_add_council_code_to_local_authorities.rb
@@ -14,6 +14,8 @@ class AddCouncilCodeToLocalAuthorities < ActiveRecord::Migration[6.1]
         local_authority.update(council_code: "SWK")
       when "buckinghamshire"
         local_authority.update(council_code: "BUC")
+      when "ripa"
+        local_authority.update(council_code: "RIPA")
       else
         raise "Did not update the council code for local authority: #{local_authority.name}"
       end


### PR DESCRIPTION
- Didn't realise we had this set up in our staging db so the migration raised an error that it did not update this

