### PR TITLE
Add button to delete policy comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class CommentsController < AuthenticationController
+  def destroy
+    policy.comment.destroy
+    render(json: { partial: comment_form })
+  end
+
+  private
+
+  def comment_form
+    render_to_string(
+      partial: "policy_classes/comment_form",
+      locals: {
+        comment: policy.build_comment,
+        policy_index: params[:policy_index]
+      }
+    )
+  end
+
+  def policy
+    @policy ||= policy_class.policies.find(params[:policy_id])
+  end
+
+  def policy_class
+    planning_application.policy_classes.find(params[:policy_class_id])
+  end
+
+  def planning_application
+    current_local_authority
+      .planning_applications
+      .find(params[:planning_application_id])
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,24 +39,24 @@ module ApplicationHelper
     if comment.persisted?
       existing_policy_comment_label(comment)
     else
-      t(".add_comment")
+      t("policy_classes.add_comment")
     end
   end
 
   def existing_policy_comment_label(comment)
-    user = comment.user.name
+    user_name = comment.user_name
 
     if comment.edited?
       t(
-        ".comment_updated_on",
+        "policy_classes.comment_updated_on",
         updated_at: comment.updated_at.strftime("%d %b %Y"),
-        user: user
+        user: user_name
       )
     else
       t(
-        ".comment_added_on",
+        "policy_classes.comment_added_on",
         created_at: comment.created_at.strftime("%d %b %Y"),
-        user: user
+        user: user_name
       )
     end
   end

