### PR TITLE
Add consistency checklist to assessment tasks

### DIFF
--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -7,6 +7,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
   before_action :ensure_planning_application_not_validated, only: %i[edit update]
   before_action :ensure_planning_application_not_invalidated, only: :edit
+  before_action :set_return_to, only: %i[new]
 
   def new
     @additional_document_validation_request = @planning_application.additional_document_validation_requests.new
@@ -24,7 +25,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
       if @additional_document_validation_request.save
         format.html do
           redirect_to(
-            create_request_redirect_url,
+            (session.delete(:return_to) || create_request_redirect_url),
             notice: I18n.t("additional_document_validation_requests.create.success")
           )
         end

--- a/app/controllers/concerns/commit_matchable.rb
+++ b/app/controllers/concerns/commit_matchable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CommitMatchable
+  extend ActiveSupport::Concern
+
+  def commit_matches?(regex)
+    params[:commit]&.downcase&.match(regex).present?
+  end
+end

--- a/app/controllers/consistency_checklists_controller.rb
+++ b/app/controllers/consistency_checklists_controller.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class ConsistencyChecklistsController < AuthenticationController
+  include CommitMatchable
+
+  before_action :set_planning_application
+  before_action :set_consistency_checklist, except: %i[new create]
+
+  def new
+    @consistency_checklist = @planning_application.build_consistency_checklist
+  end
+
+  def create
+    @consistency_checklist = @planning_application.build_consistency_checklist(
+      consistency_checklist_params
+    )
+
+    if @consistency_checklist.save
+      redirect_to(
+        after_save_path,
+        notice: t(".successfully_updated_application")
+      )
+    else
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @consistency_checklist.update(consistency_checklist_params)
+      redirect_to(
+        after_save_path,
+        notice: t(".successfully_updated_application")
+      )
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+  private
+
+  def set_consistency_checklist
+    @consistency_checklist = @planning_application.consistency_checklist
+  end
+
+  def consistency_checklist_params
+    params
+      .require(:consistency_checklist)
+      .permit(permitted_params)
+      .merge(status: status)
+  end
+
+  def permitted_params
+    %i[
+      description_matches_documents
+      documents_consistent
+      proposal_details_match_documents
+      proposal_details_match_documents_comment
+    ]
+  end
+
+  def after_save_path
+    if commit_matches?(/new document/)
+      new_planning_application_additional_document_validation_request_path(
+        @planning_application,
+        consistency_checklist: true
+      )
+    elsif commit_matches?(/change to the description/)
+      new_planning_application_description_change_validation_request_path(
+        @planning_application,
+        consistency_checklist: true
+      )
+    else
+      planning_application_assessment_tasks_path(@planning_application)
+    end
+  end
+
+  def status
+    commit_matches?(/mark as complete/) ? :complete : :in_assessment
+  end
+end

--- a/app/controllers/description_change_validation_requests_controller.rb
+++ b/app/controllers/description_change_validation_requests_controller.rb
@@ -3,6 +3,7 @@
 class DescriptionChangeValidationRequestsController < ValidationRequestsController
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
   before_action :set_description_change_request, only: %i[show cancel]
+  before_action :set_return_to, only: %i[new show]
 
   def new
     @description_change_request = @planning_application.description_change_validation_requests.new
@@ -14,7 +15,10 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
     @current_local_authority = current_local_authority
 
     if @description_change_request.save
-      redirect_to planning_application_path(@planning_application), notice: "Description change request successfully sent."
+      redirect_to(
+        (session.delete(:return_to) || @planning_application),
+        notice: "Description change request successfully sent."
+      )
     else
       render :new
     end
@@ -29,7 +33,10 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
       @description_change_request.audit_cancel!
     end
 
-    redirect_to @planning_application, notice: "Description change request successfully cancelled."
+    redirect_to(
+      (session.delete(:return_to) || @planning_application),
+      notice: "Description change request successfully cancelled."
+    )
   end
 
   private

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PolicyClassesController < PlanningApplicationsController
+  include CommitMatchable
+
   before_action :set_planning_application
   before_action :set_policy_class, only: %i[edit show update destroy]
   before_action :ensure_can_assess_planning_application, only: %i[part new create]
@@ -99,9 +101,5 @@ class PolicyClassesController < PlanningApplicationsController
 
   def status
     commit_matches?(/mark as complete/) ? :complete : :in_assessment
-  end
-
-  def commit_matches?(regex)
-    params[:commit].downcase.match(regex).present?
   end
 end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class RecommendationsController < AuthenticationController
+  include CommitMatchable
+
   before_action :set_planning_application, only: %i[new create]
   before_action :set_planning_application_with_recommendations, only: %i[edit update]
   before_action :ensure_user_is_reviewer, only: %i[update edit]
@@ -85,11 +87,7 @@ class RecommendationsController < AuthenticationController
     params
       .require(:recommendation_form)
       .permit(:decision, :public_comment, :assessor_comment)
-      .merge(assessor: current_user, save_progress: save_progress?)
-  end
-
-  def save_progress?
-    params[:commit]&.downcase&.match(/save/).present?
+      .merge(assessor: current_user, save_progress: commit_matches?(/save/))
   end
 
   def render_failed_edit(error)

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -35,6 +35,12 @@ class ValidationRequestsController < AuthenticationController
 
   private
 
