### PR TITLE
Add assessment report to submit recommendation page

### DIFF
--- a/app/components/assessment_report_component.html.erb
+++ b/app/components/assessment_report_component.html.erb
@@ -1,0 +1,57 @@
+<% if constraints.any? %>
+  <h3 class="govuk-heading-m"><%= t(".constraints_including_article") %></h3>
+  <ul class="govuk-list govuk-list--bullet">
+    <% constraints.each do |constraint| %>
+      <li><%= constraint.humanize %></li>
+    <% end %>
+  </ul>
+<% end %>
+<% if past_applications.present? %>
+  <h3 class="govuk-heading-m"><%= t(".planning_history") %></h3>
+  <h4 class="govuk-heading-s"><%= past_applications.entry %></h4>
+  <%= simple_format(
+    past_applications.additional_information,
+    class: "govuk-body"
+  ) %>
+<% end %>
+<% if summary_of_work.present? %>
+  <h3 class="govuk-heading-m"><%= t(".summary_of_works") %></h3>
+  <%= simple_format(summary_of_work.entry, class: "govuk-body") %>
+<% end %>
+<% if site_description.present? %>
+  <h3 class="govuk-heading-m"><%= t(".location_description") %></h3>
+  <%= simple_format(site_description.entry, class: "govuk-body") %>
+<% end %>
+<% if consultation_summary.present? %>
+  <h3 class="govuk-heading-m"><%= t(".consultation_documents") %></h3>
+  <ul class="govuk-list govuk-list--bullet">
+    <% consultees.each do |consultee| %>
+      <li><%= "#{consultee.name} (#{consultee.origin})" %></li>
+    <% end %>
+  </ul>
+  <%= simple_format(consultation_summary.entry, class: "govuk-body") %>
+<% end %>
+<% if policy_classes.any? %>
+  <h3 class="govuk-heading-m"><%= t(".legislation") %></h3>
+  <% policy_classes.each do |policy_class| %>
+    <%= render(PolicyClassComponent.new(policy_class: policy_class)) %>
+  <% end %>
+<% end %>
+<h3 class="govuk-heading-m"><%= t(".documents_included_in") %></h3>
+<% if documents.any? %>
+  <table class="govuk-table">
+    <tbody class="govuk-table__body">
+      <% documents.each do |document| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= link_to(
+            document.name,
+            planning_application_documents_path(planning_application, anchor: dom_id(document)),
+            class: "govuk-body govuk-link"
+            ) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/components/assessment_report_component.rb
+++ b/app/components/assessment_report_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class AssessmentReportComponent < ViewComponent::Base
+  def initialize(planning_application:)
+    @planning_application = planning_application
+  end
+
+  private
+
+  attr_reader :planning_application
+
+  delegate(
+    :constraints,
+    :past_applications,
+    :summary_of_work,
+    :site_description,
+    :consultation_summary,
+    :consultees,
+    :policy_classes,
+    to: :planning_application
+  )
+
+  def documents
+    planning_application.documents.referenced_in_decision_notice
+  end
+end

--- a/app/controllers/assessment_report_downloads_controller.rb
+++ b/app/controllers/assessment_report_downloads_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AssessmentReportDownloadsController < AuthenticationController
+  before_action :set_planning_application
+
+  def show
+    @blank_layout = true
+  end
+end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -300,3 +300,9 @@ html * {
     margin-bottom: 0px;
   }
 }
+
+.single-section-accordion {
+  .govuk-accordion__controls {
+    display: none;
+  }
+}

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -77,6 +77,11 @@ class Document < ApplicationRecord
   scope :with_tag, ->(tag) { where("tags @> ?", "\"#{tag}\"") }
   scope :with_file_attachment, -> { includes(file_attachment: :blob) }
 
+  scope(
+    :referenced_in_decision_notice,
+    -> { where(referenced_in_decision_notice: true) }
+  )
+
   before_create do
     self.api_user ||= Current.api_user
     self.user ||= Current.user

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -453,6 +453,12 @@ class PlanningApplication < ApplicationRecord
     ENV.fetch("PLANNING_HISTORY_ENABLED", "false") == "true"
   end
 
+  AssessmentDetail.categories.each_key do |category|
+    define_method(category) do
+      assessment_details.find_by(category: category)
+    end
+  end
+
   Recommendation.statuses.each_key do |status|
     delegate("#{status}?", to: :recommendation, prefix: true, allow_nil: true)
   end

--- a/app/views/assessment_report_downloads/show.html.erb
+++ b/app/views/assessment_report_downloads/show.html.erb
@@ -1,0 +1,4 @@
+<h1 class="govuk-heading-l"><%= t(".assessment_report") %><h1>
+<%= render(
+  AssessmentReportComponent.new(planning_application: @planning_application)
+) %>

