### PR TITLE
Pr reviewer is unable to edit constraints on the legislation page

### DIFF
--- a/app/views/shared/_constraints.html.erb
+++ b/app/views/shared/_constraints.html.erb
@@ -10,4 +10,7 @@
   </ul>
 <% end %>
 
-<%= link_to "Edit constraints", edit_planning_application_constraints_path(@planning_application), class: "govuk-link govuk-body" %>
+<%= link_to_if(current_user.assessor?,
+               "Edit constraints",
+               edit_planning_application_constraints_path(@planning_application),
+               class: "govuk-link govuk-body") {} %>

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "assessment against legislation", type: :system do
       end
     end
 
-    it "displays the constraints" do
+    it "displays the constraints with edit" do
       click_link("Check and assess")
       add_policy_classes(["Class D - porches"])
 
@@ -133,6 +133,9 @@ RSpec.describe "assessment against legislation", type: :system do
         click_button("Constraints")
         expect(page).to have_content("Conservation area")
         expect(page).to have_content("Listed building")
+
+        expect(page).to have_link("Edit constraints",
+                                  href: edit_planning_application_constraints_path(planning_application))
       end
     end
 
@@ -342,6 +345,36 @@ RSpec.describe "assessment against legislation", type: :system do
           "Comment added on 01 Sep 2022 by Alice Smith",
           with: "New comment"
         )
+      end
+    end
+  end
+
+  context "when I'm signed in as a reviewer" do
+    let!(:reviewer) do
+      create(
+        :user,
+        :reviewer,
+        local_authority: local_authority
+      )
+    end
+
+    before do
+      sign_in(reviewer)
+      visit planning_application_path(planning_application)
+    end
+
+    it "displays the constraints without edit" do
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+
+      click_link("Part 1, Class D")
+      within(".govuk-accordion__section") do
+        click_button("Constraints")
+        expect(page).to have_content("Conservation area")
+        expect(page).to have_content("Listed building")
+
+        expect(page).not_to have_link("Edit constraints",
+                                      href: edit_planning_application_constraints_path(planning_application))
       end
     end
   end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -13,334 +13,336 @@ RSpec.describe "assessment against legislation", type: :system do
     )
   end
 
-  let(:assessor) do
-    create(
-      :user,
-      :assessor,
-      local_authority: local_authority,
-      name: "Alice Smith"
-    )
-  end
-
-  let(:assessor2) do
-    create(
-      :user,
-      :assessor,
-      local_authority: local_authority,
-      name: "Bella Jones"
-    )
-  end
-
-  before do
-    sign_in(assessor)
-    visit planning_application_path(planning_application)
-  end
-
-  it "warns the user about unsaved changes" do
-    click_link("Check and assess")
-    click_link("Add assessment area")
-    click_link("Back")
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    dismiss_confirm { click_link("Back") }
-    click_button("Continue")
-    click_link("Back")
-    click_button("Continue")
-
-    check(
-      "Class A - enlargement, improvement or other alteration of a dwellinghouse"
-    )
-
-    dismiss_confirm { click_link("Back") }
-    click_button("Add classes")
-
-    expect(page).to have_content("Policy classes have been successfully added")
-
-    click_link("Part 1, Class A")
-    click_link("Back")
-    click_link("Part 1, Class A")
-    choose("policy_class_policies_attributes_0_status_complies")
-    dismiss_confirm { click_link("Back") }
-    click_button("Save and come back later")
-
-    expect(page).to have_content("Successfully updated policy class")
-  end
-
-  it "lets the user add policy classes once only" do
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-
-    expect(page).to have_content("Part 1, Class D").once
-
-    click_link("Add assessment area")
-    choose("Part 1 - Development within the curtilage of a dwellinghouse")
-    click_button("Continue")
-
-    expect(page).to have_checked_field("Class D - porches", disabled: true)
-
-    check("Class G - chimneys, flues etc on a dwellinghouse")
-    click_button("Add classes")
-
-    expect(page).to have_content("Part 1, Class D").once
-    expect(page).to have_content("Part 1, Class G").once
-  end
-
-  it "lets the user remove policy class" do
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-    expect(page).to have_content("Part 1, Class D").once
-
-    click_link("Part 1, Class D")
-
-    accept_confirm do
-      click_button("Remove class from assessment")
+  context "when I'm signed in as an assessor" do
+    let(:assessor) do
+      create(
+        :user,
+        :assessor,
+        local_authority: local_authority,
+        name: "Alice Smith"
+      )
     end
 
