### PR TITLE
Only show feedback text from applicant

### DIFF
--- a/app/views/planning_applications/_policy_consideration_list.html.erb
+++ b/app/views/planning_applications/_policy_consideration_list.html.erb
@@ -18,7 +18,7 @@
         message: "The applicant or agent believes the information about the property is inaccurate." %>
 
       <p class="govuk-body">
-        <strong>Reason given:</strong> These are the inaccuracies. Taken from "find_property": "<%= find_property_feedback %>"
+        <strong>Reason given:</strong> "<%= find_property_feedback %>"
       </p>
 
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -23,7 +23,7 @@
           message: "The applicant or agent believes this result is inaccurate." %>
 
         <p class="govuk-body">
-          <strong>Reason given:</strong> This is the reason that someone thought this was inaccurate. Taken from "result": "<%= result_feedback %>"
+          <strong>Reason given:</strong> "<%= result_feedback %>"
         </p>
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -22,7 +22,7 @@
           message: "The applicant or agent believes the constraints are inaccurate." %>
 
         <p class="govuk-body">
-          <strong>Reason given:</strong> These are the inaccuracies. Taken from "planning_constraints": "<%= planning_constraints_feedback %>"
+          <strong>Reason given:</strong> "<%= planning_constraints_feedback %>"
         </p>
 
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -385,7 +385,7 @@ RSpec.describe "Planning Application show page", type: :system do
           expect(page).to have_content("! Warning The applicant or agent believes this result is inaccurate.")
         end
 
-        expect(page).to have_content("Reason given: This is the reason that someone thought this was inaccurate. Taken from \"result\": \"feedback about the result\"")
+        expect(page).to have_content("Reason given: \"feedback about the result\"")
       end
 
       click_button "Proposal details"
@@ -394,7 +394,7 @@ RSpec.describe "Planning Application show page", type: :system do
           expect(page).to have_content("! Warning The applicant or agent believes the information about the property is inaccurate.")
         end
 
-        expect(page).to have_content("Reason given: These are the inaccuracies. Taken from \"find_property\": \"feedback about the property\"")
+        expect(page).to have_content("Reason given: \"feedback about the property\"")
       end
 
       click_button "Constraints"
@@ -403,7 +403,7 @@ RSpec.describe "Planning Application show page", type: :system do
           expect(page).to have_content("! Warning The applicant or agent believes the constraints are inaccurate.")
         end
 
-        expect(page).to have_content("Reason given: These are the inaccuracies. Taken from \"planning_constraints\": \"feedback about the constraints\"")
+        expect(page).to have_content("Reason given: \"feedback about the constraints\"")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Cleaning up the feedback text we show based on UAT feedback

### Story Link

https://trello.com/c/mbS4PsmF/393-display-the-free-text-collected-ripa-related-to-a-any-disagreements-about-the-applicants-planning-constraints-or-b-the-ripa-deci
