### PR TITLE
Allow user to mark assess against legislation form as complete

### DIFF
--- a/app/components/policy_class_component.html.erb
+++ b/app/components/policy_class_component.html.erb
@@ -1,0 +1,17 @@
+<h4 class="govuk-body policy-class-title">
+  <%= link_to(
+    t(".policy_class_name", part: part, class: section, name: name),
+    path,
+    class: "govuk-link"
+  ) %>
+</h4>
+<p class="govuk-body"><strong><%= policies_summary %></strong></p>
+<% if policies.to_be_determined.none? %>
+  <% policies.does_not_comply.each do |policy| %>
+    <div class="policy">
+      <h5 class="govuk-heading-s"><%= "#{section}.#{policy.section}" %></h5>
+      <p class="govuk-body policy-description"><%= policy.description %></p>
+      <p class="govuk-body"><strong><%= t(".does_not_comply") %></strong></p>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/policy_class_component.rb
+++ b/app/components/policy_class_component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class PolicyClassComponent < ViewComponent::Base
+  def initialize(policy_class:)
+    @policy_class = policy_class
+  end
+
+  private
+
+  attr_reader :policy_class
+
+  delegate(
+    :section,
+    :name,
+    :part,
+    :planning_application,
+    :policies,
+    :complete?,
+    to: :policy_class
+  )
+
+  def path
+    if complete?
+      planning_application_policy_class_path(planning_application, policy_class)
+    else
+      edit_planning_application_policy_class_path(
+        planning_application,
+        policy_class
+      )
+    end
+  end
+
+  def policies_summary
+    if policies.to_be_determined.any?
+      t(".to_be_determined")
+    elsif policies.does_not_comply.any?
+      t(".does_not_comply")
+    else
+      t(".complies")
+    end
+  end
+end

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -2,7 +2,7 @@
 
 class PolicyClassesController < PlanningApplicationsController
   before_action :set_planning_application
-  before_action :set_policy_class, only: %i[show update destroy]
+  before_action :set_policy_class, only: %i[edit show update destroy]
   before_action :ensure_can_assess_planning_application, only: %i[part new create]
 
   def part
@@ -42,6 +42,8 @@ class PolicyClassesController < PlanningApplicationsController
     end
   end
 
+  def edit; end
+
   def show; end
 
   def update
@@ -51,7 +53,7 @@ class PolicyClassesController < PlanningApplicationsController
         notice: t(".successfully_updated_policy")
       )
     else
-      render :show
+      render :edit
     end
   end
 

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -71,6 +71,7 @@ class PolicyClassesController < PlanningApplicationsController
     params
       .require(:policy_class)
       .permit(policies_attributes: [:id, :status, { comment_attributes: [:text] }])
+      .merge(status: status)
   end
 
   def set_policy_class
@@ -83,5 +84,13 @@ class PolicyClassesController < PlanningApplicationsController
 
   def ensure_can_assess_planning_application
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_assess?
+  end
+
+  def status
+    if params[:commit].downcase.match(/mark as complete/).present?
+      :complete
+    else
+      :in_assessment
+    end
   end
 end

--- a/app/helpers/policy_references_helper.rb
+++ b/app/helpers/policy_references_helper.rb
@@ -12,14 +12,4 @@ module PolicyReferencesHelper
 
     refs.join(", ").html_safe # rubocop:disable Rails/OutputSafety
   end
-
-  def policies_summary(policies)
-    if policies.to_be_determined.any?
-      t(".to_be_determined")
-    elsif policies.does_not_comply.any?
-      t(".does_not_comply")
-    else
-      t(".complies")
-    end
-  end
 end

--- a/app/helpers/policy_references_helper.rb
+++ b/app/helpers/policy_references_helper.rb
@@ -13,7 +13,7 @@ module PolicyReferencesHelper
     refs.join(", ").html_safe # rubocop:disable Rails/OutputSafety
   end
 
-  def policies_status(policies)
+  def policies_summary(policies)
     if policies.to_be_determined.any?
       t(".to_be_determined")
     elsif policies.does_not_comply.any?

--- a/app/helpers/policy_references_helper.rb
+++ b/app/helpers/policy_references_helper.rb
@@ -1,21 +1,6 @@
 # frozen_string_literal: true
 
 module PolicyReferencesHelper
-  def class_for_policy_class_status(status)
-    classes = %w[govuk-tag app-task-list__task-tag]
-
-    colour = case status
-             when "does not comply"
-               "red"
-             when "complies"
-               "green"
-             end
-
-    classes.append "govuk-tag--#{colour}" if colour.present?
-
-    classes.join(" ")
-  end
-
   def formatted_policy_refs(policy_refs)
     return if policy_refs.blank?
 
@@ -26,5 +11,15 @@ module PolicyReferencesHelper
     end
 
     refs.join(", ").html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def policies_status(policies)
