### PR TITLE
Add status to recommendations

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,4 +76,22 @@ module ApplicationHelper
       planning_application_consistency_checklist_path
     end
   end
+
+  def not_started_tag
+    tag.strong(
+      t("not_started"),
+      class: "govuk-tag govuk-tag--grey app-task-list__task-tag"
+    )
+  end
+
+  def in_progress_tag
+    tag.strong(t("in_progress"), class: "govuk-tag app-task-list__task-tag")
+  end
+
+  def complete_tag
+    tag.strong(
+      t("complete"),
+      class: "govuk-tag govuk-tag--blue app-task-list__task-tag"
+    )
+  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -24,7 +24,13 @@ class PlanningApplication < ApplicationRecord
   with_options dependent: :destroy do
     has_many :audits, -> { by_created_at }, inverse_of: :planning_application
     has_many :documents, -> { with_file_attachment.by_created_at }, inverse_of: :planning_application
-    has_many :recommendations
+
+    has_many(
+      :recommendations,
+      -> { order :created_at },
+      inverse_of: :planning_application
+    )
+
     has_many :description_change_validation_requests
     has_many :replacement_document_validation_requests
     has_many :other_change_validation_requests
@@ -444,6 +450,14 @@ class PlanningApplication < ApplicationRecord
 
   def planning_history_enabled?
     ENV.fetch("PLANNING_HISTORY_ENABLED", "false") == "true"
+  end
+
+  Recommendation.statuses.each_key do |status|
+    delegate("#{status}?", to: :recommendation, prefix: true, allow_nil: true)
+  end
+
+  def recommendation
+    @recommendation ||= recommendations.last
   end
 
   private

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -13,9 +13,18 @@ class Recommendation < ApplicationRecord
   scope :reviewed, -> { where.not(reviewer_id: nil) }
   scope :submitted, -> { where(submitted: true) }
 
-  validate :reviewer_comment_is_present?
+  validate :reviewer_comment_is_present?, if: :review_complete?
 
   delegate :audits, to: :planning_application
+
+  enum(
+    status: {
+      assessment_in_progress: 0,
+      assessment_complete: 1,
+      review_in_progress: 2,
+      review_complete: 3
+    }
+  )
 
   def current_recommendation?
     planning_application.recommendations.last == self

--- a/app/models/recommendation_form.rb
+++ b/app/models/recommendation_form.rb
@@ -3,15 +3,17 @@
 class RecommendationForm
   include ActiveModel::Model
 
-  attr_accessor :recommendation, :save_progress
+  attr_accessor :recommendation
 
   validates :decision, :public_comment, presence: true
 
   delegate(
     :planning_application,
     :assessor_comment,
+    :assessment_in_progress?,
     "assessor_comment=",
     "assessor=",
+    "status=",
     to: :recommendation
   )
 
@@ -24,10 +26,10 @@ class RecommendationForm
   )
 
   def save
-    return false unless save_progress || valid?
+    return false unless assessment_in_progress? || valid?
 
     ActiveRecord::Base.transaction do
-      if save_progress
+      if assessment_in_progress?
         planning_application.save_assessment
         recommendation.save(validate: false)
       else

--- a/app/views/planning_applications/steps/_assessment.html.erb
+++ b/app/views/planning_applications/steps/_assessment.html.erb
@@ -14,10 +14,12 @@
         class: "govuk-link"
       ) %>
     </span>
-    <% if @planning_application.assessment_complete? %>
-      <%= tag.strong "Completed", id: "validation-completed", class: "govuk-tag app-task-list__task-tag" %>
-    <% elsif @planning_application.assessment_in_progress? %>
-      <%= tag.strong "In progress", id: "assessment-in-progress", class: "govuk-tag app-task-list__task-tag" %>
+    <% if @planning_application.can_assess? && @planning_application.recommendation.blank? %>
+      <%= not_started_tag %>
+    <% elsif @planning_application.recommendation_assessment_in_progress? %>
+      <%= in_progress_tag %>
+    <% elsif @planning_application.recommendation.present? && !@planning_application.recommendation.challenged %>
+      <%= complete_tag %>
     <% end %>
   </li>
   <li class="app-task-list__item">

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -11,10 +11,17 @@
           Review assessment
         <% end %>
       </span>
