### PR TITLE
Pr create review tasklist for managers signing off cases

### DIFF
--- a/app/controllers/planning_application/review_tasks_controller.rb
+++ b/app/controllers/planning_application/review_tasks_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class ReviewTasksController < AuthenticationController
+    before_action :set_planning_application
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+  end
+end

--- a/app/controllers/review_tasks_controller.rb
+++ b/app/controllers/review_tasks_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ReviewTasksController < ApplicationController
+end

--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -1,0 +1,61 @@
+<% content_for :page_title do %>
+  Review and sign-off - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", planning_applications_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% content_for :title, "Review and sign-off" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l"><%= t(".review_and_sign_off") %></h1>
+      <p class="govuk-body govuk-!-font-size-24 govuk-!-font-weight-bold">
+        <%= @planning_application.full_address.upcase %>
+      </p>
+      <p class="govuk-body govuk-!-font-size-24">
+        <%= t("shared.proposal_header.application_number") %>
+        <span class="govuk-!-font-weight-bold">
+          <%= @planning_application.reference %>
+        </span>
+      </p>
+
+    <p class="govuk-body"><%= @planning_application.status_tag %></p>
+
+    <% if @planning_application.closed? %>
+      <p class="govuk-body">
+        <strong>Reason for being closed:</strong>
+        <%= simple_format(@planning_application.closed_or_cancellation_comment) %>
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= @planning_application.type_and_work_status %>: <%= @planning_application.description %>
+    </p>
+  </div>
+</div>
+
+<%= render "flash_content" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="app-task-list__section">
+      Review assessment
+    </h2>
+    <ul class="app-task-list__items">
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= link_to "Sign-off recommendation",
+                      edit_planning_application_recommendations_path(@planning_application),
+                      aria: { describedby: "review_assessment-completed" },
+                      class: "govuk-link" %>
+        </span>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
+</div>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -3,12 +3,18 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <% if @planning_application.awaiting_determination? && current_user.reviewer? %>
-          <%= link_to "Review assessment", edit_planning_application_recommendations_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
-        <% elsif @planning_application.awaiting_determination? && !current_user.reviewer? %>
-          <%= link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
+        <% if current_user.reviewer? %>
+          <% if @planning_application.awaiting_determination? %>
+            <%= link_to "Review and sign-off", planning_application_review_tasks_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
+          <% else %>
+            Review and sign-off
+          <% end %>
         <% else %>
-          Review assessment
+          <% if @planning_application.awaiting_determination? %>
+            <%= link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
+          <% else %>
+            View recommendation
+          <% end %>
         <% end %>
       </span>
       <%= render(

--- a/app/views/recommendations/edit.html.erb
+++ b/app/views/recommendations/edit.html.erb
@@ -2,8 +2,6 @@
   Review form - <%= t('page_title') %>
 <% end %>
 
-<% content_for :title, "Review assessment" %>
-
 <h1 class="govuk-heading-l"><%= t(".review_recommendation") %></h1>
 
 <%= render "shared/assessment_dashboard" do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,9 @@ en:
         history: History search (in testing)
         in_assessment: In assessment
         permitted_development_rights: Permitted development rights
+    review_tasks:
+      index:
+        review_and_sign_off: Review and sign-off
   planning_applications:
     assessment_report_component:
       additional_evidence: Additional evidence

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
 
       resources :assessment_tasks, only: :index
 
+      resources :review_tasks, only: :index
+
       resources :summary_of_works, only: %i[new edit create show update]
 
       resources :assessment_details, only: %i[new edit create show update]

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -98,17 +98,6 @@ Given("a recommendation is submitted for the planning application") do
   )
 end
 
-Given("the planning application is determined") do
-  steps %(
-    Given a recommendation is submitted for the planning application
-    And I press "Review assessment"
-    And I choose "Yes" for "Do you agree with the recommendation?"
-    And I press "Save"
-    And I press "Publish determination"
-    And I press "Publish determination"
-  )
-end
-
 When("I view the planning application") do
   visit planning_application_path(@planning_application)
 end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -633,7 +633,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     expect(list_item("Assess recommendation")).to have_content("Complete")
 
     ["Not started", "In progress", "Complete"].each do |status|
-      expect(list_item("Review assessment")).not_to have_content(status)
+      expect(list_item("View recommendation")).not_to have_content(status)
     end
 
     click_link("Submit recommendation")
@@ -644,19 +644,21 @@ RSpec.describe "Planning Application Assessment", type: :system do
     sign_in(reviewer)
     visit(planning_application_path(planning_application))
 
