### PR TITLE
Make comments polymorphic

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -2,7 +2,7 @@
 
 class Comment < ApplicationRecord
   belongs_to :user, optional: true
-  belongs_to :policy
+  belongs_to :commentable, polymorphic: true
 
   validates :text, presence: true
 

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -2,7 +2,7 @@
 
 class Policy < ApplicationRecord
   belongs_to :policy_class
-  has_one :comment, dependent: :destroy
+  has_one :comment, as: :commentable, dependent: :destroy
 
   default_scope { order(:section) }
 

--- a/db/migrate/20221116104134_make_comments_polymorphic.rb
+++ b/db/migrate/20221116104134_make_comments_polymorphic.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MakeCommentsPolymorphic < ActiveRecord::Migration[6.1]
+  def up
+    change_table :comments, bulk: true do |t|
+      t.references :commentable, polymorphic: true
+    end
+
+    execute(
+      "UPDATE comments
+      SET commentable_type = 'Policy', commentable_id = policy_id;"
+    )
+
+    change_table :comments, bulk: true do |t|
+      t.remove :policy_id
+    end
+  end
+
+  def down
+    change_table :comments, bulk: true do |t|
+      t.references :policy
+    end
+
+    execute("UPDATE comments SET policy_id = commentable_id;")
+
+    change_table :comments, bulk: true do |t|
+      t.remove :commentable_id
+      t.remove :commentable_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_07_110702) do
+ActiveRecord::Schema.define(version: 2022_11_16_104134) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -98,10 +98,11 @@ ActiveRecord::Schema.define(version: 2022_11_07_110702) do
   create_table "comments", force: :cascade do |t|
     t.text "text", null: false
     t.bigint "user_id"
-    t.bigint "policy_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["policy_id"], name: "ix_comments_on_policy_id"
+    t.string "commentable_type"
+    t.bigint "commentable_id"
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "ix_comments_on_user_id"
   end
 

--- a/spec/factories/comment.rb
+++ b/spec/factories/comment.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :comment do
     text { Faker::Lorem.paragraph }
-    policy
+    association :commentable, factory: :policy
     user
   end
 end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe Policy, type: :model do
       policy = create(:policy,
                       :complies,
                       section: "1A")
-      create(:comment, policy: policy)
+
+      create(:comment, commentable: policy)
 
       expect(described_class.with_a_comment).to eq [policy]
     end
@@ -93,7 +94,8 @@ RSpec.describe Policy, type: :model do
         policy = create(:policy,
                         status,
                         section: "1A")
-        create(:comment, policy: policy)
+
+        create(:comment, commentable: policy)
 
         expect(described_class.commented_or_does_not_comply).to eq [policy]
       end
@@ -106,7 +108,8 @@ RSpec.describe Policy, type: :model do
       first_section = create(:policy,
                              :complies,
                              section: "1A")
-      create(:comment, policy: first_section)
+
+      create(:comment, commentable: first_section)
 
       expect(described_class.commented_or_does_not_comply).to eq [first_section, last_section]
     end

--- a/spec/system/planning_applications/recommending/legislation_spec.rb
+++ b/spec/system/planning_applications/recommending/legislation_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe "Planning Application Assessment Legislation", type: :system do
                       :complies,
                       section: "1M",
                       policy_class: policy_class)
-      create(:comment, policy: policy)
+
+      create(:comment, commentable: policy)
 
       visit(new_planning_application_recommendation_path(planning_application))
 


### PR DESCRIPTION
### Description of change

Make the `comments` table polymorphic, so that any other table can have one or many comments as a `commentable`.

Currently comments only belong to `policies`, but a lot of current and upcoming tickets look to be needing comments associated with other things!

### Story Link

NA