### PR TITLE
Make assessment task breadcrumbs consistent

### DIFF
--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -1,43 +1,57 @@
 <% content_for :page_title do %>
   Submit recommendation - <%= t('page_title') %>
 <% end %>
-
-<% content_for :title, "Submit recommendation" %>
-
+<% render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: t(".review_and_submit_recommendation")
+  }
+) %>
 <%= render(
-  layout: "shared/assessment_dashboard",
+  partial: "shared/proposal_header",
   locals: { heading: t(".review_and_submit_recommendation") }
-) do %>
-  <%= render(
-    partial: "submit_recommendation_accordion",
-    locals: { planning_application: @planning_application }
-  ) %>
-  <h2 class="govuk-heading-m">Decision notice</h2>
-  <p class="govuk-body">The following decision notice has been created based on your answers.</p>
-  <%= render "decision_notice", planning_application: @planning_application %>
-  <p class="govuk-body">
-    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
-  </p>
-  <p class="govuk-body">
-    <br>
-    <strong>
-      If you agree with the decision notice, please submit it to your manager.
-    </strong>
-   If your manager disagrees with your recommendation they will send it back to you to make changes.
-  </p>
-  <div class="govuk-button-group">
-    <%= form_with model: @planning_application, url: submit_planning_application_path(@planning_application), local: true do |form| %>
-      <%= form.submit "Submit recommendation", class: "govuk-button", data: { module: "govuk-button" } %>
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+      partial: "submit_recommendation_accordion",
+      locals: { planning_application: @planning_application }
+    ) %>
+    <h2 class="govuk-heading-m"><%= t(".decision_notice") %></h2>
+    <p class="govuk-body"><%= t(".the_following_decision") %></p>
+    <%= render "decision_notice", planning_application: @planning_application %>
+    <p class="govuk-body">
       <%= link_to(
-        "Edit recommendation",
-        new_planning_application_recommendation_path(@planning_application),
-       class: "govuk-button govuk-button--secondary"
+        t(".download_as_pdf"),
+        decision_notice_api_v1_planning_application_path(
+          @planning_application,
+          format: "pdf"
+        ),
+        class: "govuk-link"
       ) %>
-      <%= link_to(
-        t(".back"),
-        planning_application_path(@planning_application),
-        class: "govuk-button govuk-button--secondary"
-      ) %>
-    <% end %>
+    </p>
+    <p class="govuk-body"><strong><%= t(".if_you_agree") %></strong></p>
+    <p class="govuk-body"><%= t(".if_your_manager") %></p>
+    <div class="govuk-button-group">
+      <%= form_with(
+        model: @planning_application,
+        url: submit_planning_application_path(@planning_application),
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |form| %>
+        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_submit(t(".submit_recommendation")) %>
+        <%= link_to(
+          t(".edit_recommendation"),
+          new_planning_application_recommendation_path(@planning_application),
+         class: "govuk-button govuk-button--secondary"
+        ) %>
+        <%= link_to(
+          t(".back"),
+          planning_application_path(@planning_application),
+          class: "govuk-button govuk-button--secondary"
+        ) %>
+      <% end %>
+    </div>
   </div>
-<% end %>
+</div>

--- a/app/views/policy_classes/_summary.html.erb
+++ b/app/views/policy_classes/_summary.html.erb
@@ -1,12 +1,17 @@
 <% content_for :page_title do %>
   <%= t(".assess") %> - <%= t("page_title") %>
 <% end %>
-<% add_parent_breadcrumb_link(t(".home"), planning_applications_path) %>
-<% add_parent_breadcrumb_link(
-  t(".application"),
-  planning_application_path(planning_application)
+<% render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: {
+    planning_application: planning_application,
+    current_page: t(
+      ".assess_policy_class",
+      part: policy_class.part,
+      class: policy_class.section
+    )
+  }
 ) %>
-<% content_for(:title, t(".assess")) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">

--- a/app/views/policy_classes/new.html.erb
+++ b/app/views/policy_classes/new.html.erb
@@ -1,12 +1,13 @@
 <% content_for :page_title do %>
   Assess - <%= t('page_title') %>
 <% end %>
-
-<% add_parent_breadcrumb_link "Home", planning_applications_path %>
-<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-
-<% content_for :title, "Assess" %>
-
+<% render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: t(".add_classes_to")
+  }
+) %>
 <%= render "flash_content" %>
 
 <div class="govuk-grid-row">

--- a/app/views/policy_classes/part.html.erb
+++ b/app/views/policy_classes/part.html.erb
@@ -1,12 +1,13 @@
 <% content_for :page_title do %>
   Assess - <%= t('page_title') %>
 <% end %>
