### PR TITLE
Confirmation box form when removing policy class

### DIFF
--- a/app/views/policy_classes/_summary.html.erb
+++ b/app/views/policy_classes/_summary.html.erb
@@ -37,6 +37,7 @@
         t(".remove_class_from"),
         planning_application_policy_class_path(planning_application, policy_class),
         method: :delete,
+        data: { confirm: "This action cannot be undone.\nAre you sure you want to remove this class?" },
         class: "govuk-button govuk-button--warning",
         disabled: planning_application.assessment_complete?
     ) %>

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -84,6 +84,19 @@ RSpec.describe "assessment against legislation", type: :system do
     expect(page).to have_content("Part 1, Class G").once
   end
 
+  it "lets the user remove policy class" do
+    add_policy_classes(["Class D - porches"])
+    expect(page).to have_content("Part 1, Class D").once
+
+    click_link("Part 1, Class D")
+
+    accept_confirm do
+      click_button("Remove class from assessment")
+    end
+
+    expect(page).to have_content("Policy class has been removed.")
+  end
+
   it "displays the class title" do
     add_policy_classes(
       [


### PR DESCRIPTION
### Description of change

A confirmation box when you want to delete a policy

### Story Link

https://trello.com/c/iZ2jHMzG/1166-confirmation-dialogue-box-for-remove-class-from-assessment
