### PR TITLE
Pr notapatch reviewer is able to view comments against legislation by officer

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,6 +36,10 @@ Layout/LineLength:
   Exclude:
     - spec/**/*
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - spec/models/review_policy_class_spec.rb
+
 # we tend to use update_all in migrations
 Rails/SkipsModelValidations:
   Exclude:
@@ -44,6 +48,10 @@ Rails/SkipsModelValidations:
 # Rspec
 RSpec/MultipleExpectations:
   Enabled: false
+
+Rails/NotNullColumn:
+  Exclude:
+    - db/migrate/20221116234525_add_review_mark_to_review_policy_classes.rb
 
 RSpec/ExampleLength:
   Enabled: false

--- a/app/components/review_policy_class_link_component.html.erb
+++ b/app/components/review_policy_class_link_component.html.erb
@@ -1,0 +1,5 @@
+<%= link_to(
+      link_text,
+      link_path,
+      aria: { describedby: link_text },
+      class: "govuk-link") %>

--- a/app/components/review_policy_class_link_component.rb
+++ b/app/components/review_policy_class_link_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class ReviewPolicyClassLinkComponent < ViewComponent::Base
+  def initialize(policy_class:)
+    @policy_class = policy_class
+  end
+
+  attr_reader :policy_class
+
+  def link_path
+    case policy_class&.review_policy_class&.status
+    when "complete"
+      planning_application_review_policy_class_path(policy_class.planning_application, policy_class)
+    else
+      edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class)
+    end
+  end
+
+  def link_text
+    "Review assessment of Part #{policy_class.part}, Class #{policy_class.section}"
+  end
+end

--- a/app/components/status_tags/review_policy_class_component.rb
+++ b/app/components/status_tags/review_policy_class_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module StatusTags
+  class ReviewPolicyClassComponent < StatusTags::BaseComponent
+    def initialize(review_policy_class:)
+      @review_policy_class = review_policy_class
+    end
+
+    private
+
+    def status
+      @review_policy_class&.status&.to_sym || :not_checked_yet
+    end
+  end
+end

--- a/app/controllers/planning_application/review_policy_classes_controller.rb
+++ b/app/controllers/planning_application/review_policy_classes_controller.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class ReviewPolicyClassesController < AuthenticationController
+    include CommitMatchable
+    before_action :set_planning_application
+    before_action :ensure_user_is_reviewer
+    before_action :set_policy_class, only: %i[edit update show]
+
+    def show; end
+
+    def edit
+      @policy_class.build_review_policy_class if @policy_class.review_policy_class.nil?
+    end
+
+    def update
+      if @policy_class.update(policy_class_params)
+        redirect_to(planning_application_review_tasks_path(@planning_application),
+                    notice: t(".successfully_updated_policy_class"))
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def set_policy_class
+      @policy_class = PolicyClassPresenter.new(
+        @planning_application.policy_classes.find(params[:id])
+      )
+    end
+
+    def policy_class_params
+      params
+        .require(:policy_class)
+        .permit(policies_attributes: %i[id status],
+                review_policy_class_attributes: %i[id mark comment])
+        .to_h
+        .deep_merge(status: policy_class_status,
+                    review_policy_class_attributes: { status: review_status })
+    end
+
+    def review_status
+      mark_as_complete? ? :complete : :not_checked_yet
+    end
+
+    def policy_class_status
+      return_to_officer? ? :to_be_reviewed : @policy_class.status.to_sym
+    end
+
+    def return_to_officer?
+      params.dig(:policy_class, :review_policy_class_attributes, :mark) == "return_to_officer_with_comment"
+    end
+  end
+end

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -3,14 +3,15 @@
 class PolicyClass < ApplicationRecord
   belongs_to :planning_application
   has_many :policies, dependent: :destroy
+  has_one :review_policy_class, dependent: :destroy
 
-  accepts_nested_attributes_for :policies
+  accepts_nested_attributes_for :policies, :review_policy_class
 
   validates :name, :part, :section, :schedule, presence: true
 
   validate :all_policies_are_determined, if: :complete?
 
-  enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
+  enum status: { in_assessment: 0, complete: 1, to_be_reviewed: 2 }, _default: :in_assessment
 
   class << self
     def all_parts

