### PR TITLE
Stub scope correctly for component specs

### DIFF
--- a/spec/components/policy_classes/summary_component_spec.rb
+++ b/spec/components/policy_classes/summary_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PolicyClasses::SummaryComponent, type: :component do
     before do
       summary_component.instance_variable_set(
         :@virtual_path,
-        "summary_component"
+        "policy_classes.summary_component"
       )
     end
 


### PR DESCRIPTION
### Description of change

Fix I18n scope stubbing following name-spacing of view components.