### PR TITLE
Update the Assess Recommendation report to show more legislation

### DIFF
--- a/app/components/policy_classes/summary_component.html.erb
+++ b/app/components/policy_classes/summary_component.html.erb
@@ -15,3 +15,24 @@
     </div>
   <% end %>
 <% end %>
+
+<% if policies.commented_or_does_not_comply.any? %>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <%= "View commented legislation for class #{section}" %>
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= render(partial: "policy_classes/form",
+                 locals: {
+                   planning_application: planning_application,
+                   policy_class: @policy_class,
+                   policies: @policy_class.policies.commented_or_does_not_comply,
+                   show_controls: false,
+                   editable: false
+                 })
+      %>
+    </div>
+  </details>
+<% end %>

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -21,6 +21,12 @@ class Policy < ApplicationRecord
 
   statuses.each_key { |status| scope status, -> { where(status: status) } }
 
+  scope :with_a_comment, -> { joins(:comment) }
+
+  def self.commented_or_does_not_comply
+    (does_not_comply | with_a_comment).sort_by(&:section)
+  end
+
   def existing_or_new_comment
     comment || build_comment
   end

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -1,145 +1,34 @@
+<% show_controls = true if local_assigns[:show_controls].nil? %>
+<% policies = policy_class.policies if local_assigns[:policies].nil? %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with(
-      model: [planning_application, policy_class],
-      html: { data: unsaved_changes_data },
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder
-    ) do |form| %>
+          model: [planning_application, policy_class],
+          html: { data: unsaved_changes_data },
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder
+        ) do |form| %>
       <%= form.govuk_error_summary %>