+  def set_return_to
+    return if params[:consistency_checklist].blank?
+
+    session[:return_to] = edit_planning_application_consistency_checklist_path(@planning_application)
+  end
+
   def ensure_planning_application_not_validated
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_validate?
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,4 +60,14 @@ module ApplicationHelper
       )
     end
   end
+
+  def consistency_checklist_path(consistency_checklist)
+    if consistency_checklist.blank?
+      new_planning_application_consistency_checklist_path
+    elsif consistency_checklist.in_assessment?
+      edit_planning_application_consistency_checklist_path
+    else
+      planning_application_consistency_checklist_path
+    end
+  end
 end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -289,3 +289,14 @@ html * {
     margin-bottom: 10px;
   }
 }
+
+.consistency-checklist-form {
+  .govuk-radios__conditional {
+    margin-bottom: 0
+  }
+
+  .govuk-body-s {
+    margin-top: 20px;
+    margin-bottom: 0px;
+  }
+}

--- a/app/models/additional_document_validation_request.rb
+++ b/app/models/additional_document_validation_request.rb
@@ -52,6 +52,10 @@ class AdditionalDocumentValidationRequest < ApplicationRecord
     may_cancel? && (planning_application.invalidated? || post_validation?)
   end
 
+  def document
+    @document ||= documents.order(:created_at).last
+  end
+
   private
 
   def audit_upload_files!

--- a/app/models/concerns/validation_requestable.rb
+++ b/app/models/concerns/validation_requestable.rb
@@ -211,7 +211,18 @@ module ValidationRequestable
     validation_request.update!(update_counter: true)
   end
 
+  def sent_by
+    audits.find_by(activity_type: send_events, activity_information: sequence).user
+  end
+
   private
+
+  def send_events
+    [
+      "#{self.class.name.underscore}_sent_post_validation",
+      "#{self.class.name.underscore}_sent"
+    ]
+  end
 
   def create_audit_for!(event)
     audit!(

--- a/app/models/consistency_checklist.rb
+++ b/app/models/consistency_checklist.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class ConsistencyChecklist < ApplicationRecord
+  belongs_to :planning_application
+
+  with_options if: :complete? do
+    validate :description_matches_documents_determined
+    validate :proposal_details_match_documents_determined
+    validate :documents_consistent_determined
+    validate :description_change_requests_closed
+    validate :additional_document_requests_closed
+  end
+
+  enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
+
+  enum(
+    description_matches_documents: {
+      to_be_determined: 0,
+      yes: 1,
+      no: 2
+    },
+    _default: :to_be_determined,
+    _prefix: :description_matches_documents
+  )
+
+  enum(
+    documents_consistent: {
+      to_be_determined: 0,
+      yes: 1,
+      no: 2
+    },
+    _default: :to_be_determined,
+    _prefix: :documents_consistent
+  )
+
+  enum(
+    proposal_details_match_documents: {
+      to_be_determined: 0,
+      yes: 1,
+      no: 2
+    },
+    _default: :to_be_determined,
+    _prefix: :proposal_details_match_documents
+  )
+
+  private
+
+  def description_matches_documents_determined
+    return unless description_matches_documents_to_be_determined?
+
+    errors.add(:description_matches_documents, :not_determined)
+  end
+
+  def proposal_details_match_documents_determined
+    return unless proposal_details_match_documents_to_be_determined?
+
+    errors.add(:proposal_details_match_documents, :not_determined)
+  end
+
+  def documents_consistent_determined
+    return unless documents_consistent_to_be_determined?
+
+    errors.add(:documents_consistent, :not_determined)
+  end
+
+  def description_change_requests_closed
+    return unless open_description_change_requests?
+
+    errors.add(
+      :description_matches_documents,
+      :open_description_change_requests
+    )
+  end
+
+  def additional_document_requests_closed
+    return unless open_additional_document_requests?
+
+    errors.add(:documents_consistent, :open_additional_document_requests)
+  end
+
+  def open_description_change_requests?
+    planning_application.description_change_validation_requests.open.any?
+  end
+
+  def open_additional_document_requests?
+    planning_application.additional_document_validation_requests.open.any?
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -41,6 +41,8 @@ class PlanningApplication < ApplicationRecord
       dependent: :destroy,
       inverse_of: :planning_application
     )
+
+    has_one :consistency_checklist, dependent: :destroy
   end
 
   delegate :reviewer_group_email, to: :local_authority

--- a/app/views/additional_document_validation_requests/_additional_document_validation_requests_table.html.erb
+++ b/app/views/additional_document_validation_requests/_additional_document_validation_requests_table.html.erb
@@ -1,7 +1,7 @@
 <table class="govuk-table" id="additional-document-validation-requests-table">
   <tbody class="govuk-table__body">
     <% validation_requests.each do |validation_request| %>
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row" id=<%= dom_id(validation_request) %>>
         <td class="govuk-table__cell govuk-!-width-one-third">
           <%= image_pack_tag("placeholder/blank_image.png", alt: "Blank image", width: 180, height: 220) %>
         </td>