-    expect(page).to have_content("Policy class has been removed.")
-  end
-
-  it "displays the class title" do
-    click_link("Check and assess")
-
-    add_policy_classes(
-      [
-        "Class A - enlargement, improvement or other alteration of a dwellinghouse",
-        "Class B - additions etc to the roof of a dwellinghouse"
-      ]
-    )
-
-    click_link("Part 1, Class A")
-    expect(page).to have_content("Class title - enlargement, improvement or other alteration of a dwellinghouse")
-    within(".govuk-table caption") do
-      expect(page).to have_content("Part 1, Class A - enlargement, improvement or other alteration of a dwellinghouse")
+    let(:assessor2) do
+      create(
+        :user,
+        :assessor,
+        local_authority: local_authority,
+        name: "Bella Jones"
+      )
     end
 
-    click_link("Back")
-    click_link("Part 1, Class B")
-    expect(page).to have_content("Class title - additions etc to the roof of a dwellinghouse")
-    within(".govuk-table caption") do
-      expect(page).to have_content("Part 1, Class B - additions etc to the roof of a dwellinghouse")
-    end
-  end
-
-  it "displays the constraints" do
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-
-    click_link("Part 1, Class D")
-    within(".govuk-accordion__section") do
-      click_button("Constraints")
-      expect(page).to have_content("Conservation area")
-      expect(page).to have_content("Listed building")
-    end
-  end
-
-  it "lets the user add and update comments" do
-    travel_to(Time.zone.local(2022, 9, 1))
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-    click_link("Part 1, Class D")
-
-    within(row_with_content("D.1a")) do
-      fill_in("Add comment", with: "New comment")
+    before do
+      sign_in(assessor)
+      visit planning_application_path(planning_application)
     end
 
-    click_button("Save and come back later")
-    click_link("Part 1, Class D")
+    it "warns the user about unsaved changes" do
+      click_link("Check and assess")
+      click_link("Add assessment area")
+      click_link("Back")
+      click_link("Add assessment area")
+      choose("Part 1 - Development within the curtilage of a dwellinghouse")
+      dismiss_confirm { click_link("Back") }
+      click_button("Continue")
+      click_link("Back")
+      click_button("Continue")
 
-    expect(row_with_content("D.1a")).to have_field(
-      "Comment added on 01 Sep 2022 by Alice Smith",
-      with: "New comment"
-    )
+      check(
+        "Class A - enlargement, improvement or other alteration of a dwellinghouse"
+      )
 
-    expect(row_with_content("D.1b")).to have_field("Add comment", with: "")
+      dismiss_confirm { click_link("Back") }
+      click_button("Add classes")
 
-    click_link("Log out")
-    travel_to(Time.zone.local(2022, 9, 2))
-    sign_in(assessor2)
-    visit planning_application_path(planning_application)
-    click_link("Check and assess")
-    click_link("Part 1, Class D")
+      expect(page).to have_content("Policy classes have been successfully added")
 
