### PR TITLE
Add secondary CTA to manage documents page

### DIFF
--- a/app/views/planning_application/review_documents/index.html.erb
+++ b/app/views/planning_application/review_documents/index.html.erb
@@ -73,6 +73,12 @@
               <% end %>
             <% end %>
           <% end %>
+
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell" colspan="100%">
+              <%= link_to "Manage documents", planning_application_documents_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+            </td>
+          </tr>
         </tbody>
       </table>
 

--- a/spec/system/planning_applications/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/review_documents_for_recommendation_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe "Review documents for recommendation", type: :system do
         expect(page).to have_button("Save and come back later")
         expect(page).to have_link("Back")
       end
+
+      expect(page).to have_link("Manage documents", href: planning_application_documents_path(planning_application))
     end
 
     it "I can only view active documents on the review documents for recommendation page" do


### PR DESCRIPTION
### Story Link

https://trello.com/c/6FZ2tU7d/1299-improve-the-adding-of-documents-to-the-decision-notice

Missed out an A/C to add a "Manage documents" link on the review documents for recommendation page.
Follow on from https://github.com/unboxed/bops/pull/798 