### PR TITLE
Require api-key header to retrieve files from PlanX

### DIFF
--- a/app/services/upload_documents_service.rb
+++ b/app/services/upload_documents_service.rb
@@ -9,7 +9,7 @@ class UploadDocumentsService
   def call
     files&.each do |file_params|
       filename = file_params[:filename]
-      file = URI.parse(filename).open
+      file = URI.parse(filename).open("api-key" => ENV["PLANX_FILE_API_KEY"])
 
       raise Api::V1::Errors::WrongFileTypeError.new(nil, filename) if forbidden?(file.content_type)
 


### PR DESCRIPTION
- Due to PlanX making file uploads more secure, we now required an api key to retrieve the file before we upload it into our database.
- This change adds the api-key as an ENV variable in the header when using URI to request the file