### PR TITLE
Allow multiple updates of documents

### DIFF
--- a/app/controllers/planning_application/review_documents_controller.rb
+++ b/app/controllers/planning_application/review_documents_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class ReviewDocumentsController < AuthenticationController
+    include CommitMatchable
+    include PlanningApplicationAssessable
+
+    before_action :set_planning_application
+    before_action :set_documents
+    before_action :ensure_planning_application_is_validated
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      ActiveRecord::Base.transaction do
+        @planning_application.update!(review_documents_for_recommendation_status: status)
+
+        @documents.each do |document|
+          document.update!(
+            referenced_in_decision_notice: referenced_in_decision_notice?(document.id.to_s),
+            publishable: publishable?(document.id.to_s)
+          )
+        end
+      end
+
+      redirect_to planning_application_assessment_tasks_path(@planning_application),
+                  notice: "Documents were successfully updated."
+    rescue ActiveRecord::ActiveRecordError => e
+      redirect_to planning_application_review_documents_path(@planning_application),
+                  alert: "Couldn't update documents with error: #{e.message}. Please contact support."
+    end
+
+    private
+
+    def set_planning_application
+      planning_application = planning_applications_scope.find(planning_application_id)
+
+      @planning_application = PlanningApplicationPresenter.new(view_context, planning_application)
+    end
+
+    def set_documents
+      @documents = @planning_application.documents.active
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications.includes(:documents)
+    end
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+
+    def referenced_in_decision_notice?(document_id)
+      return false unless referenced_in_decision_notice_document_ids
+
+      referenced_in_decision_notice_document_ids.include?(document_id)
+    end
+
+    def referenced_in_decision_notice_document_ids
+      params["referenced_in_decision_notice_document_ids"]
+    end
+
+    def publishable?(document_id)
+      return false unless publishable_document_ids
+
+      publishable_document_ids.include?(document_id)
+    end
+
+    def publishable_document_ids
+      params["publishable_document_ids"]
+    end
+
+    def status
+      save_progress? ? "in_progress" : "complete"
+    end
+  end
+end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -114,6 +114,10 @@ html * {
   @include govuk-visually-hidden;
 }
 
+.text-align-centre {
+  text-align: center;
+}
+
 /* Style variants
    ========================================================================== */
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -116,11 +116,15 @@ class PlanningApplication < ApplicationRecord
                                            uprn
                                            boundary_geojson].freeze
 
+  PROGRESS_STATUSES = %w[not_started in_progress complete].freeze
+
   private_constant :PLANNING_APPLICATION_PERMITTED_KEYS
 
   validates :work_status,
             inclusion: { in: WORK_STATUSES,
                          message: "Work Status should be proposed or existing" }
+  validates :review_documents_for_recommendation_status,
+            inclusion: { in: PROGRESS_STATUSES }
   validates :application_type, :application_number, :reference, presence: true
   validates :payment_amount, :invalid_payment_amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
 

--- a/app/presenters/concerns/assessment_tasks/review_documents_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/review_documents_presenter.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module AssessmentTasks
+  extend ActiveSupport::Concern
+
+  class ReviewDocumentsPresenter
+    include Presentable
+
+    def initialize(template, planning_application)
+      @planning_application = planning_application
+      @template = template
+      @status = planning_application.review_documents_for_recommendation_status
+    end
+
+    def task_list_row
+      html = tag.span class: "app-task-list__task-name" do
+        concat review_documents_link
+      end
+
+      html.concat review_documents_status_tag
+    end
+
+    private
+
+    attr_reader :status
+
+    def review_documents_link
+      link_to(
+        "Review documents for recommendation",
+        planning_application_review_documents_path(planning_application), class: "govuk-link"
+      )
+    end
+
+    def review_documents_status_tag
+      classes = ["#{govuk_tag_class} app-task-list__task-tag"]
+
+      tag.strong class: classes do
+        I18n.t("status_tag_component.#{status}")
+      end
+    end
+
+    def govuk_tag_class
+      return "govuk-tag" unless status_colour
+
+      "govuk-tag govuk-tag--#{status_colour}"
+    end
+
+    def status_colour
+      case status.humanize
+
+      when "Not started"
+        "grey"
+      when "Complete"
+        "blue"
+      when "In progress"
+        nil
+      else
+        raise ArgumentError, "The status provided: '#{status}' is not valid"
+      end
+    end
+  end
+end

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -16,6 +16,12 @@ module AssessmentTasksPresenter
       ).task_list_row
     end
 
