### PR TITLE
Prevent tests around reference breaking in 2023

### DIFF
--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   let!(:reviewer) { create :user, :reviewer, local_authority: local_authority }
   let!(:assessor) { create :user, :assessor, local_authority: local_authority }
 
-  let!(:planning_application) do
+  let(:planning_application) do
     create(
       :planning_application,
       :determined,
@@ -35,21 +35,24 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     )
   end
 
-  let!(:invalid_planning_application) { create(:planning_application, :invalidated) }
+  let(:invalid_planning_application) do
+    create(:planning_application, :invalidated)
+  end
 
   let(:host) { "ripa.example.com" }
-  let!(:validation_request) do
+
+  let(:validation_request) do
     create(:other_change_validation_request, planning_application: invalid_planning_application, user: assessor)
   end
 
-  let!(:document_with_tags) do
+  let(:document_with_tags) do
     create :document, :with_tags,
            planning_application: planning_application,
            numbers: "proposed_number_1, proposed_number_2",
            referenced_in_decision_notice: true
   end
 
-  let!(:archived_document_with_tags) do
+  let(:archived_document_with_tags) do
     create :document, :archived, :with_tags,
            planning_application: planning_application,
            numbers: "archived_number"
@@ -81,9 +84,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the address" do
@@ -155,7 +160,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
 
-    let!(:validation_request) do
+    let(:validation_request) do
       create(:other_change_validation_request, planning_application: planning_application, user: assessor)
     end
 
@@ -183,9 +188,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the address" do
@@ -226,9 +233,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the address" do
@@ -273,9 +282,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the address" do
@@ -378,9 +389,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the application received at date" do
@@ -442,7 +455,9 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include("Application number: RIPA-22-00100-LDCP")
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include("Application number: RIPA-22-00100-LDCP")
+      end
     end
 
     it "includes the address" do
@@ -490,9 +505,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the description" do
@@ -556,9 +573,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
 
       it "includes the reference" do
-        expect(mail_body).to include(
-          "Application reference number: RIPA-22-00100-LDCP"
-        )
+        travel_to(Date.new(2022)) do
+          expect(mail_body).to include(
+            "Application reference number: RIPA-22-00100-LDCP"
+          )
+        end
       end
 
       it "includes the address" do
@@ -601,9 +620,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
 
       it "includes the reference" do
-        expect(mail_body).to include(
-          "Application reference number: RIPA-22-00100-LDCP"
-        )
+        travel_to(Date.new(2022)) do
+          expect(mail_body).to include(
+            "Application reference number: RIPA-22-00100-LDCP"
+          )
+        end
       end
 
       it "includes the address" do
@@ -655,9 +676,11 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      expect(mail_body).to include(
-        "Application reference number: RIPA-22-00100-LDCP"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "Application reference number: RIPA-22-00100-LDCP"
+        )
+      end
     end
 
     it "includes the address" do

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -4,9 +4,7 @@ require "rails_helper"
 
 RSpec.describe UserMailer, type: :mailer do
   describe "#update_notification_mail" do
-    let(:planning_application) do
-      create(:planning_application, created_at: DateTime.new(2022, 5, 1))
-    end
+    let(:planning_application) { create(:planning_application) }
 
     let(:mail) do
       described_class.update_notification_mail(
@@ -18,9 +16,11 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail_body) { mail.body.encoded }
 
     it "sets subject" do
-      expect(mail.subject).to eq(
-        "BoPS case BUC-22-00100-LDCP has a new update"
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail.subject).to eq(
+          "BoPS case BUC-22-00100-LDCP has a new update"
+        )
+      end
     end
 
     it "sets recipient" do
@@ -28,9 +28,11 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it "includes planning application reference" do
-      expect(mail_body).to include(
-        "BoPS case BUC-22-00100-LDCP has a new update."
-      )
+      travel_to(Date.new(2022)) do
+        expect(mail_body).to include(
+          "BoPS case BUC-22-00100-LDCP has a new update."
+        )
+      end
     end
 
     it "includes plannng application url" do

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe "assigning planning application", type: :system do
   let(:planning_application) do
     create(
       :planning_application,
-      local_authority: local_authority,
-      created_at: DateTime.new(2022, 1, 1)
+      local_authority: local_authority
     )
   end
 
   it "lets a planning application be assigned to a user" do
+    travel_to(Date.new(2022))
     sign_in(reviewer)
     visit(assign_planning_application_path(planning_application))
     choose("Jane Smith")
@@ -39,5 +39,7 @@ RSpec.describe "assigning planning application", type: :system do
     expect(update_notification.subject).to eq(
       "BoPS case RIPA-22-00100-LDCP has a new update"
     )
+
+    travel_back
   end
 end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
   context "when clicking Save and mark as complete" do
     context "with no previous recommendations" do
       it "can create a new recommendation, edit it, and submit it" do
+        travel_to(Date.new(2022))
         click_link "In assessment"
 
         within(selected_govuk_tab) do
@@ -97,6 +98,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
         expect(page).to have_text(assessor.name)
         expect(page).to have_text("Assessor comment: Edited private assessor comment")
         expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+
+        travel_back
       end
     end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   end
 
   it "can be rejected" do
+    travel_to(Date.new(2022))
     click_link "Review assessment"
     choose "No"
     fill_in "Review comment", with: "Reviewer private comment"
@@ -98,6 +99,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(page).to have_text("Recommendation challenged")
     expect(page).to have_text("Reviewer private comment")
     expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+
+    travel_back
   end
 
   it "cannot be rejected without a review comment" do


### PR DESCRIPTION
### Description of change

The `reference` for planning applications is now set using `Date.current` rather than `created_at`. This means that a number of tests will fail on 1/1/23 as they assume that the reference will include the characters `22`, derived from the year.

These changes use `travel_to` to make sure that `Date.current` will continue to return a date in 2022.

### Story Link

NA