### PR TITLE
Add site map check to consistency checklist

### DIFF
--- a/app/controllers/consistency_checklists_controller.rb
+++ b/app/controllers/consistency_checklists_controller.rb
@@ -59,22 +59,25 @@ class ConsistencyChecklistsController < AuthenticationController
       documents_consistent
       proposal_details_match_documents
       proposal_details_match_documents_comment
+      site_map_correct
     ]
   end
 
   def after_save_path
-    if commit_matches?(/new document/)
-      new_planning_application_additional_document_validation_request_path(
-        @planning_application,
-        consistency_checklist: true
-      )
-    elsif commit_matches?(/change to the description/)
-      new_planning_application_description_change_validation_request_path(
+    if after_save_path_request_type.present?
+      send(
+        "new_planning_application_#{after_save_path_request_type}_validation_request_path",
         @planning_application,
         consistency_checklist: true
       )
     else
       planning_application_assessment_tasks_path(@planning_application)
+    end
+  end
+
+  def after_save_path_request_type
+    %i[additional_document description_change red_line_boundary_change].find do |request_type|
+      t("consistency_checklists.request_#{request_type}") == params[:commit]
     end
   end
 

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -5,6 +5,7 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
 
   before_action :ensure_no_open_or_pending_red_line_boundary_validation_request, only: %i[new]
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
+  before_action :set_return_to, only: %i[new]
 
   def show
     @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
@@ -20,8 +21,10 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
     @red_line_boundary_change_validation_request.user = current_user
 
     if @red_line_boundary_change_validation_request.save
-      redirect_to create_request_redirect_url,
-                  notice: "Validation request for red line boundary successfully created."
+      redirect_to(
+        (session.delete(:return_to) || create_request_redirect_url),
+        notice: t(".validation_request_for")
+      )
     else
       render :new
     end

--- a/app/models/concerns/planning_application/validation_requests.rb
+++ b/app/models/concerns/planning_application/validation_requests.rb
@@ -78,6 +78,12 @@ class PlanningApplication
       validation_requests(post_validation: true, include_description_change_validation_requests: true).select(&:open?)
     end
 
+    ValidationRequest::VALIDATION_REQUEST_TYPES.map(&:underscore).each do |type|
+      define_method(type) do |post_validation = false|
+        send(type.pluralize).order(:created_at).where(post_validation: post_validation).last
+      end
+    end
+
     private
 
     def no_open_post_validation_requests?

--- a/app/models/consistency_checklist.rb
+++ b/app/models/consistency_checklist.rb
@@ -3,68 +3,38 @@
 class ConsistencyChecklist < ApplicationRecord
   belongs_to :planning_application
 
+  CHECKS = %i[
+    description_matches_documents
+    documents_consistent
+    proposal_details_match_documents
+    site_map_correct
+  ].freeze
+
   with_options if: :complete? do
-    validate :description_matches_documents_determined
-    validate :proposal_details_match_documents_determined
-    validate :documents_consistent_determined
+    CHECKS.each { |check| validate("#{check}_determined".to_sym) }
     validate :description_change_requests_closed
     validate :additional_document_requests_closed
+    validate :red_line_boundary_requests_closed
   end
 
   enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
 
-  enum(
-    description_matches_documents: {
-      to_be_determined: 0,
-      yes: 1,
-      no: 2
-    },
-    _default: :to_be_determined,
-    _prefix: :description_matches_documents
-  )
-
-  enum(
-    documents_consistent: {
-      to_be_determined: 0,
-      yes: 1,
-      no: 2
-    },
-    _default: :to_be_determined,
-    _prefix: :documents_consistent
-  )
-
-  enum(
-    proposal_details_match_documents: {
-      to_be_determined: 0,
-      yes: 1,
-      no: 2
-    },
-    _default: :to_be_determined,
-    _prefix: :proposal_details_match_documents
-  )
+  CHECKS.each do |check|
+    enum(check => { to_be_determined: 0, yes: 1, no: 2 }, _prefix: check)
+  end
 
   private
 
-  def description_matches_documents_determined
-    return unless description_matches_documents_to_be_determined?
+  CHECKS.each do |check|
+    define_method("#{check}_determined") do
+      return unless send("#{check}_to_be_determined?")
 
-    errors.add(:description_matches_documents, :not_determined)
-  end
-
-  def proposal_details_match_documents_determined
-    return unless proposal_details_match_documents_to_be_determined?
-
-    errors.add(:proposal_details_match_documents, :not_determined)
-  end
-
-  def documents_consistent_determined
-    return unless documents_consistent_to_be_determined?
-
-    errors.add(:documents_consistent, :not_determined)
+      errors.add(check, :not_determined)
+    end
   end
 
   def description_change_requests_closed
-    return unless open_description_change_requests?
+    return unless planning_application.description_change_validation_requests.open.any?
 
     errors.add(
       :description_matches_documents,
@@ -72,17 +42,15 @@ class ConsistencyChecklist < ApplicationRecord
     )
   end
 
+  def red_line_boundary_requests_closed
+    return unless planning_application.red_line_boundary_change_validation_requests.open.any?
+
+    errors.add(:site_map_correct, :open_red_line_boundary_requests)
+  end
+
   def additional_document_requests_closed
-    return unless open_additional_document_requests?
+    return unless planning_application.additional_document_validation_requests.open.any?
 
     errors.add(:documents_consistent, :open_additional_document_requests)
-  end
-
-  def open_description_change_requests?
-    planning_application.description_change_validation_requests.open.any?
-  end
-
-  def open_additional_document_requests?
-    planning_application.additional_document_validation_requests.open.any?
   end
 end

--- a/app/views/consistency_checklists/_description_change_validation_request.html.erb
+++ b/app/views/consistency_checklists/_description_change_validation_request.html.erb
@@ -1,23 +1,25 @@
-<p class="govuk-body-s">
-  <%= t(".requested_a_new", name: request.sent_by.name) %><br>
-  <%= t(".proposed_description", description: request.proposed_description)%><br>
-  <%= t(".proposed", time: request.created_at) %><br>
-  <% if request.auto_closed? %>
-    <%= t(".accepted", time: request.auto_closed_at) %><br>
-  <% elsif request.approved? %>
-    <%= t(".accepted", time: request.closed_at) %><br>
-  <% elsif request.cancelled? %>
-    <%= t(".cancelled", time: request.cancelled_at) %><br>
+<% if request.present? %>
+  <p class="govuk-body-s">
+    <%= t(".requested_a_new", name: request.sent_by.name) %><br>
+    <%= t(".proposed_description", description: request.proposed_description)%><br>
+    <%= t(".proposed", time: request.created_at) %><br>
+    <% if request.auto_closed? %>
+      <%= t(".accepted", time: request.auto_closed_at) %><br>
+    <% elsif request.approved? %>
+      <%= t(".accepted", time: request.closed_at) %><br>
+    <% elsif request.cancelled? %>
+      <%= t(".cancelled", time: request.cancelled_at) %><br>
+    <% end %>
+  </p>
+  <% if request.open? %>
+    <%= link_to(
+      t(".view_and_edit"),
+      planning_application_description_change_validation_request_path(
+        planning_application,
+        request,
+        consistency_checklist: true
+      ),
+      class: "govuk-link"
+    ) %>
   <% end %>
-</p>
-<% if request.open? %>
-  <%= link_to(
-    t(".view_and_edit"),
-    planning_application_description_change_validation_request_path(
-      planning_application,
-      request,
-      consistency_checklist: true
-    ),
-    class: "govuk-link"
-  ) %>
 <% end %>

--- a/app/views/consistency_checklists/_description_matches_documents.html.erb
+++ b/app/views/consistency_checklists/_description_matches_documents.html.erb
@@ -16,7 +16,7 @@
     ) do %>
       <% unless planning_application.description_change_validation_requests.open.any? %>
         <%= form.submit(
-          t(".request_a_change"),
+          t("consistency_checklists.request_description_change"),
           class: "button-as-link"
         ) %>
       <% end %>