--- a/app/models/review_policy_class.rb
+++ b/app/models/review_policy_class.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReviewPolicyClass < ApplicationRecord
+  belongs_to :policy_class, optional: true
+
+  enum mark: { not_marked: 0, accept: 1, return_to_officer_with_comment: 2 }
+  enum status: { not_checked_yet: 0, complete: 1 }, _default: :not_checked_yet, _prefix: true
+
+  validates :mark, presence: true
+  validates :comment, presence: true, if: :return_to_officer_with_comment?
+end

--- a/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks/assess_against_legislation_presenter.rb
@@ -36,7 +36,7 @@ module AssessmentTasks
     def policy_class_tag
       tag.strong(
         I18n.t("policy_classes.#{policy_class.status}"),
-        class: "govuk-tag app-task-list__task-tag #{'govuk-tag--blue' if policy_class.complete?}"
+        class: "govuk-tag app-task-list__task-tag #{colour_class}"
       )
     end
 
@@ -46,6 +46,15 @@ module AssessmentTasks
         part: policy_class.part,
         class: policy_class.section
       )
+    end
+
+    def colour_class
+      case policy_class.status
+      when "complete"
+        "govuk-tag--blue"
+      when "to_be_reviewed"
+        "govuk-tag--yellow"
+      end
     end
   end
 end

