### PR TITLE
Show proposal refs on fee page

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -55,16 +55,4 @@ module PlanningApplicationHelper
                                         )}"
     end
   end
-
-  def proposal_details_group_id(group)
-    proposal_details_group_name(group).downcase.gsub(/[^0-9a-z]/i, "")
-  end
-
-  def proposal_details_group_title(group)
-    proposal_details_group_name(group).downcase.underscore.humanize
-  end
-
-  def proposal_details_group_name(group)
-    group || t(".other")
-  end
 end

--- a/app/helpers/proposal_details_helper.rb
+++ b/app/helpers/proposal_details_helper.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module ProposalDetailsHelper
+  def proposal_details_group_id(group)
+    proposal_details_group_name(group).downcase.gsub(/[^0-9a-z]/i, "")
+  end
+
+  def proposal_details_group_title(group)
+    proposal_details_group_name(group).downcase.underscore.humanize
+  end
+
+  def proposal_details_group_name(group)
+    group || t("proposal_details.other")
+  end
+
+  def proposal_detail_item(proposal_detail)
+    tag.p(class: "govuk-body") do
+      concat(proposal_detail_question(proposal_detail.question))
+      concat(proposal_detail_responses(proposal_detail.responses))
+      concat(proposal_detail_metadata(proposal_detail.metadata))
+    end
+  end
+
+  def proposal_detail_question(question)
+    tag.p(class: "govuk-body") { tag.strong(question) }
+  end
+
+  def proposal_detail_responses(responses)
+    tag.p(class: "govuk-body") { responses.map(&:value).compact.join(", ") }
+  end
+
+  def proposal_detail_metadata(metadata)
+    return if metadata.nil?
+
+    tag.div do
+      concat(proposal_detail_notes(metadata.notes))
+      concat(proposal_detail_auto_answered(metadata.auto_answered))
+      concat(proposal_detail_policy_refs(metadata.policy_refs))
+    end
+  end
+
+  def proposal_detail_notes(notes)
+    tag.p(tag.em(notes)) if notes.present?
+  end
+
+  def proposal_detail_auto_answered(auto_answered)
+    tag.p(tag.em(t("proposal_details.auto_answered"))) if auto_answered.present?
+  end
+
+  def proposal_detail_policy_refs(policy_refs)
+    return if policy_refs.blank?
+
+    policy_refs.map do |policy_ref|
+      if policy_ref.url.present?
+        link_to(policy_ref.url, policy_ref.url, class: "govuk-link")
+      else
+        policy_ref.text
+      end
+    end.join(", ").html_safe # rubocop:disable Rails/OutputSafety
+  end
+end

--- a/app/presenters/concerns/proposal_details_presenter.rb
+++ b/app/presenters/concerns/proposal_details_presenter.rb
@@ -4,14 +4,6 @@ module ProposalDetailsPresenter
   extend ActiveSupport::Concern
 
   included do
-    def proposal_detail_item(proposal)
-      tag.p(class: "govuk-body") do
-        concat proposal_question(proposal)
-        concat proposal_responses(proposal)
-        concat proposal_metadata(proposal)
-      end
-    end
-
     def fee_related_proposal_details
       proposal_details.select do |proposal_detail|
         proposal_detail.metadata&.portal_name&.match(/(_|\b)fee(_|\b)/i)
@@ -43,56 +35,6 @@ module ProposalDetailsPresenter
       proposal_details.map do |proposal_detail|
         proposal_detail.metadata&.portal_name
       end.uniq
-    end
-
-    def proposal_question(proposal)
-      tag.p(class: "govuk-body") do
-        tag.strong(proposal.question)
-      end
-    end
-
-    def proposal_responses(proposal)
-      tag.p(class: "govuk-body") do
-        proposal.responses.map(&:value).compact.join(", ")
-      end
-    end
-
-    def proposal_metadata(proposal)
-      metadata = proposal.metadata
-
-      return if metadata.nil?
-
-      tag.div do
-        concat proposal_notes(proposal)
-        concat proposal_auto_answered(proposal)
-        concat proposal_policy_refs(proposal)
-      end
-    end
-
-    def proposal_notes(proposal)
-      notes = proposal.metadata.notes
-
-      tag.p(tag.em(notes)) if notes.present?
-    end
-
-    def proposal_auto_answered(proposal)
-      auto_answered = proposal.metadata.auto_answered
-
-      tag.p(tag.em("Auto-answered by RIPA")) if auto_answered.present?
-    end
-
-    def proposal_policy_refs(proposal)
-      refs = proposal.metadata&.policy_refs
-
-      return if refs.blank?
-
-      refs.map do |ref|
-        if ref.url.present?
-          link_to(ref.url, ref.url, class: "govuk-link")
-        else
-          ref.text
-        end
-      end.join
     end
   end
 end

