### PR TITLE
Add option to send one time password via email

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
           RAILS_ENV: test
           SPEC_OPTS: "-f doc -P spec/models/**/*_spec.rb"
           OTP_SECRET_ENCRYPTION_KEY: ${{ secrets.OTP_SECRET_ENCRYPTION_KEY }}
+          NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
         run: |
           bundle exec rake spec:models
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,7 @@ module Users
     end
 
     def two_factor
-      render "devise/sessions/setup" unless mobile_number(@user)
+      render "devise/sessions/setup" if mobile_number_needed?(@user)
 
       respond_to do |format|
         format.html
@@ -37,7 +37,7 @@ module Users
       if can_resend_code?
         flash.now[:alert] = "Please wait at least a minute before resending your verification code."
       else
-        TwoFactor::SmsNotification.new(mobile_number(@user), @user.current_otp).deliver!
+        @user.send_otp(session[:mobile_number])
         session[:last_code_sent_at] = Time.current
         flash.now[:notice] = "You have been sent another verification code."
       end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -40,10 +40,11 @@ class UsersController < AuthenticationController
   private
 
   def user_params
-    params
-      .require(:user)
-      .permit(:name, :email, :password, :mobile_number, :role)
-      .transform_values(&:presence)
+    params.require(:user).permit(permitted_params).transform_values(&:presence)
+  end
+
+  def permitted_params
+    %i[name email otp_delivery_method password mobile_number role]
   end
 
   def set_user

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,10 @@ module ApplicationHelper
       root_path
     end
   end
+
+  def otp_delivery_method_options
+    User.otp_delivery_methods.keys.map do |key|
+      OpenStruct.new(id: key, name: t(".#{key}"))
+    end
+  end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -7,4 +7,9 @@ class UserMailer < ApplicationMailer
     subject = subject(:update_notification_mail, reference: @reference)
     view_mail(NOTIFY_TEMPLATE_ID, subject: subject, to: to)
   end
+
+  def otp_mail(user)
+    @otp = user.current_otp
+    view_mail(NOTIFY_TEMPLATE_ID, subject: subject(:otp_mail), to: user.email)
+  end
 end

--- a/app/views/user_mailer/otp_mail.text.erb
+++ b/app/views/user_mailer/otp_mail.text.erb
@@ -1,0 +1,1 @@
+<%= t(".otp_is_your", otp: @otp) %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -7,6 +7,12 @@
       <%= form.govuk_password_field :password, class: "govuk-input--width-30" %>
     <% end %>
     <%= form.govuk_text_field :mobile_number, class: "govuk-input--width-30" %>
+    <%= form.govuk_collection_select(
+      :otp_delivery_method,
+      otp_delivery_method_options,
+      :id,
+      :name
+    ) %>
     <% unless form.object == current_user %>
       <%= form.govuk_collection_select(
         :role,

--- a/app/views/users/_table.html.erb
+++ b/app/views/users/_table.html.erb
@@ -13,6 +13,9 @@
       <th scope="col" class="govuk-table__header">
         <%= t(".otp_required_for_login") %>
       </th>
+      <th scope="col" class="govuk-table__header">
+        <%= t(".otp_delivery_method") %>
+      </th>
       <th scope="col" class="govuk-table__header"><%= t(".actions") %></th>
     </tr>
   </thead>
@@ -31,6 +34,9 @@
         <td class="govuk-table__cell"><%= user.role.capitalize %></td>
         <td class="govuk-table__cell">
           <%= t(".#{user.otp_required_for_login}") %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= t(".#{user.otp_delivery_method}")%>
         </td>
         <td class="govuk-table__cell">
           <%= link_to(t(".edit"), edit_user_path(user), class: "govuk-link") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,7 @@ en:
       description_change_mail: Lawful Development Certificate application - suggested changes
       description_closure_notification_mail: Changes to your Lawful Development Certificate application
       invalidation_notice_mail: Lawful Development Certificate application - changes needed
+      otp_mail: Back Office Planning System verification code
       receipt_notice_mail: Lawful Development Certificate application received
       validation_notice_mail: Your application for a Lawful Development Certificate
       validation_request_mail: Lawful Development Certificate application  - further changes needed
@@ -31,6 +32,8 @@ en:
       update_notification_mail: BoPS case %{reference} has a new update
       validation_request_closure_mail: Changes to your Lawful Development Certificate application
   user_mailer:
+    otp_mail:
+      otp_is_your: "%{otp} is your Back Office Planning System verification code."
     update_notification_mail:
       bops_case_reference: BoPS case %{reference} has a new update.
       bops_updates: BoPS updates
@@ -128,6 +131,8 @@ en:
     edit:
       edit_user: Edit user
     form:
+      email: Email
+      sms: SMS
       submit: Submit
     new:
       add_user: Add a new user
@@ -138,8 +143,10 @@ en:
       false: "No"
       mobile_number: Mobile number
       name: Name
+      otp_delivery_method: Verification code delivery method
       otp_required_for_login: Two factor authentication
       role: Role
+      sms: SMS
       true: "Yes"
       users: Users
   proposal_details:
@@ -187,6 +194,7 @@ en:
         entry: "Add a note to this application."
       user:
         otp_attempt: "Security code"
+        otp_delivery_method: Verification code delivery method
         email: Email
         mobile_number: Mobile number
         name: Name

--- a/db/migrate/20220729131545_add_otp_delivery_method_to_users.rb
+++ b/db/migrate/20220729131545_add_otp_delivery_method_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOtpDeliveryMethodToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :otp_delivery_method, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_22_101202) do
+ActiveRecord::Schema.define(version: 2022_07_29_131545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -337,6 +337,7 @@ ActiveRecord::Schema.define(version: 2022_07_22_101202) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "mobile_number"
+    t.integer "otp_delivery_method", default: 0
     t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true
     t.index ["encrypted_otp_secret"], name: "ix_users_on_encrypted_otp_secret", unique: true
     t.index ["local_authority_id"], name: "index_users_on_local_authority_id"

--- a/spec/mailer/previews/user_mailer_preview.rb
+++ b/spec/mailer/previews/user_mailer_preview.rb
@@ -7,4 +7,8 @@ class UserMailerPreview < ActionMailer::Preview
       User.last.email
     )
   end
