### PR TITLE
Change 'Result from api_user' to 'Pre-assessment outcome'

### DIFF
--- a/app/views/shared/_result_information.html.erb
+++ b/app/views/shared/_result_information.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-accordion__section-header">
     <h3 class="govuk-accordion__section-heading">
       <button type="button" id="accordion-default-heading-5" aria-controls="accordion-default-heading-5" class="govuk-accordion__section-button" aria-expanded="false">
-        Result from <%= @planning_application.api_user.present? ? @planning_application.api_user.name : "application" %>
+        Pre-assessment outcome
       </button>
       <span class="govuk-accordion__icon" aria-hidden="true"></span>
     </h3>
@@ -47,7 +47,7 @@
       <% end %>
         <% if @planning_application.flagged_proposal_details(@planning_application.result_flag).present? %>
           <p class="govuk-body">
-            <strong> Details identified <%= @planning_application.api_user.present? ? "by #{@planning_application.api_user.name}" : "" %> as relevant to the result</strong>
+            <strong> Details identified as relevant to the result</strong>
           </p>
           <ol class="govuk-list">
             <li>
@@ -68,7 +68,7 @@
     <% else %>
       <p class='govuk-body'>
         <strong>No result</strong><br>
-        <%= @planning_application.api_user.present? ? "#{@planning_application.api_user.name} did not provide a result for this application" : "The application was not assessed on submission" %>
+        The application was not assessed on submission
       </p>
     <% end %>
   </div>

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "Result summary" do
-      click_button "Result from #{api_user.name}"
+      click_button "Pre-assessment outcome"
 
       expect(page).to have_text("Planning permission / Permission needed")
       expect(page).to have_text(planning_application.result_heading)
@@ -320,20 +320,11 @@ RSpec.describe "Planning Application show page", type: :system do
       visit planning_application_path(planning_application)
     end
 
-    it "displays the correct text in the result accordion when no API user is given" do
-      click_button "Result from application"
+    it "displays the correct text in the result accordion" do
+      click_button "Pre-assessment outcome"
 
       expect(page).to have_text("No result")
       expect(page).to have_text("The application was not assessed on submission")
-    end
-
-    it "displays the correct text in the result accordion when API user is present" do
-      planning_application.update!(api_user: api_user)
-      visit planning_application_path(planning_application)
-      click_button "Result from #{api_user.name}"
-
-      expect(page).to have_text("No result")
-      expect(page).to have_text("#{api_user.name} did not provide a result for this application")
     end
   end
 
@@ -373,7 +364,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_no_css("#govuk-warning-text")
       end
 
-      click_button "Result from application"
+      click_button "Pre-assessment outcome"
       within("#results-section") do
         expect(page).to have_no_css("#govuk-warning-text")
       end
@@ -400,7 +391,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_content("This application has been updated. Please check the site map is correct.")
       end
 
-      click_button "Result from application"
+      click_button "Pre-assessment outcome"
       within("#results-section .govuk-warning-text") do
         expect(page).to have_content("! Warning This application has been updated. The result may no longer be accurate.")
       end
@@ -426,7 +417,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "displays a warning message and the feedback text" do
-      click_button "Result from application"
+      click_button "Pre-assessment outcome"
       within("#results-section") do
         within(".govuk-warning-text") do
           expect(page).to have_content("! Warning The applicant or agent believes this result is inaccurate.")


### PR DESCRIPTION
- tom suggests that the api_user name feature wasn't successful and we should hardcode 'Pre-assessment' in all cases.

### Description of change

Hardcoding text to the static text "Pre-assessment outcome"

![Screenshot 2022-09-23 at 15 03 26](https://user-images.githubusercontent.com/1710795/191979154-de895b9e-a6e1-4e4b-8600-8d11f5621196.png)




### Story Link

https://trello.com/c/dpVHYxPq/1181-change-result-from-apiuser-to-pre-assessment-outcome

### Decisions

The choice was to remove the if / else code and have static text
