### PR TITLE
Display placeholder image and error for unrepresentable active storage blobs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -48,6 +48,7 @@ Metrics/ClassLength:
     - 'app/controllers/planning_applications_controller.rb'
     - 'app/models/planning_application.rb'
     - 'app/models/document.rb'
+    - 'app/controllers/documents_controller.rb'
 
 # Offense count: 4
 # Configuration parameters: IgnoredMethods, Max.

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -7,6 +7,7 @@ class DocumentsController < AuthenticationController
   before_action :set_document, only: %i[edit update archive confirm_archive unarchive]
   before_action :disable_flash_header, only: :index
   before_action :ensure_document_edits_unlocked, only: %i[new edit update archive unarchive]
+  before_action :ensure_blob_is_representable, only: %i[edit update archive unarchive]
   before_action :validate_document?, only: %i[edit update]
 
   def index
@@ -120,5 +121,9 @@ class DocumentsController < AuthenticationController
     else
       planning_application_documents_path(@planning_application)
     end
+  end
+
+  def ensure_blob_is_representable
+    render plain: "forbidden", status: :forbidden and return unless @document.representable?
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -6,6 +6,7 @@ class Document < ApplicationRecord
   belongs_to :planning_application
 
   delegate :audits, to: :planning_application
+  delegate :representable?, to: :file
 
   include Auditable
 

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -3,66 +3,22 @@
     <% documents.each do |document| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-quarter">
-          <% if document.file.representable? %>
-            <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                        url_for_document(document), target: :_blank %>
-            <% end %>
-          <p class="govuk-body">
-            <%= link_to "View in new window", url_for_document(document), target: :_new, class: "govuk-link" %>
-          </p>
+          <%= render "documents/document_row_image", document: document, resize: "500x500", width: 180, height: 120 %>
         </td>
+
         <td class="govuk-table__cell govuk-!-width-one-half">
-          <% if document.tags.present? %>
-            <p class="govuk-body">
-              <% document.tags.each do |tag| %>
-                <% if is_plan_tag(tag) %>
-                  <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
-                <% end %>
-              <% end %>
-            </p>
-            <% document.tags.each do |tag| %>
-              <% if is_evidence_tag(tag) %>
-                <p class="govuk-body">
-                  <strong class="govuk-tag govuk-tag--turquoise">EVIDENCE</strong><strong class="govuk-tag govuk-tag--turquoise"><%= tag  %></strong><br/>
-                </p>
-              <% end %>
-            <% end %>
-          <% end %>
-          <% if document.invalidated_document_reason %>
-            <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold">
-              Invalid: <%= document.invalidated_document_reason %>
-            </p>
-          <% end %>
-          <p class="govuk-body govuk-!-margin-bottom-1">
-            File name: <%= document.name %>
-          </p>
-          <% if document.applicant_description.present? %>
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              Applicant description: <%= document.applicant_description %>
-            </p>
-          <% end %>
-          <p class="govuk-body govuk-!-margin-bottom-1">
-            Date received: <%= document.received_at_or_created %>
-          </p>
-          <% if document.numbers.present? %>
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              Document reference(s): <%= document.numbers %>
-            </p>
-          <% end %>
-          <p class="govuk-body govuk-!-margin-bottom-1">
-            Included in decision notice: <%= document.referenced_in_decision_notice? ? "Yes" : "No" %>
-          </p>
-          <p class="govuk-body govuk-!-margin-bottom-1">
-            Public: <%= document.publishable? ? "Yes" : "No" %>
-          </p>
-        </td>
+          <%= render "documents/document_row_info", document: document %>
+        </div>
+
         <% unless action_name == "validation_documents" %>
           <td class="govuk-table__cell">
             <% if @planning_application.can_validate? %>
-              <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
-                <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br/>
-                <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %>
-              </p>
+              <% if document.representable? %>
+                <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
+                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br/>
+                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %>
+                </p>
+              <% end %>
             <% end %>
           </td>
         <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -1,0 +1,11 @@
+<% if document.representable? %>
+  <%= link_to image_tag(document.file.representation(resize: resize), style: "max-width:100%"),
+      url_for_document(document), target: :_blank %>
+  <p class="govuk-body">
+    <%= link_to "View in new window", url_for_document(document), target: :_new, class: "govuk-link" %>
+  </p>
+<% else %>
+  <div class="govuk-grid-column-one-third">
+    <%= image_pack_tag("placeholder/blank_image.png", alt: "Blank image", width: width, height: height) %>
+  </div>
+<% end %>