+
+  def otp_mail
+    UserMailer.otp_mail(User.last)
+  end
 end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -39,4 +39,25 @@ RSpec.describe UserMailer, type: :mailer do
       )
     end
   end
+
+  describe "#otp_mail" do
+    let(:user) { create(:user, email: "jane@example.com") }
+    let(:mail) { described_class.otp_mail(user) }
+
+    it "sets subject" do
+      expect(mail.subject).to eq(
+        "Back Office Planning System verification code"
+      )
+    end
+
+    it "sets recipient" do
+      expect(mail.to).to contain_exactly("jane@example.com")
+    end
+
+    it "includes user's current otp" do
+      expect(mail.body.encoded).to include(
+        "#{user.current_otp} is your Back Office Planning System verification code."
+      )
+    end
+  end
 end

--- a/spec/system/managing_users_spec.rb
+++ b/spec/system/managing_users_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe "managing users", type: :system do
       fill_in("Email", with: "alice@example.com")
       fill_in("Password", with: "password")
       fill_in("Mobile number", with: "01234123123")
+      select("Email", from: "Verification code delivery method")
       select("Assessor", from: "Role")
       click_button("Submit")
 
@@ -45,6 +46,7 @@ RSpec.describe "managing users", type: :system do
       row = row_with_content("Alice Smith")
       expect(row).to have_content("alice@example.com")
       expect(row).to have_content("01234 123 123")
+      expect(row).to have_content("Email")
       expect(row).to have_content("Assessor")
 
       click_link("Log out")
@@ -84,7 +86,8 @@ RSpec.describe "managing users", type: :system do
         :user,
         :reviewer,
         name: "Bella Jones",
-        local_authority: local_authority
+        local_authority: local_authority,
+        otp_delivery_method: :email
       )
 
       visit(administrator_dashboard_path)
@@ -105,6 +108,7 @@ RSpec.describe "managing users", type: :system do
       fill_in("Name", with: "Belle Jones")
       fill_in("Email", with: "belle@example.com")
       fill_in("Mobile number", with: "01234456456")
+      select("SMS", from: "Verification code delivery method")
       select("Assessor", from: "Role")
       click_button("Submit")
 
@@ -112,6 +116,7 @@ RSpec.describe "managing users", type: :system do
       row = row_with_content("Belle Jones")
       expect(row).to have_content("belle@example.com")
       expect(row).to have_content("01234 456 456")
+      expect(row).to have_content("SMS")
       expect(row).to have_content("Assessor")
     end
 


### PR DESCRIPTION
### Description of change

- Add `UserMailer#otp_mail`.
- Add enum `otp_delivery_method` to `users`, with `sms` and `email` options, defaulting to `sms`.
- Extract logic for sending otp into `User` model and update to send using `#otp_mail` if `otp_delivery_method` is `email`.

### Story Link

https://trello.com/c/JE7aV8rr/905-discuss-adding-email-2fa-support

### Screenshot

<img width="60%" alt="Screenshot 2022-07-29 at 17 29 43" src="https://user-images.githubusercontent.com/25392162/181804951-90dbd78e-7d0f-4bab-8972-8489d2a6c7e1.png">