### PR TITLE
Pr notapatch refactor recommendation last acs

### DIFF
--- a/app/components/review_policy_classes/navigation_component.html.erb
+++ b/app/components/review_policy_classes/navigation_component.html.erb
@@ -1,0 +1,18 @@
+<% if multiple_policy_classes? %>
+  <div class="policy-class-scroll-links">
+    <% if @policy_class.previous.present? %>
+      <%= link_to(
+            t(".view_previous_class"),
+            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.previous),
+            class: "govuk-link"
+          ) %>
+    <% end %>
+    <% if @policy_class.next.present? %>
+      <%= link_to(
+            t(".view_next_class"),
+            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.next),
+            class: "govuk-link next-policy-class-link"
+          ) %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/review_policy_classes/navigation_component.rb
+++ b/app/components/review_policy_classes/navigation_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ReviewPolicyClasses
+  class NavigationComponent < ViewComponent::Base
+    def initialize(policy_class:)
+      @policy_class = policy_class
+    end
+
+    private
+
+    def multiple_policy_classes?
+      @policy_class.planning_application.policy_classes.count > 1
+    end
+  end
+end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -57,7 +57,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def update
-    if @planning_application.recommendations.last.present? && !@planning_application.recommendations.last.submitted
+    if @planning_application.recommendation.present? && !@planning_application.recommendation.submitted
       flash.now[:alert] = "Please complete in draft assessment before updating application fields."
     end
 
@@ -155,8 +155,8 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def view_recommendation
-    @assessor_name = @planning_application.recommendations.last.assessor.name
-    @recommended_date = @planning_application.recommendations.last.created_at.strftime("%d %b %Y")
+    @assessor_name = @planning_application.recommendation.assessor.name
+    @recommended_date = @planning_application.recommendation.created_at.strftime("%d %b %Y")
   end
 
   def withdraw_recommendation

--- a/app/models/assessment_details_review.rb
+++ b/app/models/assessment_details_review.rb
@@ -102,7 +102,7 @@ class AssessmentDetailsReview
   private
 
   def recommendation_not_accepted
-    return unless planning_application.recommendation.accepted?
+    return unless planning_application.last_recommendation_accepted?
 
     errors.add(:base, :recommendation_accepted)
   end

--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -109,13 +109,13 @@ module PlanningApplicationStatus
       event :submit do
         transitions from: :in_assessment, to: :awaiting_determination,
                     guards: %i[decision_present? no_open_post_validation_requests?] do
-          after { recommendations.last.update!(submitted: true) }
+          after { recommendation.update!(submitted: true) }
         end
       end
 
       event :withdraw_recommendation do
         transitions from: :awaiting_determination, to: :in_assessment do
-          after { recommendations.last.update!(submitted: false) }
+          after { recommendation.update!(submitted: false) }
         end
       end
 

--- a/app/models/permitted_development_right.rb
+++ b/app/models/permitted_development_right.rb
@@ -64,8 +64,7 @@ class PermittedDevelopmentRight < ApplicationRecord
   end
 
   def planning_application_can_review_assessment
-    return unless reviewed_at_changed?
-    return unless planning_application.recommendation.try(:accepted?)
+    return unless planning_application.last_recommendation_accepted?
 
     errors.add(
       :base,

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -263,7 +263,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def existing_or_new_recommendation
-    recommendations.last || recommendations.build
+    recommendation || recommendations.build
   end
 
   def proposal_details
@@ -390,7 +390,7 @@ class PlanningApplication < ApplicationRecord
         planning_application_id: id,
         user: Current.user,
         activity_type: "submitted",
-        audit_comment: { assessor_comment: recommendations.last.assessor_comment }.to_json
+        audit_comment: { assessor_comment: recommendation.assessor_comment }.to_json
       )
     end
 
@@ -484,6 +484,12 @@ class PlanningApplication < ApplicationRecord
 
   def recommendation
     @recommendation ||= recommendations.last
+  end
+
+  def last_recommendation_accepted?
+    return false unless recommendation
+
+    recommendation.accepted?
   end
 
   def permitted_development_right

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -27,7 +27,7 @@ class Recommendation < ApplicationRecord
   )
 
   def current_recommendation?
