### PR TITLE
Allow officers to add a summary of works during assessment

### DIFF
--- a/app/controllers/planning_application/summary_of_works_controller.rb
+++ b/app/controllers/planning_application/summary_of_works_controller.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class SummaryOfWorksController < AuthenticationController
+    before_action :set_planning_application
+    before_action :ensure_planning_application_is_validated
+    before_action :set_summary_of_work, only: %i[show edit update]
+
+    def new
+      @summary_of_work = @planning_application.summary_of_works.new
+
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      @summary_of_work = @planning_application.summary_of_works.new(summary_of_works_params).tap do |record|
+        record.user = current_user
+        record.status = status
+      end
+
+      respond_to do |format|
+        if @summary_of_work.save
+          format.html do
+            redirect_to planning_application_assessment_tasks_path(@planning_application),
+                        notice: "Summary of works was successfully created."
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def show
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      @summary_of_work.assign_attributes(user: current_user, status: status)
+
+      respond_to do |format|
+        if @summary_of_work.update(summary_of_works_params)
+          format.html do
+            redirect_to planning_application_assessment_tasks_path(@planning_application),
+                        notice: "Summary of works was successfully updated."
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    private
+
+    def set_planning_application
+      @planning_application = planning_applications_scope.find(planning_application_id)
+    end
+
+    def set_summary_of_work
+      @summary_of_work = @planning_application.summary_of_works.find(summary_of_work_id)
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications
+    end
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+
+    def summary_of_work_id
+      Integer(params[:id])
+    end
+
+    def summary_of_works_params
+      params.require(:summary_of_work).permit(:entry)
+    end
+
+    def save_progress?
+      params[:commit] == I18n.t("form_actions.save_and_come_back_later")
+    end
+
+    def status
+      save_progress? ? "in_progress" : "completed"
+    end
+
+    def ensure_planning_application_is_validated
+      return if @planning_application.validated?
+
+      render plain: "forbidden", status: :forbidden
+    end
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -33,6 +33,7 @@ class PlanningApplication < ApplicationRecord
     has_many :red_line_boundary_change_validation_requests
     has_many :notes, -> { by_created_at_desc }, inverse_of: :planning_application
     has_many :requests, class_name: "ValidationRequest"
+    has_many :summary_of_works, -> { by_created_at_desc }, inverse_of: :planning_application
 
     has_many(
       :policy_classes,

--- a/app/models/summary_of_work.rb
+++ b/app/models/summary_of_work.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class SummaryOfWork < ApplicationRecord
+  belongs_to :planning_application
+  belongs_to :user
+
+  validates :entry, :status, presence: true
+
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+
+  enum status: {
+    in_progress: "in_progress",
+    completed: "completed"
+  }
+end

--- a/app/presenters/concerns/assessment_tasks/summary_of_works_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/summary_of_works_presenter.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module AssessmentTasks
+  extend ActiveSupport::Concern
+
+  class SummaryOfWorksPresenter < PlanningApplicationPresenter
+    def initialize(template, planning_application)
+      super(template, planning_application)
+
+      @summary_of_work = planning_application.summary_of_works.first
+      @status = summary_of_works_status
+    end
+
+    def task_list_row
+      html = tag.span class: "app-task-list__task-name" do
+        concat summary_of_works_link
+      end
+
+      html.concat summary_of_works_status_tag
+    end
+
+    private
+
+    attr_reader :status, :summary_of_work
+
+    def summary_of_works_link
+      link_to("Summary of works", summary_of_works_link_url, class: "govuk-link")
+    end
+
+    def summary_of_works_link_url
+      case status.humanize
+
+      when "Not started"
+        new_planning_application_summary_of_work_path(planning_application)
+      when "In progress"
+        edit_planning_application_summary_of_work_path(planning_application, summary_of_work)
+      when "Completed"
+        planning_application_summary_of_work_path(planning_application, summary_of_work)
+      else
+        raise ArgumentError, "The status provided: '#{status}' is not valid"
+      end
+    end
+
+    def summary_of_works_status_tag
+      classes = ["#{govuk_tag_class} app-task-list__task-tag"]
+
+      tag.strong class: classes do
+        status
+      end
+    end
+
+    def summary_of_works_status
+      return "Not started" unless summary_of_work
+
+      summary_of_work.status.humanize
+    end
+
+    def govuk_tag_class
+      return "govuk-tag" unless assessment_information_status_colour
+
+      "govuk-tag govuk-tag--#{assessment_information_status_colour}"
+    end
+
+    def assessment_information_status_colour
+      case status.humanize
+
+      when "Not started"
+        "grey"
+      when "Completed"
+        "blue"
+      when "In progress"
+        nil
+      else
+        raise ArgumentError, "The status provided: '#{status}' is not valid"
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -9,5 +9,11 @@ module AssessmentTasksPresenter
         @template, @planning_application, policy_class
       ).task_list_row
     end
