### PR TITLE
Encode filename

### DIFF
--- a/app/services/upload_documents_service.rb
+++ b/app/services/upload_documents_service.rb
@@ -8,7 +8,7 @@ class UploadDocumentsService
 
   def call
     files&.each do |file_params|
-      filename = file_params[:filename]
+      filename = URI.encode(file_params[:filename])
       file = URI.parse(filename).open("api-key" => ENV["PLANX_FILE_API_KEY"])
 
       raise Api::V1::Errors::WrongFileTypeError.new(nil, filename) if forbidden?(file.content_type)


### PR DESCRIPTION
Failed uploading of documents into our database from PlanX appears to be due to urls from them including whitespace which raised an error: URI::InvalidURIError: bad URI(is not URI?)