+    def review_documents_tasklist
+      AssessmentTasks::ReviewDocumentsPresenter.new(
+        @template, @planning_application
+      ).task_list_row
+    end
+
     def permitted_development_right_tasklist
       AssessmentTasks::PermittedDevelopmentRightPresenter.new(
         @template, @planning_application

--- a/app/views/planning_application/assessment_tasks/_complete_assessment.html.erb
+++ b/app/views/planning_application/assessment_tasks/_complete_assessment.html.erb
@@ -1,0 +1,10 @@
+<li id="complete-assessment-tasks">
+  <h2 class="app-task-list__section">
+    Complete assessment
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <%= @planning_application.review_documents_tasklist %>
+    </li>
+  </ul>
+</li>

--- a/app/views/planning_application/assessment_tasks/index.html.erb
+++ b/app/views/planning_application/assessment_tasks/index.html.erb
@@ -34,6 +34,8 @@
       <%= render "assessment_information" %>
 
       <%= render "assess_against_legislation" %>
+
+      <%= render "complete_assessment" %>
     </ol>
 
     <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/planning_application/review_documents/_checkboxes.html.erb
+++ b/app/views/planning_application/review_documents/_checkboxes.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-form-group">
+  <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+    <div class="govuk-checkboxes__item">
+      <div class="govuk-checkboxes__item">
+        <%= check_box_tag(
+          "#{field}_document_ids[]",
+          document.id,
+          document.send(field),
+          class: "govuk-checkboxes__input",
+          id: "#{field}_document_#{document.id}",
+          ) %>
+        <%= label_tag(
+          "#{field}_document_#{document.id}",
+          "",
+          class: "govuk-label govuk-checkboxes__label",
+        ) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/planning_application/review_documents/index.html.erb
+++ b/app/views/planning_application/review_documents/index.html.erb
@@ -1,0 +1,87 @@
+<% content_for :page_title do %>
+  Review documents for recommendation - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: { planning_application: @planning_application  }
+) %>
+
+<% content_for :title, "Review documents" %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-l">
+    Review documents for recommendation
+  </h1>
+
+  <%= render "shared/planning_application_address_and_reference" %>
+
+  <p class="govuk-body"><%= @planning_application.status_tag %></p>
+
+  <p class="govuk-body">
+    <%= @planning_application.type_and_work_status %>: <%= @planning_application.description %>
+  </p>
+
+  <p class="govuk-body">
+    <strong>All documents need a reference to be on the decision notice or made public</strong>
+  </p>
+
+  <% if @documents.empty? %>
+    <p class="govuk-body">There are no active documents.</p>
+  <% else %>
+    <%= form_with(
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      method: :patch,
+      multiple: true,
+      url: planning_application_review_documents_path(@planning_application),
+    ) do |form| %>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-two-thirds" colspan="2">Documents</th>
+            <th scope="col" class="govuk-table__header text-align-centre">On decision notice</th>
+            <th scope="col" class="govuk-table__header text-align-centre">Public</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% @documents.each do |document| %>
+            <%= content_tag(:tr, id: dom_id(document)) do %>
+              <td class="govuk-table__cell"><%= document.numbers.presence || document.file.filename %></td>
+              <td class="govuk-table__cell">
+                <% if document.tags.present? %>
+                  <% document.tags.each do |tag| %>
+                    <strong class="govuk-tag govuk-tag--turquoise govuk-!-margin-bottom-1"><%= tag %></strong>
+                  <% end %>
+                <% else %>
+                  <p class="govuk-body govuk govuk-!-margin-bottom-1">
+                    <em>No tags added</em>
+                  </p>
+                <% end %>
+              </td>
+              <% if document.numbers.presence %>
+                <td class="govuk-table__cell">
+                  <%= render "checkboxes", document: document, field: "referenced_in_decision_notice" %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= render "checkboxes", document: document, field: "publishable" %>
+                </td>
+              <% else %>
+                <td class="govuk-table__cell text-align-centre" colspan="2">
+                  <%= link_to "Add document reference", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %>
+                </td>
+              <% end %>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+        <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+
+        <%= back_link %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,8 @@ en:
               not_a_number: Payment amount must be a number not exceeding 2 decimal places
             public_comment:
               blank: Please state the reasons why this application is, or is not lawful
+            review_documents_for_recommendation_status:
+              inclusion: "%{attribute} must be Not started, In progress or Complete"
         policy_class:
           attributes:
             status:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,11 +113,13 @@ Rails.application.routes.draw do
 
       resources :review_tasks, only: :index
 
