### PR TITLE
Feature GHA concurrency on deploy

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -9,6 +9,9 @@ on:
         type: string
         required: true
 
+concurrency:
+  group: ${{ inputs.environment-name }}
+
 jobs:
   deploy:
     name: Deploy to ${{ inputs.environment-name }}


### PR DESCRIPTION
 - Feature: queued GHA job to deployment on a per environment basis.

 - When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any previously pending job or workflow in the concurrency group will be canceled.

 - group is what group this rule will affect - in this case per environment. So a staging job won't affect a production job.

 - Note: this does *not* cancel-in-progress
    - any running deployment will continue to completion. This only affects queued deployments.

 - Example of how it works: Add job 1 to deploy. *job 1 starts to deploy* Add job 2 to deploy *job 1 continues to deploy, job 2 is queued* Add job 3 to deploy *job 1 continues to deploy, job 2 is cancelled, job 3 is queued*
