### PR TITLE
Add address and reference to all sub pages

### DIFF
--- a/app/views/additional_document_validation_requests/_form.html.erb
+++ b/app/views/additional_document_validation_requests/_form.html.erb
@@ -2,6 +2,9 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@planning_application, @additional_document_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.govuk_fieldset legend: { text: "Request a new document", size: 'l' } do %>
+
+        <%= render "shared/planning_application_address_and_reference" %>
+
         <%= form.govuk_text_field :document_request_type,
          label: { text: 'Please specify the new document type:', size: 's' },
          hint: { text: 'Eg. Existing floor plans' } %>

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -7,7 +7,9 @@
 
 <% content_for :title, "Audit log" %>
 
-<%= render "planning_applications/proposal_header" %>
+<h1 class="govuk-heading-l">Audit log</h2>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <table class="govuk-table">
   <caption class="govuk-table__caption govuk-table__caption--m">Audit log</caption>

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -6,9 +6,9 @@
 <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
 <% content_for :title, "Edit constraints" %>
 
-<%= render "planning_applications/proposal_header" %>
+<h1 class="govuk-heading-l">Edit constraints</h2>
 
-<h2 class="govuk-heading-m">Constraints</h2>
+<%= render "shared/planning_application_address_and_reference" %>
 
 <div class="govuk-grid-row">
   <%= form_with model: @planning_application, url: planning_application_constraints_path(@planning_application), local: true do |form| %>

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -4,6 +4,8 @@
 
 <h1 class="govuk-heading-l">Check the constraints</h1>
 
+<%= render "shared/planning_application_address_and_reference" %>
+
 <% if @planning_application.api_user.present? %>
   <h2 class="govuk-heading-m">Constraints identified by <%= @planning_application.api_user.name %></h2>
 <% end %>

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -8,13 +8,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Request approval to a description change
+      Description change
     </h1>
-    <p class="govuk-body">
-      <strong>At:</strong> <%= @planning_application.full_address  %> <br>
-      <strong>Date received:</strong> <%= @planning_application.received_at %> <br>
-      <strong>Application number:</strong> <%= @planning_application.reference  %>
-    </p>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <div class="govuk-form-group">
       <h2 class="govuk-heading-m">
         Description of work

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -10,20 +10,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div class="govuk-breadcrumbs" style="margin-bottom: 20px;">
+    <div class="govuk-breadcrumbs">
       <ol class="govuk-breadcrumbs__list">
         <li class="govuk-breadcrumbs__list-item" aria-current="page"></li>
       </ol>
     </div>
-    <h1 class="govuk-heading-l" style="margin-bottom: 7px;">
-      <%= @planning_application.reference %>
-    </h1>
-    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
-      <%= @planning_application.full_address %>
-    </h2>
-    <h2 class="govuk-heading-m" style="margin-bottom: 75px;">
-      Archive document
-    </h2>
+
+    <h1 class="govuk-heading-l">Archive document</h2>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <p class="govuk-body  govuk-!-padding-top-1" >
       File name: <%= @document.name %>
     </p>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -15,8 +15,12 @@
 <% end %>
 
 <% if @validate_document %>
-  <h1 class="govuk-heading-l">Check document </h1>
+  <h1 class="govuk-heading-l">Check document</h1>
+<% else %>
+  <h1 class="govuk-heading-l">Edit document</h1>
 <% end %>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -7,32 +7,32 @@
 
 <% content_for :title, "Documents" %>
 
-<%= render "planning_applications/proposal_header" %>
+<%= render "flash_content" %>
 
 <% if @planning_application.replacement_document_validation_requests.open_or_pending.with_active_document.any? %>
-<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-  <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 25 25" height="25" width="25">
-    <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path>
-  </svg>
-  <div class="govuk-error-summary__body">
-    <ul class="govuk-list govuk-error-summary__list">
-      <li>
-        Invalid documents:
-        <span>
-          <strong>
-            <%= @planning_application.replacement_document_validation_requests.open_or_pending.with_active_document.count %>
-          </strong>
-        </span>
-      </li>
-    </ul>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 25" height="25" width="25">
+      <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path>
+    </svg>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          Invalid documents:
+          <span>
+            <strong>
+              <%= @planning_application.replacement_document_validation_requests.open_or_pending.with_active_document.count %>
+            </strong>
+          </span>
+        </li>
+      </ul>
+    </div>
   </div>
-</div>
 <% end %>
 
