### PR TITLE
Review Tasklist component displayed once reviewer knows next step

### DIFF
--- a/app/components/review_tasks/after_sign_off_component.html.erb
+++ b/app/components/review_tasks/after_sign_off_component.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">
+ Application is now in assessment and assigned to <span class="govuk-!-font-weight-bold"><%= assessor_name %> </span>
+</p>

--- a/app/components/review_tasks/after_sign_off_component.rb
+++ b/app/components/review_tasks/after_sign_off_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ReviewTasks
+  class AfterSignOffComponent < ViewComponent::Base
+    def initialize(planning_application:)
+      @planning_application = planning_application
+      @recommendation = planning_application.recommendation
+    end
+
+    private
+
+    def render?
+      @planning_application.recommendation_review_complete? && challenged?
+    end
+
+    def challenged?
+      @recommendation&.challenged || false
+    end
+
+    def assessor_name
+      @recommendation&.assessor&.name || ""
+    end
+  end
+end

--- a/app/components/review_tasks/button_group_component.html.erb
+++ b/app/components/review_tasks/button_group_component.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-button-group">
+  <% if render_publish_button? %>
+    <%= link_to "Publish decision",
+                 publish_planning_application_path(@planning_application),
+                 aria: { describedby: "publish-completed" },
+                 class: "govuk-button" %>
+  <% end %>
+
+  <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+</div>

--- a/app/components/review_tasks/button_group_component.rb
+++ b/app/components/review_tasks/button_group_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module ReviewTasks
+  class ButtonGroupComponent < ViewComponent::Base
+    def initialize(planning_application:)
+      @planning_application = planning_application
+      @challenged = planning_application&.recommendation&.challenged
+    end
+
+    private
+
+    def render_publish_button?
+      @planning_application.recommendation_review_complete? && unchallenged?
+    end
+
+    def unchallenged?
+      @challenged == false
+    end
+  end
+end

--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -56,9 +56,14 @@
     </ul>
   </div>
 </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(ReviewTasks::AfterSignOffComponent.new(planning_application: @planning_application)) %>
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+    <%= render(ReviewTasks::ButtonGroupComponent.new(planning_application: @planning_application)) %>
   </div>
 </div>

--- a/app/views/recommendations/_form.html.erb
+++ b/app/views/recommendations/_form.html.erb
@@ -23,6 +23,9 @@
       :true,
       label: { text: t(".no") }
     ) do %>
+      <p class="govuk-body">
+        Case currently assigned to: <span class="govuk-!-font-weight-bold"><%= recommendation.assessor.name %></span>
+      </p>
       <%= form.govuk_text_area(:reviewer_comment) %>
     <% end %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -326,6 +326,7 @@ en:
     validate:
       success: Fee item was marked as valid.
   form_actions:
+    publish_decision: Publish decision
     save_and_come_back_later: Save and come back later
     save_and_mark_as_complete: Save and mark as complete
   helpers:

--- a/spec/components/review_tasks/after_sign_off_component_spec.rb
+++ b/spec/components/review_tasks/after_sign_off_component_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewTasks::AfterSignOffComponent, type: :component do
+  let(:assessor) { create(:user, :assessor, name: "John") }
+
+  # this state only happens with incorrectly setup tests
+  # otherwise recommendation has been set before you ever
+  # get to sign off
+  it "renders nothing when no recommendation" do
+    pa = create(:planning_application)
+
+    render_inline(described_class.new(planning_application: pa))
+
+    expect(page).not_to have_selector("body")
+  end
+
+  it "renders nothing when not submitted" do
+    rec = create(:recommendation,
+                 :with_planning_application,
+                 submitted: false,
+                 challenged: false)
+
+    render_inline(described_class.new(planning_application: rec.planning_application))
+
+    expect(page).not_to have_selector("body")
+  end
+
+  # 3 state boolean
+  %i[true nil].each do |challenged|
+    it "renders assessment name when submitted and challenged" do
+      rec = create(:recommendation,
+                   :with_planning_application,
+                   status: :review_complete,
+                   reviewer_comment: "reviewer comment",
+                   submitted: true,
+                   challenged: challenged,
+                   assessor: assessor)
+
+      render_inline(described_class.new(planning_application: rec.planning_application))
+
+      expect(page).to have_text "Application is now in assessment and assigned to John"
+    end
+  end
+end

