### PR TITLE
Display warning if there are open post validation requests

### DIFF
--- a/app/models/concerns/planning_application/validation_requests.rb
+++ b/app/models/concerns/planning_application/validation_requests.rb
@@ -74,6 +74,10 @@ class PlanningApplication
       requests.pre_validation.with_validation_request.filter(&:update_counter?).each(&:reset_update_counter!)
     end
 
+    def all_open_post_validation_requests
+      validation_requests(post_validation: true, include_description_change_validation_requests: true).select(&:open?)
+    end
+
     private
 
     def no_open_post_validation_requests?

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -17,6 +17,20 @@
      partial: "events",
      locals: { recommendations: @planning_application.recommendations.reviewed }
   ) %>
+
+  <% if @planning_application.all_open_post_validation_requests.any? %>
+    <%= render(
+      partial: "shared/alert_banner",
+      locals: {
+        message: t(
+          ".there_are_outstanding_change_requests_html",
+          last_request: @planning_application.all_open_post_validation_requests.last.created_at,
+          href: post_validation_requests_planning_application_validation_requests_path(@planning_application)
+        )
+      }
+    ) %>
+  <% end %>
+
   <%= form_with(
     model: @recommendation,
     builder: GOVUKDesignSystemFormBuilder::FormBuilder,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,9 +502,11 @@ en:
       please_provide_supporting: Please provide supporting information for your manager.
       refer_to_the: Refer to the specific permitted development rights being evoked.
       state_the_reason: State the reasons why this application is, or is not lawful.
+      there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
       this_information_will: This information WILL appear on the decision notice.
       this_information_will_not: This information WILL NOT appear on the decision notice or the public register, however FOI still apply.
       update_assessment: Update assessment
+      view_all_requests: View all requests.
       'yes': 'Yes'
     assessment_task_breadcrumbs:
       application: Application

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -670,4 +670,62 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
     expect(list_item("View recommendation")).to have_content("Complete")
   end
+
+  context "when there are post-validation requests" do
+    before { freeze_time }
+
+    context "with an open red line boundary request" do
+      let!(:post_validation_red_line_boundary_change_validation_request) do
+        create(:red_line_boundary_change_validation_request, :post_validation, :open, planning_application: planning_application)
+      end
+
+      it "displays a warning message with a link to the post validation requests table" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        within(".moj-banner__message") do
+          expect(page).to have_content("There are outstanding change requests (last request #{Time.current}")
+          expect(page).to have_link(
+            "View all requests", href: post_validation_requests_planning_application_validation_requests_path(planning_application)
+          )
+        end
+      end
+    end
+
+    context "with an open description change request" do
+      let!(:post_description_change_validation_request) do
+        create(:description_change_validation_request, :post_validation, :open, planning_application: planning_application)
+      end
+
+      it "displays a warning message with a link to the post validation requests table" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        within(".moj-banner__message") do
+          expect(page).to have_content("There are outstanding change requests (last request #{Time.current}")
+          expect(page).to have_link(
+            "View all requests", href: post_validation_requests_planning_application_validation_requests_path(planning_application)
+          )
+        end
+      end
+    end
+
+    context "with a closed change request" do
+      let!(:post_validation_red_line_boundary_change_validation_request) do
+        create(:red_line_boundary_change_validation_request, :post_validation, :closed, planning_application: planning_application)
+      end
+
+      it "does not display any warning message" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        expect(page).not_to have_css(".moj-banner__message")
+      end
+    end
+
+    context "with no request" do
+      it "does not display any warning message" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        expect(page).not_to have_css(".moj-banner__message")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Display warning if there are open post validation requests

- Show this warning on the assess recommendation page if there are any open post validation requests and add a link to view all requests

### Story Link

https://trello.com/c/VdbaWGb9/1256-display-warnings-when-there-is-a-post-validation-request-open-of-assessing-the-recommendation