-      resources :summary_of_works, only: %i[new edit create show update]
-
       resources :assessment_details, only: %i[new edit create show update]
 
       resources :permitted_development_rights, only: %i[new create edit update show]
+
+      resources :review_documents, only: %i[index] do
+        patch :update, on: :collection
+      end
     end
   end
 

--- a/db/migrate/20221107110702_add_review_documents_for_recommendation_status_to_planning_applications.rb
+++ b/db/migrate/20221107110702_add_review_documents_for_recommendation_status_to_planning_applications.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddReviewDocumentsForRecommendationStatusToPlanningApplications < ActiveRecord::Migration[6.1]
+  def change
+    add_column :planning_applications, :review_documents_for_recommendation_status, :string, default: "not_started",
+                                                                                             null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_11_144528) do
+ActiveRecord::Schema.define(version: 2022_11_07_110702) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -311,6 +311,7 @@ ActiveRecord::Schema.define(version: 2022_10_11_144528) do
     t.string "reference"
     t.datetime "validated_at"
     t.datetime "received_at"
+    t.string "review_documents_for_recommendation_status", default: "not_started", null: false
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe PlanningApplication, type: :model do
         expect { planning_application.valid? }.not_to(change { planning_application.errors[:payment_amount] })
       end
     end
+
+    describe "#review_documents_for_recommendation_status" do
+      it "validates the type of status" do
+        planning_application = build(:planning_application, review_documents_for_recommendation_status: "bad_status")
+
+        expect do
+          planning_application.valid?
+        end.to change {
+          planning_application.errors[:review_documents_for_recommendation_status]
+        }.to ["Review documents for recommendation status must be Not started, In progress or Complete"]
+      end
+    end
   end
 
   describe "associations" do

--- a/spec/presenters/assessment_tasks/review_documents_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/review_documents_presenter_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessmentTasks::ReviewDocumentsPresenter, type: :presenter do
+  include ActionView::TestCase::Behavior
+
+  subject(:presenter) { described_class.new(view, planning_application) }
+
+  let(:context) { ActionView::Base.new }
+  let!(:planning_application) { create(:planning_application, :in_assessment) }
+
+  describe "#task_list_row" do
+    context "when not started" do
+      it "the task list row shows not started status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Review documents for recommendation",
+            planning_application_review_documents_path(planning_application),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--grey app-task-list__task-tag\">Not started</strong>"
+        )
+      end
+    end
+
+    context "when in progress" do
+      let!(:planning_application) { create(:planning_application, :in_assessment, review_documents_for_recommendation_status: "in_progress") }
+
+      it "the task list row shows in progress status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Review documents for recommendation",
+            planning_application_review_documents_path(planning_application),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag app-task-list__task-tag\">In progress</strong>"
+        )
+      end
+    end
+
+    context "when complete" do
+      let!(:planning_application) { create(:planning_application, :in_assessment, review_documents_for_recommendation_status: "complete") }
+
+      it "the task list row shows the complete status html" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          link_to(
+            "Review documents for recommendation",
+            planning_application_review_documents_path(planning_application),
+            class: "govuk-link"
+          )
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag govuk-tag--blue app-task-list__task-tag\">Complete</strong>"
+        )
+      end
+    end
+  end
+end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -12,4 +12,8 @@ module SystemSpecHelpers
   def list_item(text)
     find("li", text: text, match: :prefer_exact)
   end
+
+  def find_checkbox_by_id(id)
+    find(".govuk-checkboxes__item ##{id}")
+  end
 end

