### PR TITLE
Add consultation summary to assessment information

### DIFF
--- a/app/controllers/consultees_controller.rb
+++ b/app/controllers/consultees_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ConsulteesController < AuthenticationController
+  before_action :set_planning_application
+
+  def create
+    consultee = planning_application.consultees.new(consultee_params)
+    consultee = planning_application.consultees.new if consultee.save
+    render(json: { partial: consultees_partial(consultee) })
+  end
+
+  def destroy
+    planning_application.consultees.find(params[:id]).destroy
+    render(json: { partial: consultee_table_partial })
+  end
+
+  private
+
+  attr_reader :planning_application
+
+  def consultees_partial(consultee)
+    render_to_string(
+      partial: "planning_application/assessment_details/consultation_summary/consultees",
+      locals: {
+        planning_application: planning_application,
+        consultee: consultee,
+        read_only: false
+      }
+    )
+  end
+
+  def consultee_table_partial
+    render_to_string(
+      partial: "planning_application/assessment_details/consultation_summary/consultee_table",
+      locals: {
+        planning_application: planning_application,
+        read_only: false
+      }
+    )
+  end
+
+  def consultee_params
+    params.require(:consultee).permit(:name, :origin)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -78,16 +78,16 @@ module ApplicationHelper
   end
 
   def assessment_detail_error_presenter(category)
-    if category == "past_applications"
-      PastApplicationsErrorPresenter
+    if %w[past_applications consultation_summary].include?(category)
+      "#{category.camelize}ErrorPresenter".constantize
     else
       ErrorPresenter
     end
   end
 
   def assessment_detail_fields_partial_path(category)
-    if category == "past_applications"
-      "planning_application/assessment_details/past_applications"
+    if %w[past_applications consultation_summary].include?(category)
+      "planning_application/assessment_details/#{category}"
     else
       "planning_application/assessment_details"
     end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,5 +9,8 @@ application.register("delete-record", DeleteRecordController)
 import ShowHideController from "./show_hide_controller.js"
 application.register("show-hide", ShowHideController)
 
+import SubmitFormController from "./submit_form_controller.js"
+application.register("submit-form", SubmitFormController)
+
 import UnsavedChangesController from "./unsaved_changes_controller.js"
 application.register("unsaved-changes", UnsavedChangesController)

--- a/app/javascript/controllers/submit_form_controller.js
+++ b/app/javascript/controllers/submit_form_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from "@hotwired/stimulus"
+import { ajax } from "@rails/ujs"
+
+export default class extends Controller {
+  handleSubmit(event) {
+    event.preventDefault()
+    const form = event.currentTarget
+
+    ajax({
+      type: form.method,
+      url: form.action,
+      data: new FormData(form),
+      success: (data) => { this.element.outerHTML = data.partial }
+    })
+  }
+}

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -13,13 +13,18 @@ class AssessmentDetail < ApplicationRecord
     summary_of_work: "summary_of_work",
     additional_evidence: "additional_evidence",
     site_description: "site_description",
-    past_applications: "past_applications"
+    past_applications: "past_applications",
+    consultation_summary: "consultation_summary"
   }
 
   validates :status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
 
+  validate :consultees_added, if: :consultation_summary?
+
   scope :by_created_at_desc, -> { order(created_at: :desc) }
+
+  delegate :consultees, to: :planning_application
 
   categories.each do |category|
     scope :"#{category}", -> { where(category: category) }
@@ -30,6 +35,10 @@ class AssessmentDetail < ApplicationRecord
   def validate_entry_presence?
     summary_of_work? ||
       site_description? ||
-      (past_applications? && completed?)
+      (completed? && (past_applications? || consultation_summary?))
+  end
+
+  def consultees_added
+    errors.add(:base, :no_consultees_added) if completed? && consultees.none?
   end
 end

--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Consultee < ApplicationRecord
+  belongs_to :planning_application
+
+  validates :name, :origin, presence: true
+
+  enum origin: { internal: 0, external: 1 }
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -31,6 +31,7 @@ class PlanningApplication < ApplicationRecord
       inverse_of: :planning_application
     )
 
+    has_many :consultees, dependent: :destroy
     has_many :description_change_validation_requests
     has_many :replacement_document_validation_requests
     has_many :other_change_validation_requests

--- a/app/presenters/consultation_summary_error_presenter.rb
+++ b/app/presenters/consultation_summary_error_presenter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ConsultationSummaryErrorPresenter < ErrorPresenter
+  private
+
+  def attributes_map
+    { entry: :summary_of_consultation_responses }
+  end
+end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -13,7 +13,11 @@ class ErrorPresenter
 
   private
 
+  attr_reader :error_messages
+
   def formatted_message(message, attribute)
+    attribute = attributes_map[attribute] || attribute
+
     if message.match(/\A[A-Z].+\Z/)
       message
     else
