### PR TITLE
Revert #639

### DIFF
--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -23,11 +23,6 @@
   <p class="govuk-body govuk-!-margin-bottom-1">
     File name: <%= document.name %>
   </p>
-  <% if document.applicant_description.present? %>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      Applicant description: <%= document.applicant_description %>
-    </p>
-  <% end %>
   <p class="govuk-body govuk-!-margin-bottom-1">
     Date received: <%= document.received_at_or_created %>
   </p>

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -13,12 +13,7 @@ RSpec.describe "Documents index page", type: :system do
   end
 
   let!(:document) do
-    create(
-      :document,
-      :with_file,
-      planning_application: planning_application,
-      applicant_description: "This is the proposed side elevation"
-    )
+    create(:document, :with_file, planning_application: planning_application)
   end
 
   context "as a user who is not logged in" do
@@ -51,12 +46,6 @@ RSpec.describe "Documents index page", type: :system do
 
     it "Document management page does not contain accordion" do
       expect(page).not_to have_text("Application information")
-    end
-
-    it "shows the applicant description" do
-      expect(page).to have_text(
-        "Applicant description: This is the proposed side elevation"
-      )
     end
 
     it "File image opens in new tab" do


### PR DESCRIPTION
### Description of change

- Revert commit 796effecfad204f3d26f00d97b540a8bd7d9c640

### Story Link

Reverts https://github.com/unboxed/bops/pull/639 because I misunderstood the ticket requirement. We just needed to establish why the field _wasn't_ rendering on another page. Turns out it's because the information isn't sent through from RIPA, so no code changes needed.