### PR TITLE
Add Permitted Development Rights to assessment

### DIFF
--- a/app/controllers/concerns/planning_application_assessable.rb
+++ b/app/controllers/concerns/planning_application_assessable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PlanningApplicationAssessable
+  extend ActiveSupport::Concern
+
+  def ensure_planning_application_is_validated
+    return if @planning_application.validated?
+
+    render plain: "forbidden", status: :forbidden
+  end
+end

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ValidationRequestsController < AuthenticationController
+  include PlanningApplicationAssessable
+
   rescue_from Notifications::Client::NotFoundError, with: :validation_notice_request_error
   rescue_from Notifications::Client::ServerError, with: :validation_notice_request_error
   rescue_from Notifications::Client::RequestError, with: :validation_notice_request_error
@@ -68,12 +70,6 @@ class ValidationRequestsController < AuthenticationController
 
     Appsignal.send_error(exception)
     render "planning_applications/show"
-  end
-
-  def ensure_planning_application_is_validated
-    return if @planning_application.validated?
-
-    render plain: "forbidden", status: :forbidden
   end
 
   def ensure_planning_application_is_not_closed_or_cancelled

--- a/app/models/permitted_development_right.rb
+++ b/app/models/permitted_development_right.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PermittedDevelopmentRight < ApplicationRecord
+  belongs_to :planning_application
+
+  enum status: {
+    in_progress: "in_progress",
+    checked: "checked",
+    removed: "removed"
+  }
+
+  with_options presence: true do
+    validates :status
+    validates :removed_reason, if: :removed
+  end
+
+  before_update :reset_removed_reason, if: :removed_changed?
+
+  private
+
+  def reset_removed_reason
+    return unless removed_was && removed_reason
+
+    update!(removed_reason: nil)
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -50,6 +50,7 @@ class PlanningApplication < ApplicationRecord
     )
 
     has_one :consistency_checklist, dependent: :destroy
+    has_one :permitted_development_right, dependent: :destroy
   end
 
   delegate :reviewer_group_email, to: :local_authority

--- a/app/presenters/concerns/assessment_tasks/permitted_development_right_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/permitted_development_right_presenter.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module AssessmentTasks
+  extend ActiveSupport::Concern
+
+  class PermittedDevelopmentRightPresenter
+    include Presentable
+
+    def initialize(template, planning_application)
+      @planning_application = planning_application
+      @template = template
+      @permitted_development_right = planning_application.permitted_development_right
+      @status = @permitted_development_right&.status || "not_started"
+    end
+
+    def task_list_row
+      html = tag.span class: "app-task-list__task-name" do
+        concat permitted_development_right_link
+      end
+
+      html.concat permitted_development_rights_status_tag
+    end
+
+    private
+
+    attr_reader :status, :permitted_development_right
+
+    def permitted_development_right_link
+      link_to("Permitted development rights", permitted_development_right_link_url, class: "govuk-link")
+    end
+
+    def permitted_development_right_link_url
+      case status.humanize
+
+      when "Not started"
+        new_planning_application_permitted_development_right_path(planning_application)
+      when "In progress"
+        edit_planning_application_permitted_development_right_path(planning_application, permitted_development_right)
+      when "Checked", "Removed"
+        planning_application_permitted_development_right_path(planning_application, permitted_development_right)
+      else
+        raise ArgumentError, "The status provided: '#{status}' is not valid"
+      end
+    end
+
+    def permitted_development_rights_status_tag
+      classes = ["#{govuk_tag_class} app-task-list__task-tag"]
+
+      tag.strong class: classes do
+        I18n.t("permitted_development_rights.#{status}")
+      end
+    end
+
+    def govuk_tag_class
+      return "govuk-tag" unless permitted_development_right_status_colour
+
+      "govuk-tag govuk-tag--#{permitted_development_right_status_colour}"
+    end
+
+    def permitted_development_right_status_colour
+      case status.humanize
+
+      when "Not started"
+        "grey"
+      when "Checked"
+        "green"
+      when "Removed"
+        "red"
+      when "In progress"
+        nil
+      else
+        raise ArgumentError, "The status provided: '#{status}' is not valid"
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -15,11 +15,18 @@ module AssessmentTasksPresenter
         @template, @planning_application, category
       ).task_list_row
     end
+
+    def permitted_development_right_tasklist
+      AssessmentTasks::PermittedDevelopmentRightPresenter.new(
+        @template, @planning_application
+      ).task_list_row
+    end
   end
 
   def assessment_tasklist_in_progress?
     policy_classes.any? ||
       consistency_checklist.present? ||
