### PR TITLE
Add not null constraint on name / subdomain for local authorities

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,7 +4,7 @@ class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
 
-  validates :council_code, presence: true
+  validates :council_code, :name, :subdomain, presence: true
 
   def signatory
     "#{signatory_name}, #{signatory_job_title}"

--- a/db/migrate/20220526152433_add_not_null_constraints_to_local_authorities.rb
+++ b/db/migrate/20220526152433_add_not_null_constraints_to_local_authorities.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintsToLocalAuthorities < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :local_authorities, :name, false
+    change_column_null :local_authorities, :subdomain, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_10_131942) do
+ActiveRecord::Schema.define(version: 2022_05_26_152433) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,8 +140,8 @@ ActiveRecord::Schema.define(version: 2022_05_10_131942) do
   end
 
   create_table "local_authorities", force: :cascade do |t|
-    t.string "name"
-    t.string "subdomain"
+    t.string "name", null: false
+    t.string "subdomain", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "signatory_name"

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe LocalAuthority, type: :model do
       end
     end
 
+    describe "#name" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:name] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#subdomain" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:subdomain] }.to ["can't be blank"]
+      end
+    end
+
     describe "#signatory" do
       let(:local_authority) do
         build(


### PR DESCRIPTION
- These fields are mandatory and we don't have any UI to create local authority records so we must at least enforce integrity at the db level