### PR TITLE
FIX: capybara window-size height increased

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -14,7 +14,7 @@ Capybara.register_driver :chrome_headless do |app|
   browser_options.args << "--headless"
   browser_options.args << "--no-sandbox"
   browser_options.args << "--allow-insecure-localhost"
-  browser_options.args << "--window-size=1280,960"
+  browser_options.args << "--window-size=1280,1920"
   browser_options.args << "--disable-gpu" if Gem.win_platform?
   browser_options.args << "--host-rules=MAP * 127.0.0.1"
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options).tap do |d|


### PR DESCRIPTION
 - BoPS capybara screenshots miss the bottom part of the page.
 
 - a larger height will capture all the screen and aid debugging

 - No special reason I chose 1920 if that's not right just change
     
 - reference to the information: https://medium.com/@florian.roesler/how-to-make-rspec-feature-tests-fun-again-27428daad9d3

## Before

![failures_r_spec_example_groups_validation_banners_when_validation_request_banners_are_displayed_correctly_when_open_request_is_overdue_shows_the_correct_count_for_2_overdue_request_validations_633](https://user-images.githubusercontent.com/1710795/206843337-a8b030a2-d2a1-4697-a370-4ed9bb03074c.png)


## After
![failures_r_spec_example_groups_validation_banners_when_validation_request_banners_are_displayed_correctly_when_open_request_is_overdue_shows_the_correct_count_for_2_overdue_request_validations_811](https://user-images.githubusercontent.com/1710795/206843348-025c6903-1922-4232-8202-0c8afcdd8f2e.png)

