### PR TITLE
Refactor local authorities

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,7 +4,7 @@ class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
 
-  validates :name, :subdomain, presence: true
+  validates :subdomain, presence: true
 
   enum subdomain: {
     lambeth: "lambeth",
@@ -19,5 +19,9 @@ class LocalAuthority < ApplicationRecord
 
   def council_code
     I18n.t("council_code.#{subdomain}")
+  end
+
+  def council_name
+    ripa? ? subdomain.capitalize : "#{subdomain.capitalize} Council Authority"
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,7 +4,7 @@ class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
 
-  validates :council_code, :name, :subdomain, presence: true
+  validates :name, :subdomain, presence: true
 
   enum subdomain: {
     lambeth: "lambeth",
@@ -15,5 +15,9 @@ class LocalAuthority < ApplicationRecord
 
   def signatory
     "#{signatory_name}, #{signatory_job_title}"
+  end
+
+  def council_code
+    I18n.t("council_code.#{subdomain}")
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -6,6 +6,13 @@ class LocalAuthority < ApplicationRecord
 
   validates :council_code, :name, :subdomain, presence: true
 
+  enum subdomain: {
+    lambeth: "lambeth",
+    southwark: "southwark",
+    buckinghamshire: "buckinghamshire",
+    ripa: "ripa"
+  }
+
   def signatory
     "#{signatory_name}, #{signatory_job_title}"
   end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,7 +4,8 @@ class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
 
-  validates :subdomain, presence: true
+  validates :subdomain, :signatory_name, :signatory_job_title, :enquiries_paragraph, :email_address, :feedback_email,
+            presence: true
 
   enum subdomain: {
     lambeth: "lambeth",

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -2,9 +2,9 @@
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__content">
       <% if controller_path == "public/planning_guides" %>
-        <%= link_to "Back-office Planning System: #{current_local_authority.name}", public_planning_guides_path, class: "govuk-header__link govuk-header__link--service-name" %>
+        <%= link_to "Back-office Planning System: #{current_local_authority.council_name}", public_planning_guides_path, class: "govuk-header__link govuk-header__link--service-name" %>
       <% else %>
-        <%= link_to "Back-office Planning System: #{current_local_authority.name}", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
+        <%= link_to "Back-office Planning System: #{current_local_authority.council_name}", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
       <% end %>
     </div>
   </div>

--- a/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/cancelled_validation_request_mail.text.erb
@@ -16,4 +16,4 @@ If you need help with your application, contact us at <%= @planning_application.
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -20,4 +20,4 @@ If you have any questions about your application, contact us at <%= @planning_ap
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/description_change_mail.text.erb
+++ b/app/views/planning_application_mailer/description_change_mail.text.erb
@@ -16,4 +16,4 @@ If you need help with your application, contact us at <%= @planning_application.
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
+++ b/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
@@ -14,4 +14,4 @@ If you need help with your application, contact us at <%= @planning_application.
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -16,4 +16,4 @@ If you need help with your application, contact us at  <%= @planning_application
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -30,4 +30,4 @@ If you need help with your application, contact us at <%= @planning_application.
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -14,4 +14,4 @@ If you need help with your application, contact us at  <%= @planning_application
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_application_mailer/validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_mail.text.erb
@@ -16,4 +16,4 @@ If you need help with your application, contact us at <%= @planning_application.
 
 Regards,
 
-<%= @planning_application.local_authority.name %>
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -1,6 +1,6 @@
 <div class="decision-notice">
   <span class="govuk-caption-xl">
-    <%= planning_application.local_authority.name %>
+    <%= planning_application.local_authority.council_name %>
   </span>
   <br/>
   <h2 class="govuk-heading-s">
@@ -105,7 +105,7 @@
   </h3>
   <p class="govuk-body">
     <%= planning_application.local_authority.signatory %>, <br>
-    <%= planning_application.local_authority.name %>, <br>
+    <%= planning_application.local_authority.council_name %>, <br>
     <%= planning_application.local_authority.enquiries_paragraph %>.
   </p>
   <% if @planning_application.refused? %>

--- a/app/views/planning_applications/_validation_notice.html.erb
+++ b/app/views/planning_applications/_validation_notice.html.erb
@@ -1,6 +1,6 @@
 <div class="validation-notice">
   <span class="govuk-caption-xl">
-    <%= planning_application.local_authority.name %>
+    <%= planning_application.local_authority.council_name %>
   </span>
   <h3 class="govuk-heading-s">
     Town and Country Planning Act 1990 (as amended) <br><br>
@@ -49,7 +49,7 @@
     Any enquiries regarding this document should quote the Application Number and be sent to
     the
     <%= @planning_application.local_authority.signatory_job_title %>,
-    <%= @planning_application.local_authority.name %>,
+    <%= @planning_application.local_authority.council_name %>,
     <%= @planning_application.local_authority.enquiries_paragraph %>
     or by email to <%= @planning_application.local_authority.email_address %>
   </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,11 @@ en:
       labels:
         suggestion: Tell the applicant how the fee can be made valid.
         summary: Tell the applicant why the fee is incorrect.
+  council_code:
+    lambeth: LBH
+    southwark: SWK
+    buckinghamshire: BUC
+    ripa: RIPA
   activerecord:
     errors:
       models:

--- a/db/migrate/20220609115812_drop_council_code_to_local_authorities.rb
+++ b/db/migrate/20220609115812_drop_council_code_to_local_authorities.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DropCouncilCodeToLocalAuthorities < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :local_authorities, :council_code
+  end
+
+  def down
+    add_column :local_authorities, :council_code, :string, unique: true
+
+    LocalAuthority.find_each do |local_authority|
+      case local_authority.subdomain
+      when "lambeth"
+        local_authority.update(council_code: "LBH")
+      when "southwark"
+        local_authority.update(council_code: "SWK")
+      when "buckinghamshire"
+        local_authority.update(council_code: "BUC")
+      when "ripa"
+        local_authority.update(council_code: "RIPA")
+      else
+        raise "Did not update the council code for local authority: #{local_authority.name}"
+      end
+    end
+
+    change_column_null :local_authorities, :council_code, false
+  end
+end

--- a/db/migrate/20220614165426_drop_name_to_local_authorities.rb
+++ b/db/migrate/20220614165426_drop_name_to_local_authorities.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class DropNameToLocalAuthorities < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :local_authorities, :name
+  end
+
+  def down
+    add_column :local_authorities, :name, :string
+
+    LocalAuthority.find_each do |local_authority|
+      case local_authority.subdomain
+      when "lambeth"
+        local_authority.update(name: "Lambeth Council Authority")
+      when "southwark"
+        local_authority.update(name: "Southwark Council Authority")
+      when "buckinghamshire"
+        local_authority.update(name: "Buckinghamshire Council Authority")
+      when "ripa"
+        local_authority.update(name: "Ripa")
+      else
+        raise "Did not update the council code for local authority: #{local_authority.name}"
+      end
+    end
+
+    change_column_null :local_authorities, :name, false
+  end
+end

--- a/db/migrate/20220615151407_add_not_null_to_local_authorities.rb
+++ b/db/migrate/20220615151407_add_not_null_to_local_authorities.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddNotNullToLocalAuthorities < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :local_authorities, :signatory_name, false
+    change_column_null :local_authorities, :signatory_job_title, false
+    change_column_null :local_authorities, :enquiries_paragraph, false
+    change_column_null :local_authorities, :email_address, false
+    change_column_null :local_authorities, :feedback_email, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_14_165426) do
+ActiveRecord::Schema.define(version: 2022_06_15_151407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,12 +143,12 @@ ActiveRecord::Schema.define(version: 2022_06_14_165426) do
     t.string "subdomain", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "signatory_name"
-    t.string "signatory_job_title"
-    t.text "enquiries_paragraph"
-    t.string "email_address"
+    t.string "signatory_name", null: false
+    t.string "signatory_job_title", null: false
+    t.text "enquiries_paragraph", null: false
+    t.string "email_address", null: false
     t.string "reply_to_notify_id"
-    t.string "feedback_email"
+    t.string "feedback_email", null: false
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_115812) do
+ActiveRecord::Schema.define(version: 2022_06_14_165426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -140,7 +140,6 @@ ActiveRecord::Schema.define(version: 2022_06_09_115812) do
   end
 
   create_table "local_authorities", force: :cascade do |t|
-    t.string "name", null: false
     t.string "subdomain", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_26_152433) do
+ActiveRecord::Schema.define(version: 2022_06_09_115812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -150,7 +150,6 @@ ActiveRecord::Schema.define(version: 2022_05_26_152433) do
     t.string "email_address"
     t.string "reply_to_notify_id"
     t.string "feedback_email"
-    t.string "council_code", null: false
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,6 @@ require "faker"
 lambeth = LocalAuthority.find_or_create_by!(
   name: "Lambeth Council",
   subdomain: "lambeth",
-  council_code: "LBH",
   signatory_name: "Christina Thompson",
   signatory_job_title: "Director of Finance & Property",
   enquiries_paragraph: "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG",
@@ -15,7 +14,6 @@ lambeth = LocalAuthority.find_or_create_by!(
 southwark = LocalAuthority.find_or_create_by!(
   name: "Southwark Council",
   subdomain: "southwark",
-  council_code: "SWK",
   signatory_name: "Stephen Platts",
   signatory_job_title: "Director of Planning and Growth",
   enquiries_paragraph: "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG",
@@ -26,7 +24,6 @@ southwark = LocalAuthority.find_or_create_by!(
 buckinghamshire = LocalAuthority.find_or_create_by!(
   name: "Buckinghamshire",
   subdomain: "buckinghamshire",
-  council_code: "BUC",
   signatory_name: "Steve Bambick",
   signatory_job_title: "Director of Planning",
   enquiries_paragraph: "Planning, Buckinghamshire Council, Gatehouse Rd, Aylesbury HP19 8FF",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,6 @@
 require "faker"
 
 lambeth = LocalAuthority.find_or_create_by!(
-  name: "Lambeth Council",
   subdomain: "lambeth",
   signatory_name: "Christina Thompson",
   signatory_job_title: "Director of Finance & Property",
@@ -12,7 +11,6 @@ lambeth = LocalAuthority.find_or_create_by!(
   feedback_email: "digitalplanning@lambeth.gov.uk"
 )
 southwark = LocalAuthority.find_or_create_by!(
-  name: "Southwark Council",
   subdomain: "southwark",
   signatory_name: "Stephen Platts",
   signatory_job_title: "Director of Planning and Growth",
@@ -22,7 +20,6 @@ southwark = LocalAuthority.find_or_create_by!(
 )
 
 buckinghamshire = LocalAuthority.find_or_create_by!(
-  name: "Buckinghamshire",
   subdomain: "buckinghamshire",
   signatory_name: "Steve Bambick",
   signatory_job_title: "Director of Planning",

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -31,7 +31,7 @@ paths:
                   value:
                     id: 10000
                     reference: 20-00100-LDCP
-                    reference_in_full: SWK-20-00100-LDCP
+                    reference_in_full: RIPA-20-00100-LDCP
                     site:
                       address_1: 11 Abbey Gardens
                       address_2: Southwark
@@ -111,7 +111,7 @@ paths:
                     data:
                       - id: 10000
                         reference: 20-00100-LDCP
-                        reference_in_full: SWK-20-00100-LDCP
+                        reference_in_full: RIPA-20-00100-LDCP
                         site:
                           address_1: 11 Abbey Gardens
                           address_2: Southwark

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -32,7 +32,7 @@ paths:
                   value: &planning_application
                     id: 10000
                     reference: '20-00100-LDCP'
-                    reference_in_full: 'SWK-20-00100-LDCP'
+                    reference_in_full: 'RIPA-20-00100-LDCP'
                     site:
                       address_1: 11 Abbey Gardens
                       address_2: Southwark

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -3,13 +3,19 @@
 FactoryBot.define do
   factory :local_authority do
     subdomain { "buckinghamshire" }
-    signatory_name { Faker::FunnyName.two_word_name }
+    signatory_name { Faker::FunnyName.unique.two_word_name }
     signatory_job_title { "Director" }
     enquiries_paragraph { Faker::Lorem.unique.sentence }
     email_address { Faker::Internet.email }
+    feedback_email { "feedback_email@buckinghamshire.gov.uk" }
 
     trait :default do
       subdomain { "ripa" }
+      signatory_name { Faker::FunnyName.unique.two_word_name }
+      signatory_job_title { "Director" }
+      enquiries_paragraph { Faker::Lorem.unique.sentence }
+      email_address { "planning@ripa.uk" }
+      feedback_email { "feedback_email@ripa.uk" }
     end
 
     trait :lambeth do

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :local_authority do
     name { Faker::Name.name }
     subdomain { "buckinghamshire" }
-    council_code { "BUC" }
     signatory_name { Faker::FunnyName.two_word_name }
     signatory_job_title { "Director" }
     enquiries_paragraph { Faker::Lorem.unique.sentence }
@@ -13,13 +12,11 @@ FactoryBot.define do
     trait :default do
       name { "Default Authority" }
       subdomain { "ripa" }
-      council_code { "SWK" }
     end
 
     trait :lambeth do
       name { "Lambeth Council Authority" }
       subdomain { "lambeth" }
-      council_code { "LBH" }
       signatory_name { "Christina Thompson" }
       signatory_job_title { "Director of Finance & Property" }
       enquiries_paragraph { "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG" }
@@ -30,7 +27,6 @@ FactoryBot.define do
     trait :southwark do
       name { "Southwark Council Authority" }
       subdomain { "southwark" }
-      council_code { "SWK" }
       signatory_name { "Stephen Platts" }
       signatory_job_title { "Director of Planning and Growth" }
       enquiries_paragraph { "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG" }

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -2,7 +2,6 @@
 
 FactoryBot.define do
   factory :local_authority do
-    name { Faker::Name.name }
     subdomain { "buckinghamshire" }
     signatory_name { Faker::FunnyName.two_word_name }
     signatory_job_title { "Director" }
@@ -10,12 +9,10 @@ FactoryBot.define do
     email_address { Faker::Internet.email }
 
     trait :default do
-      name { "Default Authority" }
       subdomain { "ripa" }
     end
 
     trait :lambeth do
-      name { "Lambeth Council Authority" }
       subdomain { "lambeth" }
       signatory_name { "Christina Thompson" }
       signatory_job_title { "Director of Finance & Property" }
@@ -25,7 +22,6 @@ FactoryBot.define do
     end
 
     trait :southwark do
-      name { "Southwark Council Authority" }
       subdomain { "southwark" }
       signatory_name { "Stephen Platts" }
       signatory_job_title { "Director of Planning and Growth" }

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       signatory_name: "Mr. Biscuit",
       signatory_job_title: "Lord of BiscuitTown",
       enquiries_paragraph: "reach us on postcode SW50",
-      email_address: "biscuit@somuchbiscuit.com",
-      council_code: "ABC"
+      email_address: "biscuit@somuchbiscuit.com"
     )
   end
 
@@ -84,7 +83,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application reference number: ABC-22-00100-LDCP"
+        "Application reference number: RIPA-22-00100-LDCP"
       )
     end
 
@@ -186,7 +185,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application reference number: ABC-22-00100-LDCP"
+        "Application reference number: RIPA-22-00100-LDCP"
       )
     end
 
@@ -229,7 +228,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application reference number: ABC-22-00100-LDCP"
+        "Application reference number: RIPA-22-00100-LDCP"
       )
     end
 
@@ -276,7 +275,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application reference number: ABC-22-00100-LDCP"
+        "Application reference number: RIPA-22-00100-LDCP"
       )
     end
 
@@ -337,7 +336,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include("Application number: ABC-22-00100-LDCP")
+      expect(mail_body).to include("Application number: RIPA-22-00100-LDCP")
     end
 
     it "includes the address" do
@@ -386,7 +385,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application reference number: ABC-22-00100-LDCP"
+        "Application reference number: RIPA-22-00100-LDCP"
       )
     end
 
@@ -452,7 +451,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "includes the reference" do
         expect(mail_body).to include(
-          "Application reference number: ABC-22-00100-LDCP"
+          "Application reference number: RIPA-22-00100-LDCP"
         )
       end
 
@@ -497,7 +496,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "includes the reference" do
         expect(mail_body).to include(
-          "Application reference number: ABC-22-00100-LDCP"
+          "Application reference number: RIPA-22-00100-LDCP"
         )
       end
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     create(
       :local_authority,
       :default,
-      name: "Cookie authority",
       signatory_name: "Mr. Biscuit",
       signatory_job_title: "Lord of BiscuitTown",
       enquiries_paragraph: "reach us on postcode SW50",

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe LocalAuthority, type: :model do
   describe "validations" do
     subject(:local_authority) { described_class.new }
 
-    describe "#name" do
-      it "validates presence" do
-        expect { local_authority.valid? }.to change { local_authority.errors[:name] }.to ["can't be blank"]
-      end
-    end
-
     describe "#subdomain" do
       it "validates presence" do
         expect { local_authority.valid? }.to change { local_authority.errors[:subdomain] }.to ["can't be blank"]

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe LocalAuthority, type: :model do
       it "validates presence" do
         expect { local_authority.valid? }.to change { local_authority.errors[:subdomain] }.to ["can't be blank"]
       end
+
+      it "raises an error with wrong type" do
+        expect { build(:local_authority, subdomain: "new_name") }
+          .to raise_error(ArgumentError)
+          .with_message(/is not a valid subdomain/)
+      end
     end
 
     describe "#signatory" do

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -18,6 +18,36 @@ RSpec.describe LocalAuthority, type: :model do
       end
     end
 
+    describe "#signatory_name" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:signatory_name] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#signatory_job_title" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:signatory_job_title] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#enquiries_paragraph" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:enquiries_paragraph] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#email_address" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:email_address] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#feedback_email" do
+      it "validates presence" do
+        expect { local_authority.valid? }.to change { local_authority.errors[:feedback_email] }.to ["can't be blank"]
+      end
+    end
+
     describe "#signatory" do
       let(:local_authority) do
         build(

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe LocalAuthority, type: :model do
   describe "validations" do
     subject(:local_authority) { described_class.new }
 
-    describe "#council_code" do
-      it "validates presence" do
-        expect { local_authority.valid? }.to change { local_authority.errors[:council_code] }.to ["can't be blank"]
-      end
-    end
-
     describe "#name" do
       it "validates presence" do
         expect { local_authority.valid? }.to change { local_authority.errors[:name] }.to ["can't be blank"]
@@ -34,9 +28,14 @@ RSpec.describe LocalAuthority, type: :model do
       let(:local_authority) do
         build(
           :local_authority,
+          :lambeth,
           signatory_name: "Jane Smith",
           signatory_job_title: "Director"
         )
+      end
+
+      it "#council_code" do
+        expect(local_authority.council_code).to eq("LBH")
       end
 
       it "returns signatory name and job title" do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe PlanningApplication, type: :model do
   end
 
   describe "#reference_in_full" do
-    let(:local_authority) { create(:local_authority, council_code: "SWK") }
+    let(:local_authority) { create(:local_authority, :southwark) }
     let(:planning_application1) { create(:planning_application, application_type: 0, local_authority: local_authority, work_status: "proposed") }
     let(:planning_application2) { create(:planning_application, application_type: 0, local_authority: local_authority, work_status: "existing") }
 

--- a/spec/system/public/planning_guides_spec.rb
+++ b/spec/system/public/planning_guides_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Planning guides", type: :system do
     it "the planning guide index page is publicy accessible" do
       expect(page).to have_content("Find out how to create a valid plan")
       within(".govuk-header__content") do
-        expect(page).to have_link("Back-office Planning System: #{default_local_authority.name}",
+        expect(page).to have_link("Back-office Planning System: #{default_local_authority.council_name}",
                                   href: public_planning_guides_path)
       end
 
@@ -170,7 +170,7 @@ RSpec.describe "Planning guides", type: :system do
     it "is accessible" do
       expect(page).to have_content("Find out how to create a valid plan")
       within(".govuk-header__content") do
-        expect(page).to have_link("Back-office Planning System: #{default_local_authority.name}",
+        expect(page).to have_link("Back-office Planning System: #{default_local_authority.council_name}",
                                   href: public_planning_guides_path)
       end
     end


### PR DESCRIPTION
### Description of change

Refactor local authorities:
- Add an enum for subdomains
- Drop council_code and use locales
- Drop name and use locales
- Add not null to local authorities fields

### Story Link

https://trello.com/c/ynTH3Zbq