### PR TITLE
Show map pin when requesting change to boundary geojson

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -73,4 +73,10 @@ module PlanningApplicationHelper
       link_to "Request approval for a change to red line boundary", new_planning_application_red_line_boundary_change_validation_request_path(planning_application), class: "govuk-link"
     end
   end
+
+  def show_map_pin?(planning_application, data)
+    (data[:geojson].blank? || data[:invalid_red_line_boundary].present?) &&
+      planning_application.latitude.present? &&
+      planning_application.longitude.present?
+  end
 end

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -12,6 +12,8 @@
     zoom="19"
     latitude='<%= @planning_application.latitude %>'
     longitude='<%= @planning_application.longitude %>'
+  <% end %>
+  <% if show_map_pin?(@planning_application, locals) %>
     showMarker
     markerLatitude="<%= @planning_application.latitude %>"
     markerLongitude="<%= @planning_application.longitude %>"

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
         map_selector = find("my-map")
         expect(map_selector["latitude"]).to eq(planning_application.latitude)
         expect(map_selector["longitude"]).to eq(planning_application.longitude)
+        expect(map_selector["showMarker"]).to eq("true")
 
         # JS to emulate a polygon drawn on the map
         execute_script 'document.getElementById("planning_application_boundary_geojson").setAttribute("value", \'{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}\')'
@@ -72,6 +73,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
         click_button "Site map"
         expect(page).to have_content("Sitemap drawn by Applicant")
         expect(page).not_to have_content("No digital sitemap provided")
+        map = find("my-map")
+        expect(map["showMarker"]).to eq("false")
 
         visit planning_application_validation_tasks_path(planning_application)
         expect(page).not_to have_link("Draw red line boundary")
@@ -155,6 +158,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
 
       expect(page).to have_content(planning_application.full_address.upcase)
       expect(page).to have_content(planning_application.reference)
+      map = find("my-map")
+      expect(map["showMarker"]).to eq("true")
 
       find(".govuk-visually-hidden",
            visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'
@@ -239,6 +244,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
 
       click_button "Site map"
       click_link "Request approval for a change to red line boundary"
+      map = find("my-map")
+      expect(map["showMarker"]).to eq("true")
 
       # Draw proposed red line boundary
       find(".govuk-visually-hidden", visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'
@@ -310,6 +317,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
 
         expect(page).to have_content("Applicant approved proposed digital red line boundary")
         expect(page).to have_content("Change to red line boundary has been approved by the applicant")
+        map = find("my-map")
+        expect(map["showMarker"]).to eq("false")
       end
     end
 
@@ -325,6 +334,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
 
         expect(page).to have_content("Applicant rejected this proposed red line boundary")
         expect(page).to have_content("Reason: disagree")
+        map = find("my-map")
+        expect(map["showMarker"]).to eq("false")
       end
     end
 
@@ -343,6 +354,8 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
         click_link "View applicants response to requested red line boundary change"
 
         expect(page).to have_content("Change to red line boundary was auto closed and approved after being open for more than 5 business days")
+        map = find("my-map")
+        expect(map["showMarker"]).to eq("false")
 
         visit planning_application_audits_path(planning_application)
 


### PR DESCRIPTION
### Description of change

Show the map pin on the map when drawing the proposed new red line boundary for a red line boundary validation request (pre or post validation)

### Story Link

https://trello.com/c/FexsTSCa/1020-red-line-show-the-a-pin-for-the-identified-property-according-to-map-information - see comments!

### Screenshot

<img width='60%' src='https://user-images.githubusercontent.com/25392162/182578599-9fadbd0b-f4dc-47aa-b387-c4f1ac4ec698.png'> 

