### PR TITLE
Add high level item for what is permitted by each class

### DIFF
--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -12,7 +12,7 @@ class Policy < ApplicationRecord
     reject_if: proc { |attributes| attributes[:text].blank? }
   )
 
-  validates :description, :section, :status, presence: true
+  validates :description, :status, presence: true
 
   enum(
     status: { complies: 0, does_not_comply: 1, to_be_determined: 2 },

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -39,7 +39,7 @@
                   <%= "#{form.object.section}.#{policy_form.object.section}" %>
                 </h3>
                 <p class="govuk-body">
-                  <%= policy_form.object.description %>
+                  <%= simple_format(policy_form.object.description) %>
                 </p>
                 <% if editable %>
                   <%= render(

--- a/config/locales/references.yml
+++ b/config/locales/references.yml
@@ -14,6 +14,11 @@ en:
               name: enlargement, improvement or other alteration of a dwellinghouse
               policies_attributes:
                 -
+                  section: ""
+                  description: |
+                    The enlargement, improvement or other alteration
+                    of a dwellinghouse.
+                -
                   section: 1a
                   description: |
                     Development is not permitted by Class A if
@@ -270,6 +275,22 @@ en:
               name: enlargement of a dwellinghouse by construction of additional storeys
               policies_attributes:
                 -
+                  section: ""
+                  description: |
+                    The enlargement of a dwellinghouse consisting of
+                    the construction of—
+
+                    (a) up to two additional storeys, where the
+                    existing dwellinghouse consists of two or more
+                    storeys; or
+
+                    (b) one additional storey, where the existing
+                    dwellinghouse consists of one storey,
+                    immediately above the topmost storey of the
+                    dwellinghouse, together with any engineering
+                    operations reasonably necessary for the purpose
+                    of that construction.
+                -
                   section: 1a
                   description: |
                     Development is not permitted by Class AA if
@@ -434,6 +455,11 @@ en:
               name: additions etc to the roof of a dwellinghouse
               policies_attributes:
                 -
+                  section: ""
+                  description: |
+                    The enlargement of a dwellinghouse consisting of
+                    an addition or alteration to its roof.
+                -
                   section: 1a
                   description: |
                     "Development is not permitted by Class B if
@@ -571,6 +597,11 @@ en:
               name: other alterations to the roof of a dwellinghouse
               policies_attributes:
                 -
+                  section: ""
+                  description: |
+                    Any other alteration to the roof of a
+                    dwellinghouse
+                -
                   section: 1a
                   description: |
                     "Development is not permitted by Class C if
@@ -637,6 +668,10 @@ en:
               url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-d-porches
               name: porches
               policies_attributes:
+                - section: ""
+                  description: |
+                    The erection or construction of a porch outside
+                    any external door of a dwellinghouse.
                 -
                   section: 1a
                   description: |
@@ -677,6 +712,21 @@ en:
               url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-e-buildings-etc-incidental-to-the-enjoyment-of-a-dwellinghouse
               name: buildings etc incidental to the enjoyment of a dwellinghouse
               policies_attributes:
+                -
+                  section: ""
+                  description: |
+                    The provision within the curtilage of the
+                    dwellinghouse of—
+
+                    (a) any building or enclosure, swimming or other
+                       pool required for a purpose incidental to the
+                       enjoyment of the dwellinghouse as such, or the
+                       maintenance, improvement or other alteration
+                       of such a building or enclosure; or
+
+                    (b) a container used for domestic heating
+                       purposes for the storage of oil or liquid
+                       petroleum gas.
                 -
                   section: 1a
                   description: |
@@ -827,6 +877,18 @@ en:
               name: hard surfaces incidental to the enjoyment of a dwellinghouse
               policies_attributes:
                 -
+                  section: ""
+                  description: |
+                    Development consisting of—
+
+                    (a) the provision within the curtilage of a
+                    dwellinghouse of a hard surface for any purpose
+                    incidental to the enjoyment of the dwellinghouse
+                    as such; or
+
+                    (b) the replacement in whole or in part of such
+                    a surface.
+                -
                   section: 1a
                   description: |
                     Development is not permitted by Class F if
@@ -870,6 +932,12 @@ en:
               name: chimneys, flues etc on a dwellinghouse
               url: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/part/1/crossheading/class-g-chimneys-flues-etc-on-a-dwellinghouse
               policies_attributes:
+                -
+                  section: ""
+                  description: |
+                    The installation, alteration or replacement of a
+                    chimney, flue or soil and vent pipe on a
+                    dwellinghouse.
                 -
                   section: 1a
                   description: |

--- a/spec/models/policy_class_spec.rb
+++ b/spec/models/policy_class_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe PolicyClass, type: :model do
     it "builds policies associated with each policy class" do
       expect(policy_class.policies.first).to have_attributes(
         id: nil,
-        section: "1a",
-        description: "Development is not permitted by Class A if\npermission to use the dwellinghouse as a\ndwellinghouse has been granted only by virtue of\nClass M, MA, N, P, PA or Q of Part 3 of this\nSchedule (changes of use);\n",
+        section: "",
+        description: "The enlargement, improvement or other alteration\nof a dwellinghouse.\n",
         status: "to_be_determined"
       )
     end

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -199,6 +199,7 @@ RSpec.describe "assessment against legislation", type: :system do
       choose("policy_class_policies_attributes_1_status_complies")
       choose("policy_class_policies_attributes_2_status_complies")
       choose("policy_class_policies_attributes_3_status_complies")
+      choose("policy_class_policies_attributes_4_status_complies")
       click_button("Save and mark as complete")
 
       expect(page).to have_content("All policies must be assessed")
@@ -214,7 +215,7 @@ RSpec.describe "assessment against legislation", type: :system do
       expect(task_list_item).to have_content("In assessment")
 
       click_link("Part 1, Class D")
-      choose("policy_class_policies_attributes_4_status_complies")
+      choose("policy_class_policies_attributes_5_status_complies")
       click_button("Save and mark as complete")
 
       expect(page).to have_content("Successfully updated policy class")
@@ -293,12 +294,14 @@ RSpec.describe "assessment against legislation", type: :system do
       choose("policy_class_policies_attributes_2_status_complies")
       choose("policy_class_policies_attributes_3_status_complies")
       choose("policy_class_policies_attributes_4_status_complies")
+      choose("policy_class_policies_attributes_5_status_complies")
       click_button("Save and mark as complete")
       click_link("Part 1, Class F")
       choose("policy_class_policies_attributes_0_status_complies")
       choose("policy_class_policies_attributes_1_status_complies")
       choose("policy_class_policies_attributes_2_status_complies")
       choose("policy_class_policies_attributes_3_status_complies")
+      choose("policy_class_policies_attributes_4_status_complies")
       click_button("Save and mark as complete")
       click_link("Part 1, Class D")
 

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -415,7 +415,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
         choose("policy_class_policies_attributes_1_status_complies")
         choose("policy_class_policies_attributes_2_status_complies")
         choose("policy_class_policies_attributes_3_status_complies")
-        choose("policy_class_policies_attributes_4_status_to_be_determined")
+        choose("policy_class_policies_attributes_4_status_complies")
+        choose("policy_class_policies_attributes_5_status_to_be_determined")
         click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")
@@ -423,7 +424,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         expect(page).to have_content("To be determined")
 
         click_link("Part 1, Class D - porches")
-        choose("policy_class_policies_attributes_4_status_does_not_comply")
+        choose("policy_class_policies_attributes_5_status_does_not_comply")
         click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")
@@ -435,7 +436,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         )
 
         click_link("Part 1, Class D - porches")
-        choose("policy_class_policies_attributes_4_status_complies")
+        choose("policy_class_policies_attributes_5_status_complies")
         click_button("Save and come back later")
         click_link("Application")
         click_link("Assess recommendation")


### PR DESCRIPTION
### Description of change

The application already shows the legislation under the sub-headings.
What is required is that the "permitted development text" is also added into the checklist.

Basically: We are adding the first item for each Policy class. In the diagram below it's the text in the green box.


![high-level-item](https://user-images.githubusercontent.com/1710795/200032001-b60f4e11-d258-4ef5-ae3d-65e93323bc5e.jpg)

### Story Link

https://trello.com/c/g9CHUFK0/1167-add-high-level-item-for-what-is-permitted-by-each-class

### Decisions

**For the "High level item" there is no section.**

- To get around this I am setting an empty string for the status
  and removing this validation.

- Other options I considered is changing the status to be what is
  currently the PolicyClass section combined with the Policy section
  This would mean updating everything on the database.
