### PR TITLE
Update page copy for OTP sent by email

### DIFF
--- a/app/views/devise/sessions/two_factor.html.erb
+++ b/app/views/devise/sessions/two_factor.html.erb
@@ -5,10 +5,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      Enter the code you have received by text message
+      <%= t(".#{@user.otp_delivery_method}.enter_the_code") %>
     </h1>
 
-    <p class="govuk-body">A 6-digit code has been sent to your mobile phone. This message may take a minute to arrive.</p>
+    <p class="govuk-body">
+      <%= t(".#{@user.otp_delivery_method}.a_six_digit") %>
+    </p>
 
     <div class=" govuk-form-group ">
       <%= form_for(@user, as: :user, url: user_session_path, method: :post) do |form| %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -49,6 +49,13 @@ en:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."
       already_signed_out: "Signed out successfully."
+      two_factor:
+        email:
+          a_six_digit: A 6-digit code has been sent to your email account. This message may take a minute to arrive.
+          enter_the_code: Enter the code you have received by email
+        sms:
+          a_six_digit: A 6-digit code has been sent to your mobile phone. This message may take a minute to arrive.
+          enter_the_code: Enter the code you have received by text message
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -289,6 +289,14 @@ RSpec.describe "Sign in", type: :system do
         fill_in("Password", with: "password")
         click_button("Log in")
 
+        expect(page).to have_content(
+          "Enter the code you have received by email"
+        )
+
+        expect(page).to have_content(
+          "A 6-digit code has been sent to your email account. This message may take a minute to arrive."
+        )
+
         email = ActionMailer::Base.deliveries.last
 
         expect(email.subject).to eq(


### PR DESCRIPTION
### Description of change

- Change 'text message' and 'mobile phone' to 'email' and 'email account' when 2FA code sent via email.

### Story Link

https://trello.com/c/JE7aV8rr/905-add-email-2fa-support#comment-62e8e67fa69a497dc9844d86

### Screenshot

<img width="60%" alt="Screenshot 2022-08-02 at 10 22 47" src="https://user-images.githubusercontent.com/25392162/182340915-125e7069-d316-4b00-afe5-8743d740aca3.png">