-    planning_application.recommendations.last == self
+    planning_application.recommendation == self
   end
 
   def reviewed?

--- a/app/models/review_policy_class.rb
+++ b/app/models/review_policy_class.rb
@@ -8,4 +8,17 @@ class ReviewPolicyClass < ApplicationRecord
 
   validates :mark, presence: true
   validates :comment, presence: true, if: :return_to_officer_with_comment?
+  validate :recommendation_not_accepted
+
+  def last_recommendation_accepted?
+    policy_class&.planning_application&.last_recommendation_accepted?
+  end
+
+  private
+
+  def recommendation_not_accepted
+    return unless last_recommendation_accepted?
+
+    errors.add(:base, :recommendation_accepted)
+  end
 end

--- a/app/views/planning_application/review_policy_classes/edit.html.erb
+++ b/app/views/planning_application/review_policy_classes/edit.html.erb
@@ -54,6 +54,8 @@
           html: { data: unsaved_changes_data },
           builder: GOVUKDesignSystemFormBuilder::FormBuilder
         ) do |form| %>
+      <%= render(ReviewPolicyClasses::NavigationComponent.new(policy_class: @policy_class)) %>
+
       <%= form.fields_for :review_policy_class, @policy_class.review_policy_class do |review_form| %>
         <div class="govuk-form-group <%= review_form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
           <fieldset class="govuk-fieldset">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,10 @@ en:
           attributes:
             status:
               policies_to_be_determined: All policies must be assessed
+        review_policy_class:
+          attributes:
+            base:
+              recommendation_accepted: You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen
   additional_document_validation_requests:
     create:
       success: Additional document request successfully created.
@@ -400,8 +404,6 @@ en:
         review_heading: Review - Part%{part}, Class %{class}
         table_caption: Part %{part}, Class %{class} - %{name}
         to_be_determined: To be determined
-        view_next_class: View next class
-        view_previous_class: View previous class
       show:
         application: Application
         home: Home
@@ -551,6 +553,10 @@ en:
       no_legislation_assessed: No legislation assessed for this application.
     new:
       assess_recommendation: Assess recommendation
+  review_policy_classes:
+    navigation_component:
+      view_next_class: View next class
+      view_previous_class: View previous class
   shared:
     administrator_layout:
       add_user: Add user

--- a/spec/components/review_policy_classes/navigation_component_spec.rb
+++ b/spec/components/review_policy_classes/navigation_component_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewPolicyClasses::NavigationComponent, type: :component do
+  let(:planning_application) { create(:planning_application) }
+
+  it "hides when the only policy class" do
+    policy_class = create(:policy_class, section: "C", planning_application: planning_application)
+
+    render_inline(described_class.new(policy_class: policy_class))
+
+    expect(page).not_to have_text "View previous class"
+    expect(page).not_to have_text "View next class"
+  end
+
+  it "displays previous with lower sort policy_class" do
+    prv = create(:policy_class, section: "B", planning_application: planning_application)
+    policy_class = create(:policy_class, section: "C", planning_application: planning_application)
+
+    render_inline(described_class.new(policy_class: policy_class))
+
+    expect(page).to have_link "View previous class",
+                              href: edit_planning_application_review_policy_class_path(planning_application, prv)
+    expect(page).not_to have_text "View next class"
+  end
+
+  it "displays next with higher sort policy_class" do
+    policy_class = create(:policy_class, section: "C", planning_application: planning_application)
+    nxt = create(:policy_class, section: "D", planning_application: planning_application)
+
+    render_inline(described_class.new(policy_class: policy_class))
+
+    expect(page).not_to have_text "View previous class"
+    expect(page).to have_link "View next class",
+                              href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+  end
+
+  it "displays both links with higher and lower sort policy_class" do
+    prv = create(:policy_class, section: "B", planning_application: planning_application)
+    policy_class = create(:policy_class, section: "C", planning_application: planning_application)
+    nxt = create(:policy_class, section: "D", planning_application: planning_application)
+
+    render_inline(described_class.new(policy_class: policy_class))
+
+    expect(page).to have_link "View previous class",
+                              href: edit_planning_application_review_policy_class_path(planning_application, prv)
+    expect(page).to have_link "View next class",
+                              href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+  end
+end

