### PR TITLE
Only send email notification once if applicant/agent email are identical

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -54,9 +54,8 @@ module Api
             )
 
             send_success_response
-            if @planning_application.agent_email.present? || @planning_application.applicant_email.present?
-              receipt_notice_mail
-            end
+
+            @planning_application.send_receipt_notice_mail
           end
         end
       rescue Errors::WrongFileTypeError, Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError,
@@ -138,14 +137,6 @@ module Api
 
       def payment_amount_in_pounds(amount)
         amount.to_f / 100
-      end
-
-      def receipt_notice_mail
-        @planning_application.applicant_and_agent_email.each do |email|
-          PlanningApplicationMailer
-            .receipt_notice_mail(@planning_application, email)
-            .deliver_now
-        end
       end
     end
   end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -48,7 +48,7 @@ class PlanningApplicationsController < AuthenticationController
     @planning_application.assign_attributes(local_authority: current_local_authority)
 
     if @planning_application.save
-      receipt_notice_mail if @planning_application.applicant_and_agent_email.any?
+      @planning_application.send_receipt_notice_mail
 
       redirect_to planning_application_documents_path(@planning_application), notice: "Planning application was successfully created."
     else
@@ -113,7 +113,7 @@ class PlanningApplicationsController < AuthenticationController
     else
       @planning_application.documents_validated_at = date_from_params
       @planning_application.start!
-      validation_notice_mail
+      @planning_application.send_validation_notice_mail
 
       redirect_to @planning_application, notice: "Application is ready for assessment and an email notification has been sent."
     end
@@ -123,7 +123,7 @@ class PlanningApplicationsController < AuthenticationController
     if @planning_application.may_invalidate?
       @planning_application.invalidate!
 
-      invalidation_notice_mail
+      @planning_application.send_invalidation_notice_mail
 
       redirect_to @planning_application, notice: "Application has been invalidated and email has been sent"
     else
@@ -246,7 +246,7 @@ class PlanningApplicationsController < AuthenticationController
       if @planning_application.valid?
         @planning_application.determine!
 
-        decision_notice_mail
+        @planning_application.send_decision_notice_mail(host: request.host)
 
         format.html do
           redirect_to @planning_application, notice: "Decision Notice sent to applicant"
@@ -371,38 +371,6 @@ class PlanningApplicationsController < AuthenticationController
 
   def payment_amount_params
     params[:planning_application] ? params.require(:planning_application).permit(:payment_amount) : params.permit(:payment_amount)
-  end
-
-  def decision_notice_mail
-    @planning_application.applicant_and_agent_email.each do |user|
-      PlanningApplicationMailer.decision_notice_mail(
-        @planning_application,
-        request.host,
-        user
-      ).deliver_now
-    end
-  end
-
-  def validation_notice_mail
-    @planning_application.applicant_and_agent_email.each do |email|
-      PlanningApplicationMailer
-        .validation_notice_mail(@planning_application, email)
-        .deliver_now
-    end
-  end
-
-  def invalidation_notice_mail
-    PlanningApplicationMailer
-      .invalidation_notice_mail(@planning_application)
-      .deliver_now
-  end
-
-  def receipt_notice_mail
-    @planning_application.applicant_and_agent_email.each do |email|
-      PlanningApplicationMailer
-        .receipt_notice_mail(@planning_application, email)
-        .deliver_now
-    end
   end
 
   def ensure_user_is_reviewer

--- a/app/models/concerns/planning_application/notification.rb
+++ b/app/models/concerns/planning_application/notification.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  module Notification
+    extend ActiveSupport::Concern
+
+    def send_decision_notice_mail(host:)
+      return unless applicant_and_agent_email.any?
+
+      downcase_and_unique(applicant_and_agent_email).each do |email|
+        PlanningApplicationMailer.decision_notice_mail(
+          self,
+          host,
+          email
+        ).deliver_later
+      end
+    end
+
+    def send_validation_notice_mail
+      return unless applicant_and_agent_email.any?
+
+      downcase_and_unique(applicant_and_agent_email).each do |email|
+        PlanningApplicationMailer
+          .validation_notice_mail(self, email)
+          .deliver_later
+      end
+    end
+
+    def send_invalidation_notice_mail
+      PlanningApplicationMailer
+        .invalidation_notice_mail(self)
+        .deliver_later
+    end
+
+    def send_receipt_notice_mail
+      return unless applicant_and_agent_email.any?
+
+      downcase_and_unique(applicant_and_agent_email).each do |email|
+        PlanningApplicationMailer
+          .receipt_notice_mail(self, email)
+          .deliver_later
+      end
+    end
+
+    def send_update_notification_to_assessor
+      send_update_notification(user_email)
+    end
+
+    def send_update_notification_to_reviewers
+      send_update_notification(reviewer_group_email)
+    end
+
+    private
+
+    def send_update_notification(to)
+      return if to.blank?
+
+      UserMailer.update_notification_mail(self, to).deliver_later
+    end
+
+    def downcase_and_unique(array)
+      array.map(&:downcase).uniq
+    end
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -13,6 +13,8 @@ class PlanningApplication < ApplicationRecord
 
   include PlanningApplication::ValidationRequest
 