--- a/spec/components/review_tasks/button_group_component_spec.rb
+++ b/spec/components/review_tasks/button_group_component_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewTasks::ButtonGroupComponent, type: :component do
+  # this state only happens with incorrectly setup tests
+  # otherwise recommendation has been set before you ever
+  # get to sign off
+  it "renders only back button with no recommendation" do
+    pa = create(:planning_application)
+
+    render_inline(described_class.new(planning_application: pa))
+
+    expect(page).not_to have_link("Publish decision",
+                                  href: publish_planning_application_path(pa))
+    expect(page).to have_link("Back",
+                              href: planning_application_path(pa))
+  end
+
+  it "renders only back button when not publishing" do
+    rec = create(:recommendation,
+                 :with_planning_application,
+                 status: :review_complete,
+                 reviewer_comment: "reviewer comment",
+                 submitted: true,
+                 challenged: nil)
+    render_inline(described_class.new(planning_application: rec.planning_application))
+
+    expect(page).not_to have_link("Publish decision",
+                                  href: publish_planning_application_path(rec.planning_application))
+    expect(page).to have_link("Back",
+                              href: planning_application_path(rec.planning_application))
+  end
+
+  it "renders back and publish button when publishing" do
+    rec = create(:recommendation,
+                 :with_planning_application,
+                 status: :review_complete,
+                 reviewer_comment: "reviewer comment",
+                 submitted: true,
+                 challenged: false)
+
+    render_inline(described_class.new(planning_application: rec.planning_application))
+
+    expect(page).to have_link("Publish decision",
+                              href: publish_planning_application_path(rec.planning_application))
+    expect(page).to have_link("Back",
+                              href: planning_application_path(rec.planning_application))
+  end
+end

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -445,6 +445,8 @@ RSpec.describe "Planning Application Assessment" do
         visit(edit_planning_application_recommendations_path(planning_application))
         choose("No")
 
+        expect(page).to have_text "Case currently assigned to: Alice Aplin"
+
         fill_in(
           "Explain to the officer why the case is being returned",
           with: "Requirements not met."

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -4,8 +4,17 @@ require "rails_helper"
 
 RSpec.describe "Reviewing sign-off" do
   let(:default_local_authority) { create(:local_authority, :default) }
-  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
-  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:reviewer) do
+    create(:user,
+           :reviewer,
+           local_authority: default_local_authority)
+  end
+  let!(:assessor) do
+    create(:user,
+           :assessor,
+           name: "The name of assessor",
+           local_authority: default_local_authority)
+  end
   let(:user) { create(:user) }
 
   let!(:planning_application) do
@@ -59,9 +68,8 @@ RSpec.describe "Reviewing sign-off" do
 
     expect(list_item("Sign-off recommendation")).to have_content("Complete")
 
-    click_link "Back"
+    click_on "Publish decision"
 
-    click_link "Publish determination"
     click_button "Publish determination"
 
     planning_application.reload
@@ -82,6 +90,7 @@ RSpec.describe "Reviewing sign-off" do
 
   it "can be rejected" do
     create(:recommendation,
+           assessor: assessor,
            planning_application: planning_application,
            assessor_comment: "New assessor comment",
            submitted: true)
@@ -107,6 +116,8 @@ RSpec.describe "Reviewing sign-off" do
     expect(page).to have_text("Sign-off recommendation")
     expect(page).not_to have_link("Sign-off recommendation",
                                   href: edit_planning_application_recommendations_path(planning_application))
+
+    expect(page).to have_text "Application is now in assessment and assigned to The name of assessor"
 
     click_link "Back"
 


### PR DESCRIPTION
### Description of change

As a reviewer I need to know what has happened to the application when I finish my review so that I can move onto the next task

### Story Link

https://trello.com/c/cHxfOjNn/1319-inform-reviewer-that-a-case-has-been-returned-to-an-officer-once-they-have-completed-the-review-tasklist

## Approving

![Screenshot 2022-12-07 at 16 07 41](https://user-images.githubusercontent.com/1710795/206230291-e21a48fc-2b16-4451-ac11-86e6833da5a3.png)


## Challenged
![Screenshot 2022-12-07 at 16 05 28](https://user-images.githubusercontent.com/1710795/206229855-c55ad192-2ea0-4408-9df5-f54b7e3e4203.png)


