### PR TITLE
Add assessment details into the assess recommendation page

### DIFF
--- a/app/components/planning_applications/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment_report_component.html.erb
@@ -1,59 +1,69 @@
-<% if constraints.any? %>
+<section id="constraints-section" class="govuk-!-padding-bottom-5">
   <h3 class="govuk-heading-m"><%= t(".constraints_including_article") %></h3>
-  <ul class="govuk-list govuk-list--bullet">
-    <% constraints.each do |constraint| %>
-      <li><%= constraint.humanize %></li>
-    <% end %>
-  </ul>
-<% end %>
+
+  <%= render "shared/constraints" %>
+</section>
 <% if past_applications.present? %>
-  <h3 class="govuk-heading-m"><%= t(".planning_history") %></h3>
-  <h4 class="govuk-heading-s"><%= past_applications.entry %></h4>
-  <%= simple_format(
-    past_applications.additional_information,
-    class: "govuk-body"
-  ) %>
+  <section id="past-applications-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".planning_history") %></h3>
+    <h4 class="govuk-heading-s"><%= past_applications.entry %></h4>
+    <%= simple_format(
+      past_applications.additional_information,
+      class: "govuk-body"
+    ) %>
+  </section>
+<% end %>
+<% if permitted_development_right %>
+  <section id="permitted-development-rights-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".have_the_permitted_development_rights") %></h3>
+    <% if permitted_development_right.removed %>
+      <p class="govuk-body"><strong>Yes</strong></p>
+      <%= simple_format(permitted_development_right.removed_reason, class: "govuk-body") %>
+    <% else %>
+      <p class="govuk-body"><strong>No</strong></p>
+    <% end %>
+  </section>
 <% end %>
 <% if summary_of_work.present? %>
-  <h3 class="govuk-heading-m"><%= t(".summary_of_works") %></h3>
-  <%= simple_format(summary_of_work.entry, class: "govuk-body") %>
+  <section id="summary-of-works-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".summary_of_works") %></h3>
+    <%= simple_format(summary_of_work.entry, class: "govuk-body") %>
+  </section>
 <% end %>
 <% if site_description.present? %>
-  <h3 class="govuk-heading-m"><%= t(".location_description") %></h3>
-  <%= simple_format(site_description.entry, class: "govuk-body") %>
+  <section id="site-description-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".location_description") %></h3>
+    <%= simple_format(site_description.entry, class: "govuk-body") %>
+  </section>
 <% end %>
 <% if consultation_summary.present? %>
-  <h3 class="govuk-heading-m"><%= t(".consultation_documents") %></h3>
-  <ul class="govuk-list govuk-list--bullet">
-    <% consultees.each do |consultee| %>
-      <li><%= "#{consultee.name} (#{consultee.origin})" %></li>
-    <% end %>
-  </ul>
-  <%= simple_format(consultation_summary.entry, class: "govuk-body") %>
-<% end %>
-<% if policy_classes.any? %>
-  <h3 class="govuk-heading-m"><%= t(".legislation") %></h3>
-  <% policy_classes.each do |policy_class| %>
-    <%= render(
-      PolicyClasses::SummaryComponent.new(policy_class: policy_class)
-    ) %>
-  <% end %>
-<% end %>
-<h3 class="govuk-heading-m"><%= t(".documents_included_in") %></h3>
-<% if documents.any? %>
-  <table class="govuk-table">
-    <tbody class="govuk-table__body">
-      <% documents.each do |document| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <%= link_to(
-            document.name,
-            planning_application_documents_path(planning_application, anchor: dom_id(document)),
-            class: "govuk-body govuk-link"
-            ) %>
-          </td>
-        </tr>
+  <section id="consultation-summary-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".consultation_documents") %></h3>
+    <ul class="govuk-list govuk-list--bullet">
+      <% consultees.each do |consultee| %>
+        <li><%= "#{consultee.name} (#{consultee.origin})" %></li>
       <% end %>
-    </tbody>
-  </table>
+    </ul>
+    <%= simple_format(consultation_summary.entry, class: "govuk-body") %>
+  </section>
 <% end %>
+<% if show_additional_evidence && additional_evidence.present? %>
+  <section id="additional-evidence-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-m"><%= t(".additional_evidence") %></h3>
+    <%= simple_format(additional_evidence.entry, class: "govuk-body") %>
+  </section>
+<% end %>
+<section id="policy-classes-section" class="govuk-!-padding-bottom-5">
+  <h3 class="govuk-heading-m"><%= t(".legislation") %></h3>
+  <% if policy_classes.any? %>
+    <% policy_classes.each do |policy_class| %>
+      <%= render(
+        PolicyClasses::SummaryComponent.new(policy_class: policy_class)
+      ) %>
+    <% end %>
+  <% else %>
+    <p class="govuk-body"><%= t(".no_legislation_assessed") %></p>
+  <% end %>
+</section>
+
+<%= render "recommendations/documents", planning_application: planning_application, documents: documents %>

