### PR TITLE
Set default true for otp_required_for_login

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,6 @@ class User < ApplicationRecord
   private
 
   def generate_otp_secret
-    self.otp_required_for_login = true
     self.otp_secret = self.class.generate_otp_secret
   end
 end

--- a/db/migrate/20220825142642_add_default_value_for_otp_required_for_login.rb
+++ b/db/migrate/20220825142642_add_default_value_for_otp_required_for_login.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddDefaultValueForOtpRequiredForLogin < ActiveRecord::Migration[6.1]
+  def up
+    change_column_default :users, :otp_required_for_login, true
+
+    execute(
+      "UPDATE users
+      SET otp_required_for_login = TRUE
+      WHERE otp_required_for_login IS NULL;"
+    )
+
+    change_column_null :users, :otp_required_for_login, false
+  end
+
+  def down
+    change_column_default :users, :otp_required_for_login, nil
+    change_column_null :users, :otp_required_for_login, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_15_130202) do
+ActiveRecord::Schema.define(version: 2022_08_25_142642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 2022_08_15_130202) do
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
-    t.boolean "otp_required_for_login"
+    t.boolean "otp_required_for_login", default: true, null: false
     t.string "mobile_number"
     t.integer "otp_delivery_method", default: 0
     t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -50,6 +50,7 @@ local_authorities.each do |authority|
           "$2a$11$uvtPXUB2CmO8WEYm7ajHf.XhZtBsclT/sT45ijLMIELShaZvceW5."
       end
       user.role = admin_role
+      user.otp_required_for_login = false
     end
   end
 end


### PR DESCRIPTION
### Description of change

- Remove before create callback that sets `otp_required_for_login` to true in User model.
- Add migration that sets default to true and null to false.
- In seeds file set the value to false.

### Story Link

https://trello.com/c/VxqCqqEI/1165-test-accounts-on-development-environment-should-have-otprequiredforlogin-as-false

### Decisions [OPTIONAL]

Setting the value using a callback means that `User.create(otp_required_for_login: false)` still gives you a user with the value set to true! 

I can't see any reason why the column shouldn't just have a default value of true, which can be over-ridden using the above 🤷 
