### PR TITLE
Redirect to previous page after updating planning application

### DIFF
--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -10,7 +10,7 @@ class ConstraintsController < AuthenticationController
 
   def update
     if @planning_application.update(constraints: constraints_params[:constraints].compact_blank)
-      redirect_to @planning_application, notice: "Constraints have been updated"
+      redirect_to(after_update_path, notice: t(".success"))
     else
       render :edit
     end
@@ -35,6 +35,10 @@ class ConstraintsController < AuthenticationController
   end
 
   private
+
+  def after_update_path
+    params.dig(:planning_application, :return_to) || @planning_application
+  end
 
   def constraints_params
     params.require(:planning_application).permit(constraints: [])

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -340,8 +340,12 @@ class PlanningApplicationsController < AuthenticationController
     if params[:edit_action] == "edit_payment_amount"
       redirect_to planning_application_fee_items_path(@planning_application, validate_fee: "yes"), notice: "Planning application payment amount was successfully updated."
     else
-      redirect_to @planning_application, notice: t(".success")
+      redirect_to(after_update_url, notice: t(".success"))
     end
+  end
+
+  def after_update_url
+    params.dig(:planning_application, :return_to) || @planning_application
   end
 
   def validate_documents_notice(planning_application)

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -12,6 +12,7 @@
 
 <div class="govuk-grid-row">
   <%= form_with model: @planning_application, url: planning_application_constraints_path(@planning_application), local: true do |form| %>
+    <%= form.hidden_field(:return_to, value: @back_path) %>
     <div class="govuk-grid-column-two-thirds">
       <% t("constraints").each do |type, constraints| %>
         <fieldset class="govuk-fieldset govuk-!-margin-top-3">

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -15,7 +15,10 @@
       </ul>
     </span>
   <% end %>
-
+  <%= form.hidden_field(
+    :return_to,
+    value: local_assigns.fetch(:return_to, nil)
+  ) %>
   <%= form.hidden_field :application_type, value: "lawfulness_certificate" %>
   <div class="govuk-form-group">
     <% if action_name == "new" || action_name == "create" %>

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -9,6 +9,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render 'form', planning_application: @planning_application %>
+    <%= render(
+      partial: "form",
+      locals: {
+        planning_application: @planning_application,
+        return_to: @back_path
+      }
+    ) %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -361,6 +361,8 @@ en:
       success: Constraints was successfully checked.
     info:
       update_constraints: Update constraints
+    update:
+      success: Constraints have been updated
   council_code:
     buckinghamshire: BUC
     lambeth: LBH

--- a/features/editing_a_planning_application.feature
+++ b/features/editing_a_planning_application.feature
@@ -9,6 +9,7 @@ Feature: Editing an application's details
     And I fill in "Month" with "10"
     And I fill in "Year" with "1989"
     When I press "Save"
+    And I press "Application"
     Then the page contains "Target date: 7 November 1989"
 
   Scenario: I can edit the applicaiton's site details
@@ -26,7 +27,6 @@ Feature: Editing an application's details
   Scenario: I can edit the application's proposed or completed status
     Given I choose "Yes" for "Has the work been started?"
     When I press "Save"
-    And I press "Check and validate"
     Then the page contains "Work already started: Yes"
 
   Scenario: I can edit the application's applicant details
@@ -36,6 +36,7 @@ Feature: Editing an application's details
     And I fill in "Email address" with "pearly@poorly.com"
     And I fill in "UK telephone number" with "0777773949494312"
     When I press "Save"
+    And I press "Application"
     Then the page contains "Pearly Poorly"
     And the page contains "pearly@poorly.com"
     And the page contains "0777773949494312"
@@ -47,6 +48,7 @@ Feature: Editing an application's details
     And I fill in "Email address" with "pearly@poorly.com"
     And I fill in "UK telephone number" with "0777773949494312"
     When I press "Save"
+    And I press "Application"
     Then the page contains "Pearly Poorly"
     And the page contains "pearly@poorly.com"
     And the page contains "0777773949494312"

--- a/features/editing_an_application_constraints.feature
+++ b/features/editing_an_application_constraints.feature
@@ -14,14 +14,6 @@ Feature: Editing an application's constraints
     Given I visit the application's constraints form
     Then the "Conservation Area" option is checked
 
-  Scenario: As an assessor I can edit the application constraints
-    Given I visit the application's constraints form
-    And I check "Safeguarded land"
-    When I press "Save"
-    And I visit the application's constraints form
-    Then the "Safeguarded land" option is checked
-    And there is an audit entry containing "Constraint added"
-
   Scenario: As an assessor I can add custom constraints to the application
     Given I visit the application's constraints form
     And I fill in "Add a local constraint" with "Batcave"

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "editing planning application" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority: local_authority) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: local_authority
+    )
+  end
+
+  it "returns the user to the previous page after updating" do
+    sign_in(assessor)
+    visit(planning_application_path(planning_application))
+    click_link("Check and assess")
+    click_button("Application information")
+    click_link("Edit details")
+
+    within(find(:fieldset, text: "Agent information")) do
+      fill_in("Email address", with: "")
+    end
+
+    within(find(:fieldset, text: "Applicant information")) do
+      fill_in("Email address", with: "")
+    end
+
+    click_button("Save")
+
+    expect(page).to have_content("An applicant or agent email is required.")
+
+    within(find(:fieldset, text: "Agent information")) do
+      fill_in("Email address", with: "alice@example.com")
+    end
+
+    within(find(:fieldset, text: "Applicant information")) do
+      fill_in("Email address", with: "belle@example.com")
+    end
+
+    click_button("Save")
+
+    expect(page).to have_content(
+      "Planning application was successfully updated."
+    )
+
+    expect(page).to have_current_path(
+      planning_application_assessment_tasks_path(planning_application)
+    )
+
+    click_link("Description, documents and proposal details")
+    click_button("Application information")
+    click_link("Edit details")
+    fill_in("Address 1", with: "125 High Street")
+    click_button("Save")
+
+    expect(page).to have_content(
+      "Planning application was successfully updated."
+    )
+
+    expect(page).to have_current_path(
+      new_planning_application_consistency_checklist_path(planning_application)
+    )
+  end
+end

--- a/spec/system/planning_applications/updating_constraints_spec.rb
+++ b/spec/system/planning_applications/updating_constraints_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "updating constraints" do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      local_authority: local_authority,
+      constraints: []
+    )
+  end
+
+  let(:assessor) do
+    create(:user, :assessor, local_authority: local_authority)
+  end
+
+  it "lets the user update the constraints" do
+    sign_in(assessor)
+    visit(planning_application_assessment_tasks_path(planning_application))
+    click_button("Constraints")
+    click_link("Update constraints")
+    check("Conservation Area")
+    click_button("Save")
+
+    expect(page).to have_content("Constraints have been updated")
+
+    expect(page).to have_current_path(
+      planning_application_assessment_tasks_path(planning_application)
+    )
+
+    click_button("Constraints")
+
+    expect(page).to have_content("Conservation Area")
+
+    click_link("Application")
+    click_button("Audit log")
+
+    expect(page).to have_content("Constraint added")
+  end
+end


### PR DESCRIPTION
### Description of change

- Redirect to previous page after updating planning application details.
- Redirect to previous page after updating constraints.

### Story Link

https://trello.com/c/c2HVZjBV/1382-where-there-are-links-to-actions-from-the-accordion-users-should-return-to-the-same-place-they-left-from