-
-<% add_parent_breadcrumb_link "Home", planning_applications_path %>
-<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-
-<% content_for :title, "Assess" %>
-
+<% render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: t(".select_the_part")
+  }
+) %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -1,83 +1,94 @@
 <% content_for :page_title do %>
  <%= t(".make_draft_recommendation") %> - <%= t("page_title") %>
 <% end %>
-<% content_for(:title, t(".assess_recommendation")) %>
+<% render(
+  partial: "shared/assessment_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: t(".make_draft_recommendation")
+  }
+) %>
 <%= render(
-  layout: "shared/assessment_dashboard",
+  partial: "shared/proposal_header",
   locals: { heading: t(".make_draft_recommendation") }
-) do %>
-  <h2 class="govuk-heading-l govuk-!-padding-top-5"><%= t(".assess_proposal") %></h2>
-  <%= render(
-    PlanningApplications::AssessmentReportComponent.new(
-      planning_application: @planning_application,
-      show_additional_evidence: true
-    )
-  ) %>
-  <%= render(
-     partial: "events",
-     locals: { recommendations: @planning_application.recommendations.reviewed }
-  ) %>
-
-  <% if @planning_application.all_open_post_validation_requests.any? %>
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-l govuk-!-padding-top-5">
+      <%= t(".assess_proposal") %>
+    </h2>
     <%= render(
-      partial: "shared/alert_banner",
-      locals: {
-        message: t(
-          ".there_are_outstanding_change_requests_html",
-          last_request: @planning_application.all_open_post_validation_requests.last.created_at,
-          href: post_validation_requests_planning_application_validation_requests_path(@planning_application)
-        )
-      }
+      PlanningApplications::AssessmentReportComponent.new(
+        planning_application: @planning_application,
+        show_additional_evidence: true
+      )
     ) %>
