### PR TITLE
Show fee related proposal details on fee items page

### DIFF
--- a/app/presenters/concerns/proposal_details_presenter.rb
+++ b/app/presenters/concerns/proposal_details_presenter.rb
@@ -12,6 +12,12 @@ module ProposalDetailsPresenter
       end
     end
 
+    def fee_related_proposal_details
+      proposal_details.select do |proposal_detail|
+        proposal_detail.metadata&.portal_name&.match(/(_|\b)fee(_|\b)/i)
+      end
+    end
+
     def grouped_proposal_details
       @grouped_proposal_details ||= proposal_detail_groups.map do |group|
         [group, proposal_details_for_group(group)]

--- a/app/views/fee_items/_proposal_details_table.html.erb
+++ b/app/views/fee_items/_proposal_details_table.html.erb
@@ -1,0 +1,17 @@
+<% if proposal_details.any? %>
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">
+      <%= t(".related_questions") %>
+    </caption>
+    <% proposal_details.each do |proposal_detail| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">
+          <%= proposal_detail.question %>
+        </th>
+        <td class="govuk-table__cell">
+          <%= proposal_detail.responses.first.value %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/fee_items/show.html.erb
+++ b/app/views/fee_items/show.html.erb
@@ -11,6 +11,13 @@
   </h1>
   <%= render "fee_item_table" %>
 
+  <%= render(
+    partial: "proposal_details_table",
+    locals: {
+      proposal_details: @planning_application.fee_related_proposal_details
+    }
+  ) %>
+
   <%= form_with model: @planning_application, url: validate_planning_application_fee_items_path(@planning_application), builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true do |form| %>
     <%= form.govuk_radio_buttons_fieldset(:valid_fee) do %>
       <%= form.govuk_radio_button :valid_fee, true, label: { text: "Yes"} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
       fee_paid: Fee Paid
       item: Item
       payment_reference: Payment Reference
+    proposal_details_table:
+      related_questions: Related questions from RIPA
   other_change_validation_requests:
     form:
       labels:

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -537,6 +537,16 @@ paths:
                               - Planning permission / Permission needed
                       metadata:
                         portal_name: Actitivies
+                    - question: What type of planning application are you making?
+                      responses:
+                        - value: Existing changes
+                      metadata:
+                        portal_name: fee-calculator
+                    - question: What type of changes does the project involve?
+                      responses:
+                        - value: Alteration
+                      metadata:
+                        portal_name: Fee Exemptions
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -467,6 +467,16 @@ paths:
                               - 'Planning permission / Permission needed'
                       metadata:
                         portal_name: Actitivies
+                    - question: What type of planning application are you making?
+                      responses:
+                        - value: Existing changes
+                      metadata:
+                        portal_name: fee-calculator
+                    - question: What type of changes does the project involve?
+                      responses:
+                        - value: Alteration
+                      metadata:
+                        portal_name: Fee Exemptions
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -258,4 +258,68 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       )
     end
   end
+
+  describe "#fee_related_proposal_details" do
+    let(:proposal_details) do
+      [
+        {
+          question: "Question 1",
+          responses: [{ value: "Answer 1" }],
+          metadata: { portal_name: "Fee Related Group" }
+        },
+        {
+          question: "Question 2",
+          responses: [{ value: "Answer 2" }],
+          metadata: { portal_name: "group-about-fee" }
+        },
+        {
+          question: "Question 3",
+          responses: [{ value: "Answer 3" }],
+          metadata: { portal_name: "a_fee_group" }
+        },
+        {
+          question: "Question 4",
+          responses: [{ value: "Answer 4" }],
+          metadata: { portal_name: "Other Group" }
+        },
+        {
+          question: "Question 5",
+          responses: [{ value: "Answer 5" }],
+          metadata: { portal_name: "Birdfeed Related" }
+        }
+      ].to_json
+    end
+
+    let(:planning_application) do
+      create(:planning_application, proposal_details: proposal_details)
+    end
+
+    it "returns proposal details with 'fee' in the portal name" do
+      expect(presenter.fee_related_proposal_details).to eq(
+        [
+          OpenStruct.new(
+            {
+              question: "Question 1",
+              responses: [OpenStruct.new({ value: "Answer 1" })],
+              metadata: OpenStruct.new({ portal_name: "Fee Related Group" })
+            }
+          ),
+          OpenStruct.new(
+            {
+              question: "Question 2",
+              responses: [OpenStruct.new({ value: "Answer 2" })],
+              metadata: OpenStruct.new({ portal_name: "group-about-fee" })
+            }
+          ),
+          OpenStruct.new(
+            {
+              question: "Question 3",
+              responses: [OpenStruct.new({ value: "Answer 3" })],
+              metadata: OpenStruct.new({ portal_name: "a_fee_group" })
+            }
+          )
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Show proposal details related to fees on the fee items page.

### Story Link

https://trello.com/c/91wqsf1s/852-show-officers-all-information-related-to-the-fee-calculation

### Screenshot

<img width="50%" alt="Screenshot 2022-06-13 at 15 12 55" src="https://user-images.githubusercontent.com/25392162/173373565-b4047c33-58e7-4fa2-be6f-c00f41d10075.png">