### PR TITLE
Allow officers to add previous application references

### DIFF
--- a/app/controllers/planning_application/assessment_details_controller.rb
+++ b/app/controllers/planning_application/assessment_details_controller.rb
@@ -86,7 +86,9 @@ class PlanningApplication
     end
 
     def assessment_details_params
-      params.require(:assessment_detail).permit(:entry, :category)
+      params
+        .require(:assessment_detail)
+        .permit(:entry, :category, :additional_information)
     end
 
     def save_progress?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,4 +76,20 @@ module ApplicationHelper
       planning_application_consistency_checklist_path
     end
   end
+
+  def assessment_detail_error_presenter(category)
+    if category == "past_applications"
+      PastApplicationsErrorPresenter
+    else
+      ErrorPresenter
+    end
+  end
+
+  def assessment_detail_fields_partial_path(category)
+    if category == "past_applications"
+      "planning_application/assessment_details/past_applications"
+    else
+      "planning_application/assessment_details"
+    end
+  end
 end

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -12,7 +12,8 @@ class AssessmentDetail < ApplicationRecord
   enum category: {
     summary_of_work: "summary_of_work",
     additional_evidence: "additional_evidence",
-    site_description: "site_description"
+    site_description: "site_description",
+    past_applications: "past_applications"
   }
 
   validates :status, presence: true
@@ -27,6 +28,8 @@ class AssessmentDetail < ApplicationRecord
   private
 
   def validate_entry_presence?
-    summary_of_work? || site_description?
+    summary_of_work? ||
+      site_description? ||
+      (past_applications? && completed?)
   end
 end

--- a/app/presenters/concerns/assessment_tasks/assessment_detail_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assessment_detail_presenter.rb
@@ -73,9 +73,7 @@ module AssessmentTasks
     end
 
     def category_text
-      return category.humanize.pluralize if category == "summary_of_work"
-
-      category.humanize
+      I18n.t("assessment_details.task_list.#{category}")
     end
   end
 end

--- a/app/presenters/past_applications_error_presenter.rb
+++ b/app/presenters/past_applications_error_presenter.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class PastApplicationsErrorPresenter < ErrorPresenter
+  private
+
+  def formatted_message(message, attribute)
+    attribute = attributes_map[attribute] || attribute
+    super(message, attribute)
+  end
+
+  def attributes_map
+    {
+      entry: :application_reference_numbers,
+      additional_information: :relevant_information
+    }
+  end
+end

--- a/app/views/planning_application/assessment_details/_fields.html.erb
+++ b/app/views/planning_application/assessment_details/_fields.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body"><%= simple_format(assessment_detail.entry) %></p>

--- a/app/views/planning_application/assessment_details/_form.html.erb
+++ b/app/views/planning_application/assessment_details/_form.html.erb
@@ -1,9 +1,14 @@
 <%= render "planning_application/assessment_details/#{category}/information", category: category %>
 
 <%= form_with model: [@planning_application, @assessment_detail], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary(
+    presenter: assessment_detail_error_presenter(category)
+  ) %>
 
-  <%= form.govuk_text_area :entry, label: nil, rows: 10 %>
+  <%= render(
+    partial: "#{assessment_detail_fields_partial_path(category)}/form_fields",
+    locals: { form: form }
+  ) %>
 
   <%= form.hidden_field :category, value: category %>
 

--- a/app/views/planning_application/assessment_details/_form_fields.html.erb
+++ b/app/views/planning_application/assessment_details/_form_fields.html.erb
@@ -1,0 +1,1 @@
+<%= form.govuk_text_area :entry, label: nil, rows: 10 %>

--- a/app/views/planning_application/assessment_details/past_applications/_fields.html.erb
+++ b/app/views/planning_application/assessment_details/past_applications/_fields.html.erb
@@ -1,0 +1,6 @@
+<p class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-19">
+  <%= assessment_detail.entry %>
+</p>
+<p class="govuk-body">
+  <%= simple_format(assessment_detail.additional_information) %>
+</p>