--- a/app/views/planning_applications/_submit_recommendation_accordion.html.erb
+++ b/app/views/planning_applications/_submit_recommendation_accordion.html.erb
@@ -1,0 +1,27 @@
+<div class="govuk-accordion single-section-accordion" data-module="govuk-accordion">
+  <div class="govuk-accordion__section ">
+    <div class="govuk-accordion__section-header">
+      <h2 class="govuk-accordion__section-heading">
+        <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+          <%= t(".assessment_report") %>
+        </span>
+      </h2>
+    </div>
+    <div id="accordion-default-content-1" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-1">
+      <%= render(
+        AssessmentReportComponent.new(
+          planning_application: planning_application
+        )
+      ) %>
+      <%= link_to(
+        t(".download_assessment_report"),
+        planning_application_assessment_report_download_path(
+          planning_application,
+          format: "pdf"
+        ),
+        target: "_blank",
+        class: "govuk-body govuk-link"
+      ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -4,7 +4,17 @@
 
 <% content_for :title, "Submit recommendation" %>
 
-<%= render layout: "shared/assessment_dashboard", locals: { heading: t(".review_and_submit_recommendation") } do %>
+<%= render(
+  layout: "shared/assessment_dashboard",
+  locals: {
+    heading: t(".review_and_submit_recommendation"),
+    show_accordian: false
+  }
+) do %>
+  <%= render(
+    partial: "submit_recommendation_accordion",
+    locals: { planning_application: @planning_application }
+  ) %>
   <h2 class="govuk-heading-m">Decision notice</h2>
   <p class="govuk-body">The following decision notice has been created based on your answers.</p>
   <%= render "decision_notice", planning_application: @planning_application %>

--- a/app/views/shared/_assessment_dashboard.html.erb
+++ b/app/views/shared/_assessment_dashboard.html.erb
@@ -27,13 +27,20 @@
     <%= render "shared/description_change_auto_closed_banner" %>
   <% end %>
 </div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds application">
-    <%= render "shared/application_information" %>
-    <%= yield %>
+<% if local_assigns.fetch(:show_accordian, true) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "shared/application_information" %>
+      <%= yield %>
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <%= render "shared/supporting_information" %>
+    </div>
   </div>
-  <div class="govuk-grid-column-one-third supporting">
-    <%= render "shared/supporting_information" %>
+<% else %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= yield %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,17 @@ en:
       past_applications: History (manual)
       site_description: Site description
       summary_of_work: Summary of works
+  assessment_report_component:
+    constraints_including_article: Constraints including Article 4 direction(s)
+    consultation_documents: Consultation documents
+    documents_included_in: Documents included in decision notice
+    legislation: Legislation
+    location_description: Location description
+    planning_history: Planning history
+    summary_of_works: Summary of works
+  assessment_report_downloads:
+    show:
+      assessment_report: Assessment report
   audit_user_name:
     applicant: Applicant / Agent via %{api_user_name}
     deleted: User deleted

--- a/config/locales/planning_applications.en.yml
+++ b/config/locales/planning_applications.en.yml
@@ -23,6 +23,9 @@ en:
         check_and_assess: Check and assess
       validation:
         check_and_validate: Check and validate
+    submit_recommendation_accordion:
+      assessment_report: Assessment report
+      download_assessment_report: Download assessment report as PDF
     tabs:
       all_applications: All applications
       all_your_applications: All your applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :users, only: %i[new create edit update]
 
   resources :planning_applications, only: %i[index show new edit create update] do
+    resource :assessment_report_download, only: :show
     resources :consultees, only: %i[create destroy]
     resource(:consistency_checklist, only: %i[new create edit update show])
 

--- a/spec/factories/policy_class.rb
+++ b/spec/factories/policy_class.rb
@@ -10,7 +10,9 @@ FactoryBot.define do
     planning_application
 
     trait :complies do
-      status { :complies }
+      after(:create) do |policy_class|
+        create(:policy, :complies, policy_class: policy_class)
+      end
     end
 
     trait :in_assessment do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -246,4 +246,32 @@ RSpec.describe Document, type: :model do
       end
     end
   end
+
+  describe ".referenced_in_decision_notice" do
+    context "when referenced_in_decision_notice is true" do
+      let(:document) do
+        create(:document, referenced_in_decision_notice: true, numbers: "REF1")
+      end
+
+      it "includes document" do
+        expect(
+          described_class.referenced_in_decision_notice
+        ).to include(
+          document
+        )
+      end
+    end
+
+    context "when referenced_in_decision_notice is false" do
+      let(:document) { create(:document, referenced_in_decision_notice: false) }
+
+      it "includes document" do
+        expect(
+          described_class.referenced_in_decision_notice
+        ).not_to include(
+          document
+        )
+      end
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1068,4 +1068,86 @@ RSpec.describe PlanningApplication, type: :model do
       end
     end
   end
+
+  describe "#summary_of_work" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application
+      )
+    end
+
+    it "returns assessment detail with category 'summary_of_work'" do
+      expect(planning_application.summary_of_work).to eq(assessment_detail)
+    end
+  end
+
+  describe "#additional_evidence" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :additional_evidence,
+        planning_application: planning_application
+      )
+    end
+
+    it "returns assessment detail with category 'additional_evidence'" do
+      expect(planning_application.additional_evidence).to eq(assessment_detail)
+    end
+  end
+
+  describe "#site_description" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :site_description,
+        planning_application: planning_application
+      )
+    end
+
+    it "returns assessment detail with category 'site_description'" do
+      expect(planning_application.site_description).to eq(assessment_detail)
+    end
+  end
+
+  describe "#past_applications" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :past_applications,
+        planning_application: planning_application
+      )
+    end
+
+    it "returns assessment detail with category 'past_applications'" do
+      expect(planning_application.past_applications).to eq(assessment_detail)
+    end
+  end
+
+  describe "#consultation_summary" do
+    let(:planning_application) do
+      create(:planning_application, :with_consultees)
+    end
+
+    let!(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :consultation_summary,
+        planning_application: planning_application
+      )
+    end
+
+    it "returns assessment detail with category 'consulation_summary'" do
+      expect(planning_application.consultation_summary).to eq(assessment_detail)
+    end
+  end
 end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -338,6 +338,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(planning_application.reload.status).to eq("in_assessment")
 
       # Check latest audit
