### PR TITLE
Add option to search applications by description

### DIFF
--- a/app/services/planning_application_search.rb
+++ b/app/services/planning_application_search.rb
@@ -8,12 +8,46 @@ class PlanningApplicationSearch
   validates :query, presence: true
 
   def results
-    if valid?
-      planning_applications.where(
-        "LOWER(reference) LIKE ?", "%#{query.downcase}%"
-      )
-    else
-      planning_applications
-    end
+    valid? ? records_matching_query : planning_applications
+  end
+
+  private
+
+  def records_matching_query
+    records_matching_reference.presence || records_matching_description
+  end
+
+  def records_matching_reference
+    planning_applications.where(
+      "LOWER(reference) LIKE ?",
+      "%#{query.downcase}%"
+    )
+  end
+
+  def records_matching_description
+    planning_applications
+      .select(sanitized_select_sql)
+      .where(where_sql, query_terms)
+      .order(rank: :desc)
+  end
+
+  def sanitized_select_sql
+    ActiveRecord::Base.sanitize_sql_array([select_sql, query_terms])
+  end
+
+  def select_sql
+    "*,
+    ts_rank(
+      to_tsvector('english', description),
+      to_tsquery('english', ?)
+    ) AS rank"
+  end
+
+  def where_sql
+    "to_tsvector('english', description) @@ to_tsquery('english', ?)"
+  end
+
+  def query_terms
+    @query_terms ||= query.split.join(" | ")
   end
 end

--- a/app/views/planning_applications/_all_planning_applications_table.html.erb
+++ b/app/views/planning_applications/_all_planning_applications_table.html.erb
@@ -1,0 +1,57 @@
+<div class="govuk-tabs__panel" id="all">
+  <h2 class="govuk-heading-l"><%= all_applications_tab_title %></h2>
+  <%= render(
+    partial: "search/form",
+    locals: {
+      search: search,
+      planning_applications: planning_applications,
+      tab_id: "all"
+    }
+  ) %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          <%= t(".expiry_date") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".application_number") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".status") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".site_address") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".description") %>
+        </th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% planning_application_presenters(self, planning_applications).each do |planning_application| %>
+        <tr class="govuk-table__row" id=<%= dom_id(planning_application) %>>
+          <td class="govuk-table__cell">
+            <%= planning_application.expiry_date.strftime("%e %b") %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= link_to(
+              planning_application.reference,
+              planning_application,
+              class: "govuk-link"
+            ) %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.status_tag %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.full_address %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= planning_application.description %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/planning_applications/_planning_application_table.html.erb
+++ b/app/views/planning_applications/_planning_application_table.html.erb
@@ -1,14 +1,4 @@
 <div class="govuk-tabs__panel" id="<%= planning_application_status %>">
-  <% if local_assigns.fetch(:search, nil).present? %>
-    <%= render(
-      partial: "search/form",
-      locals: {
-        search: search,
-        planning_applications: planning_applications,
-        tab_id: planning_application_status
-      }
-    ) %>
-  <% end %>
   <h1 class="govuk-heading-l"><%= title %></h1>
   <table class="govuk-table">
     <thead class="govuk-table__head">

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -55,10 +55,8 @@
         planning_application_status: "closed"
       ) %>
       <%= render(
-         "planning_application_table",
+         "all_planning_applications_table",
          planning_applications: (@search.query ? @search.results : @planning_applications),
-         planning_application_status: "all",
-         title: all_applications_tab_title,
          search: @search
       ) %>
     </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,33 +1,13 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Mass Assignment",