--- a/app/views/planning_application/assessment_details/past_applications/_form_fields.html.erb
+++ b/app/views/planning_application/assessment_details/past_applications/_form_fields.html.erb
@@ -1,0 +1,9 @@
+<%= form.govuk_text_field(
+  :entry,
+  label: { text: t(".application_reference_numbers") }
+) %>
+<%= form.govuk_text_area(
+  :additional_information,
+  label: { text: t(".relevant_information") },
+  rows: 8
+)  %>

--- a/app/views/planning_application/assessment_details/past_applications/_information.html.erb
+++ b/app/views/planning_application/assessment_details/past_applications/_information.html.erb
@@ -1,0 +1,5 @@
+<h2 class="govuk-heading-m"><%= t(".summary_of_the") %></h2>
+<%= render(
+  partial: "shared/warning_text",
+  locals: { message: t(".this_information_will") }
+) %>

--- a/app/views/planning_application/assessment_details/show.html.erb
+++ b/app/views/planning_application/assessment_details/show.html.erb
@@ -20,14 +20,23 @@
     <div class="govuk-body">
       <%= render "planning_application/assessment_details/#{@assessment_detail.category}/information", category: @assessment_detail.category %>
 
-      <p><%= simple_format(@assessment_detail.entry) %></p>
+      <%= render(
+        partial: "#{assessment_detail_fields_partial_path(@assessment_detail.category)}/fields",
+        locals: { assessment_detail: @assessment_detail }
+      ) %>
     </div>
 
     <div class="govuk-button-group">
       <%= back_link %>
 
-      <%= link_to t("assessment_details.edit_#{@assessment_detail.category}"), edit_planning_application_assessment_detail_path(@planning_application, @assessment_detail), class: "govuk-link" %>
+      <%= link_to(
+        t(".edit_#{@assessment_detail.category}"),
+        edit_planning_application_assessment_detail_path(
+          @planning_application,
+          @assessment_detail
+        ),
+        class: "govuk-link"
+      )%>
     </div>
   </div>
 </div>
-

--- a/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
+++ b/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
@@ -3,7 +3,7 @@
     Add assessment information
   </h2>
   <ul class="app-task-list__items">
-    <% AssessmentDetail.categories.keys.each do |category| %>
+    <% AssessmentDetail.categories.keys.excluding("past_applications").each do |category| %>
       <li class="app-task-list__item" id="<%= category %>-tasklist-item">
         <%= @planning_application.assessment_detail_tasklist(category) %>
       </li>

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -17,12 +17,20 @@
         )
       ) %>
     </li>
-    <% if @planning_application.planning_history_enabled? %>
-      <li class="app-task-list__item">
+    <li class="app-task-list__item">
+      <% if @planning_application.planning_history_enabled? %>
         <span class="app-task-list__task-name">
-          <%= link_to "History", planning_application_planning_history_path(@planning_application), class: "govuk-link" %>
+          <%= link_to(
+            t(".history"),
+            planning_application_planning_history_path(@planning_application),
+            class: "govuk-link"
+          ) %>
         </span>
-      </li>
-    <% end %>
+      <% else %>
+        <%= @planning_application.assessment_detail_tasklist(
+          :past_applications
+        ) %>
+      <% end %>
+    </li>
   </ul>
 </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -77,14 +77,20 @@ en:
     additional_evidence_successfully_updated: Additional evidence was successfully updated.
     completed: Complete
     edit_additional_evidence: Edit additional evidence
+    edit_past_applications: History
     edit_site_description: Edit site description
     edit_summary_of_work: Edit summary of works
     in_progress: In progress
     new_additional_evidence: Add detail of additional evidence
+    new_past_applications: History
     new_site_description: Create a description of the site
     new_summary_of_work: Create a summary of the works
     not_started: Not started
+    past_applications: History
+    past_applications_successfully_created: History successfully added.
+    past_applications_successfully_updated: History successfully updated.
     show_additional_evidence: Detail of additional evidence
+    show_past_applications: History
     show_site_description: Site description
     show_summary_of_work: Summary of works
     site_description: Site description