--- a/app/views/planning_application/review_policy_classes/edit.html.erb
+++ b/app/views/planning_application/review_policy_classes/edit.html.erb
@@ -1,0 +1,125 @@
+<% content_for :page_title do %>
+  <%= t(".review") %> - <%= t("page_title") %>
+<% end %>
+<% add_parent_breadcrumb_link(t(".home"), planning_applications_path) %>
+<% add_parent_breadcrumb_link(
+     t(".application"),
+     planning_application_path(@planning_application)
+   ) %>
+<% content_for(:title, t(".review")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(
+            ".review_heading",
+            part: @policy_class.part,
+            class: @policy_class.section
+          ) %>
+    </h1>
+    <h2 class="govuk-heading-m govuk-!-padding-bottom-3">
+      <%= @policy_class.name.upcase_first %>
+    </h2>
+    <%= render "shared/planning_application_address_and_reference" %>
+    <p class="govuk-body">
+      <%= t(
+            ".please_indicate_if",
+            part: @policy_class.part,
+            class: @policy_class.section
+          ) %>
+    <p class="govuk-body">
+      <%= link_to(
+            t(".open_legislation_in"),
+            @policy_class.url,
+            class: "govuk-link",
+            target: "_blank"
+          ) %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with(
+          model: [@planning_application, @policy_class],
+          url: planning_application_review_policy_class_path(@planning_application, @policy_class),
+          html: { data: unsaved_changes_data },
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder
+        ) do |form| %>
+      <table class="govuk-table">
+        <%= render(partial: "policy_classes/table_head", locals: { policy_class: @policy_class }) %>
+        <tbody class="govuk-table__body">
+        <%= form.fields_for(:policies) do |policy_form| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <h3 class="govuk-heading-s">
+                <%= "#{form.object.section}.#{policy_form.object.section}" %>
+              </h3>
+              <p class="govuk-body">
+                <%= simple_format(policy_form.object.description) %>
+              </p>
+              <% if comment = policy_form.object.comment.presence %>
+                <h4 class="govuk-heading-s policy-comment-title">
+                  <%= existing_policy_comment_label(comment) %>
+                </h4>
+                <p class="govuk-body"><%= simple_format(comment.text) %></p>
+              <% end %>
+            </td>
+            <% Policy.statuses.each_key do |status| %>
+              <td class="govuk-table__cell">
+                <div class="govuk-form-group">
+                  <fieldset class="govuk-fieldset">
+                    <div class="govuk-radios" data-module="govuk-radios">
+                      <div class="govuk-radios govuk-radios--small">
+                        <div class="govuk-radios__item">
+                          <%= policy_form.radio_button(
+                                :status,
+                                status,
+                                class: "govuk-radios__input",
+                                disabled: @planning_application.assessment_complete?
+                              ) %>
+                          <%= policy_form.label(
+                                :status,
+                                "&nbsp;".html_safe,
+                                class: "govuk-label govuk-radios__label"
+                              ) %>
+                        </div>
+                      </div>
+                    </div>
+                  </fieldset>
+                </div>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+      <%= form.fields_for :review_policy_class, @policy_class.review_policy_class do |review_form| %>
+        <div class="govuk-form-group <%= review_form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+          <fieldset class="govuk-fieldset">
+            <% if review_form.object.errors.any? %>
+              <% review_form.object.errors.each do |error| %>
+                <p id="status-error" class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span><%= error.message %>
+                </p>
+              <% end %>
+            <% end %>
+
+            <div class="govuk-radios" data-module="govuk-radios">
+              <%= review_form.govuk_radio_button(:mark, :accept, label: { text: "Accept" }) %>
+              <%= review_form.govuk_radio_button(
+                :mark, :return_to_officer_with_comment, label: { text: "Return to officer with comment" }
+              ) do %>
+                <%= review_form.govuk_text_area(
+                      :comment,
+                      label: { text: "Explain to the assessor why this needs reviewing" },
+                      rows: 6
+                    ) %>
+              <% end %>
+            </div>
+          </fieldset>
+        </div>
+      <% end %>
+      <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_application/review_policy_classes/show.html.erb
+++ b/app/views/planning_application/review_policy_classes/show.html.erb
@@ -1,0 +1,72 @@
+<% content_for :page_title do %>
+  <%= t(".review") %> - <%= t("page_title") %>
+<% end %>
+<% add_parent_breadcrumb_link(t(".home"), planning_applications_path) %>
+<% add_parent_breadcrumb_link(
+     t(".application"),
+     planning_application_path(@planning_application)
+   ) %>
+<% content_for(:title, t(".review")) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(
+            ".review_heading",
+            part: @policy_class.part,
+            class: @policy_class.section
+          ) %>
+    </h1>
+    <h2 class="govuk-heading-m govuk-!-padding-bottom-3">
+      <%= @policy_class.name.upcase_first %>
+    </h2>
+    <%= render "shared/planning_application_address_and_reference" %>
+    <p class="govuk-body">
+      <%= t(
+            ".please_indicate_if",
+            part: @policy_class.part,
+            class: @policy_class.section
+          ) %>
+    <p class="govuk-body">
+      <%= link_to(
+            t(".open_legislation_in"),
+            @policy_class.url,
+            class: "govuk-link",
+            target: "_blank"
+          ) %>
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with(
+        model: [@planning_application, @policy_class],
+        url: planning_application_review_policy_class_path(@planning_application, @policy_class),
+        html: { data: unsaved_changes_data },
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |form| %>
+      <%= form.fields_for :review_policy_class, @policy_class.review_policy_class do |review_form| %>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-radios" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <%= review_form.radio_button :mark, true, class: "govuk-radios__input", "aria-controls": "conditional-mark-#{@policy_class.review_policy_class.mark}-conditional", "aria-expanded": "false", disabled: true, checked: "checked" %>
+                <%= review_form.label :show, @policy_class.review_policy_class.mark.humanize , class: "govuk-label govuk-radios__label", for: "show" %>
+              </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="govuk-button-group">
+      <%= back_link %>
+      <%= link_to(
+            "Edit review of Part #{@policy_class.part}, Class #{@policy_class.section}",
+            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class),
+            class: "govuk-link"
+          ) %>
+    </div>
+  </div>
+</div>

--- a/app/views/planning_application/review_tasks/_policy_classes.html.erb
+++ b/app/views/planning_application/review_tasks/_policy_classes.html.erb
@@ -1,0 +1,12 @@
+<% planning_application.policy_classes.each do |policy_class| %>
+  <li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+      <%= render( ReviewPolicyClassLinkComponent.new(policy_class: policy_class ) )%>
+    </span>
+    <%= render(
+          StatusTags::ReviewPolicyClassComponent.new(
+            review_policy_class: policy_class.review_policy_class
+          )
+    )%>
+  </li>
+<% end %>

--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -43,11 +43,15 @@
     </h2>
     <ul class="app-task-list__items">
       <%= render "permitted_development_rights" if @planning_application.permitted_development_right %>
+
       <%= render(
         TaskListItems::AssessmentDetailsReviewComponent.new(
           planning_application: @planning_application,
         )
       )%>
+
+      <%= render partial: "policy_classes", locals: { planning_application: @planning_application, policy_class: @policy_class } %>
+
       <%= render "sign_off_recommendation" %>
     </ul>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,31 @@ en:
         history: History search (in testing)
         in_assessment: In assessment
         permitted_development_rights: Permitted development rights
+    review_policy_classes:
+      edit:
+        application: Application
+        complies: Complies
+        does_not_comply: Does not comply
+        home: Home
+        open_legislation_in: Open legislation in new window
+        please_indicate_if: Please indicate if the application complies, does not comply, or is not applicable to each of the policies. Policies are defined in the Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part %{part}, Class %{class}.
+        policy_reference: Policy reference
+        review: Review
+        review_and_sign_off: Review and sign-off
+        review_heading: Review - Part%{part}, Class %{class}
+        table_caption: Part %{part}, Class %{class} - %{name}
+        to_be_determined: To be determined
+        view_next_class: View next class
+        view_previous_class: View previous class
+      show:
+        application: Application
+        home: Home
+        open_legislation_in: Open legislation in new window
+        please_indicate_if: Please indicate if the application complies, does not comply, or is not applicable to each of the policies. Policies are defined in the Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part %{part}, Class %{class}.
+        review: Review
+        review_heading: Review - Part%{part}, Class %{class}
+      update:
+        successfully_updated_policy_class: Successfully updated policy class
     review_tasks:
       index:
         review_and_sign_off: Review and sign-off
@@ -500,6 +525,7 @@ en:
       table_caption: Part %{part}, Class %{class} - %{name}
       to_be_determined: To be determined
     title: Part %{part}, Class %{class}
+    to_be_reviewed: To be reviewed
     update:
       successfully_updated_policy: Successfully updated policy class
   proposal_details:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,6 +114,8 @@ Rails.application.routes.draw do
 
       resources :review_tasks, only: :index
 
+      resources :review_policy_classes, only: %i[edit update show]
+
       resources :assessment_details, only: %i[new edit create show update]
 
       resources :permitted_development_rights, only: %i[new create edit update show]

--- a/db/migrate/20221123161814_create_review_policy_classes.rb
+++ b/db/migrate/20221123161814_create_review_policy_classes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateReviewPolicyClasses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :review_policy_classes do |t|
+      t.belongs_to :policy_class, null: false, foreign_key: true
+      t.integer :mark, null: false
+      t.string  :comment
+      t.integer :status, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_17_125451) do
+ActiveRecord::Schema.define(version: 2022_11_23_161814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -413,6 +413,16 @@ ActiveRecord::Schema.define(version: 2022_11_17_125451) do
     t.index ["user_id"], name: "index_document_change_requests_on_user_id"
   end
 
+  create_table "review_policy_classes", force: :cascade do |t|
+    t.bigint "policy_class_id", null: false
+    t.integer "mark", null: false
+    t.string "comment"
+    t.integer "status", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["policy_class_id"], name: "ix_review_policy_classes_on_policy_class_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -480,5 +490,6 @@ ActiveRecord::Schema.define(version: 2022_11_17_125451) do
   add_foreign_key "replacement_document_validation_requests", "documents", column: "old_document_id"
   add_foreign_key "replacement_document_validation_requests", "planning_applications"
   add_foreign_key "replacement_document_validation_requests", "users"
+  add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "validation_requests", "planning_applications"
 end

--- a/spec/components/review_policy_class_link_component_spec.rb
+++ b/spec/components/review_policy_class_link_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewPolicyClassLinkComponent, type: :component do
+  include Rails.application.routes.url_helpers
+  let(:policy_class) { create(:policy_class, section: "D") }
+
+  it "displays edit link when review policy_class nil" do
+    policy_class = create(:policy_class, part: 1, section: "D")
+
+    render_inline(described_class.new(policy_class: policy_class))
+
+    expect(page).to have_link("Review assessment of Part 1, Class D",
+                              href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+  end
+
+  it "displays edit link when status not checked yet" do
+    review_policy_class = create(:review_policy_class, status: :not_checked_yet, policy_class: policy_class)
+
+    render_inline(described_class.new(policy_class: review_policy_class.policy_class))
+
+    expect(page).to have_link("Review assessment of Part 1, Class D",
+                              href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+  end
+
+  it "displays show link when status complete" do
+    review_policy_class = create(:review_policy_class, status: :complete, policy_class: policy_class)
+
+    render_inline(described_class.new(policy_class: review_policy_class.policy_class))
+
+    expect(page).to have_link("Review assessment of Part 1, Class D",
+                              href: planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+  end
+end

--- a/spec/components/status_tags/review_policy_class_components_spec.rb
+++ b/spec/components/status_tags/review_policy_class_components_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StatusTags::ReviewPolicyClassComponent, type: :component do
+  it "displays start status" do
+    review_policy_class = create(:review_policy_class, status: :not_checked_yet)
+
+    render_inline(described_class.new(review_policy_class: review_policy_class))
+
+    expect(page).to have_css ".govuk-tag--grey", text: "Not checked yet"
+  end
+
+  it "displays complete status" do
+    review_policy_class = create(:review_policy_class, status: :complete)
+
+    render_inline(described_class.new(review_policy_class: review_policy_class))
+
+    expect(page).to have_css ".govuk-tag--blue", text: "Complete"
+  end
+end

--- a/spec/factories/policy_class.rb
+++ b/spec/factories/policy_class.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :policy_class do
     schedule { "Schedule 1" }
     part { 1 }
-    section { "A" }
+    sequence :section, ("A".."G").cycle
     name { Faker::Lorem.sentence }
     url { "https://www.example.com" }
     planning_application

--- a/spec/factories/review_policy_classes.rb
+++ b/spec/factories/review_policy_classes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :review_policy_class do
+    policy_class
+    mark { "accept" }
+    status { "not_checked_yet" }
+  end
+end

--- a/spec/models/review_policy_class_spec.rb
+++ b/spec/models/review_policy_class_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewPolicyClass, type: :model do
+  let(:review_policy_class) { build(:review_policy_class) }
+
+  describe "#valid?" do
+    it "is true for factory" do
+      expect(review_policy_class.valid?).to eq(true)
+    end
+  end
+
+  describe "validations" do
+    subject(:validation_request) { described_class.new }
+
+    describe "#mark" do
+      it "validates presence" do
+        expect { validation_request.valid? }.to change { validation_request.errors[:mark] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#comment" do
+      it "validates presence when returning to officer" do
+        validation_request.mark = :return_to_officer_with_comment
+
+        expect { validation_request.valid? }.to change { validation_request.errors[:comment] }.to ["can't be blank"]
+      end
+
+      it "does not validates presence when accepting" do
+        validation_request.mark = :accept
+
+        expect { validation_request.valid? }.not_to change { validation_request.errors[:comment] }
+      end
+    end
+  end
+end

--- a/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         )
       end
 
-      it "the task list row shows invalid status html" do
+      it "displays the task list row" do
         html = presenter.task_list_row
 
         expect(html).to include("app-task-list__task-name")
@@ -44,7 +44,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         )
       end
 
-      it "the task list row shows invalid status html" do
+      it "displays the task list row" do
         html = presenter.task_list_row
 
         expect(html).to include("app-task-list__task-name")
@@ -55,6 +55,30 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
 
         expect(html).to include(
           "<strong class=\"govuk-tag app-task-list__task-tag \">In assessment</strong>"
+        )
+      end
+    end
+
+    context "when policy class status is 'to_be_reviewed'" do
+      let(:policy_class) do
+        create(
+          :policy_class,
+          status: :to_be_reviewed,
+          planning_application: planning_application
+        )
+      end
+
+      it "displays the task list row" do
+        html = presenter.task_list_row
+
+        expect(html).to include("app-task-list__task-name")
+
+        expect(html).to include(
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}/edit\">Part 1, Class #{policy_class.section}</a>"
+        )
+
+        expect(html).to include(
+          "<strong class=\"govuk-tag app-task-list__task-tag govuk-tag--yellow\">To be reviewed</strong>"
         )
       end
     end

--- a/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
+++ b/spec/presenters/assessment_tasks/assess_against_legislation_presenter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         expect(html).to include("app-task-list__task-name")
 
         expect(html).to include(
-          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}\">Part 1, Class A</a>"
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}\">Part 1, Class #{policy_class.section}</a>"
         )
 
         expect(html).to include(
@@ -50,7 +50,7 @@ RSpec.describe AssessmentTasks::AssessAgainstLegislationPresenter, type: :presen
         expect(html).to include("app-task-list__task-name")
 
         expect(html).to include(
-          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}/edit\">Part 1, Class A</a>"
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/policy_classes/#{policy_class.id}/edit\">Part 1, Class #{policy_class.section}</a>"
         )
 
         expect(html).to include(

--- a/spec/system/planning_applications/review_tasks_index_spec.rb
+++ b/spec/system/planning_applications/review_tasks_index_spec.rb
@@ -5,6 +5,13 @@ require "rails_helper"
 RSpec.describe "Planning Application Review Tasks Index", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:reviewer) { create :user, :reviewer, local_authority: default_local_authority }
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :awaiting_determination,
+      local_authority: default_local_authority
+    )
+  end
 
   context "with a reviewer" do
     before do