--- a/app/components/planning_applications/assessment_report_component.rb
+++ b/app/components/planning_applications/assessment_report_component.rb
@@ -2,13 +2,14 @@
 
 module PlanningApplications
   class AssessmentReportComponent < ViewComponent::Base
-    def initialize(planning_application:)
+    def initialize(planning_application:, show_additional_evidence: false)
       @planning_application = planning_application
+      @show_additional_evidence = show_additional_evidence
     end
 
     private
 
-    attr_reader :planning_application
+    attr_reader :planning_application, :show_additional_evidence
 
     delegate(
       :constraints,
@@ -18,11 +19,13 @@ module PlanningApplications
       :consultation_summary,
       :consultees,
       :policy_classes,
+      :permitted_development_right,
+      :additional_evidence,
       to: :planning_application
     )
 
     def documents
-      planning_application.documents.referenced_in_decision_notice
+      planning_application.documents_for_decision_notice
     end
   end
 end

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -4,27 +4,19 @@
 <% content_for(:title, t(".assess_recommendation")) %>
 <%= render(
   layout: "shared/assessment_dashboard",
-  locals: { heading: t(".assess_recommendation") }
+  locals: { heading: t(".assess_recommendation"), show_accordian: false }
 ) do %>
+  <h2 class="govuk-heading-l govuk-!-padding-top-5"><%= t(".assess_proposal") %></h2>
   <%= render(
-    partial: "legislation",
-    locals: {
+    PlanningApplications::AssessmentReportComponent.new(
       planning_application: @planning_application,
-      policy_classes: @planning_application.policy_classes
-    }
+      show_additional_evidence: true
+    )
   ) %>
   <%= render(
      partial: "events",
      locals: { recommendations: @planning_application.recommendations.reviewed }
   ) %>
-  <%= render(
-     partial: "documents",
-     locals: {
-       planning_application: @planning_application,
-       documents: @planning_application.documents_for_decision_notice
-     }
-  ) %>
-  <h2 class="govuk-heading-m"><%= t(".assess_recommendation") %></h2>
   <%= form_with(
     model: @recommendation,
     builder: GOVUKDesignSystemFormBuilder::FormBuilder,

--- a/app/views/shared/_constraints.html.erb
+++ b/app/views/shared/_constraints.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <ul class="govuk-list govuk-list--bullet">
     <% @planning_application.constraints.each do |constraint| %>
-      <li><%= constraint %></li>
+      <li><%= constraint.humanize %></li>
     <% end %>
   </ul>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -328,11 +328,15 @@ en:
         permitted_development_rights: Permitted development rights
   planning_applications:
     assessment_report_component:
+      additional_evidence: Additional evidence
       constraints_including_article: Constraints including Article 4 direction(s)
       consultation_documents: Consultation documents
-      documents_included_in: Documents included in decision notice
+      documents_included_in: Documents included in the decision notice
+      have_the_permitted_development_rights: Have the permitted development rights relevant for this application been removed?
       legislation: Legislation
       location_description: Location description
+      no_documents_listed: No documents listed on decision notice.
+      no_legislation_assessed: No legislation assessed for this application.
       planning_history: Planning history
       summary_of_works: Summary of works
     confirm_validation:
@@ -469,6 +473,7 @@ en:
     application_information:
       exempt: Exempt
     assessment_dashboard:
+      assess_proposal: Assess the proposal
       assess_recommendation: Assess recommendation
       awaiting_approval_to: Awaiting approval to a description change (sent on %{date})
       back: Back

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe "assessment against legislation", type: :system do
     click_link("Part 1, Class D")
     within(".govuk-accordion__section") do
       click_button("Constraints")
-      expect(page).to have_content("Conservation Area")
-      expect(page).to have_content("Listed Building")
+      expect(page).to have_content("Conservation area")
+      expect(page).to have_content("Listed building")
     end
   end
 

--- a/spec/system/planning_applications/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/viewing_assessment_report_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe "viewing assessment report", type: :system do
     )
 
     create(
+      :assessment_detail,
+      :additional_evidence,
+      planning_application: planning_application,
+      entry: "This is the additional evidence."
+    )
+
+    create(
       :consultee,
       planning_application: planning_application,
       name: "Alice Smith",
@@ -100,6 +107,8 @@ RSpec.describe "viewing assessment report", type: :system do
     expect(page).to have_content("Part 1, Class A - Window boxes")
     expect(page).to have_content("Complies")
     expect(page).to have_content(document.name)
+
+    expect(page).not_to have_content("This is the additional evidence.")
 
     expect(page).to have_link(
       "Download assessment report as PDF",


### PR DESCRIPTION
### Description of change

Add assessment details into the assess recommendation page

### Story Link

https://trello.com/c/QzFgDThM/1199-include-permitted-developments-rights-into-to-assess-recommendation-page
