### PR TITLE
Make mobile number required for users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,9 +13,10 @@ class User < ApplicationRecord
   has_many :audits, dependent: :nullify
   belongs_to :local_authority, optional: false
 
-  before_create :generate_otp_secret
+  before_validation :generate_otp_secret, on: :create
 
   validates :mobile_number, format: { with: /\A\d*\z/ }
+  validates :mobile_number, presence: true, if: :otp_required_for_login
 
   def self.find_for_authentication(tainted_conditions)
     if tainted_conditions[:subdomains].present?

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -42,6 +42,8 @@ local_authorities.each do |authority|
       last_name = Faker::Name.last_name
       user.name = "#{first_name} #{last_name}"
       user.local_authority = authority
+      user.mobile_number = Faker::Base.numerify('07#########')
+
       if Rails.env.development?
         user.password = user.password_confirmation = "password"
       else

--- a/spec/system/managing_users_spec.rb
+++ b/spec/system/managing_users_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe "managing users", type: :system do
 
       expect(page).to have_content("Email can't be blank")
       expect(page).to have_content("Password can't be blank")
+      expect(page).to have_content("Mobile number can't be blank")
 
       fill_in("Email", with: "alice")
       fill_in("Mobile number", with: "not a number")
@@ -60,9 +61,11 @@ RSpec.describe "managing users", type: :system do
       row = page.find_all("tr").find { |tr| tr.has_content?("Bella Jones") }
       within(row) { click_link("Edit") }
       fill_in("Email", with: "")
+      fill_in("Mobile number", with: "")
       click_button("Submit")
 
       expect(page).to have_content("Email can't be blank")
+      expect(page).to have_content("Mobile number can't be blank")
 
       fill_in("Email", with: "bella")
       fill_in("Mobile number", with: "not a number")


### PR DESCRIPTION
### Description of change

- Validate users on presence of `mobile_number` if `otp_required_for_login` is true.
- Set `otp_required_for_login` to true as a `before_validate` callback that only runs on create.
- This means that admins can't create users without mobile numbers, but existing users on preview with no mobile number and `otp_required_for_login` set to false are still valid (and that we can manually create more like this if required).

### Story Link

https://trello.com/c/bCi8PiVJ/882-user-management-interface#comment-62b1b2c6fd65fa5adf959191 (see recent comments)

### Screenshot

<img width="342" alt="Screenshot 2022-06-21 at 14 24 12" src="https://user-images.githubusercontent.com/25392162/174810578-5ef9ea2d-1555-443c-9a7f-af42dc58d382.png">