@@ -21,5 +25,7 @@ class ErrorPresenter
     end
   end
 
-  attr_reader :error_messages
+  def attributes_map
+    {}
+  end
 end

--- a/app/presenters/past_applications_error_presenter.rb
+++ b/app/presenters/past_applications_error_presenter.rb
@@ -3,11 +3,6 @@
 class PastApplicationsErrorPresenter < ErrorPresenter
   private
 
-  def formatted_message(message, attribute)
-    attribute = attributes_map[attribute] || attribute
-    super(message, attribute)
-  end
-
   def attributes_map
     {
       entry: :application_reference_numbers,

--- a/app/views/planning_application/assessment_details/_form.html.erb
+++ b/app/views/planning_application/assessment_details/_form.html.erb
@@ -1,4 +1,8 @@
-<%= render "planning_application/assessment_details/#{category}/information", category: category %>
+<%= render(
+  "planning_application/assessment_details/#{category}/information",
+  category: category,
+  read_only: false
+) %>
 
 <%= form_with model: [@planning_application, @assessment_detail], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
   <%= form.govuk_error_summary(

--- a/app/views/planning_application/assessment_details/consultation_summary/_consultee_form.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_consultee_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_with(
+   model: [planning_application, consultee],
+   builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+   data: { action: "submit->submit-form#handleSubmit" }
+) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_text_field(:name) %>
+  <%= form.govuk_collection_radio_buttons(
+    :origin,
+    [
+      [:internal, t(".internal_consultee")],
+      [:external, t(".external_consultee")]
+    ],
+    :first,
+    :last,
+    inline: true,
+    legend: nil
+  ) %>
+  <%= form.submit(
+    t(".add_consultee"),
+    class: "govuk-button govuk-button--secondary"
+  ) %>
+<% end %>

--- a/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
@@ -1,0 +1,28 @@
+<table class="govuk-table" data-controller="delete-record">
+  <tbody class="govuk-table__body">
+    <% planning_application.consultees.select(&:persisted?).each do |consultee| %>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header"><%= consultee.name %></th>
+        <td class="govuk-table__cell">
+          <%= consultee.external? ? t(".external") : t(".internal")  %>
+        </td>
+        <% unless read_only %>
+          <td class="govuk-table__cell">
+            <%= button_tag(
+              t(".remove_from_list"),
+              class: "button-as-link",
+              type: "button",
+              data: {
+                action: "click->delete-record#handleClick",
+                delete_record_path: planning_application_consultee_path(
+                  planning_application,
+                  consultee
+                )
+              }
+            ) %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_application/assessment_details/consultation_summary/_consultees.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_consultees.html.erb
@@ -1,0 +1,21 @@
+<div data-controller="submit-form">
+  <p class="govuk-body govuk-!-font-weight-bold">
+    <%= t(".list_who_was") %>
+  </p>
+  <%= render(
+    partial: "planning_application/assessment_details/consultation_summary/consultee_table",
+    locals: {
+      planning_application: planning_application,
+      read_only: read_only
+    }
+  ) %>
+  <% unless read_only %>
+    <%= render(
+      partial: "planning_application/assessment_details/consultation_summary/consultee_form",
+      locals: {
+        planning_application: planning_application,
+        consultee: consultee
+      }
+    ) %>
+  <% end %>
+</div>

--- a/app/views/planning_application/assessment_details/consultation_summary/_fields.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_fields.html.erb
@@ -1,0 +1,8 @@
+<p class="govuk-body govuk-!-font-weight-bold">
+  <%= t(".summary_of_consultation") %>
+</p>
+<%= render(
+  partial: "shared/warning_text",
+  locals: { message: t(".this_information_will") }
+) %>
+<p class="govuk-body"><%= simple_format(assessment_detail.entry) %></p>

--- a/app/views/planning_application/assessment_details/consultation_summary/_form_fields.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_form_fields.html.erb
@@ -1,0 +1,10 @@
+<%= label_tag(
+  "assessment-detail-entry-field",
+  t(".summary_of_consultation"),
+  class: "govuk-label govuk-!-font-weight-bold"
+) %>
+<%= render(
+  partial: "shared/warning_text",
+  locals: { message: t(".this_information_will") }
+) %>
+<%= form.govuk_text_area :entry, label: nil, rows: 10 %>

--- a/app/views/planning_application/assessment_details/consultation_summary/_information.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_information.html.erb
@@ -1,0 +1,8 @@
+<%= render(
+  partial: "planning_application/assessment_details/consultation_summary/consultees",
+  locals: {
+    planning_application: @planning_application,
+    consultee: @planning_application.consultees.new,
+    read_only: read_only
+  }
+) %>

--- a/app/views/planning_application/assessment_details/show.html.erb
+++ b/app/views/planning_application/assessment_details/show.html.erb
@@ -18,7 +18,11 @@
     <%= render "shared/planning_application_address_and_reference" %>
 
     <div class="govuk-body">
-      <%= render "planning_application/assessment_details/#{@assessment_detail.category}/information", category: @assessment_detail.category %>
+      <%= render(
+        "planning_application/assessment_details/#{@assessment_detail.category}/information",
+        category: @assessment_detail.category,
+        read_only: true
+      ) %>
 
       <%= render(
         partial: "#{assessment_detail_fields_partial_path(@assessment_detail.category)}/fields",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,10 @@ en:
   activerecord:
     errors:
       models:
+        assessment_detail:
+          attributes:
+            base:
+              no_consultees_added: Consultees must be added
         consistency_checklist:
           attributes:
             description_matches_documents:
@@ -76,12 +80,17 @@ en:
     additional_evidence_successfully_created: Additional evidence was successfully created.
     additional_evidence_successfully_updated: Additional evidence was successfully updated.
     completed: Complete
+    consultation_summary: Add consultation details
+    consultation_summary_successfully_created: Consultation summary successfully added.
+    consultation_summary_successfully_updated: Consultation summary successfully updated.
     edit_additional_evidence: Edit additional evidence
+    edit_consultation_summary: Add consultation details
     edit_past_applications: History
     edit_site_description: Edit site description
     edit_summary_of_work: Edit summary of works
     in_progress: In progress
     new_additional_evidence: Add detail of additional evidence
+    new_consultation_summary: Add consultation details
     new_past_applications: History
     new_site_description: Create a description of the site
     new_summary_of_work: Create a summary of the works
@@ -90,6 +99,7 @@ en:
     past_applications_successfully_created: History successfully added.
     past_applications_successfully_updated: History successfully updated.
     show_additional_evidence: Detail of additional evidence
+    show_consultation_summary: Consultation details
     show_past_applications: History
     show_site_description: Site description
     show_summary_of_work: Summary of works
@@ -101,6 +111,7 @@ en:
     summary_of_work_successfully_updated: Summary of works was successfully updated.
     task_list:
       additional_evidence: Additional evidence
+      consultation_summary: Summary of consultation
       past_applications: History
       site_description: Site description
       summary_of_work: Summary of works
@@ -212,6 +223,8 @@ en:
     label:
       additional_document_validation_request:
         cancel_reason: Explain to the applicant why this request is being cancelled
+      consultee:
+        name: Enter a new consultee
       description_change_validation_request:
         cancel_reason: Explain to the applicant why this request is being cancelled
       note:
@@ -261,6 +274,23 @@ en:
   page_title: BETA BOPs - GOV.UK
   planning_application:
     assessment_details:
+      consultation_summary:
+        consultee_form:
+          add_consultee: Add consultee
+          external_consultee: External consultee
+          internal_consultee: Internal consultee
+        consultee_table:
+          external: External
+          internal: Internal
+          remove_from_list: Remove from list
+        consultees:
+          list_who_was: List who was consulted about this application
+        fields:
+          summary_of_consultation: Summary of consultation responses
+          this_information_will: This information WILL be made public
+        form_fields:
+          summary_of_consultation: Summary of consultation responses
+          this_information_will: This information WILL be made public
       past_applications:
         form_fields:
           application_reference_numbers: Application reference number(s)
@@ -270,6 +300,7 @@ en:
           this_information_will: This information WILL be made public
       show:
         edit_additional_evidence: Edit additional evidence
+        edit_consultation_summary: Edit consultation details
         edit_past_applications: Edit history
         edit_site_description: Edit site description
         edit_summary_of_work: Edit summary of work

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create edit update]
 
   resources :planning_applications, only: %i[index show new edit create update] do
+    resources :consultees, only: %i[create destroy]
     resource(:consistency_checklist, only: %i[new create edit update show])
 
     resources :policy_classes, except: %i[index] do

--- a/db/migrate/20221011115140_create_consultees.rb
+++ b/db/migrate/20221011115140_create_consultees.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateConsultees < ActiveRecord::Migration[6.1]
+  def change
+    create_table :consultees do |t|
+      t.string :name, null: false
+      t.integer :origin, null: false
+      t.references :planning_application
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_10_085320) do
+ActiveRecord::Schema.define(version: 2022_10_11_115140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,15 @@ ActiveRecord::Schema.define(version: 2022_10_10_085320) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["planning_application_id"], name: "ix_consistency_checklists_on_planning_application_id"
+  end
+
+  create_table "consultees", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "origin", null: false
+    t.bigint "planning_application_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "ix_consultees_on_planning_application_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/factories/assessment_detail.rb
+++ b/spec/factories/assessment_detail.rb
@@ -9,24 +9,14 @@ FactoryBot.define do
     status { "completed" }
     entry { "This is a description about the summary of works" }
 
-    trait :in_progress do
-      status { "in_progress" }
+    AssessmentDetail.categories.each_key do |category|
+      trait category do
+        category { category }
+      end
     end
 
-    trait :summary_of_work do
-      category { "summary_of_work" }
-    end
-
-    trait :additional_evidence do
-      category { "additional_evidence" }
-    end
-
-    trait :site_description do
-      category { "site_description" }
-    end
-
-    trait :past_applications do
-      category { "past_applications" }
+    trait :with_consultees do
+      planning_application { create(:planning_application, :with_consultees) }
     end
   end
 end

--- a/spec/factories/consultee.rb
+++ b/spec/factories/consultee.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :consultee do
+    name { Faker::Name.name }
+    origin { :internal }
+  end
+end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -213,6 +213,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_consultees do
+      after(:create) do |planning_application|
+        create_list(:consultee, 3, planning_application: planning_application)
+      end
+    end
+
     trait :with_recommendation do
       after(:create) do |planning_application|
         create(:recommendation, planning_application: planning_application)

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -2,7 +2,7 @@
 
 module SystemSpecHelpers
   def row_with_content(content, element = page)
-    element.find_all("tr").find { |tr| tr.has_content?(content) }
+    element.find("tr", text: content)
   end
 
   def selected_govuk_tab

--- a/spec/system/planning_applications/adding_consultation_summary_spec.rb
+++ b/spec/system/planning_applications/adding_consultation_summary_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "adding consultation summary", type: :system do
+  let(:default_local_authority) { create(:local_authority, :default) }
+
+  let!(:assessor) do
+    create(:user, :assessor, local_authority: default_local_authority)
+  end
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: default_local_authority
+    )
+  end
+
+  it "lets user save draft, mark as complete, and edit" do
+    sign_in(assessor)
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+
+    expect(list_item("Summary of consultation")).to have_content("Not started")
+
+    click_link("Summary of consultation")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("Consultees must be added")
+
+    expect(page).to have_content(
+      "Summary of consultation responses can't be blank"
+    )
+
+    click_button("Add consultee")
+
+    expect(page).to have_content("Name can't be blank")
+    expect(page).to have_content("Origin can't be blank")
+
+    fill_in("Enter a new consultee", with: "Alice Smith")
+    choose("Internal consultee")
+    click_button("Add consultee")
+
+    expect(page).to have_row_for("Alice Smith", with: "Internal")
+
+    fill_in("Enter a new consultee", with: "Bella Jones")
+    choose("External consultee")
+    click_button("Add consultee")
+
+    expect(page).to have_row_for("Bella Jones", with: "External")
+
+    within(row_with_content("Bella Jones")) { click_button("Remove from list") }
+
+    expect(page).not_to have_content("Bella Jones")
+
+    click_button("Save and come back later")
+
+    expect(page).to have_content("Consultation summary successfully added.")
+    expect(list_item("Summary of consultation")).to have_content("In progress")
+
+    click_link("Summary of consultation")
+    fill_in("Summary of consultation responses", with: "Lorem ipsum")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("Consultation summary successfully updated.")
+    expect(list_item("Summary of consultation")).to have_content("Complete")
+
+    click_link("Summary of consultation")
+
+    expect(page).to have_row_for("Alice Smith", with: "Internal")
+    expect(page).to have_content("Lorem ipsum")
+
+    click_link("Edit consultation details")
+    fill_in("Summary of consultation responses", with: "dolor sit amet")
+    click_button("Save and mark as complete")
+
+    expect(page).to have_content("Consultation summary successfully updated.")
+  end
+end


### PR DESCRIPTION
### Description of change

- Add page where officer can add consultees and consultation summary.

### Story Link

https://trello.com/c/CRYlENOq/1158-create-consultation-task-on-assessment-tasklist-where-officer-can-create-a-summary-of-consultation-responses-1-2

https://trello.com/c/iqj6xg1e/1157-add-ability-to-list-consultees-to-consultation-task-on-assessment-tasklist-2-2

### Screenshots

<img width="60%" alt="Screenshot 2022-10-13 at 16 24 08" src="https://user-images.githubusercontent.com/25392162/195652851-6e7f4055-ed6d-4328-8964-98f7bf3e5528.png">

<img width="60%" alt="Screenshot 2022-10-13 at 16 24 28" src="https://user-images.githubusercontent.com/25392162/195652894-809528be-941d-46ff-b6b3-d38357e45afd.png">

<img width="60%" alt="Screenshot 2022-10-13 at 16 24 51" src="https://user-images.githubusercontent.com/25392162/195652917-47f4bd59-5aa6-46c8-919c-3edc173644a1.png">


