### PR TITLE
FIX: Sign-off link converts to text for rejected application

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,6 +71,10 @@ class ApplicationController < ActionController::Base
     redirect_to administrator_dashboard_path if current_user&.administrator?
   end
 
+  def ensure_user_is_reviewer
+    render plain: "forbidden", status: :forbidden and return unless Current.user.reviewer?
+  end
+
   def ensure_user_is_reviewer_checking_assessment
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_review_assessment?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,7 +71,7 @@ class ApplicationController < ActionController::Base
     redirect_to administrator_dashboard_path if current_user&.administrator?
   end
 
-  def ensure_user_is_reviewer
+  def ensure_user_is_reviewer_checking_assessment
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_review_assessment?
   end
 end

--- a/app/controllers/planning_application/review_tasks_controller.rb
+++ b/app/controllers/planning_application/review_tasks_controller.rb
@@ -3,6 +3,7 @@
 class PlanningApplication
   class ReviewTasksController < AuthenticationController
     before_action :set_planning_application
+    before_action :ensure_user_is_reviewer
 
     def index
       respond_to do |format|

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -5,7 +5,7 @@ class PlanningApplicationsController < AuthenticationController
 
   before_action :set_planning_application, except: %i[new create index]
 
-  before_action :ensure_user_is_reviewer, only: %i[edit_public_comment]
+  before_action :ensure_user_is_reviewer_checking_assessment, only: %i[edit_public_comment]
 
   before_action :set_last_audit, only: %i[show view_recommendation submit_recommendation publish]
 

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -5,7 +5,7 @@ class RecommendationsController < AuthenticationController
 
   before_action :set_planning_application, only: %i[new create]
   before_action :set_planning_application_with_recommendations, only: %i[edit update]
-  before_action :ensure_user_is_reviewer, only: %i[update edit]
+  before_action :ensure_user_is_reviewer_checking_assessment, only: %i[update edit]
   before_action :set_recommendations, only: %i[update edit]
   before_action :set_recommendation, only: :update
 

--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -44,10 +44,12 @@
     <ul class="app-task-list__items">
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <%= link_to "Sign-off recommendation",
-                      edit_planning_application_recommendations_path(@planning_application),
-                      aria: { describedby: "review_assessment-completed" },
-                      class: "govuk-link" %>
+          <%= link_to_if(
+                @planning_application.awaiting_determination?,
+                "Sign-off recommendation",
+                edit_planning_application_recommendations_path(@planning_application),
+                aria: { describedby: "review_assessment-completed" },
+                class: "govuk-link") %>
         </span>
         <%= render(
               StatusTags::SignoffRecommendationComponent.new(

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     expect(page).to have_selector("h1", text: "Review and sign-off")
     expect(page).to have_content("Recommendation was successfully reviewed.")
+    expect(page).to have_link("Sign-off recommendation",
+                              href: edit_planning_application_recommendations_path(planning_application))
 
     expect(list_item("Sign-off recommendation")).to have_content("Complete")
 
@@ -97,6 +99,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     expect(page).to have_content("Recommendation was successfully reviewed.")
     expect(list_item("Sign-off recommendation")).to have_content("Complete")
+    expect(page).to have_text("Sign-off recommendation")
+    expect(page).not_to have_link("Sign-off recommendation",
+                                  href: edit_planning_application_recommendations_path(planning_application))
 
     click_link "Back"
 

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -245,6 +245,10 @@ RSpec.describe "Planning Application Reviewing", type: :system do
       visit edit_public_comment_planning_application_path(planning_application)
 
       expect(page).to have_content("forbidden")
+
+      visit planning_application_review_tasks_path(planning_application)
+
+      expect(page).to have_content("forbidden")
     end
   end
 end


### PR DESCRIPTION
FIX: Sign-off link converts to text for rejected application

  - Trello for: Create review tasklist for managers signing off cases
  - Accepted applications can be rejected if the reviewer changes
      their mind
  - Rejected applications have to wait for the assessor to fix the
      issue
  - To show this visually we change the link to text on rejection


### Story Link

https://trello.com/c/cuDX5hsQ/1263-create-review-tasklist-for-managers-signing-off-cases