### PR TITLE
Review assessment summaries statuses

### DIFF
--- a/app/components/concerns/assessment_detailable.rb
+++ b/app/components/concerns/assessment_detailable.rb
@@ -4,10 +4,37 @@ module AssessmentDetailable
   extend ActiveSupport::Concern
 
   included do
+    delegate(:recommendation, to: :planning_application)
+
     def assessment_details
       @assessment_details ||= AssessmentDetailsReview::ASSESSMENT_DETAILS.map do |assessment_detail|
         planning_application.send(assessment_detail)
       end.compact
+    end
+
+    def assessment_details_updated?
+      return false unless recommendation_submitted_and_unchallenged?
+
+      assessment_details.any? do |assessment_detail|
+        assessment_detail_updated?(assessment_detail)
+      end
+    end
+
+    def assessment_detail_updated?(assessment_detail)
+      assessment_detail.review_required? &&
+        rejected_assessment_detail_for_category?(assessment_detail.category)
+    end
+
+    def assessment_detail_update_required?(assessment_detail)
+      recommendation&.rejected? && assessment_detail&.update_required?
+    end
+
+    def rejected_assessment_detail_for_category?(category)
+      planning_application.rejected_assessment_detail(category: category).present?
+    end
+
+    def recommendation_submitted_and_unchallenged?
+      recommendation&.submitted_and_unchallenged?
     end
 
     def assessment_details_review_complete?

--- a/app/components/status_tags/assessment_details_review_component.rb
+++ b/app/components/status_tags/assessment_details_review_component.rb
@@ -17,7 +17,7 @@ module StatusTags
         :updated
       elsif assessment_details_review_complete?
         :checked
-      elsif assessment_details.any?(&:review_status)
+      elsif assessment_details.any?(&:reviewer_verdict)
         :in_progress
       else
         :not_started

--- a/app/components/status_tags/assessment_details_review_component.rb
+++ b/app/components/status_tags/assessment_details_review_component.rb
@@ -13,7 +13,7 @@ module StatusTags
     attr_reader :planning_application
 
     def status
-      if assessment_details.any?(&:updated?)
+      if assessment_details_updated?
         :updated
       elsif assessment_details_review_complete?
         :checked

--- a/app/components/status_tags/base_component.html.erb
+++ b/app/components/status_tags/base_component.html.erb
@@ -1,6 +1,3 @@
 <% if status.present? %>
-  <%= tag.strong(
-    t("status_tag_component.#{status}"),
-    class: "govuk-tag #{colour_class} #{'app-task-list__task-tag' if task_list?}"
-  ) %>
+  <%= tag.strong(t("status_tag_component.#{status}"), class: html_classes) %>
 <% end %>

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -10,6 +10,14 @@ module StatusTags
 
     attr_reader :status
 
+    def html_classes
+      [
+        "govuk-tag",
+        colour_class,
+        ("app-task-list__task-tag" if task_list?)
+      ].compact.join(" ")
+    end
+
     def colour_class
       case status
       when :not_started, :not_checked_yet

--- a/app/components/status_tags/review_recommendation_component.rb
+++ b/app/components/status_tags/review_recommendation_component.rb
@@ -37,7 +37,7 @@ module StatusTags
 
     def in_progress?
       planning_application.recommendation_review_in_progress? ||
-        assessment_details.any?(&:review_status)
+        assessment_details.any?(&:reviewer_verdict)
     end
   end
 end

--- a/app/components/status_tags/review_recommendation_component.rb
+++ b/app/components/status_tags/review_recommendation_component.rb
@@ -22,7 +22,7 @@ module StatusTags
     end
 
     def reviewer_status
-      if assessment_details.any?(&:updated?)
+      if assessment_details_updated?
         :updated
       elsif in_progress?
         :in_progress

--- a/app/components/status_tags/reviewer_assessment_detail_component.rb
+++ b/app/components/status_tags/reviewer_assessment_detail_component.rb
@@ -2,16 +2,34 @@
 
 module StatusTags
   class ReviewerAssessmentDetailComponent < StatusTags::BaseComponent
-    def initialize(assessment_detail:)
+    include AssessmentDetailable
+
+    def initialize(assessment_detail:, planning_application:)
+      @planning_application = planning_application
       @assessment_detail = assessment_detail
     end
 
     private
 
-    attr_reader :assessment_detail
+    attr_reader :planning_application, :assessment_detail
 
     def status
-      :updated if assessment_detail.updated?
+      if assessment_detail.assessment_not_started?
+        :not_started
+      elsif assessment_detail_update_required?(assessment_detail)
+        :to_be_reviewed
+      elsif updated?
+        :updated
+      elsif assessment_detail.assessment_complete?
+        :complete
+      elsif assessment_detail.assessment_in_progress?
+        :in_progress
+      end
+    end
+
+    def updated?
+      recommendation_submitted_and_unchallenged? &&
+        assessment_detail_updated?(assessment_detail)
     end
 
     def task_list?

--- a/app/components/task_list_items/assessment_detail_component.rb
+++ b/app/components/task_list_items/assessment_detail_component.rb
@@ -2,6 +2,8 @@
 
 module TaskListItems
   class AssessmentDetailComponent < TaskListItems::BaseComponent
+    include AssessmentDetailable
+
     def initialize(planning_application:, category:)
       @planning_application = planning_application
       @category = category
@@ -40,7 +42,7 @@ module TaskListItems
     end
 
     def status
-      if update_required?
+      if assessment_detail_update_required?(assessment_detail)
         :to_be_reviewed
       elsif not_started?
         :not_started
@@ -49,11 +51,6 @@ module TaskListItems
       else
         :complete
       end
-    end
-
-    def update_required?
-      planning_application.recommendation&.rejected? &&
-        assessment_detail&.update_required?
     end
 
     def not_started?

--- a/app/components/task_list_items/assessment_detail_component.rb
+++ b/app/components/task_list_items/assessment_detail_component.rb
@@ -40,12 +40,12 @@ module TaskListItems
     end
 
     def status
-      if assessment_detail.blank?
+      if update_required?
+        :to_be_reviewed
+      elsif not_started?
         :not_started
       elsif assessment_detail.assessment_in_progress?
         :in_progress
-      elsif update_required?
-        :to_be_reviewed
       else
         :complete
       end
@@ -53,7 +53,11 @@ module TaskListItems
 
     def update_required?
       planning_application.recommendation&.rejected? &&
-        assessment_detail.update_required?
+        assessment_detail&.update_required?
+    end
+
+    def not_started?
+      assessment_detail.blank? || assessment_detail.assessment_not_started?
     end
 
     def assessment_detail

--- a/app/controllers/assessment_details_reviews_controller.rb
+++ b/app/controllers/assessment_details_reviews_controller.rb
@@ -41,7 +41,7 @@ class AssessmentDetailsReviewsController < AuthenticationController
   def permitted_attributes
     AssessmentDetailsReview::ASSESSMENT_DETAILS.map do |assessment_detail|
       [
-        "#{assessment_detail}_review_status",
+        "#{assessment_detail}_reviewer_verdict",
         "#{assessment_detail}_entry",
         "#{assessment_detail}_comment_text"
       ]

--- a/app/controllers/planning_application/assessment_details_controller.rb
+++ b/app/controllers/planning_application/assessment_details_controller.rb
@@ -19,9 +19,7 @@ class PlanningApplication
     end
 
     def create
-      @assessment_detail = @planning_application.assessment_details.new(assessment_details_params).tap do |record|
-        record.reviewer_verdict = :updated if @rejected_assessment_detail.present?
-      end
+      @assessment_detail = @planning_application.assessment_details.new(assessment_details_params)
 
       respond_to do |format|
         if @assessment_detail.save
@@ -70,6 +68,8 @@ class PlanningApplication
     end
 
     def set_rejected_assessment_detail
