### PR TITLE
Pr review and publish determination

### DIFF
--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -2,10 +2,19 @@
   Publish the recommendation - <%= t('page_title') %>
 <% end %>
 
-<%= render "shared/assessment_dashboard" do %>
+<%= render(layout: "shared/assessment_dashboard",
+           locals: {
+             heading: t(".review_and_publish_determination"),
+             show_accordian: false
+           }
+          ) do %>
+  <%= render(
+    partial: "submit_recommendation_accordion",
+    locals: { planning_application: @planning_application }
+  ) %>
   <% content_for :title, "Publish the recommendation" %>
 
-    <h2 class="govuk-heading-m">Publish the recommendation</h2>
+    <h2 class="govuk-heading-m">Decision notice</h2>
     <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. Please review and publish it.</p>
 
   <%= render "decision_notice", planning_application: @planning_application %>
@@ -43,7 +52,14 @@
         ) %>
       <% end %>
       <%= form.govuk_date_field :determination_date, id: "determination-date" %>
-      <%= form.submit "Determine application", class: "govuk-button" %>
+      <div class="govuk-button-group">
+        <%= form.submit "Publish determination", class: "govuk-button" %>
+        <%= link_to(
+              t(".back"),
+              planning_application_path(@planning_application),
+              class: "govuk-button govuk-button--secondary"
+        ) %>
+      </div>
     <% end %>
   <% else %>
     <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,8 @@ en:
       user_name: Planning officer
     policy_consideration_list:
       proposal_details: Proposal details
+    publish:
+      review_and_publish_determination: Review and publish determination
     search_form_component:
       clear_search: Clear search
       find_an_application: Find an application

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -105,7 +105,7 @@ Given("the planning application is determined") do
     And I choose "Yes" for "Do you agree with the recommendation?"
     And I press "Save"
     And I press "Publish determination"
-    And I press "Determine application"
+    And I press "Publish determination"
   )
 end
 

--- a/spec/system/planning_applications/determine_application_spec.rb
+++ b/spec/system/planning_applications/determine_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           fill_in "Year", with: "2024"
         end
 
-        click_button("Determine application")
+        click_button("Publish determination")
 
         within(find_all(".govuk-error-summary").last) do
           expect(page).to have_content("Determination date must be today or in the past")
@@ -70,7 +70,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           fill_in "Year", with: "2024"
         end
 
-        click_button("Determine application")
+        click_button("Publish determination")
 
         expect(page).to have_content("Decision Notice sent to applicant")
 
@@ -110,6 +110,14 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
       end
 
+      it "I can navigate back" do
+        click_link("Publish determination")
+
+        click_link("Back")
+
+        expect(page).to have_title "Planning Application"
+      end
+
       context "when open description_change_validation_request" do
         before do
           create(
@@ -130,7 +138,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           fill_in("Day", with: "2")
           fill_in("Month", with: "1")
           fill_in("Year", with: "2024")
-          click_button("Determine application")
+          click_button("Publish determination")
 
           expect(page).to have_content("Decision Notice sent to applicant")
         end

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     fill_in "Review comment", with: "Reviewer private comment"
     click_button "Save and mark as complete"
     click_link "Publish determination"
-    click_button "Determine application"
+    click_button "Publish determination"
 
     planning_application.reload
     expect(planning_application.status).to eq("determined")
@@ -122,7 +122,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     find("#recommendation_challenged_false").click
     click_button "Save and mark as complete"
     click_link "Publish determination"
-    click_button "Determine application"
+    click_button "Publish determination"
 
     planning_application.reload
     expect(planning_application.status).to eq("determined")


### PR DESCRIPTION
### Update 'review and publish determination' page for reviewers

Support reviewers to have confidence in publishing decisions

As a reviewer I need to publish a decision so that I can complete the assessment of applications and share the results with the applicant and the public

## Acceptance criteria
1. Title (H1) reads "Review and publish determination" as per design
2. Reviewer can see assessment report in an accordion
3. Decision notice subtitle is H2
4. Change Primary CTA into "Publish determination"
5. Add "Back" button

## Full screen shot - assessment report closed
![southwark bops-care link_3000_planning_applications_1_publish](https://user-images.githubusercontent.com/1710795/197775771-da939f66-dd30-43d5-96bd-64df59c2e256.jpg)

## Assessment report open
![assment-report-open](https://user-images.githubusercontent.com/1710795/197776512-2504f57e-a135-4664-aad6-71b037fe5b0b.jpg)


### Story Link

https://trello.com/c/CJXVBCoy/1266-update-review-and-publish-determination-page-for-reviewers


### Commits
 - are organised by AC
 - after approval they will be squashed together

