### PR TITLE
Extract shared submit buttons

### DIFF
--- a/app/controllers/concerns/commit_matchable.rb
+++ b/app/controllers/concerns/commit_matchable.rb
@@ -6,4 +6,12 @@ module CommitMatchable
   def commit_matches?(regex)
     params[:commit]&.downcase&.match(regex).present?
   end
+
+  def mark_as_complete?
+    params[:commit] == I18n.t("form_actions.save_and_mark_as_complete")
+  end
+
+  def save_progress?
+    params[:commit] == I18n.t("form_actions.save_and_come_back_later")
+  end
 end

--- a/app/controllers/consistency_checklists_controller.rb
+++ b/app/controllers/consistency_checklists_controller.rb
@@ -79,6 +79,6 @@ class ConsistencyChecklistsController < AuthenticationController
   end
 
   def status
-    commit_matches?(/mark as complete/) ? :complete : :in_assessment
+    mark_as_complete? ? :complete : :in_assessment
   end
 end

--- a/app/controllers/planning_application/summary_of_works_controller.rb
+++ b/app/controllers/planning_application/summary_of_works_controller.rb
@@ -2,6 +2,8 @@
 
 class PlanningApplication
   class SummaryOfWorksController < AuthenticationController
+    include CommitMatchable
+
     before_action :set_planning_application
     before_action :ensure_planning_application_is_validated
     before_action :set_summary_of_work, only: %i[show edit update]
@@ -83,10 +85,6 @@ class PlanningApplication
 
     def summary_of_works_params
       params.require(:summary_of_work).permit(:entry)
-    end
-
-    def save_progress?
-      params[:commit] == I18n.t("form_actions.save_and_come_back_later")
     end
 
     def status

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -100,6 +100,6 @@ class PolicyClassesController < PlanningApplicationsController
   end
 
   def status
-    commit_matches?(/mark as complete/) ? :complete : :in_assessment
+    mark_as_complete? ? :complete : :in_assessment
   end
 end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -87,7 +87,7 @@ class RecommendationsController < AuthenticationController
     params
       .require(:recommendation_form)
       .permit(:decision, :public_comment, :assessor_comment)
-      .merge(assessor: current_user, save_progress: commit_matches?(/save/))
+      .merge(assessor: current_user, save_progress: save_progress?)
   end
 
   def render_failed_edit(error)

--- a/app/views/consistency_checklists/_form.html.erb
+++ b/app/views/consistency_checklists/_form.html.erb
@@ -31,28 +31,16 @@
       consistency_checklist: consistency_checklist
     }
   ) %>
-  <div class="govuk-button-group">
-    <% if can_edit %>
-      <%= form.submit(
-        t(".save_and_mark"),
-        class: "govuk-button"
-      ) %>
-      <%= form.submit(
-        t(".save_and_come"),
-        class: "govuk-button govuk-button--secondary"
-      ) %>
-    <% end %>
-    <%= link_to(
-      t(".back"),
-      planning_application_assessment_tasks_path(planning_application),
-      class: "govuk-button govuk-button--secondary"
-    ) %>
-    <% unless can_edit %>
+  <% if can_edit %>
+    <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+  <% else %>
+    <div class="govuk-button-group">
+      <%= back_link %>
       <%= link_to(
         t(".edit_check_description"),
         edit_planning_application_consistency_checklist_path(planning_application),
         class: "govuk-link"
       ) %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/planning_application/summary_of_works/_form.html.erb
+++ b/app/views/planning_application/summary_of_works/_form.html.erb
@@ -20,10 +20,5 @@
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
   <%= form.govuk_text_area :entry, label: nil, rows: 10 %>
-
-  <div class="govuk-button-group">
-    <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
-    <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
-    <%= back_link %>
-  </div>
+  <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
 <% end %>

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -120,21 +120,17 @@
           <% end %>
         <% end %>
       </div>