+      return unless @planning_application.recommendation&.rejected?
+
       @rejected_assessment_detail = @planning_application.rejected_assessment_detail(category: @category)
     end
 
@@ -97,7 +97,7 @@ class PlanningApplication
       params
         .require(:assessment_detail)
         .permit(:entry, :category, :additional_information)
-        .merge(assessment_status: assessment_status, user: current_user)
+        .merge(assessment_status: assessment_status)
     end
 
     def assessment_status

--- a/app/controllers/planning_application/assessment_details_controller.rb
+++ b/app/controllers/planning_application/assessment_details_controller.rb
@@ -22,7 +22,7 @@ class PlanningApplication
       @assessment_detail = @planning_application.assessment_details.new(assessment_details_params).tap do |record|
         record.user = current_user
         record.status = status
-        record.review_status = :updated if @rejected_assessment_detail.present?
+        record.reviewer_verdict = :updated if @rejected_assessment_detail.present?
       end
 
       respond_to do |format|

--- a/app/controllers/planning_application/assessment_details_controller.rb
+++ b/app/controllers/planning_application/assessment_details_controller.rb
@@ -20,8 +20,6 @@ class PlanningApplication
 
     def create
       @assessment_detail = @planning_application.assessment_details.new(assessment_details_params).tap do |record|
-        record.user = current_user
-        record.status = status
         record.reviewer_verdict = :updated if @rejected_assessment_detail.present?
       end
 
@@ -53,8 +51,6 @@ class PlanningApplication
     end
 
     def update
-      @assessment_detail.assign_attributes(user: current_user, status: status)
-
       respond_to do |format|
         if @assessment_detail.update(assessment_details_params)
           format.html do
@@ -101,10 +97,11 @@ class PlanningApplication
       params
         .require(:assessment_detail)
         .permit(:entry, :category, :additional_information)
+        .merge(assessment_status: assessment_status, user: current_user)
     end
 
-    def status
-      save_progress? ? :assessment_in_progress : :assessment_complete
+    def assessment_status
+      save_progress? ? :in_progress : :complete
     end
 
     def created_notice

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -12,7 +12,7 @@ class AssessmentDetail < ApplicationRecord
     review_complete: "review_complete"
   }
 
