### PR TITLE
Add update notifications for users

### DIFF
--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -40,7 +40,7 @@ module Api
 
         if @additional_document_validation_request.can_upload?
           @additional_document_validation_request.upload_files!(params[:files])
-
+          @planning_application.send_update_notification_to_assessor
           render json: { message: "Validation request updated" }, status: :ok
         else
           render_failed_request

--- a/app/controllers/api/v1/description_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_validation_requests_controller.rb
@@ -35,7 +35,7 @@ module Api
             @planning_application.update!(description: @description_change_validation_request.proposed_description)
           end
           @description_change_validation_request.create_api_audit!
-
+          @planning_application.send_update_notification_to_assessor
           render json: { message: "Description change request updated" }, status: :ok
         else
           render json: { message: "Unable to update request. Please ensure rejection_reason is present if approved is false." },

--- a/app/controllers/api/v1/other_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/other_change_validation_requests_controller.rb
@@ -32,7 +32,7 @@ module Api
         if params[:data][:response].present? && @other_change_validation_request.update(response: params[:data][:response])
           @other_change_validation_request.update!(state: "closed")
           @other_change_validation_request.create_api_audit!
-
+          @planning_application.send_update_notification_to_assessor
           render json: { message: "Change request updated" }, status: :ok
         else
           render json: { message: "Unable to update request. Please ensure response is present" }, status: :bad_request

--- a/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
@@ -36,7 +36,7 @@ module Api
           end
 
           @red_line_boundary_change_validation_request.create_api_audit!
-
+          @planning_application.send_update_notification_to_assessor
           render json: { message: "Validation request updated" }, status: :ok
         else
           render json: { message: "Unable to update request. Please ensure rejection_reason is present if approved is false." },

--- a/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
@@ -38,7 +38,7 @@ module Api
         if @replacement_document_validation_request.save
           archive_old_document
           @replacement_document_validation_request.create_api_audit!
-
+          @planning_application.send_update_notification_to_assessor
           render json: { message: "Validation request updated" }, status: :ok
         else
           render json: { message: "Unable to update request" }, status: :bad_request

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < Mail::Notify::Mailer
+  NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
+
+  private
+
+  def subject(key, args = {})
+    I18n.t(key, args.merge(scope: "emails.subjects"))
+  end
 end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-class PlanningApplicationMailer < Mail::Notify::Mailer
+class PlanningApplicationMailer < ApplicationMailer
   helper :planning_application
-
-  NOTIFY_TEMPLATE_ID = "7cb31359-e913-4590-a458-3d0cefd0d283"
 
   def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application
@@ -116,11 +114,5 @@ class PlanningApplicationMailer < Mail::Notify::Mailer
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
-  end
-
-  private
-
-  def subject(key)
-    I18n.t(key, scope: "planning_applications.emails.subjects")
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserMailer < ApplicationMailer
+  def update_notification_mail(planning_application, to)
+    @planning_application = planning_application
+    @reference = planning_application.reference_in_full
+    subject = subject(:update_notification_mail, reference: @reference)
+    view_mail(NOTIFY_TEMPLATE_ID, subject: subject, to: to)
+  end
+end

--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -81,6 +81,8 @@ module PlanningApplicationStatus
       event :request_correction do
         transitions from: :awaiting_determination, to: :awaiting_correction,
                     after: proc { |comment| audit!(activity_type: "challenged", audit_comment: comment) }
+
+        after { send_update_notification_to_assessor }
       end
 
       event :return do

--- a/app/views/user_mailer/update_notification_mail.text.erb
+++ b/app/views/user_mailer/update_notification_mail.text.erb
@@ -1,0 +1,5 @@
+# <%= t(".bops_updates") %>
+
+<%= t(".bops_case_reference", reference: @reference) %>
+
+[<%= t(".view_reference_on", reference: @reference) %>](<%= planning_application_url(@planning_application, subdomain: @planning_application.local_authority.subdomain) %>)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,6 +46,8 @@ Rails.application.configure do
     from: "mail@example.com"
   }
 
