### PR TITLE
Render "Main" as group title when portal_name is "_root"

### DIFF
--- a/app/helpers/proposal_details_helper.rb
+++ b/app/helpers/proposal_details_helper.rb
@@ -10,7 +10,14 @@ module ProposalDetailsHelper
   end
 
   def proposal_details_group_name(group)
-    group || t("proposal_details.other")
+    case group
+    when "_root"
+      t("proposal_details.main")
+    when nil
+      t("proposal_details.other")
+    else
+      group
+    end
   end
 
   def proposal_detail_item(proposal_detail)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,7 @@ en:
       true: "Yes"
   proposal_details:
     auto_answered: Auto-answered by RIPA
+    main: Main
     other: Other
   activerecord:
     errors:

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "Planning Application show page", type: :system do
       {
         question: "What do you want to do?",
         responses: [{ value: "Modify or extend" }],
-        metadata: { portal_name: "General" }
+        metadata: { portal_name: "_root" }
       },
       {
         question: "Is the property a house?",
         responses: [{ value: "Yes" }],
-        metadata: { portal_name: "General" }
+        metadata: { portal_name: "_root" }
       },
       {
         question: "What will the height of the new structure be?",
@@ -167,9 +167,9 @@ RSpec.describe "Planning Application show page", type: :system do
       click_button("Proposal details")
 
       within("#proposal-details-section") do
-        click_link("General")
+        click_link("Main")
 
-        expect(URI.parse(current_url).fragment).to eq("general")
+        expect(URI.parse(current_url).fragment).to eq("main")
 
         group1 = find_all("ol")[0]
 


### PR DESCRIPTION
### Description of change

- When rendering proposal details, show "Main" as group title where `portal_name` is "_root".

### Story Link

https://trello.com/c/pef2JLp6/1063-rename-portal-name-from-root-to-main

### Decisions [OPTIONAL]

Alternatively we could manipulate the JSON data before saving it to the `proposal_details` column. But I'm a bit worried that could lead to confusion!