### PR TITLE
'Updated' status tags

### DIFF
--- a/app/components/concerns/assessment_detailable.rb
+++ b/app/components/concerns/assessment_detailable.rb
@@ -4,15 +4,11 @@ module AssessmentDetailable
   extend ActiveSupport::Concern
 
   included do
-    delegate(:recommendation, to: :planning_application)
-
     def assessment_details
       @assessment_details ||= planning_application.assessment_details_for_review
     end
 
     def assessment_details_updated?
-      return false unless recommendation_submitted_and_unchallenged?
-
       assessment_details.any? do |assessment_detail|
         assessment_detail_updated?(assessment_detail)
       end
@@ -24,15 +20,12 @@ module AssessmentDetailable
     end
 
     def assessment_detail_update_required?(assessment_detail)
-      recommendation&.rejected? && assessment_detail&.update_required?
+      planning_application.recommendation&.rejected? &&
+        assessment_detail&.update_required?
     end
 
     def rejected_assessment_detail_for_category?(category)
       planning_application.rejected_assessment_detail(category: category).present?
-    end
-
-    def recommendation_submitted_and_unchallenged?
-      recommendation&.submitted_and_unchallenged?
     end
 
     def assessment_details_review_complete?

--- a/app/components/concerns/permitted_development_rightable.rb
+++ b/app/components/concerns/permitted_development_rightable.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PermittedDevelopmentRightable
+  extend ActiveSupport::Concern
+
+  included do
+    def permitted_development_right_updated?
+      planning_application.permitted_development_rights.count > 1 &&
+        permitted_development_right.review_not_started?
+    end
+  end
+end

--- a/app/components/concerns/recommendable.rb
+++ b/app/components/concerns/recommendable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Recommendable
+  extend ActiveSupport::Concern
+
+  included do
+    def recommendation_submitted_and_unchallenged?
+      planning_application.recommendation&.submitted_and_unchallenged?
+    end
+  end
+end

--- a/app/components/status_tags/assessment_details_review_component.rb
+++ b/app/components/status_tags/assessment_details_review_component.rb
@@ -3,6 +3,7 @@
 module StatusTags
   class AssessmentDetailsReviewComponent < StatusTags::BaseComponent
     include AssessmentDetailable
+    include Recommendable
 
     def initialize(planning_application:)
       @planning_application = planning_application
@@ -13,7 +14,7 @@ module StatusTags
     attr_reader :planning_application
 
     def status
-      if assessment_details_updated?
+      if updated?
         :updated
       elsif assessment_details_review_complete?
         :checked
@@ -22,6 +23,10 @@ module StatusTags
       else
         :not_started
       end
+    end
+
+    def updated?
+      recommendation_submitted_and_unchallenged? && assessment_details_updated?
     end
   end
 end

--- a/app/components/status_tags/permitted_development_right_review_component.rb
+++ b/app/components/status_tags/permitted_development_right_review_component.rb
@@ -2,22 +2,33 @@
 
 module StatusTags
   class PermittedDevelopmentRightReviewComponent < StatusTags::BaseComponent
-    def initialize(permitted_development_right:)
+    include PermittedDevelopmentRightable
+    include Recommendable
+
+    def initialize(planning_application:, permitted_development_right:)
+      @planning_application = planning_application
       @permitted_development_right = permitted_development_right
     end
 
     private
 
-    attr_reader :permitted_development_right
+    attr_reader :planning_application, :permitted_development_right
 
     def status
-      if permitted_development_right.review_complete?
+      if updated?
+        :updated
+      elsif permitted_development_right.review_complete?
         :complete
       elsif permitted_development_right.review_in_progress?
         :in_progress
       else
         :not_started
       end
+    end
+
+    def updated?
+      recommendation_submitted_and_unchallenged? &&
+        permitted_development_right_updated?
     end
   end
 end

--- a/app/components/status_tags/review_recommendation_component.rb
+++ b/app/components/status_tags/review_recommendation_component.rb
@@ -3,6 +3,8 @@
 module StatusTags
   class ReviewRecommendationComponent < StatusTags::BaseComponent
     include AssessmentDetailable
