### PR TITLE
Fix back link bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :set_current_user
   before_action :enforce_user_permissions
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :set_back_path
 
   attr_reader :current_local_authority
 
@@ -40,6 +41,11 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_back_path
+    session[:back_path] = request.referer if request.get?
+    @back_path = session[:back_path]
+  end
 
   def find_current_local_authority_from_subdomain
     unless @current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  attr_reader :back_path
+
+  def back_link(classname: "govuk-button govuk-button--secondary")
+    link_to(t("back"), back_path, class: classname)
+  end
+
   def url_for_document(document)
     if document.published?
       api_v1_planning_application_document_url(document.planning_application, document)

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -60,10 +60,6 @@ module ValidationRequestHelper
     end
   end
 
-  def validation_requests_back_url(classname: nil)
-    link_to("Back", :back, class: classname)
-  end
-
   def document_url(document)
     link_to(document.name.to_s,
             edit_planning_application_document_path(document.planning_application, document.id))

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -60,11 +60,7 @@
       rows: 5 %>
         <div class="govuk-button-group">
           <%= form.govuk_submit "Send" %>
-          <%= link_to(
-            "Back",
-            :back,
-            class: "govuk-button govuk-button--secondary"
-          ) %>
+          <%= back_link %>
         </div>
       <% end %>
     </div>

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -19,7 +19,7 @@
       <% if @validate_document %>
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       <% else %>
-        <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+        <%= back_link %>
       <% end %>
     </div>
   </div>

--- a/app/views/planning_application/summary_of_works/_form.html.erb
+++ b/app/views/planning_application/summary_of_works/_form.html.erb
@@ -24,7 +24,6 @@
   <div class="govuk-button-group">
     <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
     <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
-
-    <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+    <%= back_link %>
   </div>
 <% end %>

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -133,11 +133,7 @@
             disabled: planning_application.assessment_complete?
           ) %>
         <% end %>
-        <%= link_to(
-          t(".back"),
-          :back,
-          class: "govuk-button govuk-button--secondary"
-        ) %>
+        <%= back_link %>
         <% if !editable %>
           <%= link_to(
             t(".edit_assessment"),

--- a/app/views/policy_classes/part.html.erb
+++ b/app/views/policy_classes/part.html.erb
@@ -48,7 +48,7 @@
 
       <div class="govuk-button-group">
         <%= form.submit "Continue", class: "govuk-button" %>
-        <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+        <%= back_link %>
       </div>
     <% end %>
   </div>

--- a/app/views/recommendations/edit.html.erb
+++ b/app/views/recommendations/edit.html.erb
@@ -68,7 +68,7 @@
 
       <div class="govuk-button-group">
         <%= form.govuk_submit "Save" %>
-        <%= link_to "Back", :back, class: "govuk-button govuk-button--secondary" %>
+        <%= back_link %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/red_line_boundary_change_validation_requests/_applicant_approved_response.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_applicant_approved_response.html.erb
@@ -16,5 +16,5 @@
 </div>
 
 <div class="govuk-button-group">
-  <%= validation_requests_back_url(classname: "govuk-button govuk-button--secondary") %>
+  <%= back_link %>
 </div>

--- a/app/views/red_line_boundary_change_validation_requests/_applicant_rejected_response.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_applicant_rejected_response.html.erb
@@ -15,9 +15,9 @@
 
 <div class="govuk-button-group">
   <% if @planning_application.validated? %>
-    <%= validation_requests_back_url(classname: "govuk-button") %>
+    <%= back_link(classname: "govuk-button") %>
   <% else %>
     <%= link_to "Continue", planning_application_sitemap_path(@planning_application), class: "govuk-button" %>
-    <%= validation_requests_back_url(classname: "govuk-button govuk-button--secondary") %>
+    <%= back_link %>
   <% end %>
 </div>

--- a/app/views/shared/_administrator_layout.html.erb
+++ b/app/views/shared/_administrator_layout.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-width-container">
   <% if local_assigns.fetch(:back_button, true) %>
-    <%= link_to(t(".back"), :back, class: "govuk-back-link") %>
+    <%= back_link(classname: "govuk-back-link") %>
   <% end %>
   <main class="govuk-main-wrapper">
     <div class="govuk-grid-row">

--- a/app/views/shared/_validation_request_form_actions.html.erb
+++ b/app/views/shared/_validation_request_form_actions.html.erb
@@ -12,6 +12,5 @@
   <% if allow_submit %>
     <%= form.govuk_submit submit_button_text(@planning_application, action_name) %>
   <% end %>
-
-  <%= validation_requests_back_url(classname: "govuk-button govuk-button--secondary") %>
+  <%= back_link %>
 </div>

--- a/app/views/shared/_validation_request_show_actions.html.erb
+++ b/app/views/shared/_validation_request_show_actions.html.erb
@@ -6,7 +6,7 @@
       <%= link_to "Continue", planning_application_fee_items_path(planning_application, validate_fee: "yes"), class: "govuk-button" %>
     <% end %>
   <% end %>
-  <%= validation_requests_back_url(classname: "govuk-button #{"govuk-button--secondary" if show_continue_link}") %>
+  <%= back_link(classname: "govuk-button #{"govuk-button--secondary" if show_continue_link}") %>
 
   <% if validation_request.open_or_pending? %>
     <% if planning_application.validation_complete? %>

--- a/app/views/validation_requests/_cancel_confirmation_form.html.erb
+++ b/app/views/validation_requests/_cancel_confirmation_form.html.erb
@@ -23,7 +23,6 @@
 
   <div class="govuk-button-group">
     <%= form.submit "Confirm cancellation", class: "govuk-button", data: { module: "govuk-button" } %>
-
-    <%= validation_requests_back_url(classname: "govuk-button govuk-button--secondary") %>
+    <%= back_link %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,7 @@ en:
         auto_closed_validation: 'Auto-closed: validation request (description#%{sequence})'
       red_line_boundary_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (red line boundary#%{sequence})'
+  back: Back
   consistency_checklists:
     additional_document_validation_request:
       cancelled: Cancelled %{time}
@@ -273,7 +274,6 @@ en:
     comment_updated_on: Comment updated on %{updated_at} by %{user}
     complete: Complete
     form:
-      back: Back
       complies: Complies
       does_not_comply: Does not comply
       edit_assessment: Edit assessment
@@ -333,7 +333,6 @@ en:
   shared:
     administrator_layout:
       add_user: Add user
-      back: Back
       reviewer_group_email: Manager group email
       submit: Submit
     alert_banner:

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -92,6 +92,12 @@ RSpec.describe "Requesting other changes to a planning application", type: :syst
 
     expect(page).to have_content("Summary can't be blank")
     expect(page).to have_content("Suggestion can't be blank")
+
+    click_link("Back")
+
+    expect(page).to have_current_path(
+      planning_application_validation_tasks_path(planning_application)
+    )
   end
 
   it "lists the current change requests and their statuses" do


### PR DESCRIPTION
### Description of change

- The rails `:back` view helper returns `request.referer`.  If a form has been submitted and re-rendered with errors this will be a post path. So instead of using it store the last get path in the session and use that on all pages which might be re-rendered due to submission of a form.

### Story Link

https://trello.com/c/Uua4J17a/1210-back-crashes-after-a-failed-submit

### Decisions [OPTIONAL]

Is this a good way to handle this? We can use specific path helpers instead, but the problem is that increasingly we have multiple user journeys to each page.