-  enum review_status: {
+  enum reviewer_verdict: {
     updated: "updated",
     accepted: "accepted",
     edited_and_accepted: "edited_and_accepted",

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -5,12 +5,22 @@ class AssessmentDetail < ApplicationRecord
   belongs_to :user
   has_one :comment, as: :commentable, dependent: :destroy
 
-  enum status: {
-    assessment_in_progress: "assessment_in_progress",
-    assessment_complete: "assessment_complete",
-    review_in_progress: "review_in_progress",
-    review_complete: "review_complete"
-  }
+  enum(
+    assessment_status: {
+      not_started: "not_started",
+      in_progress: "in_progress",
+      complete: "complete"
+    },
+    _prefix: "assessment"
+  )
+
+  enum(
+    review_status: {
+      in_progress: "in_progress",
+      complete: "complete"
+    },
+    _prefix: "review"
+  )
 
   enum reviewer_verdict: {
     updated: "updated",
@@ -29,7 +39,7 @@ class AssessmentDetail < ApplicationRecord
 
   before_validation :set_user
 
-  validates :status, presence: true
+  validates :assessment_status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
 
   validate :consultees_added, if: :consultation_summary?

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -11,6 +11,7 @@ class AssessmentDetail < ApplicationRecord
       in_progress: "in_progress",
       complete: "complete"
     },
+    _default: "not_started",
     _prefix: "assessment"
   )
 
@@ -23,7 +24,6 @@ class AssessmentDetail < ApplicationRecord
   )
 
   enum reviewer_verdict: {
-    updated: "updated",
     accepted: "accepted",
     edited_and_accepted: "edited_and_accepted",
     rejected: "rejected"
@@ -58,6 +58,10 @@ class AssessmentDetail < ApplicationRecord
 
   def update_required?
     review_complete? && rejected?
+  end
+
+  def review_required?
+    assessment_complete? && reviewer_verdict.blank?
   end
 
   private

--- a/app/models/assessment_details_review.rb
+++ b/app/models/assessment_details_review.rb
@@ -35,8 +35,8 @@ class AssessmentDetailsReview
     end
 
     delegate(
-      :review_status,
-      "review_status=",
+      :reviewer_verdict,
+      "reviewer_verdict=",
       :entry,
       "entry=",
       to: assessment_detail,
@@ -46,7 +46,7 @@ class AssessmentDetailsReview
     delegate(:text, "text=", to: "#{assessment_detail}_comment", prefix: true)
 
     validates(
-      "#{assessment_detail}_review_status",
+      "#{assessment_detail}_reviewer_verdict",
       presence: true,
       if: :status_complete?
     )
@@ -54,30 +54,30 @@ class AssessmentDetailsReview
     validates(
       "#{assessment_detail}_comment_text",
       presence: true,
-      if: "#{assessment_detail}_review_status_rejected?".to_sym
+      if: "#{assessment_detail}_reviewer_verdict_rejected?".to_sym
     )
 
     validates(
       "#{assessment_detail}_entry",
       presence: true,
-      if: "#{assessment_detail}_review_status_edited_and_accepted?".to_sym
+      if: "#{assessment_detail}_reviewer_verdict_edited_and_accepted?".to_sym
     )
 
     validate(
       "#{assessment_detail}_entry_changed".to_sym,
-      if: "#{assessment_detail}_review_status_edited_and_accepted?".to_sym
+      if: "#{assessment_detail}_reviewer_verdict_edited_and_accepted?".to_sym
     )
 
-    define_method("#{assessment_detail}_review_status_rejected?") do
-      send("#{assessment_detail}_review_status") == "rejected"
+    define_method("#{assessment_detail}_reviewer_verdict_rejected?") do
+      send("#{assessment_detail}_reviewer_verdict") == "rejected"
     end
 
-    define_method("#{assessment_detail}_review_status_edited_and_accepted?") do
-      send("#{assessment_detail}_review_status") == "edited_and_accepted"
+    define_method("#{assessment_detail}_reviewer_verdict_edited_and_accepted?") do
+      send("#{assessment_detail}_reviewer_verdict") == "edited_and_accepted"
     end
 
     define_method("#{assessment_detail}_entry_changed") do
-      return if !send(assessment_detail).review_status_changed? || send(assessment_detail).entry_changed?
+      return if !send(assessment_detail).reviewer_verdict_changed? || send(assessment_detail).entry_changed?
 
       errors.add("#{assessment_detail}_entry", :not_changed)
     end
@@ -89,7 +89,7 @@ class AssessmentDetailsReview
     ActiveRecord::Base.transaction do
       run_callbacks :save do
         assessment_details.each do |assessment_detail|
-          next if assessment_detail.review_status.blank?
+          next if assessment_detail.reviewer_verdict.blank?
 
           assessment_detail.save!
         end
@@ -111,7 +111,7 @@ class AssessmentDetailsReview
     assessment_details.each do |assessment_detail|
       if status_complete?
         assessment_detail.status = :review_complete
-      elsif assessment_detail.review_status.present?
+      elsif assessment_detail.reviewer_verdict.present?
         assessment_detail.status = :review_in_progress
       end
     end

--- a/app/models/assessment_details_review.rb
+++ b/app/models/assessment_details_review.rb
@@ -109,8 +109,7 @@ class AssessmentDetailsReview
 
   def set_statuses
     assessment_details.each do |assessment_detail|
-      assessment_detail.review_status = status if assessment_detail.reviewer_verdict.present?
-      assessment_detail.assessment_status = :not_started if assessment_detail.new_record?
+      assessment_detail.review_status = status
     end
   end
 

--- a/app/models/assessment_details_review.rb
+++ b/app/models/assessment_details_review.rb
@@ -109,11 +109,8 @@ class AssessmentDetailsReview
 
   def set_statuses
     assessment_details.each do |assessment_detail|
-      if status_complete?
-        assessment_detail.status = :review_complete
-      elsif assessment_detail.reviewer_verdict.present?
-        assessment_detail.status = :review_in_progress
-      end
+      assessment_detail.review_status = status if assessment_detail.reviewer_verdict.present?
+      assessment_detail.assessment_status = :not_started if assessment_detail.new_record?
     end
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -463,7 +463,7 @@ class PlanningApplication < ApplicationRecord
 
     assessment_details.where(
       category: category,
-      status: :review_complete,
+      review_status: :complete,
       reviewer_verdict: :rejected
     ).first
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -464,7 +464,7 @@ class PlanningApplication < ApplicationRecord
     assessment_details.where(
       category: category,
       status: :review_complete,
-      review_status: :rejected
+      reviewer_verdict: :rejected
     ).first
   end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -459,8 +459,6 @@ class PlanningApplication < ApplicationRecord
   end
 
   def rejected_assessment_detail(category:)
-    return unless recommendation&.rejected?
-
     assessment_details.where(
       category: category,
       review_status: :complete,

--- a/app/views/assessment_details_reviews/_form.html.erb
+++ b/app/views/assessment_details_reviews/_form.html.erb
@@ -10,7 +10,7 @@
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <% end %>
     <%= form.govuk_radio_buttons_fieldset(
-      "#{assessment_detail}_review_status".to_sym,
+      "#{assessment_detail}_reviewer_verdict".to_sym,
       legend: { text: t(".#{assessment_detail}") }
     ) do %>
       <%= render(
@@ -30,13 +30,13 @@
         { class: "govuk-body" }
       ) %>
       <%= form.govuk_radio_button(
-        "#{assessment_detail}_review_status",
+        "#{assessment_detail}_reviewer_verdict",
         :accepted,
         label: { text: t(".accept") },
         disabled: disabled
       ) %>
       <%= form.govuk_radio_button(
-        "#{assessment_detail}_review_status",
+        "#{assessment_detail}_reviewer_verdict",
         :edited_and_accepted,
         label: { text: t(".edit_to_accept") },
         disabled: disabled
@@ -48,7 +48,7 @@
         ) %>
       <% end %>
       <%= form.govuk_radio_button(
-        "#{assessment_detail}_review_status",
+        "#{assessment_detail}_reviewer_verdict",
         :rejected,
         label: { text: t(".return_to_officer") },
         disabled: disabled

--- a/app/views/assessment_details_reviews/_form.html.erb
+++ b/app/views/assessment_details_reviews/_form.html.erb
@@ -15,6 +15,7 @@
     ) do %>
       <%= render(
         StatusTags::ReviewerAssessmentDetailComponent.new(
+          planning_application: planning_application,
           assessment_detail: form.object.send(assessment_detail)
         )
       ) %>
@@ -27,7 +28,7 @@
       <% end %>
       <%= simple_format(
         form.object.send("#{assessment_detail}_entry"),
-        { class: "govuk-body" }
+        { class: "govuk-body govuk-!-margin-top-2" }
       ) %>
       <%= form.govuk_radio_button(
         "#{assessment_detail}_reviewer_verdict",

--- a/db/migrate/20221125151759_rename_assessment_detail_review_status.rb
+++ b/db/migrate/20221125151759_rename_assessment_detail_review_status.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameAssessmentDetailReviewStatus < ActiveRecord::Migration[6.1]
+  def change
+    rename_column(:assessment_details, :review_status, :reviewer_verdict)
+  end
+end

--- a/db/migrate/20221125153219_split_assessment_details_status.rb
+++ b/db/migrate/20221125153219_split_assessment_details_status.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class SplitAssessmentDetailsStatus < ActiveRecord::Migration[6.1]
+  # rubocop:disable Metrics/MethodLength
+  def up
+    rename_column(:assessment_details, :status, :assessment_status)
+    add_column(:assessment_details, :review_status, :string)
+
+    execute(
+      "UPDATE assessment_details
+      SET review_status = 'in_progress'
+      WHERE assessment_status = 'review_in_progress';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET review_status = 'complete'
+      WHERE assessment_status = 'review_complete';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'in_progress'
+      WHERE assessment_status = 'assessment_in_progress';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'complete'
+      WHERE assessment_status
+      IN ('assessment_in_progress', 'review_in_progress', 'review_complete');"
+    )
+  end
+
+  def down
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'assessment_in_progress'
+      WHERE assessment_status = 'in_progress';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'assessment_complete'
+      WHERE assessment_status = 'complete';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'review_in_progress'
+      WHERE review_status = 'in_progress';"
+    )
+
+    execute(
+      "UPDATE assessment_details
+      SET assessment_status = 'review_complete'
+      WHERE review_status = 'complete';"
+    )
+
+    rename_column(:assessment_details, :assessment_status, :status)
+    remove_column(:assessment_details, :review_status, :string)
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/migrate/20221125171818_remove_updated_from_assessment_detail_reviewer_verdict.rb
+++ b/db/migrate/20221125171818_remove_updated_from_assessment_detail_reviewer_verdict.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemoveUpdatedFromAssessmentDetailReviewerVerdict < ActiveRecord::Migration[6.1]
+  def up
+    execute(
+      "UPDATE assessment_details
+      SET reviewer_verdict = NULL
+      WHERE reviewer_verdict = 'updated';"
+    )
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_25_151759) do
+ActiveRecord::Schema.define(version: 2022_11_25_153219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,12 +71,13 @@ ActiveRecord::Schema.define(version: 2022_11_25_151759) do
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
     t.text "entry"
-    t.string "status", null: false
+    t.string "assessment_status", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "category", null: false
     t.text "additional_information"
     t.string "reviewer_verdict"
+    t.string "review_status"
     t.index ["planning_application_id"], name: "ix_assessment_details_on_planning_application_id"
     t.index ["user_id"], name: "ix_assessment_details_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_25_153219) do
+ActiveRecord::Schema.define(version: 2022_11_25_171818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_23_161814) do
+ActiveRecord::Schema.define(version: 2022_11_25_151759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2022_11_23_161814) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "category", null: false
     t.text "additional_information"
-    t.string "review_status"
+    t.string "reviewer_verdict"
     t.index ["planning_application_id"], name: "ix_assessment_details_on_planning_application_id"
     t.index ["user_id"], name: "ix_assessment_details_on_user_id"
   end

--- a/spec/components/status_tags/assessment_details_review_component_spec.rb
+++ b/spec/components/status_tags/assessment_details_review_component_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   let(:planning_application) { create(:planning_application) }
-  let(:status) { :assessment_complete }
+  let(:review_status) { nil }
+  let(:assessment_status) { :complete }
   let(:reviewer_verdict) { :accepted }
 
   before do
@@ -12,7 +13,8 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
       :assessment_detail,
       planning_application: planning_application,
       reviewer_verdict: reviewer_verdict,
-      status: status
+      review_status: review_status,
+      assessment_status: assessment_status
     )
   end
 
@@ -31,7 +33,7 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   end
 
   context "when the review is complete" do
-    let(:status) { :review_complete }
+    let(:review_status) { :complete }
 
     before do
       render_inline(
@@ -45,7 +47,7 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   end
 
   context "when the review is in progress" do
-    let(:status) { :review_in_progress }
+    let(:review_status) { :in_progress }
 
     before do
       render_inline(

--- a/spec/components/status_tags/assessment_details_review_component_spec.rb
+++ b/spec/components/status_tags/assessment_details_review_component_spec.rb
@@ -11,17 +11,34 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   before do
     create(
       :assessment_detail,
+      :summary_of_work,
       planning_application: planning_application,
       reviewer_verdict: reviewer_verdict,
       review_status: review_status,
-      assessment_status: assessment_status
+      assessment_status: assessment_status,
+      created_at: 1.day.ago
     )
   end
 
   context "when an assessment detail has been updated" do
-    let(:reviewer_verdict) { :updated }
+    let(:reviewer_verdict) { nil }
 
     before do
+      create(
+        :recommendation,
+        submitted: true,
+        planning_application: planning_application
+      )
+
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        review_status: :complete,
+        reviewer_verdict: :rejected,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+
       render_inline(
         described_class.new(planning_application: planning_application)
       )

--- a/spec/components/status_tags/assessment_details_review_component_spec.rb
+++ b/spec/components/status_tags/assessment_details_review_component_spec.rb
@@ -5,19 +5,19 @@ require "rails_helper"
 RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   let(:planning_application) { create(:planning_application) }
   let(:status) { :assessment_complete }
-  let(:review_status) { :accepted }
+  let(:reviewer_verdict) { :accepted }
 
   before do
     create(
       :assessment_detail,
       planning_application: planning_application,
-      review_status: review_status,
+      reviewer_verdict: reviewer_verdict,
       status: status
     )
   end
 
   context "when an assessment detail has been updated" do
-    let(:review_status) { :updated }
+    let(:reviewer_verdict) { :updated }
 
     before do
       render_inline(
@@ -59,7 +59,7 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
   end
 
   context "when the review has not been started" do
-    let(:review_status) { nil }
+    let(:reviewer_verdict) { nil }
 
     before do
       render_inline(

--- a/spec/components/status_tags/reviewer_assessment_detail_component_spec.rb
+++ b/spec/components/status_tags/reviewer_assessment_detail_component_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StatusTags::ReviewerAssessmentDetailComponent, type: :component do
+  let(:planning_application) { create(:planning_application) }
+
+  let(:component) do
+    described_class.new(
+      planning_application: planning_application,
+      assessment_detail: assessment_detail
+    )
+  end
+
+  context "when assessor has not started assessment detail" do
+    let(:assessment_detail) do
+      planning_application.assessment_details.new(category: :summary_of_work)
+    end
+
+    it "renders 'Not started' status" do
+      render_inline(component)
+
+      expect(page).to have_content("Not started")
+    end
+  end
+
+  context "when assessor has started but no completed assessment detail" do
+    let(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        assessment_status: :in_progress
+      )
+    end
+
+    it "renders 'In progress' status" do
+      render_inline(component)
+
+      expect(page).to have_content("In progress")
+    end
+  end
+
+  context "when assessor has completed assessment detail" do
+    let(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        assessment_status: :complete
+      )
+    end
+
+    it "renders 'Complete' status" do
+      render_inline(component)
+
+      expect(page).to have_content("Complete")
+    end
+  end
+
+  context "when reviewer has requested update to assessment detail" do
+    let(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        assessment_status: :complete,
+        review_status: :complete,
+        reviewer_verdict: :rejected
+      )
+    end
+
+    let(:component) do
+      described_class.new(
+        planning_application: planning_application,
+        assessment_detail: assessment_detail
+      )
+    end
+
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        challenged: true,
+        status: :review_complete,
+        reviewer_comment: "rejected"
+      )
+    end
+
+    it "renders 'To be reviewed' status" do
+      render_inline(component)
+
+      expect(page).to have_content("To be reviewed")
+    end
+  end
+
+  context "when assessor has updated assessment detail" do
+    let(:assessment_detail) do
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        assessment_status: :complete
+      )
+    end
+
+    let(:component) do
+      described_class.new(
+        planning_application: planning_application,
+        assessment_detail: assessment_detail
+      )
+    end
+
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        submitted: true
+      )
+
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        review_status: :complete,
+        reviewer_verdict: :rejected,
+        created_at: 2.days.ago
+      )
+    end
+
+    it "renders 'Updated' status" do
+      render_inline(component)
+
+      expect(page).to have_content("Updated")
+    end
+
+    context "when reviewer has re-reviewed assessment detail" do
+      let(:assessment_detail) do
+        create(
+          :assessment_detail,
+          :summary_of_work,
+          planning_application: planning_application,
+          assessment_status: :complete,
+          review_status: :complete,
+          reviewer_verdict: :accepted
+        )
+      end
+
+      it "renders 'Complete' status" do
+        render_inline(component)
+
+        expect(page).to have_content("Complete")
+      end
+    end
+  end
+end

--- a/spec/components/task_list_items/assessment_detail_component_spec.rb
+++ b/spec/components/task_list_items/assessment_detail_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TaskListItems::AssessmentDetailComponent, type: :component do
         :summary_of_work,
         planning_application: planning_application,
         status: :review_complete,
-        review_status: :rejected
+        reviewer_verdict: :rejected
       )
 
       create(

--- a/spec/components/task_list_items/assessment_detail_component_spec.rb
+++ b/spec/components/task_list_items/assessment_detail_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe TaskListItems::AssessmentDetailComponent, type: :component do
         :assessment_detail,
         :summary_of_work,
         planning_application: planning_application,
-        status: :review_complete,
+        review_status: :complete,
         reviewer_verdict: :rejected
       )
 
@@ -71,7 +71,7 @@ RSpec.describe TaskListItems::AssessmentDetailComponent, type: :component do
         :assessment_detail,
         :summary_of_work,
         planning_application: planning_application,
-        status: :assessment_in_progress
+        assessment_status: :in_progress
       )
     end
 