+    include PermittedDevelopmentRightable
+    include Recommendable
 
     def initialize(planning_application:, user:)
       @planning_application = planning_application
@@ -13,6 +15,8 @@ module StatusTags
 
     attr_reader :planning_application, :user
 
+    delegate(:permitted_development_right, to: :planning_application)
+
     def status
       if planning_application.recommendation_review_complete?
         :complete
@@ -22,11 +26,13 @@ module StatusTags
     end
 
     def reviewer_status
-      if assessment_details_updated?
+      return unless planning_application.awaiting_determination?
+
+      if updated?
         :updated
-      elsif in_progress?
+      elsif planning_application.review_in_progress?
         :in_progress
-      elsif planning_application.awaiting_determination?
+      else
         :not_started
       end
     end
@@ -35,9 +41,9 @@ module StatusTags
       :awaiting_determination if planning_application.awaiting_determination?
     end
 
-    def in_progress?
-      planning_application.recommendation_review_in_progress? ||
-        assessment_details.any?(&:reviewer_verdict)
+    def updated?
+      recommendation_submitted_and_unchallenged? &&
+        (permitted_development_right_updated? || assessment_details_updated?)
     end
   end
 end

--- a/app/components/status_tags/reviewer_assessment_detail_component.rb
+++ b/app/components/status_tags/reviewer_assessment_detail_component.rb
@@ -3,6 +3,7 @@
 module StatusTags
   class ReviewerAssessmentDetailComponent < StatusTags::BaseComponent
     include AssessmentDetailable
+    include Recommendable
 
     def initialize(assessment_detail:, planning_application:)
       @planning_application = planning_application

--- a/app/components/task_list_items/permitted_development_right_review_component.rb
+++ b/app/components/task_list_items/permitted_development_right_review_component.rb
@@ -32,6 +32,7 @@ module TaskListItems
 
     def status_tag_component
       StatusTags::PermittedDevelopmentRightReviewComponent.new(
+        planning_application: planning_application,
         permitted_development_right: permitted_development_right
       )
     end

--- a/app/models/permitted_development_right.rb
+++ b/app/models/permitted_development_right.rb
@@ -43,6 +43,10 @@ class PermittedDevelopmentRight < ApplicationRecord
     review_complete? && !accepted
   end
 
+  def review_started?
+    review_in_progress? || review_complete?
+  end
+
   private
 
   def set_status_to_be_reviewed

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -499,6 +499,13 @@ class PlanningApplication < ApplicationRecord
       policy_classes.any?(&:update_required?)
   end
 
+  def review_in_progress?
+    recommendation.review_in_progress? ||
+      assessment_details_for_review.any?(&:reviewer_verdict) ||
+      policy_classes.any?(&:review_policy_class) ||
+      permitted_development_right&.review_started?
+  end
+
   def assessment_details_for_review
     AssessmentDetailsReview::ASSESSMENT_DETAILS.map do |assessment_detail|
       send(assessment_detail)

--- a/spec/components/status_tags/assessment_details_review_component_spec.rb
+++ b/spec/components/status_tags/assessment_details_review_component_spec.rb
@@ -18,18 +18,18 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
       assessment_status: assessment_status,
       created_at: 1.day.ago
     )
+
+    create(
+      :recommendation,
+      submitted: true,
+      planning_application: planning_application
+    )
   end
 
   context "when an assessment detail has been updated" do
     let(:reviewer_verdict) { nil }
 
     before do
-      create(
-        :recommendation,
-        submitted: true,
-        planning_application: planning_application
-      )
-
       create(
         :assessment_detail,
         :summary_of_work,
@@ -86,7 +86,7 @@ RSpec.describe StatusTags::AssessmentDetailsReviewComponent, type: :component do
       )
     end
 
-    it "renders 'Not stated' status" do
+    it "renders 'Not started' status" do
       expect(page).to have_content("Not started")
     end
   end