@@ -93,6 +99,11 @@ en:
     summary_of_work: Summary
     summary_of_work_successfully_created: Summary of works was successfully created.
     summary_of_work_successfully_updated: Summary of works was successfully updated.
+    task_list:
+      additional_evidence: Additional evidence
+      past_applications: History
+      site_description: Site description
+      summary_of_work: Summary of works
   audit_user_name:
     applicant: Applicant / Agent via %{api_user_name}
     deleted: User deleted
@@ -249,11 +260,25 @@ en:
         summary: Tell the applicant why the fee is incorrect.
   page_title: BETA BOPs - GOV.UK
   planning_application:
+    assessment_details:
+      past_applications:
+        form_fields:
+          application_reference_numbers: Application reference number(s)
+          relevant_information: Relevant information
+        information:
+          summary_of_the: Summary of the relevant historical applications
+          this_information_will: This information WILL be made public
+      show:
+        edit_additional_evidence: Edit additional evidence
+        edit_past_applications: Edit history
+        edit_site_description: Edit site description
+        edit_summary_of_work: Edit summary of work
     assessment_tasks:
       check_consistency:
         check_application: Check application
         complete: Complete
         description_documents_and: Description, documents and proposal details
+        history: History
         in_assessment: In assessment
   planning_application_panel_component:
     all: All

--- a/db/migrate/20221010085320_add_additional_information_to_assessment_details.rb
+++ b/db/migrate/20221010085320_add_additional_information_to_assessment_details.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAdditionalInformationToAssessmentDetails < ActiveRecord::Migration[6.1]
+  def change
+    add_column(:assessment_details, :additional_information, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_04_110545) do
+ActiveRecord::Schema.define(version: 2022_10_10_085320) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2022_10_04_110545) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "category", null: false
+    t.text "additional_information"
     t.index ["planning_application_id"], name: "ix_assessment_details_on_planning_application_id"
     t.index ["user_id"], name: "ix_assessment_details_on_user_id"
   end

--- a/spec/factories/assessment_detail.rb
+++ b/spec/factories/assessment_detail.rb
@@ -24,5 +24,9 @@ FactoryBot.define do
     trait :site_description do
       category { "site_description" }
     end
+
+    trait :past_applications do
+      category { "past_applications" }
+    end
   end
 end

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -4,14 +4,19 @@ require "rails_helper"
 
 RSpec.describe AssessmentDetail, type: :model do
   describe "validations" do
-    let(:summary_of_work) { described_class.new }
-    let(:additional_evidence) { described_class.new }
-    let(:site_description) { described_class.new }
-
     describe "#entry" do
       let(:summary_of_work) { create(:assessment_detail, :summary_of_work, entry: "") }
       let(:additional_evidence) { create(:assessment_detail, :additional_evidence, entry: "") }
       let(:site_description) { create(:assessment_detail, :site_description, entry: "") }
+
+      let(:past_applications) do
+        create(
+          :assessment_detail,
+          :past_applications,
+          entry: "",
+          status: status
+        )
+      end
 
       it "validates presence for summary of work" do
         expect { summary_of_work }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Entry can't be blank")
@@ -24,10 +29,29 @@ RSpec.describe AssessmentDetail, type: :model do
       it "validates presence for for site description" do
         expect { site_description }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Entry can't be blank")
       end
+
+      context "when status is completed" do
+        let(:status) { :completed }
+
+        it "validates presence for assessment_detail" do
+          expect { past_applications }.to raise_error(
+            ActiveRecord::RecordInvalid,
+            "Validation failed: Entry can't be blank"
+          )
+        end
+      end
+
+      context "when status is in_progress" do
+        let(:status) { :in_progress }
+
+        it "does not validates presence for assessment_detail" do
+          expect { past_applications }.not_to raise_error
+        end
+      end
     end
 
     described_class.categories.each_key do |category_type|
-      let(:category) { send(category_type) }
+      let(:category) { described_class.new(category: category_type) }
 
       describe "#status" do
         it "validates presence" do

