### PR TITLE
Handle Active Storage missing image errors

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -144,6 +144,13 @@ class Document < ApplicationRecord
     replacement_document_validation_request.try(:reason) || super
   end
 
+  def image_url(resize_to_limit = [1000, 1000])
+    file.representation(resize_to_limit: resize_to_limit).processed.url
+  rescue ActiveStorage::PreviewError => e
+    logger.warn("Image retrieval failed for document ##{id} with error '#{e.message}'")
+    nil
+  end
+
   private
 
   def tag_values_permitted

--- a/app/views/api/v1/replacement_document_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/replacement_document_validation_requests/_show.json.jbuilder
@@ -11,16 +11,12 @@ json.extract! replacement_document_validation_request,
 json.old_document do
   json.name replacement_document_validation_request.old_document.file.filename
   json.invalid_document_reason replacement_document_validation_request.invalidated_document_reason
-  json.url replacement_document_validation_request.old_document.file.representation(
-    resize_to_limit: [1000, 1000]
-  ).processed.url
+  json.url replacement_document_validation_request.old_document.image_url
 end
 
 json.new_document do
   if replacement_document_validation_request.new_document
     json.name replacement_document_validation_request.new_document.file.filename
-    json.url replacement_document_validation_request.new_document.file.representation(
-      resize_to_limit: [1000, 1000]
-    ).processed.url
+    json.url replacement_document_validation_request.new_document.image_url
   end
 end

--- a/spec/requests/api/replacement_document_validation_request_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_spec.rb
@@ -6,72 +6,123 @@ RSpec.describe "Replacement document validation requests API", type: :request, s
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
+  let(:document) { create(:document) }
+
   let!(:replacement_document_validation_request) do
-    create(:replacement_document_validation_request, planning_application: planning_application)
+    create(
+      :replacement_document_validation_request,
+      planning_application: planning_application,
+      created_at: DateTime.new(2022, 1, 1),
+      old_document: document
+    )
   end
+
   let(:token) { "Bearer #{api_user.token}" }
 
+  let(:processed_active_storage_variant) do
+    instance_double(
+      "ActiveStorage::VariantWithRecord",
+      url: "http://www.example.com/test_image"
+    )
+  end
+
   describe "#index" do
-    let(:path) { "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests" }
-    let!(:replacement_document_validation_request2) do
-      create(:replacement_document_validation_request, :with_response, :closed, planning_application: planning_application)
-    end
-    let!(:replacement_document_validation_request3) do
-      create(:replacement_document_validation_request, :cancelled, planning_application: planning_application)
+    let(:path) do
+      api_v1_planning_application_replacement_document_validation_requests_path(
+        planning_application
+      )
     end
 
-    context "when the request is successful" do
-      it "retrieves all replacement document validation requests for a given planning application" do
-        get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+    let!(:replacement_document_validation_request2) do
+      create(
+        :replacement_document_validation_request,
+        :with_response,
+        :closed,
+        planning_application: planning_application,
+        created_at: DateTime.new(2022, 1, 2)
+      )
+    end
+
+    let!(:replacement_document_validation_request3) do
+      create(
+        :replacement_document_validation_request,
+        :cancelled,
+        planning_application: planning_application,
+        created_at: DateTime.new(2022, 1, 3),
+        cancelled_at: DateTime.new(2022, 1, 4)
+      )
+    end
+
+    context "when the request is valid" do
+      before do
+        allow_any_instance_of(ActiveStorage::VariantWithRecord)
+          .to receive(:processed)
+          .and_return(processed_active_storage_variant)
+      end
+
+      it "is successful" do
+        get(
+          path,
+          params: { change_access_id: planning_application.change_access_id },
+          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+        )
 
         expect(response).to be_successful
