### PR TITLE
Add logging for cron jobs

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,6 +21,8 @@
 
 # Learn more: http://github.com/javan/whenever
 
+set :output, "#{Whenever.path}/log/scheduled_jobs.log"
+
 every 1.day, at: "9:00 am" do
   rake "jobs:close_description_change"
 end


### PR DESCRIPTION
### Description of change

Specify an output file for cron jobs, as per the [whenever gem documentation](https://github.com/javan/whenever/wiki/Output-redirection-aka-logging-your-cron-jobs).

Currently we have one scheduled job, and it's clear from the data that it hasn't been running in the preview environment. The job runs fine when I execute it manually. And as far as I can see we are writing to the crontab correctly. So in order to debug this I think we need more logging!

### Story Link

https://trello.com/c/clR8DFF4/667-check-why-description-change-auto-closed-after-5-days