--- a/app/views/consistency_checklists/_additional_document_validation_request.html.erb
+++ b/app/views/consistency_checklists/_additional_document_validation_request.html.erb
@@ -1,0 +1,29 @@
+<p class="govuk-body-s">
+  <%= t(".requested_a_new", name: request.sent_by&.name) %><br>
+  <%= request.document_request_type %><br>
+  <%= t(".reason", reason: request.document_request_reason) %><br>
+  <%= t(".requested", time: request.created_at) %><br>
+  <% if request.cancelled? %>
+    <%= t(".cancelled", time: request.cancelled_at) %><br>
+  <% elsif document = request.document.presence %>
+    <%= t(".responded", time: document.created_at) %><br>
+    <%= link_to(
+      t(".view_new_document"),
+      planning_application_documents_path(
+        planning_application,
+        anchor: dom_id(document)
+      ),
+      class: "govuk-link"
+    ) %>
+  <% end %>
+</p>
+<% if request.open? %>
+  <%= link_to(
+    t(".view_and_edit"),
+    planning_application_documents_path(
+      planning_application,
+      anchor: dom_id(request)
+    ),
+    class: "govuk-link"
+  ) %>
+<% end %>

--- a/app/views/consistency_checklists/_description_change_validation_request.html.erb
+++ b/app/views/consistency_checklists/_description_change_validation_request.html.erb
@@ -1,0 +1,23 @@
+<p class="govuk-body-s">
+  <%= t(".requested_a_new", name: request.sent_by.name) %><br>
+  <%= t(".proposed_description", description: request.proposed_description)%><br>
+  <%= t(".proposed", time: request.created_at) %><br>
+  <% if request.auto_closed? %>
+    <%= t(".accepted", time: request.auto_closed_at) %><br>
+  <% elsif request.approved? %>
+    <%= t(".accepted", time: request.closed_at) %><br>
+  <% elsif request.cancelled? %>
+    <%= t(".cancelled", time: request.cancelled_at) %><br>
+  <% end %>
+</p>
+<% if request.open? %>
+  <%= link_to(
+    t(".view_and_edit"),
+    planning_application_description_change_validation_request_path(
+      planning_application,
+      request,
+      consistency_checklist: true
+    ),
+    class: "govuk-link"
+  ) %>
+<% end %>

--- a/app/views/consistency_checklists/_description_matches_documents.html.erb
+++ b/app/views/consistency_checklists/_description_matches_documents.html.erb
@@ -1,0 +1,43 @@
+<%= form.govuk_radio_buttons_fieldset(
+  :description_matches_documents,
+  legend: { text: t(".does_the_description"), size: "s" }
+) do %>
+  <% if can_edit %>
+    <%= form.govuk_radio_button(
+      :description_matches_documents,
+      :yes,
+      label: { text: t(".yes") },
+      link_errors: true
+    ) %>
+    <%= form.govuk_radio_button(
+      :description_matches_documents,
+      :no,
+      label: { text: t(".no") }
+    ) do %>
+      <% unless planning_application.description_change_validation_requests.open.any? %>
+        <%= form.submit(
+          t(".request_a_change"),
+          class: "button-as-link"
+        ) %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= form.govuk_radio_button(
+      :description_matches_documents,
+      consistency_checklist.description_matches_documents,
+      label: {
+        text: t(".#{consistency_checklist.description_matches_documents}")
+      },
+      disabled: true
+    ) %>
+  <% end %>
+  <% if request = planning_application.description_change_validation_requests.post_validation.order(:created_at).last.presence %>
+    <%= render(
+      partial: "description_change_validation_request",
+      locals: {
+        request: request,
+        planning_application: planning_application
+      }
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/consistency_checklists/_documents_consistent.html.erb
+++ b/app/views/consistency_checklists/_documents_consistent.html.erb
@@ -1,0 +1,33 @@
+<%= form.govuk_radio_buttons_fieldset(
+  :documents_consistent,
+  legend: { text: t(".are_the_plans"), size: "s" }
+) do %>
+  <% if can_edit %>
+    <%= form.govuk_radio_button(
+      :documents_consistent,
+      :yes,
+      label: { text: t(".yes") },
+      link_errors: true
+    ) %>
+    <%= form.govuk_radio_button(
+      :documents_consistent,
+      :no,
+      label: { text: t(".no") }
+    ) do %>
+      <%= form.submit(t(".request_a_new"), class: "button-as-link") %>
+    <% end %>
+  <% else %>
+    <%= form.govuk_radio_button(
+      :documents_consistent,
+      consistency_checklist.documents_consistent,
+      label: { text: t(".#{consistency_checklist.documents_consistent}") },
+      disabled: true
+    ) %>
+  <% end %>
+  <% planning_application.additional_document_validation_requests.post_validation.order(:created_at).each do |request| %>
+    <%= render(
+      partial: "additional_document_validation_request",
+      locals: { request: request, planning_application: planning_application }
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/consistency_checklists/_form.html.erb
+++ b/app/views/consistency_checklists/_form.html.erb
@@ -1,0 +1,58 @@
+<%= form_with(
+  model: [planning_application, consistency_checklist],
+  url: planning_application_consistency_checklist_path(planning_application),
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  class: "consistency-checklist-form"
+) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= render(
+    partial: "description_matches_documents",
+    locals: {
+      form: form,
+      consistency_checklist: consistency_checklist,
+      planning_application: planning_application,
+      can_edit: can_edit
+    }
+  ) %>
+  <%= render(
+    partial: "documents_consistent",
+    locals: {
+      form: form,
+      consistency_checklist: consistency_checklist,
+      planning_application: planning_application,
+      can_edit: can_edit
+    }
+  ) %>
+  <%= render(
+    partial: "proposal_details_match_documents",
+    locals: {
+      form: form,
+      can_edit: can_edit,
+      consistency_checklist: consistency_checklist
+    }
+  ) %>
+  <div class="govuk-button-group">
+    <% if can_edit %>
+      <%= form.submit(
+        t(".save_and_mark"),
+        class: "govuk-button"
+      ) %>
+      <%= form.submit(
+        t(".save_and_come"),
+        class: "govuk-button govuk-button--secondary"
+      ) %>
+    <% end %>
+    <%= link_to(
+      t(".back"),
+      planning_application_assessment_tasks_path(planning_application),
+      class: "govuk-button govuk-button--secondary"
+    ) %>
+    <% unless can_edit %>
+      <%= link_to(
+        t(".edit_check_description"),
+        edit_planning_application_consistency_checklist_path(planning_application),
+        class: "govuk-link"
+      ) %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/consistency_checklists/_introduction.html.erb
+++ b/app/views/consistency_checklists/_introduction.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  <%= t(".check_description_documents") %> - <%= t("page_title") %>
+<% end %>
+<%= render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: { planning_application: planning_application  }
+) %>
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: t(".check_description_documents")  }
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds application">
+    <%= render("shared/application_information") %>
+    <%= yield %>
+  </div>
+  <div class="govuk-grid-column-one-third supporting">
+    <%= render("shared/supporting_information", show_cancel_link: false) %>
+  </div>
+</div>