--- a/spec/models/concerns/planning_application_status_spec.rb
+++ b/spec/models/concerns/planning_application_status_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe PlanningApplicationStatus do
         it "sets the recommendation to submitted" do
           planning_application.submit
 
-          expect(planning_application.recommendations.last.submitted).to eq(true)
+          expect(planning_application.recommendation.submitted).to eq(true)
         end
 
         it "sets the timestamp for awaiting_determination_at to now" do
@@ -371,7 +371,7 @@ RSpec.describe PlanningApplicationStatus do
       it "sets recommendation submitted to false" do
         planning_application.withdraw_recommendation
 
-        expect(planning_application.recommendations.last.submitted).to eq(false)
+        expect(planning_application.recommendation.submitted).to eq(false)
       end
 
       it "sets the timestamp for awaiting_determination_at to now" do

--- a/spec/models/recommendation_form_spec.rb
+++ b/spec/models/recommendation_form_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe RecommendationForm do
 
         it "updates recommendation" do
           expect(
-            planning_application.reload.recommendations.last
+            planning_application.reload.recommendation
           ).to have_attributes(
             assessor: assessor,
             assessor_comment: "LGTM"
@@ -178,7 +178,7 @@ RSpec.describe RecommendationForm do
 
         it "updates recommendation" do
           expect(
-            planning_application.reload.recommendations.last
+            planning_application.reload.recommendation
           ).to have_attributes(
             assessor: assessor,
             assessor_comment: "LGTM"
@@ -209,7 +209,7 @@ RSpec.describe RecommendationForm do
 
         it "updates recommendation" do
           expect(
-            planning_application.reload.recommendations.last
+            planning_application.reload.recommendation
           ).to have_attributes(
             assessor: assessor,
             assessor_comment: "LGTM"
@@ -240,7 +240,7 @@ RSpec.describe RecommendationForm do
 
         it "updates recommendation" do
           expect(
-            planning_application.reload.recommendations.last
+            planning_application.reload.recommendation
           ).to have_attributes(
             assessor: assessor,
             assessor_comment: "LGTM"

--- a/spec/models/review_policy_class_spec.rb
+++ b/spec/models/review_policy_class_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ReviewPolicyClass, type: :model do
 
   describe "#valid?" do
     it "is true for factory" do
-      expect(review_policy_class.valid?).to eq(true)
+      expect(review_policy_class.valid?).to be(true)
     end
   end
 
@@ -31,6 +31,26 @@ RSpec.describe ReviewPolicyClass, type: :model do
         validation_request.mark = :accept
 
         expect { validation_request.valid? }.not_to change { validation_request.errors[:comment] }
+      end
+    end
+
+    describe "#recommendation_not_accepted" do
+      it "errors if recommendation accepted" do
+        allow_any_instance_of(described_class).to receive(:last_recommendation_accepted?).and_return(true)
+
+        expect { validation_request.valid? }.to change { validation_request.errors[:base] }.to ["You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen"]
+      end
+
+      it "does not errors if recommendation not accepted" do
+        allow_any_instance_of(described_class).to receive(:last_recommendation_accepted?).and_return(false)
+
+        expect { validation_request.valid? }.not_to change { validation_request.errors[:base] }
+      end
+
+      it "does not errors if recommendation has not been asked" do
+        allow_any_instance_of(described_class).to receive(:last_recommendation_accepted?).and_return(nil)
+
+        expect { validation_request.valid? }.not_to change { validation_request.errors[:base] }
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,4 +38,5 @@ RSpec.configure do |config|
 
   config.include(ActiveJob::TestHelper)
   config.include(SystemSpecHelpers)
+  config.include Rails.application.routes.url_helpers
 end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       planning_application.reload
       expect(planning_application.recommendations.count).to eq(2)
       expect(planning_application.public_comment).to eq("This is so granted and GDPO everything")
-      expect(planning_application.recommendations.last.assessor_comment).to eq("This is a private assessor comment")
+      expect(planning_application.recommendation.assessor_comment).to eq("This is a private assessor comment")
       expect(planning_application.decision).to eq("granted")
 
       click_link "Assess recommendation"

--- a/spec/system/planning_applications/reviewing/policy_class_spec.rb
+++ b/spec/system/planning_applications/reviewing/policy_class_spec.rb
@@ -161,6 +161,22 @@ RSpec.describe "Planning Application Reviewing Policy Class", type: :system do
       end
     end
 
+    it "displays policy class navigation" do
+      prv = create(:policy_class, section: "A", planning_application: planning_application)
+      policy_class = create(:policy_class, section: "B", planning_application: planning_application)
+      nxt = create(:policy_class, section: "C", planning_application: planning_application)
+      create(:policy, policy_class: policy_class)
+      visit(planning_application_review_tasks_path(planning_application))
+
+      expect(page).to have_selector("h1", text: "Review and sign-off")
+      click_on "Review assessment of Part 1, Class B"
+
+      expect(page).to have_link "View previous class",
+                                href: edit_planning_application_review_policy_class_path(planning_application, prv)
+      expect(page).to have_link "View next class",
+                                href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+    end
+
     it "can display errors" do
       policy_class = create(:policy_class, section: "A", planning_application: planning_application)
       create(:policy, policy_class: policy_class)

--- a/spec/system/planning_applications/reviewing_spec.rb
+++ b/spec/system/planning_applications/reviewing_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     planning_application.reload
     expect(planning_application.status).to eq("determined")
-    expect(planning_application.recommendations.last.reviewer).to eq(reviewer)
-    expect(planning_application.recommendations.last.reviewed_at).not_to be_nil
-    expect(planning_application.recommendations.last.reviewer_comment).to eq("Reviewer private comment")
+    expect(planning_application.recommendation.reviewer).to eq(reviewer)
+    expect(planning_application.recommendation.reviewed_at).not_to be_nil
+    expect(planning_application.recommendation.reviewer_comment).to eq("Reviewer private comment")
     expect(page).not_to have_content("Assigned to:")
     expect(page).not_to have_content("Process Application")
     expect(page).not_to have_content("Review and sign-off")
@@ -110,9 +110,9 @@ RSpec.describe "Planning Application Reviewing", type: :system do
 
     planning_application.reload
     expect(planning_application.status).to eq("awaiting_correction")
-    expect(planning_application.recommendations.last.reviewer).to eq(reviewer)
-    expect(planning_application.recommendations.last.reviewed_at).not_to be_nil
-    expect(planning_application.recommendations.last.reviewer_comment).to eq("Reviewer private comment")
+    expect(planning_application.recommendation.reviewer).to eq(reviewer)
+    expect(planning_application.recommendation.reviewed_at).not_to be_nil
+    expect(planning_application.recommendation.reviewer_comment).to eq("Reviewer private comment")
 
     perform_enqueued_jobs
     update_notification = ActionMailer::Base.deliveries.last


### PR DESCRIPTION
## Description

[This Pr refactors the code before fixes the last AC in the trello card.](https://trello.com/c/F5YRGSA0/1219-reviewer-is-able-to-view-comments-against-legislation-by-officer)
There's also missing fucntionality of next/prev added with component.



[PlanningApplication.recommendation (from recommendations.last) - refactor](https://github.com/unboxed/bops/commit/4147aa691689910d5405b0425635d2e6a9551a8f)
- recommendation from recommendations.last
  - I just wanted to hide that there was an array and that they wanted the last and instead used the method that simply returned the last. 

[Planning application interface for #last_recommendation_accepted? - refactor](https://github.com/unboxed/bops/commit/6c31b02c6a370757b0ea2a78a91a9a4ed12d0ca8)
- My code to access if recommendation accepted was using 3 dots - in short the structure was over exposed. The other effect of the exposure made it hard to test. So I added a method #last_recommendation_accepted? to planning application and made the code for the other reviewing code use it.

[Review policy class navigation component - missing functinality](https://github.com/unboxed/bops/commit/e01563b4846ff4a9c2e8871e71ca7a2b14d88782)

- component for Next previous navigation between policy classes

[ReviewPolicyClass errors if you save after accepting recommendation - last AC](https://github.com/unboxed/bops/commit/6141de4234471cdb1c8b928934d8e6e10df90fc1)
- used the method #last_recommendation_accepted? to solve the last AC