-      <table class="govuk-table">
-        <caption class="govuk-table__caption govuk-table__caption--l">
-          <%= t(
-            ".table_caption",
-            part: policy_class.part,
-            class: policy_class.section,
-            name: policy_class.name
+      <%= render(
+            partial: "policy_classes/table",
+            locals: {
+              form: form,
+              planning_application: planning_application,
+              policy_class: policy_class,
+              policies: policies,
+              editable: editable
+            }
           ) %>
-        </caption>
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-half">
-              <%= t(".policy_reference") %>
-            </th>
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-              <%= t(".complies") %>
-            </th>
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-              <%= t(".does_not_comply") %>
-            </th>
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-              <%= t(".to_be_determined") %>
-            </th>
-          </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <%= form.fields_for(:policies) do |policy_form| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">
-                <h3 class="govuk-heading-s">
-                  <%= "#{form.object.section}.#{policy_form.object.section}" %>
-                </h3>
-                <p class="govuk-body">
-                  <%= simple_format(policy_form.object.description) %>
-                </p>
-                <% if editable %>
-                  <%= render(
-                    partial: "comment_form",
-                    locals: {
-                      planning_application: planning_application,
-                      policy_class: policy_class,
-                      policy: policy_form.object,
-                      comment: policy_form.object.existing_or_new_comment,
-                      policy_index: policy_form.options[:child_index]
-                    }
-                  ) %>
-                <% elsif comment = policy_form.object.comment.presence %>
-                  <h4 class="govuk-heading-s policy-comment-title">
-                    <%=existing_policy_comment_label(comment)%>
-                  </h4>
-                  <p class="govuk-body"><%= simple_format(comment.text) %></p>
-                <% end %>
-              </td>
-              <% Policy.statuses.each_key do |status| %>
-                <td class="govuk-table__cell">
-                  <% if editable || policy_form.object.status == status %>
-                    <div class="govuk-form-group">
-                      <fieldset class="govuk-fieldset">
-                        <div class="govuk-radios" data-module="govuk-radios">
-                          <div class="govuk-radios govuk-radios--small">
-                            <div class="govuk-radios__item">
-                              <%= policy_form.radio_button(
-                                :status,
-                                status,
-                                class: "govuk-radios__input",
-                                disabled: planning_application.assessment_complete?
-                              ) %>
-                              <%= policy_form.label(
-                                :status,
-                                "&nbsp;".html_safe,
-                                class: "govuk-label govuk-radios__label"
-                              ) %>
-                            </div>
-                          </div>
-                        </div>
-                      </fieldset>
-                    </div>
-                  <% end %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-      <div class="policy-class-scroll-links">
-        <% if policy_class.previous.present? %>
-          <% if editable && !planning_application.assessment_complete? %>
-            <%= form.submit(
-              t(".save_changes_and_view_previous"),
-              class: "button-as-link"
-            ) %>
-          <% else %>
-            <%= link_to(
-              t(".view_previous_class"),
-              policy_class.previous.default_path,
-              class: "govuk-link"
-            ) %>
-          <% end %>
-        <% end %>
-        <% if policy_class.next.present? %>
-          <% if editable %>
-            <%= form.submit(
-              t(".save_changes_and_view_next"),
-              class: "button-as-link next-policy-class-link"
-            ) %>
-          <% else %>
-            <%= link_to(
-              t(".view_next_class"),
-              policy_class.next.default_path,
-              class: "govuk-link next-policy-class-link"
-            ) %>
-          <% end %>
-        <% end %>
-      </div>
-      <% if editable %>
+      <% if show_controls %>
         <%= render(
-          partial: "shared/submit_buttons",
-          locals: {
-            form: form,
-            disabled: planning_application.assessment_complete?
-          }
-        ) %>
-      <% else %>
-        <div class="govuk-button-group">
-          <%= back_link %>
-          <%= link_to(
-            t(".edit_assessment"),
-            edit_planning_application_policy_class_path(
-              planning_application,
-              policy_class
-            ),
-            class: "govuk-link"
-          ) %>
-        </div>
+              partial: "policy_classes/form_controls",
+              locals: {
+                form: form,
+                planning_application: planning_application,
+                policy_class: policy_class,
+                editable: editable
+              }
+            ) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/policy_classes/_form_controls.html.erb
+++ b/app/views/policy_classes/_form_controls.html.erb
@@ -1,0 +1,51 @@
+<div class="policy-class-scroll-links">
+  <% if policy_class.previous.present? %>
+    <% if editable && !planning_application.assessment_complete? %>
+      <%= form.submit(
+            t(".save_changes_and_view_previous"),
+            class: "button-as-link"
+          ) %>
+    <% else %>
+      <%= link_to(
+            t(".view_previous_class"),
+            policy_class.previous.default_path,
+            class: "govuk-link"
+          ) %>
+    <% end %>
+  <% end %>
+  <% if policy_class.next.present? %>
+    <% if editable %>
+      <%= form.submit(
+            t(".save_changes_and_view_next"),
+            class: "button-as-link next-policy-class-link"
+          ) %>
+    <% else %>
+      <%= link_to(
+            t(".view_next_class"),
+            policy_class.next.default_path,
+            class: "govuk-link next-policy-class-link"
+          ) %>
+    <% end %>
+  <% end %>
+</div>
+<% if editable %>
+  <%= render(
+        partial: "shared/submit_buttons",
+        locals: {
+          form: form,
+          disabled: planning_application.assessment_complete?
+        }
+      ) %>
+<% else %>
+  <div class="govuk-button-group">
+    <%= back_link %>
+    <%= link_to(
+          t(".edit_assessment"),
+          edit_planning_application_policy_class_path(
+            planning_application,
+            policy_class
+          ),
+          class: "govuk-link"
+        ) %>
+  </div>
+<% end %>

