### PR TITLE
Improve auditing of auto-closed requests

### DIFF
--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -52,8 +52,6 @@ module AuditHelper
       "Application withdrawn"
     when "closed"
       "Application closed"
-    when "auto_closed"
-      "Request was auto-closed and approved after being open for 5 business days."
     when "description_change_validation_request_sent"
       "Sent: description change request (description##{args})"
     when "description_change_request_cancelled"

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -30,7 +30,8 @@ class Audit < ApplicationRecord
     started: "started",
     withdrawn: "withdrawn",
     closed: "closed",
-    auto_closed: "auto_closed",
+    red_line_boundary_change_validation_request_auto_closed: "red_line_boundary_change_validation_request_auto_closed",
+    description_change_validation_request_auto_closed: "description_change_validation_request_auto_closed",
     document_invalidated: "document_invalidated",
     document_changed_to_validated: "document_changed_to_validated",
     document_received_at_changed: "document_received_at_changed",
@@ -63,4 +64,19 @@ class Audit < ApplicationRecord
   }
 
   validates :activity_type, presence: true
+
+  def validation_request
+    return if request_type.blank?
+
+    request_type.find_by(
+      planning_application: planning_application,
+      sequence: activity_information
+    )
+  end
+
+  private
+
+  def request_type
+    activity_type.try(:[], /[a-z|_]+_request/)&.camelize&.constantize
+  end
 end

--- a/app/models/concerns/validation_requestable.rb
+++ b/app/models/concerns/validation_requestable.rb
@@ -187,7 +187,11 @@ module ValidationRequestable
       auto_close!
       update_planning_application_for_auto_closed_request!
       update!(approved: true, auto_closed: true, auto_closed_at: Time.current)
-      audit!(activity_type: "auto_closed")
+
+      audit!(
+        activity_type: "#{self.class.name.underscore}_auto_closed",
+        activity_information: sequence
+      )
     end
   rescue ActiveRecord::ActiveRecordError, AASM::InvalidTransition => e
     Appsignal.send_error(e.message)

--- a/app/views/audits/types/_auto_closed.html.erb
+++ b/app/views/audits/types/_auto_closed.html.erb
@@ -1,1 +1,0 @@
-<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>

--- a/app/views/audits/types/_description_change_validation_request_auto_closed.html.erb
+++ b/app/views/audits/types/_description_change_validation_request_auto_closed.html.erb
@@ -1,0 +1,10 @@
+<%= link_to(
+  t(
+    ".auto_closed_validation",
+    sequence: locals[:item].validation_request.sequence
+  ),
+  planning_application_description_change_validation_request_path(
+    locals[:item].planning_application,
+    locals[:item].validation_request
+  )
+) %>

--- a/app/views/audits/types/_red_line_boundary_change_validation_request_auto_closed.html.erb
+++ b/app/views/audits/types/_red_line_boundary_change_validation_request_auto_closed.html.erb
@@ -1,0 +1,10 @@
+<%= link_to(
+  t(
+    ".auto_closed_validation",
+    sequence: locals[:item].validation_request.sequence
+  ),
+  planning_application_red_line_boundary_change_validation_request_path(
+    locals[:item].planning_application,
+    locals[:item].validation_request
+  )
+) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,10 @@ en:
       additional_document_validation_request_sent_post_validation:
         document: "Document:"
         reason: "Reason:"
+      description_change_validation_request_auto_closed:
+        auto_closed_validation: "Auto-closed: validation request (description#%{sequence})"
+      red_line_boundary_change_validation_request_auto_closed:
+        auto_closed_validation: "Auto-closed: validation request (red line boundary#%{sequence})"
   documents:
     document_row_image:
       view_in_new: View in new window

