### PR TITLE
Show alert dialogue for unsaved changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem "puma", "~> 4"
 gem "rails", "~> 6.1"
 gem "rswag-ui"
 gem "sassc", "~> 2.4.0"
+gem "stimulus-rails"
 gem "webpacker", "~> 5.4"
 gem "whenever"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    stimulus-rails (1.0.4)
+      railties (>= 6.0.0)
     sys-uname (1.2.2)
       ffi (~> 1.1)
     thor (1.2.1)
@@ -520,6 +522,7 @@ DEPENDENCIES
   rubocop-rspec
   sassc (~> 2.4.0)
   selenium-webdriver
+  stimulus-rails
   web-console
   webdrivers
   webmock

--- a/README.md
+++ b/README.md
@@ -154,3 +154,9 @@ and running:
 ```
 swagger-cli bundle public/api-docs/v1/swagger_doc.yaml --outfile public/api-docs/v1/_build/swagger_doc.yaml --type yaml
 ```
+
+## Javascript
+
+We are using [Stimulus](https://stimulus.hotwired.dev) to handle our minimal JavaScript requirements.
+
+After adding a new Stimulus controller run `./bin/rails stimulus:manifest:update`. Alternatively you can create the controller with `./bin/rails generate stimulus controllerName`.

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -4,7 +4,9 @@ class PolicyClassesController < PlanningApplicationsController
   before_action :set_planning_application
   before_action :set_policy_class, only: %i[show update destroy]
 
-  def part; end
+  def part
+    @part_number = params[:part]&.to_i
+  end
 
   def new
     @part = params[:part]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,4 +12,12 @@ module ApplicationHelper
   def accessible_time(datetime)
     tag.time(datetime.strftime("%e %B %G at %R%P"), { datetime: datetime.iso8601 })
   end
+
+  def unsaved_changes_data
+    {
+      controller: "unsaved-changes",
+      action: "beforeunload@window->unsaved-changes#handleBeforeUnload submit->unsaved-changes#handleSubmit",
+      unsaved_changes_target: "form"
+    }
+  end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,0 +1,5 @@
+import { Application } from "@hotwired/stimulus"
+const application = Application.start()
+application.debug = false
+window.Stimulus = application
+export { application }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,3 @@
+import { application } from "./application"
+import UnsavedChangesController from "./unsaved_changes_controller"
+application.register("unsaved-changes", UnsavedChangesController)

--- a/app/javascript/controllers/unsaved_changes_controller.js
+++ b/app/javascript/controllers/unsaved_changes_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["form"]
+
+  connect() {
+    this.originalValues = this.currentValues()
+  }
+
+  handleBeforeUnload(event) {
+    if (this.submitEvent || this.valuesUnchanged()) return
+    event.returnValue = "false"
+    return event.returnValue
+  }
+
+  currentValues() {
+    const formData = new FormData(this.formTarget)
+    formData.delete("authenticity_token")
+    return Array.from(formData.values())
+  }
+
+  handleSubmit(_event) {
+    this.submitEvent = true
+  }
+
+  valuesUnchanged() {
+    return this.currentValues().every((value, index) => {
+      return value === this.originalValues[index]
+    })
+  }
+}

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -11,3 +11,5 @@ require("@rails/activestorage").start();
 import "@opensystemslab/map";
 
 const images = require.context('../images', true)
+
+import "controllers"

--- a/app/views/policy_classes/new.html.erb
+++ b/app/views/policy_classes/new.html.erb
@@ -11,7 +11,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: planning_application_policy_classes_path(@planning_application)) do |form| %>
+    <%= form_with(
+      url: planning_application_policy_classes_path(@planning_application),
+      html: { data: unsaved_changes_data }
+    ) do |form| %>
       <%= form.hidden_field :part, value: @part %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset" aria-describedby="nationality-hint">

--- a/app/views/policy_classes/part.html.erb
+++ b/app/views/policy_classes/part.html.erb
@@ -32,7 +32,11 @@
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <% PolicyClass.all_parts.each do |part_number, part| %>
               <div class="govuk-radios__item">