@@ -102,7 +102,7 @@ RSpec.describe TaskListItems::AssessmentDetailComponent, type: :component do
         :assessment_detail,
         :summary_of_work,
         planning_application: planning_application,
-        status: :assessment_complete
+        assessment_status: :complete
       )
     end
 

--- a/spec/components/task_list_items/assessment_details_review_component_spec.rb
+++ b/spec/components/task_list_items/assessment_details_review_component_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe TaskListItems::AssessmentDetailsReviewComponent, type: :component
   before do
     create(
       :assessment_detail,
-      status: status,
+      review_status: review_status,
       planning_application: planning_application
     )
   end
 
   context "when the assessment details review is complete" do
-    let(:status) { :review_complete }
+    let(:review_status) { :complete }
 
     before do
       render_inline(
@@ -33,7 +33,7 @@ RSpec.describe TaskListItems::AssessmentDetailsReviewComponent, type: :component
   end
 
   context "when the assessment details review is not complete" do
-    let(:status) { :review_in_progress }
+    let(:review_status) { :in_progress }
 
     before do
       render_inline(

--- a/spec/factories/assessment_detail.rb
+++ b/spec/factories/assessment_detail.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     user
 
     category { "summary_of_work" }
-    status { "assessment_complete" }
+    assessment_status { :complete }
     entry { "This is a description about the summary of works" }
 
     AssessmentDetail.categories.each_key do |category|

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AssessmentDetail, type: :model do
           :assessment_detail,
           :past_applications,
           entry: "",
-          status: status
+          assessment_status: assessment_status
         )
       end
 
@@ -24,7 +24,7 @@ RSpec.describe AssessmentDetail, type: :model do
           :consultation_summary,
           :with_consultees,
           entry: "",
-          status: status
+          assessment_status: assessment_status
         )
       end
 
@@ -40,8 +40,8 @@ RSpec.describe AssessmentDetail, type: :model do
         expect { site_description }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Entry can't be blank")
       end
 
