### PR TITLE
Update content of cancelled validation request email

### DIFF
--- a/app/controllers/concerns/validation_requests.rb
+++ b/app/controllers/concerns/validation_requests.rb
@@ -97,10 +97,9 @@ module ValidationRequests
               "Validation request: #{request_klass_name}, ID: #{request_type_instance.id} must have a cancelled state."
       end
 
-      PlanningApplicationMailer.cancelled_validation_request_mail(
-        @planning_application,
-        request_type_instance
-      ).deliver_now
+      PlanningApplicationMailer
+        .cancelled_validation_request_mail(@planning_application)
+        .deliver_now
     end
   end
 end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -61,8 +61,15 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
-  def cancelled_validation_request_mail(planning_application, validation_request)
-    build_validation_request_mail(planning_application, validation_request)
+  def cancelled_validation_request_mail(planning_application)
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: "Update on your application for a Lawful Development Certificate",
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+    )
   end
 
   def description_change_mail(planning_application, description_change_request)
@@ -84,20 +91,6 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: "Changes to your Lawful Development Certificate application",
-      to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
-    )
-  end
-
-  private
-
-  def build_validation_request_mail(planning_application, validation_request)
-    @planning_application = planning_application
-    @validation_request = validation_request
-
-    view_mail(
-      NOTIFY_TEMPLATE_ID,
-      subject: "Your planning application at: #{@planning_application.full_address}",
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )

--- a/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
@@ -1,16 +1,19 @@
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
 Application number: <%= @planning_application.reference_in_full %>
-Application received: <%= @planning_application.received_at %>
-At: <%= @planning_application.full_address %>
 
-Hi <%= @planning_application.agent_or_applicant_name %>,
+Address: <%= @planning_application.full_address.upcase %>
 
-<%= @validation_request.user.name %>, the officer working on your planning application has cancelled one of the validation requests(s) on your application. You no longer need to take action for this request.
+We no longer need you to make a change to your application. You do not need to take further action for this request.
 
-To see the reason this request was cancelled and review any remaining validation requests please follow the link below:
+To see why this request was cancelled and review any remaining changes, go to:
 
 <%= @planning_application.secure_change_url %>
 
-If you have no further changes left the officer will shortly review your case to decide if it is valid.
+We cannot continue with your application until you make all the necessary changes.
 
-Yours faithfully,
+If you need help with your application, contact us at <%= @planning_application.local_authority.email_address %>.
+
+Regards,
+
 <%= @planning_application.local_authority.name %>

--- a/features/step_definitions/validation_requests_steps.rb
+++ b/features/step_definitions/validation_requests_steps.rb
@@ -166,7 +166,8 @@ end
 Then("an email is sent to the applicant confirming the validation request cancellation") do
   body = ActionMailer::Base.deliveries.last.body.to_s
   expect(body).to include(@planning_application.secure_change_url)
+
   expect(body).to include(
-    "officer working on your planning application has cancelled one of the validation requests(s) on your application."
+    "We no longer need you to make a change to your application."
   )
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -279,8 +279,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
   describe "#cancelled_validation_request_mail" do
     let(:cancelled_validation_request_mail) do
-      described_class.cancelled_validation_request_mail(planning_application.reload, validation_request)
+      described_class.cancelled_validation_request_mail(planning_application)
     end
+
+    let(:mail_body) { cancelled_validation_request_mail.body.encoded }
 
     it "emails only the agent when the agent is present" do
       expect(cancelled_validation_request_mail.to).to eq([planning_application.agent_email])
@@ -288,28 +290,35 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "emails only the applicant when the agent is missing" do
       planning_application.update!(agent_email: "")
-      mail = described_class.cancelled_validation_request_mail(planning_application.reload, validation_request)
+      mail = described_class.cancelled_validation_request_mail(planning_application.reload)
 
       expect(mail.to).to eq([planning_application.applicant_email])
     end
 
-    it "renders the headers" do
-      expect(cancelled_validation_request_mail.subject).to eq("Your planning application at: #{planning_application.full_address}")
-      expect(cancelled_validation_request_mail.to).to eq([planning_application.agent_email])
+    it "sets subject" do
+      expect(cancelled_validation_request_mail.subject).to eq(
+        "Update on your application for a Lawful Development Certificate"
+      )
     end
 
-    it "renders the body" do
-      body = cancelled_validation_request_mail.body.encoded
-      expect(body).to include("Application number: #{planning_application.reference_in_full}")
-      expect(body).to include("Application received: #{planning_application.received_at}")
-      expect(body).to include("At: #{planning_application.full_address}")
-      expect(body).to include("Hi #{planning_application.agent_or_applicant_name}")
-      expect(body).to include("#{validation_request.user.name}, the officer working on your planning application has cancelled one of the validation requests(s) on your application. You no longer need to take action for this request.")
-      expect(body).to include("To see the reason this request was cancelled and review any remaining validation requests please follow the link below:")
-      expect(body).to include(planning_application.change_access_id)
-      expect(body).to include("http://cookies.example.com/validation_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}")
-      expect(body).to include("Yours faithfully")
-      expect(body).to include(planning_application.local_authority.name.to_s)
+    it "sets recipient" do
+      expect(cancelled_validation_request_mail.to).to contain_exactly(
+        "cookie_crackers@example.com"
+      )
+    end
+
+    it "includes the reference" do
+      expect(mail_body).to include("Application number: ABC-22-00100-LDCP")
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include("Address: 123 HIGH STREET, BIG CITY, AB3 4EF")
+    end
+
+    it "includes the validation request url" do
+      expect(mail_body).to include(
+        "http://cookies.example.com/validation_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}"
+      )
     end
 
     it "includes the name of the agent in the body if agent is present" do
@@ -319,7 +328,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the name of the applicant in the body if no agent is present" do
       planning_application.update!(agent_first_name: "")
-      mail = described_class.cancelled_validation_request_mail(planning_application.reload, validation_request)
+      mail = described_class.cancelled_validation_request_mail(planning_application.reload)
 
       expect(mail.body.encoded).to include(planning_application.applicant_first_name)
       expect(mail.body.encoded).to include(planning_application.applicant_last_name)

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -50,4 +50,10 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   def validation_request_mail
     PlanningApplicationMailer.validation_request_mail(PlanningApplication.last)
   end
+
+  def cancelled_validation_request_mail
+    PlanningApplicationMailer.cancelled_validation_request_mail(
+      PlanningApplication.last
+    )
+  end
 end


### PR DESCRIPTION
### Description of change

- Update email content.
- Remove redundant `validation_request argument` from `PlanningApplicationMailer#cancelled_validation_request_mail`.
- Add email to mailer previews.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Decisions [OPTIONAL]

NA

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA

<img width="531" alt="Screenshot 2022-05-23 at 08 27 11" src="https://user-images.githubusercontent.com/25392162/169767658-82866377-5ac3-4628-b325-f6ca24af237a.png">