-  <% end %>
-
-  <%= form_with(
-    model: @recommendation,
-    builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-    url: planning_application_recommendations_path(@planning_application)
-  ) do |form| %>
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-    <%= form.govuk_collection_radio_buttons(
-      :decision,
-      [[:granted, t(".yes")], [:refused, t(".no")]],
-      :first,
-      :last,
-      legend: { text: t(".is_the_use"), size: "s" }
+    <%= render(
+       partial: "events",
+       locals: {
+         recommendations: @planning_application.recommendations.reviewed
+       }
     ) %>
-    <div class="govuk-form-group <%= "govuk-form-group--error" if form.object.errors[:public_comment].any? %>">
-      <%= form.label(:public_comment, t(".state_the_reason"), class: "govuk-label govuk-label--s") %>
-      <div class="govuk-hint"><%= t(".refer_to_the") %></div>
+    <% if @planning_application.all_open_post_validation_requests.any? %>
       <%= render(
-        partial: "shared/warning_text",
-        locals: { message: t(".this_information_will") }
+        partial: "shared/alert_banner",
+        locals: {
+          message: t(
+            ".there_are_outstanding_change_requests_html",
+            last_request: @planning_application.all_open_post_validation_requests.last.created_at,
+            href: post_validation_requests_planning_application_validation_requests_path(@planning_application)
+          )
+        }
       ) %>
-      <% if form.object.errors[:public_comment].any? %>
-        <p id="recommendation-form-public-comment-field-error" class="govuk-error-message">
-          <span class="govuk-visually-hidden">
-            <%= t(".error") %>
-          </span>
-          <%= form.object.errors[:public_comment].first %>
-        </p>
-      <% end %>
-      <%= form.text_area(
-        :public_comment,
-        class: "govuk-textarea #{"govuk-textarea--error" if form.object.errors[:public_comment].any?}",
+    <% end %>
+    <%= form_with(
+      model: @recommendation,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      url: planning_application_recommendations_path(@planning_application)
+    ) do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_collection_radio_buttons(
+        :decision,
+        [[:granted, t(".yes")], [:refused, t(".no")]],
+        :first,
+        :last,
+        legend: { text: t(".is_the_use"), size: "s" }
+      ) %>
+      <div class="govuk-form-group <%= "govuk-form-group--error" if form.object.errors[:public_comment].any? %>">
+        <%= form.label(:public_comment, t(".state_the_reason"), class: "govuk-label govuk-label--s") %>
+        <div class="govuk-hint"><%= t(".refer_to_the") %></div>
+        <%= render(
+          partial: "shared/warning_text",
+          locals: { message: t(".this_information_will") }
+        ) %>
+        <% if form.object.errors[:public_comment].any? %>
+          <p id="recommendation-form-public-comment-field-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">
+              <%= t(".error") %>
+            </span>
+            <%= form.object.errors[:public_comment].first %>
+          </p>
+        <% end %>
+        <%= form.text_area(
+          :public_comment,
+          class: "govuk-textarea #{"govuk-textarea--error" if form.object.errors[:public_comment].any?}",
+          rows: 9
+        ) %>
+      </div>
+      <%= form.govuk_text_area(
+        :assessor_comment,
+        label: { text: t(".please_provide_supporting"), size: "s" },
+        hint: { text: t(".this_information_will_not") },
         rows: 9
       ) %>
-    </div>
-    <%= form.govuk_text_area(
-      :assessor_comment,
-      label: { text: t(".please_provide_supporting"), size: "s" },
-      hint: { text: t(".this_information_will_not") },
-      rows: 9
-    ) %>
-    <% if @planning_application.assessment_submitted? %>
-      <div class="govuk-button-group">
-        <%= form.govuk_submit(t(".update_assessment")) %>
-        <%= back_link %>
-      </div>
-    <% else %>
-      <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+      <% if @planning_application.assessment_submitted? %>
+        <div class="govuk-button-group">
+          <%= form.govuk_submit(t(".update_assessment")) %>
+          <%= back_link %>
+        </div>
+      <% else %>
+        <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+      <% end %>
     <% end %>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/shared/_assessment_task_breadcrumbs.html.erb
+++ b/app/views/shared/_assessment_task_breadcrumbs.html.erb
@@ -7,6 +7,9 @@
   planning_application_path(planning_application)
 ) %>
 <% add_parent_breadcrumb_link(
-   t(".assess_application"), 
+   t(".assess_application"),
    planning_application_assessment_tasks_path(planning_application)
 ) %>
+<% if current_page = local_assigns.fetch(:current_page, nil).presence %>
+  <%= content_for(:title, current_page) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -644,7 +644,15 @@ en:
     submit:
       success: Recommendation was successfully submitted.
     submit_recommendation:
+      back: Back
+      decision_notice: Decision notice
+      download_as_pdf: Download as PDF
+      edit_recommendation: Edit recommendation
+      if_you_agree: If you agree with the decision notice, please submit it to your manager.
+      if_your_manager: If your manager disagrees with your recommendation they will send it back to you to make changes.
       review_and_submit_recommendation: Review and submit recommendation
+      submit_recommendation: Submit recommendation
+      the_following_decision: The following decision notice has been created based on your answers.
     submit_recommendation_accordion:
       assessment_report: Assessment report
       download_assessment_report: Download assessment report as PDF
@@ -682,7 +690,10 @@ en:
       view_next_class: View next class
       view_previous_class: View previous class
     new:
+      add_classes_to: Add classes to assess
       failure: Please choose one of the policy parts
+    part:
+      select_the_part: Select the part to assess
     summary:
       application: Application
       assess: Assess
@@ -738,8 +749,20 @@ en:
       legislation: Legislation
       no_legislation_assessed: No legislation assessed for this application.
     new:
+      assess_proposal: Assess the proposal
       assess_recommendation: Assess recommendation
+      error: 'Error:'
+      is_the_use: Is the use or operation lawful?
       make_draft_recommendation: Make draft recommendation
+      'no': 'No'
+      please_provide_supporting: Please provide supporting information for your manager.
+      refer_to_the: Refer to the specific permitted development rights being evoked.
+      state_the_reason: State the reasons why this application is, or is not lawful.
+      there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
+      this_information_will: This information WILL appear on the decision notice.
+      this_information_will_not: This information WILL NOT appear on the decision notice or the public register, however FOI still apply.
+      update_assessment: Update assessment
+      'yes': 'Yes'
     update:
       success: Recommendation was successfully reviewed.
   red_line_boundary_change_validation_requests:
@@ -766,24 +789,12 @@ en:
     application_information:
       exempt: Exempt
     assessment_dashboard:
-      assess_proposal: Assess the proposal
       assess_recommendation: Assess recommendation
       awaiting_approval_to: Awaiting approval to a description change (sent on %{date})
       back: Back
       close_or_cancel: Close or cancel application
       details: Details
-      error: 'Error:'
-      is_the_use: Is the use or operation lawful?
-      'no': 'No'
-      please_provide_supporting: Please provide supporting information for your manager.
-      refer_to_the: Refer to the specific permitted development rights being evoked.
-      state_the_reason: State the reasons why this application is, or is not lawful.
-      there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
-      this_information_will: This information WILL appear on the decision notice.
-      this_information_will_not: This information WILL NOT appear on the decision notice or the public register, however FOI still apply.
-      update_assessment: Update assessment
       view_all_requests: View all requests.
-      'yes': 'Yes'
     assessment_task_breadcrumbs:
       application: Application
       assess_application: Assess application


### PR DESCRIPTION
### Description of change

Make sure all assessment task pages have breadcrumbs in the format  `Home > Application > Assess application > Current page`

### Story Link

https://trello.com/c/dsZtqvNc/1318-move-assess-recommendation-and-submit-recommendation-tasks-onto-the-check-and-assess-tasklist-and-rename-the-tasks (See comments)