--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -1,0 +1,58 @@
+<% if document.representable? %>
+  <% if document.tags.present? %>
+    <p class="govuk-body">
+      <% document.tags.each do |tag| %>
+        <% if is_plan_tag(tag) %>
+          <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+        <% end %>
+      <% end %>
+    </p>
+    <% document.tags.each do |tag| %>
+      <% if is_evidence_tag(tag) %>
+        <p class="govuk-body">
+          <strong class="govuk-tag govuk-tag--turquoise">EVIDENCE</strong> <strong class="govuk-tag govuk-tag--turquoise"><%= tag  %></strong><br/>
+        </p>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if document.invalidated_document_reason %>
+    <p class="govuk-body govuk-!-margin-bottom-1 govuk-!-font-weight-bold">
+      Invalid: <%= document.invalidated_document_reason %>
+    </p>
+  <% end %>
+  <p class="govuk-body govuk-!-margin-bottom-1">
+    File name: <%= document.name %>
+  </p>
+  <% if document.applicant_description.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      Applicant description: <%= document.applicant_description %>
+    </p>
+  <% end %>
+  <p class="govuk-body govuk-!-margin-bottom-1">
+    Date received: <%= document.received_at_or_created %>
+  </p>
+  <% if document.numbers.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      Document reference(s): <%= document.numbers %>
+    </p>
+  <% end %>
+  <p class="govuk-body govuk-!-margin-bottom-1">
+    Included in decision notice: <%= document.referenced_in_decision_notice? ? "Yes" : "No" %>
+  </p>
+  <p class="govuk-body govuk-!-margin-bottom-1">
+    Public: <%= document.publishable? ? "Yes" : "No" %>
+  </p>
+<% else %>
+  <p class="govuk-body">
+    <strong>This document has been removed due to a security issue</strong>
+  </p>
+  <p class="govuk-body">
+    Error: Infected file found
+  </p>
+  <p class="govuk-body">
+    File name: <%= document.name %>
+  </p>
+  <p class="govuk-body">
+    Date received: <%= document.received_at_or_created %>
+  </p>
+<% end %>

--- a/app/views/planning_application/validation_tasks/_document_validation.html.erb
+++ b/app/views/planning_application/validation_tasks/_document_validation.html.erb
@@ -13,6 +13,8 @@
         </li>
       <% else %>
         <% @planning_application.documents.active.each_with_index do |document, index| %>
+          <% next unless document.representable? %>
+
           <%= content_tag(:li, id: dom_id(document), class: "app-task-list__item") do %>
             <%= @planning_application.document_task_list(document) %>
           <% end %>

--- a/app/views/planning_applications/validation_documents.html.erb
+++ b/app/views/planning_applications/validation_documents.html.erb
@@ -13,6 +13,12 @@
   <p class="govuk-body-m">
     Check all necessary documents have been provided and add requests for any missing documents.
   </p>
+
+  <% unless @documents.any? && @documents.all?(&:representable?) %>
+    <%= render "shared/warning_text",
+        message: "One or more documents that the applicant submitted are not available due to a security issue. Ask the applicant or agent for replacements." %>
+  <% end %>
+
   <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
   <p class="govuk-body">
     <%= link_to "Add a request for a missing document",

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -16,62 +16,20 @@
       <%= link_to "Manage documents", planning_application_documents_path(@planning_application), class: "govuk-link" %>
     </p>
 
-      <div class="scroll-docs">
-        <% filter_current(@planning_application.documents).each do |document| %>
-          <hr>
+    <div class="scroll-docs">
+      <% filter_current(@planning_application.documents).each do |document| %>
+        <hr>
+
         <div class="govuk-grid-row">
-          <main class="govuk-main-wrapper">
           <div class="govuk-grid-column-one-third">
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              <% if document.file.representable? %>
-                <%= link_to image_tag(document.file.representation(resize: "200x110")),
-                url_for_document(document), target: :_blank %>
-              <% end %>
-            </p>
-            <p class="govuk-body">
-              <%= link_to "View in new window", url_for_document(document), target: :_blank, class: "govuk-link" %>
-            </p>
+            <%= render "documents/document_row_image", document: document, resize: "200x110", width: 90, height: 110 %>
           </div>
 
           <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-            <% if document.tags.present? %>