--- a/db/migrate/20220815123315_update_auto_closed_audits.rb
+++ b/db/migrate/20220815123315_update_auto_closed_audits.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class UpdateAutoClosedAudits < ActiveRecord::Migration[6.1]
+  def up
+    execute(
+      "UPDATE audits AS a
+      SET activity_type = 'description_change_validation_request_auto_closed', activity_information = d.sequence
+      FROM description_change_validation_requests AS d
+      WHERE a.activity_type = 'auto_closed'
+      AND a.planning_application_id = d.planning_application_id
+      AND d.auto_closed_at BETWEEN (a.created_at - INTERVAL '1 second') AND (a.created_at + INTERVAL '1 second');"
+    )
+
+    execute(
+      "UPDATE audits AS a
+      SET activity_type = 'red_line_boundary_change_validation_request_auto_closed', activity_information = d.sequence
+      FROM red_line_boundary_change_validation_requests AS d
+      WHERE a.activity_type = 'auto_closed'
+      AND a.planning_application_id = d.planning_application_id
+      AND d.auto_closed_at BETWEEN (a.created_at - INTERVAL '1 second') AND (a.created_at + INTERVAL '1 second');"
+    )
+  end
+
+  def down
+    execute(
+      "UPDATE audits
+      SET activity_type = 'auto_closed', activity_information = NULL
+      WHERE activity_type IN (
+        'description_change_validation_request_auto_closed',
+        'red_line_boundary_change_validation_request_auto_closed'
+      );"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_11_080557) do
+ActiveRecord::Schema.define(version: 2022_08_15_123315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -65,4 +65,4 @@ Feature: Creating a description change on the application
     When the description request has been auto-closed
     And I view the planning application
     Then the page contains "Add a ball pit"
-    And there is an audit entry containing "Request was auto-closed and approved after being open for 5 business days."
+    And there is an audit entry containing "Auto-closed: validation request (description#1)"

--- a/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
+++ b/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe CloseRedLineBoundaryChangeValidationRequestJob, type: :job do
 
       audit = red_line_boundary_change_validation_request.reload.audits.max
 
-      expect(audit.activity_type).to eq("auto_closed")
+      expect(audit.activity_type).to eq(
+        "red_line_boundary_change_validation_request_auto_closed"
+      )
     end
   end
 

--- a/spec/models/audit_spec.rb
+++ b/spec/models/audit_spec.rb
@@ -17,5 +17,29 @@ RSpec.describe Audit, type: :model do
         expect { audit.valid? }.to change { audit.errors[:planning_application] }.to ["must exist"]
       end
     end
+
+    describe "#validation_request" do
+      let(:planning_application) { create(:planning_application) }
+      let(:audit) { planning_application.audits.last }
+
+      context "when there is an associated request" do
+        let!(:validation_request) do
+          create(
+            :red_line_boundary_change_validation_request,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns the correct request" do
+          expect(audit.validation_request).to eq(validation_request)
+        end
+      end
+
+      context "when there is no associated request" do
+        it "returns nil" do
+          expect(audit.validation_request).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -49,4 +49,58 @@ RSpec.describe "Auditing changes to a planning application", type: :system do
     expect(page).to have_text("floor_plan.pdf")
     expect(page).to have_text("Applicant / Agent via Api Wizard")
   end
+
+  context "when red line boundary change request is auto closed" do
+    let(:planning_application) do
+      create(:planning_application, local_authority: default_local_authority)
+    end
+
+    let(:validation_request) do
+      create(
+        :red_line_boundary_change_validation_request,
+        planning_application: planning_application
+      )
+    end
+
+    before { validation_request.auto_close_request! }
+
+    it "shows correct information with link to request" do
+      visit(planning_application_audits_path(planning_application))
+      click_link("Auto-closed: validation request (red line boundary#1)")
+
+      expect(page).to have_current_path(
+        planning_application_red_line_boundary_change_validation_request_path(
+          planning_application,
+          validation_request
+        )
+      )
+    end
+  end
+
+  context "when description change request is auto closed" do
+    let(:planning_application) do
+      create(:planning_application, local_authority: default_local_authority)
+    end
+
+    let(:validation_request) do
+      create(
+        :description_change_validation_request,
+        planning_application: planning_application
+      )
+    end
+
+    before { validation_request.auto_close_request! }
+
+    it "shows correct information with link to request" do
+      visit(planning_application_audits_path(planning_application))
+      click_link("Auto-closed: validation request (description#1)")
+
+      expect(page).to have_current_path(
+        planning_application_description_change_validation_request_path(
+          planning_application,
+          validation_request
+        )
+      )
+    end
+  end
 end

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -360,7 +360,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system do
         visit planning_application_audits_path(planning_application)
 
         within("#audit_#{Audit.last.id}") do
-          expect(page).to have_content("Request was auto-closed and approved after being open for 5 business days.")
+          expect(page).to have_content("Auto-closed: validation request (red line boundary#1)")
           expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
         end
       end


### PR DESCRIPTION
### Description of change

- Replace `auto_closed` audit activity type with `red_line_boundary_change_validation_request_auto_closed` and `description_change_validation_request_auto_closed` types.
- Update `#auto_close_request!` to set activity type correctly, and to set `activity_information` to `sequence` of validation request.
- Add migration to update existing audits.
- Add link to validation requests in audit log.

### Story Link

https://trello.com/c/wRntF5L6/1071-recording-the-validation-request-against-the-entry-in-the-audit-log

### Screenshot

<img width="1005" alt="Screenshot 2022-08-10 at 13 26 30" src="https://user-images.githubusercontent.com/25392162/183889936-90e3fff4-f8fb-4e01-bafb-02c30d18508e.png">

(I'm going to have a look at the 'User deleted' issue, but in a separate branch and PR since it's not strictly related to the above ticket and also I think might be more complicated that I'd hoped!)