### PR TITLE
Update content of description closure notification email

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -83,7 +83,7 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: "Your planning application at: #{@planning_application.full_address}",
+      subject: "Changes to your Lawful Development Certificate application",
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )

--- a/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
+++ b/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
@@ -1,14 +1,17 @@
 Dear <%= @planning_application.agent_or_applicant_name %>,
 
-Reference: <%= @planning_application.reference_in_full %>
-Site address: <%= @planning_application.full_address %>
-Description: <%= @planning_application.description %>
+Application reference number: <%= @planning_application.reference_in_full %>
 
-The proposed description change which you were told about 5 business days ago has been automatically accepted.
-To see the updated description please follow the link below:
+Address: <%= @planning_application.full_address.upcase %>
+
+We have changed the project description on your application for a Lawful Development Certificate. The changes were made automatically because you did not review them by <%= @description_change_request.request_expiry_date.strftime("%-d %B %Y") %>.
+
+To see the updated description, go to:
 
 <%= @planning_application.secure_change_url %>
 
+If you need help with your application, contact us at <%= @planning_application.local_authority.email_address %>.
 
-Yours faithfully,
+Regards,
+
 <%= @planning_application.local_authority.name %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -370,7 +370,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   context "creating description changes for an undetermined application" do
-    let!(:planning_application) do
+    let(:planning_application) do
       create(
         :planning_application,
         agent_email: "agent@example.com",
@@ -435,22 +435,48 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
     end
 
-    describe "# description_closure_notification_mail" do
-      let!(:description_closure_mail) do
-        described_class.description_closure_notification_mail(planning_application, description_change_request)
+    describe "#description_closure_notification_mail" do
+      let(:description_closure_mail) do
+        described_class.description_closure_notification_mail(
+          planning_application,
+          description_change_request
+        )
       end
 
-      it "renders the headers" do
-        expect(description_closure_mail.subject).to eq("Your planning application at: #{planning_application.full_address}")
-        expect(description_closure_mail.to).to eq([planning_application.agent_email])
+      let(:mail_body) { description_closure_mail.body.encoded }
+
+      it "sets the subject" do
+        expect(description_closure_mail.subject).to eq(
+          "Changes to your Lawful Development Certificate application"
+        )
       end
 
-      it "renders the body" do
-        expect(description_closure_mail.body.encoded).to match("Reference: #{planning_application.reference_in_full}")
-        expect(description_closure_mail.body.encoded).to match("Site address: #{planning_application.full_address}")
-        expect(description_closure_mail.body.encoded).to match("Description: #{planning_application.description}")
-        expect(description_closure_mail.body.encoded).to match("The proposed description change which you were told about 5 business days ago has been automatically accepted.")
-        expect(description_closure_mail.body.encoded).to match("To see the updated description please follow the link below:")
+      it "sets the recipient" do
+        expect(description_closure_mail.to).to contain_exactly(
+          "agent@example.com"
+        )
+      end
+
+      it "includes the reference" do
+        expect(mail_body).to include(
+          "Application reference number: ABC-22-00100-LDCP"
+        )
+      end
+
+      it "includes the address" do
+        expect(mail_body).to include(
+          "Address: 123 HIGH STREET, BIG CITY, AB3 4EF"
+        )
+      end
+
+      it "includes the review deadline" do
+        expect(mail_body).to include("17 May 2022")
+      end
+
+      it "includes the validation request url" do
+        expect(mail_body).to include(
+          "http://cookies.example.com/validation_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}"
+        )
       end
     end
   end

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -38,6 +38,15 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
     )
   end
 
+  def description_closure_notification_mail
+    planning_application = PlanningApplication.last
+
+    PlanningApplicationMailer.description_closure_notification_mail(
+      planning_application,
+      planning_application.description_change_validation_requests.last
+    )
+  end
+
   def validation_request_mail
     PlanningApplicationMailer.validation_request_mail(PlanningApplication.last)
   end


### PR DESCRIPTION
### Description of change

- Update content of `PlanningApplicationMailer#description_closure_notification_email`.
- Add email to previews.

A brief description of the change, with enough context for the reviewer to be able to understand why we're making this change.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Decisions [OPTIONAL]

NA

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA

<img width="531" alt="Screenshot 2022-05-23 at 08 43 53" src="https://user-images.githubusercontent.com/25392162/169769396-e0ea2688-73cb-4c50-9147-cf067192ebd7.png">