### PR TITLE
Fix failing test

### DIFF
--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -9,9 +9,16 @@ RSpec.describe "Planning Application index page", type: :system do
   let!(:planning_application_started) do
     create :planning_application, :awaiting_determination, local_authority: default_local_authority
   end
+
   let!(:planning_application_completed) do
-    create :planning_application, :determined, local_authority: default_local_authority
+    create(
+      :planning_application,
+      :determined,
+      local_authority: default_local_authority,
+      expiry_date: Date.new(2022, 10, 10)
+    )
   end
+
   let(:assessor) { create :user, :assessor, local_authority: default_local_authority }
   let(:reviewer) { create :user, :reviewer, local_authority: default_local_authority }
 


### PR DESCRIPTION
### Description of change

- Set the `expiry_date` of the planning application so that the test doesn't need to be updated daily 🤣 

### Story Link

NA