-      assessment_details.any?
+      assessment_details.any? ||
+      permitted_development_right.present?
   end
 end

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -60,7 +60,7 @@
 
       <div class="govuk-button-group">
         <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
-        <%= link_to 'Cancel', planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= back_link %>
       </div>
     </div>
   <% end %>

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -33,5 +33,8 @@
         </span>
       </li>
     <% end %>
+    <li class="app-task-list__item" id="permitted-development-right-tasklist">
+      <%= @planning_application.permitted_development_right_tasklist %>
+    </li>
   </ul>
 </li>

--- a/app/views/planning_application/permitted_development_rights/_constraints.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_constraints.html.erb
@@ -1,0 +1,19 @@
+<section id="constraints-section">
+  <h2 class="govuk-heading-m">
+    Constraints - including Article 4 direction(s)
+  </h2>
+
+  <% if @planning_application.constraints.empty? %>
+    <p class="govuk-body">
+      There are no constraints
+    </p>
+  <% else %>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @planning_application.constraints.each do |constraint| %>
+        <li><%= constraint %></li>
+      <% end %>
+    </ul>
+  <% end %>
+
+  <%= link_to "Edit constraints", edit_planning_application_constraints_path(@planning_application), class: "govuk-link govuk-body" %>
+</section>

--- a/app/views/planning_application/permitted_development_rights/_form.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_form.html.erb
@@ -1,0 +1,30 @@
+<%= form_with model: [@planning_application, @permitted_development_right],
+              local: true,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              class: "govuk-!-margin-top-7" do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+    :removed,
+    legend: { size: "s" }
+  ) do %>
+    <%= form.govuk_radio_button(
+      :removed, true, checked: @permitted_development_right.removed, label: { text: "Yes" }
+    ) do %>
+      <%= form.govuk_text_area(
+        :removed_reason, rows: 6
+      ) %>
+    <% end %>
+
+    <%= form.govuk_radio_button(
+      :removed, false, checked: !@permitted_development_right.removed, label: { text: "No" }
+    ) %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/planning_application/permitted_development_rights/_information.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_information.html.erb
@@ -1,0 +1,12 @@
+<h1 class="govuk-heading-l govuk-!-margin-top-7">
+  Permitted development rights
+</h1>
+
+<%= render "shared/planning_application_address_and_reference" %>
+
+<%= render "shared/warning_text",
+    message: "This information WILL be made public" %>
+
+<%= render "constraints" %>
+
+<%= render "planning_history" %>

--- a/app/views/planning_application/permitted_development_rights/_planning_history.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_planning_history.html.erb
@@ -1,0 +1,18 @@
+<section id="planning-history-section">
+  <h2 class="govuk-heading-m govuk-!-margin-top-5">
+    Planning history
+  </h2>
+
+  <% if past_application = @planning_application.past_applications %>
+    <ul class="govuk-list">
+      <li><p><strong><%= past_application.additional_information %></strong></p></li>
+      <li><p><%= past_application.entry %><p></li>
+      <%= link_to "Edit history", edit_planning_application_assessment_detail_path(@planning_application, past_application), class: "govuk-link" %>
+    </ul>
+  <% else %>
+    <p class="govuk-body">
+      There is no relevant planning history
+    </p>
+    <%= link_to "Edit history", new_planning_application_assessment_detail_path(@planning_application, category: "past_applications"), class: "govuk-link" %>
+  <% end %>
+</section>

--- a/app/views/planning_application/permitted_development_rights/edit.html.erb
+++ b/app/views/planning_application/permitted_development_rights/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  Permitted development rights - <%= t('page_title') %>
+<% end %>
+
+<%= render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: { planning_application: @planning_application  }
+) %>
+
+<% content_for :title, "Permitted development rights" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "information" %>
+
+    <%= render "form", planning_application: @planning_application %>
+  </div>
+</div>

--- a/app/views/planning_application/permitted_development_rights/new.html.erb
+++ b/app/views/planning_application/permitted_development_rights/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  Permitted development rights - <%= t('page_title') %>
+<% end %>
+
+<%= render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: { planning_application: @planning_application  }
+) %>
+
+<% content_for :title, "Permitted development rights" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "information" %>
+
+    <%= render "form", planning_application: @planning_application %>
+  </div>
+</div>