-    expect(list_item("Review assessment")).to have_content("Not started")
+    expect(list_item("Review and sign-off")).to have_content("Not started")
 
-    click_link("Review assessment")
+    click_link("Review and sign-off")
+    click_link("Sign-off recommendation")
     choose("recommendation_challenged_true")
     fill_in("Review comment", with: "Application invalid")
     click_button("Save and come back later")
 
-    expect(list_item("Review assessment")).to have_content("In progress")
+    expect(list_item("Review and sign-off")).to have_content("In progress")
 
-    click_link("Review assessment")
+    click_link("Review and sign-off")
+    click_link("Sign-off recommendation")
     click_button("Save and mark as complete")
 
-    expect(list_item("Review assessment")).to have_content("Complete")
+    expect(list_item("Review and sign-off")).to have_content("Complete")
 
     ["Not started", "In progress", "Complete"].each do |status|
       expect(list_item("Assess recommendation")).not_to have_content(status)
@@ -684,15 +686,16 @@ RSpec.describe "Planning Application Assessment", type: :system do
     sign_in(reviewer)
     visit(planning_application_path(planning_application))
 
-    expect(list_item("Review assessment")).to have_content("Not started")
+    expect(list_item("Review and sign-off")).to have_content("Not started")
 
-    click_link("Review assessment")
+    click_link("Review and sign-off")
+    click_link("Sign-off recommendation")
     choose("recommendation_challenged_false")
     fill_in("Review comment", with: "Application valid")
     click_button("Save and mark as complete")
 
     expect(list_item("Assess recommendation")).to have_content("Complete")
-    expect(list_item("Review assessment")).to have_content("Complete")
+    expect(list_item("Review and sign-off")).to have_content("Complete")
 
     sign_in(assessor)
     visit(planning_application_path(planning_application))

--- a/spec/system/planning_applications/review_tasks_index_spec.rb
+++ b/spec/system/planning_applications/review_tasks_index_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application Review Tasks Index", type: :system do
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let(:reviewer) { create :user, :reviewer, local_authority: default_local_authority }
+
+  context "with a reviewer" do
+    before do
+      sign_in reviewer
+    end
+
+    it "while awaiting determination it can navigate around review tasks" do
+      visit planning_application_path(create(:planning_application, :awaiting_determination,
+                                             local_authority: default_local_authority))
+
+      click_on "Review and sign-off"
+
+      expect(page).to have_title("Review and sign-off")
+
+      click_on "Back"
+
+      expect(page).to have_title("Planning Application")
+    end
+
+    it "without awaiting determination there is no navigation" do
+      visit planning_application_path(create(:planning_application,
+                                             :not_started,
+                                             local_authority: default_local_authority))
+
+      expect(page).to have_content("Review and sign-off")
+    end
+  end
+end

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   it "can be accepted" do
     delivered_emails = ActionMailer::Base.deliveries.count
-    click_link "Review assessment"
+    click_link "Review and sign-off"
+    click_link "Sign-off recommendation"
 
     expect(page).to have_content("Review the recommendation")
 
@@ -62,7 +63,7 @@ RSpec.describe "Planning Application Reviewing", type: :system do
     expect(planning_application.recommendations.last.reviewer_comment).to eq("Reviewer private comment")
     expect(page).not_to have_content("Assigned to:")
     expect(page).not_to have_content("Process Application")
-    expect(page).not_to have_content("Review Assessment")
+    expect(page).not_to have_content("Review and sign-off")
     perform_enqueued_jobs
     expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 2)
     click_link("View decision notice")
@@ -74,7 +75,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   it "can be rejected" do
     travel_to(Date.new(2022))
-    click_link "Review assessment"
+    click_link "Review and sign-off"
+    click_link "Sign-off recommendation"
+
     find("#recommendation_challenged_true").click
     fill_in "Review comment", with: "Reviewer private comment"
     click_button "Save and mark as complete"
@@ -106,7 +109,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   end
 
   it "cannot be rejected without a review comment" do
-    click_link "Review assessment"
+    click_link "Review and sign-off"
+    click_link "Sign-off recommendation"
+
     find("#recommendation_challenged_true").click
     click_button "Save and mark as complete"
 
@@ -118,7 +123,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   end
 
   it "can be accepted without a review comment" do
-    click_link "Review assessment"
+    click_link "Review and sign-off"
+    click_link "Sign-off recommendation"
+
     find("#recommendation_challenged_false").click
     click_button "Save and mark as complete"
     click_link "Publish determination"
