### PR TITLE
Show description change requests in post-validation validation requests table

### DIFF
--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -21,7 +21,11 @@ class ValidationRequestsController < AuthenticationController
   end
 
   def post_validation_requests
-    validation_requests = @planning_application.validation_requests(post_validation: true)
+    validation_requests = @planning_application.validation_requests(
+      post_validation: true,
+      include_description_change_validation_requests: true
+    )
+
     @cancelled_validation_requests, @active_validation_requests = validation_requests.partition(&:cancelled?)
 
     respond_to do |format|

--- a/app/views/description_change_validation_requests/_description_change_validation_request.html.erb
+++ b/app/views/description_change_validation_requests/_description_change_validation_request.html.erb
@@ -1,15 +1,21 @@
 <td class="govuk-table__cell change-request-list">
-  Change of description
+  <%= t(".change_description") %>
 </td>
 <% if description_change_validation_request.cancelled? %>
   <td class="govuk-table__cell change-request-list">
     <%= description_change_validation_request.proposed_description %>
   </td>
+<% elsif description_change_validation_request.post_validation? %>
+  <td class="govuk-table__cell change-request-list">
+    <%= t(".proposed_description") %>
+    <%= description_change_validation_request.proposed_description %>
+  </td>
 <% else %>
   <td class="govuk-table__cell change-request-list">
-    New description: <%= description_change_validation_request.proposed_description %>
+    <%= t(".new_description") %>
+    <%= description_change_validation_request.proposed_description %>
   </td>
   <td class="govuk-table__cell change-request-list">
-    Description change
+    <%= t(".description_change") %>
   </td>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,12 @@ en:
     southwark: SWK
     buckinghamshire: BUC
     ripa: RIPA
+  description_change_validation_requests:
+    description_change_validation_request:
+      change_description: Change description
+      description_change: Description change
+      new_description: "New description:"
+      proposed_description: "Propsed description:"
   users:
     edit:
       edit_user: Edit user

--- a/spec/models/concerns/planning_application/validation_request_spec.rb
+++ b/spec/models/concerns/planning_application/validation_request_spec.rb
@@ -34,24 +34,52 @@ RSpec.describe PlanningApplication::ValidationRequest do
     let(:planning_application) { create(:planning_application, :invalidated) }
 
     let!(:red_line_boundary_change_validation_request) do
-      create(:red_line_boundary_change_validation_request, planning_application: planning_application)
+      create(
+        :red_line_boundary_change_validation_request,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
     end
+
     let!(:post_validation_red_line_boundary_change_validation_request) do
       create(:red_line_boundary_change_validation_request, :post_validation, planning_application: planning_application)
     end
+
     let!(:other_change_validation_request) do
-      create(:other_change_validation_request, planning_application: planning_application)
+      create(
+        :other_change_validation_request,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
     end
+
     let!(:replacement_document_validation_request) do
-      create(:replacement_document_validation_request, planning_application: planning_application)
+      create(
+        :replacement_document_validation_request,
+        planning_application: planning_application,
+        created_at: 3.days.ago
+      )
     end
+
     let!(:additional_document_validation_request) do
-      create(:additional_document_validation_request, planning_application: planning_application)
+      create(
+        :additional_document_validation_request,
+        planning_application: planning_application,
+        created_at: 4.days.ago
+      )
+    end
+
+    let!(:description_change_validation_request) do
+      create(
+        :description_change_validation_request,
+        planning_application: planning_application,
+        created_at: 5.days.ago
+      )
     end
 
     context "when no argument is supplied" do
       it "returns validation requests where post_validation is false" do
-        expect(planning_application.validation_requests).to match_array(
+        expect(planning_application.validation_requests).to eq(
           [red_line_boundary_change_validation_request, other_change_validation_request, replacement_document_validation_request, additional_document_validation_request]
         )
       end
@@ -61,6 +89,24 @@ RSpec.describe PlanningApplication::ValidationRequest do
       it "returns validation requests where post_validation is true" do
         expect(planning_application.validation_requests(post_validation: true)).to match_array(
           [post_validation_red_line_boundary_change_validation_request]
+        )
+      end
+    end
+
+    context "when include_description_change_validation_requests is true" do
+      it "returns all validation requests" do
+        expect(
+          planning_application.validation_requests(
+            include_description_change_validation_requests: true
+          )
+        ).to eq(
+          [
+            red_line_boundary_change_validation_request,
+            other_change_validation_request,
+            replacement_document_validation_request,
+            additional_document_validation_request,
+            description_change_validation_request
+          ]
         )
       end
     end

--- a/spec/system/planning_applications/post_validation_requests.rb
+++ b/spec/system/planning_applications/post_validation_requests.rb
@@ -68,6 +68,19 @@ RSpec.describe "Validation tasks", type: :system do
         create(:red_line_boundary_change_validation_request, :closed, planning_application: planning_application)
         create(:red_line_boundary_change_validation_request, :cancelled, planning_application: planning_application)
 
+        create(
+          :description_change_validation_request,
+          :cancelled,
+          planning_application: planning_application,
+          proposed_description: "New description 1"
+        )
+
+        create(
+          :description_change_validation_request,
+          planning_application: planning_application,
+          proposed_description: "New description 2"
+        )
+
         visit planning_application_validation_requests_path(planning_application)
       end
 
@@ -75,16 +88,20 @@ RSpec.describe "Validation tasks", type: :system do
         expect(page).not_to have_content("Red line boundary changes")
         expect(page).not_to have_content("View request red line boundary")
         expect(page).not_to have_content("Cancelled requests")
+        expect(page).not_to have_content("New description 1")
+        expect(page).not_to have_content("New description 2")
 
         # check post valiation requests table
         visit post_validation_requests_planning_application_validation_requests_path(planning_application)
         within(".validation-requests-table") do
           expect(page).to have_content("Red line boundary changes")
           expect(page).to have_content("View request red line boundary")
+          expect(page).to have_content("New description 2")
         end
 
         within(".cancelled-requests") do
           expect(page).to have_content("Red line boundary changes")
+          expect(page).to have_content("New description 1")
         end
       end
     end


### PR DESCRIPTION
### Description of change

- Update `PlanningApplication#validation_requests` to take an optional `include_description_change_validation_requests` option.
- In `ValidationRequestsController#post_validation_requests` use the `include_description_change_validation_requests` option when setting `@validation_requests`. 
- Update partial so aligns with existing table headers.

### Story Link

https://trello.com/c/l0E2kVlx/713-add-description-changes-to-post-validation-requests-table-2

### Screenshot

<img src='https://user-images.githubusercontent.com/25392162/178245478-2d4693c5-9679-48b2-bd5a-5c55444b655b.png' width='60%'>