### PR TITLE
Let users add comments to policies

### DIFF
--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -46,7 +46,10 @@ class PolicyClassesController < PlanningApplicationsController
 
   def update
     if @policy_class.update(policy_class_params)
-      redirect_to @planning_application, notice: "Successfully updated policy class"
+      redirect_to(
+        planning_application_assessment_tasks_path(@planning_application),
+        notice: t(".successfully_updated_policy")
+      )
     else
       render :show
     end
@@ -65,7 +68,9 @@ class PolicyClassesController < PlanningApplicationsController
   end
 
   def policy_class_params
-    params.require(:policy_class).permit(policies_attributes: %i[id status])
+    params
+      .require(:policy_class)
+      .permit(policies_attributes: [:id, :status, { comment_attributes: [:text] }])
   end
 
   def set_policy_class

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,4 +34,30 @@ module ApplicationHelper
       OpenStruct.new(id: key, name: t(".#{key}"))
     end
   end
+
+  def policy_comment_label(comment)
+    if comment.persisted?
+      existing_policy_comment_label(comment)
+    else
+      t(".add_comment")
+    end
+  end
+
+  def existing_policy_comment_label(comment)
+    user = comment.user.name
+
+    if comment.edited?
+      t(
+        ".comment_updated_on",
+        updated_at: comment.updated_at.strftime("%d %b %Y"),
+        user: user
+      )
+    else
+      t(
+        ".comment_added_on",
+        created_at: comment.created_at.strftime("%d %b %Y"),
+        user: user
+      )
+    end
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :user, optional: true
+  belongs_to :policy
+
+  validates :text, presence: true
+
+  before_save :set_user
+
+  def edited?
+    created_at != updated_at
+  end
+
+  private
+
+  def set_user
+    self.user = Current.user
+  end
+end

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -2,6 +2,13 @@
 
 class Policy < ApplicationRecord
   belongs_to :policy_class
+  has_one :comment, dependent: :destroy
+
+  accepts_nested_attributes_for(
+    :comment,
+    update_only: true,
+    reject_if: proc { |attributes| attributes[:text].blank? }
+  )
 
   validates :description, :section, :status, presence: true
 
@@ -11,4 +18,8 @@ class Policy < ApplicationRecord
   )
 
   statuses.each_key { |status| scope status, -> { where(status: status) } }
+
+  def existing_or_new_comment
+    comment || build_comment
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
 
   has_many :planning_applications, dependent: :nullify
   has_many :audits, dependent: :nullify
+  has_many :comments, dependent: :nullify
   belongs_to :local_authority, optional: false
 
   before_create :generate_otp_secret

--- a/app/views/policy_classes/show.html.erb
+++ b/app/views/policy_classes/show.html.erb
@@ -10,7 +10,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Assess - <%= @policy_class %></h1>
-    <h2 class="govuk-heading-m">Class title - <%= @policy_class.name %></h1>
+    <h2 class="govuk-heading-m">
+      <%= t(".class_title", policy_class: @policy_class.name) %>
+    </h2>
 
     <p class="govuk-body">
       Please indicate if the application complies, does not comply, or
@@ -36,7 +38,8 @@
   <div class="govuk-grid-column-full">
     <%= form_with(
       model: [@planning_application, @policy_class],
-      html: { data: unsaved_changes_data }
+      html: { data: unsaved_changes_data },
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
     ) do |form| %>
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--l"><%= @policy_class %> - <%= @policy_class.name %></caption>
@@ -58,9 +61,22 @@
                 <h3 class="govuk-heading-s">
                   <%= "#{form.object.section}.#{policy_form.object.section}" %>
                 </h3>
-                <div class="govuk-body">
+                <p class="govuk-body">
                   <%= policy_form.object.description %>
-                </div>
+                </p>
+                <%= policy_form.fields_for(
+                  :comment,
+                  policy_form.object.existing_or_new_comment
+                ) do |comment_form| %>
+                  <%= comment_form.govuk_text_area(
+                    :text,
+                    label: {
+                      text: policy_comment_label(comment_form.object),
+                      size: "s"
+                    },
+                    rows: 2
+                  ) %>
+                <% end %>
               </td>
               <% Policy.statuses.each_key do |status| %>
                 <td class="govuk-table__cell">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -192,6 +192,14 @@ en:
   planning_applications:
     confirm_validation:
       validate_application: Validate application