--- a/app/views/consistency_checklists/_proposal_details_match_documents.html.erb
+++ b/app/views/consistency_checklists/_proposal_details_match_documents.html.erb
@@ -1,0 +1,39 @@
+<%= form.govuk_radio_buttons_fieldset(
+  :proposal_details_match_documents,
+  legend: { text: t(".are_the_proposal"), size: "s" }
+) do %>
+  <% if can_edit %>
+    <%= form.govuk_radio_button(
+      :proposal_details_match_documents,
+      :yes,
+      label: { text: t(".yes") },
+      link_errors: true
+    ) %>
+    <%= form.govuk_radio_button(
+      :proposal_details_match_documents,
+      :no,
+      label: { text: t(".no") }
+    ) do %>
+      <% form.govuk_text_area(
+        :proposal_details_match_documents_comment,
+        label: { text: t(".how_are_the") },
+        rows: 6
+      ) %>
+    <% end %>
+  <% else %>
+    <%= form.govuk_radio_button(
+      :proposal_details_match_documents,
+      consistency_checklist.proposal_details_match_documents,
+      label: {
+        text: t(".#{consistency_checklist.proposal_details_match_documents}")
+      },
+      disabled: true
+    ) %>
+  <% end %>
+<% end %>
+<% unless can_edit || consistency_checklist.proposal_details_match_documents_yes?  %>
+  <h4 class="govuk-heading-s"><%= t(".how_are_the") %></h4>
+  <p class="govuk-body">
+    <%= consistency_checklist.proposal_details_match_documents_comment %>
+  <p>
+<% end %>

--- a/app/views/consistency_checklists/edit.html.erb
+++ b/app/views/consistency_checklists/edit.html.erb
@@ -1,0 +1,13 @@
+<%= render(
+  layout: "introduction",
+  locals: { planning_application: @planning_application }
+) do %>
+  <%= render(
+    partial: "form",
+    locals: {
+      planning_application: @planning_application,
+      consistency_checklist: @consistency_checklist,
+      can_edit: true
+    }
+  ) %>
+<% end %>

--- a/app/views/consistency_checklists/new.html.erb
+++ b/app/views/consistency_checklists/new.html.erb
@@ -1,0 +1,13 @@
+<%= render(
+  layout: "introduction",
+  locals: { planning_application: @planning_application }
+) do %>
+  <%= render(
+    partial: "form",
+    locals: {
+      planning_application: @planning_application,
+      consistency_checklist: @consistency_checklist,
+      can_edit: true
+    }
+  ) %>
+<% end %>

--- a/app/views/consistency_checklists/show.html.erb
+++ b/app/views/consistency_checklists/show.html.erb
@@ -1,0 +1,13 @@
+<%= render(
+  layout: "introduction",
+  locals: { planning_application: @planning_application }
+) do %>
+  <%= render(
+    partial: "form",
+    locals: {
+      planning_application: @planning_application,
+      consistency_checklist: @consistency_checklist,
+      can_edit: false
+    }
+  ) %>
+<% end %>

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -60,7 +60,11 @@
       rows: 5 %>
         <div class="govuk-button-group">
           <%= form.govuk_submit "Send" %>
-          <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+          <%= link_to(
+            "Back",
+            :back,
+            class: "govuk-button govuk-button--secondary"
+          ) %>
         </div>
       <% end %>
     </div>

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -1,7 +1,7 @@
 <table class="govuk-table current-documents">
   <tbody class="govuk-table__body">
     <% documents.each do |document| %>
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row" id=<%= dom_id(document) %>>
         <td class="govuk-table__cell govuk-!-width-one-quarter">
           <%= render "documents/document_row_image", document: document, resize: "500x500", width: 180, height: 120, edit_and_archive: false %>
         </td>

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -1,12 +1,21 @@
 <li id="check-consistency-assessment-tasks">
   <h2 class="app-task-list__section">
-    Check consistency
+    <%= t(".check_application") %>
   </h2>
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
-        Description, documents and proposal details
+        <%= link_to(
+        t(".description_documents_and"),
+        consistency_checklist_path(consistency_checklist),
+        class: "govuk-link"
+        ) %>
       </span>
