### PR TITLE
Add post_validation to additional document request get requests

### DIFF
--- a/app/views/api/v1/additional_document_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/additional_document_validation_requests/_show.json.jbuilder
@@ -1,14 +1,17 @@
 # frozen_string_literal: true
 
-json.extract! additional_document_validation_request,
-              :id,
-              :state,
-              :response_due,
-              :days_until_response_due,
-              :document_request_type,
-              :document_request_reason,
-              :cancel_reason,
-              :cancelled_at
+json.extract!(
+  additional_document_validation_request,
+  :id,
+  :state,
+  :response_due,
+  :days_until_response_due,
+  :document_request_type,
+  :document_request_reason,
+  :cancel_reason,
+  :cancelled_at,
+  :post_validation
+)
 
 json.documents additional_document_validation_request.documents do |document|
   json.name document.file.filename

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
               "document_request_reason" => "Missing floor plan",
               "cancel_reason" => nil,
               "cancelled_at" => nil,
-              "documents" => []
+              "documents" => [],
+              "post_validation" => false
             },
             {
               "id" => additional_document_validation_request2.id,
@@ -53,7 +54,8 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
                   "name" => "proposed-floorplan.png",
                   "url" => json["data"][1]["documents"][0]["url"]
                 }
-              ]
+              ],
+              "post_validation" => false
             },
             {
               "id" => additional_document_validation_request3.id,
@@ -64,7 +66,8 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
               "document_request_reason" => "Missing floor plan",
               "cancel_reason" => "Made by mistake!",
               "cancelled_at" => json_time_format(additional_document_validation_request3.cancelled_at),
-              "documents" => []
+              "documents" => [],
+              "post_validation" => false
             }
           ]
         )
@@ -105,7 +108,8 @@ RSpec.describe "Additional document validation requests API", type: :request, sh
             "document_request_reason" => "Missing floor plan",
             "cancel_reason" => nil,
             "cancelled_at" => nil,
-            "documents" => []
+            "documents" => [],
+            "post_validation" => false
           }
         )
       end


### PR DESCRIPTION
### Description of change

Add `post_validation` to additional document request get requests.

### Story Link

https://trello.com/c/LQG1atOK/735-enable-amendment-requests-for-new-documents-that-can-be-actioned-after-validation-2

See also https://github.com/unboxed/bops-applicants/pull/89