### PR TITLE
Make status tags more consistent

### DIFF
--- a/app/presenters/concerns/assessment_tasks/assessment_detail_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assessment_detail_presenter.rb
@@ -8,7 +8,7 @@ module AssessmentTasks
       super(template, planning_application)
 
       @assessment_detail = planning_application.assessment_details.send(category).first
-      @status = assessment_details_status
+      @status = assessment_detail&.status || "not_started"
       @category = category
     end
 
@@ -46,14 +46,8 @@ module AssessmentTasks
       classes = ["#{govuk_tag_class} app-task-list__task-tag"]
 
       tag.strong class: classes do
-        status
+        I18n.t("assessment_details.#{status}")
       end
-    end
-
-    def assessment_details_status
-      return "Not started" unless assessment_detail
-
-      assessment_detail.status.humanize
     end
 
     def govuk_tag_class

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -11,11 +11,13 @@
         class: "govuk-link"
         ) %>
       </span>
-      <%= content_tag(
-      :strong,
-      t(".#{consistency_checklist&.status || 'in_assessment'}"),
-      class: "govuk-tag app-task-list__task-tag #{'govuk-tag--blue' if consistency_checklist&.complete?}"
-      ) %>
+      <% if consistency_checklist.blank? %>
+        <%= not_started_tag %>
+      <% elsif consistency_checklist.in_assessment? %>
+        <%= in_progress_tag %>
+      <% else %>
+        <%= complete_tag %>
+      <% end %>
     </li>
     <% if @planning_application.planning_history_enabled? %>
       <li class="app-task-list__item">

--- a/app/views/planning_applications/steps/_assessment.html.erb
+++ b/app/views/planning_applications/steps/_assessment.html.erb
@@ -41,7 +41,7 @@
       <% end %>
     </span>
     <% if @planning_application.submit_recommendation_complete? %>
-      <%= tag.strong "Completed", id: "submit_recommendation-completed", class: "govuk-tag app-task-list__task-tag" %>
+      <%= complete_tag %>
     <% end %>
   </li>
 </ul>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -33,7 +33,7 @@
         <% end %>
       </span>
       <% if @planning_application.publish_complete? %>
-        <%= tag.strong "Completed", id: "publish-completed", class: "govuk-tag app-task-list__task-tag" %>
+        <%= complete_tag %>
       <% elsif @planning_application.can_publish? && current_user.assessor? %>
         <%= tag.strong "Waiting", id: "review_assessment-waiting", class: "govuk-tag app-task-list__task-tag" %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,10 +75,13 @@ en:
     additional_evidence: Additional evidence
     additional_evidence_successfully_created: Additional evidence was successfully created.
     additional_evidence_successfully_updated: Additional evidence was successfully updated.
+    completed: Complete
     edit_additional_evidence: Edit additional evidence
     edit_summary_of_work: Edit summary of works
+    in_progress: In progress
     new_additional_evidence: Add detail of additional evidence
     new_summary_of_work: Create a summary of the works
+    not_started: Not started
     show_additional_evidence: Detail of additional evidence
     show_summary_of_work: Summary of works
     summary_of_work: Summary

--- a/spec/presenters/assessment_tasks/assessment_detail_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/assessment_detail_presenter_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe AssessmentTasks::AssessmentDetailPresenter, type: :presenter do
           )
 
           expect(html).to include(
-            "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Completed</strong>"
+            "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Complete</strong>"
           )
         end
       end
@@ -121,7 +121,7 @@ RSpec.describe AssessmentTasks::AssessmentDetailPresenter, type: :presenter do
           )
 
           expect(html).to include(
-            "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Completed</strong>"
+            "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Complete</strong>"
           )
         end
       end

--- a/spec/system/planning_applications/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/checking_consistency_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "checking consistency", type: :system do
   end
 
   it "lets user save draft or mark as complete" do
+    expect(task_list_item).to have_content("Not started")
     click_link("Description, documents and proposal details")
     click_button("Save and mark as complete")
 
@@ -58,11 +59,7 @@ RSpec.describe "checking consistency", type: :system do
 
     expect(page).to have_content("Successfully updated application checklist")
 
-    task_list_item = task_list_item_with_name(
-      "Description, documents and proposal details"
-    )
-
-    expect(task_list_item).to have_content("In assessment")
+    expect(task_list_item).to have_content("In progress")
 
     click_link("Description, documents and proposal details")
 
@@ -80,10 +77,6 @@ RSpec.describe "checking consistency", type: :system do
     click_button("Save and mark as complete")
 
     expect(page).to have_content("Successfully updated application checklist")
-
-    task_list_item = task_list_item_with_name(
-      "Description, documents and proposal details"
-    )
 
     expect(task_list_item).to have_content("Complete")
 
@@ -295,7 +288,8 @@ RSpec.describe "checking consistency", type: :system do
     find("legend", text: legend).find(:xpath, "..")
   end
 
-  def task_list_item_with_name(name)
-    find("span", text: name).find(:xpath, "..")
+  def task_list_item
+    text = "Description, documents and proposal details"
+    find("span", text: text).find(:xpath, "..")
   end
 end


### PR DESCRIPTION
### Description of change

- Replace 'Completed' with 'Complete' for all tags.
- Update consistency checklist tag so that initial status is 'Not started', not 'In assessment'.

### Story Link

NA