--- a/spec/components/status_tags/permitted_development_right_review_component_spec.rb
+++ b/spec/components/status_tags/permitted_development_right_review_component_spec.rb
@@ -3,20 +3,62 @@
 require "rails_helper"
 
 RSpec.describe StatusTags::PermittedDevelopmentRightReviewComponent, type: :component do
-  let(:permitted_development_right) do
-    build(:permitted_development_right, review_status: review_status)
-  end
+  let(:planning_application) { create(:planning_application) }
 
-  before do
-    render_inline(
-      described_class.new(
-        permitted_development_right: permitted_development_right
+  context "when permitted development right has been updated" do
+    before do
+      create(
+        :permitted_development_right,
+        review_status: :review_not_started,
+        planning_application: planning_application,
+        created_at: 1.day.ago,
+        status: :to_be_reviewed
       )
-    )
+
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        submitted: true
+      )
+
+      render_inline(
+        described_class.new(
+          permitted_development_right: permitted_development_right,
+          planning_application: planning_application
+        )
+      )
+    end
+
+    let(:permitted_development_right) do
+      create(
+        :permitted_development_right,
+        review_status: :review_not_started,
+        planning_application: planning_application
+      )
+    end
+
+    it "renders 'Updated' status" do
+      expect(page).to have_content("Updated")
+    end
   end
 
   context "when review_status is 'review_complete'" do
-    let(:review_status) { :review_complete }
+    let(:permitted_development_right) do
+      create(
+        :permitted_development_right,
+        review_status: :review_complete,
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      render_inline(
+        described_class.new(
+          permitted_development_right: permitted_development_right,
+          planning_application: planning_application
+        )
+      )
+    end
 
     it "renders 'Complete' status" do
       expect(page).to have_content("Complete")
@@ -24,7 +66,22 @@ RSpec.describe StatusTags::PermittedDevelopmentRightReviewComponent, type: :comp
   end
 
   context "when review_status is 'review_in_progress'" do
-    let(:review_status) { :review_in_progress }
+    let(:permitted_development_right) do
+      create(
+        :permitted_development_right,
+        review_status: :review_in_progress,
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      render_inline(
+        described_class.new(
+          permitted_development_right: permitted_development_right,
+          planning_application: planning_application
+        )
+      )
+    end
 
     it "renders 'In progress' status" do
       expect(page).to have_content("In progress")
@@ -32,7 +89,22 @@ RSpec.describe StatusTags::PermittedDevelopmentRightReviewComponent, type: :comp
   end
 
   context "when review_status is 'review_not_started'" do
-    let(:review_status) { :review_not_started }
+    let(:permitted_development_right) do
+      create(
+        :permitted_development_right,
+        review_status: :review_not_started,
+        planning_application: planning_application
+      )
+    end
+
+    before do
+      render_inline(
+        described_class.new(
+          permitted_development_right: permitted_development_right,
+          planning_application: planning_application
+        )
+      )
+    end
 
     it "renders 'Not started' status" do
       expect(page).to have_content("Not started")

--- a/spec/components/status_tags/review_recommendation_component_spec.rb
+++ b/spec/components/status_tags/review_recommendation_component_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StatusTags::ReviewRecommendationComponent, type: :component do
+  let(:user) { create(:user, :reviewer) }
+
+  let(:planning_application) do
+    create(:planning_application, :awaiting_determination)
+  end
+
+  context "when review has not been started" do
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: :assessment_complete
+      )
+
+      render_inline(
+        described_class.new(
+          planning_application: planning_application,
+          user: user
+        )
+      )
+    end
+
+    it "renders 'Not started' status" do
+      expect(page).to have_content("Not started")
+    end
+  end
+
+  context "when review is complete" do
+    before do
+      create(
+        :recommendation,
+        status: :review_complete,
+        planning_application: planning_application
+      )
+
+      render_inline(
+        described_class.new(
+          planning_application: planning_application,
+          user: user
+        )
+      )
+    end
+
+    it "renders 'Complete' status" do
+      expect(page).to have_content("Complete")
+    end
+  end
+
+  context "when permitted development right has been updated" do
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        submitted: true,
+        challenged: false
+      )
+
+      create(
+        :permitted_development_right,
+        planning_application: planning_application,
+        created_at: 1.day.ago,
+        status: :to_be_reviewed
+      )
+
+      create(
+        :permitted_development_right,
+        planning_application: planning_application,
+        review_status: :review_not_started
+      )
+
+      render_inline(
+        described_class.new(
+          planning_application: planning_application,
+          user: user
+        )
+      )
+    end
+
+    it "renders 'Updated' status" do
+      expect(page).to have_content("Updated")
+    end
+  end
+
+  context "when assessment detail has been updated" do
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        submitted: true,
+        challenged: false
+      )
+
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        review_status: :complete,
+        reviewer_verdict: :rejected
+      )
+
+      create(
+        :assessment_detail,
+        :summary_of_work,
+        planning_application: planning_application,
+        assessment_status: :complete
+      )
+
+      render_inline(
+        described_class.new(
+          planning_application: planning_application,
+          user: user
+        )
+      )
+    end
+
+    it "renders 'Updated' status" do
+      expect(page).to have_content("Updated")
+    end
+  end
+
+  context "when review is in progress" do
+    before do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: :review_in_progress
+      )
+
+      render_inline(
+        described_class.new(
+          planning_application: planning_application,
+          user: user
+        )
+      )
+    end
+
+    it "renders 'In progress' status" do
+      expect(page).to have_content("In progress")
+    end
+  end
+end

