### PR TITLE
Refactor use constant instead of magic number

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -15,6 +15,8 @@ class PlanningApplication < ApplicationRecord
 
   include PlanningApplication::Notification
 
+  DAYS_TO_EXPIRE = 56
+
   enum application_type: { lawfulness_certificate: 0, full: 1 }
 
   enum user_role: { applicant: 0, agent: 1, proxy: 2 }
@@ -444,7 +446,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def set_key_dates
-    self.expiry_date = 56.days.after(validated_at || received_at)
+    self.expiry_date = DAYS_TO_EXPIRE.days.after(validated_at || received_at)
     self.target_date = 35.days.after(validated_at || received_at)
   end
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -398,17 +398,18 @@ RSpec.describe PlanningApplication, type: :model do
       context "when there were no documents validated" do
         before { planning_application.update!(validated_at: nil) }
 
-        it "is set as received_at + 56 days" do
-          expect(planning_application.expiry_date).to eq(56.days.after(planning_application.received_at).to_date)
+        it "is set as received_at + DAYS_TO_EXPIRE days" do
+          expect(planning_application.expiry_date)
+            .to eq(PlanningApplication::DAYS_TO_EXPIRE.days.after(planning_application.received_at).to_date)
         end
       end
 
       context "when there are validated documents" do
         before { planning_application.update!(validated_at: 1.week.ago) }
 
-        it "is set to validated_at + 56 days" do
-          planning_application.update!(validated_at: 1.week.ago)
-          expect(planning_application.expiry_date).to eq(56.days.after(planning_application.validated_at).to_date)
+        it "is set to validated_at + DAYS_TO_EXPIRE days" do
+          expect(planning_application.expiry_date)
+            .to eq(PlanningApplication::DAYS_TO_EXPIRE.days.after(planning_application.validated_at).to_date)
         end
       end
     end


### PR DESCRIPTION
- the 56 day constant should be used in other tests which are based
  on expiry date: days_left and days_overdue. But keeping the
  change as simple as possible
