### PR TITLE
Fix isses with audit user

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -48,14 +48,15 @@ module Api
       private
 
       def authenticate
-        authenticate_or_request_with_http_token do |token, _options|
+        api_user = authenticate_or_request_with_http_token do |token, _options|
           ApiUser.find_by(token: token)
         end
+
+        Current.api_user = api_user
       end
 
       def current_api_user
         @current_api_user ||= authenticate
-        Current.api_user = @current_api_user
       end
 
       protected

--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -109,14 +109,34 @@ module AuditHelper
     end
   end
 
-  def define_audit_user(audit)
+  def audit_user_name(audit)
     if audit.api_user.present?
-      audit.activity_type.include?("received") ? "Applicant / Agent via #{audit.api_user.name}" : audit.api_user.name
+      audit_api_user_name(audit)
     elsif audit.user.present?
       audit.user.name
+    elsif audit.automated_activity?
+      t("audit_user_name.system")
     else
-      "User deleted"
+      t("audit_user_name.deleted")
     end
+  end
+
+  def audit_api_user_name(audit)
+    if applicant_activity_types.include?(audit.activity_type)
+      t("audit_user_name.applicant", api_user_name: audit.api_user.name)
+    else
+      audit.api_user.name
+    end
+  end
+
+  def applicant_activity_types
+    %w[
+      description_change_validation_request_received
+      replacement_document_validation_request_received
+      additional_document_validation_request_received
+      red_line_boundary_change_validation_request_received
+      other_change_validation_request_received
+    ]
   end
 
   def audit_entry_template(audit)

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -8,12 +8,25 @@ module Auditable
 
     def audit!(activity_type:, activity_information: nil, audit_comment: nil)
       audits.create!(
-        user: Current.user,
+        user: current_user,
         activity_type: activity_type,
         activity_information: activity_information,
         audit_comment: audit_comment,
-        api_user: Current.api_user
+        api_user: current_api_user,
+        automated_activity: no_current_user?
       )
+    end
+
+    def no_current_user?
+      current_user.blank? && current_api_user.blank?
+    end
+
+    def current_user
+      @current_user ||= Current.user
+    end
+
+    def current_api_user
+      @current_api_user ||= Current.api_user
     end
   end
 end

--- a/app/views/audits/index.html.erb
+++ b/app/views/audits/index.html.erb
@@ -25,7 +25,7 @@
       <tr class="govuk-table__row">
         <%= content_tag(:tr, id: dom_id(audit_item)) do %>
           <td class="govuk-table__cell"><%= audit_item.created_at.strftime("%d-%m-%Y %H:%M") %></td>
-          <td class="govuk-table__cell"><%= define_audit_user(audit_item) %></td>
+          <td class="govuk-table__cell"><%= audit_user_name(audit_item) %></td>
           <td colspan="2" class="govuk-table__cell">
             <% if audit_item.activity_type.include?("request") || audit_item.activity_type.include?("document_received_at_changed") %>
               <% if audit_item.activity_type.match("/*_validation_request_cancelled") %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -135,7 +135,7 @@
           <%= render "audits/types/#{audit_entry_template(@last_audit)}", locals: { item: @last_audit } %>
 
           <p class="govuk-body">
-            <%= define_audit_user(@last_audit) %>
+            <%= audit_user_name(@last_audit) %>
           </p>
           <p class="govuk-body">
             <%= @last_audit.created_at.to_date %> at <%= @last_audit.created_at.strftime("%H:%M") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  audit_user_name:
+    applicant: Applicant / Agent via %{api_user_name}
+    deleted: User deleted
+    system: Automated by the system
   application:
     header:
       back_office_planning: "Back-office Planning System"

