### PR TITLE
Include signatory name in decision notice

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -5,4 +5,8 @@ class LocalAuthority < ApplicationRecord
   has_many :planning_applications, dependent: :destroy
 
   validates :council_code, presence: true
+
+  def signatory
+    "#{signatory_name}, #{signatory_job_title}"
+  end
 end

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -104,7 +104,7 @@
     Post
   </h3>
   <p class="govuk-body">
-    <%= planning_application.local_authority.signatory_job_title %>, <br>
+    <%= planning_application.local_authority.signatory %>, <br>
     <%= planning_application.local_authority.name %>, <br>
     <%= planning_application.local_authority.enquiries_paragraph %>.
   </p>

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -11,5 +11,19 @@ RSpec.describe LocalAuthority, type: :model do
         expect { local_authority.valid? }.to change { local_authority.errors[:council_code] }.to ["can't be blank"]
       end
     end
+
+    describe "#signatory" do
+      let(:local_authority) do
+        build(
+          :local_authority,
+          signatory_name: "Jane Smith",
+          signatory_job_title: "Director"
+        )
+      end
+
+      it "returns signatory name and job title" do
+        expect(local_authority.signatory).to eq("Jane Smith, Director")
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/determine_application_spec.rb
+++ b/spec/system/planning_applications/determine_application_spec.rb
@@ -3,7 +3,15 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application Assessment", type: :system do
-  let(:default_local_authority) { create(:local_authority, :default) }
+  let(:default_local_authority) do
+    create(
+      :local_authority,
+      :default,
+      signatory_name: "Jane Smith",
+      signatory_job_title: "Director"
+    )
+  end
+
   let!(:planning_application) do
     create(:planning_application, :awaiting_determination,
            local_authority: default_local_authority,
@@ -66,6 +74,14 @@ RSpec.describe "Planning Application Assessment", type: :system do
           "View decision notice",
           href: decision_notice_planning_application_path(planning_application)
         )
+
+        click_link("View decision notice")
+
+        expect(page).to have_content(
+          "Certificate of Lawful Use or Development Granted"
+        )
+
+        expect(page).to have_content("Jane Smith, Director")
 
         visit planning_application_path(planning_application)
 


### PR DESCRIPTION
### Description of change

Include signatory name in postal address rendered in decision notice.

### Story Link

https://trello.com/c/H0B3Uvwa/946-directors-name-missing-from-decision-notice

### Screenshot

<img width="689" alt="Screenshot 2022-05-23 at 14 35 26" src="https://user-images.githubusercontent.com/25392162/169838089-23d81262-9939-4f5e-9889-4875fdc97336.png">
