### PR TITLE
Fix bug where users can add policy class twice

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -429,6 +429,10 @@ class PlanningApplication < ApplicationRecord
     assessment_complete? && policy_classes.none?
   end
 
+  def has_policy_class?(section)
+    policy_classes.pluck(:section).include?(section)
+  end
+
   private
 
   def set_reference

--- a/app/views/policy_classes/new.html.erb
+++ b/app/views/policy_classes/new.html.erb
@@ -42,7 +42,7 @@
               :name
             ) do |b| %>
               <div class="govuk-checkboxes__item">
-                <% if @planning_application.policy_classes.include?(b.object) %>
+                <% if @planning_application.has_policy_class?(b.object.section) %>
                   <%= b.check_box(class: "govuk-checkboxes__input", disabled: true, checked: true) %>
                 <% else %>
                   <%= b.check_box(class: "govuk-checkboxes__input") %>

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -900,4 +900,28 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  describe "#has_policy_class?" do
+    let(:planning_application) { create(:planning_application) }
+
+    context "when planning application has policy class" do
+      before do
+        create(
+          :policy_class,
+          section: "1A",
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(planning_application.has_policy_class?("1A")).to eq(true)
+      end
+    end
+
+    context "when planning application does not have policy class" do
+      it "returns false" do
+        expect(planning_application.has_policy_class?("1A")).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -66,6 +66,28 @@ RSpec.describe "assessment against legislation", type: :system do
     expect(page).to have_content("Successfully updated policy class")
   end
 
+  it "lets the user add policy classes once only" do
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+    check("Class D - porches")
+    click_button("Add classes")
+
+    expect(page).to have_content("Part 1, Class D").once
+
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+
+    expect(page).to have_checked_field("Class D - porches", disabled: true)
+
+    check("Class G - chimneys, flues etc on a dwellinghouse")
+    click_button("Add classes")
+
+    expect(page).to have_content("Part 1, Class D").once
+    expect(page).to have_content("Part 1, Class G").once
+  end
+
   it "displays the class title" do
     click_link("Add assessment area")
     choose("Part 1 - Development within the curtilage of a dwellinghouse")


### PR DESCRIPTION
### Description of change

- Make sure previously added policy classes are checked and disabled on the add policy classes form, so that they can't be added twice!

### Story Link

NA. The issue is due to [this refactor](https://github.com/unboxed/bops/pull/744).

### Screenshot

<img width="65%" alt="Screenshot 2022-09-08 at 16 50 45" src="https://user-images.githubusercontent.com/25392162/189168154-f3d355e0-4943-4ff8-90a6-b0e824312ead.png">
