### PR TITLE
Fix failing spec

### DIFF
--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -426,6 +426,8 @@ RSpec.describe PlanningApplication, type: :model do
     context "when the application is valid" do
       context "when there have been validation requests" do
         before do
+          travel_to(DateTime.new(2022, 8, 17))
+
           [
             [3.days.ago, :closed],
             [2.days.ago, :cancelled],


### PR DESCRIPTION
### Description of change

- Use travel_to helper to fix spec failing because expectation is off by microseconds.
- Not entirely sure why this spec wasn't failing before 🤔 

### Story Link

NA

