### PR TITLE
Make corrections to email text

### DIFF
--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -10,7 +10,7 @@ To make changes, go to:
 
 <%= @planning_application.secure_change_url %>
 
-If no changes are made by 16 September 2021, we may close your application and send you a refund.
+If no changes are made by <%= @planning_application.invalidation_response_due.strftime("%-d %B %Y") %>, we may close your application and send you a refund.
 
 If you need help with your application, contact us at  <%= @planning_application.local_authority.email_address %>.
 

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -18,7 +18,7 @@ If there are no issues with your application, we will start assessing it against
 
 We may contact you or a person of your choosing to arrange a site visit.
 
-You have the right to appeal to the Secretary of State if by <%= (@planning_application.received_at + 8.weeks).strftime("%-d %B %Y") %>
+You have the right to appeal to the Secretary of State if by <%= (@planning_application.received_at + 8.weeks).strftime("%-d %B %Y") %>:
 
 - you have not been told that the application is invalid
 - you have not been given a decision in writing

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         local_authority: local_authority,
         address_1: "123 High Street", # rubocop:disable Naming/VariableNumber
         town: "Big City",
-        postcode: "AB3 4EF"
+        postcode: "AB3 4EF",
+        invalidated_at: DateTime.new(2022, 6, 5)
       )
     end
 
@@ -197,6 +198,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(mail_body).to include(
         "http://cookies.example.com/validation_requests?planning_application_id=#{planning_application.id}&change_access_id=#{planning_application.change_access_id}"
       )
+    end
+
+    it "includes the invalidation response due date" do
+      expect(mail_body).to include("27 June 2022")
     end
   end
 

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -3,13 +3,11 @@
 class PlanningApplicationMailerPreview < ActionMailer::Preview
   def cancelled_validation_request_mail
     PlanningApplicationMailer.cancelled_validation_request_mail(
-      PlanningApplication.last
+      planning_application
     )
   end
 
   def decision_notice_mail
-    planning_application = PlanningApplication.last
-
     PlanningApplicationMailer.decision_notice_mail(
       planning_application,
       "https://www.example.com",
@@ -18,8 +16,6 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   end
 
   def description_change_mail
-    planning_application = PlanningApplication.last
-
     PlanningApplicationMailer.description_change_mail(
       planning_application,
       planning_application.description_change_validation_requests.last
@@ -27,8 +23,6 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   end
 
   def description_closure_notification_mail
-    planning_application = PlanningApplication.last
-
     PlanningApplicationMailer.description_closure_notification_mail(
       planning_application,
       planning_application.description_change_validation_requests.last
@@ -36,12 +30,10 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   end
 
   def invalidation_notice_mail
-    PlanningApplicationMailer.invalidation_notice_mail(PlanningApplication.last)
+    PlanningApplicationMailer.invalidation_notice_mail(planning_application)
   end
 
   def receipt_notice_mail
-    planning_application = PlanningApplication.last
-
     PlanningApplicationMailer.receipt_notice_mail(
       planning_application,
       planning_application.agent_email
@@ -49,8 +41,6 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   end
 
   def validation_notice_mail
-    planning_application = PlanningApplication.last
-
     PlanningApplicationMailer.validation_notice_mail(
       planning_application,
       planning_application.agent_email
@@ -58,6 +48,12 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   end
 
   def validation_request_mail
-    PlanningApplicationMailer.validation_request_mail(PlanningApplication.last)
+    PlanningApplicationMailer.validation_request_mail(planning_application)
+  end
+
+  private
+
+  def planning_application
+    @planning_application ||= PlanningApplication.last
   end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -595,4 +595,18 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  describe "#invalidation_response_due" do
+    let(:planning_application) do
+      create(:planning_application, invalidated_at: DateTime.new(2020, 6, 5))
+    end
+
+    it "returns date 15 business days after invalidated date" do
+      expect(
+        planning_application.invalidation_response_due
+      ).to eq(
+        Date.new(2020, 6, 26)
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Replace accidentally hard-coded (🤦 ) date in `invalidation_notice_mail` email with dynamic date.
- Add colon in `receipt_notice_mail`.

### Story Link

https://trello.com/c/k5gJiyx8/855-resolve-notifications-text-and-incorporate-more-recent-comments

### Screenshots

`receipt_notice_mail`:
![Screenshot 2022-06-06 at 09 53 46](https://user-images.githubusercontent.com/25392162/172133736-fcf6717e-9ac0-4044-be7d-33ce400cb921.png)

`invalidation_notice_mail`:
![Screenshot 2022-06-06 at 10 07 12](https://user-images.githubusercontent.com/25392162/172133744-3047d704-4634-4317-ae96-6e1de4f994f0.png)