--- a/app/views/policy_classes/_table.html.erb
+++ b/app/views/policy_classes/_table.html.erb
@@ -1,0 +1,84 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--l">
+    <%= t(
+      ".table_caption",
+      part: policy_class.part,
+      class: policy_class.section,
+      name: policy_class.name
+    ) %>
+  </caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+        <%= t(".policy_reference") %>
+      </th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+        <%= t(".complies") %>
+      </th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+        <%= t(".does_not_comply") %>
+      </th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+        <%= t(".to_be_determined") %>
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <%= form.fields_for(:policies, policies) do |policy_form| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <h3 class="govuk-heading-s">
+            <%= "#{form.object.section}.#{policy_form.object.section}" %>
+          </h3>
+          <p class="govuk-body">
+            <%= simple_format(policy_form.object.description) %>
+          </p>
+          <% if editable %>
+            <%= render(
+              partial: "policy_classes/comment_form",
+              locals: {
+                planning_application: planning_application,
+                policy_class: policy_class,
+                policy: policy_form.object,
+                comment: policy_form.object.existing_or_new_comment,
+                policy_index: policy_form.options[:child_index]
+              }
+            ) %>
+          <% elsif comment = policy_form.object.comment.presence %>
+            <h4 class="govuk-heading-s policy-comment-title">
+              <%=existing_policy_comment_label(comment)%>
+            </h4>
+            <p class="govuk-body"><%= simple_format(comment.text) %></p>
+          <% end %>
+        </td>
+        <% Policy.statuses.each_key do |status| %>
+          <td class="govuk-table__cell">
+            <% if editable || policy_form.object.status == status %>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <div class="govuk-radios" data-module="govuk-radios">
+                    <div class="govuk-radios govuk-radios--small">
+                      <div class="govuk-radios__item">
+                        <%= policy_form.radio_button(
+                          :status,
+                          status,
+                          class: "govuk-radios__input",
+                          disabled: planning_application.assessment_complete?
+                        ) %>
+                        <%= policy_form.label(
+                          :status,
+                          "&nbsp;".html_safe,
+                          class: "govuk-label govuk-radios__label"
+                        ) %>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+            <% end %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,15 +415,10 @@ en:
       delete_comment: Delete comment
     comment_updated_on: Comment updated on %{updated_at} by %{user}
     complete: Complete
-    form:
-      complies: Complies
-      does_not_comply: Does not comply
+    form_controls:
       edit_assessment: Edit assessment
-      policy_reference: Policy reference
       save_changes_and_view_next: Save changes and view next class
       save_changes_and_view_previous: Save changes and view previous class
-      table_caption: Part %{part}, Class %{class} - %{name}
-      to_be_determined: To be determined
       view_next_class: View next class
       view_previous_class: View previous class
     in_assessment: In assessment
@@ -440,6 +435,12 @@ en:
       complies: Complies
       does_not_comply: Does not comply
       policy_class_name: Part %{part}, Class %{class} - %{name}
+      to_be_determined: To be determined
+    table:
+      complies: Complies
+      does_not_comply: Does not comply
+      policy_reference: Policy reference
+      table_caption: Part %{part}, Class %{class} - %{name}
       to_be_determined: To be determined
     title: Part %{part}, Class %{class}
     update:

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -49,4 +49,66 @@ RSpec.describe Policy, type: :model do
       expect(described_class.to_be_determined).to contain_exactly(policy)
     end
   end
+
+  describe ".with_a_comment" do
+    it "returns policies with a comment" do
+      policy = create(:policy,
+                      :complies,
+                      section: "1A")
+      create(:comment, policy: policy)
+
+      expect(described_class.with_a_comment).to eq [policy]
+    end
+
+    it "excludes policies without a comment" do
+      create(:policy,
+             :complies,
+             section: "1A")
+
+      expect(described_class.with_a_comment).to eq []
+    end
+  end
+
+  describe ".existing_or_new_comment" do
+    it "returns policies that do not comply" do
+      policy = create(:policy,
+                      :does_not_comply,
+                      section: "1A")
+
+      expect(described_class.commented_or_does_not_comply).to eq [policy]
+    end
+
+    %i[complies to_be_determined].each do |status|
+      it "excludes policies that " do
+        create(:policy,
+               status,
+               section: "1A")
+
+        expect(described_class.commented_or_does_not_comply).to eq []
+      end
+    end
+
+    %i[complies does_not_comply to_be_determined].each do |status|
+      it "includes any commented legal clause" do
+        policy = create(:policy,
+                        status,
+                        section: "1A")
+        create(:comment, policy: policy)
+
+        expect(described_class.commented_or_does_not_comply).to eq [policy]
+      end
+    end
+
+    it "orders by section" do
+      last_section = create(:policy,
+                            :does_not_comply,
+                            section: "2B")
+      first_section = create(:policy,
+                             :complies,
+                             section: "1A")
+      create(:comment, policy: first_section)
+
+      expect(described_class.commented_or_does_not_comply).to eq [first_section, last_section]
+    end
+  end
 end

