### PR TITLE
Show reviewer comment on assessment details page

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -310,3 +310,7 @@ html * {
     display: none;
   }
 }
+
+.italic {
+  font-style: italic;
+}

--- a/app/views/planning_application/assessment_details/_comment.html.erb
+++ b/app/views/planning_application/assessment_details/_comment.html.erb
@@ -1,0 +1,9 @@
+<% if comment.present? %>
+  <div class="govuk-inset-text">
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+      <%= t(".user_marked_this", user: comment.user.name) %>
+    </p>
+    <p class="govuk-body govuk-!-margin-top-1"><%= comment.created_at %></p>
+    <%= simple_format(comment.text, { class: "govuk-body italic" }) %>
+  </div>
+<% end %>

--- a/app/views/planning_application/assessment_details/_form.html.erb
+++ b/app/views/planning_application/assessment_details/_form.html.erb
@@ -1,7 +1,8 @@
 <%= render(
   "planning_application/assessment_details/#{category}/information",
   category: category,
-  read_only: false
+  read_only: false,
+  rejected_assessment_detail: rejected_assessment_detail
 ) %>
 
 <%= form_with model: [@planning_application, @assessment_detail], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
@@ -13,10 +14,7 @@
     partial: "#{assessment_detail_fields_partial_path(category)}/form_fields",
     locals: {
       form: form,
-      rejected_assessment_detail: local_assigns.fetch(
-        :rejected_assessment_detail,
-        nil
-      )
+      rejected_assessment_detail: rejected_assessment_detail
     }
   ) %>
 

--- a/app/views/planning_application/assessment_details/additional_evidence/_information.html.erb
+++ b/app/views/planning_application/assessment_details/additional_evidence/_information.html.erb
@@ -2,7 +2,10 @@
   <strong class="govuk-!-padding-bottom-3">What is the impact of any additional evidence on the application?</strong>
 
   <p class="govuk-!-padding-bottom-3">This information will <strong>NOT</strong> be made public.</p>
-
+  <%= render(
+    partial: "comment",
+    locals: { comment: rejected_assessment_detail&.comment }
+  ) %>
   <% unless action_name == "show" %>
     <p>Optional. Enter any additional information that will impact the assessment of this application.</p>
   <% end %>

--- a/app/views/planning_application/assessment_details/consultation_summary/_form_fields.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_form_fields.html.erb
@@ -7,6 +7,10 @@
   partial: "shared/warning_text",
   locals: { message: t(".this_information_will") }
 ) %>
+<%= render(
+  partial: "comment",
+  locals: { comment: rejected_assessment_detail&.comment }
+) %>
 <%= form.govuk_text_area(
   :entry,
   label: nil,

--- a/app/views/planning_application/assessment_details/edit.html.erb
+++ b/app/views/planning_application/assessment_details/edit.html.erb
@@ -17,6 +17,11 @@
 
     <%= render "shared/planning_application_address_and_reference" %>
 
-    <%= render "form", planning_application: @planning_application, category: @assessment_detail.category %>
+    <%= render(
+      "form",
+      planning_application: @planning_application,
+      category: @assessment_detail.category,
+      rejected_assessment_detail: nil
+    ) %>
   </div>
 </div>

--- a/app/views/planning_application/assessment_details/show.html.erb
+++ b/app/views/planning_application/assessment_details/show.html.erb
@@ -21,7 +21,8 @@
       <%= render(
         "planning_application/assessment_details/#{@assessment_detail.category}/information",
         category: @assessment_detail.category,
-        read_only: true
+        read_only: true,
+        rejected_assessment_detail: nil
       ) %>
 
       <%= render(

--- a/app/views/planning_application/assessment_details/site_description/_information.html.erb
+++ b/app/views/planning_application/assessment_details/site_description/_information.html.erb
@@ -7,7 +7,10 @@
 
   <%= render "shared/warning_text",
       message: "This information WILL be made public" %>
-
+  <%= render(
+    partial: "comment",
+    locals: { comment: rejected_assessment_detail&.comment }
+  ) %>
   <% unless action_name == "show" %>
     <p>You can include:</p>
     <ul>

--- a/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
+++ b/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
@@ -7,7 +7,10 @@
 
   <%= render "shared/warning_text",
       message: "This information WILL be made public" %>
-
+  <%= render(
+    partial: "comment",
+    locals: { comment: rejected_assessment_detail&.comment }
+  ) %>
   <% unless action_name == "show" %>
     <p>You can include:</p>
     <ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -350,6 +350,8 @@ en:
     to_be_reviewed: To be reviewed
   planning_application:
     assessment_details:
+      comment:
+        user_marked_this: "%{user} marked this for review"
       consultation_summary:
         consultee_form:
           add_consultee: Add consultee

--- a/spec/models/validation_requestable_spec.rb
+++ b/spec/models/validation_requestable_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe ValidationRequestable, type: :model do
     describe "#auto_close_request!" do
       let(:planning_application) { create(:planning_application) }
 
-      let(:request) do
+      let!(:request) do
         create(
           :red_line_boundary_change_validation_request,
           :open,
@@ -375,6 +375,7 @@ RSpec.describe ValidationRequestable, type: :model do
       end
 
       it "creates audit with correct information" do
+        travel_to(5.minutes.from_now)
         request.auto_close_request!
 
         expect(planning_application.audits.reload.last).to have_attributes(

--- a/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing_assessment_summaries_spec.rb
@@ -218,6 +218,10 @@ RSpec.describe "reviewing assessment summaries", type: :system do
 
       click_link("Summary of consultation")
 
+      expect(page).to have_content("Bella Jones marked this for review")
+      expect(page).to have_content("28 November 2022 12:30")
+      expect(page).to have_content("consultation comment")
+
       expect(page).to have_field(
         "assessment-detail-entry-field",
         with: "consultation summary"


### PR DESCRIPTION
### Description of change

Show comment associated with a previous rejected assessment summary on assessment summary page.

### Story Link

https://trello.com/c/Y2gLp0mY/1354-show-reviewer-comment-on-assessment-summary-page

### Screenshot

<img width="60%" alt="Screenshot 2022-11-28 at 19 46 38" src="https://user-images.githubusercontent.com/25392162/204367671-72b1ed43-bccd-4181-8208-fb28c94e9cdc.png">