@@ -131,7 +138,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
   it "can edit an existing review of an assessment" do
     recommendation = create :recommendation, :reviewed, planning_application: planning_application,
                                                         reviewer_comment: "Reviewer private comment"
-    click_link "Review assessment"
+    click_link "Review and sign-off"
+    click_link "Sign-off recommendation"
 
     within ".recommendations" do
       expect(page).to have_content("First assessor comment")
@@ -152,7 +160,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
   context "when editing the public comment that appears on the decision notice" do
     it "as a reviewer I am able to edit" do
-      click_link "Review assessment"
+      click_link "Review and sign-off"
+      click_link "Sign-off recommendation"
 
       expect(page).to have_content("Review the recommendation")
       expect(page).to have_content("The planning officer recommends that the application is granted")
@@ -180,7 +189,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       click_button "Save"
       expect(page).to have_content("Planning application was successfully updated.")
 
-      click_link "Review assessment"
+      click_link "Review and sign-off"
+      click_link "Sign-off recommendation"
+
       expect(page).to have_content("This text will appear on the decision notice.")
 
       # Check audit log

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Planning Application show page", type: :system do
       end
 
       within "#review-section" do
-        expect(page).to have_link("Review assessment")
+        expect(page).to have_link("Review and sign-off")
         expect(page).not_to have_content("Complete")
 
         expect(page).not_to have_link("Publish determination")
@@ -88,7 +88,7 @@ RSpec.describe "Planning Application show page", type: :system do
       visit planning_application_path(planning_application)
 
       within "#review-section" do
-        expect(page).to have_link("Review assessment")
+        expect(page).to have_link("Review and sign-off")
         expect(page).to have_content("Complete")
         expect(page).to have_link("Publish determination")
         within(:xpath, '//*[@id="review-section"]/ul/li[2]') do
@@ -166,7 +166,7 @@ RSpec.describe "Planning Application show page", type: :system do
       end
 
       within "#review-section" do
-        expect(page).not_to have_link("Review assessment")
+        expect(page).not_to have_link("Review and sign-off")
         expect(page).to have_link("View recommendation")
         expect(page).not_to have_content("Complete")
 
@@ -191,7 +191,7 @@ RSpec.describe "Planning Application show page", type: :system do
       end
 
       within "#review-section" do
-        expect(page).not_to have_link("Review assessment")
+        expect(page).not_to have_link("Review and sign-off")
         expect(page).to have_content("Complete")
 
         expect(page).not_to have_link("Publish determination")


### PR DESCRIPTION
## Description of change

Create a tasklist page for the review phase of the project to contain the tasks needed to be undertaken as a review.

### User Story
As a reviewer I need to see all the tasks I need to complete so that I quickly review assessments and keep track of any changes needed

### ACs by commit
AC1: Link added to: Review and sign-off
AC2: Review assessment moved to Review and sign-off landing page
AC3: Reviewer can navigate back to application landing via back button
AC4: Is to avoid regression
AC5: Rename non-reviewers text to view recommendation

### Reviewer on the Application page - Review and sign-off

![reviewer-review-and-sign-off](https://user-images.githubusercontent.com/1710795/199358516-692dc4e0-f7b3-447c-b8a1-b8d161a78180.png)

### Reviewer on the Review and sign-off landing page

![reviewer-review-and-sign-off-landing-page](https://user-images.githubusercontent.com/1710795/199358948-cae0882c-1b38-4475-a289-e3bdb29a0529.png)

### Reviewer navigating from Review and sign-off landing page to Review the recommendation

![reviewer-review-the-recommendation](https://user-images.githubusercontent.com/1710795/199359529-e6192102-fdf8-4c9b-a1db-59a768eb7bd7.png)

### Assessor before determination
- No link and the text now reads 'View recommendation'
![assessor-before-determination](https://user-images.githubusercontent.com/1710795/199361684-80db626b-baf9-4c4d-ab89-ec89325b3024.png)

### Assessor after determination

- Link as before reads 'View recommendation'

![assessor-after-determination](https://user-images.githubusercontent.com/1710795/199361871-f6b2f06b-40f7-4e9d-8f47-622abea6e731.png)


### Story Link

https://trello.com/c/cuDX5hsQ/1263-create-review-tasklist-for-managers-signing-off-cases

### Known issues

Things you know need further follow on work but aren't in scope of this issue

1. Status tag is unlikely to be correct as it's the old status tag
2. Review the recommendation breadcrumbs are wrong
3. Assessor should be forbidden from the review tasklist landing page