-<h2 class="govuk-heading-m govuk-!-padding-top-6">
-  Documents
-</h2>
+<h1 class="govuk-heading-l">Documents</h2>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/fee_items/show.html.erb
+++ b/app/views/fee_items/show.html.erb
@@ -9,6 +9,9 @@
   <h1 class="govuk-heading-l">
     Check the fee
   </h1>
+
+  <%= render "shared/planning_application_address_and_reference" %>
+
   <%= render "fee_item_table" %>
 
   <%= render(

--- a/app/views/other_change_validation_requests/_form.html.erb
+++ b/app/views/other_change_validation_requests/_form.html.erb
@@ -4,15 +4,8 @@
     <h1 class="govuk-heading-l govuk-!-padding-top-6">
       Request other validation change <%= "(Fee)" if @validate_fee %>
     </h1>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>At:</strong> <%= @planning_application.full_address  %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= @planning_application.received_at %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-5">
-      <strong>Application number:</strong> <%= @planning_application.reference  %>
-    </p>
+
+    <%= render "shared/planning_application_address_and_reference" %>
 
     <%= render "fee_items/fee_item_table" if @validate_fee %>
 

--- a/app/views/other_change_validation_requests/show.html.erb
+++ b/app/views/other_change_validation_requests/show.html.erb
@@ -15,6 +15,8 @@
       <% end %>
     </h1>
 
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <h2 class="govuk-heading-m">Officer request</h2>
 
     <% if @other_change_validation_request.fee_item? %>

--- a/app/views/planning_application/notes/index.html.erb
+++ b/app/views/planning_application/notes/index.html.erb
@@ -13,6 +13,8 @@
       Notes
     </h1>
 
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <%= render "form" %>
 
     <% if @notes.empty? %>

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -18,18 +18,16 @@
 
   <%= form.hidden_field :application_type, value: "lawfulness_certificate" %>
   <div class="govuk-form-group">
-    <h2 class="govuk-heading-m">
-      Description
-    </h2>
-    <p class="govuk-body">
-      <%= @planning_application.description %>
-    </p>
     <% if action_name == "new" || action_name == "create" %>
       <p class="govuk-body">
         <%= form.label :description, "Description", class: "govuk-heading-m govuk-!-margin-bottom-1" %>
         <%= form.text_area :description, class: "govuk-textarea", rows: "5" %>
       </p>
     <% else %>
+      <h1 class="govuk-heading-l">Edit application</h2>
+
+      <p class="govuk-body"><%= @planning_application.description %></p>
+      <%= render "shared/planning_application_address_and_reference" %>
       <p class="govuk-body">
         <% if @planning_application.open_description_change_requests.any? %>
           <%= link_to "View requested change", planning_application_description_change_validation_request_path(@planning_application, @planning_application.open_description_change_requests.last.id), class: "govuk-link" %>

--- a/app/views/planning_applications/assign.html.erb
+++ b/app/views/planning_applications/assign.html.erb
@@ -2,30 +2,35 @@
   Assign planning application - <%= t('page_title') %>
 <% end %>
 
-<%= render "planning_applications/assessment_dashboard" do %>
-  <% content_for :title, "Assign planning application" %>
-  <h2 class="govuk-heading-m">Assign application</h2>
-  <p class="govuk-body">
-    Please select the officer you wish to assign this application to.
-  </p>
-  <%= form_for @planning_application, url: assign_planning_application_path(@planning_application) do |form| %>
-    <fieldset class="govuk-fieldset">
-      <div class="govuk-radios govuk-radios--small">
-        <div class="govuk-radios__item">
-          <%= form.radio_button :user_id, 0, class: "govuk-radios__input" %>
-          <%= form.label :user_id, "Unassigned", value: 0, class: "govuk-label govuk-radios__label" %>
-        </div>
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
 
-        <% current_local_authority.users.each do |user| %>
-          <div class="govuk-radios__item">
-            <%= form.radio_button :user_id, user.id, class: "govuk-radios__input" %>
-            <%= form.label :user_id, user.name, value: user.id, class: "govuk-label govuk-radios__label" %>
-          </div>
-        <% end %>
+<% content_for :title, "Assign planning application" %>
+
+<h1 class="govuk-heading-l">Assign planning application</h2>
+
+<%= render "shared/planning_application_address_and_reference" %>
+
+<p class="govuk-body">
+  Please select the officer you wish to assign this application to.
+</p>
+<%= form_for @planning_application, url: assign_planning_application_path(@planning_application) do |form| %>
+  <fieldset class="govuk-fieldset">
+    <div class="govuk-radios govuk-radios--small">
+      <div class="govuk-radios__item">
+        <%= form.radio_button :user_id, 0, class: "govuk-radios__input" %>
+        <%= form.label :user_id, "Unassigned", value: 0, class: "govuk-label govuk-radios__label" %>
       </div>
-    </fieldset>
-    <p>
-      <%= form.submit "Confirm", class: "govuk-button", data: { module: "govuk-button" } %>
-    </p>
-  <% end %>
+
+      <% current_local_authority.users.each do |user| %>
+        <div class="govuk-radios__item">
+          <%= form.radio_button :user_id, user.id, class: "govuk-radios__input" %>
+          <%= form.label :user_id, user.name, value: user.id, class: "govuk-label govuk-radios__label" %>
+        </div>
+      <% end %>
+    </div>
+  </fieldset>
+  <p>
+    <%= form.submit "Confirm", class: "govuk-button", data: { module: "govuk-button" } %>
+  </p>
 <% end %>

--- a/app/views/planning_applications/close_or_cancel_confirmation.html.erb
+++ b/app/views/planning_applications/close_or_cancel_confirmation.html.erb
@@ -7,16 +7,12 @@
 
 <% content_for :title, "Close or cancel application" %>
 
-<div class="govuk-grid-row">
+<h1 class="govuk-heading-l">Close or cancel application</h2>
+
+<%= render "shared/planning_application_address_and_reference" %>
+
+<div class="govuk-grid-row"></div>
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
-      <%= @planning_application.reference %>
-    </h1>
-
-    <p class="govuk-body">
-      <%= @planning_application.full_address %>
-    </p>
-
     <%= form_with model: @planning_application, url: cancel_planning_application_path(@planning_application), local: true do |form| %>
       <div class="govuk-form-group">
         <fieldset class="govuk-fieldset">

--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -8,9 +8,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l">
-      Validate Application
-    </h1>
+    <h1 class="govuk-heading-l">Validate Application</h1>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <p class="govuk-body">
       Once validated, the application cannot be invalidated. Ensure you have checked this application is valid.
     </p>

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -10,6 +10,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Send validation decision</h1>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <% if @planning_application.not_started? && @planning_application.validation_requests.empty? %>
       <p class="govuk-body">
         <strong>

--- a/app/views/planning_applications/validation_documents.html.erb
+++ b/app/views/planning_applications/validation_documents.html.erb
@@ -6,9 +6,9 @@
 <% content_for :title, "Check documents" %>
 
 <div>
-  <h1 class="govuk-heading-l">
-    Check the documents provided
-  </h1>
+  <h1 class="govuk-heading-l">Check the documents provided</h1>
+
+  <%= render "shared/planning_application_address_and_reference" %>
 
   <p class="govuk-body-m">
     Check all necessary documents have been provided and add requests for any missing documents.

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -3,15 +3,9 @@
     <h1 class="govuk-heading-l govuk-!-padding-top-6">
       Proposed red line boundary change
     </h1>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>At:</strong> <%= @planning_application.full_address  %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      <strong>Date received:</strong> <%= @planning_application.received_at %>
-    </p>
-    <p class="govuk-body govuk-!-margin-bottom-8">
-      <strong>Application number:</strong> <%= @planning_application.reference  %>
-    </p>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
     <%= form_with model: [@planning_application, @red_line_boundary_change_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <% if @red_line_boundary_change_validation_request.errors.any? %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">

--- a/app/views/red_line_boundary_change_validation_requests/_propose_change.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_propose_change.html.erb
@@ -1,15 +1,8 @@
 <h1 class="govuk-heading-l govuk-!-padding-top-6">
   Proposed red line boundary change
 </h1>
-<p class="govuk-body govuk-!-margin-bottom-1">
-  <strong>At:</strong> <%= @planning_application.full_address  %>
-</p>
-<p class="govuk-body govuk-!-margin-bottom-1">
-  <strong>Date received:</strong> <%= @planning_application.received_at %>
-</p>
-<p class="govuk-body govuk-!-margin-bottom-8">
-  <strong>Application number:</strong> <%= @planning_application.reference  %>
-</p>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <h2 class="govuk-heading-m govuk-!-padding-top-6">
  Current red line boundary

--- a/app/views/replacement_document_validation_requests/edit.html.erb
+++ b/app/views/replacement_document_validation_requests/edit.html.erb
@@ -8,9 +8,9 @@
 
 <% content_for :title, "Replacement document" %>
 
-<h1 class="govuk-heading-l">
-  Request a replacement document
-</h1>
+<h1 class="govuk-heading-l">Request a replacement document</h1>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <div class="govuk-grid-row">
   <%= render "document_summary" %>

--- a/app/views/replacement_document_validation_requests/new.html.erb
+++ b/app/views/replacement_document_validation_requests/new.html.erb
@@ -8,9 +8,9 @@
 
 <% content_for :title, "Replacement document" %>
 
-<h1 class="govuk-heading-l">
-  Request a replacement document
-</h1>
+<h1 class="govuk-heading-l">Request a replacement document</h1>
+
+<%= render "shared/planning_application_address_and_reference" %>
 
 <div class="govuk-grid-row">
   <%= render "document_summary" %>

--- a/app/views/shared/_planning_application_address_and_reference.erb
+++ b/app/views/shared/_planning_application_address_and_reference.erb
@@ -1,0 +1,8 @@
+<div class="govuk-!-padding-bottom-5">
+  <p class="govuk-body">
+    <strong><%= @planning_application.full_address.try(:upcase) %></strong>
+  </p>
+  <p class="govuk-body">
+    Application number: <strong><%= @planning_application.reference %></strong>
+  </p>
+</div>

--- a/app/views/sitemaps/_draw_red_line_boundary.html.erb
+++ b/app/views/sitemaps/_draw_red_line_boundary.html.erb
@@ -1,6 +1,8 @@
-<h2 class="govuk-heading-m">Draw a digital red line boundary</h2>
+<h1 class="govuk-heading-l">Draw a digital red line boundary</h1>
+
+<%= render "shared/planning_application_address_and_reference" %>
+
 <h3 class="govuk-heading-s">Red line site boundary on submission</h3>
-<p class="govuk-body">Site address: <%= @planning_application.full_address %></p>
 
 <%- sitemap_documents = @planning_application.documents.with_tag("Site") %>
 <% if sitemap_documents.none? %>

--- a/app/views/sitemaps/_validate_red_line_boundary.html.erb
+++ b/app/views/sitemaps/_validate_red_line_boundary.html.erb
@@ -1,4 +1,7 @@
 <h1 class="govuk-heading-l">Check the digital red line boundary</h1>
+
+<%= render "shared/planning_application_address_and_reference" %>
+
 <%= render "shared/location_map", locals: { in_accordion: true, geojson: @planning_application.boundary_geojson } %>
 
 <br>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -27,7 +27,10 @@
         <% else %>
           <h1 class="govuk-heading-l"><%= t(".validation_requests") %></h1>
         <% end %>
+
+        <%= render "shared/planning_application_address_and_reference" %>
         <%= render "validation_requests/table", requests: @active_validation_requests %>
+
       <% else %>
         <p class="govuk-body">There are no active validation requests.</p>
       <% end %>

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe "Documents index page", type: :system do
     end
 
     it "Archive page contains site info" do
-      expect(page).to have_text "Elm Grove"
+      expect(page).to have_text planning_application.full_address.upcase
     end
 
     it "Archive page contains application reference" do

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe "Edit document numbers page", type: :system do
         click_link "Manage documents"
       end
 
-      it "Assessor can see content for the right application" do
-        expect(page).to have_text(planning_application.reference)
+      it "displays the planning application address and reference" do
+        expect(page).to have_content(planning_application.full_address.upcase)
+        expect(page).to have_content(planning_application.reference)
       end
 
       it "Assessor can see information about the document" do

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe "Edit document", type: :system do
       visit planning_application_documents_path(planning_application)
     end
 
+    it "displays the planning application address and reference" do
+      expect(page).to have_content(planning_application.full_address.upcase)
+      expect(page).to have_content(planning_application.reference)
+    end
+
     it "with wrong format document" do
       visit edit_planning_application_document_path(planning_application, document)
 

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Documents index page", type: :system do
     end
 
     it "Application address is displayed on page" do
-      expect(page).to have_text "7 Elm Grove"
+      expect(page).to have_text planning_application.full_address.upcase
     end
 
     it "File image is the only one on the page" do

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -26,6 +26,11 @@ RSpec.describe "Auditing changes to a planning application", type: :system do
     click_link "View all audits"
   end
 
+  it "displays the planning application address and reference" do
+    expect(page).to have_content(planning_application.full_address.upcase)
+    expect(page).to have_content(planning_application.reference)
+  end
+
   it "displays details of other change validation request in the audit log" do
     expect(page).to have_text("Received: request for change (other validation#1)")
     expect(page).to have_text("I have sent the fee")

--- a/spec/system/planning_applications/closing_and_cancelling_spec.rb
+++ b/spec/system/planning_applications/closing_and_cancelling_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
     visit planning_application_path(planning_application)
   end
 
+  it "displays the planning application address and reference" do
+    click_link "Close or cancel application"
+
+    expect(page).to have_content(planning_application.full_address.upcase)
+    expect(page).to have_content(planning_application.reference)
+  end
+
   context "when planning application that is not started" do
     it "can withdraw an application" do
       click_link "Close or cancel application"

--- a/spec/system/planning_applications/constraints_spec.rb
+++ b/spec/system/planning_applications/constraints_spec.rb
@@ -16,6 +16,11 @@ RSpec.describe "Constraints", type: :system do
     visit planning_application_constraints_path(planning_application)
   end
 
+  it "displays the planning application address and reference" do
+    expect(page).to have_content(planning_application.full_address.upcase)
+    expect(page).to have_content(planning_application.reference)
+  end
+
   context "when application is not started or invalidated" do
     it "displays the constraints" do
       within(".govuk-heading-l") do

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "Requesting description changes to a planning application", type:
     visit planning_application_path(planning_application)
   end
 
+  it "displays the planning application address and reference" do
+    click_button "Application information"
+    click_link "Propose a change to the description"
+
+    expect(page).to have_content(planning_application.full_address.upcase)
+    expect(page).to have_content(planning_application.reference)
+  end
+
   it "is possible to create a request to update description" do
     visit new_planning_application_description_change_validation_request_path(planning_application)
 

--- a/spec/system/planning_applications/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/fee_items_validation_spec.rb
@@ -42,6 +42,14 @@ RSpec.describe "FeeItemsValidation", type: :system do
       )
     end
 
+    it "displays the planning application address and reference" do
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "Check fee"
+
+      expect(page).to have_content(planning_application.full_address.upcase)
+      expect(page).to have_content(planning_application.reference)
+    end
+
     it "I can see a summary breakdown of the fee when I go to validate" do
       visit planning_application_validation_tasks_path(planning_application)
       click_link "Check fee"

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "Requesting other changes to a planning application", type: :syst
     visit planning_application_path(planning_application)
   end
 
+  it "displays the planning application address and reference" do
+    click_link "Check and validate"
+    click_link "Add an other validation request"
+
+    expect(page).to have_content(planning_application.full_address.upcase)
+    expect(page).to have_content(planning_application.reference)
+  end
+
   it "is possible to create a request for miscellaneous changes" do
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link "Check and validate"

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -36,6 +36,9 @@ RSpec.describe "post validation requests", type: :system do
 
       click_link("Review non-validation requests")
 
+      expect(page).to have_content(planning_application.full_address.upcase)
+      expect(page).to have_content(planning_application.reference)
+
       within(".validation-requests-table") do
         expect(page).to have_content("Floor plan")
       end

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
         boundary_geojson
       end
 
+      it "displays the planning application address and reference" do
+        visit planning_application_validation_tasks_path(planning_application)
+        click_link "Draw red line boundary"
+
+        expect(page).to have_content(planning_application.full_address.upcase)
+        expect(page).to have_content(planning_application.reference)
+      end
+
       it "is possible to create a sitemap" do
         click_button "Site map"
         expect(page).to have_content("No digital sitemap provided")
@@ -144,6 +152,9 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
 
     it "creates a request to update map boundary" do
       delivered_emails = ActionMailer::Base.deliveries.count
+
+      expect(page).to have_content(planning_application.full_address.upcase)
+      expect(page).to have_content(planning_application.reference)
 
       find(".govuk-visually-hidden",
            visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'


### PR DESCRIPTION
### Description of change

- Add address and reference to all sub pages
- Keep consistency by extracting a common partial view to show the address / reference for all these pages

### Story Link

https://trello.com/c/2viC3sHi/1045-add-address-and-case-reference-number-to-all-sub-pages-on-the-validation-wizard
https://trello.com/c/WfCqdktD/1046-format-title-and-add-address-and-case-reference-number-to-sub-pages-for-documents-audit-log-description-change-edit-application