### PR TITLE
Add status tag to 'Check and assess' task

### DIFF
--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -52,6 +52,10 @@ class Recommendation < ApplicationRecord
     raise ReviewRecommendationError, e.message
   end
 
+  def submitted_and_unchallenged?
+    submitted? && !challenged
+  end
+
   private
 
   def reviewer_comment_is_present?

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -16,4 +16,10 @@ module AssessmentTasksPresenter
       ).task_list_row
     end
   end
+
+  def assessment_tasklist_in_progress?
+    policy_classes.any? ||
+      consistency_checklist.present? ||
+      assessment_details.any?
+  end
 end

--- a/app/views/planning_applications/steps/_assessment.html.erb
+++ b/app/views/planning_applications/steps/_assessment.html.erb
@@ -31,6 +31,13 @@
         class: "govuk-link"
       ) %>
     </span>
+    <% if @planning_application.recommendation&.submitted_and_unchallenged? %>
+      <%= complete_tag %>
+    <% elsif @planning_application.assessment_tasklist_in_progress? %>
+      <%= in_progress_tag %>
+    <% elsif @planning_application.validated? %>
+      <%= not_started_tag %>
+    <% end %>
   </li>
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">

--- a/spec/factories/recommendations.rb
+++ b/spec/factories/recommendations.rb
@@ -19,6 +19,7 @@ FactoryBot.define do
     reviewer { association :user, :reviewer }
     reviewer_comment { "Reviewer Comment" }
     reviewed_at { Time.zone.now }
+    status { :review_complete }
   end
 
   trait :with_planning_application do

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -164,4 +164,43 @@ RSpec.describe Recommendation, type: :model do
       end
     end
   end
+
+  describe "#submitted_and_unchallenged?" do
+    let(:recommendation) do
+      build(
+        :recommendation,
+        submitted: submitted,
+        challenged: challenged
+      )
+    end
+
+    context "when recommendation is not submitted" do
+      let(:submitted) { false }
+      let(:challenged) { false }
+
+      it "returns false" do
+        expect(recommendation.submitted_and_unchallenged?).to eq(false)
+      end
+    end
+
+    context "when recommendation is submitted" do
+      let(:submitted) { true }
+
+      context "when recommendation is not challenged" do
+        let(:challenged) { false }
+
+        it "returns true" do
+          expect(recommendation.submitted_and_unchallenged?).to eq(true)
+        end
+      end
+
+      context "when recommendation is challenged" do
+        let(:challenged) { true }
+
+        it "returns true" do
+          expect(recommendation.submitted_and_unchallenged?).to eq(false)
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
     let(:presenter) { described_class.new(view, presented) }
   end
 
+  it_behaves_like "AssessmentTasksPresenter"
+
   describe "#status_tag" do
     context "when an application is in the invalidated state" do
       let(:planning_application) { create(:invalidated_planning_application) }

