### PR TITLE
Allow for case insensitive email when logging in with 2FA

### DIFF
--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -75,7 +75,7 @@ module AuthenticateWithOtpTwoFactor
     if session[:otp_user_id]
       find_current_local_authority.users.find(session[:otp_user_id])
     elsif user_params[:email]
-      find_current_local_authority.users.find_by(email: user_params[:email])
+      find_current_local_authority.users.find_for_authentication(email: user_params[:email])
     end
   end
 

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -438,6 +438,19 @@ RSpec.describe "Sign in" do
         expect(page).to have_content(user.name)
       end
     end
+
+    context "when I use an email with uppercase letters" do
+      let!(:user) { create(:user, local_authority: default_local_authority) }
+
+      it "allows me to login with a case insensitive email address" do
+        fill_in "Email", with: user.email.upcase
+
+        click_button("Log in")
+
+        expect(page).to have_content("Enter the code you have received by text message")
+        expect(page).not_to have_content("Invalid Email or password")
+      end
+    end
   end
 
   context "with user session" do


### PR DESCRIPTION
### Description of change

With 2FA enabled we do not set this [devise helper](https://github.com/unboxed/bops/blob/main/app/models/user.rb#L11) `devise :database_authenticatable if Rails.env.development? && ENV["2FA_ENABLED"] != "true"` but have a custom login process instead. Therefore we do not pick up the [config](https://github.com/unboxed/bops/blob/main/config/initializers/devise.rb#L24) set as `config.case_insensitive_keys = [:email]` as default.

When we attempt to find the user email from the params in [this code](https://github.com/unboxed/bops/blob/main/app/controllers/concerns/authenticate_with_otp_two_factor.rb#L74-L80) we do not search for the lowercase version 
`find_current_local_authority.users.find_by(email: user_params[:email])`

Therefore, a user entering an email with uppercase letters will receive an error that their email or password is invalid.
Switching to `find_for_authentication` ignores the case sensitivity

### Story Link

https://trello.com/c/Koc0mWX1/1348-remove-case-sensitivity-for-email-addresses-when-logging-in