-      <% if @planning_application.review_assessment_complete? %>
-        <%= tag.strong "Completed", id: "review_assessment-completed", class: "govuk-tag app-task-list__task-tag" %>
-      <% elsif @planning_application.awaiting_determination? && current_user.assessor? %>
-        <%= tag.strong "Awaiting determination", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag govuk-tag--grey" %>
+      <% if @planning_application.recommendation_review_complete? %>
+        <%= complete_tag %>
+      <% elsif current_user.reviewer? && @planning_application.recommendation_review_in_progress? %>
+        <%= in_progress_tag %>
+      <% elsif current_user.reviewer? && @planning_application.awaiting_determination? %>
+        <%= not_started_tag %>
+      <% elsif current_user.assessor? && @planning_application.awaiting_determination? %>
+        <%= tag.strong(
+          t(".awaiting_determination"),
+          class: "govuk-tag app-task-list__task-tag"
+        ) %>
       <% end %>
     </li>
     <li class="app-task-list__item">

--- a/app/views/recommendations/edit.html.erb
+++ b/app/views/recommendations/edit.html.erb
@@ -65,11 +65,7 @@
         <%= form.label :reviewer_comment, class: "govuk-label" %>
         <%= form.text_area :reviewer_comment, class: "govuk-textarea", rows: "5" %>
       </div>
-
-      <div class="govuk-button-group">
-        <%= form.govuk_submit "Save" %>
-        <%= back_link %>
-      </div>
+      <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
       red_line_boundary_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (red line boundary#%{sequence})'
   back: Back
+  complete: Complete
   consistency_checklists:
     additional_document_validation_request:
       cancelled: Cancelled %{time}
@@ -225,6 +226,7 @@ en:
         valid_fee: Is the fee valid?
         valid_red_line_boundary: Is this red line boundary valid?
         validated_at: Valid from
+  in_progress: In progress
   local_authorities:
     edit:
       edit_local_authority: Edit council information
@@ -233,6 +235,7 @@ en:
       edit: Edit
       local_authority: Council information
       reviewer_group_email: Manager group email
+  not_started: Not started
   other_change_validation_requests:
     form:
       labels:

--- a/config/locales/planning_applications.en.yml
+++ b/config/locales/planning_applications.en.yml
@@ -21,6 +21,8 @@ en:
       assessment:
         assess_recommendation: Assess recommendation
         check_and_assess: Check and assess
+      review:
+        awaiting_determination: Awaiting determination
       validation:
         check_and_validate: Check and validate
     tabs:

--- a/db/migrate/20221004110545_add_status_to_recommendation.rb
+++ b/db/migrate/20221004110545_add_status_to_recommendation.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddStatusToRecommendation < ActiveRecord::Migration[6.1]
+  def up
+    add_column(:recommendations, :status, :integer, default: 0, null: false)
+
+    execute(
+      "UPDATE recommendations
+      SET status = 1
+      FROM planning_applications
+      WHERE planning_applications.id = recommendations.planning_application_id
+      AND planning_applications.status IN ('in_assessment', 'awaiting_determination');"
+    )
+
+    execute(
+      "UPDATE recommendations
+      SET status = 3
+      WHERE reviewed_at IS NOT NULL;"
+    )
+  end
+
+  def down
+    remove_column(:recommendations, :status)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_28_141056) do
+ActiveRecord::Schema.define(version: 2022_10_04_110545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -335,6 +335,7 @@ ActiveRecord::Schema.define(version: 2022_09_28_141056) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "challenged"
     t.boolean "submitted"
+    t.integer "status", default: 0, null: false
     t.index ["assessor_id"], name: "index_recommendations_on_assessor_id"
     t.index ["planning_application_id"], name: "index_recommendations_on_planning_application_id"
     t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"

--- a/features/assessing_proposal.feature
+++ b/features/assessing_proposal.feature
@@ -22,4 +22,4 @@ Scenario: I can submit an assessment on the planning application
     And I fill in "State the reasons why this application is, or is not lawful." with "Lawful as can be"
     And I fill in "Please provide supporting information for your manager." with "I'm hoping you feel supported"
     And I press "Save and mark as complete"
-    Then the assess proposal accordion displays a "Completed" tag
+    Then the assess proposal accordion displays a "Complete" tag

--- a/spec/factories/recommendations.rb
+++ b/spec/factories/recommendations.rb
@@ -24,4 +24,20 @@ FactoryBot.define do
   trait :with_planning_application do
     planning_application
   end
+
+  trait :assessment_in_progress do
+    status { :assessment_in_progress }
+  end
+
+  trait :assessment_complete do
+    status { :assessment_complete }
+  end
+
+  trait :review_in_progress do
+    status { :review_in_progress }
+  end
+
+  trait :review_complete do
+    status { :review_complete }
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -924,4 +924,148 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  describe "#recommendation_assessment_in_progress?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:recommendation) do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: status
+      )
+    end
+
+    context "recommendation has status of 'assessment_in_progress'" do
+      let(:status) { :assessment_in_progress }
+
+      it "returns true" do
+        expect(
+          planning_application.recommendation_assessment_in_progress?
+        ).to eq(
+          true
+        )
+      end
+    end
+
+    context "recommendation does not have status of 'assessment_in_progress'" do
+      let(:status) { :assessment_complete }
+
+      it "returns false" do
+        expect(
+          planning_application.recommendation_assessment_in_progress?
+        ).to eq(
+          false
+        )
+      end
+    end
+  end
+
+  describe "#recommendation_assessment_complete?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:recommendation) do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: status
+      )
+    end
+
+    context "recommendation has status of 'assessment_complete'" do
+      let(:status) { :assessment_complete }
+
+      it "returns true" do
+        expect(
+          planning_application.recommendation_assessment_complete?
+        ).to eq(
+          true
+        )
+      end
+    end
+
+    context "recommendation does not have status of 'assessment_complete'" do
+      let(:status) { :assessment_in_progress }
+
+      it "returns false" do
+        expect(
+          planning_application.recommendation_assessment_complete?
+        ).to eq(
+          false
+        )
+      end
+    end
+  end
+
+  describe "#recommendation_review_in_progress?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:recommendation) do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: status
+      )
+    end
+
+    context "recommendation has status of 'review_in_progress'" do
+      let(:status) { :review_in_progress }
+
+      it "returns true" do
+        expect(
+          planning_application.recommendation_review_in_progress?
+        ).to eq(
+          true
+        )
+      end
+    end
+
+    context "recommendation does not have status of 'review_in_progress'" do
+      let(:status) { :assessment_complete }
+
+      it "returns false" do
+        expect(
+          planning_application.recommendation_review_in_progress?
+        ).to eq(
+          false
+        )
+      end
+    end
+  end
+
+  describe "#recommendation_review_complete?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:recommendation) do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: status
+      )
+    end
+
+    context "recommendation has status of 'review_complete'" do
+      let(:status) { :review_complete }
+
+      it "returns true" do
+        expect(
+          planning_application.recommendation_review_complete?
+        ).to eq(
+          true
+        )
+      end
+    end
+
+    context "recommendation does not have status of 'review_complete'" do
+      let(:status) { :assessment_complete }
+
+      it "returns false" do
+        expect(
+          planning_application.recommendation_review_complete?
+        ).to eq(
+          false
+        )
+      end
+    end
+  end
 end