+  config.action_mailer.default_url_options = { host: "bops.services" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,24 @@ en:
     header:
       back_office_planning: "Back-office Planning System"
       log_out: Log out
+  emails:
+    subjects:
+      cancelled_validation_request_mail: Update on your application for a Lawful Development Certificate
+      decision_notice_mail: Decision on your Lawful Development Certificate  application
+      description_change_mail: Lawful Development Certificate application - suggested changes
+      description_closure_notification_mail: Changes to your Lawful Development Certificate application
+      invalidation_notice_mail: Lawful Development Certificate application - changes needed
+      receipt_notice_mail: Lawful Development Certificate application received
+      validation_notice_mail: Your application for a Lawful Development Certificate
+      validation_request_mail: Lawful Development Certificate application  - further changes needed
+      post_validation_request_mail: Lawful Development Certificate application  - changes needed
+      update_notification_mail: BoPS case %{reference} has a new update
+      validation_request_closure_mail: Changes to your Lawful Development Certificate application
+  user_mailer:
+    update_notification_mail:
+      bops_case_reference: BoPS case %{reference} has a new update.
+      bops_updates: BoPS updates
+      view_reference_on: View %{reference} on BoPS
   additional_document_validation_requests:
     create:
       success: Additional document request successfully created.

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -13,18 +13,6 @@ en:
       one: '1 day remaining'
       zero: '%{count} days overdue'
       other: '%{count} days remaining'
-    emails:
-      subjects:
-        cancelled_validation_request_mail: Update on your application for a Lawful Development Certificate
-        decision_notice_mail: Decision on your Lawful Development Certificate  application
-        description_change_mail: Lawful Development Certificate application - suggested changes
-        description_closure_notification_mail: Changes to your Lawful Development Certificate application
-        invalidation_notice_mail: Lawful Development Certificate application - changes needed
-        receipt_notice_mail: Lawful Development Certificate application received
-        validation_notice_mail: Your application for a Lawful Development Certificate
-        validation_request_mail: Lawful Development Certificate application  - further changes needed
-        post_validation_request_mail: Lawful Development Certificate application  - changes needed
-        validation_request_closure_mail: Changes to your Lawful Development Certificate application
     overdue:
       one: '1 day overdue'
       other: '%{count} days overdue'

--- a/db/migrate/20220718150755_add_reviewer_group_email_to_local_authority.rb
+++ b/db/migrate/20220718150755_add_reviewer_group_email_to_local_authority.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReviewerGroupEmailToLocalAuthority < ActiveRecord::Migration[6.1]
+  def change
+    add_column :local_authorities, :reviewer_group_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_13_114018) do
+ActiveRecord::Schema.define(version: 2022_07_18_150755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 2022_07_13_114018) do
     t.string "email_address", null: false
     t.string "reply_to_notify_id"
     t.string "feedback_email", null: false
+    t.string "reviewer_group_email"
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 
@@ -198,6 +199,7 @@ ActiveRecord::Schema.define(version: 2022_07_13_114018) do
     t.datetime "in_assessment_at"
     t.datetime "awaiting_correction_at"
     t.jsonb "proposal_details"
+    t.jsonb "audit_log"
     t.string "agent_first_name"
     t.string "agent_last_name"
     t.string "agent_phone"
@@ -251,7 +253,6 @@ ActiveRecord::Schema.define(version: 2022_07_13_114018) do
     t.decimal "invalid_payment_amount", precision: 10, scale: 2
     t.bigint "application_number", null: false
     t.string "parish_name"
-    t.jsonb "audit_log"
     t.jsonb "feedback", default: {}
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true