--- a/spec/system/planning_applications/recommending/legislation_spec.rb
+++ b/spec/system/planning_applications/recommending/legislation_spec.rb
@@ -75,4 +75,62 @@ RSpec.describe "Planning Application Assessment Legislation", type: :system do
 
     expect(page).to have_content("Complies")
   end
+
+  context "when uncommented" do
+    it "excludes 'more details' when complying or to_be_determined" do
+      policy_class = create(:policy_class,
+                            part: 1,
+                            section: "T",
+                            planning_application: planning_application)
+      create(:policy,
+             :complies,
+             section: "1A",
+             policy_class: policy_class)
+
+      create(:policy,
+             :to_be_determined,
+             section: "1A",
+             policy_class: policy_class)
+
+      visit(new_planning_application_recommendation_path(planning_application))
+
+      expect(page).to have_selector "h1", text: "Assess recommendation"
+      expect(page).not_to have_content("View commented legislation for class T")
+    end
+
+    it "includes 'more details' when clause does not comply" do
+      policy_class = create(:policy_class,
+                            part: 1,
+                            section: "T",
+                            planning_application: planning_application)
+      create(:policy,
+             :does_not_comply,
+             section: "1A",
+             policy_class: policy_class)
+
+      visit(new_planning_application_recommendation_path(planning_application))
+
+      expect(page).to have_selector "h1", text: "Assess recommendation"
+      expect(page).to have_content("View commented legislation for class T")
+    end
+  end
+
+  context "when commented" do
+    it "shows legislation paragraphs that comply" do
+      policy_class = create(:policy_class,
+                            part: 1,
+                            section: "T",
+                            planning_application: planning_application)
+      policy = create(:policy,
+                      :complies,
+                      section: "1M",
+                      policy_class: policy_class)
+      create(:comment, policy: policy)
+
+      visit(new_planning_application_recommendation_path(planning_application))
+
+      expect(page).to have_content("Complies")
+      expect(page).to have_content("View commented legislation for class T")
+    end
+  end
 end

--- a/spec/system/planning_applications/recommending/legislation_spec.rb
+++ b/spec/system/planning_applications/recommending/legislation_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application Assessment Legislation", type: :system do
+  let!(:default_local_authority) do
+    create(
+      :local_authority,
+      :default,
+      reviewer_group_email: "reviewers@example.com"
+    )
+  end
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      local_authority: default_local_authority,
+      created_at: DateTime.new(2022, 1, 1),
+      public_comment: nil
+    )
+  end
+
+  let!(:assessor) do
+    create(
+      :user,
+      :assessor,
+      local_authority: default_local_authority,
+      name: "Alice Aplin"
+    )
+  end
+
+  before do
+    sign_in assessor
+    visit root_path
+  end
+
+  it "shows assessed legislation on recommendation page" do
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+    click_link("Add assessment area")
+    choose("Part 1 - Development within the curtilage of a dwellinghouse")
+    click_button("Continue")
+    check("Class D - porches")
+    click_button("Add classes")
+    click_link("Part 1, Class D")
+    choose("policy_class_policies_attributes_0_status_complies")
+    choose("policy_class_policies_attributes_1_status_complies")
+    choose("policy_class_policies_attributes_2_status_complies")
+    choose("policy_class_policies_attributes_3_status_complies")
+    choose("policy_class_policies_attributes_4_status_complies")
+    choose("policy_class_policies_attributes_5_status_to_be_determined")
+    click_button("Save and come back later")
+    click_link("Application")
+    click_link("Assess recommendation")
+
+    expect(page).to have_content("To be determined")
+
+    click_link("Part 1, Class D - porches")
+    choose("policy_class_policies_attributes_5_status_does_not_comply")
+    click_button("Save and come back later")
+    click_link("Application")
+    click_link("Assess recommendation")
+
+    expect(page).to have_content("Does not comply")
+
+    expect(page).to have_content(
+      "Development is not permitted by Class D if the dwellinghouse is built under Part 20 of this Schedule (construction of new dwellinghouses)"
+    )
+
+    click_link("Part 1, Class D - porches")
+    choose("policy_class_policies_attributes_5_status_complies")
+    click_button("Save and come back later")
+    click_link("Application")
+    click_link("Assess recommendation")
+
+    expect(page).to have_content("Complies")
+  end
+end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -401,50 +401,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(planning_application.status).to eq("in_assessment")
     end
 