-      context "when status is assessment_complete" do
-        let(:status) { :assessment_complete }
+      context "when assessment_status is complete" do
+        let(:assessment_status) { :complete }
 
         it "validates presence for past_applications" do
           expect { past_applications }.to raise_error(
@@ -58,8 +58,8 @@ RSpec.describe AssessmentDetail, type: :model do
         end
       end
 
-      context "when status is assessment_in_progress" do
-        let(:status) { :assessment_in_progress }
+      context "when assessment_status is in_progress" do
+        let(:assessment_status) { :in_progress }
 
         it "does not validates presence for past_applications" do
           expect { past_applications }.not_to raise_error
@@ -74,9 +74,9 @@ RSpec.describe AssessmentDetail, type: :model do
     described_class.categories.each_key do |category_type|
       let(:category) { described_class.new(category: category_type) }
 
-      describe "#status" do
+      describe "#assessment_status" do
         it "validates presence" do
-          expect { category.valid? }.to change { category.errors[:status] }.to ["can't be blank"]
+          expect { category.valid? }.to change { category.errors[:assessment_status] }.to ["can't be blank"]
         end
       end
 
@@ -143,7 +143,7 @@ RSpec.describe AssessmentDetail, type: :model do
     let(:assessment_detail) do
       build(
         :assessment_detail,
-        status: status,
+        assessment_status: assessment_status,
         category: category,
         planning_application: planning_application,
         reviewer_verdict: reviewer_verdict,
@@ -151,7 +151,7 @@ RSpec.describe AssessmentDetail, type: :model do
       )
     end
 
-    let(:status) { :assessment_complete }
+    let(:assessment_status) { :complete }
     let(:category) { :summary_of_work }
     let(:reviewer_verdict) { nil }
     let(:entry) { "entry" }
@@ -194,8 +194,8 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is 'assessment_complete'" do
-      let(:status) { :assessment_complete }
+    context "when assessment_status is 'complete'" do
+      let(:assessment_status) { :complete }
 
       context "when category is 'consultation_summary'" do
         let(:category) { :consultation_summary }
@@ -239,8 +239,8 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is 'assessment_in_progress', category is 'consultation_summary' and there are no consultees" do
-      let(:status) { :assessment_in_progress }
+    context "when assessment_status is 'progress', category is 'consultation_summary' and there are no consultees" do
+      let(:assessment_status) { :in_progress }
       let(:category) { :summary_of_work }
       let(:planning_application) { create(:planning_application) }
 
@@ -264,11 +264,11 @@ RSpec.describe AssessmentDetail, type: :model do
   end
 
   describe "#update_required?" do
-    context "when status is 'review_complete' and reviewer_verdict is 'rejected'" do
+    context "when review_status is 'rcomplete' and reviewer_verdict is 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
-          status: :review_complete,
+          review_status: :complete,
           reviewer_verdict: :rejected
         )
       end
@@ -278,11 +278,11 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is 'review_complete' and reviewer_verdict is not 'rejected'" do
+    context "when reveiw_status is 'complete' and reviewer_verdict is not 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
-          status: :review_complete,
+          review_status: :complete,
           reviewer_verdict: :accepted
         )
       end
@@ -292,11 +292,11 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is not 'review_complete' and reviewer_verdict is 'rejected'" do
+    context "when review_status is not 'complete' and reviewer_verdict is 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
-          status: :review_in_progress,
+          review_status: :in_progress,
           reviewer_verdict: :rejected
         )
       end

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
+    describe "#assessment_status" do
+      it "defaults to 'not_started'" do
+        expect(described_class.new.assessment_status).to eq("not_started")
+      end
+    end
+
     described_class.categories.each_key do |category_type|
       let(:category) { described_class.new(category: category_type) }
-
-      describe "#assessment_status" do
-        it "validates presence" do
-          expect { category.valid? }.to change { category.errors[:assessment_status] }.to ["can't be blank"]
-        end
-      end
 
       describe "#user" do
         it "validates presence" do

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -146,37 +146,37 @@ RSpec.describe AssessmentDetail, type: :model do
         status: status,
         category: category,
         planning_application: planning_application,
-        review_status: review_status,
+        reviewer_verdict: reviewer_verdict,
         entry: entry
       )
     end
 
     let(:status) { :assessment_complete }
     let(:category) { :summary_of_work }
-    let(:review_status) { nil }
+    let(:reviewer_verdict) { nil }
     let(:entry) { "entry" }
 
     context "when entry is blank" do
       let(:entry) { nil }
 
-      context "when review_status is 'accepted'" do
-        let(:review_status) { :accepted }
+      context "when reviewer_verdict is 'accepted'" do
+        let(:reviewer_verdict) { :accepted }
 
         it "returns true" do
           expect(assessment_detail.valid?).to eq(true)
         end
       end
 
-      context "when review_status is 'rejected'" do
-        let(:review_status) { :rejected }
+      context "when reviewer_verdict is 'rejected'" do
+        let(:reviewer_verdict) { :rejected }
 
         it "returns true" do
           expect(assessment_detail.valid?).to eq(true)
         end
       end
 
-      context "when review_status is 'edited_and_accepted'" do
-        let(:review_status) { :edited_and_accepted }
+      context "when reviewer_verdict is 'edited_and_accepted'" do
+        let(:reviewer_verdict) { :edited_and_accepted }
 
         it "returns false" do
           expect(assessment_detail.valid?).to eq(false)
@@ -264,12 +264,12 @@ RSpec.describe AssessmentDetail, type: :model do
   end
 
   describe "#update_required?" do
-    context "when status is 'review_complete' and review_status is 'rejected'" do
+    context "when status is 'review_complete' and reviewer_verdict is 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
           status: :review_complete,
-          review_status: :rejected
+          reviewer_verdict: :rejected
         )
       end
 
@@ -278,12 +278,12 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is 'review_complete' and review_status is not 'rejected'" do
+    context "when status is 'review_complete' and reviewer_verdict is not 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
           status: :review_complete,
-          review_status: :accepted
+          reviewer_verdict: :accepted
         )
       end
 
@@ -292,12 +292,12 @@ RSpec.describe AssessmentDetail, type: :model do
       end
     end
 
-    context "when status is not 'review_complete' and review_status is 'rejected'" do
+    context "when status is not 'review_complete' and reviewer_verdict is 'rejected'" do
       let(:assessment_detail) do
         build(
           :assessment_detail,
           status: :review_in_progress,
-          review_status: :rejected
+          reviewer_verdict: :rejected
         )
       end
 

--- a/spec/models/assessment_details_review_spec.rb
+++ b/spec/models/assessment_details_review_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AssessmentDetailsReview do
           :summary_of_work,
           planning_application: planning_application,
           entry: "summary of work",
-          status: :assessment_complete
+          assessment_status: :complete
         )
       end
 
@@ -42,7 +42,7 @@ RSpec.describe AssessmentDetailsReview do
           :additional_evidence,
           planning_application: planning_application,
           entry: "additional evidence",
-          status: :assessment_complete
+          assessment_status: :complete
         )
       end
 
@@ -52,7 +52,7 @@ RSpec.describe AssessmentDetailsReview do
           :consultation_summary,
           planning_application: planning_application,
           entry: "consultation summary",
-          status: :assessment_complete
+          assessment_status: :complete
         )
       end
 
@@ -62,14 +62,14 @@ RSpec.describe AssessmentDetailsReview do
           :site_description,
           planning_application: planning_application,
           entry: "site description",
-          status: :assessment_complete
+          assessment_status: :complete
         )
       end
 
       before { assessment_details_review.save }
 
       context "when status is 'in progress'" do