--- a/app/views/fee_items/_proposal_details_table.html.erb
+++ b/app/views/fee_items/_proposal_details_table.html.erb
@@ -9,7 +9,19 @@
           <%= proposal_detail.question %>
         </th>
         <td class="govuk-table__cell">
-          <%= proposal_detail.responses.first.value %>
+          <%= proposal_detail.responses.map(&:value).compact.join(", ") %>
+          <% if proposal_detail.metadata.policy_refs.present? %>
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  <%= t(".related_legislation") %>
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <%= proposal_detail_policy_refs(proposal_detail.metadata.policy_refs) %>
+              </div>
+            </details>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/planning_applications/_policy_consideration_list.html.erb
+++ b/app/views/planning_applications/_policy_consideration_list.html.erb
@@ -34,7 +34,7 @@
           <ol class="govuk-body sub-list" start=<%= start_number %>>
             <% proposal_details.each do |proposal_detail| %>
               <li>
-                <%= @planning_application.proposal_detail_item(proposal_detail) %>
+                <%= proposal_detail_item(proposal_detail) %>
               </li>
             <% end %>
           </ol>
@@ -43,7 +43,7 @@
         <ol class="govuk-list govuk-list--number">
           <% @planning_application.proposal_details.each do |proposal_detail| %>
             <li>
-              <%= @planning_application.proposal_detail_item(proposal_detail) %>
+              <%= proposal_detail_item(proposal_detail) %>
             </li>
           <% end %>
         </ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
       payment_reference: Payment Reference
     proposal_details_table:
       related_questions: Related questions from RIPA
+      related_legislation: Related legislation
   other_change_validation_requests:
     form:
       labels:
@@ -68,6 +69,9 @@ en:
       otp_required_for_login: Two factor authentication
       role: Role
       true: "Yes"
+  proposal_details:
+    auto_answered: Auto-answered by RIPA
+    other: Other
   activerecord:
     errors:
       models:

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -18,7 +18,6 @@ en:
       one: '1 day overdue'
       other: '%{count} days overdue'
     policy_consideration_list:
-      other: Other
       proposal_details: Proposal details
     steps:
       validation:

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -542,11 +542,15 @@ paths:
                         - value: Existing changes
                       metadata:
                         portal_name: fee-calculator
+                        policy_refs:
+                          - url: 'http://example.com/planning/policy/1/234/a.html'
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
                         portal_name: Fee Exemptions
+                        policy_refs:
+                          - text: The Town and Country Planning (General Permitted Development) (England) Order 2015
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -472,11 +472,15 @@ paths:
                         - value: Existing changes
                       metadata:
                         portal_name: fee-calculator
+                        policy_refs:
+                          - url: http://example.com/planning/policy/1/234/a.html
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
                         portal_name: Fee Exemptions
+                        policy_refs:
+                          - text: The Town and Country Planning (General Permitted Development) (England) Order 2015
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/spec/system/planning_applications/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/fee_items_validation_spec.rb
@@ -21,7 +21,13 @@ RSpec.describe "FeeItemsValidation", type: :system do
         {
           question: "What type of changes does the project involve?",
           responses: [{ value: "Alteration" }],
-          metadata: { portal_name: "fee-related" }
+          metadata: {
+            portal_name: "fee-related",
+            policy_refs: [
+              { text: "The Town and Country Planning Order 2015" },
+              { url: "https://www.example.com/planning/policy/1" }
+            ]
+          }
         }
       ].to_json
     end
@@ -83,9 +89,20 @@ RSpec.describe "FeeItemsValidation", type: :system do
           "What type of planning application are you making?"
         )
 
-        expect(rows[1]).to have_content(
-          "What type of changes does the project involve?"
-        )
+        within(rows[1]) do
+          expect(page).to have_content(
+            "What type of changes does the project involve?"
+          )
+
+          find("span", text: "Related legislation").click
+
+          expect(page).to have_content("The Town and Country Planning Order 2015")
+
+          expect(page).to have_link(
+            "https://www.example.com/planning/policy/1",
+            href: "https://www.example.com/planning/policy/1"
+          )
+        end
       end
     end
 


### PR DESCRIPTION
### Description of change

Show proposal refs on fee page.

Also fix bug where proposal refs weren't rendering properly on planning application show page.

### Story Link

https://trello.com/c/91wqsf1s/852-show-officers-all-information-related-to-the-fee-calculation

### Screenshots

![Screenshot 2022-06-15 at 16 25 26](https://user-images.githubusercontent.com/25392162/173868582-efd1e199-c851-4b53-b8ed-973922811af5.png)

before:
![Screenshot 2022-06-15 at 16 40 23](https://user-images.githubusercontent.com/25392162/173868881-e7ae7287-156c-4174-b7ed-fedd264afb10.png)

after:
![Screenshot 2022-06-15 at 16 39 36](https://user-images.githubusercontent.com/25392162/173868724-ddd3d433-cce0-4998-9687-945bb05dac18.png)

