### PR TITLE
Retreive parish name from mapit API

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -474,10 +474,11 @@ class PlanningApplication < ApplicationRecord
   def set_ward_information
     return if postcode.blank?
 
-    ward_type, ward = Apis::Mapit::Query.new.fetch(postcode)
+    ward_type, ward, parish_name = Apis::Mapit::Query.new.fetch(postcode)
 
     self.ward_type = ward_type
     self.ward = ward
+    self.parish_name = parish_name
     save!
   end
 

--- a/app/services/apis/mapit/query.rb
+++ b/app/services/apis/mapit/query.rb
@@ -5,6 +5,8 @@ require "faraday"
 module Apis
   module Mapit
     class Query
+      PARISH_TYPES = %w[NCP CPC CPW].freeze
+
       def fetch(postcode)
         response = client.call(postcode)
 
@@ -23,14 +25,22 @@ module Apis
       private
 
       def parse(body)
-        ward_id = body["shortcuts"]["ward"]
-        ward_object = body["areas"][ward_id.to_s]
+        areas = body["areas"]
 
-        [ward_object["type_name"], ward_object["name"]]
+        ward_id = body["shortcuts"]["ward"]
+        ward_object = areas[ward_id.to_s]
+
+        [ward_object["type_name"], ward_object["name"], parish_name(areas)]
       end
 
       def client
         @client ||= Apis::Mapit::Client.new
+      end
+
+      def parish_name(areas)
+        parish_object = areas.values.find { |hash| PARISH_TYPES.include?(hash["type"]) }
+
+        parish_object&.fetch("name")
       end
     end
   end

--- a/app/views/shared/_application_information.html.erb
+++ b/app/views/shared/_application_information.html.erb
@@ -43,6 +43,14 @@
             <td class="govuk-table__cell"><strong>Location:</strong></td>
             <td class="govuk-table__cell"><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></td>
           </tr>
+          <% if @planning_application.parish_name %>
+            <tr class="govuk-table__row" id="parish-name">
+              <td class="govuk-table__cell"><strong>Parish:</strong></td>
+              <td class="govuk-table__cell">
+                <p class="govuk-body"><%= @planning_application.parish_name %></p>
+              </td>
+            </tr>
+          <% end %>
           <tr class="govuk-table__row" id="ward">
             <td class="govuk-table__cell"><strong>Ward:</strong></td>
             <td class="govuk-table__cell">

--- a/db/migrate/20220706101605_add_parish_name_to_planning_applications.rb
+++ b/db/migrate/20220706101605_add_parish_name_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddParishNameToPlanningApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :planning_applications, :parish_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_15_151407) do
+ActiveRecord::Schema.define(version: 2022_07_06_101605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -247,6 +247,7 @@ ActiveRecord::Schema.define(version: 2022_06_15_151407) do
     t.boolean "valid_red_line_boundary"
     t.decimal "invalid_payment_amount", precision: 10, scale: 2
     t.bigint "application_number", null: false
+    t.string "parish_name"
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"

--- a/spec/fixtures/mapit/HP92HA.json
+++ b/spec/fixtures/mapit/HP92HA.json
@@ -1,0 +1,48 @@
+{
+  "postcode": "HP9 2HA",
+  "wgs84_lon": -0.6336388619420956,
+  "wgs84_lat": 51.60653167148054,
+  "coordsyst": "G",
+  "easting": 494719,
+  "northing": 190628,
+  "areas": {
+    "58229": {
+      "id": 58229,
+      "name": "Beaconsfield",
+      "parent_area": 163793,
+      "type": "CPC",
+      "type_name": "Civil parish/community",
+      "country": "E",
+      "country_name": "England",
+      "generation_low": 12,
+      "generation_high": 47,
+      "codes": {
+        "ons": "11UE001",
+        "gss": "E04001580",
+        "unit_id": "11744"
+      },
+      "all_names": {}
+    },
+    "164398": {
+      "id": 164398,
+      "name": "Beaconsfield ward",
+      "parent_area": 163793,
+      "type": "UTW",
+      "type_name": "Unitary Authority ward (UTW)",
+      "country": "E",
+      "country_name": "England",
+      "generation_low": 43,
+      "generation_high": 47,
+      "codes": {
+        "gss": "E05013129",
+        "unit_id": "180349"
+      },
+      "all_names": {}
+    }
+  },
+  "shortcuts": {
+    "WMC": 65687,
+    "ward": 164398,
+    "council": 163793
+  }
+}

--- a/spec/fixtures/mapit/SE220HW.json
+++ b/spec/fixtures/mapit/SE220HW.json
@@ -23,6 +23,21 @@
       "generation_low": 33,
       "country_name": "England",
       "type": "LBW"
+    },
+    "164983": {
+      "id": 164983,
+      "name": "Southwark, unparished area",
+      "parent_area": null,
+      "type": "NCP",
+      "type_name": "Non-civil parished area",
+      "country": "E",
+      "country_name": "England",
+      "generation_low": 44,
+      "generation_high": 47,
+      "codes": {
+        "gss": "E43000218"
+      },
+      "all_names": {}
     }
   }
 }

