### PR TITLE
Update link text for decision notice information

### DIFF
--- a/app/views/planning_applications/review_form.html.erb
+++ b/app/views/planning_applications/review_form.html.erb
@@ -23,7 +23,11 @@
     <%= @planning_application.public_comment %>
   </p>
 
-  <%= link_to "Edit this text", edit_public_comment_planning_application_path(@planning_application), class: "govuk-link" %>
+  <%= link_to(
+    t(".edit_information_on"),
+    edit_public_comment_planning_application_path(@planning_application),
+    class: "govuk-link"
+  ) %>
 
   <%= render "recommendations", { recommendations: @planning_application.recommendations } %>
 

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -5,6 +5,7 @@ en:
       all_your_applications: All your applications
     assessment_dashboard:
       awaiting_approval_to: Awaiting approval to a description change (sent on %{date})
+      edit_information_on: Edit information on the decision notice
     index:
       assessor_alert:
         one: Your manager has requested corrections on <strong>%{count} application.</strong>

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       expect(page).to have_content("This information will appear on the decision notice:")
       expect(page).to have_content(planning_application.public_comment)
 
-      click_link "Edit this text"
+      click_link "Edit information on the decision notice"
       expect(page).to have_current_path(edit_public_comment_planning_application_path(planning_application))
 
       expect(page).to have_content("Edit the information appearing on the decision notice")


### PR DESCRIPTION
### Description of change

Change link text from 'Edit this link' to 'Edit information on the decision notice'.

### Story Link

https://trello.com/c/keipjpRK/1082-edit-this-link-to-be-changed

### Screenshot

<img width="60%" alt="Screenshot 2022-08-01 at 10 38 23" src="https://user-images.githubusercontent.com/25392162/182120385-b873f810-1da4-4b51-a25d-4bac0fade712.png">

