### PR TITLE
Disentangle policy_class show and edit views

### DIFF
--- a/app/components/policy_classes/summary_component.html.erb
+++ b/app/components/policy_classes/summary_component.html.erb
@@ -24,14 +24,14 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      <%= render(partial: "policy_classes/form",
-                 locals: {
-                   planning_application: planning_application,
-                   policy_class: @policy_class,
-                   policies: @policy_class.policies.commented_or_does_not_comply,
-                   show_controls: false,
-                   editable: false
-                 })
+      <%= render(
+        partial: "policy_classes/table",
+        locals: {
+          planning_application: planning_application,
+          policy_class: @policy_class,
+          policies: @policy_class.policies.commented_or_does_not_comply,
+        }
+       )
       %>
     </div>
   </details>

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -91,10 +91,6 @@ class PolicyClassesController < PlanningApplicationsController
     )
   end
 
-  def set_planning_application
-    @planning_application = current_local_authority.planning_applications.find(params[:planning_application_id])
-  end
-
   def ensure_can_assess_planning_application
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_assess?
   end

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -35,4 +35,8 @@ module AssessmentTasksPresenter
       assessment_details.any? ||
       permitted_development_right.present?
   end
+
+  def multiple_policy_classes?
+    policy_classes.count > 1
+  end
 end

--- a/app/views/policy_classes/_controls.html.erb
+++ b/app/views/policy_classes/_controls.html.erb
@@ -1,0 +1,29 @@
+<% if planning_application.multiple_policy_classes? %>
+  <div class="policy-class-scroll-links">
+    <% if policy_class.previous.present? %>
+      <%= link_to(
+        t(".view_previous_class"),
+        policy_class.previous.default_path,
+        class: "govuk-link"
+      ) %>
+    <% end %>
+    <% if policy_class.next.present? %>
+      <%= link_to(
+        t(".view_next_class"),
+        policy_class.next.default_path,
+        class: "govuk-link next-policy-class-link"
+      ) %>
+    <% end %>
+  </div>
+<% end %>
+<div class="govuk-button-group">
+  <%= back_link %>
+  <%= link_to(
+    t(".edit_assessment"),
+    edit_planning_application_policy_class_path(
+      planning_application,
+      policy_class
+    ),
+    class: "govuk-link"
+  ) %>
+</div>

--- a/app/views/policy_classes/_form.html.erb
+++ b/app/views/policy_classes/_form.html.erb
@@ -1,6 +1,3 @@
-<% show_controls = true if local_assigns[:show_controls].nil? %>
-<% policies = policy_class.policies if local_assigns[:policies].nil? %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with(
@@ -10,26 +7,21 @@
         ) do |form| %>
       <%= form.govuk_error_summary %>
       <%= render(
-            partial: "policy_classes/table",
-            locals: {
-              form: form,
-              planning_application: planning_application,
-              policy_class: policy_class,
-              policies: policies,
-              editable: editable
-            }
-          ) %>
-      <% if show_controls %>
-        <%= render(
-              partial: "policy_classes/form_controls",
-              locals: {
-                form: form,
-                planning_application: planning_application,
-                policy_class: policy_class,
-                editable: editable
-              }
-            ) %>
-      <% end %>
+        partial: "form_table",
+        locals: {
+          form: form,
+          planning_application: planning_application,
+          policy_class: policy_class
+        }
+      ) %>
+      <%= render(
+        partial: "form_controls",
+        locals: {
+          form: form,
+          planning_application: planning_application,
+          policy_class: policy_class
+        }
+      ) %>
     <% end %>
   </div>
 </div>

