### PR TITLE
Allow additional document requests after recommendation

### DIFF
--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -5,7 +5,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
 
   before_action :set_additional_document_validation_request, only: %i[edit update]
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
-  before_action :ensure_planning_application_not_validated, only: %i[new create edit update]
+  before_action :ensure_planning_application_not_validated, only: %i[edit update]
   before_action :ensure_planning_application_not_invalidated, only: :edit
 
   def new

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -231,4 +231,32 @@ RSpec.describe "post validation requests", type: :system do
       expect(page).to have_content("forbidden")
     end
   end
+
+  context "when the application is awaiting determination" do
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :awaiting_determination,
+        local_authority: default_local_authority
+      )
+    end
+
+    it "lets the assessor create an additional document request" do
+      click_button("Documents")
+      click_link("Manage documents")
+      click_link("Request a new document")
+      fill_in("Please specify the new document type:", with: "Floor plan")
+
+      fill_in(
+        "Please specify the reason you have requested this document?",
+        with: "Existing document inaccurate"
+      )
+
+      click_button("Send request")
+
+      expect(page).to have_content(
+        "Additional document request successfully created."
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Remove before action for `AdditionalDocumentValidationRequestsController#new` and `#create` that prevents user creating new requests when application is awaiting determination.

### Story Link

https://trello.com/c/LQG1atOK/735-enable-amendment-requests-for-new-documents-that-can-be-actioned-after-validation-2 (I missed a bit 😬)