### PR TITLE
Show the reason why a replacement document was requested once the request is complete

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,6 +9,7 @@ class DocumentsController < AuthenticationController
   before_action :ensure_document_edits_unlocked, only: %i[new edit update archive unarchive]
   before_action :ensure_blob_is_representable, only: %i[edit update archive unarchive]
   before_action :validate_document?, only: %i[edit update]
+  before_action :replacement_document_validation_request, only: %i[edit update]
 
   def index
     @documents = @planning_application.documents
@@ -117,6 +118,11 @@ class DocumentsController < AuthenticationController
 
   def validate_document?
     @validate_document ||= params[:validate] == "yes"
+  end
+
+  def replacement_document_validation_request
+    @replacement_document_validation_request ||=
+      ReplacementDocumentValidationRequest.find_by(new_document_id: @document.id)
   end
 
   def redirect_url

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -39,14 +39,30 @@
       <strong>Date received:</strong> <%= @document.received_at_or_created %>
     </p>
 
-    <p class="govuk-body">
-      <strong>Applicant reason for submitting document:</strong>
-      <% if @document.applicant_description.present? %>
-        <%= @document.applicant_description %>
-      <% else %>
-        No reason submitted
-      <% end %>
-    </p>
+    <% if @replacement_document_validation_request %>
+      <p class="govuk-body">
+        <strong>This document replaced:</strong>
+        <%= link_to @replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, @replacement_document_validation_request.old_document), target: :_new, class: "govuk-link" %>
+      </p>
+
+      <p class="govuk-body">
+        <strong>Reason this replacement document was requested:</strong> <%= @replacement_document_validation_request.invalidated_document_reason %>
+      </p>
+
+      <p class="govuk-body">
+        <strong>Applicant accepted request and uploaded this document.</strong>
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        <strong>Applicant reason for submitting document:</strong>
+
+        <% if @document.applicant_description.present? %>
+          <%= @document.applicant_description %>
+        <% else %>
+          No reason submitted
+        <% end %>
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       <%= created_by(@document)  %>

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -390,6 +390,19 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
 
         expect(page).to have_content("This application has 1 unresolved validation request and 1 resolved validation request")
       end
+
+      it "can see reason why a replacement document was requested once the request is complete" do
+        click_link "Check and validate"
+        click_link "Check document - #{replacement_document_validation_request.new_document.name.to_s.truncate(25)}"
+
+        expect(page).to have_content("This document replaced: #{replacement_document_validation_request.old_document.name}")
+        expect(page).to have_link(
+          replacement_document_validation_request.old_document.name,
+          href: edit_planning_application_document_path(planning_application, replacement_document_validation_request.old_document)
+        )
+        expect(page).to have_content("Reason this replacement document was requested: Document is invalid")
+        expect(page).to have_content("Applicant accepted request and uploaded this document.")
+      end
     end
   end
 


### PR DESCRIPTION
### Description of change

Show the reason why a replacement document was requested once the request is complete

### Story Link

https://trello.com/c/rJWGTs2u/1069-show-the-reason-why-a-replacement-document-was-requested-once-the-request-is-complete

