### PR TITLE
Show previous assessments on review assessment summaries page

### DIFF
--- a/app/components/assessment_details/previous_summaries_component.html.erb
+++ b/app/components/assessment_details/previous_summaries_component.html.erb
@@ -1,0 +1,19 @@
+<% if assessment_details.present? %>
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <%= t(".see_previous_summaries") %>
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <% assessment_details.each do |assessment_detail| %>
+      <%= render(
+        AssessmentDetails::PreviousSummaryComponent.new(
+          assessment_details: assessment_details,
+          assessment_detail: assessment_detail
+        )
+      ) %>
+      <% end %>
+    </div>
+  </details>
+<% end %>

--- a/app/components/assessment_details/previous_summaries_component.rb
+++ b/app/components/assessment_details/previous_summaries_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module AssessmentDetails
+  class PreviousSummariesComponent < ViewComponent::Base
+    def initialize(planning_application:, category:)
+      @planning_application = planning_application
+      @category = category
+    end
+
+    private
+
+    attr_reader :planning_application, :category
+
+    def assessment_details
+      planning_application.assessment_details.where(category: category)[1..]
+    end
+  end
+end

--- a/app/components/assessment_details/previous_summary_component.html.erb
+++ b/app/components/assessment_details/previous_summary_component.html.erb
@@ -1,0 +1,16 @@
+<div class="govuk-!-margin-left-4">
+  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+    <%= t(".user_marked_this", user: comment.user.name) %>
+  </p>
+  <p class="govuk-body govuk-!-margin-top-1"><%= comment.created_at %></p>
+  <%= simple_format(comment.text, { class: "govuk-body" }) %>
+</div>
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
+  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+    <%= description %>
+  </p>
+  <p class="govuk-body govuk-!-margin-top-0">
+    <%= assessment_detail.created_at %>
+  </p>
+  <%= simple_format(assessment_detail.entry, { class: "govuk-body" }) %>
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/components/assessment_details/previous_summary_component.rb
+++ b/app/components/assessment_details/previous_summary_component.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module AssessmentDetails
+  class PreviousSummaryComponent < ViewComponent::Base
+    def initialize(assessment_details:, assessment_detail:)
+      @assessment_details = assessment_details
+      @assessment_detail = assessment_detail
+    end
+
+    private
+
+    delegate(:comment, to: :assessment_detail)
+
+    attr_reader :assessment_details, :assessment_detail
+
+    def description
+      action = assessment_detail == assessment_details.last ? :created : :updated
+      key = ".user_#{action}_#{assessment_detail.category}"
+      t(key, user: assessment_detail.user.name)
+    end
+  end
+end

--- a/app/views/assessment_details_reviews/_form.html.erb
+++ b/app/views/assessment_details_reviews/_form.html.erb
@@ -30,6 +30,12 @@
         form.object.send("#{assessment_detail}_entry"),
         { class: "govuk-body govuk-!-margin-top-2" }
       ) %>
