### PR TITLE
Feature GHA concurrency on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,10 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   brakeman:
     uses: ./.github/workflows/linters.yml


### PR DESCRIPTION
- Feature kills the GHA of a tested PR on a per branch basis. This means that if you are working on a branch and you put some code up to test and then before the tests finish you make another commit and push that up  it will cancel the first job and only do the second. Thus you are only testing the current code and saving github action minutes.

- group is what group this rule will affect
- github.ref is the fully-formed ref of the branch or tag that triggered the workflow run.
- cancel-in-progress - cancel the in progress build in favour of the latest pushed code