### PR TITLE
Update how application number is set

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -571,7 +571,13 @@ class PlanningApplication < ApplicationRecord
   end
 
   def set_application_number
-    self.application_number = local_authority.planning_applications.count + 100
+    local_authority_planning_applications = local_authority.planning_applications
+
+    self.application_number = if local_authority_planning_applications.any?
+                                local_authority_planning_applications.maximum(:application_number) + 1
+                              else
+                                100
+                              end
   end
 
   def created_at_year

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -128,6 +128,24 @@ RSpec.describe PlanningApplication, type: :model do
           expect(planning_application3.application_number).to eq("00100")
         end
       end
+
+      context "when a planning application is deleted" do
+        let(:local_authority) { create :local_authority }
+        let(:planning_application1) { create :planning_application, local_authority: local_authority }
+        let(:planning_application2) { create :planning_application, local_authority: local_authority }
+        let(:planning_application3) { create :planning_application, local_authority: local_authority }
+        let(:planning_application4) { create :planning_application, local_authority: local_authority }
+
+        it "updates the application number incrementing after the existing maximum application number" do
+          expect(planning_application1.application_number).to eq("00100")
+          expect(planning_application2.application_number).to eq("00101")
+          expect(planning_application3.application_number).to eq("00102")
+
+          planning_application2.destroy
+
+          expect(planning_application4.application_number).to eq("00103")
+        end
+      end
     end
 
     describe "::after_create" do


### PR DESCRIPTION
- Previous way might be a bit problematic if planning applications are deleted since an existing application number may clash when calculating against a count