### PR TITLE
Remove 'class title' from policy class heading

### DIFF
--- a/app/views/policy_classes/_summary.html.erb
+++ b/app/views/policy_classes/_summary.html.erb
@@ -17,7 +17,7 @@
       ) %>
     </h1>
     <h2 class="govuk-heading-m govuk-!-padding-bottom-3">
-      <%= t(".class_title", policy_class: policy_class.name) %>
+      <%= policy_class.name.upcase_first %>
     </h2>
     <%= render "shared/planning_application_address_and_reference" %>
     <%= button_to(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,7 +426,6 @@ en:
       application: Application
       assess: Assess
       assess_policy_class: Assess - Part %{part}, Class %{class}
-      class_title: Class title - %{policy_class}
       home: Home
       open_legislation_in: Open legislation in new window
       please_indicate_if: Please indicate if the application complies, does not comply, or is not applicable to each of the policies. Policies are defined in the Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part %{part}, Class %{class}.

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe "assessment against legislation", type: :system do
       )
 
       click_link("Part 1, Class A")
-      expect(page).to have_content("Class title - enlargement, improvement or other alteration of a dwellinghouse")
+      expect(page).to have_content("Enlargement, improvement or other alteration of a dwellinghouse")
       within(".govuk-table caption") do
         expect(page).to have_content("Part 1, Class A - enlargement, improvement or other alteration of a dwellinghouse")
       end
 
       click_link("Back")
       click_link("Part 1, Class B")
-      expect(page).to have_content("Class title - additions etc to the roof of a dwellinghouse")
+      expect(page).to have_content("Additions etc to the roof of a dwellinghouse")
       within(".govuk-table caption") do
         expect(page).to have_content("Part 1, Class B - additions etc to the roof of a dwellinghouse")
       end


### PR DESCRIPTION
- 'class title' was a copying error from the wireframe model.

## Change we want
Work is remove "Class title" plus we capitalise the first letter. That is all.

<img width="543" alt="image" src="https://user-images.githubusercontent.com/1710795/200670182-14f86e0c-8159-4856-a13b-d6e054f78f0c.png">

## What it looks like now
![new-design](https://user-images.githubusercontent.com/1710795/200670568-2a326c8e-9dc8-469e-97a8-c9c93802dd7f.png)
