### PR TITLE
Improve phone number authentication

### DIFF
--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -4,6 +4,8 @@ module AuthenticateWithOtpTwoFactor
   extend ActiveSupport::Concern
 
   def authenticate_with_otp_two_factor
+    return unless valid_mobile_number?
+
     user = self.resource = find_user
 
     authenticate_user_with_otp_two_factor(user) if otp_input?
@@ -20,6 +22,16 @@ module AuthenticateWithOtpTwoFactor
   end
 
   private
+
+  def valid_mobile_number?
+    return true unless user_params.keys.include?("mobile_number")
+
+    @mobile_number_form = MobileNumberForm.new(user_params)
+    return true if @mobile_number_form.valid?
+
+    find_current_local_authority_from_subdomain
+    render "devise/sessions/setup" and return false
+  end
 
   def save_user_session(user)
     session[:otp_user_id] = user.id

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,6 +14,7 @@ module Users
     prepend_before_action :authenticate_with_otp_two_factor, if: :otp_two_factor_enabled?, only: :create
     before_action :find_otp_user, only: %i[setup two_factor resend_code]
     skip_before_action :enforce_user_permissions
+    before_action :set_mobile_number_form, only: %i[setup two_factor]
 
     protect_from_forgery with: :exception, prepend: true, except: :destroy
 
@@ -46,6 +47,10 @@ module Users
     end
 
     private
+
+    def set_mobile_number_form
+      @mobile_number_form = MobileNumberForm.new
+    end
 
     def find_otp_user
       @user = find_current_local_authority.users.find_by(id: session[:otp_user_id])

--- a/app/models/mobile_number_form.rb
+++ b/app/models/mobile_number_form.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class MobileNumberForm
+  include ActiveModel::Model
+
+  attr_accessor :mobile_number
+
+  validates :mobile_number, presence: true, phone_number: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
 
   before_create :generate_otp_secret
 
-  validates :mobile_number, format: { with: /\A\d*\z/ }
+  validates :mobile_number, phone_number: true
 
   def self.find_for_authentication(tainted_conditions)
     if tainted_conditions[:subdomains].present?

--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PhoneNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank? || value.delete("-+ ()").match(/\A\d{8,15}\z/)
+
+    record.errors.add(attribute, :invalid)
+  end
+end

--- a/app/views/devise/sessions/setup.html.erb
+++ b/app/views/devise/sessions/setup.html.erb
@@ -9,10 +9,18 @@
     </h1>
     <p class="govuk-body"> To use two-factor authentication we need a UK mobile phone number for your account.</p>
     <div class=" govuk-form-group">