--- a/spec/models/permitted_development_right_spec.rb
+++ b/spec/models/permitted_development_right_spec.rb
@@ -254,4 +254,36 @@ RSpec.describe PermittedDevelopmentRight do
       end
     end
   end
+
+  describe "#review_started?" do
+    context "when review_status is 'review_not_started'" do
+      let(:permitted_development_right) do
+        build(:permitted_development_right, review_status: :review_not_started)
+      end
+
+      it "returns false" do
+        expect(permitted_development_right.review_started?).to be(false)
+      end
+    end
+
+    context "when review_status is 'review_in_progress'" do
+      let(:permitted_development_right) do
+        build(:permitted_development_right, review_status: :review_in_progress)
+      end
+
+      it "returns true" do
+        expect(permitted_development_right.review_started?).to be(true)
+      end
+    end
+
+    context "when review_status is 'review_complete'" do
+      let(:permitted_development_right) do
+        build(:permitted_development_right, review_status: :review_complete)
+      end
+
+      it "returns true" do
+        expect(permitted_development_right.review_started?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1862,4 +1862,66 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  describe "#review_in_progress?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let!(:recommendation) do
+      create(
+        :recommendation,
+        planning_application: planning_application,
+        status: recommendation_status
+      )
+    end
+
+    let(:recommendation_status) { :assessment_complete }
+
+    context "when recommendation review is in progress" do
+      let(:recommendation_status) { :review_in_progress }
+
+      it "returns true" do
+        expect(planning_application.review_in_progress?).to be(true)
+      end
+    end
+
+    context "when assessment details review is in progress" do
+      before do
+        create(
+          :assessment_detail,
+          planning_application: planning_application,
+          reviewer_verdict: :accepted
+        )
+      end
+
+      it "returns true" do
+        expect(planning_application.review_in_progress?).to be(true)
+      end
+    end
+
+    context "when policy class review is in progress" do
+      let(:policy_class) do
+        create(:policy_class, planning_application: planning_application)
+      end
+
+      before { create(:review_policy_class, policy_class: policy_class) }
+
+      it "returns true" do
+        expect(planning_application.review_in_progress?).to be(true)
+      end
+    end
+
+    context "when permitted development right review is in progress" do
+      before do
+        create(
+          :permitted_development_right,
+          planning_application: planning_application,
+          review_status: :review_in_progress
+        )
+      end
+
+      it "returns true" do
+        expect(planning_application.review_in_progress?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/system/planning_applications/determine_application_spec.rb
+++ b/spec/system/planning_applications/determine_application_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe "Planning Application Assessment" do
       let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
       before do
+        create(
+          :recommendation,
+          planning_application: planning_application,
+          reviewer: reviewer
+        )
+
         travel_to Time.zone.local(2024, 2, 1)
         sign_in(reviewer)
         visit planning_application_path(planning_application)

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe "Reviewing sign-off" do
 
   before do
     sign_in reviewer
-    visit planning_application_path(planning_application)
   end
 
   it "can be accepted" do
@@ -43,6 +42,8 @@ RSpec.describe "Reviewing sign-off" do
            planning_application: planning_application,
            assessor_comment: "New assessor comment",
            submitted: true)
+
+    visit(planning_application_path(planning_application))
 
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link "Review and sign-off"
@@ -96,6 +97,7 @@ RSpec.describe "Reviewing sign-off" do
            submitted: true)
 
     travel_to(Date.new(2022))