-        expect(sort_by_id(json["data"])).to eq(
-          [
-            {
-              "id" => replacement_document_validation_request.id,
-              "state" => "open",
-              "response_due" => replacement_document_validation_request.response_due.to_s(:db),
-              "days_until_response_due" => 15,
-              "cancel_reason" => nil,
-              "cancelled_at" => nil,
-              "old_document" => {
-                "name" => "proposed-floorplan.png",
-                "invalid_document_reason" => "Document is invalid",
-                "url" => json["data"][0]["old_document"]["url"]
-              }
-            },
-            {
-              "id" => replacement_document_validation_request2.id,
-              "state" => "closed",
-              "response_due" => replacement_document_validation_request2.response_due.to_s(:db),
-              "days_until_response_due" => 15,
-              "cancel_reason" => nil,
-              "cancelled_at" => nil,
-              "old_document" => {
-                "name" => "proposed-floorplan.png",
-                "invalid_document_reason" => "Document is invalid",
-                "url" => json["data"][1]["old_document"]["url"]
-              },
-              "new_document" => {
-                "name" => "proposed-floorplan.png",
-                "url" => json["data"][1]["new_document"]["url"]
-              }
-            },
-            {
-              "id" => replacement_document_validation_request3.id,
-              "state" => "cancelled",
-              "response_due" => replacement_document_validation_request3.response_due.to_s(:db),
-              "days_until_response_due" => 15,
-              "cancel_reason" => "Made by mistake!",
-              "cancelled_at" => json_time_format(replacement_document_validation_request3.cancelled_at),
-              "old_document" => {
-                "name" => "proposed-floorplan.png",
-                "invalid_document_reason" => nil,
-                "url" => json["data"][2]["old_document"]["url"]
-              }
+      end
+
+      it "returns the request data" do
+        travel_to(DateTime.new(2022, 1, 2)) do
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+        end
+
+        expect(json["data"]).to contain_exactly(
+          {
+            id: replacement_document_validation_request.id,
+            state: "open",
+            response_due: "2022-01-25",
+            days_until_response_due: 15,
+            cancel_reason: nil,
+            cancelled_at: nil,
+            old_document: {
+              name: "proposed-floorplan.png",
+              invalid_document_reason: "Document is invalid",
+              url: "http://www.example.com/test_image"
             }
-          ]
+          }.deep_stringify_keys,
+          {
+            id: replacement_document_validation_request2.id,
+            state: "closed",
+            response_due: "2022-01-25",
+            days_until_response_due: 15,
+            cancel_reason: nil,
+            cancelled_at: nil,
+            old_document: {
+              name: "proposed-floorplan.png",
+              invalid_document_reason: "Document is invalid",
+              url: "http://www.example.com/test_image"
+            },
+            new_document: {
+              name: "proposed-floorplan.png",
+              url: "http://www.example.com/test_image"
+            }
+          }.deep_stringify_keys,
+          {
+            id: replacement_document_validation_request3.id,
+            state: "cancelled",
+            response_due: "2022-01-25",
+            days_until_response_due: 15,
+            cancel_reason: "Made by mistake!",
+            cancelled_at: "2022-01-04T00:00:00.000+00:00",
+            old_document: {
+              name: "proposed-floorplan.png",
+              invalid_document_reason: nil,
+              url: "http://www.example.com/test_image"
+            }
+          }.deep_stringify_keys
         )
       end
     end
@@ -91,30 +142,109 @@ RSpec.describe "Replacement document validation requests API", type: :request, s
 
   describe "#show" do
     let(:path) do
-      "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
+      api_v1_planning_application_replacement_document_validation_request_path(
+        planning_application,
+        replacement_document_validation_request
+      )
     end
 
-    context "when the request is successful" do
-      it "retrieves a replacement document validation request for a given planning application" do
-        get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+    context "when the request is valid" do
+      before do
+        allow_any_instance_of(ActiveStorage::VariantWithRecord)
+          .to receive(:processed)
+          .and_return(processed_active_storage_variant)
+      end
+
+      it "is successful" do
+        get(
+          path,
+          params: { change_access_id: planning_application.change_access_id },
+          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+        )
 
         expect(response).to be_successful
+      end
+
+      it "returns the request data" do
+        travel_to(DateTime.new(2022, 1, 2)) do
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+        end
+
         expect(json).to eq(
           {
-            "id" => replacement_document_validation_request.id,
-            "state" => "open",
-            "response_due" => replacement_document_validation_request.response_due.to_s(:db),
-            "days_until_response_due" => 15,
-            "cancel_reason" => nil,
-            "cancelled_at" => nil,
-            "old_document" => {
-              "name" => "proposed-floorplan.png",
-              "invalid_document_reason" => "Document is invalid",
-              "url" => json["old_document"]["url"]
+            id: replacement_document_validation_request.id,
+            state: "open",
+            response_due: "2022-01-25",
+            days_until_response_due: 15,
+            cancel_reason: nil,
+            cancelled_at: nil,
+            old_document: {
+              name: "proposed-floorplan.png",
+              invalid_document_reason: "Document is invalid",
+              url: "http://www.example.com/test_image"
             }
-          }
+          }.deep_stringify_keys
         )
+      end
+
+      context "when the image is missing" do
+        before do
+          allow_any_instance_of(ActiveStorage::VariantWithRecord)
+            .to receive(:processed)
+            .and_raise(ActiveStorage::PreviewError.new("Document stream is empty"))
+        end
+
+        it "is successful" do
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+
+          expect(response).to be_successful
+        end
+
+        it "returns the request data without a document url" do
+          travel_to(DateTime.new(2022, 1, 2)) do
+            get(
+              path,
+              params: { change_access_id: planning_application.change_access_id },
+              headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            )
+          end
+
+          expect(json).to eq(
+            {
+              id: replacement_document_validation_request.id,
+              state: "open",
+              response_due: "2022-01-25",
+              days_until_response_due: 15,
+              cancel_reason: nil,
+              cancelled_at: nil,
+              old_document: {
+                name: "proposed-floorplan.png",
+                invalid_document_reason: "Document is invalid",
+                url: nil
+              }
+            }.deep_stringify_keys
+          )
+        end
+
+        it "logs the error" do
+          expect(Rails.logger)
+            .to receive(:warn)
+            .with("Image retrieval failed for document ##{document.id} with error 'Document stream is empty'")
+
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+        end
       end
     end
 


### PR DESCRIPTION

### Description of change

- In API response for `ReplacementDocumentValidationRequest`, rescue `ActiveStorage::PreviewError` thrown when image is not present in S3, and return url as `nil`.

### Story Link

https://trello.com/c/Jp0SevPC/986-500-error-in-bops-applicants

### Decisions [OPTIONAL]

The error in the ticket is because someone has managed to create a `document` without successfully uploading an image. I don't think they should be able to do this, and we're still trying to work out how it happened.

However if it _has_ happened, it should be possible for the planner to ask the applicant to replace the image. Therefore we want the API request from bops-applicants to be successful, and get the data of the image-less document.