--- a/spec/fixtures/mapit/default.json
+++ b/spec/fixtures/mapit/default.json
@@ -23,6 +23,21 @@
       "generation_low": 33,
       "country_name": "England",
       "type": "LBW"
+    },
+    "164983": {
+      "id": 164983,
+      "name": "Southwark, unparished area",
+      "parent_area": null,
+      "type": "NCP",
+      "type_name": "Non-civil parished area",
+      "country": "E",
+      "country_name": "England",
+      "generation_low": 44,
+      "generation_high": 47,
+      "codes": {
+        "gss": "E43000218"
+      },
+      "all_names": {}
     }
   }
 }

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -167,6 +167,7 @@ RSpec.describe PlanningApplication, type: :model do
 
           expect(planning_application.ward).to eq("South Bermondsey")
           expect(planning_application.ward_type).to eq("London borough ward")
+          expect(planning_application.parish_name).to eq("Southwark, unparished area")
         end
       end
 

--- a/spec/services/apis/mapit/query_spec.rb
+++ b/spec/services/apis/mapit/query_spec.rb
@@ -10,10 +10,15 @@ RSpec.describe Apis::Mapit::Query do
       context "when a valid postcode is supplied" do
         before do
           stub_mapit_api_request_for("SE220HW").to_return(mapit_api_response(:ok, "SE220HW"))
+          stub_mapit_api_request_for("HP92HA").to_return(mapit_api_response(:ok, "HP92HA"))
         end
 
-        it "returns an array with ward type and ward name" do
-          expect(query.fetch("SE220HW")).to eq(["London borough ward", "Dulwich Hill"])
+        it "returns an array with ward type, ward name and parish name (type NPC)" do
+          expect(query.fetch("SE220HW")).to eq(["London borough ward", "Dulwich Hill", "Southwark, unparished area"])
+        end
+
+        it "returns an array with ward type, ward name and parish name (type CPC)" do
+          expect(query.fetch("HP92HA")).to eq(["Unitary Authority ward (UTW)", "Beaconsfield ward", "Beaconsfield"])
         end
       end
     end

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -89,6 +89,11 @@ RSpec.describe "Planning Application show page", type: :system do
       expect(page).to have_text("PAY123")
       expect(page).to have_text("£103.00")
 
+      within("#parish-name") do
+        expect(page).to have_text("Parish:")
+        expect(page).to have_text("Southwark, unparished area")
+      end
+
       within("#ward") do
         expect(page).to have_text("Ward:")
         expect(page).to have_text("South Bermondsey")


### PR DESCRIPTION
### Description of change

Retrieve parish name from mapit API

- Annoyingly there is no shortcut id to access the relevant parish object so we have to iterate and find the object based on the parish type code. Example json: https://mapit.mysociety.org/postcode/HP9%202HA
- We then access the "name" key in this object to reference the parish name
- From docs, there seem to be 3 types of parish types: "Non-civil parished area (NCP), Civil parish/community (CPC), Civil parish/community, Civil parish/community ward (CPW)"
- Save this to db after planning application create callback

### Story Link

https://trello.com/c/BUe9EUhm/1033-show-parish-information