-        context "when review status 'accepted'" do
+        context "when reviewer verdict 'accepted'" do
           let(:params) do
             {
               status: :in_progress,
@@ -83,33 +83,33 @@ RSpec.describe AssessmentDetailsReview do
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates consultation summmary" do
             expect(consultation_summary.reload).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
         end
 
-        context "when review status 'rejected' and comment text is present" do
+        context "when reviewer verdict 'rejected' and comment text is present" do
           let(:params) do
             {
               status: :in_progress,
@@ -127,28 +127,28 @@ RSpec.describe AssessmentDetailsReview do
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
           it "updates consultation summary" do
             expect(consultation_summary.reload).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -177,7 +177,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status is 'rejected' and comment text is blank" do
+        context "when reviewer verdict is 'rejected' and comment text is blank" do
           let(:params) do
             {
               status: :in_progress,
@@ -225,7 +225,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status 'edited and accepted' and entry is present" do
+        context "when reviewer verdict 'edited and accepted' and entry is present" do
           let(:params) do
             {
               status: :in_progress,
@@ -243,7 +243,7 @@ RSpec.describe AssessmentDetailsReview do
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited summary of work"
             )
           end
@@ -251,7 +251,7 @@ RSpec.describe AssessmentDetailsReview do
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited site description"
             )
           end
@@ -259,7 +259,7 @@ RSpec.describe AssessmentDetailsReview do
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited additional evidence"
             )
           end
@@ -267,13 +267,13 @@ RSpec.describe AssessmentDetailsReview do
           it "updates consultation summary" do
             expect(consultation_summary.reload).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited consultation summary"
             )
           end
         end
 
-        context "when review status 'edited and accepted' and entry is blank" do
+        context "when reviewer verdict 'edited and accepted' and entry is blank" do
           let(:params) do
             {
               status: :in_progress,
@@ -321,7 +321,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status 'edited and accepted' and entry not edited" do
+        context "when reviewer verdict is 'edited and accepted' and entry not edited" do
           let(:params) do
             {
               status: :in_progress,
@@ -369,7 +369,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status is nil" do
+        context "when reviewer verdict is nil" do
           let(:params) do
             {
               status: :in_progress,
@@ -401,7 +401,7 @@ RSpec.describe AssessmentDetailsReview do
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_complete"
+              review_status: "complete"
             )
           end
         end
@@ -432,7 +432,7 @@ RSpec.describe AssessmentDetailsReview do
       before { assessment_details_review.save }
 
       context "when status is 'in progress'" do
-        context "when review status 'accepted'" do
+        context "when reviewer verdict 'accepted'" do
           let(:params) do
             {
               status: :in_progress,
@@ -448,7 +448,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.summary_of_work
             ).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -457,7 +457,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.additional_evidence
             ).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -466,7 +466,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.site_description
             ).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -475,12 +475,12 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.consultation_summary
             ).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
         end
 
-        context "when review status is 'rejected' and comment text is present" do
+        context "when reviewer verdict is 'rejected' and comment text is present" do
           let(:params) do
             {
               status: :in_progress,
@@ -500,7 +500,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.summary_of_work
             ).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -509,7 +509,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.additional_evidence
             ).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -518,7 +518,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.site_description
             ).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -527,7 +527,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.consultation_summary
             ).to have_attributes(
               reviewer_verdict: "rejected",
-              status: "review_in_progress"
+              review_status: "in_progress"
             )
           end
 
@@ -564,7 +564,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status is 'rejected' and comment text is blank" do
+        context "when reviewer verdict is 'rejected' and comment text is blank" do
           let(:params) do
             {
               status: :in_progress,
@@ -612,7 +612,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when review status 'edited and accepted' and entry is present" do
+        context "when reviewer verdict is 'edited and accepted' and entry is present" do
           let(:params) do
             {
               status: :in_progress,
@@ -632,7 +632,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.summary_of_work
             ).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited summary of work"
             )
           end
@@ -642,7 +642,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.site_description
             ).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited site description"
             )
           end
@@ -652,7 +652,7 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.additional_evidence
             ).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited additional evidence"
             )
           end
@@ -662,13 +662,13 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.consultation_summary
             ).to have_attributes(
               reviewer_verdict: "edited_and_accepted",
-              status: "review_in_progress",
+              review_status: "in_progress",
               entry: "edited consultation summary"
             )
           end
         end
 
-        context "when review status is 'edited and accepted' and entry is blank" do
+        context "when reviewer verdict is 'edited and accepted' and entry is blank" do
           let(:params) do
             {
               status: :in_progress,
@@ -716,7 +716,7 @@ RSpec.describe AssessmentDetailsReview do
           end
         end
 
-        context "when any review status is nil" do
+        context "when any reviewer verdict is nil" do
           let(:params) do
             {
               status: :in_progress,
@@ -734,7 +734,7 @@ RSpec.describe AssessmentDetailsReview do
       end
 
       context "when status is 'complete'" do
-        context "when all review statuses are present" do
+        context "when all reviewer verdicts are present" do
           let(:params) do
             {
               status: :complete,
@@ -750,12 +750,12 @@ RSpec.describe AssessmentDetailsReview do
               planning_application.reload.summary_of_work
             ).to have_attributes(
               reviewer_verdict: "accepted",
-              status: "review_complete"
+              review_status: "complete"
             )
           end
         end
 
-        context "when any review status is nil" do
+        context "when any reviewer verdict is nil" do
           let(:params) do
             {
               status: :complete,

--- a/spec/models/assessment_details_review_spec.rb
+++ b/spec/models/assessment_details_review_spec.rb
@@ -73,37 +73,37 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :accepted,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: :accepted,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
 
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
 
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
 
           it "updates consultation summmary" do
             expect(consultation_summary.reload).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
@@ -113,10 +113,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :rejected,
-              site_description_review_status: :rejected,
-              additional_evidence_review_status: :rejected,
-              consultation_summary_review_status: :rejected,
+              summary_of_work_reviewer_verdict: :rejected,
+              site_description_reviewer_verdict: :rejected,
+              additional_evidence_reviewer_verdict: :rejected,
+              consultation_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "summary of work comment",
               site_description_comment_text: "site description comment",
               additional_evidence_comment_text: "additional evidence comment",
@@ -126,28 +126,28 @@ RSpec.describe AssessmentDetailsReview do
 
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
 
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
 
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
 
           it "updates consultation summary" do
             expect(consultation_summary.reload).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
@@ -181,10 +181,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :rejected,
-              site_description_review_status: :rejected,
-              additional_evidence_review_status: :rejected,
-              consultation_summary_review_status: :rejected,
+              summary_of_work_reviewer_verdict: :rejected,
+              site_description_reviewer_verdict: :rejected,
+              additional_evidence_reviewer_verdict: :rejected,
+              consultation_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "",
               site_description_comment_text: "",
               additional_evidence_comment_text: "",
@@ -229,10 +229,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :edited_and_accepted,
-              site_description_review_status: :edited_and_accepted,
-              additional_evidence_review_status: :edited_and_accepted,
-              consultation_summary_review_status: :edited_and_accepted,
+              summary_of_work_reviewer_verdict: :edited_and_accepted,
+              site_description_reviewer_verdict: :edited_and_accepted,
+              additional_evidence_reviewer_verdict: :edited_and_accepted,
+              consultation_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "edited summary of work",
               site_description_entry: "edited site description",
               additional_evidence_entry: "edited additional evidence",
@@ -242,7 +242,7 @@ RSpec.describe AssessmentDetailsReview do
 
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited summary of work"
             )
@@ -250,7 +250,7 @@ RSpec.describe AssessmentDetailsReview do
 
           it "updates site description" do
             expect(site_description.reload).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited site description"
             )
@@ -258,7 +258,7 @@ RSpec.describe AssessmentDetailsReview do
 
           it "updates additional evidence" do
             expect(additional_evidence.reload).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited additional evidence"
             )
@@ -266,7 +266,7 @@ RSpec.describe AssessmentDetailsReview do
 
           it "updates consultation summary" do
             expect(consultation_summary.reload).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited consultation summary"
             )
@@ -277,10 +277,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :edited_and_accepted,
-              site_description_review_status: :edited_and_accepted,
-              additional_evidence_review_status: :edited_and_accepted,
-              consultation_summary_review_status: :edited_and_accepted,
+              summary_of_work_reviewer_verdict: :edited_and_accepted,
+              site_description_reviewer_verdict: :edited_and_accepted,
+              additional_evidence_reviewer_verdict: :edited_and_accepted,
+              consultation_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "",
               site_description_entry: "",
               additional_evidence_entry: "",