-    context "when officer assesses legislation" do
-      it "shows assessed legislation on recommendation page" do
-        visit(planning_application_path(planning_application))
-        click_link("Check and assess")
-        click_link("Add assessment area")
-        choose("Part 1 - Development within the curtilage of a dwellinghouse")
-        click_button("Continue")
-        check("Class D - porches")
-        click_button("Add classes")
-        click_link("Part 1, Class D")
-        choose("policy_class_policies_attributes_0_status_complies")
-        choose("policy_class_policies_attributes_1_status_complies")
-        choose("policy_class_policies_attributes_2_status_complies")
-        choose("policy_class_policies_attributes_3_status_complies")
-        choose("policy_class_policies_attributes_4_status_complies")
-        choose("policy_class_policies_attributes_5_status_to_be_determined")
-        click_button("Save and come back later")
-        click_link("Application")
-        click_link("Assess recommendation")
-
-        expect(page).to have_content("To be determined")
-
-        click_link("Part 1, Class D - porches")
-        choose("policy_class_policies_attributes_5_status_does_not_comply")
-        click_button("Save and come back later")
-        click_link("Application")
-        click_link("Assess recommendation")
-
-        expect(page).to have_content("Does not comply")
-
-        expect(page).to have_content(
-          "Development is not permitted by Class D if the dwellinghouse is built under Part 20 of this Schedule (construction of new dwellinghouses)"
-        )
-
-        click_link("Part 1, Class D - porches")
-        choose("policy_class_policies_attributes_5_status_complies")
-        click_button("Save and come back later")
-        click_link("Application")
-        click_link("Assess recommendation")
-
-        expect(page).to have_content("Complies")
-      end
-    end
-
     context "when assessor submits recommendation and reviewer requests changes" do
       it "displays recommendation events" do
         travel_to(Time.zone.local(2022, 8, 23, 9))


### PR DESCRIPTION
### Description of change

Add "see more" links when a policy has been denied or has been commented on

### AC1 No show more if all legislation complies or not determined
![all_complies_or_to_be_determined](https://user-images.githubusercontent.com/1710795/200332447-32c01ee8-42f3-44d3-b2c1-78b61f205257.png)


### AC3 Show more when legislation policy does not comply
![does_not_comply](https://user-images.githubusercontent.com/1710795/200331765-ecf70c76-60fd-4254-be16-91f5143e5958.png)

### AC2, AC4 Show more if any comment

![comment](https://user-images.githubusercontent.com/1710795/200332792-4fae0de6-a93b-4b3c-80b7-90c0cff61117.png)


### Reviewing

Probably easiest on a commit by commit.
1. Refactor the form so it has the functionality I need
2. Refactor the tests as it was getting long and I needed to add even more
3. Create the class method to do the policy filtering
4. Display the "show more" 


### Story Link

https://trello.com/c/IbI3M2tO/1300-update-the-assess-recommendation-report-to-show-more-legislation