--- a/spec/support/assessment_tasks_presenter_shared_examples.rb
+++ b/spec/support/assessment_tasks_presenter_shared_examples.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "AssessmentTasksPresenter" do
+  describe "#assessment_tasklist_in_progress?" do
+    let(:planning_application) { create(:planning_application) }
+    let(:presenter) { described_class.new(view, planning_application) }
+
+    context "when no assessment tasks objects are present" do
+      it "returns false" do
+        expect(presenter.assessment_tasklist_in_progress?).to eq(false)
+      end
+    end
+
+    context "when policy class is present" do
+      before do
+        create(:policy_class, planning_application: planning_application)
+      end
+
+      it "returns true" do
+        expect(presenter.assessment_tasklist_in_progress?).to eq(true)
+      end
+    end
+
+    context "when consistency checklist is present" do
+      before do
+        create(
+          :consistency_checklist,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(presenter.assessment_tasklist_in_progress?).to eq(true)
+      end
+    end
+
+    context "when assessment detail is present" do
+      before do
+        create(
+          :assessment_detail,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(presenter.assessment_tasklist_in_progress?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -8,4 +8,8 @@ module SystemSpecHelpers
   def selected_govuk_tab
     find("div[class='govuk-tabs__panel']")
   end
+
+  def list_item(text)
+    find("li", text: text)
+  end
 end

--- a/spec/system/planning_applications/additional_evidence_spec.rb
+++ b/spec/system/planning_applications/additional_evidence_spec.rb
@@ -16,11 +16,9 @@ RSpec.describe "Additional evidence", type: :system do
   end
 
   context "when planning application is in assessment" do
-    before do
-      click_link "Check and assess"
-    end
-
     it "I can view the information on the additional evidence page" do
+      click_link "Check and assess"
+
       within("#assessment-information-tasks") do
         expect(page).to have_content("Not started")
         click_link "Additional evidence"
@@ -46,6 +44,9 @@ RSpec.describe "Additional evidence", type: :system do
     end
 
     it "I can save and come back later when adding or editing additional evidence" do
+      expect(list_item("Check and assess")).to have_content("Not started")
+
+      click_link "Check and assess"
       click_link "Additional evidence"
 
       fill_in "assessment_detail[entry]", with: "A draft entry for the additional evidence"
@@ -71,9 +72,14 @@ RSpec.describe "Additional evidence", type: :system do
       within("#assessment-information-tasks") do
         expect(page).to have_content("In progress")
       end
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
     end
 
     it "I can save and mark as complete when adding additional evidence" do
+      click_link "Check and assess"
       click_link "Additional evidence"
 
       fill_in "assessment_detail[entry]", with: "A complete entry for the additional evidence"

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe "assessment against legislation", type: :system do
   before do
     sign_in(assessor)
     visit planning_application_path(planning_application)
-    click_link("Check and assess")
   end
 
   it "warns the user about unsaved changes" do
+    click_link("Check and assess")
     click_link("Add assessment area")
     click_link("Back")
     click_link("Add assessment area")
@@ -67,6 +67,7 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "lets the user add policy classes once only" do
+    click_link("Check and assess")
     add_policy_classes(["Class D - porches"])
 
     expect(page).to have_content("Part 1, Class D").once
@@ -85,6 +86,7 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "lets the user remove policy class" do
+    click_link("Check and assess")
     add_policy_classes(["Class D - porches"])
     expect(page).to have_content("Part 1, Class D").once
 
@@ -98,6 +100,8 @@ RSpec.describe "assessment against legislation", type: :system do
   end
 
   it "displays the class title" do
+    click_link("Check and assess")
+
     add_policy_classes(
       [
         "Class A - enlargement, improvement or other alteration of a dwellinghouse",
@@ -121,6 +125,7 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user add and update comments" do
     travel_to(Time.zone.local(2022, 9, 1))
+    click_link("Check and assess")
     add_policy_classes(["Class D - porches"])
     click_link("Part 1, Class D")
 
@@ -163,6 +168,10 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user save draft and then mark as complete" do
     travel_to(Time.zone.local(2022, 9, 1))
+
+    expect(list_item("Check and assess")).to have_content("Not started")
+
+    click_link("Check and assess")
     add_policy_classes(["Class D - porches"])
     click_link("Part 1, Class D")
 
@@ -223,10 +232,16 @@ RSpec.describe "assessment against legislation", type: :system do
     expect(page).to have_selector(
       "#policy_class_policies_attributes_0_status_does_not_comply"
     )
+
+    click_link("Application")
+
+    expect(list_item("Check and assess")).to have_content("In progress")
   end
 
   it "lets the user scroll between policy classes" do
     travel_to(Time.zone.local(2022, 9, 1))
+
+    click_link("Check and assess")
 
     add_policy_classes(
       [
@@ -285,6 +300,7 @@ RSpec.describe "assessment against legislation", type: :system do
 
   it "lets the user delete comments" do
     travel_to(Time.zone.local(2022, 9, 1))
+    click_link("Check and assess")
     add_policy_classes(["Class D - porches"])
     click_link("Part 1, Class D")
 

--- a/spec/system/planning_applications/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/checking_consistency_spec.rb
@@ -24,11 +24,12 @@ RSpec.describe "checking consistency", type: :system do
 
   before do
     sign_in(user)
-    visit(planning_application_assessment_tasks_path(planning_application))
+    visit(planning_application_path(planning_application))
   end
 
   it "lets user save draft or mark as complete" do
-    expect(task_list_item).to have_content("Not started")
+    expect(list_item("Check and assess")).to have_content("Not started")
+    click_link("Check and assess")
     click_link("Description, documents and proposal details")
     click_button("Save and mark as complete")
 
@@ -106,10 +107,15 @@ RSpec.describe "checking consistency", type: :system do
 
     expect(page).to have_content("How are the proposal details inconsistent?")
     expect(page).to have_content("Reason for inconsistencty")
+
+    click_link("Application")
+
+    expect(list_item("Check and assess")).to have_content("In progress")
   end
 
   it "lets the user request a description change" do
     travel_to(Time.zone.local(2022, 9, 15, 12))
+    click_link("Check and assess")
     click_link("Description, documents and proposal details")
 
     form_group1 = form_group_with_legend(
@@ -215,6 +221,7 @@ RSpec.describe "checking consistency", type: :system do
 
   it "lets the user request an additional document" do
     travel_to(Time.zone.local(2022, 9, 15, 12))
+    click_link("Check and assess")
     click_link("Description, documents and proposal details")
 
     form_group1 = form_group_with_legend(
@@ -278,6 +285,7 @@ RSpec.describe "checking consistency", type: :system do
     end
 
     it "lets the user navigate to the document" do
+      click_link("Check and assess")
       click_link("Description, documents and proposal details")
       click_link("View new document")
       expect(page).to have_content("File name: proposed-floorplan.png")

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -89,6 +89,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_button "Submit recommendation"
 
         expect(page).to have_content("Recommendation was successfully submitted.")
+        expect(list_item("Assess recommendation")).to have_content("Complete")
 
         perform_enqueued_jobs
         update_notification = ActionMailer::Base.deliveries.last
@@ -542,7 +543,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
   it "shows the correct status tags at each stage" do
     visit(planning_application_path(planning_application))
 
-    expect(assess_list_item).to have_content("Not started")
+    expect(list_item("Assess recommendation")).to have_content("Not started")
 
     click_link("Assess recommendation")
     choose("Yes")
@@ -559,41 +560,41 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     click_button("Save and come back later")
 
-    expect(assess_list_item).to have_content("In progress")
+    expect(list_item("Assess recommendation")).to have_content("In progress")
 
     click_link("Assess recommendation")
     click_button("Save and mark as complete")
 
-    expect(assess_list_item).to have_content("Complete")
+    expect(list_item("Assess recommendation")).to have_content("Complete")
 
     ["Not started", "In progress", "Complete"].each do |status|
-      expect(review_list_item).not_to have_content(status)
+      expect(list_item("Review assessment")).not_to have_content(status)
     end
 
     click_link("Submit recommendation")
     click_button("Submit recommendation")
 
-    expect(view_list_item).to have_content("Awaiting determination")
+    expect(list_item("View recommendation")).to have_content("Awaiting determination")
 
     sign_in(reviewer)
     visit(planning_application_path(planning_application))
 
-    expect(review_list_item).to have_content("Not started")
+    expect(list_item("Review assessment")).to have_content("Not started")
 
     click_link("Review assessment")
     choose("recommendation_challenged_true")
     fill_in("Review comment", with: "Application invalid")
     click_button("Save and come back later")
 
-    expect(review_list_item).to have_content("In progress")
+    expect(list_item("Review assessment")).to have_content("In progress")
 
     click_link("Review assessment")
     click_button("Save and mark as complete")
 
-    expect(review_list_item).to have_content("Complete")
+    expect(list_item("Review assessment")).to have_content("Complete")
 
     ["Not started", "In progress", "Complete"].each do |status|
-      expect(assess_list_item).not_to have_content(status)
+      expect(list_item("Assess recommendation")).not_to have_content(status)
     end
 
     sign_in(assessor)
@@ -608,41 +609,29 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     click_button("Update")
 
-    expect(assess_list_item).to have_content("Complete")
+    expect(list_item("Assess recommendation")).to have_content("Complete")
 
     click_link("Submit recommendation")
     click_button("Submit recommendation")
 
-    expect(view_list_item).to have_content("Awaiting determination")
+    expect(list_item("View recommendation")).to have_content("Awaiting determination")
 
     sign_in(reviewer)
     visit(planning_application_path(planning_application))
 
-    expect(review_list_item).to have_content("Not started")
+    expect(list_item("Review assessment")).to have_content("Not started")
 
     click_link("Review assessment")
     choose("recommendation_challenged_false")
     fill_in("Review comment", with: "Application valid")
     click_button("Save and mark as complete")
 
-    expect(assess_list_item).to have_content("Complete")
-    expect(review_list_item).to have_content("Complete")
+    expect(list_item("Assess recommendation")).to have_content("Complete")
+    expect(list_item("Review assessment")).to have_content("Complete")
 
     sign_in(assessor)
     visit(planning_application_path(planning_application))
 
-    expect(view_list_item).to have_content("Complete")
-  end
-
-  def assess_list_item
-    find("li", text: "Assess recommendation")
-  end
-
-  def review_list_item
-    find("li", text: "Review assessment")
-  end
-
-  def view_list_item
-    find("li", text: "View recommendation")
+    expect(list_item("View recommendation")).to have_content("Complete")
   end
 end

--- a/spec/system/planning_applications/summary_of_works_spec.rb
+++ b/spec/system/planning_applications/summary_of_works_spec.rb
@@ -16,11 +16,9 @@ RSpec.describe "Summary of works", type: :system do
   end
 
   context "when planning application is in assessment" do
-    before do
-      click_link "Check and assess"
-    end
-
     it "I can view the information on the summary of works page" do
+      click_link "Check and assess"
+
       within("#assessment-information-tasks") do
         expect(page).to have_content("Not started")
         click_link "Summary of works"
@@ -45,6 +43,7 @@ RSpec.describe "Summary of works", type: :system do
     end
 
     it "there is a validation error when submitting an empty text field" do
+      click_link "Check and assess"
       click_link "Summary of works"
 
       click_button "Save and mark as complete"
@@ -59,6 +58,8 @@ RSpec.describe "Summary of works", type: :system do
     end
 
     it "I can save and come back later when adding or editing a summary of work" do
+      expect(list_item("Check and assess")).to have_content("Not started")
+      click_link "Check and assess"
       click_link "Summary of works"
 
       fill_in "assessment_detail[entry]", with: "A draft entry for the summary of works"
@@ -84,9 +85,14 @@ RSpec.describe "Summary of works", type: :system do
       within("#assessment-information-tasks") do
         expect(page).to have_content("In progress")
       end
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
     end
 
     it "I can save and mark as complete when adding a summary of work" do
+      click_link "Check and assess"
       click_link "Summary of works"
 
       fill_in "assessment_detail[entry]", with: "A complete entry for the summary of works"

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -44,14 +44,7 @@ RSpec.describe "Planning Application show page", type: :system do
 
     it "makes valid task list for when it in assessment and a proposal has been created" do
       planning_application = create(:planning_application, local_authority: default_local_authority)
-
-      create(
-        :recommendation,
-        :assessment_complete,
-        planning_application: planning_application,
-        submitted: true
-      )
-
+      create(:recommendation, planning_application: planning_application, submitted: true)
       visit planning_application_path(planning_application)
 
       within "#assess-section" do
@@ -91,14 +84,7 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
                                     local_authority: default_local_authority)
-
-      create(
-        :recommendation,
-        :review_complete,
-        :reviewed,
-        planning_application: planning_application
-      )
-
+      create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application)
 
       within "#review-section" do
@@ -114,7 +100,14 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it is awaiting correction and no re-proposal has been made" do
       planning_application = create(:planning_application, :awaiting_correction,
                                     local_authority: default_local_authority)
-      create(:recommendation, :reviewed, planning_application: planning_application)
+
+      create(
+        :recommendation,
+        :reviewed,
+        planning_application: planning_application,
+        challenged: true
+      )
+
       visit planning_application_path(planning_application)
 
       within "#validation-section" do
@@ -132,14 +125,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_correction,
                                     local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application: planning_application)
-
-      create(
-        :recommendation,
-        :assessment_complete,
-        planning_application: planning_application,
-        submitted: true
-      )
-
+      create(:recommendation, planning_application: planning_application, submitted: true)
       visit planning_application_path(planning_application)
 
       within "#validation-section" do
@@ -153,7 +139,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_content("Complete")
         expect(page).to have_link("Submit recommendation")
         within(:xpath, '//*[@id="assess-section"]/li[3]') do
-          expect(page).not_to have_content("Complete")
+          expect(page).to have_content("Complete")
         end
       end
     end
@@ -192,14 +178,7 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
                                     local_authority: default_local_authority)
-
-      create(
-        :recommendation,
-        :review_complete,
-        :reviewed,
-        planning_application: planning_application
-      )
-
+      create(:recommendation, :reviewed, planning_application: planning_application)
       visit planning_application_path(planning_application)
 
       within "#validation-section" do


### PR DESCRIPTION
### Description of change

Add a status tag to the 'Check and assess' task.

### Story Link

https://trello.com/c/PaYsVcQH/1130-create-page-structure-for-assessment-of-pd-stories

### Screenshot

![Screenshot 2022-10-06 at 15 57 52](https://user-images.githubusercontent.com/25392162/194348505-5a6d49aa-471a-48a1-9033-b61a7e687c23.png)
