### PR TITLE
List decision notice documents in assess proposal page

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -24,4 +24,8 @@ module DocumentHelper
       "This document was uploaded by #{document.api_user.name}"
     end
   end
+
+  def document_name_and_reference(document)
+    "#{document.name}#{document.numbers? ? " - #{document.numbers}" : ''}"
+  end
 end

--- a/app/views/planning_applications/recommendation_form.html.erb
+++ b/app/views/planning_applications/recommendation_form.html.erb
@@ -12,6 +12,25 @@
   </p>
 
   <%= render "recommendations", { recommendations: @planning_application.recommendations.reviewed } %>
+
+  <div id="decision-notice-documents">
+    <p class="govuk-body">
+      <strong>Documents included in the decision notice</strong>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    </p>
+
+    <% if @planning_application.documents_for_decision_notice.any? %>
+      <ul class="govuk-list">
+        <% @planning_application.documents_for_decision_notice.each do |document| %>
+          <li><%= link_to document_name_and_reference(document), edit_planning_application_document_path(document.planning_application, document.id), target: :_blank %></li>
+          <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="govuk-body">No documents listed on decision notice.</p>
+    <% end %>
+  </div>
+
   <%= form_for @planning_application, url: recommend_planning_application_path(@planning_application) do |form| %>
     <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
       <p class="govuk-body">


### PR DESCRIPTION
### Description of change

List all documents that are to be presented in the decision notice on the assess proposal page. Link these documents (name - reference) to the document edit page in a new tab

### Story Link

https://trello.com/c/hQhYF69F/1116-show-what-documents-have-been-included-in-the-decision-notice-when-writing-up-decision-notice-text-and-link-from-the-assess-the