### PR TITLE
Add edit/archive links to documents accordian section

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -24,6 +24,8 @@ class DocumentsController < AuthenticationController
   end
 
   def edit
+    set_return_to_session
+
     respond_to do |format|
       format.html { render :edit }
     end
@@ -46,6 +48,8 @@ class DocumentsController < AuthenticationController
   end
 
   def archive
+    set_return_to_session
+
     respond_to do |format|
       format.html
     end
@@ -83,7 +87,7 @@ class DocumentsController < AuthenticationController
 
     if @document.archived?
       flash[:notice] = "#{@document.name} has been archived"
-      redirect_to planning_application_documents_path
+      redirect_to(return_to_session || planning_application_documents_path(@planning_application))
     else
       flash[:alert] = "There was an error with archiving #{@document.name}"
       render :archive
@@ -128,6 +132,8 @@ class DocumentsController < AuthenticationController
   def redirect_url
     if @validate_document
       planning_application_validation_tasks_path(@planning_application)
+    elsif session[:return_to]
+      return_to_session
     else
       planning_application_documents_path(@planning_application)
     end
@@ -135,5 +141,13 @@ class DocumentsController < AuthenticationController
 
   def ensure_blob_is_representable
     render plain: "forbidden", status: :forbidden and return unless @document.representable?
+  end
+
+  def set_return_to_session
+    session[:return_to] ||= request.referer
+  end
+
+  def return_to_session
+    session.delete(:return_to)
   end
 end

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -3,7 +3,7 @@
     <% documents.each do |document| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-quarter">
-          <%= render "documents/document_row_image", document: document, resize: "500x500", width: 180, height: 120 %>
+          <%= render "documents/document_row_image", document: document, resize: "500x500", width: 180, height: 120, edit_and_archive: false %>
         </td>
 
         <td class="govuk-table__cell govuk-!-width-one-half">

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -9,6 +9,14 @@
       class: "govuk-link"
     ) %>
   </p>
+  <% if edit_and_archive %>
+    <p class="govuk-body">
+      <%= link_to(t(".edit"), edit_planning_application_document_path(@planning_application, document), class: "govuk-link") %>
+    </p>
+    <p class="govuk-body">
+      <%= link_to(t(".archive"), planning_application_document_archive_path(@planning_application, document), class: "govuk-link") %>
+    </p>
+  <% end %>
 <% else %>
   <div class="govuk-grid-column-one-third">
     <%= image_pack_tag("placeholder/blank_image.png", alt: "Blank image", width: width, height: height) %>

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -19,7 +19,7 @@
       <% if @validate_document %>
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       <% else %>
-        <%= link_to "Back", planning_application_documents_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_proposal_documents.html.erb
+++ b/app/views/shared/_proposal_documents.html.erb
@@ -22,7 +22,7 @@
 
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-one-third">
-            <%= render "documents/document_row_image", document: document, resize: "200x110", width: 90, height: 110 %>
+            <%= render "documents/document_row_image", document: document, resize: "200x110", width: 90, height: 110, edit_and_archive: true %>
           </div>
 
           <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
   documents:
     document_row_image:
       view_in_new: View in new window
+      edit: Edit
+      archive: Archive
     index:
       request_a_new: Request a new document
       upload_document: Upload document

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -65,5 +65,104 @@ RSpec.describe "Edit document", type: :system do
         expect(page).to have_content("forbidden")
       end
     end
+
+    context "when editing/archiving document from the documents accordian section" do
+      it "can edit document and return back to the planning applications index page" do
+        visit planning_application_path(planning_application)
+        click_button "Documents"
+
+        within(".scroll-docs") do
+          click_link "Edit"
+        end
+
+        fill_in "numbers", with: "DOCREF123"
+
+        click_button "Save"
+
+        expect(page).to have_content("Document has been updated")
+        expect(page).to have_current_path(planning_application_path(planning_application))
+      end
+
+      it "can archive document and return back to the planning applications index page" do
+        visit planning_application_path(planning_application)
+        click_button "Documents"
+
+        within(".scroll-docs") do
+          click_link "Archive"
+        end
+
+        fill_in "archive_reason", with: "an archive reason"
+
+        click_button "Archive"
+
+        expect(page).to have_content("#{document.name} has been archived")
+        expect(page).to have_current_path(planning_application_path(planning_application))
+      end
+
+      it "the back button returns to the planning applications index page" do
+        visit planning_application_path(planning_application)
+        click_button "Documents"
+
+        within(".scroll-docs") do
+          click_link "Edit"
+        end
+
+        click_link "Back"
+        expect(page).to have_current_path(planning_application_path(planning_application))
+      end
+    end
+
+    context "when editing/archiving document from the documents index" do
+      it "can edit document and return back to the documents index page" do
+        within(".current-documents") do
+          click_link "Edit"
+        end
+
+        fill_in "numbers", with: "DOCREF123"
+
+        click_button "Save"
+
+        expect(page).to have_content("Document has been updated")
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+
+      it "can archive document and return back to the documents index page" do
+        within(".current-documents") do
+          click_link "Archive"
+        end
+
+        fill_in "archive_reason", with: "an archive reason"
+
+        click_button "Archive"
+
+        expect(page).to have_content("#{document.name} has been archived")
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+
+      it "the back button returns to the documents index page" do
+        within(".current-documents") do
+          click_link "Edit"
+        end
+
+        click_link "Back"
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+    end
+
+    context "when visiting the edit/archive url directly" do
+      it "edit returns to the documents index page" do
+        visit edit_planning_application_document_path(planning_application, document)
+
+        click_button "Save"
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+
+      it "arhive returns to the documents index page" do
+        visit planning_application_document_archive_path(planning_application, document)
+
+        click_button "Archive"
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description of change

- Add edit/archive links to documents accordian section
- Redirect user back to where the edit/archive link was clicked from

### Story Link

https://trello.com/c/oTvq6ulF/1111-instead-of-a-single-manage-documents-link-provide-the-option-to-edit-archive-at-the-document-level-in-the-accordion