### PR TITLE
Add links for scrolling between policy classes

### DIFF
--- a/app/components/policy_class_component.html.erb
+++ b/app/components/policy_class_component.html.erb
@@ -1,7 +1,7 @@
 <h4 class="govuk-body policy-class-title">
   <%= link_to(
     t(".policy_class_name", part: part, class: section, name: name),
-    path,
+    default_path,
     class: "govuk-link"
   ) %>
 </h4>

--- a/app/components/policy_class_component.rb
+++ b/app/components/policy_class_component.rb
@@ -2,7 +2,7 @@
 
 class PolicyClassComponent < ViewComponent::Base
   def initialize(policy_class:)
-    @policy_class = policy_class
+    @policy_class = PolicyClassPresenter.new(policy_class)
   end
 
   private
@@ -15,20 +15,9 @@ class PolicyClassComponent < ViewComponent::Base
     :part,
     :planning_application,
     :policies,
-    :complete?,
+    :default_path,
     to: :policy_class
   )
-
-  def path
-    if complete?
-      planning_application_policy_class_path(planning_application, policy_class)
-    else
-      edit_planning_application_policy_class_path(
-        planning_application,
-        policy_class
-      )
-    end
-  end
 
   def policies_summary
     if policies.to_be_determined.any?

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -237,3 +237,46 @@ html * {
 .policy-comment-title {
   margin-bottom: 0
 }
+
+.button-as-link {
+  border: none;
+  background: none;
+  color: #1d70b8;
+  font-size: 16px;
+  text-decoration: underline;
+
+  &:active {
+    color: #0b0c0c;
+  }
+
+  &:hover {
+    color: #003078;
+  }
+
+  &:focus {
+    color: #0b0c0c;
+    background-color: #ffdd00;
+    box-shadow: 0 -2px #ffdd00, 0 4px #0b0c0c;
+    text-decoration: none;
+    outline: none;
+  }
+}
+
+.policy-class-scroll-links {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-bottom: 30px;
+  border-bottom: 1px solid #b1b4b6;
+  margin-bottom: 30px;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+  }
+}
+
+.next-policy-class-link {
+  @media (min-width: 768px) {
+    margin-left: auto;
+  }
+}

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -33,7 +33,13 @@ class PlanningApplication < ApplicationRecord
     has_many :red_line_boundary_change_validation_requests
     has_many :notes, -> { by_created_at_desc }, inverse_of: :planning_application
     has_many :requests, class_name: "ValidationRequest"
-    has_many :policy_classes, dependent: :destroy
+
+    has_many(
+      :policy_classes,
+      -> { order(:section) },
+      dependent: :destroy,
+      inverse_of: :planning_application
+    )
   end
 
   delegate :reviewer_group_email, to: :local_authority

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -30,16 +30,20 @@ class PolicyClass < ApplicationRecord
     attributes.as_json
   end
 
-  def to_s
-    "Part #{part}, Class #{section}"
-  end
-
   def ==(other)
     if other.is_a? Hash
       part == other[:part] && id == other[:id]
     else
       part == other.part && id == other.id
     end
+  end
+
+  def previous
+    @previous ||= planning_application.policy_classes.where("section < ?", section).last
+  end
+
+  def next
+    @next ||= planning_application.policy_classes.where("section > ?", section).first
   end
 
   private

--- a/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
@@ -11,7 +11,7 @@ module AssessmentTasks
     def initialize(template, planning_application, policy_class)
       super(template, planning_application)
 
-      @policy_class = policy_class
+      @policy_class = PolicyClassPresenter.new(policy_class)
     end
 
     def task_list_row
@@ -26,30 +26,24 @@ module AssessmentTasks
 
     def policy_class_link
       link_to(
-        policy_class,
-        policy_class_path,
+        policy_class_title,
+        policy_class.default_path,
         class: "govuk-link"
       )
-    end
-
-    def policy_class_path
-      if policy_class.complete?
-        planning_application_policy_class_path(
-          planning_application,
-          policy_class
-        )
-      else
-        edit_planning_application_policy_class_path(
-          planning_application,
-          policy_class
-        )
-      end
     end
 
     def policy_class_tag
       tag.strong(
         I18n.t("policy_classes.#{policy_class.status}"),
         class: "govuk-tag app-task-list__task-tag #{'govuk-tag--blue' if policy_class.complete?}"
+      )
+    end
+
+    def policy_class_title
+      I18n.t(
+        "policy_classes.title",
+        part: policy_class.part,
+        class: policy_class.section
       )
     end
   end

