### PR TITLE
Add the title of the class to class assessment pages

### DIFF
--- a/app/views/policy_classes/show.html.erb
+++ b/app/views/policy_classes/show.html.erb
@@ -10,6 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Assess - <%= @policy_class %></h1>
+    <h2 class="govuk-heading-m">Class title - <%= @policy_class.name %></h1>
 
     <p class="govuk-body">
       Please indicate if the application complies, does not comply, or
@@ -39,7 +40,7 @@
       html: { data: unsaved_changes_data }
     ) do |form| %>
       <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--l"><%= @policy_class %></caption>
+        <caption class="govuk-table__caption govuk-table__caption--l"><%= @policy_class %> - <%= @policy_class.name %></caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th scope="col" class="govuk-table__header govuk-!-width-one-half">Policy reference</th>

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe "assessment against legislation", type: :system do
 
   let(:assessor) { create :user, :assessor, local_authority: local_authority }
 
-  it "warns the user about unsaved changes" do
+  before do
     sign_in(assessor)
     visit planning_application_path(planning_application)
+  end
+
+  it "warns the user about unsaved changes" do
     click_link("Add assessment area")
     click_link("Back")
     click_link("Add assessment area")
@@ -44,5 +47,33 @@ RSpec.describe "assessment against legislation", type: :system do
     click_button("Save assessments")
 
     expect(page).to have_content("Successfully updated policy class")
+  end
+
+  it "displays the class title" do
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+
+    check(
+      "Class A - enlargement, improvement or other alteration of a dwellinghouse"
+    )
+    check(
+      "Class B - additions etc to the roof of a dwellinghouse"
+    )
+
+    click_button("Add classes")
+
+    click_link("Part 1, Class A")
+    expect(page).to have_content("Class title - enlargement, improvement or other alteration of a dwellinghouse")
+    within(".govuk-table caption") do
+      expect(page).to have_content("Part 1, Class A - enlargement, improvement or other alteration of a dwellinghouse")
+    end
+
+    click_link("Back")
+    click_link("Part 1, Class B")
+    expect(page).to have_content("Class title - additions etc to the roof of a dwellinghouse")
+    within(".govuk-table caption") do
+      expect(page).to have_content("Part 1, Class B - additions etc to the roof of a dwellinghouse")
+    end
   end
 end


### PR DESCRIPTION
### Story Link

https://trello.com/c/52pyrgQQ/842-add-the-title-of-the-class-to-class-assessment-pages-in-the-assess-against-policy-section


![Screenshot 2022-07-22 at 12 22 32](https://user-images.githubusercontent.com/34001723/180472592-2bbba455-3fbd-4a9f-bd58-b340eca4d0d4.png)