@@ -325,10 +325,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :edited_and_accepted,
-              site_description_review_status: :edited_and_accepted,
-              additional_evidence_review_status: :edited_and_accepted,
-              consultation_summary_review_status: :edited_and_accepted,
+              summary_of_work_reviewer_verdict: :edited_and_accepted,
+              site_description_reviewer_verdict: :edited_and_accepted,
+              additional_evidence_reviewer_verdict: :edited_and_accepted,
+              consultation_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "summary of work",
               site_description_entry: "site description",
               additional_evidence_entry: "additional evidence",
@@ -373,10 +373,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: nil,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: nil,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -391,16 +391,16 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :complete,
-              summary_of_work_review_status: :accepted,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: :accepted,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
           it "updates summary of work" do
             expect(summary_of_work.reload).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_complete"
             )
           end
@@ -410,16 +410,16 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :complete,
-              summary_of_work_review_status: nil,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: nil,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
           it "sets an error" do
             expect(
-              assessment_details_review.errors.messages[:summary_of_work_review_status]
+              assessment_details_review.errors.messages[:summary_of_work_reviewer_verdict]
             ).to contain_exactly(
               "can't be blank"
             )
@@ -436,10 +436,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :accepted,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: :accepted,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -447,7 +447,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.summary_of_work
             ).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
@@ -456,7 +456,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.additional_evidence
             ).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
@@ -465,7 +465,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.site_description
             ).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
@@ -474,7 +474,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.consultation_summary
             ).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_in_progress"
             )
           end
@@ -484,10 +484,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :rejected,
-              site_description_review_status: :rejected,
-              additional_evidence_review_status: :rejected,
-              consultation_summary_review_status: :rejected,
+              summary_of_work_reviewer_verdict: :rejected,
+              site_description_reviewer_verdict: :rejected,
+              additional_evidence_reviewer_verdict: :rejected,
+              consultation_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "summary of work comment",
               site_description_comment_text: "site description comment",
               additional_evidence_comment_text: "additional evidence comment",
@@ -499,7 +499,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.summary_of_work
             ).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
@@ -508,7 +508,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.additional_evidence
             ).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
@@ -517,7 +517,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.site_description
             ).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
@@ -526,7 +526,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.consultation_summary
             ).to have_attributes(
-              review_status: "rejected",
+              reviewer_verdict: "rejected",
               status: "review_in_progress"
             )
           end
@@ -568,10 +568,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :rejected,
-              site_description_review_status: :rejected,
-              additional_evidence_review_status: :rejected,
-              consultation_summary_review_status: :rejected,
+              summary_of_work_reviewer_verdict: :rejected,
+              site_description_reviewer_verdict: :rejected,
+              additional_evidence_reviewer_verdict: :rejected,
+              consultation_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "",
               site_description_comment_text: "",
               additional_evidence_comment_text: "",
@@ -616,10 +616,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :edited_and_accepted,
-              site_description_review_status: :edited_and_accepted,
-              additional_evidence_review_status: :edited_and_accepted,
-              consultation_summary_review_status: :edited_and_accepted,
+              summary_of_work_reviewer_verdict: :edited_and_accepted,
+              site_description_reviewer_verdict: :edited_and_accepted,
+              additional_evidence_reviewer_verdict: :edited_and_accepted,
+              consultation_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "edited summary of work",
               site_description_entry: "edited site description",
               additional_evidence_entry: "edited additional evidence",
@@ -631,7 +631,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.summary_of_work
             ).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited summary of work"
             )
@@ -641,7 +641,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.site_description
             ).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited site description"
             )
@@ -651,7 +651,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.additional_evidence
             ).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited additional evidence"
             )
@@ -661,7 +661,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.consultation_summary
             ).to have_attributes(
-              review_status: "edited_and_accepted",
+              reviewer_verdict: "edited_and_accepted",
               status: "review_in_progress",
               entry: "edited consultation summary"
             )
@@ -672,10 +672,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: :edited_and_accepted,
-              site_description_review_status: :edited_and_accepted,
-              additional_evidence_review_status: :edited_and_accepted,
-              consultation_summary_review_status: :edited_and_accepted,
+              summary_of_work_reviewer_verdict: :edited_and_accepted,
+              site_description_reviewer_verdict: :edited_and_accepted,
+              additional_evidence_reviewer_verdict: :edited_and_accepted,
+              consultation_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "",
               site_description_entry: "",
               additional_evidence_entry: "",
@@ -720,10 +720,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :in_progress,
-              summary_of_work_review_status: nil,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: nil,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -738,10 +738,10 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :complete,
-              summary_of_work_review_status: :accepted,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: :accepted,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -749,7 +749,7 @@ RSpec.describe AssessmentDetailsReview do
             expect(
               planning_application.reload.summary_of_work
             ).to have_attributes(
-              review_status: "accepted",
+              reviewer_verdict: "accepted",
               status: "review_complete"
             )
           end
@@ -759,16 +759,16 @@ RSpec.describe AssessmentDetailsReview do
           let(:params) do
             {
               status: :complete,
-              summary_of_work_review_status: nil,
-              additional_evidence_review_status: :accepted,
-              site_description_review_status: :accepted,
-              consultation_summary_review_status: :accepted
+              summary_of_work_reviewer_verdict: nil,
+              additional_evidence_reviewer_verdict: :accepted,
+              site_description_reviewer_verdict: :accepted,
+              consultation_summary_reviewer_verdict: :accepted
             }
           end
 
           it "sets an error" do
             expect(
-              assessment_details_review.errors.messages[:summary_of_work_review_status]
+              assessment_details_review.errors.messages[:summary_of_work_reviewer_verdict]
             ).to contain_exactly(
               "can't be blank"
             )
@@ -781,10 +781,10 @@ RSpec.describe AssessmentDetailsReview do
       let(:params) do
         {
           status: :complete,
-          summary_of_work_review_status: :accepted,
-          additional_evidence_review_status: :accepted,
-          site_description_review_status: :accepted,
-          consultation_summary_review_status: :rejected,
+          summary_of_work_reviewer_verdict: :accepted,
+          additional_evidence_reviewer_verdict: :accepted,
+          site_description_reviewer_verdict: :accepted,
+          consultation_summary_reviewer_verdict: :rejected,
           consultation_summary_comment_text: "consultation summary comment"
         }
       end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1084,7 +1084,7 @@ RSpec.describe PlanningApplication, type: :model do
   describe "#rejected_assessment_detail" do
     let(:planning_application) { create(:planning_application) }
     let(:status) { :review_complete }
-    let(:review_status) { :rejected }
+    let(:reviewer_verdict) { :rejected }
     let(:challenged) { true }
     let(:recommendation_status) { :review_complete }
 
@@ -1094,7 +1094,7 @@ RSpec.describe PlanningApplication, type: :model do
         :summary_of_work,
         planning_application: planning_application,
         status: status,
-        review_status: review_status
+        reviewer_verdict: reviewer_verdict
       )
     end
 
@@ -1143,7 +1143,7 @@ RSpec.describe PlanningApplication, type: :model do
     end
 
     context "when assessment_detail accepted" do