--- a/app/presenters/concerns/presentable.rb
+++ b/app/presenters/concerns/presentable.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Presentable
+  extend ActiveSupport::Concern
+  include Rails.application.routes.url_helpers
+
+  delegate :to_param, to: :presented
+
+  class_methods do
+    def presents(presented)
+      define_method(:presented) do
+        @presented ||= send(presented)
+      end
+    end
+  end
+
+  private
+
+  def method_missing(method_name, *args, &block)
+    if presented.respond_to?(method_name)
+      presented.send(method_name, *args, &block)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, *args)
+    presented.respond_to?(method_name) || super
+  end
+end

--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class PlanningApplicationPresenter
-  include Rails.application.routes.url_helpers
+  include Presentable
 
   attr_reader :template, :planning_application
 
+  presents :planning_application
+
   delegate :tag, :concat, :link_to, :truncate, :link_to_if, to: :template
-  delegate :to_param, to: :planning_application
 
   include StatusPresenter
   include ProposalDetailsPresenter
@@ -16,18 +17,6 @@ class PlanningApplicationPresenter
   def initialize(template, planning_application)
     @template = template
     @planning_application = planning_application
-  end
-
-  def method_missing(symbol, *args)
-    if planning_application.respond_to?(symbol)
-      planning_application.send(symbol, *args)
-    else
-      super
-    end
-  end
-
-  def respond_to_missing?(symbol, include_private = false)
-    super || planning_application.respond_to?(symbol)
   end
 
   def outcome_date

--- a/app/presenters/policy_class_presenter.rb
+++ b/app/presenters/policy_class_presenter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class PolicyClassPresenter
+  include Presentable
+
+  presents :policy_class
+
+  def initialize(policy_class)
+    @policy_class = policy_class
+  end
+
+  def previous
+    self.class.new(super) if super.present?
+  end
+
+  def next
+    self.class.new(super) if super.present?
+  end
+
+  def default_path
+    if complete?
+      planning_application_policy_class_path(planning_application, self)
+    else
+      edit_planning_application_policy_class_path(planning_application, self)
+    end
+  end
+
+  private
+
+  attr_reader :policy_class
+end

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -93,6 +93,36 @@
           <% end %>
         </tbody>
       </table>