-              <p class="govuk-body">
-                <% document.tags.each do |tag| %>
-                  <% if is_plan_tag(tag) %>
-                    <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
-                  <% end %>
-                <% end %>
-              </p>
-              <% document.tags.each do |tag| %>
-                <% if is_evidence_tag(tag) %>
-                  <p class="govuk-body">
-                    <strong class="govuk-tag govuk-tag--turquoise">EVIDENCE</strong> <strong class="govuk-tag govuk-tag--turquoise"><%= tag  %></strong><br/>
-                  </p>
-                <% end %>
-              <% end %>
-            <% end %>
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              File name: <%= document.name %>
-            </p>
-            <p class="govuk-body govuk-!-margin-bottom-1">
-              Date received: <%= document.received_at_or_created %>
-            </p>
-            <% if document.numbers.present? %>
-              <p class="govuk-body govuk-!-margin-bottom-1">
-                Document reference(s): <%= document.numbers %>
-              </p>
-              <p class="govuk-body govuk-!-margin-bottom-1">
-                Included in decision notice: <%= document.referenced_in_decision_notice? ? "Yes" : "No" %>
-              </p>
-              <p class="govuk-body govuk-!-margin-bottom-1">
-                Public: <%= document.publishable? ? "Yes" : "No" %>
-              </p>
-            <% end %>
+            <%= render "documents/document_row_info", document: document %>
           </div>
-        </main>
         </div>
-        <% end %>
-      </div>
-
+      <% end %>
+    </div>
   </div>
 </div>

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -242,4 +242,21 @@ RSpec.describe "Documents index page", type: :system do
       expect(page).to have_content("Cannot archive document with an open or pending validation request")
     end
   end
+
+  context "when a document has been removed due to a security issue" do
+    let!(:document) do
+      create :document, planning_application: planning_application
+    end
+
+    before do
+      sign_in assessor
+      allow_any_instance_of(Document).to receive(:representable?).and_return(false)
+    end
+
+    it "cannot archive" do
+      visit edit_planning_application_document_path(planning_application, document)
+
+      expect(page).to have_content("forbidden")
+    end
+  end
 end

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -152,5 +152,25 @@ RSpec.describe "Edit document numbers page", type: :system do
         expect(page).to have_content "All documents listed on the decision notice must have a document number"
       end
     end
+
+    context "when a document has been removed due to a security issue" do
+      let!(:document) do
+        create :document, planning_application: planning_application
+      end
+
+      before do
+        allow_any_instance_of(Document).to receive(:representable?).and_return(false)
+
+        click_button "Documents"
+        click_link "Manage documents"
+      end
+
+      it "displays a placeholder image with error information" do
+        expect(page).to have_content("This document has been removed due to a security issue")
+        expect(page).to have_content("Error: Infected file found")
+        expect(page).to have_content("File name: proposed-floorplan.png")
+        expect(page).to have_content("Date received: #{document.received_at_or_created}")
+      end
+    end
   end
 end

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -44,5 +44,21 @@ RSpec.describe "Edit document", type: :system do
       expect(page).not_to have_content("Is the document valid?")
       expect(page).not_to have_css("#validate-document")
     end
+
+    context "when a document has been removed due to a security issue" do
+      let!(:document) do
+        create :document, planning_application: planning_application
+      end
+
+      before do
+        allow_any_instance_of(Document).to receive(:representable?).and_return(false)
+      end
+
+      it "cannot edit" do
+        visit edit_planning_application_document_path(planning_application, document)
+
+        expect(page).to have_content("forbidden")
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -475,4 +475,28 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       end
     end
   end
+
+  context "when a document has been removed due to a security issue" do
+    let!(:document) do
+      create :document, planning_application: planning_application
+    end
+
+    before do
+      allow_any_instance_of(Document).to receive(:representable?).and_return(false)
+
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "Validate required documents are on application"
+    end
+
+    it "I can see a warning if a document has been removed due to a security issue" do
+      within(".govuk-warning-text") do
+        expect(page).to have_content("One or more documents that the applicant submitted are not available due to a security issue. Ask the applicant or agent for replacements.")
+      end
+
+      expect(page).to have_content("This document has been removed due to a security issue")
+      expect(page).to have_content("Error: Infected file found")
+      expect(page).to have_content("File name: proposed-floorplan.png")
+      expect(page).to have_content("Date received: #{document.received_at_or_created}")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Display placeholder image and error for unrepresentable active storage blobs
- This occurs when a file has been removed in S3 due to security issues flagged by our virus scanning service BucketAV
- When we call #representable? on a blob and it returns false it would blow up our pages where we invoke #representation.

### Story Link

https://trello.com/c/MnUFOKkE/952-develop-ticket-for-displaying-documents-with-virus-malware