### PR TITLE
Auto close red line boundary change requests after 5 business days

### DIFF
--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -29,10 +29,6 @@ module ValidationRequestHelper
     end
   end
 
-  def request_closed_at(validation_request)
-    validation_request.updated_at if validation_request.closed?
-  end
-
   def edit_request_url(planning_application, validation_request, classname: nil)
     link_to "Edit request",
             send("edit_planning_application_#{request_type(validation_request)}_path", planning_application,

--- a/app/jobs/close_description_change_job.rb
+++ b/app/jobs/close_description_change_job.rb
@@ -7,7 +7,7 @@ class CloseDescriptionChangeJob < ApplicationJob
     description_change_requests = DescriptionChangeValidationRequest.open_change_created_over_5_business_days_ago
 
     description_change_requests.each do |change_request|
-      change_request.auto_approve!
+      change_request.auto_close_request!
 
       PlanningApplicationMailer.description_closure_notification_mail(
         change_request.planning_application,

--- a/app/jobs/close_red_line_boundary_change_validation_request_job.rb
+++ b/app/jobs/close_red_line_boundary_change_validation_request_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CloseRedLineBoundaryChangeValidationRequestJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    validation_requests = RedLineBoundaryChangeValidationRequest.open_change_created_over_5_business_days_ago
+
+    validation_requests.each do |request|
+      request.auto_close_request!
+
+      PlanningApplicationMailer.validation_request_closure_mail(request.planning_application).deliver_now
+    end
+  end
+end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -107,6 +107,17 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
     )
   end
 
+  def validation_request_closure_mail(planning_application)
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:validation_request_closure_mail),
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+    )
+  end
+
   private
 
   def subject(key)

--- a/app/models/description_change_validation_request.rb
+++ b/app/models/description_change_validation_request.rb
@@ -15,7 +15,6 @@ class DescriptionChangeValidationRequest < ApplicationRecord
   validate :allows_only_one_open_description_change, on: :create
   validate :planning_application_has_not_been_determined, on: :create
 
-  scope :open_change_created_over_5_business_days_ago, -> { open.where("created_at <= ?", 5.business_days.ago) }
   scope :responded, -> { closed.where(cancelled_at: nil, auto_closed: false).order(created_at: :asc) }
 
   def rejected_reason_is_present?
@@ -59,6 +58,10 @@ class DescriptionChangeValidationRequest < ApplicationRecord
 
   def response_due
     RESPONSE_TIME_IN_DAYS.business_days.after(created_at).to_date
+  end
+
+  def update_planning_application_for_auto_closed_request!
+    planning_application.update!(description: proposed_description)
   end
 
   private

--- a/app/models/red_line_boundary_change_validation_request.rb
+++ b/app/models/red_line_boundary_change_validation_request.rb
@@ -24,6 +24,10 @@ class RedLineBoundaryChangeValidationRequest < ApplicationRecord
     new_geojson.presence || planning_application.boundary_geojson
   end
 
+  def update_planning_application_for_auto_closed_request!
+    planning_application.update!(boundary_geojson: new_geojson)
+  end
+
   private
 
   def set_original_geojson

--- a/app/views/planning_application_mailer/validation_request_closure_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_closure_mail.text.erb
@@ -1,0 +1,19 @@
+Application reference number: <%= @planning_application.reference_in_full %>
+
+Application received: <%= @planning_application.received_at.strftime("%-d %B %Y") %>
+
+At: <%= @planning_application.full_address.upcase %>
+
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
+A proposed change to your application which you were told about 5 days ago has been automatically accepted as we have not had a response from you.
+
+To see the change please follow the link below:
+
+<%= @planning_application.secure_change_url %>
+
+If you have any questions, send them to <%= @planning_application.local_authority.email_address %> and someone will get back to you.
+
+Yours faithfully,
+
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/red_line_boundary_change_validation_requests/_applicant_approved_response.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_applicant_approved_response.html.erb
@@ -8,7 +8,11 @@
 <%= render "shared/location_map", locals: { geojson: @red_line_boundary_change_validation_request.new_geojson } %>
 
 <div class="govuk-inset-text">