+      <%= content_tag(
+      :strong,
+      t(".#{consistency_checklist&.status || 'in_assessment'}"),
+      class: "govuk-tag app-task-list__task-tag #{'govuk-tag--blue' if consistency_checklist&.complete?}"
+      ) %>
     </li>
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">

--- a/app/views/planning_application/assessment_tasks/index.html.erb
+++ b/app/views/planning_application/assessment_tasks/index.html.erb
@@ -25,8 +25,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <ol class="app-task-list">
-      <%= render "check_consistency" %>
-
+      <%= render(
+        partial: "check_consistency",
+        locals: {
+          consistency_checklist: @planning_application.consistency_checklist
+        }
+      ) %>
       <%= render "assessment_information" %>
 
       <%= render "assess_against_legislation" %>

--- a/app/views/shared/_assessment_task_breadcrumbs.html.erb
+++ b/app/views/shared/_assessment_task_breadcrumbs.html.erb
@@ -1,0 +1,12 @@
+<% add_parent_breadcrumb_link(
+  t(".home"),
+  planning_applications_path
+) %>
+<% add_parent_breadcrumb_link(
+  t(".application"),
+  planning_application_path(planning_application)
+) %>
+<% add_parent_breadcrumb_link(
+   t(".assess_application"), 
+   planning_application_assessment_tasks_path(planning_application)
+) %>

--- a/app/views/shared/_supporting_information.html.erb
+++ b/app/views/shared/_supporting_information.html.erb
@@ -175,7 +175,7 @@
     </div>
   </div>
 </div>
-<% if @planning_application.in_progress? %>
+<% if @planning_application.in_progress? && local_assigns.fetch(:show_cancel_link, true) %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full cancel">
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,16 @@ en:
   activerecord:
     errors:
       models:
+        consistency_checklist:
+          attributes:
+            description_matches_documents:
+              not_determined: Determine whether the description matches the development or use in the plans
+              open_description_change_requests: Description change requests must be closed or cancelled
+            documents_consistent:
+              not_determined: Determine whether the plans are consistent with each other
+              open_additional_document_requests: Additional document requests must be closed or cancelled
+            proposal_details_match_documents:
+              not_determined: Determine whether the proposal details are consistent with the plans
         document:
           attributes:
             file:
@@ -74,6 +84,48 @@ en:
         auto_closed_validation: 'Auto-closed: validation request (description#%{sequence})'
       red_line_boundary_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (red line boundary#%{sequence})'
+  consistency_checklists:
+    additional_document_validation_request:
+      cancelled: Cancelled %{time}
+      reason: 'Reason: %{reason}'
+      requested: Requested %{time}
+      requested_a_new: "%{name} requested a new document"
+      responded: Responded %{time}
+      view_and_edit: View and edit request
+      view_new_document: View new document
+    create:
+      successfully_updated_application: Successfully updated application checklist
+    description_change_validation_request:
+      accepted: Accepted %{time}
+      cancelled: Cancelled %{time}
+      proposed: Proposed %{time}
+      proposed_description: 'Proposed description: %{description}'
+      requested_a_new: "%{name} requested a new description"
+      view_and_edit: View and edit request
+    description_matches_documents:
+      does_the_description: Does the description match the development or use in the plans?
+      'no': 'No'
+      request_a_change: Request a change to the description
+      'yes': 'Yes'
+    documents_consistent:
+      are_the_plans: Are the plans consistent with each other?
+      'no': 'No'
+      request_a_new: Request a new document
+      'yes': 'Yes'
+    form:
+      back: Back
+      edit_check_description: Edit check description, documents and proposal
+      save_and_come: Save and come back later
+      save_and_mark: Save and mark as complete
+    introduction:
+      check_description_documents: Check description, documents, proposal details
+    proposal_details_match_documents:
+      are_the_proposal: Are the proposal details consistent with the plans?
+      how_are_the: How are the proposal details inconsistent?
+      'no': 'No'
+      'yes': 'Yes'
+    update:
+      successfully_updated_application: Successfully updated application checklist
   council_code:
     buckinghamshire: BUC
     lambeth: LBH
@@ -175,6 +227,13 @@ en:
         suggestion: Tell the applicant how the fee can be made valid.
         summary: Tell the applicant why the fee is incorrect.
   page_title: BETA BOPs - GOV.UK
+  planning_application:
+    assessment_tasks:
+      check_consistency:
+        check_application: Check application
+        complete: Complete
+        description_documents_and: Description, documents and proposal details
+        in_assessment: In assessment
   planning_application_panel_component:
     all: All
     all_applications: All applications
@@ -299,6 +358,10 @@ en:
       this_information_will_not: This information WILL NOT appear on the decision notice or the public register, however FOI still apply.
       update_assessment: Update assessment
       'yes': 'Yes'
+    assessment_task_breadcrumbs:
+      application: Application
+      assess_application: Assess application
+      home: Home
     back_to_top_link:
       back_to_top: Back to top
     proposal_header:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,8 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create edit update]
 
   resources :planning_applications, only: %i[index show new edit create update] do
+    resource(:consistency_checklist, only: %i[new create edit update show])
+
     resources :policy_classes, except: %i[index] do
       get :part, on: :new
 

