### PR TITLE
Fix: Locator for selector must be an instance of String or Symbol

### DIFF
--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
 
         expect(page).to have_content("This document replaced: #{replacement_document_validation_request.old_document.name}")
         expect(page).to have_link(
-          replacement_document_validation_request.old_document.name,
+          replacement_document_validation_request.old_document.name.to_s,
           href: edit_planning_application_document_path(planning_application, replacement_document_validation_request.old_document)
         )
         expect(page).to have_content("Reason this replacement document was requested: Document is invalid")


### PR DESCRIPTION
- this is a warning that will become an error in a later version
  of Capybara

- found the test causing the warning by switchinging rspec format:
   --format documenation

- object instance was a `ActiveStorage::Filename` the
  object returns a santizied string if you call to_s on it and it
  still passed the test.