+    if policies.to_be_determined.any?
+      t(".to_be_determined")
+    elsif policies.does_not_comply.any?
+      t(".does_not_comply")
+    else
+      t(".complies")
+    end
   end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -233,3 +233,7 @@ html * {
 .display-none {
   display: none;
 }
+
+.policy-comment-title {
+  margin-bottom: 0
+}

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -4,6 +4,8 @@ class Policy < ApplicationRecord
   belongs_to :policy_class
   has_one :comment, dependent: :destroy
 
+  default_scope { order(:section) }
+
   accepts_nested_attributes_for(
     :comment,
     update_only: true,

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -8,6 +8,8 @@ class PolicyClass < ApplicationRecord
 
   validates :name, :part, :section, :schedule, presence: true
 
+  validate :all_policies_are_determined, if: :complete?
+
   enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
 
   class << self
@@ -37,6 +39,14 @@ class PolicyClass < ApplicationRecord
       part == other[:part] && id == other[:id]
     else
       part == other.part && id == other.id
+    end
+  end
+
+  private
+
+  def all_policies_are_determined
+    if policies.any?(&:to_be_determined?)
+      errors.add(:status, :policies_to_be_determined)
     end
   end
 end

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -45,8 +45,8 @@ class PolicyClass < ApplicationRecord
   private
 
   def all_policies_are_determined
-    if policies.any?(&:to_be_determined?)
-      errors.add(:status, :policies_to_be_determined)
-    end
+    return if policies.none?(&:to_be_determined?)
+
+    errors.add(:status, :policies_to_be_determined)
   end
 end

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -8,6 +8,8 @@ class PolicyClass < ApplicationRecord
 
   validates :name, :part, :section, :schedule, presence: true
 
+  enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
+
   class << self
     def all_parts
       # NOTE: we might do multiple schedules at some point in the
@@ -20,19 +22,6 @@ class PolicyClass < ApplicationRecord
         PolicyClass.new(attributes)
       end
     end
-  end
-
-  %w[in_assessment does_not_comply complies].each do |potential_status|
-    define_method("#{potential_status}?") do
-      status == potential_status.tr("_", " ")
-    end
-  end
-
-  def status
-    return "in assessment" if policies.to_be_determined.any?
-    return "does not comply" if policies.does_not_comply.any?
-
-    "complies"
   end
 
   def as_json(_options = nil)

--- a/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
@@ -27,15 +27,29 @@ module AssessmentTasks
     def policy_class_link
       link_to(
         policy_class,
-        planning_application_policy_class_path(planning_application, policy_class),
+        policy_class_path,
         class: "govuk-link"
       )
+    end
+
+    def policy_class_path
+      if policy_class.complete?
+        planning_application_policy_class_path(
+          planning_application,
+          policy_class
+        )
+      else
+        edit_planning_application_policy_class_path(
+          planning_application,
+          policy_class
+        )
+      end
     end
 
     def policy_class_tag
       tag.strong(
         I18n.t("policy_classes.#{policy_class.status}"),
-        class: "govuk-tag app-task-list__task-tag #{"govuk-tag--blue" if policy_class.complete?}"
+        class: "govuk-tag app-task-list__task-tag #{'govuk-tag--blue' if policy_class.complete?}"
       )
     end
   end

--- a/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
@@ -33,7 +33,10 @@ module AssessmentTasks
     end
 
     def policy_class_tag
-      tag.strong policy_class.status, class: class_for_policy_class_status(policy_class.status)
+      tag.strong(
+        I18n.t("policy_classes.#{policy_class.status}"),
+        class: "govuk-tag app-task-list__task-tag #{"govuk-tag--blue" if policy_class.complete?}"
+      )
     end
   end
 end

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -1,0 +1,127 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with(
+      model: [planning_application, policy_class],
+      html: { data: unsaved_changes_data },
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |form| %>
+      <%= form.govuk_error_summary %>
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--l">
+          <%= t(
+            ".table_caption",
+            part: policy_class.part,
+            class: policy_class.section,
+            name: policy_class.name
+          ) %>
+        </caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+              <%= t(".policy_reference") %>
+            </th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+              <%= t(".complies") %>
+            </th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+              <%= t(".does_not_comply") %>
+            </th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+              <%= t(".to_be_determined") %>
+            </th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <%= form.fields_for(:policies) do |policy_form| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <h3 class="govuk-heading-s">
+                  <%= "#{form.object.section}.#{policy_form.object.section}" %>
+                </h3>
+                <p class="govuk-body">
+                  <%= policy_form.object.description %>
+                </p>
+                <% if editable %>
+                  <%= policy_form.fields_for(
+                    :comment,
+                    policy_form.object.existing_or_new_comment
+                  ) do |comment_form| %>
+                    <%= comment_form.govuk_text_area(
+                      :text,
+                      label: {
+                        text: policy_comment_label(comment_form.object),
+                        size: "s"
+                      },
+                      rows: 2
+                    ) %>
+                  <% end %>
+                <% elsif comment = policy_form.object.comment.presence %>
+                  <h4 class="govuk-heading-s policy-comment-title">
+                    <%=existing_policy_comment_label(comment)%>
+                  </h4>
+                  <p class="govuk-body"><%= comment.text %></p>
+                <% end %>
+              </td>
+              <% Policy.statuses.each_key do |status| %>
+                <td class="govuk-table__cell">
+                  <% if editable || policy_form.object.status == status %>
+                    <div class="govuk-form-group">
+                      <fieldset class="govuk-fieldset">
+                        <div class="govuk-radios" data-module="govuk-radios">
+                          <div class="govuk-radios govuk-radios--small">
+                            <div class="govuk-radios__item">
+                              <%= policy_form.radio_button(
+                                :status,
+                                status,
+                                class: "govuk-radios__input",
+                                disabled: planning_application.assessment_complete?
+                              ) %>
+                              <%= policy_form.label(
+                                :status,
+                                "&nbsp;".html_safe,
+                                class: "govuk-label govuk-radios__label"
+                              ) %>
+                            </div>
+                          </div>
+                        </div>
+                      </fieldset>
+                    </div>
+                  <% end %>
+                </td>
+              <% end %>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <div class="govuk-button-group">
+        <% if editable %>
+          <%= form.submit(
+            t(".save_and_mark"),
+            class: "govuk-button",
+            disabled: planning_application.assessment_complete?
+          ) %>
+          <%= form.submit(
+            t(".save_and_come"),
+            class: "govuk-button govuk-button--secondary",
+            disabled: planning_application.assessment_complete?
+          ) %>
+        <% end %>
+        <%= link_to(
+          t(".back"),
+          :back,
+          class: "govuk-button govuk-button--secondary"
+        ) %>
+        <% if !editable %>
+          <%= link_to(
+            t(".edit_assessment"),
+            edit_planning_application_policy_class_path(
+              planning_application,
+              policy_class
+            ),
+            class: "govuk-link"
+          ) %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/policy_classes/_summary.html.erb
+++ b/app/views/policy_classes/_summary.html.erb
@@ -1,0 +1,44 @@
+<% content_for :page_title do %>
+  <%= t(".assess") %> - <%= t("page_title") %>
+<% end %>
+<% add_parent_breadcrumb_link(t(".home"), planning_applications_path) %>
+<% add_parent_breadcrumb_link(
+  t(".application"),
+  planning_application_path(planning_application)
+) %>
+<% content_for(:title, t(".assess")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(
+        ".assess_policy_class",
+        part: policy_class.part,
+        class: policy_class.section
+      ) %>
+    </h1>
+    <h2 class="govuk-heading-m">
+      <%= t(".class_title", policy_class: policy_class.name) %>
+    </h2>
+    <p class="govuk-body">
+      <%= t(
+        ".please_indicate_if",
+        part: policy_class.part,
+        class: policy_class.section
+      ) %>
+    <p class="govuk-body">
+      <%= link_to(
+        t(".open_legislation_in"),
+        policy_class.url,
+        class: "govuk-link",
+        target: "_blank"
+      ) %>
+    </p>
+    <%= button_to(
+        t(".remove_class_from"),
+        nil,
+        method: :delete,
+        class: "govuk-button govuk-button--warning",
+        disabled: planning_application.assessment_complete?
+    ) %>
+  </div>
+</div>

--- a/app/views/policy_classes/_summary.html.erb
+++ b/app/views/policy_classes/_summary.html.erb
@@ -35,7 +35,7 @@
     </p>
     <%= button_to(
         t(".remove_class_from"),
-        nil,
+        planning_application_policy_class_path(planning_application, policy_class),
         method: :delete,
         class: "govuk-button govuk-button--warning",
         disabled: planning_application.assessment_complete?

--- a/app/views/policy_classes/edit.html.erb
+++ b/app/views/policy_classes/edit.html.erb
@@ -10,6 +10,6 @@
   locals: {
     planning_application: @planning_application,
     policy_class: @policy_class,
-    editable: false
+    editable: true
   }
 ) %>

--- a/app/views/policy_classes/show.html.erb
+++ b/app/views/policy_classes/show.html.erb
@@ -41,6 +41,7 @@
       html: { data: unsaved_changes_data },
       builder: GOVUKDesignSystemFormBuilder::FormBuilder
     ) do |form| %>
+      <%= form.govuk_error_summary %>
       <table class="govuk-table">
         <caption class="govuk-table__caption govuk-table__caption--l"><%= @policy_class %> - <%= @policy_class.name %></caption>
         <thead class="govuk-table__head">
@@ -52,10 +53,7 @@
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <%= form.fields_for(
-            :policies,
-            @policy_class.policies.order(:section)
-          ) do |policy_form| %>
+          <%= form.fields_for(:policies) do |policy_form| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell">
                 <h3 class="govuk-heading-s">
@@ -109,7 +107,16 @@
       </table>
 
       <div class="govuk-button-group">
-        <%= form.submit "Save assessments", class: "govuk-button", disabled: @planning_application.assessment_complete? %>
+        <%= form.submit(
+          t(".save_and_mark"),
+          class: "govuk-button",
+          disabled: @planning_application.assessment_complete?
+        ) %>
+        <%= form.submit(
+          t(".save_and_come"),
+          class: "govuk-button govuk-button--secondary",
+          disabled: @planning_application.assessment_complete?
+        ) %>
         <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
       </div>
     <% end %>

--- a/app/views/recommendations/_legislation.html.erb
+++ b/app/views/recommendations/_legislation.html.erb
@@ -12,7 +12,7 @@
   </h4>
   <p class="govuk-body">
     <strong>
-      <%= policies_status(policy_class.policies) %>
+      <%= policies_summary(policy_class.policies) %>
     </strong>
   </p>
   <% if policy_class.policies.to_be_determined.none? %>

--- a/app/views/recommendations/_legislation.html.erb
+++ b/app/views/recommendations/_legislation.html.erb
@@ -12,10 +12,10 @@
   </h4>
   <p class="govuk-body">
     <strong>
-      <%= t(".#{policy_class.status.tr(" ", "_")}") %>
+      <%= policies_status(policy_class.policies) %>
     </strong>
   </p>
-  <% if policy_class.does_not_comply? %>
+  <% if policy_class.policies.to_be_determined.none? %>
     <% policy_class.policies.does_not_comply.each do |policy| %>
       <div class="policy">
         <h5 class="govuk-heading-s">

--- a/app/views/recommendations/_legislation.html.erb
+++ b/app/views/recommendations/_legislation.html.erb
@@ -3,27 +3,5 @@
   <p class="govuk-body"><%= t(".no_legislation_assessed") %></p>
 <% end %>
 <% policy_classes.each do |policy_class| %>
-  <h4 class="govuk-body policy-class-title">
-    <%= link_to(
-      "#{policy_class} - #{policy_class.name}",
-      planning_application_policy_class_path(planning_application, policy_class),
-      class: "govuk-link"
-    ) %>
-  </h4>
-  <p class="govuk-body">
-    <strong>
-      <%= policies_summary(policy_class.policies) %>
-    </strong>
-  </p>
-  <% if policy_class.policies.to_be_determined.none? %>
-    <% policy_class.policies.does_not_comply.each do |policy| %>
-      <div class="policy">
-        <h5 class="govuk-heading-s">
-          <%= "#{policy_class.id}.#{policy["id"]}" %>
-        </h5>
-        <p class="govuk-body policy-description"><%= policy["description"] %></p>
-        <p class="govuk-body"><strong><%= t(".does_not_comply") %></strong></p>
-      </div>
-    <% end %>
-  <% end %>
+  <%= render(PolicyClassComponent.new(policy_class: policy_class)) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,10 +12,6 @@ en:
   activerecord:
     errors:
       models:
-        policy_class:
-          attributes:
-            status:
-              policies_to_be_determined: All policies must be assessed
         document:
           attributes:
             file:
@@ -36,6 +32,10 @@ en:
               not_a_number: Payment amount must be a number not exceeding 2 decimal places
             public_comment:
               blank: Please state the reasons why this application is, or is not lawful
+        policy_class:
+          attributes:
+            status:
+              policies_to_be_determined: All policies must be assessed
   additional_document_validation_requests:
     create:
       success: Additional document request successfully created.
@@ -198,14 +198,29 @@ en:
       validate_application: Validate application
   policy_classes:
     complete: Complete
-    in_assessment: In assessment
-    show:
+    form:
       add_comment: Add comment
-      class_title: Class title - %{policy_class}
+      back: Back
       comment_added_on: Comment added on %{created_at} by %{user}
       comment_updated_on: Comment updated on %{updated_at} by %{user}
-      save_and_mark: Save and mark as complete
+      complies: Complies
+      does_not_comply: Does not comply
+      edit_assessment: Edit assessment
+      policy_reference: Policy reference
       save_and_come: Save and come back later
+      save_and_mark: Save and mark as complete
+      table_caption: Part %{part}, Class %{class} - %{name}
+      to_be_determined: To be determined
+    in_assessment: In assessment
+    summary:
+      application: Application
+      assess: Assess
+      assess_policy_class: Assess - Part %{part}, Class %{class}
+      class_title: Class title - %{policy_class}
+      home: Home
+      open_legislation_in: Open legislation in new window
+      please_indicate_if: Please indicate if the application complies, does not comply, or is not applicable to each of the policies. Policies are defined in the Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part %{part}, Class %{class}.
+      remove_class_from: Remove class from assessment
     update:
       successfully_updated_policy: Successfully updated policy class
   proposal_detail_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,11 @@ en:
   planning_applications:
     confirm_validation:
       validate_application: Validate application
+  policy_class_component:
+    complies: Complies
+    does_not_comply: Does not comply
+    policy_class_name: Part %{part}, Class %{class} - %{name}
+    to_be_determined: To be determined
   policy_classes:
     complete: Complete
     form:
@@ -245,11 +250,8 @@ en:
       recommendation_queried: Recommendation queried
       submitted_recommendation: Submitted recommendation
     legislation:
-      complies: Complies
-      does_not_comply: Does not comply
       legislation: Legislation
       no_legislation_assessed: No legislation assessed for this application.
-      to_be_determined: To be determined
     new:
       assess_recommendation: Assess recommendation
   search_form_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,8 @@ en:
     confirm_validation:
       validate_application: Validate application
   policy_classes:
+    complete: Complete
+    in_assessment: In assessment
     show:
       add_comment: Add comment
       class_title: Class title - %{policy_class}
@@ -224,9 +226,9 @@ en:
     legislation:
       complies: Complies
       does_not_comply: Does not comply
-      in_assessment: To be determined
       legislation: Legislation
       no_legislation_assessed: No legislation assessed for this application.
+      to_be_determined: To be determined
     new:
       assess_recommendation: Assess recommendation
   search_form_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,10 @@ en:
   activerecord:
     errors:
       models:
+        policy_class:
+          attributes:
+            status:
+              policies_to_be_determined: All policies must be assessed
         document:
           attributes:
             file:
@@ -200,6 +204,8 @@ en:
       class_title: Class title - %{policy_class}
       comment_added_on: Comment added on %{created_at} by %{user}
       comment_updated_on: Comment updated on %{updated_at} by %{user}
+      save_and_mark: Save and mark as complete
+      save_and_come: Save and come back later
     update:
       successfully_updated_policy: Successfully updated policy class
   proposal_detail_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create edit update]
 
   resources :planning_applications, only: %i[index show new edit create update] do
-    resources :policy_classes, except: %i[index edit] do
+    resources :policy_classes, except: %i[index] do
       get :part, on: :new
     end
 

--- a/db/migrate/20220907161526_add_status_to_policy_classes.rb
+++ b/db/migrate/20220907161526_add_status_to_policy_classes.rb
@@ -1,0 +1,23 @@
+class AddStatusToPolicyClasses < ActiveRecord::Migration[6.1]
+  def up
+    add_column :policy_classes, :status, :integer
+
+    execute(
+      "UPDATE policy_classes
+      SET status = 0
+      FROM policies
+      WHERE policies.policy_class_id = policy_classes.id
+      AND policies.status = 2;"
+    )
+
+    execute(
+      "UPDATE policy_classes
+      SET status = 1
+      WHERE status IS NULL;"
+    )
+  end
+
+  def down
+    remove_column :policy_classes, :status
+  end
+end

--- a/db/migrate/20220907161526_add_status_to_policy_classes.rb
+++ b/db/migrate/20220907161526_add_status_to_policy_classes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddStatusToPolicyClasses < ActiveRecord::Migration[6.1]
   def up
     add_column :policy_classes, :status, :integer

--- a/db/migrate/20220907161526_add_status_to_policy_classes.rb
+++ b/db/migrate/20220907161526_add_status_to_policy_classes.rb
@@ -15,6 +15,8 @@ class AddStatusToPolicyClasses < ActiveRecord::Migration[6.1]
       SET status = 1
       WHERE status IS NULL;"
     )
+
+    change_column_null :policy_classes, :status, false
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -296,7 +296,7 @@ ActiveRecord::Schema.define(version: 2022_09_07_161526) do
     t.bigint "planning_application_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status"
+    t.integer "status", null: false
     t.index ["planning_application_id"], name: "ix_policy_classes_on_planning_application_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_07_112857) do
+ActiveRecord::Schema.define(version: 2022_09_07_161526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,6 +296,7 @@ ActiveRecord::Schema.define(version: 2022_09_07_112857) do
     t.bigint "planning_application_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status"
     t.index ["planning_application_id"], name: "ix_policy_classes_on_planning_application_id"
   end
 

--- a/features/adding_policy_assessment_areas.feature
+++ b/features/adding_policy_assessment_areas.feature
@@ -11,9 +11,9 @@ Feature: Adding policy assessment area to the application
 
   Scenario: As an assessor I can add classes to a validated application
     Given I add the policy classes "AA, B, F" to the application
-    Then there is a row for the "Part 1, Class AA" policy with an "in assessment" status
-    And there is a row for the "Part 1, Class B" policy with an "in assessment" status
-    And there is a row for the "Part 1, Class F" policy with an "in assessment" status
+    Then there is a row for the "Part 1, Class AA" policy with an "In assessment" status
+    And there is a row for the "Part 1, Class B" policy with an "In assessment" status
+    And there is a row for the "Part 1, Class F" policy with an "In assessment" status
 
   Scenario: As an assessor I can remove classes from a validated application
     Given I add the policy class "AA" to the application
@@ -26,4 +26,4 @@ Feature: Adding policy assessment area to the application
     And I press "Check and assess"
     When I press "Part 1, Class A"
     Then I can't press the "Remove class from assessment" button
-    And I can't press the "Save assessments" button
+    And I can't press the "Save and mark as complete" button

--- a/spec/components/policy_class_component_spec.rb
+++ b/spec/components/policy_class_component_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PolicyClassComponent, type: :component do
+  let(:policy_class_component) do
+    described_class.new(policy_class: policy_class)
+  end
+
+  describe "#policies_summary" do
+    before do
+      policy_class_component.instance_variable_set(
+        :@virtual_path,
+        "policy_class_component"
+      )
+    end
+
+    let(:policy_class) { create(:policy_class, policies: [policy1, policy2]) }
+    let(:policy1) { create(:policy, :complies) }
+
+    context "when all policies comply" do
+      let(:policy2) { create(:policy, :complies) }
+
+      it "returns 'Complies'" do
+        expect(policy_class_component.send(:policies_summary)).to eq("Complies")
+      end
+    end
+
+    context "when a policy does not comply" do
+      let(:policy2) { create(:policy, :does_not_comply) }
+
+      it "returns 'Does not comply'" do
+        expect(
+          policy_class_component.send(:policies_summary)
+        ).to eq(
+          "Does not comply"
+        )
+      end
+    end
+
+    context "when a policy is to be determined" do
+      let(:policy1) { create(:policy, :to_be_determined) }
+      let(:policy2) { create(:policy, :does_not_comply) }
+
+      it "returns 'To be determined'" do
+        expect(
+          policy_class_component.send(:policies_summary)
+        ).to eq(
+          "To be determined"
+        )
+      end
+    end
+  end
+end

--- a/spec/factories/policy_class.rb
+++ b/spec/factories/policy_class.rb
@@ -8,5 +8,13 @@ FactoryBot.define do
     name { Faker::Lorem.sentence }
     url { "https://www.example.com" }
     planning_application
+
+    trait :complies do
+      status { :complies }
+    end
+
+    trait :in_assessment do
+      status { :in_assessment }
+    end
   end
 end

--- a/spec/models/policy_class_spec.rb
+++ b/spec/models/policy_class_spec.rb
@@ -29,107 +29,64 @@ RSpec.describe PolicyClass, type: :model do
     end
   end
 
-  describe "#complies?" do
-    let(:policy_class) do
-      create(:policy_class, policies: [policy1, policy2, policy3])
-    end
-
-    let(:policy1) { create(:policy, :complies) }
-    let(:policy2) { create(:policy, :complies) }
-    let(:policy3) { create(:policy, :complies) }
-
-    context "when all policies are complies" do
-      it "returns true" do
-        expect(policy_class.complies?).to eq(true)
-      end
-    end
-
-    context "when a policy does not comply" do
-      let(:policy3) { create(:policy, :does_not_comply) }
-
-      it "returns false" do
-        expect(policy_class.complies?).to eq(false)
-      end
-    end
-
-    context "when a policy is to be determined" do
-      let(:policy3) { create(:policy, :to_be_determined) }
-
-      it "returns false" do
-        expect(policy_class.complies?).to eq(false)
-      end
-    end
-  end
-
-  describe "#does_not_comply?" do
-    let(:policy_class) do
-      create(:policy_class, policies: [policy1, policy2, policy3])
-    end
-
-    let(:policy1) { create(:policy, :complies) }
-    let(:policy2) { create(:policy, :complies) }
-    let(:policy3) { create(:policy, :complies) }
-
-    context "when all policies are complies" do
-      it "returns false" do
-        expect(policy_class.does_not_comply?).to eq(false)
-      end
-    end
-
-    context "when a policy does not comply" do
-      let(:policy3) { create(:policy, :does_not_comply) }
-
-      it "returns true" do
-        expect(policy_class.does_not_comply?).to eq(true)
-      end
-    end
-
-    context "when a policy is do be determined" do
-      let(:policy2) { create(:policy, :does_not_comply) }
-      let(:policy3) { create(:policy, :to_be_determined) }
-
-      it "returns false" do
-        expect(policy_class.does_not_comply?).to eq(false)
-      end
-    end
-  end
-
-  describe "#in_assessment?" do
-    let(:policy_class) do
-      create(:policy_class, policies: [policy1, policy2, policy3])
-    end
-
-    let(:policy1) { create(:policy, :complies) }
-    let(:policy2) { create(:policy, :complies) }
-    let(:policy3) { create(:policy, :complies) }
-
-    context "when all policies are complies" do
-      it "returns false" do
-        expect(policy_class.in_assessment?).to eq(false)
-      end
-    end
-
-    context "when a policy does not comply" do
-      let(:policy3) { create(:policy, :does_not_comply) }
-
-      it "returns false" do
-        expect(policy_class.in_assessment?).to eq(false)
-      end
-    end
-
-    context "when a policy is do be determined" do
-      let(:policy2) { create(:policy, :does_not_comply) }
-      let(:policy3) { create(:policy, :to_be_determined) }
-
-      it "returns false" do
-        expect(policy_class.in_assessment?).to eq(true)
-      end
-    end
-  end
-
-  describe "validation" do
+  describe "#valid?" do
     it "has a valid factory" do
       expect(build(:policy_class)).to be_valid
+    end
+
+    context "when all policies are determined" do
+      let(:policy) { create(:policy, :complies) }
+
+      context "when status is complete" do
+        let(:policy_class) do
+          create(:policy_class, :complete, policies: [policy])
+        end
+
+        it "returns true" do
+          expect(policy_class.valid?).to eq(true)
+        end
+      end
+
+      context "when status is in_assessment" do
+        let(:policy_class) do
+          create(:policy_class, :in_assessment, policies: [policy])
+        end
+
+        it "returns true" do
+          expect(policy_class.valid?).to eq(true)
+        end
+      end
+    end
+
+    context "when some policies are to be determined" do
+      let(:policy) { create(:policy, :to_be_determined) }
+
+      context "when status is complete" do
+        let(:policy_class) do
+          create(:policy_class, :complete, policies: [policy])
+        end
+
+        it "returns false" do
+          expect(policy_class.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          policy_class.valid?
+          expect(policy_class.errors.messages[:status]).to contain_exactly(
+            "All policies must be assessed"
+          )
+        end
+      end
+
+      context "when status is in_assessment" do
+        let(:policy_class) do
+          create(:policy_class, :in_assessment, policies: [policy])
+        end
+
+        it "returns true" do
+          expect(policy_class.valid?).to eq(true)
+        end
+      end
     end
   end
 end

--- a/spec/models/policy_class_spec.rb
+++ b/spec/models/policy_class_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe PolicyClass, type: :model do
     end
 
     context "when all policies are determined" do
-      let(:policy) { create(:policy, :complies) }
+      let(:policy) { build(:policy, :complies) }
 
       context "when status is complete" do
         let(:policy_class) do
-          create(:policy_class, :complete, policies: [policy])
+          build(:policy_class, :complete, policies: [policy])
         end
 
         it "returns true" do
@@ -49,7 +49,7 @@ RSpec.describe PolicyClass, type: :model do
 
       context "when status is in_assessment" do
         let(:policy_class) do
-          create(:policy_class, :in_assessment, policies: [policy])
+          build(:policy_class, :in_assessment, policies: [policy])
         end
 
         it "returns true" do
@@ -59,11 +59,11 @@ RSpec.describe PolicyClass, type: :model do
     end
 
     context "when some policies are to be determined" do
-      let(:policy) { create(:policy, :to_be_determined) }
+      let(:policy) { build(:policy, :to_be_determined) }
 
       context "when status is complete" do
         let(:policy_class) do
-          create(:policy_class, :complete, policies: [policy])
+          build(:policy_class, :complete, policies: [policy])
         end
 
         it "returns false" do
@@ -80,7 +80,7 @@ RSpec.describe PolicyClass, type: :model do
 
       context "when status is in_assessment" do
         let(:policy_class) do
-          create(:policy_class, :in_assessment, policies: [policy])
+          build(:policy_class, :in_assessment, policies: [policy])
         end
 
         it "returns true" do

--- a/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
@@ -11,10 +11,8 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
   let!(:planning_application) { create(:planning_application, :in_assessment) }
 
   describe "#task_list_row" do
-    context "when policy class complies" do
-      let(:policy_class) { build(:policy_class) }
-
-      before { planning_application.policy_classes += [policy_class] }
+    context "when policy class status is 'complete'" do
+      let(:policy_class) { create(:policy_class, :complete) }
 
       it "the task list row shows invalid status html" do
         html = presenter.task_list_row
@@ -30,19 +28,13 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         )
 
         expect(html).to include(
-          "<strong class=\"govuk-tag app-task-list__task-tag govuk-tag--green\">complies</strong>"
+          "<strong class=\"govuk-tag app-task-list__task-tag govuk-tag--blue\">Complete</strong>"
         )
       end
     end
 
-    context "when policy class does not comply" do
-      let(:policy_class) do
-        build(:policy_class, policies: [policy])
-      end
-
-      let(:policy) { build(:policy, :does_not_comply) }
-
-      before { planning_application.policy_classes += [policy_class] }
+    context "when policy class status is 'in_assessment'" do
+      let(:policy_class) { create(:policy_class, :in_assessment) }
 
       it "the task list row shows invalid status html" do
         html = presenter.task_list_row
@@ -52,41 +44,13 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         expect(html).to include(
           link_to(
             policy_class,
-            planning_application_policy_class_path(planning_application, policy_class),
+            edit_planning_application_policy_class_path(planning_application, policy_class),
             class: "govuk-link"
           )
         )
 
         expect(html).to include(
-          "<strong class=\"govuk-tag app-task-list__task-tag govuk-tag--red\">does not comply</strong>"
-        )
-      end
-    end
-
-    context "when policy class is in assessment" do
-      let(:policy_class) do
-        build(:policy_class, policies: [policy])
-      end
-
-      let(:policy) { build(:policy, :to_be_determined) }
-
-      before { planning_application.policy_classes += [policy_class] }
-
-      it "the task list row shows invalid status html" do
-        html = presenter.task_list_row
-
-        expect(html).to include("app-task-list__task-name")
-
-        expect(html).to include(
-          link_to(
-            policy_class,
-            planning_application_policy_class_path(planning_application, policy_class),
-            class: "govuk-link"
-          )
-        )
-
-        expect(html).to include(
-          "<strong class=\"govuk-tag app-task-list__task-tag\">in assessment</strong>"
+          "<strong class=\"govuk-tag app-task-list__task-tag \">In assessment</strong>"
         )
       end
     end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "lets the user save draft and then mark as complete" do
+    travel_to(Time.zone.local(2022, 9, 1))
     visit(planning_application_path(planning_application))
     click_link("Check and assess")
     click_link("Add assessment area")
@@ -183,5 +184,29 @@ RSpec.describe "assessment against legislation", type: :system do
     end
 
     expect(task_list_item).to have_content("Complete")
+
+    click_link("Part 1, Class D")
+    expect(page).to have_content("Comment added on 01 Sep 2022 by Alice Smith")
+    expect(page).to have_content("Test comment")
+
+    expect(page).not_to have_field(
+      "Comment added on 01 Sep 2022 by Alice Smith",
+      with: "Test comment"
+    )
+
+    expect(page).not_to have_selector(
+      "#policy_class_policies_attributes_0_status_does_not_comply"
+    )
+
+    click_link("Edit assessment")
+
+    expect(page).to have_field(
+      "Comment added on 01 Sep 2022 by Alice Smith",
+      with: "Test comment"
+    )
+
+    expect(page).to have_selector(
+      "#policy_class_policies_attributes_0_status_does_not_comply"
+    )
   end
 end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "assessment against legislation", type: :system do
     click_link("Part 1, Class A")
     choose("policy_class_policies_attributes_0_status_complies")
     dismiss_confirm { click_link("Back") }
-    click_button("Save assessments")
+    click_button("Save and come back later")
 
     expect(page).to have_content("Successfully updated policy class")
   end
@@ -107,7 +107,7 @@ RSpec.describe "assessment against legislation", type: :system do
       fill_in("Add comment", with: "New comment")
     end
 
-    click_button("Save assessments")
+    click_button("Save and come back later")
     click_link("Part 1, Class D")
 
     expect(row_with_content("D.1a")).to have_field(
@@ -131,12 +131,57 @@ RSpec.describe "assessment against legislation", type: :system do
       )
     end
 
-    click_button("Save assessments")
+    click_button("Save and come back later")
     click_link("Part 1, Class D")
 
     expect(row_with_content("D.1a")).to have_field(
       "Comment updated on 02 Sep 2022 by Bella Jones",
       with: "Updated comment"
     )
+  end
+
+  it "lets the user save draft and then mark as complete" do
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+    check("Class D - porches")
+    click_button("Add classes")
+    click_link("Part 1, Class D")
+
+    within(row_with_content("D.1a")) do
+      fill_in("Add comment", with: "Test comment")
+    end
+
+    choose("policy_class_policies_attributes_0_status_complies")
+    choose("policy_class_policies_attributes_1_status_complies")
+    choose("policy_class_policies_attributes_2_status_complies")
+    choose("policy_class_policies_attributes_3_status_complies")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("All policies must be assessed")
+
+    click_button("Save and come back later")
+
+    expect(page).to have_content("Successfully updated policy class")
+
+    task_list_item = find_all("li").find do |list_item|
+      list_item.has_content?("Part 1, Class D")
+    end
+
+    expect(task_list_item).to have_content("In assessment")
+
+    click_link("Part 1, Class D")
+    choose("policy_class_policies_attributes_4_status_complies")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("Successfully updated policy class")
+
+    task_list_item = find_all("li").find do |list_item|
+      list_item.has_content?("Part 1, Class D")
+    end
+
+    expect(task_list_item).to have_content("Complete")
   end
 end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -365,7 +365,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         choose("policy_class_policies_attributes_2_status_complies")
         choose("policy_class_policies_attributes_3_status_complies")
         choose("policy_class_policies_attributes_4_status_to_be_determined")
-        click_button("Save assessments")
+        click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")
 
@@ -373,7 +373,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         click_link("Part 1, Class D - porches")
         choose("policy_class_policies_attributes_4_status_does_not_comply")
-        click_button("Save assessments")
+        click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")
 
@@ -385,7 +385,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         click_link("Part 1, Class D - porches")
         choose("policy_class_policies_attributes_4_status_complies")
-        click_button("Save assessments")
+        click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")
 


### PR DESCRIPTION
### Description of change

- Add `status` column to `policy_classes`, which defaults to `:in_assessment`.
- Add 'Save and mark as complete' and 'Save and come back later' buttons. 'Save and mark as complete' updates the status to `:complete.`
- Replace 'show' action with 'show' and 'edit' actions. When the user clicks on the policy class link they are taken to show if the status is `:complete` and edit if it's `:in_assessment`.

### Story Link

https://trello.com/c/90BX4FSz/1140-allow-users-to-save-and-mark-as-complete-or-save-and-come-back-later-on-assess-legislation-page

### Screenshots

New buttons:

<img width="65%" alt="Screenshot 2022-09-08 at 15 58 51" src="https://user-images.githubusercontent.com/25392162/189157304-49650f3a-aa93-4d1d-95a2-3640a97f3e28.png">

Error message if click 'Save and mark as complete' when some policies are still 'To be determined':

<img width="65%" alt="Screenshot 2022-09-08 at 15 59 07" src="https://user-images.githubusercontent.com/25392162/189157466-b1107618-ec1f-4501-bd5d-7c2526bc7c28.png">

Show view for 'Complete' policy classes:

<img width="65%" alt="Screenshot 2022-09-08 at 16 00 03" src="https://user-images.githubusercontent.com/25392162/189157527-8534ed96-66bc-4ae6-941c-18f942ecc5ce.png">