### PR TITLE
Pr fix remove made from legislation url

### DIFF
--- a/config/locales/references.yml
+++ b/config/locales/references.yml
@@ -430,7 +430,7 @@ en:
               schedule: "Schedule 1"
               part: 1
               section: B
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-a-enlargement-improvement-or-other-alteration-of-a-dwellinghouse
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-b-additions-etc-to-the-roof-of-a-dwellinghouse
               name: additions etc to the roof of a dwellinghouse
               policies_attributes:
                 -
@@ -567,7 +567,7 @@ en:
               schedule: "Schedule 1"
               part: 1
               section: C
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-c-other-alterations-to-the-roof-of-a-dwellinghouse/made
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-c-other-alterations-to-the-roof-of-a-dwellinghouse
               name: other alterations to the roof of a dwellinghouse
               policies_attributes:
                 -
@@ -634,7 +634,7 @@ en:
               schedule: "Schedule 1"
               part: 1
               section: D
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-d-porches/made
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-d-porches
               name: porches
               policies_attributes:
                 -
@@ -674,7 +674,7 @@ en:
               schedule: "Schedule 1"
               part: 1
               section: E
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-e-buildings-etc-incidental-to-the-enjoyment-of-a-dwellinghouse/made
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-e-buildings-etc-incidental-to-the-enjoyment-of-a-dwellinghouse
               name: buildings etc incidental to the enjoyment of a dwellinghouse
               policies_attributes:
                 -
@@ -823,7 +823,7 @@ en:
               schedule: "Schedule 1"
               part: 1
               section: F
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-f-hard-surfaces-incidental-to-the-enjoyment-of-a-dwellinghouse/made
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-f-hard-surfaces-incidental-to-the-enjoyment-of-a-dwellinghouse
               name: hard surfaces incidental to the enjoyment of a dwellinghouse
               policies_attributes:
                 -
@@ -868,7 +868,7 @@ en:
               part: 1
               section: G
               name: chimneys, flues etc on a dwellinghouse
-              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-g-chimneys-flues-etc-on-a-dwellinghouse/made
+              url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-g-chimneys-flues-etc-on-a-dwellinghouse
               policies_attributes:
                 -
                   section: 1a


### PR DESCRIPTION
`config/locals/reference.yml `has a list of URL that are used to link the application to legislation. 

When discussing it with the designers they explained it should point to the latest version of the legislation and not the original version. However, some of the URLs are pointing to the original versions of the legislation.

For example reference.yml points to the original '/made' version the URL will be changed by removing '/made'

   ` url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-g-chimneys-flues-etc-on-a-dwellinghouse/made`