### PR TITLE
Show nil payment amount as £0.00 in application information

### DIFF
--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -78,7 +78,7 @@
             <td class="govuk-table__cell"><strong>Payment Reference:</strong></td>
             <td class="govuk-table__cell">
               <p class="govuk-body">
-                <%= @planning_application.payment_reference %>
+                <%= @planning_application.payment_reference || t(".exempt") %>
               </p>
             </td>
           </tr>
@@ -86,7 +86,10 @@
             <td class="govuk-table__cell"><strong>Payment Amount:</strong></td>
             <td class="govuk-table__cell">
               <p class="govuk-body">
-                <%= number_to_currency (@planning_application.payment_amount), unit: '£' %>
+                <%= number_to_currency(
+                  @planning_application.payment_amount || 0,
+                  unit: '£'
+                ) %>
               </p>
             </td>
           </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  shared:
+    application_information:
+      exempt: Exempt
   page_title: "BETA BOPs - GOV.UK"
   statuses:
     not_started: "Not started"

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe "Planning Application show page", type: :system do
       end
     end
 
+    context "when no fee paid" do
+      let!(:planning_application) do
+        create(
+          :planning_application,
+          local_authority: default_local_authority,
+          payment_reference: nil,
+          payment_amount: nil
+        )
+      end
+
+      it "shows the payment amount as £0.00" do
+        visit planning_application_path(planning_application)
+        click_button "Application information"
+
+        payment_amount_row = find_all("tr").find do |row|
+          row.has_content?("Payment Amount")
+        end
+
+        expect(payment_amount_row).to have_content("£0.00")
+
+        payment_reference_row = find_all("tr").find do |row|
+          row.has_content?("Payment Reference")
+        end
+
+        expect(payment_reference_row).to have_content("Exempt")
+      end
+    end
+
     it "Constraints accordion" do
       click_button "Constraints"
 


### PR DESCRIPTION
### Description of change

In application information accordion:

- Show payment amount as '£0.00' if nil.
- Show payment reference as 'Exempt' if nil.

### Story Link

https://trello.com/c/XODTSXzE/1010-when-no-fee-paid-display-0-and-payment-reference-saying-exempt

### Screenshot

<img width="60%" alt="Screenshot 2022-07-06 at 14 38 20" src="https://user-images.githubusercontent.com/25392162/177563420-b8009208-cd76-4cca-8b7c-99e471b04032.png">