-      <%= form_for(@user, as: :user, url: user_session_path, method: :post) do |form| %>
-        <%= form.label :mobile_number, class: "govuk-label" %>
-        <%= form.text_field :mobile_number, class: "govuk-textarea govuk-input" %>
-        <%= form.submit "Send code", class: "govuk-button", data: { module: "govuk-button" } %>
+      <%= form_for(
+        @mobile_number_form,
+        as: :user,
+        url: user_session_path,
+        method: :post,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |form| %>
+        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_text_field(:mobile_number) %>
+        <div class="govuk-button-group">
+          <%= form.govuk_submit(t(".send_code")) %>
+        </div>
       <% end %>
     </div>
   </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -46,6 +46,8 @@ en:
       updated_but_not_signed_in: Your account has been updated successfully, but since your password was changed, you need to sign in again
     sessions:
       already_signed_out: Signed out successfully.
+      setup:
+        send_code: Send code
       signed_in: Signed in successfully.
       signed_out: Signed out successfully.
       two_factor:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -289,6 +289,8 @@ en:
         name: Enter a new consultee
       description_change_validation_request:
         cancel_reason: Explain to the applicant why this request is being cancelled
+      mobile_number_form:
+        mobile_number: Mobile number
       note:
         entry: Add a note to this application.
       other_change_validation_request:

--- a/spec/models/mobile_number_form_spec.rb
+++ b/spec/models/mobile_number_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MobileNumberForm do
+  it_behaves_like("PhoneNumberValidator") do
+    let(:record) { described_class.new }
+    let(:attribute) { :mobile_number }
+  end
+
+  describe "#valid?" do
+    context "when mobile number is blank" do
+      let(:form) { described_class.new(mobile_number: nil) }
+
+      it "returns true" do
+        expect(form.valid?).to be(false)
+      end
+
+      it "sets error" do
+        form.valid?
+
+        expect(
+          form.errors.messages[:mobile_number]
+        ).to contain_exactly(
+          "can't be blank"
+        )
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,11 @@
 require "rails_helper"
 
 RSpec.describe User do
+  it_behaves_like("PhoneNumberValidator") do
+    let(:record) { build(:user) }
+    let(:attribute) { :mobile_number }
+  end
+
   describe "validations" do
     subject(:user) { described_class.new }
 
@@ -105,21 +110,11 @@ RSpec.describe User do
     expect(user_two.errors.messages[:email]).to include("has already been taken")
   end
 
-  describe "#mobile_number" do
-    context "when it contains non digits" do
-      let(:user) { build(:user, mobile_number: "not a number") }
+  describe "#valid?" do
+    context "when mobile number is blank" do
+      let(:user) { build(:user, mobile_number: nil) }
 
-      it "is invalid" do
-        expect { user.valid? }
-          .to change { user.errors[:mobile_number] }
-          .to ["is invalid"]
-      end
-    end
-
-    context "when it contains only digits" do
-      let(:user) { build(:user, mobile_number: "01234123123") }
-
-      it "is valid" do
+      it "returns true" do
         expect(user.valid?).to be(true)
       end
     end

--- a/spec/support/phone_number_validator_shared_examples.rb
+++ b/spec/support/phone_number_validator_shared_examples.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "PhoneNumberValidator" do
+  describe "#valid?" do
+    %w[qwerty 123 1234567890123456].each do |value|
+      context "when value is #{value}" do
+        before { record.send("#{attribute}=", value) }
+
+        it "returns false" do
+          expect(record.valid?).to be(false)
+        end
+
+        it "sets error message" do
+          record.valid?
+
+          expect(
+            record.errors.messages[attribute]
+          ).to contain_exactly(
+            "is invalid"
+          )
+        end
+      end
+    end
+
+    ["07717-123-123", "07717123123", "+447717123123", "07717 123 123", "(07717)123123"].each do |value|
+      context "when value is #{value}" do
+        it "returns true" do
+          record.send("#{attribute}=", value)
+          expect(record.valid?).to be(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Alter validation of `mobile_number` in `users` table so that it

1. Can include white spaces, `-`, `(`, `)` or `+`.
2. Excluding the above characters contains only digits and is between 8 and 15 characters long.

- Apply these validations when the user submits the mobile number during the login process.

NB I've copied the accepted characters and length criteria from [Notify](https://github.com/alphagov/notifications-utils/blob/8c8c8fb591e27f11fab5cf17c64aead0870d40d2/notifications_utils/recipients.py#L567). It's safe to be pretty generous because if Notify rejects the number the user will see an error at the next step. The important thing at our end is to apply the same validations when the user submits the mobile number as we do when we save the number to the database (we weren't doing this, which is what was causing the bug).

### Story Link

https://trello.com/c/igCiPkfe/1257-some-valid-mobile-number-formats-arent-accepted

### Screenshot

<img width="60%" alt="Screenshot 2022-11-30 at 18 13 32" src="https://user-images.githubusercontent.com/25392162/204876375-a0cfb5ec-f156-4891-96e3-d403739a635c.png">

### Decisions

I've opted not to use a gem for now, since in a sense the phone number is being validated by the log in process (if the request to notify succeeds the user gets a code etc). But we explore the gem option? [phonelib](https://github.com/daddyz/phonelib) looks like a good candidate. It uses google's [libphonenumber](https://github.com/google/libphonenumber) which is recommended by GOV.UK Design System.