--- a/spec/mailer/previews/user_mailer_preview.rb
+++ b/spec/mailer/previews/user_mailer_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class UserMailerPreview < ActionMailer::Preview
+  def update_notification_mail
+    UserMailer.update_notification_mail(
+      PlanningApplication.last,
+      User.last.email
+    )
+  end
+end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UserMailer, type: :mailer do
+  describe "#update_notification_mail" do
+    let(:planning_application) do
+      create(:planning_application, created_at: DateTime.new(2022, 5, 1))
+    end
+
+    let(:mail) do
+      described_class.update_notification_mail(
+        planning_application,
+        "assessor@example.com"
+      )
+    end
+
+    let(:mail_body) { mail.body.encoded }
+
+    it "sets subject" do
+      expect(mail.subject).to eq(
+        "BoPS case BUC-22-00100-LDCP has a new update"
+      )
+    end
+
+    it "sets recipient" do
+      expect(mail.to).to contain_exactly("assessor@example.com")
+    end
+
+    it "includes planning application reference" do
+      expect(mail_body).to include(
+        "BoPS case BUC-22-00100-LDCP has a new update."
+      )
+    end
+
+    it "includes plannng application url" do
+      expect(mail_body).to include(
+        "http://buckinghamshire.bops.services/planning_applications/#{planning_application.id}"
+      )
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,4 +35,6 @@ RSpec.configure do |config|
   config.before type: :request do
     host!("ripa.example.com")
   end
+
+  config.include(ActiveJob::TestHelper)
 end

--- a/spec/requests/api/other_change_validation_request_put_spec.rb
+++ b/spec/requests/api/other_change_validation_request_put_spec.rb
@@ -4,8 +4,34 @@ require "rails_helper"
 
 RSpec.describe "API request to list change requests", type: :request, show_exceptions: true do
   let!(:api_user) { create :api_user }
+
+  let(:path) do
+    "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}"
+  end
+
+  let(:params) do
+    {
+      change_access_id: planning_application.change_access_id,
+      data: { response: "I will send an extra payment" }
+    }
+  end
+
+  let(:headers) do
+    { Authorization: "Bearer #{api_user.token}" }
+  end
+
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
+  let(:user) { create(:user) }
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :invalidated,
+      user: user,
+      local_authority: default_local_authority
+    )
+  end
+
   let!(:other_change_validation_request) do
     create(:other_change_validation_request,
            planning_application: planning_application)
@@ -24,9 +50,7 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
   }'
 
   it "successfully accepts a response" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: valid_response,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+    patch(path, params: params, headers: headers)
 
     expect(response).to be_successful
 
@@ -37,6 +61,18 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
     expect(Audit.all.last.activity_type).to eq("other_change_validation_request_received")
     expect(Audit.all.last.audit_comment).to eq({ response: "I will send an extra payment" }.to_json)
     expect(Audit.all.last.activity_information).to eq("1")
+  end
+
+  it "sends notification to assigned user" do
+    expect { patch(path, params: params, headers: headers) }
+      .to have_enqueued_job
+      .on_queue("mailers")
+      .with(
+        "UserMailer",
+        "update_notification_mail",
+        "deliver_now",
+        args: [planning_application, user.email]
+      )
   end
 
   it "returns a 400 if the update is missing a response" do

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "assigning planning application", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:reviewer) { create(:user, :reviewer, local_authority: local_authority) }
+
+  let!(:assessor) do
+    create(
+      :user,
+      :assessor,
+      local_authority: local_authority,
+      name: "Jane Smith"
+    )
+  end
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      local_authority: local_authority,
+      created_at: DateTime.new(2022, 1, 1)
+    )
+  end
+
+  it "lets a planning application be assigned to a user" do
+    sign_in(reviewer)
+    visit(assign_planning_application_path(planning_application))
+    choose("Jane Smith")
+    click_button("Confirm")
+
+    expect(page).to have_content("Assigned to: Jane Smith")
+
+    perform_enqueued_jobs
+    update_notification = ActionMailer::Base.deliveries.last
+
+    expect(update_notification.to).to contain_exactly(assessor.email)
+
+    expect(update_notification.subject).to eq(
+      "BoPS case RIPA-22-00100-LDCP has a new update"
+    )
+  end
+end


### PR DESCRIPTION
### Description of change

- Add `UserMailer`, with `#update_notification_mail`.
- Send notifications to affected users.

### Story Link

https://trello.com/c/3fHsvIUm/776-feature-request-email-notification-to-officer-of-changes-in-bops

### Screenshot

<img width="60%" alt="Screenshot 2022-07-18 at 11 29 46" src="https://user-images.githubusercontent.com/25392162/179558976-13958d37-bb43-443b-8c28-01bf7bee5f29.png">