### PR TITLE
Terminate a named character reference with semicolon

### DIFF
--- a/app/components/proposal_detail_component.html.erb
+++ b/app/components/proposal_detail_component.html.erb
@@ -3,7 +3,7 @@
   data: { show_hide_target: ("hideable" if auto_answered?) },
   class: "proposal-detail"
 ) do %>
-  <div><p class="govuk-body"><%= "#{number}." %>&nbsp</p></div>
+  <div><p class="govuk-body"><%= "#{number}." %>&nbsp;</p></div>
   <div>
     <p class="govuk-body govuk-!-font-weight-bold"><%= question %></p>
     <p class="govuk-body"><%= responses.map(&:value).compact.join(", ") %></p>


### PR DESCRIPTION
There are a number of validation issues.

- if you don't use the standards anything can happen.  You will find something doesn't work on one browser and it does on another.
- for instance one browser will ignored &nbsp and another might add the semicolon on for you. 