### PR TITLE
Bug red line boundary

### DIFF
--- a/app/models/red_line_boundary_change_validation_request.rb
+++ b/app/models/red_line_boundary_change_validation_request.rb
@@ -20,6 +20,10 @@ class RedLineBoundaryChangeValidationRequest < ApplicationRecord
     end
   end
 
+  def geojson
+    new_geojson.presence || planning_application.boundary_geojson
+  end
+
   private
 
   def set_original_geojson

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -32,7 +32,9 @@
                                         size: 's',
                                         class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4' },
                                class: "govuk-visually-hidden" %>
-      <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
+
+      <% geojson = @red_line_boundary_change_validation_request.new_geojson.present? ? @red_line_boundary_change_validation_request.new_geojson : @planning_application.boundary_geojson %>
+      <%= render "shared/location_map", locals: { geojson: geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
 
       <% if action_name.eql?("edit") %>
         <h2 class="govuk-heading-m govuk-!-padding-top-6">

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -33,8 +33,7 @@
                                         class: 'govuk-label govuk-label--s govuk-!-padding-bottom-4' },
                                class: "govuk-visually-hidden" %>
 
-      <% geojson = @red_line_boundary_change_validation_request.new_geojson.present? ? @red_line_boundary_change_validation_request.new_geojson : @planning_application.boundary_geojson %>
-      <%= render "shared/location_map", locals: { geojson: geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
+      <%= render "shared/location_map", locals: { geojson: @red_line_boundary_change_validation_request.geojson, geojson_field: 'red-line-boundary-change-validation-request-new-geojson-field' } %>
 
       <% if action_name.eql?("edit") %>
         <h2 class="govuk-heading-m govuk-!-padding-top-6">

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -19,7 +19,7 @@
   const map = document.querySelector("my-map");
   <% if locals[:geojson_field].present? %>
     map.addEventListener("geojsonChange", ({ detail: geoJSON }) => {
-      document.getElementById("<%= locals[:geojson_field] %>").value = JSON.stringify(geoJSON);
+      document.querySelector("[id^='<%= locals[:geojson_field] %>']").value = JSON.stringify(geoJSON);
     });
   <% end %>
   <% if locals[:in_accordion] == true %>


### PR DESCRIPTION
### Description of change

On red line boundary request page we validate the fields `new_geojson` and `reason`. There are 2 issues now
- When the user submits the form with a new geojson and without a reason, the form returns an error that the reason must be present. The issue here was that we were passing always the old geojson, so it was drawing the new geojson the one that it was drawn by the user.
- When the user submits the form with a reason and without new geojson, the form returns an error that the red line boundary must be drawn. The issue here was that we were getting the values of the new geojson by a specific id. When Rails raise an error the id was having an addition `-error` at the end so it was unable to get the new values. The solution was to make it more dynamic and get the values using a regex

### Story Link

https://trello.com/c/VL8dgKVG