### PR TITLE
Remove edit red line boundary change functionality

### DIFF
--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -3,14 +3,15 @@
 class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsController
   include ValidationRequests
 
-  before_action :set_red_line_boundary_validation_request, only: %i[show edit update]
   before_action :ensure_no_open_or_pending_red_line_boundary_validation_request, only: %i[new]
 
   def new
     @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.new
   end
 
-  def show; end
+  def show
+    @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
+  end
 
   def create
     @red_line_boundary_change_validation_request = RedLineBoundaryChangeValidationRequest.new(red_line_boundary_change_validation_request_params
@@ -27,24 +28,9 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
     end
   end
 
-  def edit; end
-
-  def update
-    if @red_line_boundary_change_validation_request.update(red_line_boundary_change_validation_request_params)
-      redirect_to planning_application_validation_tasks_path(@planning_application),
-                  notice: "Validation request for red line boundary successfully updated"
-    else
-      render :edit
-    end
-  end
-
   private
 
   def red_line_boundary_change_validation_request_params
     params.require(:red_line_boundary_change_validation_request).permit(:new_geojson, :reason)
-  end
-
-  def set_red_line_boundary_validation_request
-    @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
   end
 end

--- a/app/views/red_line_boundary_change_validation_requests/_propose_change.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_propose_change.html.erb
@@ -30,5 +30,11 @@
 </h2>
 <%= render "shared/location_map", locals: { geojson: @red_line_boundary_change_validation_request.new_geojson } %>
 
-<%= render "shared/validation_request_show_actions",
-    planning_application: @planning_application, validation_request: @red_line_boundary_change_validation_request %>
+<%= render(
+ partial: "shared/validation_request_show_actions",
+ locals: {
+   planning_application: @planning_application,
+   validation_request: @red_line_boundary_change_validation_request,
+   include_edit: false
+ }
+) %>

--- a/app/views/red_line_boundary_change_validation_requests/edit.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/edit.html.erb
@@ -1,8 +1,0 @@
-<% content_for :page_title do %>
-  Update red line boundary validation request - <%= t('page_title') %>
-<% end %>
-
-<%= render "validation_requests/validation_requests_breadcrumbs" %>
-<% content_for :title, "Update red line boundary change" %>
-
-<%= render "form" %>

--- a/app/views/shared/_validation_request_show_actions.html.erb
+++ b/app/views/shared/_validation_request_show_actions.html.erb
@@ -14,7 +14,13 @@
     <% end %>
 
     <% if planning_application.not_started? %>
-      <%= edit_request_url(planning_application, validation_request, classname: "govuk-button govuk-button--secondary") %>
+      <% if local_assigns.fetch(:include_edit, true) %>
+        <%= edit_request_url(
+          planning_application,
+          validation_request,
+          classname: "govuk-button govuk-button--secondary"
+        ) %>
+      <% end %>
       <%= delete_confirmation_request_url(planning_application, validation_request, classname: "govuk-button govuk-button--secondary") %>
     <% end %>
   <% end %>

--- a/features/editing_validation_requests.feature
+++ b/features/editing_validation_requests.feature
@@ -28,16 +28,6 @@ Scenario: I can edit an other type of validation request before its been sent
   And I view the application's validations requests
   Then the page contains "change those manners"
 
-Scenario: I can edit a red line boundary request before its been sent
-  When I view the application's validations requests
-  And I click link "View and update" in table row for "Red line boundary changes"
-  And I press "Edit request"
-  And I fill in "Explain to the applicant why changes are proposed to the red line boundary" with "bound to be changes"
-  When I press "Update"
-  And I view the application's validations requests
-  And I press "View request red line boundary"
-  Then the page contains "bound to be changes"
-
 Scenario: I cannot edit a validation request after its been sent
   When the planning application is invalidated
   And I view the application's validations requests


### PR DESCRIPTION
### Description of change

- Don't render button for editing `RedLineBoundaryChangeValidationRequest`.
- Remove redundant views and actions.

### Story Link

https://trello.com/c/Qc5m79FS/975-fix-issues-with-edit-red-line-request