--- a/app/views/policy_classes/_form_controls.html.erb
+++ b/app/views/policy_classes/_form_controls.html.erb
@@ -1,51 +1,39 @@
-<div class="policy-class-scroll-links">
-  <% if policy_class.previous.present? %>
-    <% if editable && !planning_application.assessment_complete? %>
-      <%= form.submit(
-            t(".save_changes_and_view_previous"),
-            class: "button-as-link"
-          ) %>
-    <% else %>
-      <%= link_to(
-            t(".view_previous_class"),
-            policy_class.previous.default_path,
-            class: "govuk-link"
-          ) %>
-    <% end %>
-  <% end %>
-  <% if policy_class.next.present? %>
-    <% if editable %>
-      <%= form.submit(
-            t(".save_changes_and_view_next"),
-            class: "button-as-link next-policy-class-link"
-          ) %>
-    <% else %>
-      <%= link_to(
-            t(".view_next_class"),
-            policy_class.next.default_path,
-            class: "govuk-link next-policy-class-link"
-          ) %>
-    <% end %>
-  <% end %>
-</div>
-<% if editable %>
-  <%= render(
-        partial: "shared/submit_buttons",
-        locals: {
-          form: form,
-          disabled: planning_application.assessment_complete?
-        }
-      ) %>
-<% else %>
-  <div class="govuk-button-group">
-    <%= back_link %>
-    <%= link_to(
-          t(".edit_assessment"),
-          edit_planning_application_policy_class_path(
-            planning_application,
-            policy_class
-          ),
+<% if planning_application.multiple_policy_classes? %>
+  <div class="policy-class-scroll-links">
+    <% if policy_class.previous.present? %>
+      <% if planning_application.assessment_complete? %>
+        <%= link_to(
+          t(".view_previous_class"),
+          policy_class.previous.default_path,
           class: "govuk-link"
         ) %>
+      <% else %>
+        <%= form.submit(
+          t(".save_changes_and_view_previous"),
+          class: "button-as-link"
+        ) %>
+      <% end %>
+    <% end %>
+    <% if policy_class.next.present? %>
+      <% if planning_application.assessment_complete? %>
+        <%= link_to(
+          t(".view_next_class"),
+          policy_class.next.default_path,
+          class: "govuk-link next-policy-class-link"
+        ) %>
+      <% else %>
+        <%= form.submit(
+          t(".save_changes_and_view_next"),
+          class: "button-as-link next-policy-class-link"
+        ) %>
+      <% end %>
+    <% end %>
   </div>
 <% end %>
+<%= render(
+  partial: "shared/submit_buttons",
+  locals: {
+    form: form,
+    disabled: planning_application.assessment_complete?
+  }
+) %>

--- a/app/views/policy_classes/_form_table.html.erb
+++ b/app/views/policy_classes/_form_table.html.erb
@@ -1,0 +1,52 @@
+<table class="govuk-table">
+  <%= render(partial: "table_head", locals: { policy_class: policy_class }) %>
+  <tbody class="govuk-table__body">
+    <%= form.fields_for(:policies) do |policy_form| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <h3 class="govuk-heading-s">
+            <%= "#{form.object.section}.#{policy_form.object.section}" %>
+          </h3>
+          <p class="govuk-body">
+            <%= simple_format(policy_form.object.description) %>
+          </p>
+          <%= render(
+            partial: "policy_classes/comment_form",
+            locals: {
+              planning_application: planning_application,
+              policy_class: policy_class,
+              policy: policy_form.object,
+              comment: policy_form.object.existing_or_new_comment,
+              policy_index: policy_form.options[:child_index]
+            }
+          ) %>
+        </td>
+        <% Policy.statuses.each_key do |status| %>
+          <td class="govuk-table__cell">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios govuk-radios--small">
+                    <div class="govuk-radios__item">
+                      <%= policy_form.radio_button(
+                        :status,
+                        status,
+                        class: "govuk-radios__input",
+                        disabled: planning_application.assessment_complete?
+                      ) %>
+                      <%= policy_form.label(
+                        :status,
+                        "&nbsp;".html_safe,
+                        class: "govuk-label govuk-radios__label"
+                      ) %>
+                    </div>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/policy_classes/_table.html.erb
+++ b/app/views/policy_classes/_table.html.erb
@@ -1,50 +1,19 @@
 <table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--l">
-    <%= t(
-      ".table_caption",
-      part: policy_class.part,
-      class: policy_class.section,
-      name: policy_class.name
-    ) %>
-  </caption>
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">
-        <%= t(".policy_reference") %>
-      </th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-        <%= t(".complies") %>
-      </th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-        <%= t(".does_not_comply") %>
-      </th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
-        <%= t(".to_be_determined") %>
-      </th>
-    </tr>
-  </thead>
+  <%= render(
+    partial: "policy_classes/table_head",
+    locals: { policy_class: policy_class }
+  ) %>
   <tbody class="govuk-table__body">
-    <%= form.fields_for(:policies, policies) do |policy_form| %>
+    <% policies.each do |policy| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <h3 class="govuk-heading-s">
-            <%= "#{form.object.section}.#{policy_form.object.section}" %>
+            <%= "#{policy_class.section}.#{policy.section}" %>
           </h3>
           <p class="govuk-body">
-            <%= simple_format(policy_form.object.description) %>
+            <%= simple_format(policy.description) %>
           </p>
-          <% if editable %>
-            <%= render(
-              partial: "policy_classes/comment_form",
-              locals: {
-                planning_application: planning_application,
-                policy_class: policy_class,
-                policy: policy_form.object,
-                comment: policy_form.object.existing_or_new_comment,
-                policy_index: policy_form.options[:child_index]
-              }
-            ) %>
-          <% elsif comment = policy_form.object.comment.presence %>
+          <% if comment = policy.comment.presence %>
             <h4 class="govuk-heading-s policy-comment-title">
               <%=existing_policy_comment_label(comment)%>
             </h4>
@@ -53,23 +22,15 @@
         </td>
         <% Policy.statuses.each_key do |status| %>
           <td class="govuk-table__cell">
-            <% if editable || policy_form.object.status == status %>
+            <% if policy.status == status %>
               <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                   <div class="govuk-radios" data-module="govuk-radios">
                     <div class="govuk-radios govuk-radios--small">
                       <div class="govuk-radios__item">
-                        <%= policy_form.radio_button(
-                          :status,
-                          status,
-                          class: "govuk-radios__input",
-                          disabled: planning_application.assessment_complete?
-                        ) %>
-                        <%= policy_form.label(
-                          :status,
-                          "&nbsp;".html_safe,
-                          class: "govuk-label govuk-radios__label"
-                        ) %>
+                        <input class="govuk-radios__input" type="radio" checked="checked" disabled="disabled" name=<%= dom_id(policy) %>>
+                        <label class="govuk-label govuk-radios__label" for=<%= dom_id(policy) %>>
+                        </label>
                       </div>
                     </div>
                   </div>

--- a/app/views/policy_classes/_table_head.html.erb
+++ b/app/views/policy_classes/_table_head.html.erb
@@ -1,0 +1,24 @@
+<caption class="govuk-table__caption govuk-table__caption--l">
+  <%= t(
+    ".table_caption",
+    part: policy_class.part,
+    class: policy_class.section,
+    name: policy_class.name
+  ) %>
+</caption>
+<thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+      <%= t(".policy_reference") %>
+    </th>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+      <%= t(".complies") %>
+    </th>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+      <%= t(".does_not_comply") %>
+    </th>
+    <th scope="col" class="govuk-table__header govuk-!-width-one-quarter-width">
+      <%= t(".to_be_determined") %>
+    </th>
+  </tr>
+</thead>

--- a/app/views/policy_classes/edit.html.erb
+++ b/app/views/policy_classes/edit.html.erb
@@ -9,7 +9,6 @@
   partial: "form",
   locals: {
     planning_application: @planning_application,
-    policy_class: @policy_class,
-    editable: true
+    policy_class: @policy_class
   }
 ) %>

