### PR TITLE
Remove policy_classes_bak from planning_applications

### DIFF
--- a/db/migrate/20221205085506_remove_policy_classes_bak.rb
+++ b/db/migrate/20221205085506_remove_policy_classes_bak.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class RemovePolicyClassesBak < ActiveRecord::Migration[6.1]
+  def change
+    remove_column(
+      :planning_applications,
+      :policy_classes_bak,
+      :jsonb,
+      default: [],
+      array: true
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_02_120121) do
+ActiveRecord::Schema.define(version: 2022_12_05_085506) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -302,7 +302,6 @@ ActiveRecord::Schema.define(version: 2022_12_02_120121) do
     t.string "result_override"
     t.bigint "api_user_id"
     t.bigint "boundary_created_by_id"
-    t.jsonb "policy_classes_bak", default: [], array: true
     t.datetime "assessment_in_progress_at"
     t.string "ward"
     t.string "ward_type"


### PR DESCRIPTION
### Description of change

Delete the `policy_classes_bak` column.

We moved the information in the `planning_application.policy_classes` column into new `policy_classes` and `policies` tables almost three moths ago - see https://github.com/unboxed/bops/pull/744. At the time we renamed the `policy_classes` column to `policy_classes_bak` and kept it as a backup. But I think it's probably safe to remove it now!