--- a/db/migrate/20220914061734_create_consistency_checklists.rb
+++ b/db/migrate/20220914061734_create_consistency_checklists.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateConsistencyChecklists < ActiveRecord::Migration[6.1]
+  def change
+    create_table :consistency_checklists do |t|
+      t.integer :status, null: false
+      t.integer :description_matches_documents, null: false
+      t.integer :documents_consistent, null: false
+      t.integer :proposal_details_match_documents, null: false
+      t.text :proposal_details_match_documents_comment
+      t.references :planning_application
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_07_161526) do
+ActiveRecord::Schema.define(version: 2022_09_14_061734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,6 +90,18 @@ ActiveRecord::Schema.define(version: 2022_09_07_161526) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["policy_id"], name: "ix_comments_on_policy_id"
     t.index ["user_id"], name: "ix_comments_on_user_id"
+  end
+
+  create_table "consistency_checklists", force: :cascade do |t|
+    t.integer "status", null: false
+    t.integer "description_matches_documents", null: false
+    t.integer "documents_consistent", null: false
+    t.integer "proposal_details_match_documents", null: false
+    t.text "proposal_details_match_documents_comment"
+    t.bigint "planning_application_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "ix_consistency_checklists_on_planning_application_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/factories/additional_document_validation_requests.rb
+++ b/spec/factories/additional_document_validation_requests.rb
@@ -10,8 +10,13 @@ FactoryBot.define do
     post_validation { false }
 
     trait :with_documents do
-      before(:create) do |additional_document_validation_request|
-        additional_document_validation_request.documents << create(:document)
+      before(:create) do |request|
+        document = create(
+          :document,
+          planning_application: request.planning_application
+        )
+
+        request.documents << document
       end
     end
 

--- a/spec/factories/consistency_checklist.rb
+++ b/spec/factories/consistency_checklist.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :consistency_checklist do
+    planning_application
+
+    trait :complete do
+      status { :complete }
+    end
+
+    trait :in_assessment do
+      status { :in_assessment }
+    end
+
+    trait :all_checks_assessed do
+      description_matches_documents { :yes }
+      documents_consistent { :yes }
+      proposal_details_match_documents { :yes }
+    end
+  end
+end

--- a/spec/models/additional_document_validation_request_spec.rb
+++ b/spec/models/additional_document_validation_request_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe AdditionalDocumentValidationRequest, type: :model do
     let(:subject) { create(:additional_document_validation_request) }
   end
 
+  it_behaves_like("ValidationRequestable")
+
   describe "validations" do
     subject(:additional_document_validation_request) { described_class.new }
 

--- a/spec/models/consistency_checklist_spec.rb
+++ b/spec/models/consistency_checklist_spec.rb
@@ -1,0 +1,271 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConsistencyChecklist, type: :model do
+  describe "#valid?" do
+    let(:planning_application) { build(:planning_application) }
+
+    it "is true for factory" do
+      expect(build(:consistency_checklist).valid?).to eq(true)
+    end
+
+    context "when status is 'complete'" do
+      let(:consistency_checklist) do
+        build(
+          :consistency_checklist,
+          :complete,
+          :all_checks_assessed,
+          planning_application: planning_application
+        )
+      end
+
+      context "when there are open description change requests" do
+        before do
+          create(
+            :description_change_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:description_matches_documents]
+          ).to contain_exactly(
+            "Description change requests must be closed or cancelled"
+          )
+        end
+      end
+
+      context "when there are open additional document requests" do
+        before do
+          create(
+            :additional_document_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:documents_consistent]
+          ).to contain_exactly(
+            "Additional document requests must be closed or cancelled"
+          )
+        end
+      end
+
+      context "when all requests are closed" do
+        before do
+          create(
+            :additional_document_validation_request,
+            :closed,
+            planning_application: planning_application
+          )
+
+          create(
+            :description_change_validation_request,
+            :closed,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+
+      context "when description_matches_documents is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            description_matches_documents: :to_be_determined,
+            documents_consistent: :yes,
+            proposal_details_match_documents: :yes
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:description_matches_documents]
+          ).to contain_exactly(
+            "Determine whether the description matches the development or use in the plans"
+          )
+        end
+      end
+
+      context "when proposal_details_match_documents is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            description_matches_documents: :yes,
+            documents_consistent: :yes,
+            proposal_details_match_documents: :to_be_determined
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:proposal_details_match_documents]
+          ).to contain_exactly(
+            "Determine whether the proposal details are consistent with the plans"
+          )
+        end
+      end
+
+      context "when documents_consistent is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            description_matches_documents: :yes,
+            documents_consistent: :to_be_determined,
+            proposal_details_match_documents: :yes
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to eq(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:documents_consistent]
+          ).to contain_exactly(
+            "Determine whether the plans are consistent with each other"
+          )
+        end
+      end
+
+      context "when all checks are determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            :all_checks_assessed
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+    end
+
+    context "when status is 'in_assessment'" do
+      let(:consistency_checklist) do
+        build(
+          :consistency_checklist,
+          :in_assessment,
+          :all_checks_assessed,
+          planning_application: planning_application
+        )
+      end
+
+      context "when there are open description change requests" do
+        before do
+          create(
+            :description_change_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+
+      context "when there are open additional document requests" do
+        before do
+          create(
+            :additional_document_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+
+      context "when description_matches_documents is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :in_assessment,
+            description_matches_documents: :to_be_determined,
+            documents_consistent: :yes,
+            proposal_details_match_documents: :yes
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+
+      context "when proposal_details_match_documents is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :in_assessment,
+            description_matches_documents: :yes,
+            documents_consistent: :yes,
+            proposal_details_match_documents: :to_be_determined
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+
+      context "when documents_consistent is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :in_assessment,
+            description_matches_documents: :yes,
+            documents_consistent: :to_be_determined,
+            proposal_details_match_documents: :yes
+          )
+        end
+
+        it "returns true" do
+          expect(consistency_checklist.valid?).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/description_change_validation_request_spec.rb
+++ b/spec/models/description_change_validation_request_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe DescriptionChangeValidationRequest, type: :model do
     let(:subject) { create(:description_change_validation_request) }
   end
 
+  it_behaves_like("ValidationRequestable")
+
   describe "validations" do
     let!(:request) { create(:description_change_validation_request) }
 

--- a/spec/support/validation_requestable_shared_examples.rb
+++ b/spec/support/validation_requestable_shared_examples.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "ValidationRequestable" do
+  describe "#sent_by" do
+    let(:user) { create(:user) }
+    let(:request) { create(described_class.name.underscore) }
+
+    before { Current.user = user }
+
+    it "returns user for audit associated with send event" do
+      expect(request.sent_by).to eq(user)
+    end
+  end
+end

--- a/spec/system/planning_applications/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/checking_consistency_spec.rb
@@ -1,0 +1,301 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "checking consistency", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  let(:user) do
+    create(
+      :user,
+      :assessor,
+      local_authority: local_authority,
+      name: "Alice Smith"
+    )
+  end
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: local_authority
+    )
+  end
+
+  before do
+    sign_in(user)
+    visit(planning_application_assessment_tasks_path(planning_application))
+  end
+
+  it "lets user save draft or mark as complete" do
+    click_link("Description, documents and proposal details")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content(
+      "Determine whether the description matches the development or use in the plans"
+    )
+
+    expect(page).to have_content(
+      "Determine whether the proposal details are consistent with the plans"
+    )
+
+    expect(page).to have_content(
+      "Determine whether the plans are consistent with each other"
+    )
+
+    form_group1 = form_group_with_legend(
+      "Does the description match the development or use in the plans?"
+    )
+
+    within(form_group1) { choose("Yes") }
+
+    form_group2 = form_group_with_legend(
+      "Are the plans consistent with each other?"
+    )
+
+    within(form_group2) { choose("Yes") }
+    click_button("Save and come back later")
+
+    expect(page).to have_content("Successfully updated application checklist")
+
+    task_list_item = task_list_item_with_name(
+      "Description, documents and proposal details"
+    )
+
+    expect(task_list_item).to have_content("In assessment")
+
+    click_link("Description, documents and proposal details")
+
+    form_group3 = form_group_with_legend(
+      "Are the proposal details consistent with the plans?"
+    )
+
+    within(form_group3) { choose("No") }
+
+    fill_in(
+      "How are the proposal details inconsistent?",
+      with: "Reason for inconsistencty"
+    )
+
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("Successfully updated application checklist")
+
+    task_list_item = task_list_item_with_name(
+      "Description, documents and proposal details"
+    )
+
+    expect(task_list_item).to have_content("Complete")
+
+    click_link("Description, documents and proposal details")
+
+    field1 = find(
+      "#consistency-checklist-description-matches-documents-yes-field"
+    )
+
+    field2 = find("#consistency-checklist-documents-consistent-yes-field")
+
+    field3 = find(
+      "#consistency-checklist-proposal-details-match-documents-no-field"
+    )
+
+    expect(field1).to be_disabled
+    expect(field1).to be_checked
+    expect(field2).to be_disabled
+    expect(field2).to be_checked
+    expect(field3).to be_disabled
+    expect(field3).to be_checked
+
+    expect(page).not_to have_field(
+      "How are the proposal details inconsistent?",
+      with: "Reason for inconsistencty"
+    )
+
+    expect(page).to have_content("How are the proposal details inconsistent?")
+    expect(page).to have_content("Reason for inconsistencty")
+  end
+
+  it "lets the user request a description change" do
+    travel_to(Time.zone.local(2022, 9, 15, 12))
+    click_link("Description, documents and proposal details")
+
+    form_group1 = form_group_with_legend(
+      "Does the description match the development or use in the plans?"
+    )
+
+    within(form_group1) { choose("No") }
+    click_button("Request a change to the description")
+
+    fill_in(
+      "Please suggest a new application description",
+      with: "New description"
+    )
+
+    click_button("Send")
+
+    expect(page).to have_content(
+      "Description change request successfully sent."
+    )
+
+    expect(page).not_to have_button("Request a change to the description")
+    expect(page).to have_content("Alice Smith requested a new description")
+    expect(page).to have_content("Proposed description: New description")
+    expect(page).to have_content("Proposed 15 September 2022 12:00")
+
+    click_link("View and edit request")
+    click_link("Cancel this request")
+
+    expect(page).to have_content("Cancelled 15 September 2022 12:00")
+
+    travel_to(Time.zone.local(2022, 9, 15, 13))
+    click_button("Request a change to the description")
+
+    fill_in(
+      "Please suggest a new application description",
+      with: "New description 2"
+    )
+
+    click_button("Send")
+
+    expect(page).to have_content(
+      "Description change request successfully sent."
+    )
+
+    expect(page).not_to have_button("Request a change to the description")
+    expect(page).to have_content("Proposed description: New description 2")
+    expect(page).to have_content("Proposed 15 September 2022 13:00")
+
+    planning_application
+      .description_change_validation_requests
+      .open
+      .last
+      .auto_close_request!
+
+    visit(planning_application_assessment_tasks_path(planning_application))
+    click_link("Description, documents and proposal details")
+
+    expect(page).to have_content("Accepted 15 September 2022 13:00")
+
+    travel_to(Time.zone.local(2022, 9, 15, 14))
+    click_button("Request a change to the description")
+
+    fill_in(
+      "Please suggest a new application description",
+      with: "New description 3"
+    )
+
+    click_button("Send")
+
+    expect(page).to have_content(
+      "Description change request successfully sent."
+    )
+
+    expect(page).not_to have_button("Request a change to the description")
+    expect(page).to have_content("Proposed description: New description 3")
+    expect(page).to have_content("Proposed 15 September 2022 14:00")
+
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content(
+      "Description change requests must be closed or cancelled"
+    )
+
+    request = planning_application
+              .description_change_validation_requests
+              .open
+              .last
+
+    request.close!
+    request.update!(approved: true)
+    visit(planning_application_assessment_tasks_path(planning_application))
+    click_link("Description, documents and proposal details")
+
+    expect(page).to have_content("Accepted 15 September 2022 14:00")
+    expect(page).to have_button("Request a change to the description")
+
+    click_button("Save and mark as complete")
+
+    expect(page).not_to have_content(
+      "Description change requests must be closed or cancelled"
+    )
+  end
+
+  it "lets the user request an additional document" do
+    travel_to(Time.zone.local(2022, 9, 15, 12))
+    click_link("Description, documents and proposal details")
+
+    form_group1 = form_group_with_legend(
+      "Are the plans consistent with each other?"
+    )
+
+    within(form_group1) { choose("No") }
+    click_button("Request a new document")
+
+    fill_in(
+      "Please specify the new document type:",
+      with: "New document type"
+    )
+
+    fill_in(
+      "Please specify the reason you have requested this document?",
+      with: "Reason for new document"
+    )
+
+    click_button("Send request")
+
+    expect(page).to have_content("Alice Smith requested a new document")
+    expect(page).to have_content("New document type")
+    expect(page).to have_content("Reason: Reason for new document")
+    expect(page).to have_content("Requested 15 September 2022 12:00")
+
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content(
+      "Additional document requests must be closed or cancelled"
+    )
+
+    click_link("View and edit request")
+    click_link("Cancel request")
+
+    fill_in(
+      "Explain to the applicant why this request is being cancelled",
+      with: "Cancellation reason"
+    )
+
+    click_button("Confirm cancellation")
+    visit(planning_application_assessment_tasks_path(planning_application))
+    click_link("Description, documents and proposal details")
+
+    expect(page).to have_content("Cancelled 15 September 2022 12:00")
+
+    click_button("Save and mark as complete")
+
+    expect(page).not_to have_content(
+      "Additional document requests must be closed or cancelled"
+    )
+  end
+
+  context "when applicant has provided additional document" do
+    before do
+      create(
+        :additional_document_validation_request,
+        :with_documents,
+        planning_application: planning_application
+      )
+    end
+
+    it "lets the user navigate to the document" do
+      click_link("Description, documents and proposal details")
+      click_link("View new document")
+      expect(page).to have_content("File name: proposed-floorplan.png")
+    end
+  end
+
+  def form_group_with_legend(legend)
+    find("legend", text: legend).find(:xpath, "..")
+  end
+
+  def task_list_item_with_name(name)
+    find("span", text: name).find(:xpath, "..")
+  end
+end


