### PR TITLE
Implement closed tab redesign

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -79,4 +79,10 @@ module PlanningApplicationHelper
       planning_application.latitude.present? &&
       planning_application.longitude.present?
   end
+
+  def planning_application_presenters(template, planning_applications)
+    planning_applications.map do |planning_application|
+      PlanningApplicationPresenter.new(template, planning_application)
+    end
+  end
 end

--- a/app/helpers/planning_application_status_helper.rb
+++ b/app/helpers/planning_application_status_helper.rb
@@ -11,11 +11,6 @@ module PlanningApplicationStatusHelper
       "Status"
     ]
 
-    if planning_application_status.eql?("closed")
-      options << "Determination date"
-      options.delete("Days left to expiry")
-    end
-
     if planning_application_status.eql?("awaiting_determination")
       options << "Recommendation date"
       options.delete("Status")

--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -28,4 +28,8 @@ class PlanningApplicationPresenter
   def respond_to_missing?(symbol, include_private = false)
     super || planning_application.respond_to?(symbol)
   end
+
+  def outcome_date
+    send("#{status}_at")
+  end
 end

--- a/app/views/planning_applications/_closed_planning_applications_table.html.erb
+++ b/app/views/planning_applications/_closed_planning_applications_table.html.erb
@@ -1,0 +1,49 @@
+<div class="govuk-tabs__panel" id="closed">
+  <h2 class="govuk-heading-l"><%= t(".closed") %></h2>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          <%= t(".application_number") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".outcome") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".outcome_date") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".site_address") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".description") %>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% planning_application_presenters(self, planning_applications).each do |planning_application| %>
+        <tr class="govuk-table__row" id=<%= dom_id(planning_application) %>>
+          <td class="govuk-table__cell">
+            <%= link_to(
+              planning_application.reference,
+              planning_application,
+              class: "govuk-link"
+            ) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.status_tag %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.outcome_date.strftime("%e %b") %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.full_address %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.description %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -21,7 +21,7 @@
     </thead>
 
     <tbody class="govuk-table__body">
-      <% planning_applications.map { |p| PlanningApplicationPresenter.new(self, p) }.each do |planning_application| %>
+      <% planning_application_presenters(self, planning_applications).each do |planning_application| %>
         <%= content_tag(:tr, id: dom_id(planning_application), class: "govuk-table__row") do %>
           <td class="govuk-table__cell">
             <%= link_to planning_application.reference, planning_application, class: "govuk-link" %>
@@ -29,11 +29,9 @@
           <td class="govuk-table__cell"><%= planning_application.full_address %></td>
           <td class="govuk-table__cell"><%= t("application_types.#{planning_application.application_type}") %></td>
           <td class="govuk-table__cell"><%= planning_application.expiry_date.strftime("%e %b") %></td>
-          <% if planning_application_status != "closed" %>
-            <td class="govuk-table__cell">
-              <%= planning_application.remaining_days_status_tag %>
-            </td>
-          <% end %>
+          <td class="govuk-table__cell">
+            <%= planning_application.remaining_days_status_tag %>
+          </td>
           <% if planning_application_status != "awaiting_determination" %>
             <td class="govuk-table__cell">
               <%= planning_application.status_tag %>
@@ -41,9 +39,6 @@
           <% end %>
           <% if planning_application_status == "awaiting_determination" %>
             <td class="govuk-table__cell"><%= planning_application.awaiting_determination_at.strftime("%e %b") %></td>
-          <% end %>
-          <% if planning_application_status == "closed" %>
-            <td class="govuk-table__cell"><%= planning_application.determination_date.strftime("%e %b") if planning_application.determination_date %></td>
           <% end %>
           <td class="govuk-table__cell">
             <% if planning_application.user %>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -49,7 +49,11 @@
       <%= render "planning_application_table", planning_applications: @planning_applications.under_assessment, planning_application_status: "under_assessment", title: "In assessment" unless exclude_others? && current_user.reviewer?  %>
       <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_determination, planning_application_status: "awaiting_determination", title: "Awaiting determination" %>
       <%= render "planning_application_table", planning_applications: @planning_applications.awaiting_correction, planning_application_status: "awaiting_correction", title: "Corrections requested" unless current_user.assessor?%>
