### PR TITLE
Fix: Capybara/Webmock - Too many open files

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -6,7 +6,8 @@ RSpec.configure do |config|
   config.before(:all) do
     WebMock.disable_net_connect!(
       allow_localhost: true,
-      allow: "chromedriver.storage.googleapis.com"
+      allow: "chromedriver.storage.googleapis.com",
+      net_http_connect_on_start: true
     )
   end
 end


### PR DESCRIPTION
- people complaining it happened with switch to Ruby 2.7

https://github.com/teamcapybara/capybara#gotchas

If WebMock is enabled, you may encounter a "Too many open files"
error. A simple page.find call may cause thousands of HTTP requests until
the timeout occurs. By default, WebMock will cause each of these requests
to spawn a new connection. To work around this problem, you may need to
enable WebMock's:

 net_http_connect_on_start: true parameter.