### PR TITLE
Show open description change request warning

### DIFF
--- a/app/models/concerns/planning_application_decorator.rb
+++ b/app/models/concerns/planning_application_decorator.rb
@@ -3,6 +3,10 @@
 module PlanningApplicationDecorator
   extend ActiveSupport::Concern
 
+  def open_description_change_request
+    @open_description_change_request ||= description_change_validation_requests.open.last
+  end
+
   def agent_full_name
     [agent_first_name, agent_last_name].compact.join(" ")
   end

--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -34,9 +34,15 @@
           </div>
         </div>
       <% end %>
-
+      <% if @planning_application.open_description_change_request.present? %>
+        <%= render(
+          partial: "shared/warning_text",
+          locals: {
+            message: t(".awaiting_approval_to", date: @planning_application.open_description_change_request.created_at.strftime("%d/%m/%Y"))
+          }
+        ) %>
+      <% end %>
       <%= form.govuk_date_field :determination_date, id: "determination-date" %>
-
       <%= form.submit "Determine application", class: "govuk-button" %>
     <% end %>
   <% else %>

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -1,5 +1,7 @@
 en:
   planning_applications:
+    assessment_dashboard:
+      awaiting_approval_to: Awaiting approval to a description change (sent on %{date})
     days_left:
       one: '1 day remaining'
       zero: '%{count} days overdue'

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -406,4 +406,40 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       )
     end
   end
+
+  describe "#open_description_change_request" do
+    let(:planning_application) { create(:planning_application) }
+
+    context "when open description_change_validation_request present" do
+      let!(:description_change_validation_request) do
+        create(
+          :description_change_validation_request,
+          :open,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns description_change_validation_request" do
+        expect(
+          planning_application.open_description_change_request
+        ).to eq(
+          description_change_validation_request
+        )
+      end
+    end
+
+    context "when no open description_change_validation_request present" do
+      before do
+        create(
+          :description_change_validation_request,
+          :closed,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns nil" do
+        expect(planning_application.open_description_change_request).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Show warning for open `description_change_validation_request` on determination page.

### Story Link

https://trello.com/c/LC0A2pTC/1034-prevent-an-officer-from-unknowingly-determining-an-application-with-an-outstanding-description-change-request

### Screenshot

<img width="70%" alt="Screenshot 2022-07-04 at 16 46 01" src="https://user-images.githubusercontent.com/25392162/177186903-50dbf180-6e8d-4db8-9b56-841d9c1c6712.png">

