### PR TITLE
Add workaround for Active Storage misidentifying pdf file blob content type

### DIFF
--- a/config/initializers/marcel.rb
+++ b/config/initializers/marcel.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# config/initializers/marcel.rb
+
+# NOTE: https://github.com/rails/marcel/issues/77
+Marcel::Magic.remove("video/x-ms-wmv") if Marcel::MimeType.for("%PDF-1.6.%wmv2") == "video/x-ms-wmv"


### PR DESCRIPTION
### Description of change

- There is a bug with the signature for WMV2
- Magic priority for WMV is 60 but PDF is only 50 https://github.com/rails/marcel/blob/8e285636063d3617df6f73bc73de6574d83a53d5/data/tika.xml#L673-L693
- This workaround will identify a PDF and check to see if the bug is still present before removing the rule
https://github.com/rails/marcel/issues/77