-    within(row_with_content("D.1a")) do
-      fill_in(
+      click_link("Part 1, Class A")
+      click_link("Back")
+      click_link("Part 1, Class A")
+      choose("policy_class_policies_attributes_0_status_complies")
+      dismiss_confirm { click_link("Back") }
+      click_button("Save and come back later")
+
+      expect(page).to have_content("Successfully updated policy class")
+    end
+
+    it "lets the user add policy classes once only" do
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+
+      expect(page).to have_content("Part 1, Class D").once
+
+      click_link("Add assessment area")
+      choose("Part 1 - Development within the curtilage of a dwellinghouse")
+      click_button("Continue")
+
+      expect(page).to have_checked_field("Class D - porches", disabled: true)
+
+      check("Class G - chimneys, flues etc on a dwellinghouse")
+      click_button("Add classes")
+
+      expect(page).to have_content("Part 1, Class D").once
+      expect(page).to have_content("Part 1, Class G").once
+    end
+
+    it "lets the user remove policy class" do
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+      expect(page).to have_content("Part 1, Class D").once
+
+      click_link("Part 1, Class D")
+
+      accept_confirm do
+        click_button("Remove class from assessment")
+      end
+
+      expect(page).to have_content("Policy class has been removed.")
+    end
+
+    it "displays the class title" do
+      click_link("Check and assess")
+
+      add_policy_classes(
+        [
+          "Class A - enlargement, improvement or other alteration of a dwellinghouse",
+          "Class B - additions etc to the roof of a dwellinghouse"
+        ]
+      )
+
+      click_link("Part 1, Class A")
+      expect(page).to have_content("Class title - enlargement, improvement or other alteration of a dwellinghouse")
+      within(".govuk-table caption") do
+        expect(page).to have_content("Part 1, Class A - enlargement, improvement or other alteration of a dwellinghouse")
+      end
+
+      click_link("Back")
+      click_link("Part 1, Class B")
+      expect(page).to have_content("Class title - additions etc to the roof of a dwellinghouse")
+      within(".govuk-table caption") do
+        expect(page).to have_content("Part 1, Class B - additions etc to the roof of a dwellinghouse")
+      end
+    end
+
+    it "displays the constraints" do
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+
+      click_link("Part 1, Class D")
+      within(".govuk-accordion__section") do
+        click_button("Constraints")
+        expect(page).to have_content("Conservation area")
+        expect(page).to have_content("Listed building")
+      end
+    end
+
+    it "lets the user add and update comments" do
+      travel_to(Time.zone.local(2022, 9, 1))
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+      click_link("Part 1, Class D")
+
+      within(row_with_content("D.1a")) do
+        fill_in("Add comment", with: "New comment")
+      end
+
+      click_button("Save and come back later")
+      click_link("Part 1, Class D")
+
+      expect(row_with_content("D.1a")).to have_field(
         "Comment added on 01 Sep 2022 by Alice Smith",
+        with: "New comment"
+      )
+
+      expect(row_with_content("D.1b")).to have_field("Add comment", with: "")
+
+      click_link("Log out")
+      travel_to(Time.zone.local(2022, 9, 2))
+      sign_in(assessor2)
+      visit planning_application_path(planning_application)
+      click_link("Check and assess")
+      click_link("Part 1, Class D")
+
+      within(row_with_content("D.1a")) do
+        fill_in(
+          "Comment added on 01 Sep 2022 by Alice Smith",
+          with: "Updated comment"
+        )
+      end
+
+      click_button("Save and come back later")
+      click_link("Part 1, Class D")
+
+      expect(row_with_content("D.1a")).to have_field(
+        "Comment updated on 02 Sep 2022 by Bella Jones",
         with: "Updated comment"
       )
     end
 
-    click_button("Save and come back later")
-    click_link("Part 1, Class D")
+    it "lets the user save draft and then mark as complete" do
+      travel_to(Time.zone.local(2022, 9, 1))
 
-    expect(row_with_content("D.1a")).to have_field(
-      "Comment updated on 02 Sep 2022 by Bella Jones",
-      with: "Updated comment"
-    )
-  end
+      expect(list_item("Check and assess")).to have_content("Not started")
 
-  it "lets the user save draft and then mark as complete" do
-    travel_to(Time.zone.local(2022, 9, 1))
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+      click_link("Part 1, Class D")
 
-    expect(list_item("Check and assess")).to have_content("Not started")
+      within(row_with_content("D.1a")) do
+        fill_in("Add comment", with: "Test comment")
+      end
 
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-    click_link("Part 1, Class D")
+      choose("policy_class_policies_attributes_0_status_complies")
+      choose("policy_class_policies_attributes_1_status_complies")
+      choose("policy_class_policies_attributes_2_status_complies")
+      choose("policy_class_policies_attributes_3_status_complies")
+      click_button("Save and mark as complete")
 
-    within(row_with_content("D.1a")) do
-      fill_in("Add comment", with: "Test comment")
-    end
+      expect(page).to have_content("All policies must be assessed")
 
-    choose("policy_class_policies_attributes_0_status_complies")
-    choose("policy_class_policies_attributes_1_status_complies")
-    choose("policy_class_policies_attributes_2_status_complies")
-    choose("policy_class_policies_attributes_3_status_complies")
-    click_button("Save and mark as complete")
+      click_button("Save and come back later")
 
-    expect(page).to have_content("All policies must be assessed")
+      expect(page).to have_content("Successfully updated policy class")
 
-    click_button("Save and come back later")
+      task_list_item = find_all("li").find do |list_item|
+        list_item.has_content?("Part 1, Class D")
+      end
 
-    expect(page).to have_content("Successfully updated policy class")
+      expect(task_list_item).to have_content("In assessment")
 
-    task_list_item = find_all("li").find do |list_item|
-      list_item.has_content?("Part 1, Class D")
-    end
+      click_link("Part 1, Class D")
+      choose("policy_class_policies_attributes_4_status_complies")
+      click_button("Save and mark as complete")
 
-    expect(task_list_item).to have_content("In assessment")
+      expect(page).to have_content("Successfully updated policy class")
 
-    click_link("Part 1, Class D")
-    choose("policy_class_policies_attributes_4_status_complies")
-    click_button("Save and mark as complete")
+      task_list_item = find_all("li").find do |list_item|
+        list_item.has_content?("Part 1, Class D")
+      end
 
-    expect(page).to have_content("Successfully updated policy class")
+      expect(task_list_item).to have_content("Complete")
 
-    task_list_item = find_all("li").find do |list_item|
-      list_item.has_content?("Part 1, Class D")
-    end
+      click_link("Part 1, Class D")
+      expect(page).to have_content("Comment added on 01 Sep 2022 by Alice Smith")
+      expect(page).to have_content("Test comment")
 
-    expect(task_list_item).to have_content("Complete")
+      expect(page).not_to have_field(
+        "Comment added on 01 Sep 2022 by Alice Smith",
+        with: "Test comment"
+      )
 
-    click_link("Part 1, Class D")
-    expect(page).to have_content("Comment added on 01 Sep 2022 by Alice Smith")
-    expect(page).to have_content("Test comment")
+      expect(page).not_to have_selector(
+        "#policy_class_policies_attributes_0_status_does_not_comply"
+      )
 
-    expect(page).not_to have_field(
-      "Comment added on 01 Sep 2022 by Alice Smith",
-      with: "Test comment"
-    )
+      click_link("Edit assessment")
 
-    expect(page).not_to have_selector(
-      "#policy_class_policies_attributes_0_status_does_not_comply"
-    )
-
-    click_link("Edit assessment")
-
-    expect(page).to have_field(
-      "Comment added on 01 Sep 2022 by Alice Smith",
-      with: "Test comment"
-    )
-
-    expect(page).to have_selector(
-      "#policy_class_policies_attributes_0_status_does_not_comply"
-    )
-
-    click_link("Application")
-
-    expect(list_item("Check and assess")).to have_content("In progress")
-  end
-
-  it "lets the user scroll between policy classes" do
-    travel_to(Time.zone.local(2022, 9, 1))
-
-    click_link("Check and assess")
-
-    add_policy_classes(
-      [
-        "Class D - porches",
-        "Class F - hard surfaces incidental to the enjoyment of a dwellinghouse"
-      ]
-    )
-
-    click_link("Part 1, Class D")
-
-    expect(page).not_to have_content("Save changes and view previous class")
-
-    within(row_with_content("D.1a")) do
-      fill_in("Add comment", with: "Test comment")
-    end
-
-    click_button("Save changes and view next class")
-
-    expect(page).to have_content("Part 1, Class F")
-    expect(page).not_to have_content("Save changes and view next class")
-
-    click_button("Save changes and view previous class")
-
-    expect(page).to have_content("Part 1, Class D")
-
-    expect(page).to have_field(
-      "Comment added on 01 Sep 2022 by Alice Smith",
-      with: "Test comment"
-    )
-
-    choose("policy_class_policies_attributes_0_status_complies")
-    choose("policy_class_policies_attributes_1_status_complies")
-    choose("policy_class_policies_attributes_2_status_complies")
-    choose("policy_class_policies_attributes_3_status_complies")
-    choose("policy_class_policies_attributes_4_status_complies")
-    click_button("Save and mark as complete")
-    click_link("Part 1, Class F")
-    choose("policy_class_policies_attributes_0_status_complies")
-    choose("policy_class_policies_attributes_1_status_complies")
-    choose("policy_class_policies_attributes_2_status_complies")
-    choose("policy_class_policies_attributes_3_status_complies")
-    click_button("Save and mark as complete")
-    click_link("Part 1, Class D")
-
-    expect(page).not_to have_content("View previous class")
-
-    click_link("View next class")
-
-    expect(page).to have_content("Part 1, Class F")
-    expect(page).not_to have_content("View next class")
-
-    click_link("View previous class")
-
-    expect(page).to have_content("Part 1, Class D")
-  end
-
-  it "lets the user delete comments" do
-    travel_to(Time.zone.local(2022, 9, 1))
-    click_link("Check and assess")
-    add_policy_classes(["Class D - porches"])
-    click_link("Part 1, Class D")
-
-    within(row_with_content("D.1a")) do
-      fill_in("Add comment", with: "Test comment")
-    end
-
-    click_button("Save and come back later")
-    click_link("Part 1, Class D")
-
-    within(row_with_content("D.1a")) do
       expect(page).to have_field(
         "Comment added on 01 Sep 2022 by Alice Smith",
         with: "Test comment"
       )
 
-      click_button("Delete comment")
-      fill_in("Add comment", with: "New comment")
+      expect(page).to have_selector(
+        "#policy_class_policies_attributes_0_status_does_not_comply"
+      )
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
     end
 
-    click_button("Save and come back later")
-    click_link("Part 1, Class D")
+    it "lets the user scroll between policy classes" do
+      travel_to(Time.zone.local(2022, 9, 1))
 
-    within(row_with_content("D.1a")) do
+      click_link("Check and assess")
+
+      add_policy_classes(
+        [
+          "Class D - porches",
+          "Class F - hard surfaces incidental to the enjoyment of a dwellinghouse"
+        ]
+      )
+
+      click_link("Part 1, Class D")
+
+      expect(page).not_to have_content("Save changes and view previous class")
+
+      within(row_with_content("D.1a")) do
+        fill_in("Add comment", with: "Test comment")
+      end
+
+      click_button("Save changes and view next class")
+
+      expect(page).to have_content("Part 1, Class F")
+      expect(page).not_to have_content("Save changes and view next class")
+
+      click_button("Save changes and view previous class")
+
+      expect(page).to have_content("Part 1, Class D")
+
       expect(page).to have_field(
         "Comment added on 01 Sep 2022 by Alice Smith",
-        with: "New comment"
+        with: "Test comment"
       )
+
+      choose("policy_class_policies_attributes_0_status_complies")
+      choose("policy_class_policies_attributes_1_status_complies")
+      choose("policy_class_policies_attributes_2_status_complies")
+      choose("policy_class_policies_attributes_3_status_complies")
+      choose("policy_class_policies_attributes_4_status_complies")
+      click_button("Save and mark as complete")
+      click_link("Part 1, Class F")
+      choose("policy_class_policies_attributes_0_status_complies")
+      choose("policy_class_policies_attributes_1_status_complies")
+      choose("policy_class_policies_attributes_2_status_complies")
+      choose("policy_class_policies_attributes_3_status_complies")
+      click_button("Save and mark as complete")
+      click_link("Part 1, Class D")
+
+      expect(page).not_to have_content("View previous class")
+
+      click_link("View next class")
+
+      expect(page).to have_content("Part 1, Class F")
+      expect(page).not_to have_content("View next class")
+
+      click_link("View previous class")
+
+      expect(page).to have_content("Part 1, Class D")
+    end
+
+    it "lets the user delete comments" do
+      travel_to(Time.zone.local(2022, 9, 1))
+      click_link("Check and assess")
+      add_policy_classes(["Class D - porches"])
+      click_link("Part 1, Class D")
+
+      within(row_with_content("D.1a")) do
+        fill_in("Add comment", with: "Test comment")
+      end
+
+      click_button("Save and come back later")
+      click_link("Part 1, Class D")
+
+      within(row_with_content("D.1a")) do
+        expect(page).to have_field(
+          "Comment added on 01 Sep 2022 by Alice Smith",
+          with: "Test comment"
+        )
+
+        click_button("Delete comment")
+        fill_in("Add comment", with: "New comment")
+      end
+
+      click_button("Save and come back later")
+      click_link("Part 1, Class D")
+
+      within(row_with_content("D.1a")) do
+        expect(page).to have_field(
+          "Comment added on 01 Sep 2022 by Alice Smith",
+          with: "New comment"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change

Reviewer wants to understand the reasoning of the officer who has assessed the class related to constraints. But not change the constraints. 

Assessor want to relate the constraints to the legislation and change them.

## Story Link

https://trello.com/c/RrilPSF6/1296-reviewer-is-unable-to-edit-constraints-on-the-legislation-page


## Screenshots

### Legislation page with assessor
- current user is an assessor 
![Screenshot 2022-10-27 at 22 52 04](https://user-images.githubusercontent.com/1710795/198405504-fcc2ffbb-69ad-4311-9539-f927a69fc899.png)


- current user is a reviewer
![Screenshot 2022-10-27 at 22 51 25](https://user-images.githubusercontent.com/1710795/198405535-4e67493b-9123-4c74-85e0-aeac536545af.png)


## Commits
- PR shows two commits the first is just to add a assessor context block around original tests so that the diff for the actual work is clearer
- Commits to be squashed before merge