--- a/app/views/planning_application/permitted_development_rights/show.html.erb
+++ b/app/views/planning_application/permitted_development_rights/show.html.erb
@@ -1,0 +1,35 @@
+<% content_for :page_title do %>
+  Permitted development rights - <%= t('page_title') %>
+<% end %>
+
+<%= render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: { planning_application: @planning_application  }
+) %>
+
+<% content_for :title, "Permitted development rights" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "information" %>
+
+    <p class="govuk-body"><strong>Have the permitted development rights relevant for this application been removed?</strong></p>
+
+    <% if @permitted_development_right.removed %>
+      <p class="govuk-body"><strong>Yes</strong></p>
+      <p class="govuk-body"><%= @permitted_development_right.removed_reason %></p>
+    <% else %>
+      <p class="govuk-body"><strong>No</strong></p>
+    <% end %>
+
+    <div class="govuk-button-group">
+      <%= back_link %>
+
+      <%= link_to(
+        "Edit permitted development rights",
+        edit_planning_application_permitted_development_right_path(@planning_application),
+        class: "govuk-link"
+      ) %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,8 @@ en:
         cancel_reason: Explain to the applicant why this request is being cancelled
         suggestion: Explain to the applicant how the application can be made valid.
         summary: Tell the applicant another reason why the application is invalid.
+      permitted_development_right:
+        removed_reason: Describe how permitted development rights have been removed
       planning_application:
         closed_or_cancellation_comment: Provide a reason
         public_comment: 'This information will appear on the decision notice:'
@@ -255,6 +257,8 @@ en:
         password: Password
         role: Role
     legend:
+      permitted_development_right:
+        removed: Have the permitted development rights relevant for this application been removed?
       planning_application:
         determination_date: Enter determination date
         received_at: Date received
@@ -275,6 +279,13 @@ en:
         suggestion: Tell the applicant how the fee can be made valid.
         summary: Tell the applicant why the fee is incorrect.
   page_title: BETA BOPs - GOV.UK
+  permitted_development_rights:
+    checked: Checked
+    in_progress: In progress
+    not_started: Not started
+    removed: Removed
+    successfully_created: Permitted development rights response was successfully created
+    successfully_updated: Permitted development rights response was successfully updated
   planning_application:
     assessment_details:
       consultation_summary:
@@ -314,6 +325,7 @@ en:
         description_documents_and: Description, documents and proposal details
         history: History search (in testing)
         in_assessment: In assessment
+        permitted_development_rights: Permitted development rights
   planning_applications:
     assessment_report_component:
       constraints_including_article: Constraints including Article 4 direction(s)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
       resources :summary_of_works, only: %i[new edit create show update]
 
       resources :assessment_details, only: %i[new edit create show update]
+
+      resources :permitted_development_rights, only: %i[new create edit update show]
     end
   end
 

