### PR TITLE
Ensure mobile number requested if missing on login

### DIFF
--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -68,7 +68,7 @@ module AuthenticateWithOtpTwoFactor
   end
 
   def mobile_number(user)
-    user.try(:mobile_number) || session[:mobile_number]
+    user.try(:mobile_number).presence || session[:mobile_number]
   end
 
   def otp_input?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,6 +39,7 @@ class UsersController < AuthenticationController
     params
       .require(:user)
       .permit(:name, :email, :password, :mobile_number, :role)
+      .transform_values(&:presence)
   end
 
   def set_user

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Sign in", type: :system do
 
         expect(page).to have_current_path(users_path)
 
-        find(:xpath, "//input[@value='Log out']").click
+        click_button("Log out")
 
         expect(page).to have_current_path(new_user_session_path)
       end

--- a/spec/system/managing_users_spec.rb
+++ b/spec/system/managing_users_spec.rb
@@ -46,6 +46,37 @@ RSpec.describe "managing users", type: :system do
       expect(row).to have_content("alice@example.com")
       expect(row).to have_content("01234 123 123")
       expect(row).to have_content("Assessor")
+
+      click_button("Log out")
+      fill_in("Email", with: "alice@example.com")
+      fill_in("Password", with: "password")
+      click_button("Log in")
+      fill_in("Security code", with: User.last.current_otp)
+      click_button("Enter code")
+
+      expect(page).to have_current_path(root_path)
+    end
+
+    it "allows adding of new user without mobile number" do
+      visit new_user_path
+      fill_in("Name", with: "Alice Smith")
+      fill_in("Email", with: "alice@example.com")
+      fill_in("Password", with: "password")
+      select("Assessor", from: "Role")
+      click_button("Submit")
+
+      expect(page).to have_content("User successfully created")
+
+      click_button("Log out")
+      fill_in("Email", with: "alice@example.com")
+      fill_in("Password", with: "password")
+      click_button("Log in")
+      fill_in("Mobile number", with: "01234123123")
+      click_button("Send code")
+      fill_in("Security code", with: User.last.current_otp)
+      click_button("Enter code")
+
+      expect(page).to have_current_path(root_path)
     end
 
     it "allows editing of existing user" do


### PR DESCRIPTION
### Description of change

- Make sure mobile number isn't saved as blank string in users controller.
- Also make sure a blank string isn't treated as an existing mobile number on log in.

### Story Link

https://trello.com/c/bCi8PiVJ/882-user-management-interface.

When admins create new users without mobile numbers, they should be prompted to enter their mobile number on first log in. Currently they are created with `""` as a mobile number, and then the system tries and fails to send their one time password to this number.