--- a/spec/models/recommendation_form_spec.rb
+++ b/spec/models/recommendation_form_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RecommendationForm do
     let(:recommendation) { planning_application.recommendations.build }
     let(:assessor) { create(:user, :assessor) }
 
-    context "when save_progress is false" do
+    context "when status is 'assessment_complete'" do
       let(:planning_application) do
         create(
           :planning_application,
@@ -33,7 +33,7 @@ RSpec.describe RecommendationForm do
           public_comment: "GDPO compliant",
           assessor_comment: "LGTM",
           assessor: assessor,
-          save_progress: false
+          status: :assessment_complete
         )
       end
 
@@ -66,7 +66,8 @@ RSpec.describe RecommendationForm do
             decision: :granted,
             public_comment: nil,
             assessor_comment: "LGTM",
-            assessor: assessor
+            assessor: assessor,
+            status: :assessment_complete
           )
         end
 
@@ -107,7 +108,8 @@ RSpec.describe RecommendationForm do
             decision: nil,
             public_comment: "GDPO compliant",
             assessor_comment: "LGTM",
-            assessor: assessor
+            assessor: assessor,
+            status: :assessment_complete
           )
         end
 
@@ -141,7 +143,7 @@ RSpec.describe RecommendationForm do
       end
     end
 
-    context "when save_progress is true" do
+    context "when status is 'assessment_in_progress'" do
       let(:planning_application) do
         create(
           :planning_application,
@@ -159,7 +161,7 @@ RSpec.describe RecommendationForm do
           public_comment: "GDPO compliant",
           assessor_comment: "LGTM",
           assessor: assessor,
-          save_progress: true
+          status: :assessment_in_progress
         )
       end
 