--- a/db/migrate/20220815130120_add_automated_activity_to_audits.rb
+++ b/db/migrate/20220815130120_add_automated_activity_to_audits.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class AddAutomatedActivityToAudits < ActiveRecord::Migration[6.1]
+  # rubocop:disable Metrics/MethodLength
+  def up
+    add_column(
+      :audits,
+      :automated_activity,
+      :boolean,
+      default: false,
+      null: false
+    )
+
+    execute(
+      "UPDATE audits
+      SET automated_activity = TRUE
+      WHERE activity_type IN (
+        'description_change_validation_request_auto_closed',
+        'red_line_boundary_change_validation_request_auto_closed'
+      );"
+    )
+
+    execute(
+      "UPDATE audits AS a
+      SET automated_activity = TRUE
+      FROM audits AS b
+      WHERE a.activity_type = 'updated'
+      AND a.activity_information = 'Description'
+      AND a.user_id IS NULL
+      AND a.api_user_id IS NULL
+      AND a.planning_application_id = b.planning_application_id
+      AND b.activity_type = 'description_change_validation_request_auto_closed'
+      AND b.created_at BETWEEN (a.created_at - INTERVAL '1 second') AND (a.created_at + INTERVAL '1 second');"
+    )
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def down
+    remove_column :audits, :automated_activity
+  end
+end

--- a/db/migrate/20220815130202_update_audits_generated_by_api_user.rb
+++ b/db/migrate/20220815130202_update_audits_generated_by_api_user.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UpdateAuditsGeneratedByApiUser < ActiveRecord::Migration[6.1]
+  # rubocop:disable Metrics/MethodLength
+  def up
+    execute(
+      "UPDATE audits
+      SET api_user_id = 1
+      WHERE api_user_id IS NULL
+      AND user_id IS NULL
+      AND activity_type IN (
+        'description_change_validation_request_received',
+        'replacement_document_validation_request_received',
+        'additional_document_validation_request_received',
+        'red_line_boundary_change_validation_request_received',
+        'other_change_validation_request_received'
+      );"
+    )
+
+    execute(
+      "UPDATE audits as a
+      SET api_user_id = 1
+      FROM audits as b
+      WHERE a.api_user_id IS NULL
+      AND a.user_id IS NULL
+      AND a.activity_type = 'uploaded'
+      AND a.planning_application_id = b.planning_application_id
+      AND b.activity_type = 'replacement_document_validation_request_received'
+      AND b.created_at BETWEEN (a.created_at - INTERVAL '1 second') AND (a.created_at + INTERVAL '1 second');"
+    )
+  end
+  # rubocop:enable Metrics/MethodLength
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_15_123315) do
+ActiveRecord::Schema.define(version: 2022_08_15_130202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2022_08_15_123315) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "api_user_id"
+    t.boolean "automated_activity", default: false, null: false
     t.index ["api_user_id"], name: "index_audits_on_api_user_id"
     t.index ["planning_application_id"], name: "index_audits_on_planning_application_id"
     t.index ["user_id"], name: "index_audits_on_user_id"

--- a/spec/models/additional_document_validation_request_spec.rb
+++ b/spec/models/additional_document_validation_request_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe AdditionalDocumentValidationRequest, type: :model do
 
   it_behaves_like "ValidationRequest", described_class, "additional_document_validation_request"
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:additional_document_validation_request) }
+  end
+
   describe "validations" do
     subject(:additional_document_validation_request) { described_class.new }
 

--- a/spec/models/description_change_validation_request_spec.rb
+++ b/spec/models/description_change_validation_request_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe DescriptionChangeValidationRequest, type: :model do
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:description_change_validation_request) }
+  end
+
   describe "validations" do
     let!(:request) { create(:description_change_validation_request) }
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe Document, type: :model do
   subject(:document) { FactoryBot.build :document }
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:document) }
+  end
+
   describe "scopes" do
     describe ".active" do
       let!(:active_document) { create :document }

--- a/spec/models/other_change_validation_request_spec.rb
+++ b/spec/models/other_change_validation_request_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe OtherChangeValidationRequest, type: :model do
   it_behaves_like "ValidationRequest", described_class, "other_change_validation_request"
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:other_change_validation_request) }
+  end
+
   describe "validations" do
     subject(:other_change_validation_request) { described_class.new }
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe PlanningApplication, type: :model do
   subject(:planning_application) { create :planning_application }
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:planning_application) }
+  end
+
   describe "validations" do
     describe "#determination_date" do
       it "validates that date is not in the future" do

--- a/spec/models/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/models/red_line_boundary_change_validation_request_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe RedLineBoundaryChangeValidationRequest, type: :model do
   it_behaves_like "ValidationRequest", described_class, "red_line_boundary_change_validation_request"
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:red_line_boundary_change_validation_request) }
+  end
+
   describe "validations" do
     subject(:red_line_boundary_change_validation_request) { described_class.new }
 

