### PR TITLE
Add button to clear search form

### DIFF
--- a/app/components/planning_application_panel_component.html.erb
+++ b/app/components/planning_application_panel_component.html.erb
@@ -9,25 +9,29 @@
       )
     ) %>
   <% end %>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <% attributes.each do |attribute| %>
-          <th scope="col" class="govuk-table__header">
-            <%= t(".#{attribute}") %>
-          </th>
+  <% if search&.query && planning_applications.empty? %>
+    <p class="govuk-body"><%= t(".no_planning_applications") %></p>
+  <% else %>
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <% attributes.each do |attribute| %>
+            <th scope="col" class="govuk-table__header">
+              <%= t(".#{attribute}") %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% planning_applications.each do |planning_application| %>
+          <%= render(
+            PlanningApplicationRowComponent.new(
+              planning_application: planning_application,
+              attributes: attributes
+            )
+          ) %>
         <% end %>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% planning_applications.each do |planning_application| %>
-        <%= render(
-          PlanningApplicationRowComponent.new(
-            planning_application: planning_application,
-            attributes: attributes
-          )
-        ) %>
-      <% end %>
-    </tbody>
-  </table>
+      </tbody>
+    </table>
+  <% end %>
 </div>

--- a/app/components/search_form_component.html.erb
+++ b/app/components/search_form_component.html.erb
@@ -2,7 +2,8 @@
   model: search,
   builder: GOVUKDesignSystemFormBuilder::FormBuilder,
   method: :get,
-  url: "#{planning_applications_path}##{panel_type}"
+  url: planning_applications_path(anchor: panel_type),
+  data: { controller: "clear-form" }
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
   <div class="search-form-inputs">
@@ -18,5 +19,11 @@
       <%= hidden_field_tag(:q, "exclude_others") %>
     <% end %>
     <%= form.govuk_submit(t(".search")) %>
+    <%= link_to(
+      t(".clear_search"),
+      clear_search_url,
+      class: "govuk-button govuk-button--secondary",
+      data: { action: "click->clear-form#handleClick" }
+    ) %>
   </div>
 <% end %>

--- a/app/components/search_form_component.rb
+++ b/app/components/search_form_component.rb
@@ -10,4 +10,9 @@ class SearchFormComponent < ViewComponent::Base
   private
 
   attr_reader :search, :panel_type, :exclude_others
+
+  def clear_search_url
+    q = exclude_others ? "exclude_others" : nil
+    planning_applications_path(anchor: panel_type, q: q)
+  end
 end

--- a/app/javascript/controllers/clear_form_controller.js
+++ b/app/javascript/controllers/clear_form_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  handleClick(_event) {
+    this.element.querySelectorAll("input").forEach((input) => {
+      input.value = null
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,3 +1,7 @@
 import { application } from "./application"
-import UnsavedChangesController from "./unsaved_changes_controller"
+
+import ClearFormController from "./clear_form_controller.js"
+application.register("clear-form", ClearFormController)
+
+import UnsavedChangesController from "./unsaved_changes_controller.js"
 application.register("unsaved-changes", UnsavedChangesController)

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -177,7 +177,7 @@ html * {
 .search-form-inputs {
   display: flex;
 
-  button {
+  button, a {
     height: fit-content;
     margin-left: 10px;
     align-self: flex-end;

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,7 @@ en:
     formatted_expiry_date: Expiry date
     formatted_outcome_date: Outcome date
     full_address: Site address
+    no_planning_applications: No planning applications match your search
     not_started_and_invalid: Not started
     outcome: Outcome
     reference: Application number
@@ -213,6 +214,7 @@ en:
     new:
       assess_recommendation: Assess recommendation
   search_form_component:
+    clear_search: Clear search
     find_an_application: Find an application
     search: Search
     you_can_search: You can search by application number or description

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe "searching planning applications", type: :system do
         expect(page).not_to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
       end
+
+      click_link("Clear search")
+
+      expect(find_field("Find an application").value).to eq("")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("All your applications")
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+      end
     end
 
     it "allows user to search planning applications by description" do
@@ -96,6 +107,27 @@ RSpec.describe "searching planning applications", type: :system do
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
       end
+    end
+
+    it "allows user to clear form without submitting it" do
+      fill_in("Find an application", with: "abc")
+      click_link("Clear search")
+
+      expect(find_field("Find an application").value).to eq("")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("All your applications")
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+      end
+    end
+
+    it "shows message when there are no search results" do
+      fill_in("Find an application", with: "something else entirely")
+      click_button("Search")
+
+      expect(page).to have_content("No planning applications match your search")
     end
   end
 
@@ -146,6 +178,17 @@ RSpec.describe "searching planning applications", type: :system do
         expect(page).not_to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
       end
+
+      click_link("Clear search")
+
+      expect(find_field("Find an application").value).to eq("")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("All applications")
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).to have_content(planning_application3.reference)
+      end
     end
 
     it "allows user to search planning applications by description" do
@@ -157,6 +200,27 @@ RSpec.describe "searching planning applications", type: :system do
         expect(page).not_to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
       end
+    end
+
+    it "allows user to clear form without submitting it" do
+      fill_in("Find an application", with: "abc")
+      click_link("Clear search")
+
+      expect(find_field("Find an application").value).to eq("")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("All applications")
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).to have_content(planning_application3.reference)
+      end
+    end
+
+    it "shows message when there are no search results" do
+      fill_in("Find an application", with: "something else entirely")
+      click_button("Search")
+
+      expect(page).to have_content("No planning applications match your search")
     end
   end
 end


### PR DESCRIPTION
### Description of change

- Add a button-styled link that 'clears' the search by reloading the page without search parameters.

### Story Link

https://trello.com/c/ScrpaQJD/1162-add-a-clear-button-to-delete-the-text-in-the-search-box

### Screenshot

<img width="60%" alt="Screenshot 2022-08-25 at 17 51 18" src="https://user-images.githubusercontent.com/25392162/186713623-003139fc-dc39-483f-bbfe-23a9b65987d7.png">