+  include PlanningApplication::Notification
+
   enum application_type: { lawfulness_certificate: 0, full: 1 }
 
   enum user_role: { applicant: 0, agent: 1, proxy: 2 }
@@ -409,14 +411,6 @@ class PlanningApplication < ApplicationRecord
     end
   end
 
-  def send_update_notification_to_assessor
-    send_update_notification(user_email)
-  end
-
-  def send_update_notification_to_reviewers
-    send_update_notification(reviewer_group_email)
-  end
-
   private
 
   def set_reference
@@ -425,12 +419,6 @@ class PlanningApplication < ApplicationRecord
       application_number,
       application_type_code
     ].join("-")
-  end
-
-  def send_update_notification(to)
-    return if to.blank?
-
-    UserMailer.update_notification_mail(self, to).deliver_later
   end
 
   def set_key_dates

--- a/spec/models/concerns/planning_application/notification_spec.rb
+++ b/spec/models/concerns/planning_application/notification_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplication::Notification do
+  let(:planning_application) { create(:planning_application) }
+  let(:planning_application_with_same_agent_and_applicant_email) do
+    create(:planning_application, applicant_email: "email@example.com", agent_email: "Email@example.com")
+  end
+
+  describe "#send_decision_notice_mail" do
+    context "when there is an applicant an agent email" do
+      it "sends an email to both applicant and agent" do
+        expect(PlanningApplicationMailer).to receive(:decision_notice_mail).twice.and_call_original
+
+        planning_application.send_decision_notice_mail(host: "host")
+      end
+    end
+
+    context "when applicant and agent email are the same" do
+      it "sends only one email" do
+        expect(PlanningApplicationMailer).to receive(:decision_notice_mail).once.and_call_original
+
+        planning_application_with_same_agent_and_applicant_email.send_decision_notice_mail(host: "host")
+      end
+    end
+  end
+
+  describe "#send_validation_notice_mail" do
+    context "when there is an applicant an agent email" do
+      it "sends an email to both applicant and agent" do
+        expect(PlanningApplicationMailer).to receive(:validation_notice_mail).twice.and_call_original
+
+        planning_application.send_validation_notice_mail
+      end
+    end
+
+    context "when applicant and agent email are the same" do
+      it "sends only one email" do
+        expect(PlanningApplicationMailer).to receive(:validation_notice_mail).once.and_call_original
+
+        planning_application_with_same_agent_and_applicant_email.send_validation_notice_mail
+      end
+    end
+  end
+
+  describe "#send_receipt_notice_mail" do
+    context "when there is an applicant an agent email" do
+      it "sends an email to both applicant and agent" do
+        expect(PlanningApplicationMailer).to receive(:receipt_notice_mail).twice.and_call_original
+
+        planning_application.send_receipt_notice_mail
+      end
+    end
+
+    context "when applicant and agent email are the same" do
+      it "sends only one email" do
+        expect(PlanningApplicationMailer).to receive(:receipt_notice_mail).once.and_call_original
+
+        planning_application_with_same_agent_and_applicant_email.send_receipt_notice_mail
+      end
+    end
+  end
+end

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -81,9 +81,11 @@ RSpec.describe "Creating a planning application via the API", type: :request, sh
 
       it "sends the receipt email" do
         post_with(params: permitted_development_json)
+        perform_enqueued_jobs
 
         email = ActionMailer::Base.deliveries.last
         expect(email.body).to include(PlanningApplication.all[0].reference)
+        expect(email.body).to include("We’ve received your application for a Lawful Development Certificate.")
       end
 
       it "downloads and saves the plan against the planning application" do

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(page).not_to have_content("Assigned to:")
     expect(page).not_to have_content("Process Application")
     expect(page).not_to have_content("Review Assessment")
+    perform_enqueued_jobs
     expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 2)
     click_link("View decision notice")
     expect(page).to have_content("We certify that on the date of the application")

--- a/spec/system/planning_applications/validating_spec.rb
+++ b/spec/system/planning_applications/validating_spec.rb
@@ -150,6 +150,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       planning_application.reload
       expect(planning_application.status).to eq("invalidated")
 
+      perform_enqueued_jobs
       expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
     end
   end


### PR DESCRIPTION
### Description of change

Only send email notification once if applicant/agent email are identical
- Move notification methods out of controller  to model concern

### Story Link

https://trello.com/c/byj8MIBS/1097-email-notification-sent-twice-when-applicant-email-address-are-set-to-the-same-value