+      <div class="policy-class-scroll-links">
+        <% if policy_class.previous.present? %>
+          <% if editable && !planning_application.assessment_complete? %>
+            <%= form.submit(
+              t(".save_changes_and_view_previous"),
+              class: "button-as-link"
+            ) %>
+          <% else %>
+            <%= link_to(
+              t(".view_previous_class"),
+              policy_class.previous.default_path,
+              class: "govuk-link"
+            ) %>
+          <% end %>
+        <% end %>
+        <% if policy_class.next.present? %>
+          <% if editable %>
+            <%= form.submit(
+              t(".save_changes_and_view_next"),
+              class: "button-as-link next-policy-class-link"
+            ) %>
+          <% else %>
+            <%= link_to(
+              t(".view_next_class"),
+              policy_class.next.default_path,
+              class: "govuk-link next-policy-class-link"
+            ) %>
+          <% end %>
+        <% end %>
+      </div>
       <div class="govuk-button-group">
         <% if editable %>
           <%= form.submit(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,8 +214,12 @@ en:
       policy_reference: Policy reference
       save_and_come: Save and come back later
       save_and_mark: Save and mark as complete
+      save_changes_and_view_next: Save changes and view next class
+      save_changes_and_view_previous: Save changes and view previous class
       table_caption: Part %{part}, Class %{class} - %{name}
       to_be_determined: To be determined
+      view_next_class: View next class
+      view_previous_class: View previous class
     in_assessment: In assessment
     summary:
       application: Application
@@ -226,6 +230,7 @@ en:
       open_legislation_in: Open legislation in new window
       please_indicate_if: Please indicate if the application complies, does not comply, or is not applicable to each of the policies. Policies are defined in the Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part %{part}, Class %{class}.
       remove_class_from: Remove class from assessment
+    title: Part %{part}, Class %{class}
     update:
       successfully_updated_policy: Successfully updated policy class
   proposal_detail_component:

--- a/spec/models/policy_class_spec.rb
+++ b/spec/models/policy_class_spec.rb
@@ -89,4 +89,56 @@ RSpec.describe PolicyClass, type: :model do
       end
     end
   end
+
+  describe "#next" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:policy_class) do
+      create(
+        :policy_class,
+        section: "1b",
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      %w[1a 2a 2b].each do |section|
+        create(
+          :policy_class,
+          section: section,
+          planning_application: planning_application
+        )
+      end
+    end
+
+    it "returns next policy class for the application ordered by section" do
+      expect(policy_class.next.section).to eq("2a")
+    end
+  end
+
+  describe "#previous" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:policy_class) do
+      create(
+        :policy_class,
+        section: "2a",
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      %w[1a 1b 2b].each do |section|
+        create(
+          :policy_class,
+          section: section,
+          planning_application: planning_application
+        )
+      end
+    end
+
+    it "returns previous policy class for the application ordered by section" do
+      expect(policy_class.previous.section).to eq("1b")
+    end
+  end
 end

--- a/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
 
   describe "#task_list_row" do
     context "when policy class status is 'complete'" do
-      let(:policy_class) { create(:policy_class, :complete) }
+      let(:policy_class) do
+        create(
+          :policy_class,
+          :complete,
+          planning_application: planning_application
+        )
+      end
 
       it "the task list row shows invalid status html" do
         html = presenter.task_list_row
@@ -20,11 +26,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         expect(html).to include("app-task-list__task-name")
 
         expect(html).to include(
-          link_to(
-            policy_class,
-            planning_application_policy_class_path(planning_application, policy_class),
-            class: "govuk-link"
-          )
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}\">Part 1, Class A</a>"
         )
 
         expect(html).to include(
@@ -34,7 +36,13 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
     end
 
     context "when policy class status is 'in_assessment'" do
-      let(:policy_class) { create(:policy_class, :in_assessment) }
+      let(:policy_class) do
+        create(
+          :policy_class,
+          :in_assessment,
+          planning_application: planning_application
+        )
+      end
 
       it "the task list row shows invalid status html" do
         html = presenter.task_list_row
@@ -42,11 +50,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         expect(html).to include("app-task-list__task-name")
 
         expect(html).to include(
-          link_to(
-            policy_class,
-            edit_planning_application_policy_class_path(planning_application, policy_class),
-            class: "govuk-link"
-          )
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}/edit\">Part 1, Class A</a>"
         )
 
         expect(html).to include(

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -10,12 +10,9 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
   let(:context) { ActionView::Base.new }
   let!(:planning_application) { create(:not_started_planning_application) }
 
-  it "delegates missing methods to its application" do
-    expect(presenter.id).to eq planning_application.id
-  end
-
-  it "advertises the methods it responds to" do
-    expect(presenter).to respond_to :id
+  it_behaves_like "Presentable" do
+    let(:presented) { create(:planning_application) }
+    let(:presenter) { described_class.new(view, presented) }
   end
 
   describe "#status_tag" do

--- a/spec/presenters/policy_class_presenter_spec.rb
+++ b/spec/presenters/policy_class_presenter_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PolicyClassPresenter, type: :presenter do
+  let(:presenter) { described_class.new(policy_class) }
+
+  it_behaves_like "Presentable" do
+    let(:presented) { create(:policy_class) }
+    let(:presenter) { described_class.new(presented) }
+  end
+
+  describe "#default_path" do
+    let(:planning_application) { create(:planning_application) }
+
+    context "when status is 'complete'" do
+      let(:policy_class) do
+        create(
+          :policy_class,
+          :complete,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns show path" do
+        expect(
+          presenter.default_path
+        ).to eq(
+          "/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}"
+        )
+      end
+    end
+
+    context "when status is 'in_assessment'" do
+      let(:policy_class) do
+        create(
+          :policy_class,
+          :in_assessment,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns edit path" do
+        expect(
+          presenter.default_path
+        ).to eq(
+          "/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}/edit"
+        )
+      end
+    end
+  end
+
+  describe "#previous" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:policy_class) do
+      create(
+        :policy_class,
+        section: "B",
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      create(
+        :policy_class,
+        section: "A",
+        planning_application: planning_application
+      )
+    end
+
+    it "returns record wrapped in presenter" do
+      expect(presenter.previous).to be_instance_of(described_class)
+    end
+
+    it "wraps previous record" do
+      expect(presenter.previous.section).to eq("A")
+    end
+  end
+
+  describe "#next" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:policy_class) do
+      create(
+        :policy_class,
+        section: "A",
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      create(
+        :policy_class,
+        section: "B",
+        planning_application: planning_application
+      )
+    end
+
+    it "returns record wrapped in presenter" do
+      expect(presenter.next).to be_instance_of(described_class)
+    end
+
+    it "wraps previous record" do
+      expect(presenter.next.section).to eq("B")
+    end
+  end
+end

--- a/spec/support/presentable_shared_examples.rb
+++ b/spec/support/presentable_shared_examples.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "Presentable" do
+  it "delegates missing methods to presented record" do
+    expect(presenter.id).to eq(presented.id)
+  end
+
+  it "advertises the methods it responds to" do
+    expect(presenter).to respond_to(:id)
+  end
+
+  it "delegates #to_param to presented record" do
+    expect(presenter.to_param).to eq(presented.to_param)
+  end
+end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -231,4 +231,66 @@ RSpec.describe "assessment against legislation", type: :system do
       "#policy_class_policies_attributes_0_status_does_not_comply"
     )
   end
+
+  it "lets the user scroll between policy classes" do
+    travel_to(Time.zone.local(2022, 9, 1))
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+    check("Class D - porches")
+
+    check(
+      "Class F - hard surfaces incidental to the enjoyment of a dwellinghouse"
+    )
+
+    click_button("Add classes")
+    click_link("Part 1, Class D")
+
+    expect(page).not_to have_content("Save changes and view previous class")
+
+    within(row_with_content("D.1a")) do
+      fill_in("Add comment", with: "Test comment")
+    end
+
+    click_button("Save changes and view next class")
+
+    expect(page).to have_content("Part 1, Class F")
+    expect(page).not_to have_content("Save changes and view next class")
+
+    click_button("Save changes and view previous class")
+
+    expect(page).to have_content("Part 1, Class D")
+
+    expect(page).to have_field(
+      "Comment added on 01 Sep 2022 by Alice Smith",
+      with: "Test comment"
+    )
+
+    choose("policy_class_policies_attributes_0_status_complies")
+    choose("policy_class_policies_attributes_1_status_complies")
+    choose("policy_class_policies_attributes_2_status_complies")
+    choose("policy_class_policies_attributes_3_status_complies")
+    choose("policy_class_policies_attributes_4_status_complies")
+    click_button("Save and mark as complete")
+    click_link("Part 1, Class F")
+    choose("policy_class_policies_attributes_0_status_complies")
+    choose("policy_class_policies_attributes_1_status_complies")
+    choose("policy_class_policies_attributes_2_status_complies")
+    choose("policy_class_policies_attributes_3_status_complies")
+    click_button("Save and mark as complete")
+    click_link("Part 1, Class D")
+
+    expect(page).not_to have_content("View previous class")
+
+    click_link("View next class")
+
+    expect(page).to have_content("Part 1, Class F")
+    expect(page).not_to have_content("View next class")
+
+    click_link("View previous class")
+
+    expect(page).to have_content("Part 1, Class D")
+  end
 end


### PR DESCRIPTION
### Description of change

- Add 'links' to scroll between policy classes.
- If policy class is not marked as complete 'link' is in fact a button which submits the form, saves any changes, and then redirects to the previous/next policy class.
- If policy class is marked as complete link is just a link to the next/previous policy class.

### Story Link

https://trello.com/c/90BX4FSz/1140-add-save-changes-and-view-next-previous-class-links-to-assess-legislation-page

### Screenshots

#### 'Complete' policy class:
<img width="65%" alt="Screenshot 2022-09-09 at 13 48 28" src="https://user-images.githubusercontent.com/25392162/189357778-0af82d89-f1cd-4ea9-8fb0-d315c87231c0.png">

#### Policy class still in assessment:
<img width="65%" alt="Screenshot 2022-09-09 at 13 48 52" src="https://user-images.githubusercontent.com/25392162/189357791-bf996a8e-a365-43b8-bea2-0d69d76eb2b7.png">