@@ -31,13 +31,11 @@
       disabled: true
     ) %>
   <% end %>
-  <% if request = planning_application.description_change_validation_requests.post_validation.order(:created_at).last.presence %>
-    <%= render(
-      partial: "description_change_validation_request",
-      locals: {
-        request: request,
-        planning_application: planning_application
-      }
-    ) %>
-  <% end %>
+  <%= render(
+    partial: "description_change_validation_request",
+    locals: {
+      request: planning_application.description_change_validation_request(post_validation: true),
+      planning_application: planning_application
+    }
+  ) %>
 <% end %>

--- a/app/views/consistency_checklists/_documents_consistent.html.erb
+++ b/app/views/consistency_checklists/_documents_consistent.html.erb
@@ -14,7 +14,10 @@
       :no,
       label: { text: t(".no") }
     ) do %>
-      <%= form.submit(t(".request_a_new"), class: "button-as-link") %>
+      <%= form.submit(
+        t("consistency_checklists.request_additional_document"),
+        class: "button-as-link"
+      ) %>
     <% end %>
   <% else %>
     <%= form.govuk_radio_button(

--- a/app/views/consistency_checklists/_form.html.erb
+++ b/app/views/consistency_checklists/_form.html.erb
@@ -6,6 +6,15 @@
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
   <%= render(
+    partial: "site_map_correct",
+    locals: {
+      form: form,
+      consistency_checklist: consistency_checklist,
+      planning_application: planning_application,
+      can_edit: can_edit
+    }
+  ) %>
+  <%= render(
     partial: "description_matches_documents",
     locals: {
       form: form,

--- a/app/views/consistency_checklists/_red_line_boundary_change_validation_request.html.erb
+++ b/app/views/consistency_checklists/_red_line_boundary_change_validation_request.html.erb
@@ -1,0 +1,24 @@
+<% if request.present? %>
+  <p class="govuk-body-s">
+    <%= t(".proposed_a_new", user: request.sent_by.name) %><br>
+    <%= t(".reason") %> <%= request.reason %><br>
+    <%= t(".proposed") %> <%= request.created_at %><br>
+    <% if request.auto_closed? %>
+      <%= t(".accepted") %> <%= request.auto_closed_at %>
+    <% elsif request.approved? %>
+      <%= t(".accepted") %> <%= request.closed_at %>
+    <% elsif request.cancelled? %>
+      <%= t(".cancelled") %> <%= request.cancelled_at %>
+    <% end %>
+  </p>
+  <% if request.open? %>
+    <%= link_to(
+      t(".view_and_edit"),
+      planning_application_red_line_boundary_change_validation_request_path(
+        planning_application,
+        request
+      ),
+      class: "govuk-link"
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/consistency_checklists/_site_map_correct.html.erb
@@ -1,0 +1,39 @@
+<%= form.govuk_radio_buttons_fieldset(
+  :site_map_correct,
+  legend: { text: t(".is_the_red"), size: "s" }
+) do %>
+  <% if can_edit %>
+    <%= form.govuk_radio_button(
+      :site_map_correct,
+      :yes,
+      label: { text: t(".yes") },
+      link_errors: true
+    ) %>
+    <%= form.govuk_radio_button(
+      :site_map_correct,
+      :no,
+      label: { text: t(".no") }
+    ) do %>
+      <% unless planning_application.red_line_boundary_change_validation_requests.post_validation.open.any? %>
+        <%= form.submit(
+          t("consistency_checklists.request_red_line_boundary_change"),
+          class: "button-as-link"
+        ) %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= form.govuk_radio_button(
+      :site_map_correct,
+      consistency_checklist.site_map_correct,
+      label: { text: t(".#{consistency_checklist.documents_consistent}") },
+      disabled: true
+    ) %>
+  <% end %>
+  <%= render(
+    partial: "red_line_boundary_change_validation_request",
+    locals: {
+      request: planning_application.red_line_boundary_change_validation_request(post_validation: true),
+      planning_application: planning_application
+    }
+  ) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,9 @@ en:
               open_additional_document_requests: Additional document requests must be closed or cancelled
             proposal_details_match_documents:
               not_determined: Determine whether the proposal details are consistent with the plans
+            site_map_correct:
+              not_determined: Determine whether the red line on the site map is correct
+              open_red_line_boundary_requests: Red line boundary change requests must be closed or cancelled
         document:
           attributes:
             file:
@@ -212,12 +215,10 @@ en:
     description_matches_documents:
       does_the_description: Does the description match the development or use in the plans?
       'no': 'No'
-      request_a_change: Request a change to the description
       'yes': 'Yes'
     documents_consistent:
       are_the_plans: Are the plans consistent with each other?
       'no': 'No'
-      request_a_new: Request a new document
       'yes': 'Yes'
     form:
       back: Back
@@ -227,6 +228,20 @@ en:
     proposal_details_match_documents:
       are_the_proposal: Are the proposal details consistent with the plans?
       how_are_the: How are the proposal details inconsistent?
+      'no': 'No'
+      'yes': 'Yes'
+    red_line_boundary_change_validation_request:
+      accepted: Accepted
+      cancelled: Cancelled
+      proposed: Proposed
+      proposed_a_new: "%{user} proposed a new red line boundary"
+      reason: 'Reason:'
+      view_and_edit: View and edit request
+    request_additional_document: Request a new document
+    request_description_change: Request a change to the description
+    request_red_line_boundary_change: Request a change to the red line boundary
+    site_map_correct:
+      is_the_red: Is the red line on the site map correct for the site and proposed works?
       'no': 'No'
       'yes': 'Yes'
     update:
@@ -562,6 +577,9 @@ en:
       no_legislation_assessed: No legislation assessed for this application.
     new:
       assess_recommendation: Assess recommendation
+  red_line_boundary_change_validation_requests:
+    create:
+      validation_request_for: Validation request for red line boundary successfully created.
   review_policy_classes:
     navigation_component:
       view_next_class: View next class

--- a/db/migrate/20221202115603_add_default_to_consistency_checklist_enums.rb
+++ b/db/migrate/20221202115603_add_default_to_consistency_checklist_enums.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddDefaultToConsistencyChecklistEnums < ActiveRecord::Migration[6.1]
+  def change
+    change_table :consistency_checklists, bulk: true do |t|
+      t.change_default(:description_matches_documents, from: nil, to: 0)
+      t.change_default(:documents_consistent, from: nil, to: 0)
+      t.change_default(:proposal_details_match_documents, from: nil, to: 0)
+    end
+  end
+end

--- a/db/migrate/20221202120121_add_site_map_correct_to_consistency_checklists.rb
+++ b/db/migrate/20221202120121_add_site_map_correct_to_consistency_checklists.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddSiteMapCorrectToConsistencyChecklists < ActiveRecord::Migration[6.1]
+  def change
+    add_column(
+      :consistency_checklists,
+      :site_map_correct,
+      :integer,
+      default: 0,
+      null: false
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_25_171818) do
+ActiveRecord::Schema.define(version: 2022_12_02_120121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,13 +110,14 @@ ActiveRecord::Schema.define(version: 2022_11_25_171818) do
 
   create_table "consistency_checklists", force: :cascade do |t|
     t.integer "status", null: false
-    t.integer "description_matches_documents", null: false
-    t.integer "documents_consistent", null: false
-    t.integer "proposal_details_match_documents", null: false
+    t.integer "description_matches_documents", default: 0, null: false
+    t.integer "documents_consistent", default: 0, null: false
+    t.integer "proposal_details_match_documents", default: 0, null: false
     t.text "proposal_details_match_documents_comment"
     t.bigint "planning_application_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "site_map_correct", default: 0, null: false
     t.index ["planning_application_id"], name: "ix_consistency_checklists_on_planning_application_id"
   end
 

--- a/spec/factories/consistency_checklist.rb
+++ b/spec/factories/consistency_checklist.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
       description_matches_documents { :yes }
       documents_consistent { :yes }
       proposal_details_match_documents { :yes }
+      site_map_correct { :yes }
     end
   end
 end

--- a/spec/models/consistency_checklist_spec.rb
+++ b/spec/models/consistency_checklist_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe ConsistencyChecklist do
         )
       end
 
+      context "when there are open red line boundary requests" do
+        before do
+          create(
+            :red_line_boundary_change_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to be(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:site_map_correct]
+          ).to contain_exactly(
+            "Red line boundary change requests must be closed or cancelled"
+          )
+        end
+      end
+
       context "when there are open description change requests" do
         before do
           create(
@@ -95,7 +119,8 @@ RSpec.describe ConsistencyChecklist do
             :complete,
             description_matches_documents: :to_be_determined,
             documents_consistent: :yes,
-            proposal_details_match_documents: :yes
+            proposal_details_match_documents: :yes,
+            site_map_correct: :yes
           )
         end
 
@@ -121,7 +146,8 @@ RSpec.describe ConsistencyChecklist do
             :complete,
             description_matches_documents: :yes,
             documents_consistent: :yes,
-            proposal_details_match_documents: :to_be_determined
+            proposal_details_match_documents: :to_be_determined,
+            site_map_correct: :yes
           )
         end
 
@@ -147,7 +173,8 @@ RSpec.describe ConsistencyChecklist do
             :complete,
             description_matches_documents: :yes,
             documents_consistent: :to_be_determined,
-            proposal_details_match_documents: :yes
+            proposal_details_match_documents: :yes,
+            site_map_correct: :yes
           )
         end
 
@@ -162,6 +189,33 @@ RSpec.describe ConsistencyChecklist do
             consistency_checklist.errors.messages[:documents_consistent]
           ).to contain_exactly(
             "Determine whether the plans are consistent with each other"
+          )
+        end
+      end
+
+      context "when site_map_correct is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            description_matches_documents: :yes,
+            documents_consistent: :to_be_determined,
+            proposal_details_match_documents: :yes,
+            site_map_correct: :to_be_determined
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to be(false)
+        end
+
+        it "sets error message" do
+          consistency_checklist.valid?
+
+          expect(
+            consistency_checklist.errors.messages[:site_map_correct]
+          ).to contain_exactly(
+            "Determine whether the red line on the site map is correct"
           )
         end
       end
@@ -189,6 +243,20 @@ RSpec.describe ConsistencyChecklist do
           :all_checks_assessed,
           planning_application: planning_application
         )