### PR DESCRIPTION
### Description of change

- Add `concistency_checklists` table and `ConistsencyChecklist` model. A planning application has one consistency checklist.
- Add consistency checklist controller and views, and functionality so that users can create and edit consistency checklist, and view it once marked as commplete.

### Story Link

https://trello.com/c/s9bqs7dY/1154-descriptions-need-to-match-documents-drawings-proposals-from-ripa

### Screenshots

<img width="65%" alt="Screenshot 2022-09-16 at 15 02 31" src="https://user-images.githubusercontent.com/25392162/190659918-8df6dc2e-33c2-4c84-98fd-b63037b1fcf4.png">

#### With errors (when user clicks 'Save and mark as complete'):

<img width="65%" alt="Screenshot 2022-09-16 at 15 02 53" src="https://user-images.githubusercontent.com/25392162/190659944-8b6e1853-921e-4b9e-a1c5-daa71ce85910.png">

#### 'No' conditionals:

<img width="65%" alt="Screenshot 2022-09-16 at 15 04 00" src="https://user-images.githubusercontent.com/25392162/190660014-3ae65454-a273-4b21-8615-51023b0020fb.png">

#### Description change requested ('Request a change to the description' link hidden because only one request can be open at a time):

<img width="65%" alt="Screenshot 2022-09-16 at 15 07 45" src="https://user-images.githubusercontent.com/25392162/190660225-ece34941-f5d1-40b6-b487-9545ecb9e703.png">

#### Additional document requested ('Request a new document' link still visible because you can open multiple requests):

<img width="40%" alt="Screenshot 2022-09-16 at 15 08 40" src="https://user-images.githubusercontent.com/25392162/190660349-665a459a-20a6-4fde-a278-d0050c8489c8.png">

#### Marked as complete:

<img width="65%" alt="Screenshot 2022-09-16 at 15 11 06" src="https://user-images.githubusercontent.com/25392162/190660400-593ecd87-1aab-4717-8e3a-cfbe9e8f4f9e.png">