-  <strong>Change to red line boundary has been approved by the applicant</strong>
+  <% if @red_line_boundary_change_validation_request.auto_closed? %>
+    <strong>Change to red line boundary was auto closed and approved after being open for more than 5 business days</strong>
+  <% else %>
+    <strong>Change to red line boundary has been approved by the applicant</strong>
+  <% end %>
 </div>
 
 <div class="govuk-button-group">

--- a/app/views/validation_requests/_table.html.erb
+++ b/app/views/validation_requests/_table.html.erb
@@ -2,6 +2,9 @@
   <caption class="govuk-table__caption govuk-table__caption--l">
     <% if post_validation_requests_index? %>
       Post-validation requests
+      <p class="govuk-body-m govuk-!-padding-top-3">
+        For redline and description requests, the applicant can reject or accept these changes within 5 working days, after that these requests will be automatically accepted.
+      </p>
     <% else %>
       Validation requests
     <% end %>

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -24,6 +24,7 @@ en:
         validation_notice_mail: Your application for a Lawful Development Certificate
         validation_request_mail: Lawful Development Certificate application  - further changes needed
         post_validation_request_mail: Lawful Development Certificate application  - changes needed
+        validation_request_closure_mail: Changes to your Lawful Development Certificate application
     overdue:
       one: '1 day overdue'
       other: '%{count} days overdue'

--- a/db/migrate/20220711085009_add_auto_closed_at_to_description_change_validation_requests.rb
+++ b/db/migrate/20220711085009_add_auto_closed_at_to_description_change_validation_requests.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddAutoClosedAtToDescriptionChangeValidationRequests < ActiveRecord::Migration[6.1]
+  class DescriptionChangeValidationRequest < ApplicationRecord
+    scope :auto_closed, -> { where(auto_closed: true) }
+  end
+
+  def change
+    add_column :description_change_validation_requests, :auto_closed_at, :datetime
+
+    DescriptionChangeValidationRequest.auto_closed.find_each do |request|
+      request.update(auto_closed_at: request.updated_at)
+    end
+  end
+end

--- a/db/migrate/20220712102525_add_auto_closed_fields_to_red_line_boundary_change_validation_requests.rb
+++ b/db/migrate/20220712102525_add_auto_closed_fields_to_red_line_boundary_change_validation_requests.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAutoClosedFieldsToRedLineBoundaryChangeValidationRequests < ActiveRecord::Migration[6.1]
+  def change
+    change_table :red_line_boundary_change_validation_requests, bulk: true do |t|
+      t.boolean :auto_closed, default: false, null: false
+      t.datetime :auto_closed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_06_101605) do
+ActiveRecord::Schema.define(version: 2022_07_12_102525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 2022_07_06_101605) do
     t.datetime "cancelled_at"
     t.boolean "auto_closed", default: false
     t.boolean "post_validation", default: false, null: false
+    t.datetime "auto_closed_at"
     t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
     t.index ["user_id"], name: "index_description_change_requests_on_user_id"
   end
@@ -290,6 +291,8 @@ ActiveRecord::Schema.define(version: 2022_07_06_101605) do
     t.datetime "cancelled_at"
     t.json "original_geojson"
     t.boolean "post_validation", default: false, null: false
+    t.boolean "auto_closed", default: false, null: false
+    t.datetime "auto_closed_at"
   end
 
   create_table "replacement_document_validation_requests", force: :cascade do |t|

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -36,7 +36,7 @@ When("I cancel the existing description change request") do
 end
 
 When("the description change request has been auto-closed after 5 days") do
-  @planning_application.description_change_validation_requests.last.auto_approve!
+  @planning_application.description_change_validation_requests.last.auto_close_request!
 end
 
 When("the request has been responded to") do

