### PR TITLE
Breadcrumb full width and add missing breadcrumb

### DIFF
--- a/app/views/application/_breadcrumb_navigation.html.erb
+++ b/app/views/application/_breadcrumb_navigation.html.erb
@@ -1,6 +1,6 @@
 <% if current_user.present? && controller_path != "public/planning_guides" %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
           <%= render(

--- a/app/views/consistency_checklists/_introduction.html.erb
+++ b/app/views/consistency_checklists/_introduction.html.erb
@@ -1,6 +1,9 @@
 <% content_for :page_title do %>
   <%= t(".check_description_documents") %> - <%= t("page_title") %>
 <% end %>
+
+<% content_for :title, t(".check_description_documents") %>
+
 <%= render(
   partial: "shared/assessment_task_breadcrumbs",
   locals: { planning_application: @planning_application  }


### PR DESCRIPTION
![Screenshot 2022-11-23 at 14 37 13](https://user-images.githubusercontent.com/1710795/203573871-a0a28f2d-2520-4198-bef9-6d6a53bf4a66.png)


### Description of change

1. Log in as a Register user
2. Open an application
3. On the reviewer check list select: "Description, documents and proposal details"
4. On the "Check description, documents, proposal details" page the final part of the breadcrumb (the page currently open) is missing

### Story Link

https://trello.com/c/KVIRZjmp/1332-part-of-the-breadcrumb-is-missing

### Decisions

To be able to get the long title in I changed the width of the breadcrumbs from 2/3rd to full screen.