--- a/app/views/policy_classes/show.html.erb
+++ b/app/views/policy_classes/show.html.erb
@@ -5,11 +5,22 @@
     policy_class: @policy_class
   }
 ) %>
-<%= render(
-  partial: "form",
-  locals: {
-    planning_application: @planning_application,
-    policy_class: @policy_class,
-    editable: false
-  }
-) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+      partial: "table",
+      locals: {
+        planning_application: @planning_application,
+        policy_class: @policy_class,
+        policies: @policy_class.policies
+      }
+    ) %>
+    <%= render(
+      partial: "controls",
+      locals: {
+        planning_application: @planning_application,
+        policy_class: @policy_class
+      }
+    ) %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -415,8 +415,11 @@ en:
       delete_comment: Delete comment
     comment_updated_on: Comment updated on %{updated_at} by %{user}
     complete: Complete
-    form_controls:
+    controls:
       edit_assessment: Edit assessment
+      view_next_class: View next class
+      view_previous_class: View previous class
+    form_controls:
       save_changes_and_view_next: Save changes and view next class
       save_changes_and_view_previous: Save changes and view previous class
       view_next_class: View next class
@@ -435,7 +438,7 @@ en:
       does_not_comply: Does not comply
       policy_class_name: Part %{part}, Class %{class} - %{name}
       to_be_determined: To be determined
-    table:
+    table_head:
       complies: Complies
       does_not_comply: Does not comply
       policy_reference: Policy reference

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -278,4 +278,29 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       end
     end
   end
+
+  describe "#multiple_policy_classes?" do
+    let(:planning_application) { create(:planning_application) }
+    let(:presenter) { described_class.new(view, planning_application) }
+
+    before do
+      create(:policy_class, planning_application: planning_application)
+    end
+
+    context "when there is a single policy class" do
+      it "returns false" do
+        expect(presenter.multiple_policy_classes?).to eq(false)
+      end
+    end
+
+    context "when there are multiple policy classes" do
+      before do
+        create(:policy_class, planning_application: planning_application)
+      end
+
+      it "returns true" do
+        expect(presenter.multiple_policy_classes?).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

The policy classes 'show' and 'edit' pages are very similar visually. However one is a form, and one is 100% not a form. However in a previous change I used the `form` element for both, with an `editable` boolean to determine whether the form could be filled out and submitted.

I think this was probably a bad idea! Pretty sure it's not great accessibility-wise, and may create issues further down the line.

So this PR separates the two different views, only using a 'form' element where it's required in the edit view.

### Story Link

NA