--- a/lib/tasks/close_red_line_boundary_change_request.rake
+++ b/lib/tasks/close_red_line_boundary_change_request.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace :jobs do
+  desc "Close red line boundary change requests that have been open for more than 5 business days"
+  task close_description_change: :environment do
+    CloseRedLineBoundaryChangeValidationRequestJob.perform_later
+  end
+end

--- a/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
+++ b/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CloseRedLineBoundaryChangeValidationRequestJob, type: :job do
+  let!(:planning_application) { create :planning_application, boundary_geojson: nil }
+
+  context "when over 5 business days have passed" do
+    before { freeze_time }
+
+    let!(:red_line_boundary_change_validation_request) do
+      create :red_line_boundary_change_validation_request, :open,
+             planning_application: planning_application,
+             created_at: 6.business_days.ago
+    end
+
+    it "changes the planning application's boundary geojson" do
+      expect { described_class.perform_now }.to(change { planning_application.reload.boundary_geojson }.from(planning_application.boundary_geojson).to(red_line_boundary_change_validation_request.new_geojson))
+    end
+
+    it "auto-closes the request and approves the change" do
+      expect { described_class.perform_now }
+        .to(change { red_line_boundary_change_validation_request.reload.state }.from("open").to("closed")
+          .and(change { red_line_boundary_change_validation_request.reload.auto_closed }.from(false).to(true))
+          .and(change { red_line_boundary_change_validation_request.reload.auto_closed_at }.from(nil).to(Time.current)))
+    end
+
+    it "sends an email" do
+      expect { described_class.perform_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+
+    it "adds an auto-close audit entry" do
+      described_class.perform_now
+
+      audit = red_line_boundary_change_validation_request.reload.audits.max
+
+      expect(audit.activity_type).to eq("auto_closed")
+    end
+  end
+
+  context "when less than 5 business days have passed" do
+    let!(:red_line_boundary_change_validation_request) do
+      create :red_line_boundary_change_validation_request, :open,
+             planning_application: planning_application,
+             created_at: 4.business_days.ago
+    end
+
+    it "does not change the planning application's boundary geojson" do
+      expect { described_class.perform_now }.not_to(change { planning_application.reload.boundary_geojson })
+    end
+
+    it "does not auto-close the request" do
+      expect { described_class.perform_now }
+        .not_to(change { red_line_boundary_change_validation_request.reload.state })
+    end
+
+    it "does not send an email" do
+      expect { described_class.perform_now }.not_to(change { ActionMailer::Base.deliveries.count })
+    end
+  end
+end

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -57,6 +57,10 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
     PlanningApplicationMailer.validation_request_mail(planning_application)
   end
 
+  def validation_request_closure_mail
+    PlanningApplicationMailer.validation_request_closure_mail(planning_application)
+  end
+
   private
 
   def planning_application

--- a/spec/support/state_machine_shared_examples.rb
+++ b/spec/support/state_machine_shared_examples.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples "PlanningApplicationStateMachineTransitions" do |state, va
 end
 
 RSpec.shared_examples "ValidationRequestStateMachineEvents" do |request_type, state, valid_events|
-  events = %i[mark_as_sent cancel auto_approve]
+  events = %i[mark_as_sent cancel auto_close]
   invalid_events = events - valid_events
 
   let(:validation_request) { create("#{request_type}_validation_request", :"#{state}") }


### PR DESCRIPTION
### Description of change

Auto close red line boundary change requests after 5 business days

- Add migration for auto_closed and auto_closed_at column on red line boundary change requests
- Add missing migration for auto_closed_at column on description changes
- Wrap event and subsequent updates in transaction as we want to update everything successfully or nothing at all. If there is an error raised we send the error to AppSignal 

### Story Link

https://trello.com/c/yA3qHp8h/1030-red-line-requests-auto-accept-after-5-days-according-to-rules-in-use-for-description-changes