+
+    def summary_of_works_tasklist
+      AssessmentTasks::SummaryOfWorksPresenter.new(
+        @template, @planning_application
+      ).task_list_row
+    end
   end
 end

--- a/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
+++ b/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
@@ -1,0 +1,10 @@
+<li id="assessment-information-tasks">
+  <h2 class="app-task-list__section">
+    Add assessment information
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <%= @planning_application.summary_of_works_tasklist %>
+    </li>
+  </ul>
+</li>

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -1,12 +1,12 @@
 <li id="check-consistency-assessment-tasks">
- <h2 class="app-task-list__section">
-   Check consistency
- </h2>
- <ul class="app-task-list__items">
-   <li class="app-task-list__item">
-     <span class="app-task-list__task-name">
+  <h2 class="app-task-list__section">
+    Check consistency
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
         Description, documents and proposal details
-     </span>
-   </li>
- </ul>
+      </span>
+    </li>
+  </ul>
 </li>

--- a/app/views/planning_application/assessment_tasks/index.html.erb
+++ b/app/views/planning_application/assessment_tasks/index.html.erb
@@ -11,6 +11,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="planning-application-details">
     <span class="govuk-caption-l"><%= @planning_application.reference %></span>
+
     <h1 class="govuk-heading-l"><%= @planning_application.full_address %></h1>
 
     <p class="govuk-body"><%= @planning_application.status_tag %></p>
@@ -18,7 +19,6 @@
     <p class="govuk-body">
       <%= @planning_application.type_and_work_status %>: <%= @planning_application.description %>
     </p>
-
   </div>
 </div>
 
@@ -26,6 +26,8 @@
   <div class="govuk-grid-column-two-thirds">
     <ol class="app-task-list">
       <%= render "check_consistency" %>
+
+      <%= render "assessment_information" %>
 
       <%= render "assess_against_legislation" %>
     </ol>

--- a/app/views/planning_application/summary_of_works/_form.html.erb
+++ b/app/views/planning_application/summary_of_works/_form.html.erb
@@ -1,0 +1,30 @@
+<div class="govuk-body">
+  <p><strong>Create a summary of the works</strong></p>
+
+  <%= render "shared/warning_text",
+      message: "This information WILL be made public" %>
+
+  <p>You can include:</p>
+  <ul>
+    <li>
+      A list of the works involved in the project, such as alterations and extensions
+    </li>
+    <li>Key dimension</li>
+    <li>Materials used in external works</li>
+    <li>Specific features you want to draw attention to</li>
+    <li>Details of a proposed use, such as opening hours</li>
+  </ul>
+</div>
+
+<%= form_with model: [@planning_application, @summary_of_work], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_text_area :entry, label: nil, rows: 10 %>
+
+  <div class="govuk-button-group">
+    <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+
+    <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+  </div>
+<% end %>

--- a/app/views/planning_application/summary_of_works/edit.html.erb
+++ b/app/views/planning_application/summary_of_works/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title do %>
+  Edit summary of works - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Assess application", planning_application_assessment_tasks_path(@planning_application) %>
+
+<% content_for :title, "Edit summary" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-top-7">
+      Edit summary of works
+    </h1>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
+    <%= render "form", planning_application: @planning_application %>
+  </div>
+</div>

--- a/app/views/planning_application/summary_of_works/new.html.erb
+++ b/app/views/planning_application/summary_of_works/new.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title do %>
+  New summary of works - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Assess application", planning_application_assessment_tasks_path(@planning_application) %>
+
+<% content_for :title, "Add summary" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-top-7">
+      Add summary of works
+    </h1>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
+    <%= render "form", planning_application: @planning_application %>
+  </div>
+</div>

--- a/app/views/planning_application/summary_of_works/show.html.erb
+++ b/app/views/planning_application/summary_of_works/show.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title do %>
+  Summary of works - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Assess application", planning_application_assessment_tasks_path(@planning_application) %>
+
+<% content_for :title, "Summary" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l govuk-!-margin-top-7">
+      Summary of works
+    </h1>
+
+    <%= render "shared/planning_application_address_and_reference" %>
+
+    <div class="govuk-body">
+      <p><strong>Summary of works</strong></p>
+
+      <%= render "shared/warning_text",
+          message: "This information WILL be made public" %>
+
+      <p><%= @summary_of_work.entry %></p>
+    </div>
+
+    <div class="govuk-button-group">
+      <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+
+      <%= link_to "Edit summary of work", edit_planning_application_summary_of_work_path(@planning_application, @summary_of_work), class: "govuk-link" %>
+    </div>
+  </div>
+</div>
+

--- a/app/views/recommendations/edit.html.erb
+++ b/app/views/recommendations/edit.html.erb
@@ -43,7 +43,8 @@
     url: planning_application_recommendation_path(@planning_application, @recommendation)
   ) do |form| %>
 
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
     <%= form.govuk_fieldset(legend: { text: t(".do_you_agree") }) do %>
       <div class="govuk-form-group">
         <div class="govuk-radios" data-module="govuk-radios">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,6 +118,9 @@ en:
     proposal_details_table:
       related_legislation: Related legislation
       related_questions: Related questions from RIPA