+      <%= render(
+        AssessmentDetails::PreviousSummariesComponent.new(
+          planning_application: planning_application,
+          category: assessment_detail
+        )
+      ) %>
       <%= form.govuk_radio_button(
         "#{assessment_detail}_reviewer_verdict",
         :accepted,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,18 @@ en:
     past_applications: History
     past_applications_successfully_created: History successfully added.
     past_applications_successfully_updated: History successfully updated.
+    previous_summaries_component:
+      see_previous_summaries: See previous summaries
+    previous_summary_component:
+      user_created_additional_evidence: "%{user} created additional evidence"
+      user_created_consultation_summary: "%{user} created consultation summary"
+      user_created_site_description: "%{user} created site description"
+      user_created_summary_of_work: "%{user} created summary of works"
+      user_marked_this: "%{user} marked this for review"
+      user_updated_additional_evidence: "%{user} updated additional evidence"
+      user_updated_consultation_summary: "%{user} updated consultation summary"
+      user_updated_site_description: "%{user} updated site description"
+      user_updated_summary_of_work: "%{user} updated summary of works"
     show_additional_evidence: Detail of additional evidence
     show_consultation_summary: Consultation details
     show_past_applications: History
@@ -157,13 +169,6 @@ en:
       refused: To refuse
       review_assessment_summaries: Review assessment summaries
       this_information_will: This information WILL be made public
-    previous_assessment_details:
-      see_previous_summaries: See previous summaries
-      user_marked_this: "%{user} marked this for review"
-      user_updated_additional_evidence: "%{user} updated additional evidence"
-      user_updated_consultation_summary: "%{user} updated consultation summary"
-      user_updated_site_description: "%{user} updated site description"
-      user_updated_summary_of_work: "%{user} updated summary of works"
     saved: Review saved
   assessment_report_downloads:
     show:

--- a/spec/components/assessment_details/previous_summaries_component_spec.rb
+++ b/spec/components/assessment_details/previous_summaries_component_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessmentDetails::PreviousSummariesComponent, type: :component do
+  let(:planning_application) { create(:planning_application) }
+  let(:assessor) { create(:user, :assessor, name: "Alice Smith") }
+  let(:reviewer) { create(:user, :reviewer, name: "Bella Jones") }
+
+  let(:assessment_detail1) do
+    create(
+      :assessment_detail,
+      :summary_of_work,
+      planning_application: planning_application,
+      user: assessor,
+      entry: "version 1",
+      created_at: Time.zone.local(2022, 11, 28, 10, 15)
+    )
+  end
+
+  let(:assessment_detail2) do
+    create(
+      :assessment_detail,
+      :summary_of_work,
+      planning_application: planning_application,
+      user: assessor,
+      entry: "version 2",
+      created_at: Time.zone.local(2022, 11, 29, 10, 15)
+    )
+  end
+
+  before do
+    Current.user = reviewer
+
+    create(
+      :comment,
+      commentable: assessment_detail1,
+      text: "comment 1",
+      created_at: Time.zone.local(2022, 11, 28, 10, 30)
+    )
+
+    create(
+      :comment,
+      commentable: assessment_detail2,
+      text: "comment 2",
+      created_at: Time.zone.local(2022, 11, 29, 10, 30)
+    )
+
+    create(
+      :assessment_detail,
+      :summary_of_work,
+      planning_application: planning_application,
+      user: assessor,
+      entry: "version 3",
+      created_at: Time.zone.local(2022, 11, 30, 10, 15)
+    )
+
+    component = described_class.new(
+      planning_application: planning_application,
+      category: :summary_of_work
+    )
+
+    render_inline(component)
+  end
+
+  it "renders first summary" do
+    expect(page).to have_content("Alice Smith created summary of works")
+    expect(page).to have_content("28 November 2022 10:15")
+    expect(page).to have_content("version 1")
+  end
+
+  it "renders first comment" do
+    expect(page).to have_content("Bella Jones marked this for review")
+    expect(page).to have_content("28 November 2022 10:30")
+    expect(page).to have_content("comment 1")
+  end
+
+  it "renders second summary" do
+    expect(page).to have_content("Alice Smith updated summary of works")
+    expect(page).to have_content("29 November 2022 10:15")
+    expect(page).to have_content("version 2")
+  end
+
+  it "renders second comment" do
+    expect(page).to have_content("Bella Jones marked this for review")
+    expect(page).to have_content("29 November 2022 10:30")
+    expect(page).to have_content("comment 2")
+  end
+
+  it "does not render third summary" do
+    expect(page).not_to have_content("version 3")
+  end
+end


### PR DESCRIPTION
### Description of change

For each category of `assessment_detail`, show previous records and associated comments on 'Review assessment summaries' page.

### Story Link

https://trello.com/c/VrNtQVe7/1355-show-reviewer-comment-on-assessment-summary-page

### Screenshot

<img width="50%" alt="Screenshot 2022-11-28 at 15 50 14" src="https://user-images.githubusercontent.com/25392162/204321752-cdee8c11-84b9-4615-a39c-5167a90b0813.png">