### PR TITLE
FactoryBot local_authority signatory_name attrib no longer unique

### DIFF
--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :local_authority do
     subdomain { "buckinghamshire" }
-    signatory_name { Faker::FunnyName.unique.two_word_name }
+    signatory_name { Faker::FunnyName.two_word_name }
     signatory_job_title { "Director" }
     enquiries_paragraph { Faker::Lorem.unique.sentence }
     email_address { Faker::Internet.email }
@@ -11,7 +11,7 @@ FactoryBot.define do
 
     trait :default do
       subdomain { "ripa" }
-      signatory_name { Faker::FunnyName.unique.two_word_name }
+      signatory_name { Faker::FunnyName.two_word_name }
       signatory_job_title { "Director" }
       enquiries_paragraph { Faker::Lorem.unique.sentence }
       email_address { "planning@ripa.uk" }


### PR DESCRIPTION
FactoryBot local_authority signatory_name attrib no longer unique

- When I run bundle exec rspec I get this:
 ```
     Faker::UniqueGenerator::RetryLimitExceeded:
           Retry limit exceeded for last_name
```

- The schema doesn't require it to be unique
- If you wanted it unique you could do:
```
      sequence(:signatory_name) {|n| Faker::FunnyName.two_word_name +
        "(#{n}" }
```
- However, just removing unique as not required. Simple
      as possible
