### PR TITLE
Improve submit recommendations page

### DIFF
--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -4,8 +4,8 @@
 
 <% content_for :title, "Submit recommendation" %>
 
-<%= render "shared/assessment_dashboard" do %>
-  <h2 class="govuk-heading-m">Submit Recommendation</h2>
+<%= render layout: "shared/assessment_dashboard", locals: { heading: t(".review_and_submit_recommendation") } do %>
+  <h2 class="govuk-heading-m">Decision notice</h2>
   <p class="govuk-body">The following decision notice has been created based on your answers.</p>
   <%= render "decision_notice", planning_application: @planning_application %>
   <p class="govuk-body">
@@ -18,7 +18,19 @@
     </strong>
    If your manager disagrees with your recommendation they will send it back to you to make changes.
   </p>
-  <%= form_with model: @planning_application, url: submit_planning_application_path(@planning_application), local: true do |form| %>
-    <%= form.submit "Submit to manager", class: "govuk-button", data: { module: "govuk-button" } %>
-  <% end %>
+  <div class="govuk-button-group">
+    <%= form_with model: @planning_application, url: submit_planning_application_path(@planning_application), local: true do |form| %>
+      <%= form.submit "Submit recommendation", class: "govuk-button", data: { module: "govuk-button" } %>
+      <%= link_to(
+        "Edit recommendation",
+        new_planning_application_recommendation_path(@planning_application),
+       class: "govuk-button govuk-button--secondary"
+      ) %>
+      <%= link_to(
+        t(".back"),
+        planning_application_path(@planning_application),
+        class: "govuk-button govuk-button--secondary"
+      ) %>
+    <% end %>
+  </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -199,6 +199,8 @@ en:
   planning_applications:
     confirm_validation:
       validate_application: Validate application
+    submit_recommendation:
+      review_and_submit_recommendation: Review and submit recommendation
   policy_class_component:
     complies: Complies
     does_not_comply: Does not comply

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -94,7 +94,7 @@ Given("a recommendation is submitted for the planning application") do
     Given the planning application is validated
     And the planning application is assessed
     And I press "Submit recommendation"
-    And I press "Submit to manager"
+    And I press "Submit recommendation"
   )
 end
 

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "post validation requests", type: :system do
 
         click_button("Save and mark as complete")
         click_link("Submit recommendation")
-        click_button("Submit to manager")
+        click_button("Submit recommendation")
 
         expect(page).to have_content(
           "This application has open non-validation requests."

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         expect(page).to have_content("not lawful")
         expect(page).to have_content("aggrieved")
 
-        click_button "Submit to manager"
+        click_button "Submit recommendation"
 
         expect(page).to have_content("Recommendation was successfully submitted.")
 
@@ -193,7 +193,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_button("Save and mark as complete")
 
       click_link("Submit recommendation")
-      click_button("Submit to manager")
+      click_button("Submit recommendation")
 
       expect(page).to have_content("Recommendation was successfully submitted.")
       expect(page).to have_current_path(planning_application_path(planning_application))
@@ -228,6 +228,46 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
     end
 
+    it "allows navigation to assess recommendation page" do
+      click_link("In assessment")
+
+      within(selected_govuk_tab) do
+        click_link(planning_application.reference)
+      end
+
+      click_link("Assess recommendation")
+
+      choose("Yes")
+      fill_in("State the reasons why this application is, or is not lawful.", with: "This is a public comment")
+      click_button("Save and mark as complete")
+
+      click_link("Submit recommendation")
+
+      click_link("Edit recommendation")
+
+      expect(page).to have_title("Assess recommendation")
+    end
+
+    it "allows navigation back to the planning application page" do
+      click_link("In assessment")
+
+      within(selected_govuk_tab) do
+        click_link(planning_application.reference)
+      end
+
+      click_link("Assess recommendation")
+
+      choose("Yes")
+      fill_in("State the reasons why this application is, or is not lawful.", with: "This is a public comment")
+      click_button("Save and mark as complete")
+
+      click_link("Submit recommendation")
+
+      click_link("Back")
+
+      expect(page).to have_title("Planning Application")
+    end
+
     context "when there are open post validation requests" do
       let!(:planning_application) { create(:in_assessment_planning_application, local_authority: default_local_authority) }
       let!(:red_line_boundary_change_validation_request) { create(:red_line_boundary_change_validation_request, :open, :post_validation, planning_application: planning_application) }
@@ -246,7 +286,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_button("Save and mark as complete")
 
         click_link("Submit recommendation")
-        click_button("Submit to manager")
+        click_button("Submit recommendation")
 
         within(".govuk-error-summary") do
           expect(page).to have_content("There is a problem")
@@ -283,7 +323,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       expect(page).to have_content("Recommendation was successfully withdrawn.")
       expect(page).to have_current_path(submit_recommendation_planning_application_path(planning_application))
-      expect(page).to have_button("Submit to manager")
+      expect(page).to have_button("Submit recommendation")
       expect(page).not_to have_button("Withdraw recommendation")
       expect(planning_application.reload.status).to eq("in_assessment")
 
@@ -424,7 +464,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         click_button("Save and mark as complete")
         click_link("Submit recommendation")
-        click_button("Submit to manager")
+        click_button("Submit recommendation")
         sign_in(reviewer)
         visit(edit_planning_application_recommendations_path(planning_application))
         find("#recommendation_challenged_true").click


### PR DESCRIPTION
### Description of change

Submit Recommendations page has some design driven changes to improve the usage. 
Each AC has a commit

1. Add H1 at the top of the page
2. Add H2 "Decision notice"  on top of the grey area (i.e. decision notice)
3. Rename the primary action into "Submit recommendation"   from "Submit to manager"
4. Secondary call to "Edit recommendation" that takes the user to "Assess proposal" page
5. Secondary call to action to go "Back"

### Story Link

https://trello.com/c/LpLWeXXd/1118-improve-submit-recommendation-page

### Merging commits after approval
- I will merge all these commits after approval into one message:

"Improve Submit recommendation page"

