### PR TITLE
Add suffix LDCP for proposed and LDCE for existing LDCs

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -585,6 +585,6 @@ class PlanningApplication < ApplicationRecord
   end
 
   def application_type_code
-    I18n.t(application_type, scope: "application_type_codes")
+    I18n.t(work_status, scope: "application_type_codes.#{application_type}")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,9 @@ en:
     full: "Full Householder Application"
     lawfulness_certificate: "Lawful Development Certificate"
   application_type_codes:
-    lawfulness_certificate: "LDCP"
+    lawfulness_certificate:
+      proposed: "LDCP"
+      existing: "LDCE"
   archive_reasons:
     scale: "Missing scale bar or north arrow"
     design: "Revise design"

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -229,14 +229,19 @@ RSpec.describe PlanningApplication, type: :model do
 
   describe "#reference_in_full" do
     let(:local_authority) { create(:local_authority, council_code: "SWK") }
-    let(:planning_application) { create(:planning_application, application_type: 0, local_authority: local_authority) }
+    let(:planning_application1) { create(:planning_application, application_type: 0, local_authority: local_authority, work_status: "proposed") }
+    let(:planning_application2) { create(:planning_application, application_type: 0, local_authority: local_authority, work_status: "existing") }
 
     before do
       travel_to Time.zone.local(2022, 10, 10)
     end
 
-    it "returns a string constructed of the council code and reference" do
-      expect(planning_application.reference_in_full).to eq("SWK-22-00100-LDCP")
+    it "returns a string constructed of the council code and reference for proposed LDCs" do
+      expect(planning_application1.reference_in_full).to eq("SWK-22-00100-LDCP")
+    end
+
+    it "returns a string constructed of the council code and reference for existing LDCs" do
+      expect(planning_application2.reference_in_full).to eq("SWK-22-00100-LDCE")
     end
   end
 


### PR DESCRIPTION
### Description of change

- Use work_status on planning application to determine whether LDC is existing or proposed

### Story Link

https://trello.com/c/zSxcxMr8/910-case-numbering-mvp