+      click_link "Application"
       click_button "Audit log"
       within("#latest-audit") do
         expect(page).to have_content("Recommendation withdrawn")

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -260,13 +260,13 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "Application information accordion is minimised by default" do
-      within(".govuk-grid-column-two-thirds.application") do
+      within(find_all(".govuk-accordion").first) do
         expect(page).to have_button("Open all")
       end
     end
 
     it "Supporting information accordion is minimised by default" do
-      within(".govuk-grid-column-one-third.supporting") do
+      within(find_all(".govuk-accordion").last) do
         expect(page).to have_button("Open all")
       end
     end

--- a/spec/system/planning_applications/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/viewing_assessment_report_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "viewing assessment report", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  let!(:assessor) do
+    create(
+      :user,
+      :assessor,
+      local_authority: local_authority
+    )
+  end
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: local_authority,
+      decision: :granted,
+      constraints: ["conservation_area"]
+    )
+  end
+
+  let!(:document) do
+    create(
+      :document,
+      planning_application: planning_application,
+      referenced_in_decision_notice: true,
+      numbers: "REF1"
+    )
+  end
+
+  before do
+    create(
+      :recommendation,
+      planning_application: planning_application
+    )
+
+    create(
+      :assessment_detail,
+      :past_applications,
+      planning_application: planning_application,
+      entry: "22-00999-LDCP",
+      additional_information: "This is the past application history summary."
+    )
+
+    create(
+      :assessment_detail,
+      :summary_of_work,
+      planning_application: planning_application,
+      entry: "This is the summary of work."
+    )
+
+    create(
+      :assessment_detail,
+      :site_description,
+      planning_application: planning_application,
+      entry: "This is the location description."
+    )
+
+    create(
+      :consultee,
+      planning_application: planning_application,
+      name: "Alice Smith",
+      origin: :external
+    )
+
+    create(
+      :assessment_detail,
+      :consultation_summary,
+      planning_application: planning_application,
+      entry: "This is the consulation summary."
+    )
+
+    create(
+      :policy_class,
+      :complies,
+      planning_application: planning_application,
+      part: 1,
+      section: "A",
+      name: "Window boxes"
+    )
+  end
+
+  it "lets the user view and download the report" do
+    sign_in(assessor)
+    visit(planning_application_path(planning_application))
+    click_link("Submit recommendation")
+    click_button("Assessment report")
+
+    expect(page).to have_content("Conservation area")
+    expect(page).to have_content("22-00999-LDCP")
+    expect(page).to have_content("This is the past application history summary.")
+    expect(page).to have_content("This is the summary of work.")
+    expect(page).to have_content("This is the location description.")
+    expect(page).to have_content("Alice Smith (external)")
+    expect(page).to have_content("This is the consulation summary.")
+    expect(page).to have_content("Part 1, Class A - Window boxes")
+    expect(page).to have_content("Complies")
+    expect(page).to have_content(document.name)
+
+    expect(page).to have_link(
+      "Download assessment report as PDF",
+      href: planning_application_assessment_report_download_path(
+        planning_application,
+        format: "pdf"
+      )
+    )
+  end
+end


### PR DESCRIPTION
### Description of change

- Remove planning application accordion from submit recommendation page.
- Replace with single-section accordion which contains assessment report.
- Add route to download assessment report as PDF, with link on submit recommendation page.

### Story Link

https://trello.com/c/MnuYnFaS/1198-include-full-assessment-summary-on-submit-recommendation-page

### Screenshot

<img width="60%" alt="Screenshot 2022-10-19 at 17 01 15" src="https://user-images.githubusercontent.com/25392162/196744156-e6e01489-7c44-4691-af64-4ee5ac99fe95.png">