-      <%= render "planning_application_table", planning_applications: @planning_applications.closed, planning_application_status: "closed", title: "Closed" %>
+      <%= render(
+        "closed_planning_applications_table",
+        planning_applications: @planning_applications.closed,
+        planning_application_status: "closed"
+      ) %>
       <%= render(
          "planning_application_table",
          planning_applications: (@search.query ? @search.results : @planning_applications),

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -1,5 +1,12 @@
 en:
   planning_applications:
+    closed_planning_applications_table:
+      application_number: Application number
+      closed: Closed
+      description: Description
+      outcome: Outcome
+      outcome_date: Outcome date
+      site_address: Site address
     tabs:
       all_applications: All applications
       all_your_applications: All your applications

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -90,40 +90,101 @@ RSpec.describe "Planning Application index page", type: :system do
       end
 
       context "when I view the closed tab" do
-        before do
-          click_link "Closed"
+        let!(:determined_planning_application) do
+          create(
+            :planning_application,
+            :determined,
+            decision: :granted,
+            determined_at: DateTime.new(2022, 8, 1),
+            address_1: "1 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add a fence",
+            local_authority: default_local_authority
+          )
         end
 
-        it "Only Planning Applications that are determined are present in this tab" do
-          within("#closed") do
-            expect(page).to have_text("Closed")
-            expect(page).to have_link(planning_application_completed.reference)
-            expect(page).not_to have_link(planning_application_1.reference)
-            expect(page).not_to have_link(planning_application_2.reference)
-            expect(page).not_to have_link(planning_application_started.reference)
+        let!(:withdrawn_planning_application) do
+          create(
+            :planning_application,
+            :withdrawn,
+            withdrawn_at: DateTime.new(2022, 8, 2),
+            address_1: "2 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add a window",
+            local_authority: default_local_authority
+          )
+        end
+
+        let!(:returned_planning_application) do
+          create(
+            :planning_application,
+            :returned,
+            returned_at: DateTime.new(2022, 8, 3),
+            address_1: "3 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add a chimney",
+            local_authority: default_local_authority
+          )
+        end
+
+        let!(:closed_planning_application) do
+          create(
+            :planning_application,
+            :closed,
+            closed_at: DateTime.new(2022, 8, 4),
+            address_1: "4 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add an attic",
+            local_authority: default_local_authority
+          )
+        end
+
+        before do
+          visit(planning_applications_path)
+          click_link("Closed")
+        end
+
+        it "shows determined application" do
+          within(selected_govuk_tab) do
+            row = row_with_content(determined_planning_application.reference)
+            expect(row).to have_content("Granted")
+            expect(row).to have_content("1 Aug")
+            expect(row).to have_content("1 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add a fence")
           end
         end
 
-        it "I see the relevant table headers and information" do
-          click_link "Closed"
+        it "shows withdrawn application" do
+          within(selected_govuk_tab) do
+            row = row_with_content(withdrawn_planning_application.reference)
+            expect(row).to have_content("Withdrawn")
+            expect(row).to have_content("2 Aug")
+            expect(row).to have_content("2 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add a window")
+          end
+        end
 
-          within("#closed") do
-            expect(page).to have_content("Application number")
-            expect(page).to have_content("Site address")
-            expect(page).to have_content("Application type")
-            expect(page).to have_content("Expiry date")
-            expect(page).to have_content("Status")
-            expect(page).to have_content("Determination date")
-            expect(page).to have_content("Planning officer")
+        it "shows returned application" do
+          within(selected_govuk_tab) do
+            row = row_with_content(returned_planning_application.reference)
+            expect(row).to have_content("Returned")
+            expect(row).to have_content("3 Aug")
+            expect(row).to have_content("3 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add a chimney")
+          end
+        end
 
-            within("#planning_application_#{planning_application_completed.id}") do
-              expect(page).to have_link("22-00103-LDCP")
-              expect(page).to have_content(planning_application_completed.full_address)
-              expect(page).to have_content("Lawful Development Certificate")
-              expect(page).to have_content(planning_application_completed.expiry_date.strftime("%e %b"))
-              expect(page).to have_content("Granted")
-              expect(page).to have_content(planning_application_completed.determination_date.strftime("%e %b"))
-            end
+        it "shows closed application" do
+          within(selected_govuk_tab) do
+            row = row_with_content(closed_planning_application.reference)
+            expect(row).to have_content("Closed")
+            expect(row).to have_content("4 Aug")
+            expect(row).to have_content("4 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add an attic")
           end
         end
       end


### PR DESCRIPTION
### Description of change

- Add a new partial for closed planning applications tab, with columns as per new design.

### Story Link

https://trello.com/c/CLTIDDb9/814-closed-tab-redesign

### Decisions

I added a new partial instead of adding more logic to the existing `_planning_applications_table` partial as the logic in there is already pretty hairy!

### Screenshot

<img width='70%' src='https://user-images.githubusercontent.com/25392162/182414400-bc92360e-086d-4cfb-a576-38c83dae0f6b.png'> 