### PR TITLE
Show feedback

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -59,7 +59,8 @@ module Api
             end
           end
         end
-      rescue Errors::WrongFileTypeError, Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError => e
+      rescue Errors::WrongFileTypeError, Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError,
+             NoMethodError => e
         send_failed_response(e)
       end
 
@@ -83,22 +84,24 @@ module Api
       private
 
       def planning_application_params
-        permitted_keys = %i[application_type
-                            description
-                            applicant_first_name
-                            applicant_last_name
-                            applicant_phone
-                            applicant_email
-                            agent_first_name
-                            agent_last_name
-                            agent_phone
-                            agent_email
-                            user_role
-                            proposal_details
-                            files
-                            payment_reference
-                            work_status
-                            planx_debug_data]
+        permitted_keys = [:application_type,
+                          :description,
+                          :applicant_first_name,
+                          :applicant_last_name,
+                          :applicant_phone,
+                          :applicant_email,
+                          :agent_first_name,
+                          :agent_last_name,
+                          :agent_phone,
+                          :agent_email,
+                          :user_role,
+                          :proposal_details,
+                          :files,
+                          :payment_reference,
+                          :work_status,
+                          :planx_debug_data,
+                          { feedback: %i[result find_property planning_constraints] }]
+
         params.permit permitted_keys
       end
 

--- a/db/migrate/20220713114018_add_feedback_to_planning_applications.rb
+++ b/db/migrate/20220713114018_add_feedback_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFeedbackToPlanningApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :planning_applications, :feedback, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_12_102525) do
+ActiveRecord::Schema.define(version: 2022_07_13_114018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -198,7 +198,6 @@ ActiveRecord::Schema.define(version: 2022_07_12_102525) do
     t.datetime "in_assessment_at"
     t.datetime "awaiting_correction_at"
     t.jsonb "proposal_details"
-    t.jsonb "audit_log"
     t.string "agent_first_name"
     t.string "agent_last_name"
     t.string "agent_phone"
@@ -252,6 +251,8 @@ ActiveRecord::Schema.define(version: 2022_07_12_102525) do
     t.decimal "invalid_payment_amount", precision: 10, scale: 2
     t.bigint "application_number", null: false
     t.string "parish_name"
+    t.jsonb "audit_log"
+    t.jsonb "feedback", default: {}
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -399,6 +399,10 @@ paths:
                   agent_phone: '237878889'
                   agent_email: agent@example.com
                   user_role: agent
+                  feedback:
+                    result: feedback about the result
+                    find_property: feedback about the property
+                    planning_constraints: feedback about the constraints
                   result:
                     flag: Planning permission / Permission needed
                     heading: It looks like these changes will need planning permission

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -329,6 +329,10 @@ paths:
                   agent_phone: '237878889'
                   agent_email: agent@example.com
                   user_role: agent
+                  feedback:
+                    result: feedback about the result
+                    find_property: feedback about the property
+                    planning_constraints: feedback about the constraints
                   result:
                     flag: 'Planning permission / Permission needed'
                     heading: It looks like these changes will need planning permission

--- a/spec/fixtures/files/valid_planning_application.json
+++ b/spec/fixtures/files/valid_planning_application.json
@@ -1056,5 +1056,10 @@
         }
       ]
     }
-  ]
+  ],
+  "feedback": {
+    "result": "feedback about the result",
+    "find_property": "feedback about the property",
+    "planning_constraints": "feedback about the constraints"
+  }
 }

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -67,6 +67,18 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
         expect(JSON.parse(planning_application.planx_data)).to be_a(Hash)
       end
 
+      it "saves the feedback as a hash" do
+        post_with(params: permitted_development_json)
+
+        expect(PlanningApplication.last.feedback).to eq(
+          {
+            "result" => "feedback about the result",
+            "find_property" => "feedback about the property",
+            "planning_constraints" => "feedback about the constraints"
+          }
+        )
+      end
+
       it "sends the receipt email" do
         post_with(params: permitted_development_json)
 


### PR DESCRIPTION
### Description of change

Add feedback column to planning applications

### Story Link

Part 1 for https://trello.com/c/mbS4PsmF/393-display-the-free-text-collected-ripa-related-to-a-any-disagreements-about-the-applicants-planning-constraints-or-b-the-ripa-deci

- Still need to add to the frontend when designs are completed