+    visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
 
     expect(list_item("Sign-off recommendation")).to have_content("Not started")
@@ -155,6 +157,7 @@ RSpec.describe "Reviewing sign-off" do
            assessor_comment: "New assessor comment",
            submitted: true)
 
+    visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
     click_link "Sign-off recommendation"
 
@@ -174,6 +177,7 @@ RSpec.describe "Reviewing sign-off" do
            assessor_comment: "New assessor comment",
            submitted: true)
 
+    visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
     click_link "Sign-off recommendation"
 
@@ -195,6 +199,8 @@ RSpec.describe "Reviewing sign-off" do
   it "can edit an existing review of an assessment" do
     recommendation = create(:recommendation, :reviewed, planning_application: planning_application,
                                                         reviewer_comment: "Reviewer private comment")
+
+    visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
     click_link "Sign-off recommendation"
 
@@ -230,6 +236,7 @@ RSpec.describe "Reviewing sign-off" do
              assessor_comment: "New assessor comment",
              submitted: true)
 
+      visit(planning_application_path(planning_application))
       click_link "Review and sign-off"
       click_link "Sign-off recommendation"
 
@@ -300,6 +307,7 @@ RSpec.describe "Reviewing sign-off" do
     end
 
     it "raises an error if the reviewer accepts the recommendation" do
+      visit(planning_application_path(planning_application))
       click_link("Review and sign-off")
       click_link("Permitted development rights")
       choose("Return to officer with comment")

--- a/spec/system/planning_applications/reviewing/tasks_index_spec.rb
+++ b/spec/system/planning_applications/reviewing/tasks_index_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Reviewing Tasks Index" do
     end
 
     it "while awaiting determination it can navigate around review tasks" do
-      visit planning_application_path(create(:planning_application, :awaiting_determination,
-                                             local_authority: default_local_authority))
+      create(:recommendation, planning_application: planning_application)
+      visit planning_application_path(planning_application)
 
       click_on "Review and sign-off"
 


### PR DESCRIPTION
### Description of change

- Update 'Review and sign-off' link on planning application home page to show 'In progress' if any review tasks are in progress.
- Update 'Review and sign-off' link on planning application home page to show 'Updated' for updates to permitted development rights.
- Update 'Permitted development rights' link on review tasks page to show 'Updated' if assessor has updated it and resubmitted the recommendation.

NB This just addresses a couple of issues I came across while clicking around (and around, and around) for https://trello.com/c/EzMdSBMV/1222-officer-is-able-to-see-what-needs-reviewing-to-make-changes. 

I've added [a separate ticket](https://trello.com/c/uuUftYhb/1379-show-updated-tag-for-review-assessment-of-policy-class) for showing the 'Updated' tag for policy classes because I can't see an easy way to do it yet. I think once we've done [the audit piece](https://trello.com/c/Bo5YCoX4/1378-show-the-assessor-reviewer-any-previous-versions-of-comments-against-legislation-in-a-revealable-details-section) it might be easier!