### PR TITLE
Update content of decision notice email

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -7,12 +7,11 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
 
   def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application
-    @documents = @planning_application.documents.for_display
     @host = host
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: "Lawful Development Certificate: #{@planning_application.decision}",
+      subject: "Decision on your Lawful Development Certificate  application",
       to: user
     )
   end

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -1,12 +1,23 @@
 Dear <%= @planning_application.agent_or_applicant_name %>,
 
-Reference: <%= @planning_application.reference_in_full %>
-Site address: <%= @planning_application.full_address %>
-Description: <%= @planning_application.description %>
+Application reference number: <%= @planning_application.reference_in_full %>
 
-Your Lawful Development Certificate (<%= @planning_application.work_status %>) has been <%= @planning_application.decision %>.
+Address: <%= @planning_application.full_address.upcase %>
 
-To see the full decision notice, please visit <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
+<% if @planning_application.refused? %>
+  We regret to inform you that your application for a Lawful Development Certificate has been refused. For details of our decision, go to:
 
-Yours faithfully,
+  <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
+
+  To appeal this decision, read [Appeal a decision about a lawful development certificate on GOV.UK](https://www.gov.uk/appeal-lawful-development-certificate-decision).
+<% else %>
+  We are pleased to inform you that a decision has been made to grant you a Lawful Development Certificate. To see your certificate, go to:
+
+  <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
+<% end %>
+
+If you have any questions about your application, contact us at <%= @planning_application.local_authority.email_address %>.
+
+Regards,
+
 <%= @planning_application.local_authority.name %>

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -18,4 +18,14 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
       planning_application.agent_email
     )
   end
+
+  def decision_notice_mail
+    planning_application = PlanningApplication.last
+
+    PlanningApplicationMailer.decision_notice_mail(
+      planning_application,
+      "https://www.example.com",
+      planning_application.agent_email
+    )
+  end
 end


### PR DESCRIPTION

### Description of change

- Update content of `PlanningApplicationMailer#decision_notice_mail`.
- Add email to previews.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Decisions [OPTIONAL]

NA

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA

<img width="536" alt="Screenshot 2022-05-23 at 08 53 31" src="https://user-images.githubusercontent.com/25392162/169771181-7f914322-a08e-4546-8cdf-5d5899db9d30.png">

<img width="530" alt="Screenshot 2022-05-23 at 13 24 49" src="https://user-images.githubusercontent.com/25392162/169818883-ef13a446-ad04-46fc-a3eb-19a50503b984.png">