-      <div class="govuk-button-group">
-        <% if editable %>
-          <%= form.submit(
-            t(".save_and_mark"),
-            class: "govuk-button",
+      <% if editable %>
+        <%= render(
+          partial: "shared/submit_buttons",
+          locals: {
+            form: form,
             disabled: planning_application.assessment_complete?
-          ) %>
-          <%= form.submit(
-            t(".save_and_come"),
-            class: "govuk-button govuk-button--secondary",
-            disabled: planning_application.assessment_complete?
-          ) %>
-        <% end %>
-        <%= back_link %>
-        <% if !editable %>
+          }
+        ) %>
+      <% else %>
+        <div class="govuk-button-group">
+          <%= back_link %>
           <%= link_to(
             t(".edit_assessment"),
             edit_planning_application_policy_class_path(
@@ -143,8 +139,8 @@
             ),
             class: "govuk-link"
           ) %>
-        <% end %>
-      </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -65,22 +65,13 @@
       hint: { text: t(".this_information_will_not") },
       rows: 9
     ) %>
-    <div class="govuk-button-group">
-      <% if @planning_application.assessment_submitted? %>
+    <% if @planning_application.assessment_submitted? %>
+      <div class="govuk-button-group">
         <%= form.govuk_submit(t(".update_assessment")) %>
-      <% else %>
-        <%= form.govuk_submit(t(".save_and_mark")) %>
-        <%= form.submit(
-          t(".save_and_come"),
-          class: "govuk-button govuk-button--secondary",
-          data: { module: "govuk-button" }
-        ) %>
-      <% end %>
-      <%= link_to(
-        t(".back"),
-        planning_application_path(@planning_application),
-        class: "govuk-button govuk-button--secondary"
-      ) %>
-    </div>
+        <%= back_link %>
+      </div>
+    <% else %>
+      <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-button-group">
+  <%= form.submit(
+    t("form_actions.save_and_mark_as_complete"),
+    class: "govuk-button",
+    data: { module: "govuk-button" },
+    disabled: local_assigns.fetch(:disabled, false)
+  ) %>
+  <%= form.submit(
+    t("form_actions.save_and_come_back_later"),
+    class: "govuk-button govuk-button--secondary",
+    data: { module: "govuk-button" },
+    disabled: local_assigns.fetch(:disabled, false)
+  ) %>
+  <%= back_link %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,8 +116,6 @@ en:
     form:
       back: Back
       edit_check_description: Edit check description, documents and proposal
-      save_and_come: Save and come back later
-      save_and_mark: Save and mark as complete
     introduction:
       check_description_documents: Check description, documents, proposal details
     proposal_details_match_documents:
@@ -278,8 +276,6 @@ en:
       does_not_comply: Does not comply
       edit_assessment: Edit assessment
       policy_reference: Policy reference
-      save_and_come: Save and come back later
-      save_and_mark: Save and mark as complete
       save_changes_and_view_next: Save changes and view next class
       save_changes_and_view_previous: Save changes and view previous class
       table_caption: Part %{part}, Class %{class} - %{name}
@@ -350,8 +346,6 @@ en:
       'no': 'No'
       please_provide_supporting: Please provide supporting information for your manager.
       refer_to_the: Refer to the specific permitted development rights being evoked.
-      save_and_come: Save and come back later
-      save_and_mark: Save and mark as complete
       state_the_reason: State the reasons why this application is, or is not lawful.
       this_information_will: This information WILL appear on the decision notice.
       this_information_will_not: This information WILL NOT appear on the decision notice or the public register, however FOI still apply.


### PR DESCRIPTION
### Description of change

In preparation for [this story](https://trello.com/c/AOywBVuR/1121-update-button-groups-on-all-assessment-and-review-pages-to-be-consistent-with-pattern) extract shared logic for commit submit button pattern.

### Story Link

https://trello.com/c/AOywBVuR/1121-update-button-groups-on-all-assessment-and-review-pages-to-be-consistent-with-pattern