--- a/app/javascript/controllers/delete_record_controller.js
+++ b/app/javascript/controllers/delete_record_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import { ajax } from "@rails/ujs"
+
+export default class extends Controller {
+  handleClick(event) {
+    ajax({
+      type: "delete",
+      url: event.currentTarget.dataset["deleteRecordPath"],
+      success: (data) => { this.element.outerHTML = data.partial }
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -3,6 +3,9 @@ import { application } from "./application"
 import ClearFormController from "./clear_form_controller.js"
 application.register("clear-form", ClearFormController)
 
+import DeleteRecordController from "./delete_record_controller.js"
+application.register("delete-record", DeleteRecordController)
+
 import ShowHideController from "./show_hide_controller.js"
 application.register("show-hide", ShowHideController)
 

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -241,6 +241,7 @@ html * {
 .button-as-link {
   border: none;
   background: none;
+  padding: 0;
   color: #1d70b8;
   font-size: 16px;
   text-decoration: underline;
@@ -278,5 +279,13 @@ html * {
 .next-policy-class-link {
   @media (min-width: 768px) {
     margin-left: auto;
+  }
+}
+
+.govuk-form-group.comment-form {
+  margin-bottom: 10px;
+
+  .govuk-textarea {
+    margin-bottom: 10px;
   }
 }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,6 +8,8 @@ class Comment < ApplicationRecord
 
   before_save :set_user
 
+  delegate :name, to: :user, prefix: true, allow_nil: true
+
   def edited?
     created_at != updated_at
   end

--- a/app/views/policy_classes/_comment_form.html.erb
+++ b/app/views/policy_classes/_comment_form.html.erb
@@ -1,0 +1,34 @@
+<%= content_tag(
+  :div,
+  class: "govuk-form-group comment-form",
+  data: { controller: "delete-record" }
+) do %>
+  <%= label_tag(
+    "policy-class-policies-attributes-#{policy_index}-comment-attributes-text-field",
+    policy_comment_label(comment),
+    class: "govuk-label govuk-label--s"
+  ) %>
+  <%= text_area_tag(
+    "policy_class[policies_attributes][#{policy_index}][comment_attributes][text]",
+    comment.text,
+    id: "policy-class-policies-attributes-#{policy_index}-comment-attributes-text-field",
+    class: "govuk-textarea",
+    rows: 2
+  ) %>
+  <% if comment.persisted? %>
+    <%= button_tag(
+      t(".delete_comment"),
+      class: "button-as-link",
+      type: "button",
+      data: {
+        action: "click->delete-record#handleClick",
+        delete_record_path: planning_application_policy_class_policy_comment_path(
+          planning_application,
+          policy_class,
+          policy,
+          policy_index: policy_index
+        )
+      }
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -42,19 +42,16 @@
                   <%= policy_form.object.description %>
                 </p>
                 <% if editable %>
-                  <%= policy_form.fields_for(
-                    :comment,
-                    policy_form.object.existing_or_new_comment
-                  ) do |comment_form| %>
-                    <%= comment_form.govuk_text_area(
-                      :text,
-                      label: {
-                        text: policy_comment_label(comment_form.object),
-                        size: "s"
-                      },
-                      rows: 2
-                    ) %>
-                  <% end %>
+                  <%= render(
+                    partial: "comment_form",
+                    locals: {
+                      planning_application: planning_application,
+                      policy_class: policy_class,
+                      policy: policy_form.object,
+                      comment: policy_form.object.existing_or_new_comment,
+                      policy_index: policy_form.options[:child_index]
+                    }
+                  ) %>
                 <% elsif comment = policy_form.object.comment.presence %>
                   <h4 class="govuk-heading-s policy-comment-title">
                     <%=existing_policy_comment_label(comment)%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -202,12 +202,14 @@ en:
     policy_class_name: Part %{part}, Class %{class} - %{name}
     to_be_determined: To be determined
   policy_classes:
+    add_comment: Add comment
+    comment_added_on: Comment added on %{created_at} by %{user}
+    comment_form:
+      delete_comment: Delete comment
+    comment_updated_on: Comment updated on %{updated_at} by %{user}
     complete: Complete
     form:
-      add_comment: Add comment
       back: Back
-      comment_added_on: Comment added on %{created_at} by %{user}
-      comment_updated_on: Comment updated on %{updated_at} by %{user}
       complies: Complies
       does_not_comply: Does not comply
       edit_assessment: Edit assessment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,10 @@ Rails.application.routes.draw do
   resources :planning_applications, only: %i[index show new edit create update] do
     resources :policy_classes, except: %i[index] do
       get :part, on: :new
+
+      resources :policies, only: [] do
+        resource :comment, only: %i[destroy]
+      end
     end
 
     resources :recommendations, only: %i[new create update]

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -67,11 +67,7 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "lets the user add policy classes once only" do
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-    check("Class D - porches")
-    click_button("Add classes")
+    add_policy_classes(["Class D - porches"])
 
     expect(page).to have_content("Part 1, Class D").once
 
@@ -89,18 +85,12 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "displays the class title" do
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-
-    check(
-      "Class A - enlargement, improvement or other alteration of a dwellinghouse"
+    add_policy_classes(
+      [
+        "Class A - enlargement, improvement or other alteration of a dwellinghouse",
+        "Class B - additions etc to the roof of a dwellinghouse"
+      ]
     )
-    check(
-      "Class B - additions etc to the roof of a dwellinghouse"
-    )
-
-    click_button("Add classes")
 
     click_link("Part 1, Class A")
     expect(page).to have_content("Class title - enlargement, improvement or other alteration of a dwellinghouse")
@@ -118,11 +108,7 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user add and update comments" do
     travel_to(Time.zone.local(2022, 9, 1))
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-    check("Class D - porches")
-    click_button("Add classes")
+    add_policy_classes(["Class D - porches"])
     click_link("Part 1, Class D")
 
     within(row_with_content("D.1a")) do
@@ -164,13 +150,7 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user save draft and then mark as complete" do
     travel_to(Time.zone.local(2022, 9, 1))
-    visit(planning_application_path(planning_application))
-    click_link("Check and assess")
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-    check("Class D - porches")
-    click_button("Add classes")
+    add_policy_classes(["Class D - porches"])
     click_link("Part 1, Class D")
 
     within(row_with_content("D.1a")) do
@@ -234,18 +214,14 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user scroll between policy classes" do
     travel_to(Time.zone.local(2022, 9, 1))
-    visit(planning_application_path(planning_application))
-    click_link("Check and assess")
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-    check("Class D - porches")
 
-    check(
-      "Class F - hard surfaces incidental to the enjoyment of a dwellinghouse"
+    add_policy_classes(
+      [
+        "Class D - porches",
+        "Class F - hard surfaces incidental to the enjoyment of a dwellinghouse"
+      ]
     )
 
-    click_button("Add classes")
     click_link("Part 1, Class D")
 
     expect(page).not_to have_content("Save changes and view previous class")
@@ -292,5 +268,46 @@ RSpec.describe "assessment against legislation", type: :system do
     click_link("View previous class")
 
     expect(page).to have_content("Part 1, Class D")
+  end
+
+  it "lets the user delete comments" do
+    travel_to(Time.zone.local(2022, 9, 1))
+    add_policy_classes(["Class D - porches"])
+    click_link("Part 1, Class D")
+
+    within(row_with_content("D.1a")) do
+      fill_in("Add comment", with: "Test comment")
+    end
+
+    click_button("Save and come back later")
+    click_link("Part 1, Class D")
+
+    within(row_with_content("D.1a")) do
+      expect(page).to have_field(
+        "Comment added on 01 Sep 2022 by Alice Smith",
+        with: "Test comment"
+      )
+
+      click_button("Delete comment")
+      fill_in("Add comment", with: "New comment")
+    end
+
+    click_button("Save and come back later")
+    click_link("Part 1, Class D")
+
+    within(row_with_content("D.1a")) do
+      expect(page).to have_field(
+        "Comment added on 01 Sep 2022 by Alice Smith",
+        with: "New comment"
+      )
+    end
+  end
+
+  def add_policy_classes(policy_classes)
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+    policy_classes.each { |policy_class| check(policy_class) }
+    click_button("Add classes")
   end
 end


### PR DESCRIPTION
### Description of change

- Add 'Delete comment' button to each comment in form.
- Button triggers javascript that makes delete comment request and refreshes the comment field partial.

### Story Link

https://trello.com/c/IFJqyJTg/1192-delete-comment-button-for-each-comment-on-assess-legislation-page

### Screenshots

<img width="65%" alt="Screenshot 2022-09-13 at 10 55 28" src="https://user-images.githubusercontent.com/25392162/189872761-13255f70-30d8-4e32-b27e-11ff4783bb2c.png">
