### PR TITLE
Make response time for description change requests 5 days

### DIFF
--- a/app/models/description_change_validation_request.rb
+++ b/app/models/description_change_validation_request.rb
@@ -3,6 +3,8 @@
 class DescriptionChangeValidationRequest < ApplicationRecord
   include ValidationRequest
 
+  RESPONSE_TIME_IN_DAYS = 5
+
   before_create :set_previous_application_description
 
   belongs_to :planning_application
@@ -57,6 +59,10 @@ class DescriptionChangeValidationRequest < ApplicationRecord
       activity_information: sequence,
       audit_comment: Current.user&.name
     )
+  end
+
+  def response_due
+    RESPONSE_TIME_IN_DAYS.business_days.after(created_at).to_date
   end
 
   private

--- a/spec/models/description_change_validation_request_spec.rb
+++ b/spec/models/description_change_validation_request_spec.rb
@@ -24,5 +24,18 @@ RSpec.describe DescriptionChangeValidationRequest, type: :model do
         expect(other_request).not_to be_valid
       end
     end
+
+    describe "#response_due" do
+      let(:request) do
+        build(
+          :description_change_validation_request,
+          created_at: DateTime.new(2022, 6, 20)
+        )
+      end
+
+      it "returns date 5 working days after created_at" do
+        expect(request.response_due).to eq(Date.new(2022, 6, 27))
+      end
+    end
   end
 end

--- a/spec/requests/api/description_change_validation_request_spec.rb
+++ b/spec/requests/api/description_change_validation_request_spec.rb
@@ -3,39 +3,69 @@
 require "rails_helper"
 
 RSpec.describe "Description change validation requests API", type: :request, show_exceptions: true do
-  let!(:api_user) { create(:api_user) }
-  let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
-  let!(:description_change_validation_request) do
-    create(:description_change_validation_request, planning_application: planning_application)
+  let(:api_user) { create(:api_user) }
+  let(:default_local_authority) { create(:local_authority, :default) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      local_authority: default_local_authority,
+      description: "Current description"
+    )
   end
+
+  let!(:description_change_validation_request) do
+    create(
+      :description_change_validation_request,
+      planning_application: planning_application,
+      created_at: DateTime.new(2022, 6, 20),
+      proposed_description: "New description"
+    )
+  end
+
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
-    let(:path) { "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests" }
+    let(:path) do
+      api_v1_planning_application_description_change_validation_requests_path(
+        planning_application
+      )
+    end
 
-    context "when the request is successful" do
-      it "retrieves all description change validation requests for a given planning application" do
-        get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+    context "when the request is valid" do
+      it "succeeds" do
+        get(
+          path,
+          params: { change_access_id: planning_application.change_access_id },
+          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+        )
 
         expect(response).to be_successful
-        expect(sort_by_id(json["data"])).to eq(
-          [
+      end
+
+      it "retrieves all description change validation requests for a given planning application" do
+        travel_to(DateTime.new(2022, 6, 20)) do
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+
+          expect(json["data"]).to contain_exactly(
             {
               "id" => description_change_validation_request.id,
               "state" => "open",
-              "response_due" => description_change_validation_request.response_due.to_s(:db),
+              "response_due" => "2022-06-27",
               "proposed_description" => "New description",
-              "previous_description" => description_change_validation_request.previous_description,
+              "previous_description" => "Current description",
               "rejection_reason" => nil,
               "approved" => nil,
-              "days_until_response_due" => 15,
+              "days_until_response_due" => 5,
               "cancel_reason" => nil,
               "cancelled_at" => nil
             }
-          ]
-        )
+          )
+        end
       end
     end
 
@@ -54,29 +84,46 @@ RSpec.describe "Description change validation requests API", type: :request, sho
 
   describe "#show" do
     let(:path) do
-      "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}"
+      api_v1_planning_application_description_change_validation_request_path(
+        planning_application,
+        description_change_validation_request
+      )
     end
 
-    context "when the request is successful" do
-      it "retrieves an description change validation request for a given planning application" do
-        get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+    context "when request is valid" do
+      it "is successful" do
+        get(
+          path,
+          params: { change_access_id: planning_application.change_access_id },
+          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+        )
 
         expect(response).to be_successful
-        expect(json).to eq(
-          {
-            "id" => description_change_validation_request.id,
-            "state" => "open",
-            "response_due" => description_change_validation_request.response_due.to_s(:db),
-            "proposed_description" => "New description",
-            "previous_description" => description_change_validation_request.previous_description,
-            "rejection_reason" => nil,
-            "approved" => nil,
-            "days_until_response_due" => 15,
-            "cancel_reason" => nil,
-            "cancelled_at" => nil
-          }
-        )
+      end
+
+      it "retrieves an description change validation request for a given planning application" do
+        travel_to(DateTime.new(2022, 6, 20)) do
+          get(
+            path,
+            params: { change_access_id: planning_application.change_access_id },
+            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          )
+
+          expect(json).to eq(
+            {
+              "id" => description_change_validation_request.id,
+              "state" => "open",
+              "response_due" => "2022-06-27",
+              "proposed_description" => "New description",
+              "previous_description" => "Current description",
+              "rejection_reason" => nil,
+              "approved" => nil,
+              "days_until_response_due" => 5,
+              "cancel_reason" => nil,
+              "cancelled_at" => nil
+            }
+          )
+        end
       end
     end
 


### PR DESCRIPTION
### Description of change

Overwrite default `#response_due` method that `DescriptionChangeValidationRequest` inherits from `ValidationRequest`, which returns date 15 days from the created at date, with one that uses 5 days instead. 

Previously 15 days was correct for description change requests, but this has been changed and they are now auto-closed after 5 days.

Linked to https://github.com/unboxed/bops-applicants/pull/82

### Story Link

https://trello.com/c/O1qA5sVv/682-support-both-15-day-validation-and-5-day-post-validation-time-limited-request-from-applicants-3