### PR TITLE
Block validation if application has no boundary geojson

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -101,14 +101,21 @@ class PlanningApplicationsController < AuthenticationController
   def validate
     if validation_date_fields_invalid?
       @planning_application.errors.add(:planning_application, "Please enter a valid date")
-      render "confirm_validation"
     elsif @planning_application.open_validation_requests?
       @planning_application.errors.add(:planning_application,
                                        "Planning application cannot be validated if open validation requests exist.")
-      render "confirm_validation"
     elsif @planning_application.invalid_documents.present?
       @planning_application.errors.add(:planning_application,
                                        "This application has an invalid document. You cannot validate an application with invalid documents.")
+    elsif @planning_application.boundary_geojson.blank?
+      @planning_application.errors.add(
+        :base,
+        :no_boundary_geojson,
+        path: planning_application_sitemap_path(@planning_application)
+      )
+    end
+
+    if @planning_application.errors.any?
       render "confirm_validation"
     else
       @planning_application.documents_validated_at = date_from_params

--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -24,7 +24,7 @@
           <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
               <% @planning_application.errors.each do |error| %>
-                <li><%= error.message %></li>
+                <li><%= error.message.html_safe %></li>
               <% end %>
             </ul>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,8 @@ en:
               missing_numbers: "All documents listed on the decision notice must have a document number"
         planning_application:
           attributes:
+            base:
+              no_boundary_geojson: "This application does not have a digital sitemap and cannot be validated. Please <a href='%{path}'>create a digital site map</a> before validating this application."
             payment_amount:
               greater_than_or_equal_to: "Payment amount (£) must be greater than or equal to 0"
               not_a_number: "Payment amount must be a number not exceeding 2 decimal places"

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -43,6 +43,7 @@ Given("a new planning application") do
   @planning_application = FactoryBot.create(
     :planning_application,
     :not_started,
+    :with_boundary_geojson,
     local_authority: @officer.local_authority
   )
 end


### PR DESCRIPTION
### Description of change

- Add and render error if validation form is submitted for planning application that has no `boundary_geojson`.

### Story Link

https://trello.com/c/May15sJH/711-prevent-applications-from-being-marked-as-valid-if-they-do-not-have-a-digital-sitemap

### Screenshot

<img width="60%" alt="Screenshot 2022-07-29 at 13 02 30" src="https://user-images.githubusercontent.com/25392162/181754664-4369ecae-c6f4-47b0-9044-09cbb1caa7ba.png">