@@ -30,6 +37,18 @@ RSpec.describe "Planning Application Review Tasks Index", type: :system do
                                              local_authority: default_local_authority))
 
       expect(page).to have_content("Review and sign-off")
+    end
+
+    it "displays chosen policy class in a list" do
+      policy_classes =  create_list(:policy_class, 3, planning_application: planning_application)
+      visit(planning_application_review_tasks_path(planning_application))
+
+      expect(page).to have_selector("h1", text: "Review and sign-off")
+      policy_classes.each do |policy_class|
+        expect(page).to have_link("Review assessment of Part 1, Class #{policy_class.section}",
+                                  href: edit_planning_application_review_policy_class_path(planning_application, policy_class))
+        expect(list_item("Review assessment of Part 1, Class #{policy_class.section}")).to have_content("Not checked yet")
+      end
     end
   end
 end

--- a/spec/system/planning_applications/reviewing/policy_class_spec.rb
+++ b/spec/system/planning_applications/reviewing/policy_class_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Planning Application Reviewing Policy Class", type: :system do
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let(:reviewer) { create :user, :reviewer, local_authority: default_local_authority }
+  let!(:assessor) { create :user, name: "Chuck The Assessor", local_authority: default_local_authority }
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :awaiting_determination,
+      :with_recommendation,
+      local_authority: default_local_authority
+    )
+  end
+
+  context "with a reviewer" do
+    before do
+      sign_in reviewer
+    end
+
+    it "can make the policy class reviewed" do
+      policy_class = create(:policy_class, section: "A", planning_application: planning_application)
+      create(:policy, policy_class: policy_class)
+      visit(planning_application_review_tasks_path(planning_application))
+
+      expect(page).to have_selector("h1", text: "Review and sign-off")
+      click_on "Review assessment of Part 1, Class A"
+
+      choose "Accept"
+
+      click_on "Save and mark as complete"
+
+      expect(page).to have_text "Successfully updated policy class"
+      expect(list_item("Review assessment of Part 1, Class A")).to have_content("Complete")
+
+      click_on "Review assessment of Part 1, Class A"
+
+      expect(page).to have_text "Accept"
+
+      click_on "Edit review of Part 1, Class A"
+
+      click_on "Save and come back later"
+
+      expect(page).to have_text "Successfully updated policy class"
+      expect(list_item("Review assessment of Part 1, Class A")).to have_content("Not checked yet")
+    end
+
+    it "can return legislation to officer with comment" do
+      policy_class = create(:policy_class, section: "A", planning_application: planning_application)
+      create(:policy, policy_class: policy_class)
+      visit(planning_application_review_tasks_path(planning_application))
+
+      expect(page).to have_selector("h1", text: "Review and sign-off")
+      click_on "Review assessment of Part 1, Class A"
+
+      choose "Return to officer with comment"
+
+      fill_in "Explain to the assessor why this needs reviewing", with: "Officer comment"
+
+      click_on "Save and mark as complete"
+
+      expect(page).to have_text "Successfully updated policy class"
+      expect(list_item("Review assessment of Part 1, Class A")).to have_content("Complete")
+
+      click_on "Review assessment of Part 1, Class A"
+
+      expect(page).to have_text "Return to officer with comment"
+
+      click_on "Back"
+
+      visit(planning_application_assessment_tasks_path(planning_application))
+
+      expect(list_item("Part 1, Class A")).to have_content("To be reviewed")
+    end
+
+    it "displays policy_class with comments" do
+      travel_to Time.zone.local(2020, 10, 15, 12, 0, 1) do
+        Current.user = assessor
+        policy_class = create(:policy_class, section: "A", name: "Roof", planning_application: planning_application)
+        policy = create(:policy, policy_class: policy_class, description: "Policy description")
+        create(:comment, commentable: policy, text: "policy comment", user: assessor)
+        visit(planning_application_review_tasks_path(planning_application))
+        click_on "Review assessment of Part 1, Class A"
+
+        expect(page).to have_text("Part 1, Class A - Roof")
+        expect(page).to have_selector("p", text: "Policy description")
+        expect(page).to have_text("15 Oct 2020 by Chuck The Assessor")
+        expect(page).to have_text("policy comment")
+      end
+    end
+
+    it "can display errors" do
+      policy_class = create(:policy_class, section: "A", planning_application: planning_application)
+      create(:policy, policy_class: policy_class)
+      visit(planning_application_review_tasks_path(planning_application))
+
+      expect(page).to have_selector("h1", text: "Review and sign-off")
+      click_on "Review assessment of Part 1, Class A"
+
+      click_on "Save and mark as complete"
+
+      expect(page).to have_text("can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

AC1: Create a review page for each class selected by the assessor during the assessment  and link as a new task on review tasklist

![Screenshot 2022-11-22 at 23 37 35](https://user-images.githubusercontent.com/1710795/203442581-134f3c88-c835-46d1-a365-3d387ee21d99.png)


AC2: Review tasklist status tag will be "NOT CHECKED YET" before visiting the review page and then "COMPLETE" after accepting or rejecting with comment.
![Screenshot 2022-11-22 at 23 39 11](https://user-images.githubusercontent.com/1710795/203442767-cca45cee-46cd-4381-948f-05f4fbbcc91d.png)



AC3: the reviewer cannot change the status of an item from complies / does not comply

AC4: the reviewer is able to read the comments made against individual paragraphs of legislation

AC5: (not attempted) the reviewer is able to edit the assessors comments to update any text

AC6: (Not attempted) When a comment is shown, the comment heading shows last action and who it was by (added by..., edited by...)

AC7: Reviewer can mark the legislation for the section as 'Accept' or 'Return to officer with a comment', this makes the page read only

![Screenshot 2022-11-22 at 23 50 07](https://user-images.githubusercontent.com/1710795/203443971-794cc43b-9dda-4251-9444-c2e6db9787b8.png)

![Screenshot 2022-11-22 at 23 50 52](https://user-images.githubusercontent.com/1710795/203444019-3582dd11-72d1-44e5-9868-b692ff134807.png)


AC8: Return to officer with comment allows reviewer to send back to the officer with a free text comment.The status of item on the assessment tasklist becomes 'to be reviewed' with Gov.uk yellow design (govuk-tag--yellow).
![Screenshot 2022-11-22 at 23 51 59](https://user-images.githubusercontent.com/1710795/203444145-a8730771-8860-43e9-b6ab-851583abebcf.png)



AC9: After updating the reviewed policy class the message to the reviewer is: "Successfully updated policy class"

![Screenshot 2022-11-22 at 23 37 35](https://user-images.githubusercontent.com/1710795/203444772-4761ed1f-ee8f-4c6c-a189-05b6fbe5a952.png)

AC10: Accept results in the summary being accepted, status of item on assessment tasklist remains complies/does not comply.

AC11: (Not attempted) Once decision is accepted on "Sign-off recommendation" page prevent any updates to the other reviewer screens (including this one). If they need to request changes they must first change their recommendation from 'Yes' to 'No' for the the question "Do you agree with the recommendation?".  Display the error: "You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen"

### Story Link

https://trello.com/c/F5YRGSA0/1219-reviewer-is-able-to-view-comments-against-legislation-by-officer

## Decisions 

### Review state added to policy_class
- policy class has a state which covers if the assessor has
  either started but not finished (in_assessment) or finished
  (complete). However, nothing forces the assessor to finish before
  sending it to the reviewer so the assessment state is separate
  from the review state. Adding review state to hold state that
  covers what the reviewer has done.