-                <%= form.radio_button :part, part_number, class: "govuk-radios__input" %>
+                <%= form.radio_button(
+                  :part, part_number,
+                  class: "govuk-radios__input",
+                  checked: @part_number == part_number
+                ) %>
                 <%= form.label :part, value: part_number, class: "govuk-label govuk-radios__label" do %>
                   <strong>Part <%= part_number %></strong> - <%= part[:name] %>
                 <% end %>

--- a/app/views/policy_classes/part.html.erb
+++ b/app/views/policy_classes/part.html.erb
@@ -9,7 +9,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with(url: new_planning_application_policy_class_path(@planning_application), method: :get) do |form| %>
+    <%= form_with(
+      url: new_planning_application_policy_class_path(@planning_application),
+      method: :get,
+      html: { data: unsaved_changes_data }
+    ) do |form| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/app/views/policy_classes/show.html.erb
+++ b/app/views/policy_classes/show.html.erb
@@ -33,7 +33,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with method: :put, scope: "policies" do |form| %>
+    <%= form_with(
+      method: :put,
+      scope: "policies",
+      html: { data: unsaved_changes_data }
+    ) do |form| %>
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--l"><%= @policy_class %></caption>
         <thead class="govuk-table__head">

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bops",
   "private": true,
   "dependencies": {
+    "@hotwired/stimulus": "^3.0.1",
     "@opensystemslab/map": "^0.5.5",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "assessment against legislation", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: local_authority
+    )
+  end
+
+  let(:assessor) { create :user, :assessor, local_authority: local_authority }
+
+  it "warns the user about unsaved changes" do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    dismiss_confirm { click_link("Back") }
+    click_button("Continue")
+
+    check(
+      "Class A - enlargement, improvement or other alteration of a dwellinghouse"
+    )
+
+    dismiss_confirm { click_link("Back") }
+    click_button("Add classes")
+    click_link("Part 1, Class A")
+    choose("policies_1a_complies")
+    dismiss_confirm { click_link("Back") }
+    click_button("Save assessments")
+
+    expect(page).to have_content("Successfully updated policy class")
+  end
+end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -16,11 +16,15 @@ RSpec.describe "assessment against legislation", type: :system do
   let(:assessor) { create :user, :assessor, local_authority: local_authority }
 
   it "warns the user about unsaved changes" do
-    sign_in assessor
+    sign_in(assessor)
     visit planning_application_path(planning_application)
+    click_link("Add assessment area")
+    click_link("Back")
     click_link("Add assessment area")
     choose("Part 1 - Development within the curtilage of a dwellinghouse")
     dismiss_confirm { click_link("Back") }
+    click_button("Continue")
+    click_link("Back")
     click_button("Continue")
 
     check(
@@ -29,6 +33,11 @@ RSpec.describe "assessment against legislation", type: :system do
 
     dismiss_confirm { click_link("Back") }
     click_button("Add classes")
+
+    expect(page).to have_content("Policy classes have been successfully added")
+
+    click_link("Part 1, Class A")
+    click_link("Back")
     click_link("Part 1, Class A")
     choose("policies_1a_complies")
     dismiss_confirm { click_link("Back") }

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@hotwired/stimulus@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
+  integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
+
 "@lit/reactive-element@^1.0.0-rc.2":
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz#f24dba16ea571a08dca70f1783bd2ca5ec8de3ee"


### PR DESCRIPTION
### Description of change

- Add [stimulus](https://stimulus.hotwired.dev/) to the project using the [stimulus-rails](https://github.com/hotwired/stimulus-rails) gem.
- Intercept `beforeunload` eventsand show alert dialogue if policy class forms have changes that have not been submitted.
- Fix small bug where part is deselected if you click 'Back' in multipart policy form.

### Story Link

https://trello.com/c/rllvuyz8/1035-when-assessing-against-legislation-provide-warning-that-data-may-be-lost-when-navigating-away

### Screenshot

<img width="60%" alt="Screenshot 2022-07-14 at 14 43 17" src="https://user-images.githubusercontent.com/25392162/178996686-d7c11263-9249-4dc6-8056-e3d91e0b3087.png">