+  policy_classes:
+    show:
+      add_comment: Add comment
+      class_title: Class title - %{policy_class}
+      comment_added_on: Comment added on %{created_at} by %{user}
+      comment_updated_on: Comment updated on %{updated_at} by %{user}
+    update:
+      successfully_updated_policy: Successfully updated policy class
   proposal_detail_component:
     auto_answered: Auto-answered by RIPA
   proposal_details:

--- a/db/migrate/20220907112857_create_comments.rb
+++ b/db/migrate/20220907112857_create_comments.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateComments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :comments do |t|
+      t.text :text, null: false
+      t.references :user
+      t.references :policy
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_05_134840) do
+ActiveRecord::Schema.define(version: 2022_09_07_112857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,16 @@ ActiveRecord::Schema.define(version: 2022_09_05_134840) do
     t.index ["api_user_id"], name: "index_audits_on_api_user_id"
     t.index ["planning_application_id"], name: "index_audits_on_planning_application_id"
     t.index ["user_id"], name: "index_audits_on_user_id"
+  end
+
+  create_table "comments", force: :cascade do |t|
+    t.text "text", null: false
+    t.bigint "user_id"
+    t.bigint "policy_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["policy_id"], name: "ix_comments_on_policy_id"
+    t.index ["user_id"], name: "ix_comments_on_user_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :comment do
+    text { Faker::Lorem.paragraph }
+    policy
+    user
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Comment, type: :model do
+  describe "#valid?" do
+    let(:comment) { build(:comment) }
+
+    it "is true for factory" do
+      expect(comment.valid?).to eq(true)
+    end
+  end
+
+  describe "#edited?" do
+    context "when created_at and updated_at are the same" do
+      let(:comment) { create(:comment) }
+
+      it "returns false" do
+        expect(comment.edited?).to eq(false)
+      end
+    end
+
+    context "when created_at and updated_at are different" do
+      let(:comment) { create(:comment, created_at: 1.day.ago) }
+
+      it "returns true" do
+        expect(comment.edited?).to eq(true)
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:user) { create(:user) }
+    let(:comment) { build(:comment) }
+
+    before { Current.user = user }
+
+    it "sets the user" do
+      comment.save
+      expect(comment.user).to eq(user)
+    end
+  end
+end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -366,6 +366,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         choose("policy_class_policies_attributes_3_status_complies")
         choose("policy_class_policies_attributes_4_status_to_be_determined")
         click_button("Save assessments")
+        click_link("Application")
         click_link("Assess recommendation")
 
         expect(page).to have_content("To be determined")
@@ -373,6 +374,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_link("Part 1, Class D - porches")
         choose("policy_class_policies_attributes_4_status_does_not_comply")
         click_button("Save assessments")
+        click_link("Application")
         click_link("Assess recommendation")
 
         expect(page).to have_content("Does not comply")
@@ -384,6 +386,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_link("Part 1, Class D - porches")
         choose("policy_class_policies_attributes_4_status_complies")
         click_button("Save assessments")
+        click_link("Application")
         click_link("Assess recommendation")
 
         expect(page).to have_content("Complies")


### PR DESCRIPTION
### Description of change

- Add a text areas to the policy class form which allow users to add a comment for each policy.

### Story Link

https://trello.com/c/90BX4FSz/1140-comment-option-for-each-paragraph-of-legislation-and-check-what-is-permitted-overall-by-class (covers first two Acceptance Criteria only)

### Screenshots

No comment added:
<img width="65%" alt="Screenshot 2022-09-02 at 16 53 41" src="https://user-images.githubusercontent.com/25392162/188176578-27b0a2c9-2c69-443b-b6cb-f912900b3330.png">

Comment added:
<img width="65%" alt="Screenshot 2022-09-02 at 16 52 50" src="https://user-images.githubusercontent.com/25392162/188176596-ad16b54f-ef5d-4c2d-854c-6df2b656269e.png">

Comment updated:
<img width="65%" alt="Screenshot 2022-09-02 at 16 53 14" src="https://user-images.githubusercontent.com/25392162/188176626-ccda3fba-6ca3-4230-82be-e69bbeeb354c.png">

### Decisions

We've talked about extracting the information in the `policy_classes` column in `planning_applications` into separated `policy_classes` and `policies` tables with their own models. I've left it as is for now because I'd like to have worked with this aspect of the application a bit more and understand a bit more about it before making any big architectural decisions!