### PR TITLE
Revert "GHA testing ubuntu 22.04"

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deploy:
     name: Deploy to ${{ inputs.environment-name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     environment: ${{ inputs.environment-name }}
 
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   linters:
     name: Linters
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: development
     steps:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   tests:
     name: ${{ inputs.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     services:
       postgres:


### PR DESCRIPTION
This reverts commit 662522417cd3e45b77ff16946b18b752b77c90b6.

Everything seems to work on Ubuntu 22.04
- Github will move to 22.04 in the next 4 months.