@@ -193,7 +195,7 @@ RSpec.describe RecommendationForm do
             public_comment: nil,
             assessor_comment: "LGTM",
             assessor: assessor,
-            save_progress: true
+            status: :assessment_in_progress
           )
         end
 
@@ -224,7 +226,7 @@ RSpec.describe RecommendationForm do
             public_comment: "GDPO compliant",
             assessor_comment: "LGTM",
             assessor: assessor,
-            save_progress: true
+            status: :assessment_in_progress
           )
         end
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     find("#recommendation_challenged_false").click
     fill_in "Review comment", with: "Reviewer private comment"
-    click_button "Save"
+    click_button "Save and mark as complete"
     click_link "Publish determination"
     click_button "Determine application"
 
@@ -77,7 +77,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     click_link "Review assessment"
     find("#recommendation_challenged_true").click
     fill_in "Review comment", with: "Reviewer private comment"
-    click_button "Save"
+    click_button "Save and mark as complete"
     expect(page).not_to have_link("Publish determination")
 
     planning_application.reload
@@ -108,7 +108,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   it "cannot be rejected without a review comment" do
     click_link "Review assessment"
     find("#recommendation_challenged_true").click
-    click_button "Save"
+    click_button "Save and mark as complete"
 
     find_all(".govuk-error-summary").each do |error|
       within(error) do
@@ -120,7 +120,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   it "can be accepted without a review comment" do
     click_link "Review assessment"
     find("#recommendation_challenged_false").click
-    click_button "Save"
+    click_button "Save and mark as complete"
     click_link "Publish determination"
     click_button "Determine application"
 
@@ -144,7 +144,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     find("#recommendation_challenged_true").click
     fill_in "Review comment", with: "Edited reviewer private comment"
-    click_button "Save"
+    click_button "Save and mark as complete"
 
     recommendation.reload
     expect(recommendation.reviewer_comment).to eq("Edited reviewer private comment")

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -44,7 +44,14 @@ RSpec.describe "Planning Application show page", type: :system do
 
     it "makes valid task list for when it in assessment and a proposal has been created" do
       planning_application = create(:planning_application, local_authority: default_local_authority)
-      create(:recommendation, planning_application: planning_application, submitted: true)
+
+      create(
+        :recommendation,
+        :assessment_complete,
+        planning_application: planning_application,
+        submitted: true
+      )
+
       visit planning_application_path(planning_application)
 
       within "#assess-section" do
@@ -84,7 +91,14 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
                                     local_authority: default_local_authority)
-      create(:recommendation, :reviewed, planning_application: planning_application)
+
+      create(
+        :recommendation,
+        :review_complete,
+        :reviewed,
+        planning_application: planning_application
+      )
+
       visit planning_application_path(planning_application)
 
       within "#review-section" do
@@ -118,7 +132,14 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_correction,
                                     local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application: planning_application)
-      create(:recommendation, planning_application: planning_application, submitted: true)
+
+      create(
+        :recommendation,
+        :assessment_complete,
+        planning_application: planning_application,
+        submitted: true
+      )
+
       visit planning_application_path(planning_application)
 
       within "#validation-section" do
@@ -171,7 +192,14 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
                                     local_authority: default_local_authority)
-      create(:recommendation, :reviewed, planning_application: planning_application)
+
+      create(
+        :recommendation,
+        :review_complete,
+        :reviewed,
+        planning_application: planning_application
+      )
+
       visit planning_application_path(planning_application)
 
       within "#validation-section" do


### PR DESCRIPTION
### Description of change

- Add `status` column to `recommendations`.
- Use recommendation status to display correct tags in task list for 'Assess the recommendation' and 'Review the recommendation'.
- Add `Save and mark as complete` and 'Save and come back later' buttons to 'Review the recommendation' form, which set status to `review_in_progress` and `review_complete`.

### Story Link

https://trello.com/c/gXXs6W5z/1249-update-button-groups-on-review-the-recommendation-page

### Screenshot

<img width="60%" alt="Screenshot 2022-10-06 at 10 09 58" src="https://user-images.githubusercontent.com/25392162/194274191-0ed22fc0-8bbd-4dad-b94b-0771fbd5db80.png">

