### PR TITLE
Fix migration to ensure all assessment_details have valid assessment_status

### DIFF
--- a/db/migrate/20221125153219_split_assessment_details_status.rb
+++ b/db/migrate/20221125153219_split_assessment_details_status.rb
@@ -28,7 +28,7 @@ class SplitAssessmentDetailsStatus < ActiveRecord::Migration[6.1]
       "UPDATE assessment_details
       SET assessment_status = 'complete'
       WHERE assessment_status
-      IN ('assessment_in_progress', 'review_in_progress', 'review_complete');"
+      IN ('assessment_complete', 'review_in_progress', 'review_complete');"
     )
   end
 


### PR DESCRIPTION
### Description of change

Fix migration to split `status` column in `assesment_details` into `assessment_status` and `review_status` correctly updates the `assessment_status` column!

### Story Link

NA