--- a/db/migrate/20221011144528_create_permitted_development_rights.rb
+++ b/db/migrate/20221011144528_create_permitted_development_rights.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreatePermittedDevelopmentRights < ActiveRecord::Migration[6.1]
+  def change
+    create_table :permitted_development_rights do |t|
+      t.string :status, null: false
+      t.boolean :removed
+      t.text :removed_reason
+      t.references :planning_application
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_11_115140) do
+ActiveRecord::Schema.define(version: 2022_10_11_144528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -228,6 +228,16 @@ ActiveRecord::Schema.define(version: 2022_10_11_115140) do
     t.boolean "post_validation", default: false, null: false
     t.index ["planning_application_id"], name: "ix_other_change_validation_requests_on_planning_application_id"
     t.index ["user_id"], name: "ix_other_change_validation_requests_on_user_id"
+  end
+
+  create_table "permitted_development_rights", force: :cascade do |t|
+    t.string "status", null: false
+    t.boolean "removed"
+    t.text "removed_reason"
+    t.bigint "planning_application_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["planning_application_id"], name: "ix_permitted_development_rights_on_planning_application_id"
   end
 
   create_table "planning_applications", force: :cascade do |t|

--- a/spec/factories/permitted_development_right.rb
+++ b/spec/factories/permitted_development_right.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :permitted_development_right do
+    planning_application
+
+    status { "checked" }
+    removed { false }
+
+    trait :removed do
+      status { "removed" }
+      removed { true }
+      removed_reason { "Removal reason" }
+    end
+
+    trait :checked do
+      status { "checked" }
+      removed { false }
+    end
+
+    trait :in_progress do
+      status { "in_progress" }
+    end
+  end
+end

--- a/spec/models/permitted_development_right_spec.rb
+++ b/spec/models/permitted_development_right_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PermittedDevelopmentRight, type: :model do
+  describe "validations" do
+    subject(:permitted_development_right) { described_class.new }
+
+    describe "#removed_reason" do
+      context "when removed" do
+        let(:permitted_development_right) { create(:permitted_development_right, removed: true, removed_reason: nil) }
+
+        it "validates presence for removed_reason" do
+          expect { permitted_development_right }.to raise_error(
+            ActiveRecord::RecordInvalid,
+            "Validation failed: Removed reason can't be blank"
+          )
+        end
+      end
+
+      context "when not removed" do
+        let(:permitted_development_right) { create(:permitted_development_right, :checked) }
+
+        it "does not validates presence for removed_reason" do
+          expect { permitted_development_right }.not_to raise_error
+        end
+      end
+    end
+
+    describe "#status" do
+      it "validates presence" do
+        expect { permitted_development_right.valid? }.to change { permitted_development_right.errors[:status] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { permitted_development_right.valid? }.to change { permitted_development_right.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+
+  describe "callbacks" do
+    describe "::before_update #reset_removed_reason" do
+      context "when choosing 'No' after previously providing a reason for removing the permitted development rights" do
+        let(:permitted_development_right) { create(:permitted_development_right, :removed) }
+
+        it "sets the removed reason to nil" do
+          expect do
+            permitted_development_right.update!(removed: false)
+          end.to change(permitted_development_right, :removed_reason).from("Removal reason").to(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/assessment_tasks/permitted_development_right_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/permitted_development_right_presenter_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessmentTasks::PermittedDevelopmentRightPresenter, type: :presenter do
+  include ActionView::TestCase::Behavior
+
+  subject(:presenter) { described_class.new(view, planning_application) }
+
+  let(:context) { ActionView::Base.new }
+  let!(:planning_application) { create(:planning_application, :in_assessment) }
+
+  describe "#task_list_row" do
+    context "when not started" do
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Permitted development rights",
+            new_planning_application_permitted_development_right_path(planning_application),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--grey app-task-list__task-tag\">Not started</strong>"
+        )
+      end
+    end
+
+    context "when checked" do
+      let!(:permitted_development_right) { create(:permitted_development_right, :checked, planning_application: planning_application) }
+
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Permitted development rights",
+            planning_application_permitted_development_right_path(planning_application, permitted_development_right),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--green app-task-list__task-tag\">Checked</strong>"
+        )
+      end
+    end
+
+    context "when removed" do
+      let!(:permitted_development_right) { create(:permitted_development_right, :removed, planning_application: planning_application) }
+
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Permitted development rights",
+            planning_application_permitted_development_right_path(planning_application, permitted_development_right),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--red app-task-list__task-tag\">Removed</strong>"
+        )
+      end
+    end
+
+    context "when in progress" do
+      let!(:permitted_development_right) { create(:permitted_development_right, :in_progress, planning_application: planning_application) }
+
+      it "the task list row shows invalid status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Permitted development rights",
+            edit_planning_application_permitted_development_right_path(planning_application, permitted_development_right),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag app-task-list__task-tag\">In progress</strong>"
+        )
+      end
+    end
+  end
+end

--- a/spec/support/assessment_tasks_presenter_shared_examples.rb
+++ b/spec/support/assessment_tasks_presenter_shared_examples.rb
@@ -48,5 +48,18 @@ RSpec.shared_examples "AssessmentTasksPresenter" do
         expect(presenter.assessment_tasklist_in_progress?).to eq(true)
       end
     end
