### PR TITLE
Show applicant descriptions on documents page

### DIFF
--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -36,6 +36,11 @@
           <p class="govuk-body govuk-!-margin-bottom-1">
             File name: <%= document.name %>
           </p>
+          <% if document.applicant_description.present? %>
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              Applicant description: <%= document.applicant_description %>
+            </p>
+          <% end %>
           <p class="govuk-body govuk-!-margin-bottom-1">
             Date received: <%= document.received_at_or_created %>
           </p>

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -13,8 +13,12 @@ RSpec.describe "Documents index page", type: :system do
   end
 
   let!(:document) do
-    create :document, :with_file,
-           planning_application: planning_application
+    create(
+      :document,
+      :with_file,
+      planning_application: planning_application,
+      applicant_description: "This is the proposed side elevation"
+    )
   end
 
   context "as a user who is not logged in" do
@@ -47,6 +51,12 @@ RSpec.describe "Documents index page", type: :system do
 
     it "Document management page does not contain accordion" do
       expect(page).not_to have_text("Application information")
+    end
+
+    it "shows the applicant description" do
+      expect(page).to have_text(
+        "Applicant description: This is the proposed side elevation"
+      )
     end
 
     it "File image opens in new tab" do


### PR DESCRIPTION
### Description of change

Display the `applicant_description` for each document on the documents page.

### Story Link

https://trello.com/c/clR8DFF4/667-check-why-description-change-auto-closed-after-5-days