### PR TITLE
Update content of validation request email

### DIFF
--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -16,11 +16,10 @@ class ValidationRequestsController < AuthenticationController
 
   private
 
-  def send_validation_request_email(request)
-    PlanningApplicationMailer.validation_request_mail(
-      @planning_application,
-      request
-    ).deliver_now
+  def send_validation_request_email
+    PlanningApplicationMailer
+      .validation_request_mail(@planning_application)
+      .deliver_now
   end
 
   def send_description_request_email(request)
@@ -34,7 +33,7 @@ class ValidationRequestsController < AuthenticationController
     if request.is_a?(DescriptionChangeValidationRequest)
       send_description_request_email(request)
     else
-      send_validation_request_email(request)
+      send_validation_request_email
     end
 
     request.mark_as_sent!

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -50,8 +50,15 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
-  def validation_request_mail(planning_application, validation_request)
-    build_validation_request_mail(planning_application, validation_request)
+  def validation_request_mail(planning_application)
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: "Lawful Development Certificate application  - further changes needed",
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+    )
   end
 
   def cancelled_validation_request_mail(planning_application, validation_request)

--- a/app/views/planning_application_mailer/validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_mail.text.erb
@@ -1,19 +1,19 @@
-Application number: <%= @planning_application.reference_in_full %>
-Application received: <%= @planning_application.received_at %>
-At: <%= @planning_application.full_address %>
-
 Dear <%= @planning_application.agent_or_applicant_name %>,
 
-<%= @validation_request.user.name %>, the case officer working on your planning application has requested change(s) on your application.
+Application reference number: <%= @planning_application.reference_in_full %>
 
-To review the requested change please follow the link below:
+Address: <%= @planning_application.full_address %>
+
+We need you to make some more changes to your application for a Lawful Development Certificate. We cannot continue with your application until you make these changes.
+
+To make the changes, go to:
 
 <%= @planning_application.secure_change_url %>
 
-We will take no further action on your application until you respond to the requested change(s) at the link above.
+If we do not hear from you we may close your application and send you a refund.
 
-If these change(s) are not received by <%= @validation_request.response_due %>, your application will be returned to you and your payment refunded.
+If you need help with your application, contact us at <%= @planning_application.local_authority.email_address %>.
 
-Yours faithfully,
+Regards,
 
 <%= @planning_application.local_authority.name %>

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -37,4 +37,8 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
       planning_application.description_change_validation_requests.last
     )
   end
+
+  def validation_request_mail
+    PlanningApplicationMailer.validation_request_mail(PlanningApplication.last)
+  end
 end


### PR DESCRIPTION
### Description of change

- Update content of `PlanningApplicationMailer.validation_request_mail`.
- Remove redundant `validation_request` argument.
- Add to previews.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Decisions [OPTIONAL]

NA

### Known issues [OPTIONAL]

NA

### Further testing or sign off required [OPTIONAL]

NA

<img width="530" alt="Screenshot 2022-05-23 at 09 25 12" src="https://user-images.githubusercontent.com/25392162/169776693-d1474068-550c-4f70-8a2e-d1b74a90eb3e.png">