+  form_actions:
+    save_and_come_back_later: Save and come back later
+    save_and_mark_as_complete: Save and mark as complete
   helpers:
     hint:
       other_change_validation_request:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,6 +104,8 @@ Rails.application.routes.draw do
       resources :validation_tasks, only: :index
 
       resources :assessment_tasks, only: :index
+
+      resources :summary_of_works, only: %i[new edit create show update]
     end
   end
 

--- a/db/migrate/20220907110038_create_summary_of_works.rb
+++ b/db/migrate/20220907110038_create_summary_of_works.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateSummaryOfWorks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :summary_of_works do |t|
+      t.references :planning_application, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :entry
+      t.string :status, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -356,6 +356,17 @@ ActiveRecord::Schema.define(version: 2022_09_07_161526) do
     t.index ["user_id"], name: "index_document_change_requests_on_user_id"
   end
 
+  create_table "summary_of_works", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.text "entry"
+    t.string "status", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "ix_summary_of_works_on_planning_application_id"
+    t.index ["user_id"], name: "ix_summary_of_works_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -419,5 +430,7 @@ ActiveRecord::Schema.define(version: 2022_09_07_161526) do
   add_foreign_key "replacement_document_validation_requests", "documents", column: "old_document_id"
   add_foreign_key "replacement_document_validation_requests", "planning_applications"
   add_foreign_key "replacement_document_validation_requests", "users"
+  add_foreign_key "summary_of_works", "planning_applications"
+  add_foreign_key "summary_of_works", "users"
   add_foreign_key "validation_requests", "planning_applications"
 end

--- a/spec/factories/summary_of_work.rb
+++ b/spec/factories/summary_of_work.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :summary_of_work do
+    planning_application
+    user
+
+    status { "completed" }
+    entry { "This is a description about the summary of works" }
+
+    trait :in_progress do
+      status { "in_progress" }
+    end
+  end
+end

--- a/spec/models/summary_of_work_spec.rb
+++ b/spec/models/summary_of_work_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SummaryOfWork, type: :model do
+  describe "validations" do
+    subject(:summary_of_work) { described_class.new }
+
+    describe "#entry" do
+      it "validates presence" do
+        expect { summary_of_work.valid? }.to change { summary_of_work.errors[:entry] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#status" do
+      it "validates presence" do
+        expect { summary_of_work.valid? }.to change { summary_of_work.errors[:status] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#user" do
+      it "validates presence" do
+        expect { summary_of_work.valid? }.to change { summary_of_work.errors[:user] }.to ["must exist"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { summary_of_work.valid? }.to change { summary_of_work.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".by_created_at_desc" do
+      let!(:summary_of_works1) { create(:summary_of_work, created_at: Time.zone.now - 1.day) }
+      let!(:summary_of_works2) { create(:summary_of_work, created_at: Time.zone.now) }
+      let!(:summary_of_works3) { create(:summary_of_work, created_at: Time.zone.now - 2.days) }
+
+      it "returns summary_of_works sorted by created at desc (i.e. most recent first)" do
+        expect(described_class.by_created_at_desc).to eq([summary_of_works2, summary_of_works1, summary_of_works3])
+      end
+    end
+  end
+end

--- a/spec/presenters/assessment_tasks/summary_of_works_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/summary_of_works_presenter_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessmentTasks::SummaryOfWorksPresenter, type: :presenter do
+  include ActionView::TestCase::Behavior
+
+  subject(:presenter) { described_class.new(view, planning_application) }
+
+  let(:context) { ActionView::Base.new }
+  let!(:planning_application) { create(:planning_application, :in_assessment) }
+
+  describe "#task_list_row" do
+    context "when summary of works has not been started" do
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Summary of works",
+            new_planning_application_summary_of_work_path(planning_application),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--grey app-task-list__task-tag\">Not started</strong>"
+        )
+      end
+    end
+
+    context "when summary of works has been completed" do
+      let!(:summary_of_work) { create(:summary_of_work, planning_application: planning_application) }
+
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Summary of works",
+            planning_application_summary_of_work_path(planning_application, summary_of_work),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Completed</strong>"
+        )
+      end
+    end
+
+    context "when summary of works is in progress" do
+      let!(:summary_of_work) { create(:summary_of_work, :in_progress, planning_application: planning_application) }
+
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Summary of works",
+            edit_planning_application_summary_of_work_path(planning_application, summary_of_work),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag app-task-list__task-tag\">In progress</strong>"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Officers can add/edit a summary of work and either save and come back later or save as complete
- "Not started", "In progress" and "Complete" statuses are associated with the different options
- The 'planning_application has_many summary_of_works' association has been added as future work planned  will involve having a history of different summary of work entries

### Story Link

https://trello.com/c/5c71QJXt/1153-assessor-to-entering-summary-of-works-for-manager-sign-off