--- a/spec/system/planning_applications/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/review_documents_for_recommendation_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Review documents for recommendation", type: :system do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create :user, :assessor, local_authority: default_local_authority }
+
+  let!(:planning_application) do
+    create :planning_application, :in_assessment, local_authority: default_local_authority
+  end
+
+  let!(:document_with_reference) { create(:document, numbers: "REF222", planning_application: planning_application) }
+  let!(:document_with_reference_and_tags) { create(:document, :with_tags, numbers: "REF111", planning_application: planning_application) }
+  let!(:document_decision_notice) { create(:document, :referenced, planning_application: planning_application) }
+  let!(:document_publishable) { create(:document, :referenced, :public, planning_application: planning_application) }
+  let!(:document_without_reference) { create(:document, planning_application: planning_application) }
+  let!(:document_archived) { create(:document, :archived, planning_application: planning_application) }
+
+  %w[document_with_reference document_with_reference_and_tags document_decision_notice document_publishable].each do |type|
+    let("#{type}__decision_notice_checkbox") { find_checkbox_by_id("referenced_in_decision_notice_document_#{send(type).id}") }
+    let("#{type}__publishable_checkbox") { find_checkbox_by_id("publishable_document_#{send(type).id}") }
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  context "when planning application is in assessment" do
+    it "I can view the information on the review documents for recommendation page" do
+      click_link "Check and assess"
+
+      within("#complete-assessment-tasks") do
+        expect(page).to have_content("Not started")
+        click_link "Review documents for recommendation"
+      end
+
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Review documents")
+      end
+
+      expect(page).to have_current_path(
+        planning_application_review_documents_path(planning_application)
+      )
+
+      within(".govuk-heading-l") do
+        expect(page).to have_content("Review documents for recommendation")
+      end
+      expect(page).to have_content("Application number: #{planning_application.reference}")
+      expect(page).to have_content(planning_application.full_address.upcase)
+      expect(page).to have_content("#{planning_application.type_and_work_status}: #{planning_application.description}")
+      expect(page).to have_content("All documents need a reference to be on the decision notice or made public")
+
+      within(".govuk-table__head") do
+        expect(page).to have_content("Documents")
+        expect(page).to have_content("On decision notice")
+        expect(page).to have_content("Public")
+      end
+
+      within(".govuk-button-group") do
+        expect(page).to have_button("Save and mark as complete")
+        expect(page).to have_button("Save and come back later")
+        expect(page).to have_link("Back")
+      end
+    end
+
+    it "I can only view active documents on the review documents for recommendation page" do
+      click_link "Check and assess"
+      click_link "Review documents for recommendation"
+
+      expect(page).not_to have_css("#document_#{document_archived.id}")
+
+      expect(page).to have_css("#document_#{document_with_reference.id}")
+      expect(page).to have_css("#document_#{document_with_reference_and_tags.id}")
+      expect(page).to have_css("#document_#{document_decision_notice.id}")
+      expect(page).to have_css("#document_#{document_publishable.id}")
+      expect(page).to have_css("#document_#{document_without_reference.id}")
+    end
+
+    it "I can view the document reference and associated tags" do
+      click_link "Check and assess"
+      click_link "Review documents for recommendation"
+
+      within("#document_#{document_with_reference.id}") do
+        expect(page).to have_content(document_with_reference.numbers)
+        expect(page).not_to have_content(document_with_reference.file.filename)
+        expect(page).to have_content("No tags added")
+      end
+
+      within("#document_#{document_with_reference_and_tags.id}") do
+        expect(page).to have_content(document_with_reference_and_tags.numbers)
+        expect(page).not_to have_content(document_with_reference_and_tags.file.filename)
+        expect(page).to have_content("Side Elevation Proposed Photograph")
+      end
+
+      within("#document_#{document_without_reference.id}") do
+        expect(page).to have_content(document_without_reference.file.filename)
+      end
+    end
+
+    it "I can edit whether documents are on the decision notice / made public and save and mark as complete" do
+      click_link "Check and assess"
+      click_link "Review documents for recommendation"
+
+      within(".govuk-table__body") do
+        # Check for documents that are or aren't on decision notice / public
+        expect(document_with_reference__decision_notice_checkbox).not_to be_checked
+        expect(document_with_reference__publishable_checkbox).not_to be_checked
+
+        expect(document_with_reference_and_tags__decision_notice_checkbox).not_to be_checked
+        expect(document_with_reference_and_tags__publishable_checkbox).not_to be_checked
+
+        expect(document_decision_notice__decision_notice_checkbox).to be_checked
+        expect(document_decision_notice__publishable_checkbox).not_to be_checked
+
+        expect(document_publishable__decision_notice_checkbox).to be_checked
+        expect(document_publishable__publishable_checkbox).to be_checked
+
+        # Now edit a few checkboxes
+        document_with_reference__decision_notice_checkbox.click
+        document_with_reference_and_tags__decision_notice_checkbox.click
+        document_with_reference_and_tags__publishable_checkbox.click
+        document_decision_notice__decision_notice_checkbox.click
+        document_publishable__publishable_checkbox.click
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Documents were successfully updated.")
+      expect(planning_application.reload.review_documents_for_recommendation_status).to eq("complete")
+
+      within("#complete-assessment-tasks") do
+        expect(page).to have_content("Complete")
+        click_link "Review documents for recommendation"
+      end
+
+      # Check for updated documents that are or aren't on decision notice / public
+      expect(document_with_reference__decision_notice_checkbox).to be_checked
+      expect(document_with_reference__publishable_checkbox).not_to be_checked
+      expect(document_with_reference.reload).to have_attributes(
+        referenced_in_decision_notice: true,
+        publishable: false
+      )
+
+      expect(document_with_reference_and_tags__decision_notice_checkbox).to be_checked
+      expect(document_with_reference_and_tags__publishable_checkbox).to be_checked
+      expect(document_with_reference_and_tags.reload).to have_attributes(
+        referenced_in_decision_notice: true,
+        publishable: true
+      )
+
+      expect(document_decision_notice__decision_notice_checkbox).not_to be_checked
+      expect(document_decision_notice__publishable_checkbox).not_to be_checked
+      expect(document_decision_notice.reload).to have_attributes(
+        referenced_in_decision_notice: false,
+        publishable: false
+      )
+
+      expect(document_publishable__decision_notice_checkbox).to be_checked
+      expect(document_publishable__publishable_checkbox).not_to be_checked
+      expect(document_publishable.reload).to have_attributes(
+        referenced_in_decision_notice: true,
+        publishable: false
+      )
+    end
+
+    it "I can edit whether documents are on the decision notice / made public and save and come back later" do
+      click_link "Check and assess"
+      click_link "Review documents for recommendation"
+
+      within(".govuk-table__body") do
+        document_with_reference_and_tags__decision_notice_checkbox.click
+        document_with_reference_and_tags__publishable_checkbox.click
+      end
+
+      click_button "Save and come back later"
+      expect(page).to have_content("Documents were successfully updated.")
+      expect(planning_application.reload.review_documents_for_recommendation_status).to eq("in_progress")
+
+      within("#complete-assessment-tasks") do
+        expect(page).to have_content("In progress")
+        click_link "Review documents for recommendation"
+      end
+
+      expect(document_with_reference_and_tags__decision_notice_checkbox).to be_checked
+      expect(document_with_reference_and_tags__publishable_checkbox).to be_checked
+    end
+
+    it "I see a link to add a document reference when a reference hasn't been set" do
+      click_link "Check and assess"
+      click_link "Review documents for recommendation"
+
+      within("#document_#{document_without_reference.id}") do
+        expect(page).to have_link(
+          "Add document reference",
+          href: edit_planning_application_document_path(planning_application, document_without_reference)
+        )
+        expect(page).not_to have_css("govuk-checkboxes")
+      end
+    end
+
+    context "when there is an ActiveRecord Error raised" do
+      before do
+        allow_any_instance_of(Document).to receive(:update!).and_raise(ActiveRecord::ActiveRecordError)
+      end
+
+      it "there is an error message and no update is persisted" do
+        click_link "Check and assess"
+        click_link "Review documents for recommendation"
+
+        document_with_reference__decision_notice_checkbox.click
+        document_with_reference_and_tags__decision_notice_checkbox.click
+
+        click_button "Save and mark as complete"
+        expect(page).to have_content("Couldn't update documents with error: ActiveRecord::ActiveRecordError. Please contact support.")
+
+        expect(planning_application.review_documents_for_recommendation_status).to eq("not_started")
+        expect(document_with_reference__decision_notice_checkbox).not_to be_checked
+        expect(document_with_reference_and_tags__decision_notice_checkbox).not_to be_checked
+      end
+    end
+  end
+
+  context "when planning application has not been validated yet" do
+    let!(:planning_application) do
+      create :planning_application, :not_started, local_authority: default_local_authority
+    end
+
+    it "does not allow me to visit the page" do
+      visit planning_application_review_documents_path(planning_application)
+
+      expect(page).to have_content("forbidden")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Allow multiple updates of documents

- Whether an active document is to be show on the decision notice / made public can be edited on this new review documents for recommendation page. Multiple updates to several documents can occur here via checking / unchecking checkboxes
- Show a link to "Add document reference" if a document does not have an associated reference number
- Wrap the update action in a transaction so if one update fails none of the updates will persist
- Add status tag to indicate the progress of reviewing these documents

### Story Link

https://trello.com/c/6FZ2tU7d/1299-improve-the-adding-of-documents-to-the-decision-notice


![Screenshot 2022-11-07 at 18 26 44](https://user-images.githubusercontent.com/34001723/200386659-672cfb49-555b-44e0-b23e-b04f3fe3c4e5.png)
![Screenshot 2022-11-07 at 18 27 10](https://user-images.githubusercontent.com/34001723/200386730-092c996b-3cfc-479f-9306-e7e21b70d5b0.png)
