### PR TITLE
Set 30mb limit per file size when uploading

### DIFF
--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -56,8 +56,10 @@ module Api
       end
 
       def check_files_size
-        if params[:files].map(&:size).sum > 30.megabytes
-          render json: { message: "The total file size must be 30MB or less" }, status: :bad_request
+        params[:files].each do |file|
+          if file_size_over_30mb?(file)
+            render json: { message: "The file: '#{file.original_filename}' exceeds the limit of 30mb. Each file must be 30MB or less" }, status: :bad_request
+          end
         end
       end
 

--- a/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
@@ -47,6 +47,18 @@ module Api
 
       private
 
+      def check_file_type
+        unless Document::PERMITTED_CONTENT_TYPES.include? params[:new_file].content_type
+          render json: { message: "The file type must be JPEG, PNG or PDF" }, status: :bad_request
+        end
+      end
+
+      def check_file_size
+        if file_size_over_30mb?(params[:new_file])
+          render json: { message: "The file must be 30MB or less" }, status: :bad_request
+        end
+      end
+
       def check_file_params_are_present
         if params[:new_file].blank?
           render json: { message: "A file must be selected to proceed." }, status: :bad_request

--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -9,24 +9,16 @@ module Api
 
       private
 
-      def check_file_size
-        if params[:new_file].size > 30.megabytes
-          render json: { message: "The file must be 30MB or less" }, status: :bad_request
-        end
-      end
-
-      def check_file_type
-        unless Document::PERMITTED_CONTENT_TYPES.include? params[:new_file].content_type
-          render json: { message: "The file type must be JPEG, PNG or PDF" }, status: :bad_request
-        end
-      end
-
       def unauthorized_response
         render json: {}, status: :unauthorized
       end
 
       def render_failed_request
         render json: { message: "Validation request could not be updated - please contact support" }, status: :bad_request
+      end
+
+      def file_size_over_30mb?(file)
+        file.size > 30.megabytes
       end
     end
   end

--- a/spec/requests/api/additional_document_validation_request_patch_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_patch_spec.rb
@@ -89,4 +89,16 @@ RSpec.describe "API request to patch document create requests", type: :request, 
     expect(json).to eq({ "message" => "At least one file must be selected to proceed." })
     expect(response.status).to eq(400)
   end
+
+  it "returns a 400 if the file size exceeds 30mb" do
+    # Return byte size greater than limit of 30mb (31457280 bytes)
+    allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
+
+    patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: { files: [file] },
+          headers: { Authorization: "Bearer #{api_user.token}" }
+
+    expect(json).to eq({ "message" => "The file: 'proposed-floorplan.png' exceeds the limit of 30mb. Each file must be 30MB or less" })
+    expect(response.status).to eq(400)
+  end
 end

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -96,4 +96,16 @@ RSpec.describe "API request to patch document validation requests", type: :reque
 
     expect(response.status).to eq(400)
   end
+
+  it "returns a 400 if the file size exceeds 30mb" do
+    # Return byte size greater than limit of 30mb (31457280 bytes)
+    allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
+
+    patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+          params: { new_file: file },
+          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+
+    expect(json).to eq({ "message" => "The file must be 30MB or less" })
+    expect(response.status).to eq(400)
+  end
 end


### PR DESCRIPTION
### Description of change

- Set 30mb limit per file size when uploading
- Now that we've moved the file uploading to a background job, we should be able to lift the overall 30mb limit and do it per file instead to be consistent with the other planning services

### Story Link

https://trello.com/c/zA0j9epO/1065-increase-file-limits-to-30mb-per-item-not-30mb-for-all-items-on-one-application-aligning-with-ripa