--- a/spec/models/replacement_document_validation_request_spec.rb
+++ b/spec/models/replacement_document_validation_request_spec.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 RSpec.describe ReplacementDocumentValidationRequest, type: :model do
   it_behaves_like "ValidationRequest", described_class, "replacement_document_validation_request"
 
+  it_behaves_like("Auditable") do
+    let(:subject) { create(:replacement_document_validation_request) }
+  end
+
   describe "validations" do
     subject(:replacement_document_validation_request) { described_class.new }
 

--- a/spec/requests/api/additional_document_validation_request_patch_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_patch_spec.rb
@@ -52,10 +52,17 @@ RSpec.describe "API request to patch document create requests", type: :request, 
 
     expect(additional_document_validation_request.state).to eq("closed")
     expect(additional_document_validation_request.documents.last).to be_a(Document)
+  end
 
-    expect(Audit.all.last.activity_type).to eq("additional_document_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq("proposed-floorplan.png")
-    expect(Audit.all.last.activity_information).to eq("1")
+  it "creates audit associated with API user" do
+    patch(path, params: params, headers: headers)
+
+    expect(planning_application.audits.reload.last).to have_attributes(
+      activity_type: "additional_document_validation_request_received",
+      audit_comment: "proposed-floorplan.png",
+      activity_information: "1",
+      api_user: api_user
+    )
   end
 
   it "sends notification to assigned user" do

--- a/spec/requests/api/description_change_validation_request_put_spec.rb
+++ b/spec/requests/api/description_change_validation_request_put_spec.rb
@@ -68,9 +68,6 @@ RSpec.describe "API request to list validation requests", type: :request, show_e
     expect(description_change_validation_request.approved).to eq(true)
     expect(description_change_validation_request.approved).to eq(true)
     expect(planning_application.description).to eq("new roof")
-    expect(Audit.all.last.activity_type).to eq("description_change_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq({ response: "approved" }.to_json)
-    expect(Audit.all.last.activity_information).to eq("1")
   end
 
   it "sends notification to assigned user" do
@@ -83,6 +80,17 @@ RSpec.describe "API request to list validation requests", type: :request, show_e
         "deliver_now",
         args: [planning_application, user.email]
       )
+  end
+
+  it "creates audit associated with API user" do
+    patch(path, params: params, headers: headers)
+
+    expect(planning_application.audits.reload.last).to have_attributes(
+      activity_type: "description_change_validation_request_received",
+      audit_comment: { response: "approved" }.to_json,
+      activity_information: "1",
+      api_user: api_user
+    )
   end
 
   it "successfully accepts a rejection" do

--- a/spec/requests/api/other_change_validation_request_put_spec.rb
+++ b/spec/requests/api/other_change_validation_request_put_spec.rb
@@ -58,9 +58,17 @@ RSpec.describe "API request to list change requests", type: :request, show_excep
     planning_application.reload
     expect(other_change_validation_request.state).to eq("closed")
     expect(other_change_validation_request.response).to eq("I will send an extra payment")
-    expect(Audit.all.last.activity_type).to eq("other_change_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq({ response: "I will send an extra payment" }.to_json)
-    expect(Audit.all.last.activity_information).to eq("1")
+  end
+
+  it "creates audit associated with API user" do
+    patch(path, params: params, headers: headers)
+
+    expect(planning_application.audits.reload.last).to have_attributes(
+      activity_type: "other_change_validation_request_received",
+      audit_comment: { response: "I will send an extra payment" }.to_json,
+      activity_information: "1",
+      api_user: api_user
+    )
   end
 
   it "sends notification to assigned user" do

--- a/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
@@ -63,13 +63,17 @@ RSpec.describe "API request to patch document validation requests", type: :reque
     expect(red_line_boundary_change_validation_request.approved).to eq(true)
     expect(red_line_boundary_change_validation_request.approved).to eq(true)
     expect(planning_application.boundary_geojson).to eq(red_line_boundary_change_validation_request.new_geojson)
+  end
 
-    red_line_boundary_change_validation_request.reload
-    planning_application.reload
+  it "creates audit associated with API user" do
+    patch(path, params: params, headers: headers)
 
-    expect(Audit.all.last.activity_type).to eq("red_line_boundary_change_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq({ response: "approved" }.to_json)
-    expect(Audit.all.last.activity_information).to eq("1")
+    expect(planning_application.audits.reload.last).to have_attributes(
+      activity_type: "red_line_boundary_change_validation_request_received",
+      audit_comment: { response: "approved" }.to_json,
+      activity_information: "1",
+      api_user: api_user
+    )
   end
 
   it "sends notification to assigned user" do

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -61,10 +61,35 @@ RSpec.describe "API request to patch document validation requests", type: :reque
     expect(replacement_document_validation_request.new_document).to be_a(Document)
     expect(document.archived_at).not_to eq(nil)
     expect(document.archive_reason).to eq("Applicant has provived a replacement document.")
+  end
 
-    expect(Audit.all.last.activity_type).to eq("replacement_document_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq("proposed-floorplan.png")
-    expect(Audit.all.last.activity_information).to eq("1")
+  it "creates request received audit associated with API user" do
+    patch(path, params: params, headers: headers)
+
+    audit = planning_application
+            .audits
+            .where(activity_type: "replacement_document_validation_request_received")
+            .last
+
+    expect(audit).to have_attributes(
+      audit_comment: "proposed-floorplan.png",
+      activity_information: "1",
+      api_user: api_user
+    )
+  end
+
+  it "creates document uploaded audit associated with API user" do
+    patch(path, params: params, headers: headers)
+
+    audit = planning_application
+            .audits
+            .where(activity_type: "uploaded")
+            .last
+
+    expect(audit).to have_attributes(
+      activity_information: "proposed-floorplan.png",
+      api_user: api_user
+    )
   end
 
   it "sends notification to assigned user" do

--- a/spec/support/auditable_shared_examples.rb
+++ b/spec/support/auditable_shared_examples.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "Auditable" do
+  describe "#audit!" do
+    context "when current user is present" do
+      let(:user) { create(:user) }
+
+      before { Current.user = user }
+
+      it "creates audit assoicated with user" do
+        subject.send(:audit!, { activity_type: "assigned" })
+
+        expect(subject.audits.reload.last).to have_attributes(
+          activity_type: "assigned",
+          user: user,
+          api_user: nil,
+          automated_activity: false
+        )
+      end
+    end
+
+    context "when current API user is present" do
+      let(:api_user) { create(:api_user) }
+
+      before { Current.api_user = api_user }
+
+      it "creates audit assoicated with API user" do
+        subject.send(:audit!, { activity_type: "assigned" })
+
+        expect(subject.audits.reload.last).to have_attributes(
+          activity_type: "assigned",
+          user: nil,
+          api_user: api_user,
+          automated_activity: false
+        )
+      end
+    end
+
+    context "when no user is present" do
+      it "creates audit with automated_activity set to true" do
+        subject.send(:audit!, { activity_type: "assigned" })
+
+        expect(subject.audits.reload.last).to have_attributes(
+          activity_type: "assigned",
+          user: nil,
+          api_user: nil,
+          automated_activity: true
+        )
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -66,6 +66,12 @@ RSpec.describe "Auditing changes to a planning application", type: :system do
 
     it "shows correct information with link to request" do
       visit(planning_application_audits_path(planning_application))
+
+      expect(page).to have_row_for(
+        "Auto-closed: validation request (red line boundary#1)",
+        with: "Automated by the system"
+      )
+
       click_link("Auto-closed: validation request (red line boundary#1)")
 
       expect(page).to have_current_path(
@@ -93,6 +99,12 @@ RSpec.describe "Auditing changes to a planning application", type: :system do
 
     it "shows correct information with link to request" do
       visit(planning_application_audits_path(planning_application))
+
+      expect(page).to have_row_for(
+        "Auto-closed: validation request (description#1)",
+        with: "Automated by the system"
+      )
+
       click_link("Auto-closed: validation request (description#1)")
 
       expect(page).to have_current_path(


### PR DESCRIPTION
### Description of change

- Fix bug where we're not setting the api user for audits associated with API activity.
- Add `automated_activity` column to `audits`
-  Set `automated_activity` to true on audit creation if there is no current user or API user.
- Only show 'User deleted' in audit log if there is no user and `automated_activity` is false.
- Update existing audits.

### Story Link

NA