+      end
+
+      context "when there are open red line boundary requests" do
+        before do
+          create(
+            :red_line_boundary_change_validation_request,
+            :open,
+            planning_application: planning_application
+          )
+        end
+
+        it "returns false" do
+          expect(consistency_checklist.valid?).to be(true)
+        end
       end
 
       context "when there are open description change requests" do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1457,4 +1457,252 @@ RSpec.describe PlanningApplication do
       expect(planning_application.consultation_summary).to eq(assessment_detail1)
     end
   end
+
+  describe "#red_line_boundary_change_validation_request" do
+    let(:planning_application) do
+      create(:planning_application, status: status)
+    end
+
+    let!(:request) do
+      create(
+        :red_line_boundary_change_validation_request,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
+    end
+
+    before do
+      create(
+        :red_line_boundary_change_validation_request,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+    end
+
+    context "when pre validation request is present" do
+      let(:status) { :not_started }
+
+      it "returns pre validation request" do
+        expect(
+          planning_application.red_line_boundary_change_validation_request
+        ).to eq(
+          request
+        )
+      end
+
+      it "does not return post validation request" do
+        expect(
+          planning_application.red_line_boundary_change_validation_request(post_validation: true)
+        ).to be_nil
+      end
+    end
+
+    context "when post validation request is present" do
+      let(:status) { :in_assessment }
+
+      it "does not return pre validation request" do
+        expect(
+          planning_application.red_line_boundary_change_validation_request
+        ).to be_nil
+      end
+
+      it "returns post validation request" do
+        expect(
+          planning_application.red_line_boundary_change_validation_request(post_validation: true)
+        ).to eq(
+          request
+        )
+      end
+    end
+  end
+
+  describe "#additional_document_validation_request" do
+    let(:planning_application) do
+      create(:planning_application, status: status)
+    end
+
+    let!(:request) do
+      create(
+        :additional_document_validation_request,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
+    end
+
+    before do
+      create(
+        :additional_document_validation_request,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+    end
+
+    context "when pre validation request is present" do
+      let(:status) { :not_started }
+
+      it "returns pre validation request" do
+        expect(
+          planning_application.additional_document_validation_request
+        ).to eq(
+          request
+        )
+      end
+
+      it "does not return post validation request" do
+        expect(
+          planning_application.additional_document_validation_request(post_validation: true)
+        ).to be_nil
+      end
+    end
+
+    context "when post validation request is present" do
+      let(:status) { :in_assessment }
+
+      it "does not return pre validation request" do
+        expect(
+          planning_application.additional_document_validation_request
+        ).to be_nil
+      end
+
+      it "returns post validation request" do
+        expect(
+          planning_application.additional_document_validation_request(post_validation: true)
+        ).to eq(
+          request
+        )
+      end
+    end
+  end
+
+  describe "#description_change_validation_request" do
+    let(:planning_application) do
+      create(:planning_application, status: status)
+    end
+
+    let!(:request) do
+      create(
+        :description_change_validation_request,
+        :closed,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
+    end
+
+    before do
+      create(
+        :description_change_validation_request,
+        :closed,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+    end
+
+    context "when pre validation request is present" do
+      let(:status) { :not_started }
+
+      it "returns pre validation request" do
+        expect(
+          planning_application.description_change_validation_request
+        ).to eq(
+          request
+        )
+      end
+
+      it "does not return post validation request" do
+        expect(
+          planning_application.description_change_validation_request(post_validation: true)
+        ).to be_nil
+      end
+    end
+
+    context "when post validation request is present" do
+      let(:status) { :in_assessment }
+
+      it "does not return pre validation request" do
+        expect(
+          planning_application.description_change_validation_request
+        ).to be_nil
+      end
+
+      it "returns post validation request" do
+        expect(
+          planning_application.description_change_validation_request(post_validation: true)
+        ).to eq(
+          request
+        )
+      end
+    end
+  end
+
+  describe "#replacement_document_validation_request" do
+    let(:planning_application) do
+      create(:planning_application, :not_started)
+    end
+
+    let!(:request) do
+      create(
+        :replacement_document_validation_request,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
+    end
+
+    before do
+      create(
+        :replacement_document_validation_request,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+    end
+
+    it "returns pre validation request" do
+      expect(
+        planning_application.replacement_document_validation_request
+      ).to eq(
+        request
+      )
+    end
+
+    it "does not return post validation request" do
+      expect(
+        planning_application.replacement_document_validation_request(post_validation: true)
+      ).to be_nil
+    end
+  end
+
+  describe "#other_change_validation_request" do
+    let(:planning_application) do
+      create(:planning_application, :not_started)
+    end
+
+    let!(:request) do
+      create(
+        :other_change_validation_request,
+        planning_application: planning_application,
+        created_at: 1.day.ago
+      )
+    end
+
+    before do
+      create(
+        :other_change_validation_request,
+        planning_application: planning_application,
+        created_at: 2.days.ago
+      )
+    end
+
+    it "returns pre validation request" do
+      expect(
+        planning_application.other_change_validation_request
+      ).to eq(
+        request
+      )
+    end
+
+    it "does not return post validation request" do
+      expect(
+        planning_application.other_change_validation_request(post_validation: true)
+      ).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Add `site_map_check` enum to `consistency_checklists`.
- Add the check to the 'Description, documents, proposal details' page, following the same pattern as other checks.

### Story Link

https://trello.com/c/XSKKjzy0/1310-add-site-map-to-check-description-document-and-proposal-details-task-in-assessment-phase

### Screenshots
<img width="60%" alt="Screenshot 2022-12-02 at 18 51 36" src="https://user-images.githubusercontent.com/25392162/205365062-0d89d741-ae28-42d6-b465-a6b35b36404f.png">

<img width="60%" alt="Screenshot 2022-12-02 at 18 51 09" src="https://user-images.githubusercontent.com/25392162/205365070-10cd6f43-29c5-4e82-89bd-2dfd6bfaec16.png">