-      let(:review_status) { :accepted }
+      let(:reviewer_verdict) { :accepted }
 
       it "returns nil" do
         expect(

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1085,8 +1085,6 @@ RSpec.describe PlanningApplication, type: :model do
     let(:planning_application) { create(:planning_application) }
     let(:review_status) { :complete }
     let(:reviewer_verdict) { :rejected }
-    let(:challenged) { true }
-    let(:recommendation_status) { :review_complete }
 
     let!(:assessment_detail) do
       create(
@@ -1098,47 +1096,13 @@ RSpec.describe PlanningApplication, type: :model do
       )
     end
 
-    before do
-      create(
-        :recommendation,
-        planning_application: planning_application,
-        challenged: challenged,
-        status: recommendation_status,
-        reviewer_comment: "challenged"
-      )
-    end
-
-    context "when recommendation and assessment detail are both rejected" do
+    context "when assessment detail is rejected" do
       it "returns assessment_detail" do
         expect(
           planning_application.rejected_assessment_detail(
             category: :summary_of_work
           )
         ).to eq(assessment_detail)
-      end
-    end
-
-    context "when recommendation not challenged" do
-      let(:challenged) { false }
-
-      it "returns nil" do
-        expect(
-          planning_application.rejected_assessment_detail(
-            category: :summary_of_work
-          )
-        ).to eq(nil)
-      end
-    end
-
-    context "when recommendation review not complete" do
-      let(:recommendation_status) { :review_in_progress }
-
-      it "returns nil" do
-        expect(
-          planning_application.rejected_assessment_detail(
-            category: :summary_of_work
-          )
-        ).to eq(nil)
       end
     end
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1083,7 +1083,7 @@ RSpec.describe PlanningApplication, type: :model do
 
   describe "#rejected_assessment_detail" do
     let(:planning_application) { create(:planning_application) }
-    let(:status) { :review_complete }
+    let(:review_status) { :complete }
     let(:reviewer_verdict) { :rejected }
     let(:challenged) { true }
     let(:recommendation_status) { :review_complete }
@@ -1093,7 +1093,7 @@ RSpec.describe PlanningApplication, type: :model do
         :assessment_detail,
         :summary_of_work,
         planning_application: planning_application,
-        status: status,
+        review_status: review_status,
         reviewer_verdict: reviewer_verdict
       )
     end
@@ -1155,7 +1155,7 @@ RSpec.describe PlanningApplication, type: :model do
     end
 
     context "when assessment_detail review not complete" do
-      let(:status) { :review_in_progress }
+      let(:review_status) { :in_progress }
 
       it "returns nil" do
         expect(

--- a/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
@@ -77,7 +77,12 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       )
 
       click_link("Review assessment summaries")
-      within(find("fieldset", text: "Summary of works")) { choose("Accept") }
+
+      within(find("fieldset", text: "Summary of works")) do
+        expect(find(".govuk-tag")).to have_content("Complete")
+
+        choose("Accept")
+      end
 
       click_button("Save and mark as complete")
 
@@ -168,6 +173,12 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       choose("recommendation_challenged_true")
       fill_in("Review comment", with: "recommendation challenged")
       click_button("Save and mark as complete")
+      click_link("Review assessment summaries")
+
+      within(find("fieldset", text: "Consultation")) do
+        expect(find(".govuk-tag")).to have_content("To be reviewed")
+      end
+
       click_link("Log out")
       sign_in(assessor)
       visit(planning_application_path(planning_application))
@@ -224,13 +235,25 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       click_link("Review assessment summaries")
       expect(page).to have_content("updated consultation summary")
 
-      within(find("fieldset", text: "Consultation")) { choose("Accept") }
+      within(find("fieldset", text: "Consultation")) do
+        expect(find(".govuk-tag")).to have_content("Updated")
+
+        choose("Accept")
+      end
+
       click_button("Save and mark as complete")
 
       expect(page).to have_list_item_for(
         "Review assessment summaries", with: "Checked"
       )
 
+      click_link("Review assessment summaries")
+
+      within(find("fieldset", text: "Consultation")) do
+        expect(find(".govuk-tag")).to have_content("Complete")
+      end
+
+      click_link("Review")
       click_link("Sign-off recommendation")
       choose("recommendation_challenged_false")
       click_button("Save and mark as complete")
@@ -292,7 +315,12 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       )
 
       click_link("Review assessment summaries")
-      within(find("fieldset", text: "Summary of works")) { choose("Accept") }
+
+      within(find("fieldset", text: "Summary of works")) do
+        expect(find(".govuk-tag")).to have_content("Not started")
+
+        choose("Accept")
+      end
 
       click_button("Save and mark as complete")
 

--- a/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       create(
         :assessment_detail,
         :summary_of_work,
-        status: :assessment_complete,
+        assessment_status: :complete,
         planning_application: planning_application,
         user: assessor,
         entry: "summary of works"
@@ -35,7 +35,7 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       create(
         :assessment_detail,
         :site_description,
-        status: :assessment_complete,
+        assessment_status: :complete,
         planning_application: planning_application,
         user: assessor,
         entry: "site description"
@@ -46,7 +46,7 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       create(
         :assessment_detail,
         :consultation_summary,
-        status: :assessment_complete,
+        assessment_status: :complete,
         planning_application: planning_application,
         user: assessor,
         entry: "consultation summary"
@@ -55,7 +55,7 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       create(
         :assessment_detail,
         :additional_evidence,
-        status: :assessment_complete,
+        assessment_status: :complete,
         planning_application: planning_application,
         user: assessor,
         entry: "additional evidence"

--- a/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
@@ -82,15 +82,15 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       click_button("Save and mark as complete")
 
       expect(page).to have_content(
-        "Additional evidence review status can't be blank"
+        "Additional evidence reviewer verdict can't be blank"
       )
 
       expect(page).to have_content(
-        "Site description review status can't be blank"
+        "Site description reviewer verdict can't be blank"
       )
 
       expect(page).to have_content(
-        "Consultation summary review status can't be blank"
+        "Consultation summary reviewer verdict can't be blank"
       )
 
       click_button("Save and come back later")
@@ -297,15 +297,15 @@ RSpec.describe "reviewing assessment summaries", type: :system do
       click_button("Save and mark as complete")
 
       expect(page).to have_content(
-        "Additional evidence review status can't be blank"
+        "Additional evidence reviewer verdict can't be blank"
       )
 
       expect(page).to have_content(
-        "Site description review status can't be blank"
+        "Site description reviewer verdict can't be blank"
       )
 
       expect(page).to have_content(
-        "Consultation summary review status can't be blank"
+        "Consultation summary reviewer verdict can't be blank"
       )
 
       click_button("Save and come back later")


### PR DESCRIPTION
### Description of change

- Rename `review_status` to `reviewer_verdict`, since what it contains is the reviewer decision which isn't really a status!
- Split `status` into `assessor_status` and `reviewer_status`, since we want to preserve information about the assessor's activity even when the record has been reviewed.
- Add logic to `ReviewerAssessmentDetailComponent` to display all statuses.

### Story Link

https://trello.com/c/DdrC2wdW/1344-review-assessment-summary-page-status-tags

### Screenshots

As per the trello ticket: When the assessor has not filled out the assessment:
<img width="50%" alt="Screenshot 2022-11-28 at 10 55 12" src="https://user-images.githubusercontent.com/25392162/204261012-6c05ee50-9cea-42e3-8031-65a8b1f601c7.png">

When the assessor has completed the assessment:
<img width="50%" alt="Screenshot 2022-11-28 at 10 55 28" src="https://user-images.githubusercontent.com/25392162/204261022-f900a975-9298-4490-92f3-ac147566df31.png">

When the reviewer has requested that the assessor amend the assessment:
<img width="50%" alt="Screenshot 2022-11-28 at 10 55 58" src="https://user-images.githubusercontent.com/25392162/204261066-fde0c394-c285-459b-acce-8a6ae99e09c1.png">

When the assessor has amended assessment (nb https://trello.com/c/w2Z6jsct/1343-reviewer-and-assessor-can-see-audit-of-previous-assessments will involve adding the 'previous assessments' section so the reviewer can see what changes have been made):
<img width="50%" alt="Screenshot 2022-11-28 at 10 56 22" src="https://user-images.githubusercontent.com/25392162/204261071-692629c7-1ef0-4a32-b344-7ed5f5395335.png">