-      "warning_code": 105,
-      "fingerprint": "17848eaedea3f609c289b9ab3468c74935be427a3c2b6444235479eb0ef77272",
-      "check_name": "PermitAttributes",
-      "message": "Potentially dangerous key allowed for mass assignment",
-      "file": "app/controllers/users_controller.rb",
-      "line": 42,
-      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
-      "code": "params.require(:user).permit(:name, :email, :password, :mobile_number, :role)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "UsersController",
-        "method": "user_params"
-      },
-      "user_input": ":role",
-      "confidence": "Medium",
-      "note": ""
-    },
-    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "430bf938fd433354dbb3ad73c5ec1c0e08b84a5aaf7f478c3f1bf73bd7e3d2a3",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/policy_classes_controller.rb",
-      "line": 35,
+      "line": 37,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(current_local_authority.planning_applications.find(params[:planning_application_id]), :notice => \"Policy classes have been successfully added\")",
       "render_path": null,
@@ -47,7 +27,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/policy_classes_controller.rb",
-      "line": 61,
+      "line": 63,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(current_local_authority.planning_applications.find(params[:planning_application_id]), :notice => \"Policy class has been removed.\")",
       "render_path": null,
@@ -67,7 +47,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/shared/_supporting_information.html.erb",
-      "line": 124,
+      "line": 135,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => \"audits/types/#{audit_entry_template(PlanningApplicationPresenter.new(view_context, current_local_authority.planning_applications.find((params[:planning_application_id] or params[:id]))).audits.last)}\", { :locals => ({ :item => PlanningApplicationPresenter.new(view_context, current_local_authority.planning_applications.find((params[:planning_application_id] or params[:id]))).audits.last }) })",
       "render_path": [
@@ -75,7 +55,7 @@
           "type": "controller",
           "class": "PlanningApplicationsController",
           "method": "show",
-          "line": 27,
+          "line": 39,
           "file": "app/controllers/planning_applications_controller.rb",
           "rendered": {
             "name": "planning_applications/show",
@@ -118,7 +98,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/policy_classes_controller.rb",
-      "line": 55,
+      "line": 57,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(current_local_authority.planning_applications.find(params[:planning_application_id]), :notice => \"Successfully updated policy class\")",
       "render_path": null,
@@ -132,6 +112,6 @@
       "note": ""
     }
   ],
-  "updated": "2022-06-08 15:01:23 +0100",
+  "updated": "2022-08-12 00:35:40 +0200",
   "brakeman_version": "5.1.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,7 +42,7 @@ en:
     form:
       find_an_application: Find an application
       search: Search
-      you_can_search: You can search by application number
+      you_can_search: You can search by application number or description
   additional_document_validation_requests:
     create:
       success: Additional document request successfully created.

--- a/config/locales/planning_applications.yml
+++ b/config/locales/planning_applications.yml
@@ -1,5 +1,12 @@
 en:
   planning_applications:
+    all_planning_applications_table:
+      application_number: Application number
+      description: Description
+      expiry_date: Expiry date
+      planning_officer: Planning officer
+      site_address: Site address
+      status: Status
     closed_planning_applications_table:
       application_number: Application number
       closed: Closed

--- a/db/migrate/20220805173425_add_description_index_to_planning_applications.rb
+++ b/db/migrate/20220805173425_add_description_index_to_planning_applications.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddDescriptionIndexToPlanningApplications < ActiveRecord::Migration[6.1]
+  def up
+    add_index(
+      :planning_applications,
+      "to_tsvector('english', description)",
+      name: "index_planning_applications_on_description",
+      using: :gin
+    )
+  end
+
+  def down
+    remove_index(
+      :planning_applications,
+      name: "index_planning_applications_on_description"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -257,6 +257,7 @@ ActiveRecord::Schema.define(version: 2022_08_11_080557) do
     t.string "reference"
     t.datetime "validated_at"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
+    t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -189,6 +189,64 @@ RSpec.describe "Planning Application index page", type: :system do
         end
       end
 
+      context "when I view the 'All applications' tab" do
+        let!(:planning_application) do
+          create(
+            :planning_application,
+            :not_started,
+            address_1: "1 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add a fence",
+            created_at: DateTime.new(2022, 1, 1),
+            local_authority: default_local_authority
+          )
+        end
+
+        it "shows relevant application details" do
+          visit(planning_applications_path)
+          click_link("All applications")
+
+          within(selected_govuk_tab) do
+            expect(page).to have_content("All applications")
+            row = row_with_content(planning_application.reference)
+            expect(row).to have_content("Not started")
+            expect(row).to have_content("1 Mar")
+            expect(row).to have_content("1 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add a fence")
+          end
+        end
+      end
+
+      context "when I view the 'All your applications' tab" do
+        let!(:planning_application) do
+          create(
+            :planning_application,
+            :not_started,
+            address_1: "1 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add a fence",
+            created_at: DateTime.new(2022, 1, 1),
+            local_authority: default_local_authority
+          )
+        end
+
+        it "shows relevant application details" do
+          visit(planning_applications_path(q: "exclude_others"))
+          click_link("All your applications")
+
+          within(selected_govuk_tab) do
+            expect(page).to have_content("All your applications")
+            row = row_with_content(planning_application.reference)
+            expect(row).to have_content("Not started")
+            expect(row).to have_content("1 Mar")
+            expect(row).to have_content("1 Long Lane, London, AB3 4EF")
+            expect(row).to have_content("Add a fence")
+          end
+        end
+      end
+
       it "Breadcrumbs are not displayed" do
         expect(find(".govuk-breadcrumbs__list").text).to be_empty
       end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -11,28 +11,41 @@ RSpec.describe "searching planning applications", type: :system do
   end
 
   let!(:planning_application1) do
-    create(:planning_application, user: user, local_authority: local_authority)
+    create(
+      :planning_application,
+      user: user,
+      local_authority: local_authority,
+      description: "Add a chimney stack"
+    )
   end
 
   let!(:planning_application2) do
-    create(:planning_application, user: nil, local_authority: local_authority)
+    create(
+      :planning_application,
+      user: nil,
+      local_authority: local_authority,
+      description: "Add a patio"
+    )
   end
 
   let!(:planning_application3) do
     create(
       :planning_application,
       user: other_user,
-      local_authority: local_authority
+      local_authority: local_authority,
+      description: "Add a skylight"
     )
   end
 
   before { sign_in(user) }
 
-  context "when users views her own planning applications" do
-    it "allows user to search planning applications by reference" do
+  context "when user views her own planning applications" do
+    before do
       visit(planning_applications_path(q: "exclude_others"))
       click_link("All your applications")
+    end
 
+    it "allows user to search planning applications by reference" do
       within(selected_govuk_tab) do
         expect(page).to have_content("All your applications")
         expect(page).not_to have_content("Query can't be blank")
@@ -74,13 +87,25 @@ RSpec.describe "searching planning applications", type: :system do
         expect(page).not_to have_content(planning_application3.reference)
       end
     end
+
+    it "allows user to search planning applications by description" do
+      fill_in("Find an application", with: "chimney")
+      click_button("Search")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+      end
+    end
   end
 
   context "when user views all planning applications" do
-    it "allows user to search planning applications by reference" do
+    before do
       visit(planning_applications_path)
       click_link("All applications")
+    end
 
+    it "allows user to search planning applications by reference" do
       within(selected_govuk_tab) do
         expect(page).to have_content("All applications")
         expect(page).not_to have_content("Query can't be blank")
@@ -117,6 +142,17 @@ RSpec.describe "searching planning applications", type: :system do
       within(selected_govuk_tab) do
         expect(page).to have_content("All applications")
         expect(page).not_to have_content("Query can't be blank")
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+      end
+    end
+
+    it "allows user to search planning applications by description" do
+      fill_in("Find an application", with: "chimney")
+      click_button("Search")
+
+      within(selected_govuk_tab) do
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)


### PR DESCRIPTION
### Description of change

- Update `PlanningApplicationsSearch` so that `#results` returns applications with either references OR descriptions that match the query.
- Update query field hint.
- Update the 'All planning applications' tab as per the [dashboard redesign.](https://beta-bops-prototypes.herokuapp.com/v20/application-list3#all-cases)

### Story Link

https://trello.com/c/qWkAsPnX/1026-dashboard-add-description-to-search-feature-on-planning-application-dashboard

### Screenshot

<img width="65%" alt="Screenshot 2022-08-03 at 16 00 02" src="https://user-images.githubusercontent.com/25392162/182646549-e4f8f20b-0bb8-44b9-bdc3-08b8968bd15f.png">