+
+    context "when permitted development right is present" do
+      before do
+        create(
+          :permitted_development_right,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(presenter.assessment_tasklist_in_progress?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/permitted_development_right_spec.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Permitted development right", type: :system do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create :user, :assessor, local_authority: default_local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :in_assessment, local_authority: default_local_authority
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  context "when planning application is in assessment" do
+    it "I can view the information on the permitted development rights page" do
+      click_link "Check and assess"
+
+      within("#check-consistency-assessment-tasks") do
+        within("#permitted-development-right-tasklist") do
+          expect(page).to have_content("Not started")
+          click_link "Permitted development rights"
+        end
+      end
+
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Permitted development rights")
+      end
+
+      expect(page).to have_current_path(
+        new_planning_application_permitted_development_right_path(planning_application)
+      )
+
+      within(".govuk-heading-l") do
+        expect(page).to have_content("Permitted development rights")
+      end
+      expect(page).to have_content("Application number: #{planning_application.reference}")
+      expect(page).to have_content(planning_application.full_address.upcase)
+
+      within(".govuk-warning-text") do
+        expect(page).to have_content("This information WILL be made public")
+      end
+
+      within("#constraints-section") do
+        expect(page).to have_content("Constraints - including Article 4 direction(s)")
+      end
+
+      within("#planning-history-section") do
+        expect(page).to have_content("Planning history")
+      end
+    end
+
+    it "there is a validation error when submitting an empty text field when selecting 'Yes'" do
+      click_link "Check and assess"
+      click_link "Permitted development rights"
+      choose "Yes"
+
+      click_button "Save and mark as complete"
+      within(".govuk-error-summary") do
+        expect(page).to have_content "Removed reason can't be blank"
+      end
+
+      click_button "Save and come back later"
+      within(".govuk-error-summary") do
+        expect(page).to have_content "Removed reason can't be blank"
+      end
+    end
+
+    it "there is no validation error when submitting an empty text field when selecting 'No'" do
+      click_link "Check and assess"
+      click_link "Permitted development rights"
+      choose "No"
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully created")
+    end
+
+    it "I can save and come back later when adding or editing the permitted development right" do
+      click_link "Check and assess"
+      click_link "Permitted development rights"
+
+      choose "Yes"
+      fill_in "permitted_development_right[removed_reason]", with: "A reason"
+      click_button "Save and come back later"
+
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      within("#permitted-development-right-tasklist") do
+        expect(page).to have_content("In progress")
+        click_link "Permitted development rights"
+      end
+
+      within(".govuk-warning-text") do
+        expect(page).to have_content("This information WILL be made public")
+      end
+
+      within("#constraints-section") do
+        expect(page).to have_content("Constraints - including Article 4 direction(s)")
+      end
+
+      within("#planning-history-section") do
+        expect(page).to have_content("Planning history")
+      end
+
+      fill_in "permitted_development_right[removed_reason]", with: "Another reason"
+
+      click_button "Save and come back later"
+      expect(page).to have_content("Permitted development rights response was successfully updated")
+
+      within("#permitted-development-right-tasklist") do
+        expect(page).to have_content("In progress")
+      end
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
+    end
+
+    it "I can save and mark as complete when adding the permitted development right" do
+      click_link "Check and assess"
+      click_link "Permitted development rights"
+
+      choose "Yes"
+      fill_in "permitted_development_right[removed_reason]", with: "A reason"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      within("#permitted-development-right-tasklist") do
+        expect(page).to have_content("Removed")
+      end
+
+      click_link "Permitted development rights"
+      expect(page).to have_content("Have the permitted development rights relevant for this application been removed?")
+      expect(page).to have_content("Yes")
+      expect(page).to have_content("A reason")
+
+      click_link "Edit permitted development rights"
+      choose "No"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Permitted development rights response was successfully updated")
+
+      within("#permitted-development-right-tasklist") do
+        expect(page).to have_content("Checked")
+      end
+
+      click_link "Permitted development rights"
+      expect(page).to have_content("Have the permitted development rights relevant for this application been removed?")
+      expect(page).to have_content("No")
+    end
+  end
+
+  context "when planning application has not been validated yet" do
+    let!(:planning_application) do
+      create :planning_application, :not_started, local_authority: default_local_authority
+    end
+
+    it "does not allow me to visit the page" do
+      expect(page).not_to have_link("Permitted development rights")
+
+      visit new_planning_application_permitted_development_right_path(planning_application)
+
+      expect(page).to have_content("forbidden")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add Permitted Development Rights to assessment

- Allow officers to choose "Yes" or "No" when answering whether permitted development rights for the planning application has been removed. If "Yes", then they must provide a reason
- Add statuses to the permitted development rights tasklist depending on actions taken by the officer
- Incorporate constraints and planning history on all permitted development rights screens
- Set removed_reason to nil if "No" has been chosen after a previous "Yes" answer

### Story Link

https://trello.com/c/EJMHgoSy/1196-permitted-development-right-assessment-screen

![Screenshot 2022-10-20 at 12 51 16](https://user-images.githubusercontent.com/34001723/196942196-fc01d7c9-e15d-421c-a7d1-8c908ea35f55.png)
![Screenshot 2022-10-20 at 12 51 52](https://user-images.githubusercontent.com/34001723/196942204-06d9507e-4034-4491-9335-fbae8133a95f.png)
![Screenshot 2022-10-20 at 12 51 58](https://user-images.githubusercontent.com/34001723/196942209-0e4b0c72-a4af-4415-a0a9-3ce22127e6ba.png)