--- a/spec/presenters/past_applications_error_presenter_spec.rb
+++ b/spec/presenters/past_applications_error_presenter_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PastApplicationsErrorPresenter do
+  let(:error_messages) do
+    [
+      [:entry, ["can't be blank"]],
+      [:additional_information, ["can't be blank"]]
+    ]
+  end
+
+  let(:presenter) { described_class.new(error_messages) }
+
+  describe "#formatted_error_messages" do
+    it "returns formatted error messages" do
+      expect(
+        presenter.formatted_error_messages
+      ).to contain_exactly(
+        [:entry, "Application reference numbers can't be blank"],
+        [:additional_information, "Relevant information can't be blank"]
+      )
+    end
+  end
+end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -10,6 +10,6 @@ module SystemSpecHelpers
   end
 
   def list_item(text)
-    find("li", text: text)
+    find("li", text: text, match: :prefer_exact)
   end
 end

--- a/spec/system/planning_applications/adding_past_application_references_spec.rb
+++ b/spec/system/planning_applications/adding_past_application_references_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "adding past application references", type: :system do
+  let(:default_local_authority) { create(:local_authority, :default) }
+
+  let!(:assessor) do
+    create(:user, :assessor, local_authority: default_local_authority)
+  end
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: default_local_authority
+    )
+  end
+
+  it "lets user save draft, mark as complete, and edit" do
+    sign_in(assessor)
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+
+    expect(list_item("History")).to have_content("Not started")
+
+    click_link("History")
+    fill_in("Relevant information", with: "Application granted.")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content(
+      "Application reference numbers can't be blank"
+    )
+
+    click_button("Save and come back later")
+
+    expect(page).to have_content("History successfully added.")
+    expect(list_item("History")).to have_content("In progress")
+
+    click_link("History")
+    fill_in("Application reference number(s)", with: "22-00107-LDCP")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("History successfully updated.")
+    expect(list_item("History")).to have_content("Complete")
+
+    click_link("History")
+
+    expect(page).to have_content("22-00107-LDCP")
+    expect(page).to have_content("Application granted.")
+
+    click_link("Edit history")
+    fill_in("Application reference number(s)", with: "22-00108-LDCP")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("History successfully updated.")
+
+    click_link("History")
+
+    expect(page).to have_content("22-00108-LDCP")
+  end
+end

--- a/spec/system/planning_applications/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessment_tasks_index_spec.rb
@@ -30,22 +30,6 @@ RSpec.describe "Assessment tasks", type: :system do
         end
       end
     end
-
-    context "when planning_history Feature flag is missing" do
-      before do
-        allow(ENV).to receive(:fetch).with("PLANNING_HISTORY_ENABLED", "false").and_return("false")
-      end
-
-      it "does not include the History link" do
-        visit planning_application_assessment_tasks_path(planning_application)
-
-        within(".app-task-list") do
-          within("#check-consistency-assessment-tasks") do
-            expect(page).not_to have_link("History")
-          end
-        end
-      end
-    end
   end
 
   context "when I cannot assess the planning application" do


### PR DESCRIPTION
### Description of change

- Add `additional_information` to `assessment_details`.
- Add `past_application_references` category to `assessment_details`.
-  Use existing `assessment_details` structure to add editing and updating 'History'.

### Story Link

https://trello.com/c/bk4LXxFY/1183-add-field-application-reference-numbers-to-the-history-page-in-assessment-tasklist

### Screenshots

<img width="60%" alt="Screenshot 2022-10-11 at 12 18 58" src="https://user-images.githubusercontent.com/25392162/195079100-39fd2470-c47b-46dc-b7b6-7830d88187c7.png">

Validation error:

<img width="60%" alt="Screenshot 2022-10-11 at 12 19 31" src="https://user-images.githubusercontent.com/25392162/195079110-44dd11f8-6575-425f-9599-9011071b2b2d.png">

### Decisions [OPTIONAL]

Adding an `additional_information` field to `assessment_details` instead of creating a new table. But I think this should be the last field we add! We want to keep this table as generic as possible.
