### PR TITLE
Remove duplicate breadcrumbs on recommendation page

### DIFF
--- a/app/views/planning_applications/view_recommendation.html.erb
+++ b/app/views/planning_applications/view_recommendation.html.erb
@@ -1,10 +1,6 @@
 <% content_for :page_title do %>
   View recommendation - <%= t('page_title') %>
 <% end %>
-
-<% add_parent_breadcrumb_link "Home", planning_applications_path %>
-<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-
 <%= render "assessment_dashboard" do %>
   <h2 class="govuk-heading-m">
     View recommendation


### PR DESCRIPTION
### Description of change

- Remove breadcrumbs from view, as are also rendered by the `assessment_dashboard` partial.

### Story Link

https://trello.com/c/Mm12bdWe/1028-duplicated-breadcrumb

### Decisions 

`it "does not render the breadcrumbs twice"` seems like maybe an excessive test to add - but I'm open to persausion!

### Screenshot

<img width="60%" alt="Screenshot 2022-07-04 at 17 15 01" src="https://user-images.githubusercontent.com/25392162/177191166-4ec70246-5d56-4fcd-804f-b715c6e39271.png">


