### PR TITLE
Remove buttons masquerading as links from consistency checklist page

### DIFF
--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -7,7 +7,6 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
   before_action :ensure_planning_application_not_validated, only: %i[edit update]
   before_action :ensure_planning_application_not_invalidated, only: :edit
-  before_action :set_return_to, only: %i[new]
 
   def new
     @additional_document_validation_request = @planning_application.additional_document_validation_requests.new
@@ -31,7 +30,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
       if @additional_document_validation_request.save
         format.html do
           redirect_to(
-            (session.delete(:return_to) || create_request_redirect_url),
+            create_request_redirect_url,
             notice: I18n.t("additional_document_validation_requests.create.success")
           )
         end
@@ -54,6 +53,10 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
   end
 
   private
+
+  def create_request_redirect_url
+    params.dig(:additional_document_validation_request, :return_to) || super
+  end
 
   def additional_document_validation_request_params
     params.require(:additional_document_validation_request).permit(:document_request_type, :document_request_reason)

--- a/app/controllers/consistency_checklists_controller.rb
+++ b/app/controllers/consistency_checklists_controller.rb
@@ -21,7 +21,7 @@ class ConsistencyChecklistsController < AuthenticationController
 
     if @consistency_checklist.save
       redirect_to(
-        after_save_path,
+        planning_application_assessment_tasks_path(@planning_application),
         notice: t(".successfully_updated_application")
       )
     else
@@ -32,7 +32,7 @@ class ConsistencyChecklistsController < AuthenticationController
   def update
     if @consistency_checklist.update(consistency_checklist_params)
       redirect_to(
-        after_save_path,
+        planning_application_assessment_tasks_path(@planning_application),
         notice: t(".successfully_updated_application")
       )
     else
@@ -61,24 +61,6 @@ class ConsistencyChecklistsController < AuthenticationController
       proposal_details_match_documents_comment
       site_map_correct
     ]
-  end
-
-  def after_save_path
-    if after_save_path_request_type.present?
-      send(
-        "new_planning_application_#{after_save_path_request_type}_validation_request_path",
-        @planning_application,
-        consistency_checklist: true
-      )
-    else
-      planning_application_assessment_tasks_path(@planning_application)
-    end
-  end
-
-  def after_save_path_request_type
-    %i[additional_document description_change red_line_boundary_change].find do |request_type|
-      t("consistency_checklists.request_#{request_type}") == params[:commit]
-    end
   end
 
   def status

--- a/app/controllers/description_change_validation_requests_controller.rb
+++ b/app/controllers/description_change_validation_requests_controller.rb
@@ -3,7 +3,6 @@
 class DescriptionChangeValidationRequestsController < ValidationRequestsController
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
   before_action :set_description_change_request, only: %i[show cancel]
-  before_action :set_return_to, only: %i[new show]
 
   def show; end
 
@@ -17,10 +16,7 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
     @current_local_authority = current_local_authority
 
     if @description_change_request.save
-      redirect_to(
-        (session.delete(:return_to) || @planning_application),
-        notice: t(".success")
-      )
+      redirect_to(after_save_path, notice: t(".success"))
     else
       render :new
     end
@@ -33,13 +29,15 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
       @description_change_request.audit_cancel!
     end
 
-    redirect_to(
-      (session.delete(:return_to) || @planning_application),
-      notice: t(".success")
-    )
+    redirect_to(after_save_path, notice: t(".success"))
   end
 
   private
+
+  def after_save_path
+    params.dig(:description_change_validation_request, :return_to) ||
+      @planning_application
+  end
 
   def set_description_change_request
     @description_change_request = @planning_application.description_change_validation_requests.find(params[:id] ||= params[:description_change_validation_request_id])

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -5,7 +5,6 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
 
   before_action :ensure_no_open_or_pending_red_line_boundary_validation_request, only: %i[new]
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
-  before_action :set_return_to, only: %i[new]
 
   def show
     @red_line_boundary_change_validation_request = @planning_application.red_line_boundary_change_validation_requests.find(params[:id])
@@ -22,12 +21,27 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
 
     if @red_line_boundary_change_validation_request.save
       redirect_to(
-        (session.delete(:return_to) || create_request_redirect_url),
+        create_request_redirect_url,
         notice: t(".validation_request_for")
       )
     else
       render :new
     end
+  end
+
+  def create_request_redirect_url
+    case return_to
+    when nil
+      super
+    when planning_application_sitemap_url(@planning_application)
+      planning_application_validation_tasks_path(@planning_application)
+    else
+      return_to
+    end
+  end
+
+  def return_to
+    params.dig(:red_line_boundary_change_validation_request, :return_to)
   end
 
   private

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -37,12 +37,6 @@ class ValidationRequestsController < AuthenticationController
 
   private
 
-  def set_return_to
-    return if params[:consistency_checklist].blank?
-
-    session[:return_to] = edit_planning_application_consistency_checklist_path(@planning_application)
-  end
-
   def ensure_planning_application_not_validated
     render plain: "forbidden", status: :forbidden and return unless @planning_application.can_validate?
   end

--- a/app/models/assessment_details_review.rb
+++ b/app/models/assessment_details_review.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class AssessmentDetailsReview
+  include Memoizable
   include ActiveModel::Model
   extend ActiveModel::Callbacks
 
@@ -119,9 +120,5 @@ class AssessmentDetailsReview
 
   def status_complete?
     status == :complete
-  end
-
-  def memoize(key, value)
-    instance_variable_get("@#{key}") || instance_variable_set("@#{key}", value)
   end
 end

--- a/app/models/concerns/memoizable.rb
+++ b/app/models/concerns/memoizable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Memoizable
+  extend ActiveSupport::Concern
+
+  def memoize(key, value)
+    instance_variable_get("@#{key}") || instance_variable_set("@#{key}", value)
+  end
+end

--- a/app/models/concerns/planning_application/validation_requests.rb
+++ b/app/models/concerns/planning_application/validation_requests.rb
@@ -79,8 +79,8 @@ class PlanningApplication
     end
 
     ValidationRequest::VALIDATION_REQUEST_TYPES.map(&:underscore).each do |type|
-      define_method(type) do |post_validation = false|
-        send(type.pluralize).order(:created_at).where(post_validation: post_validation).last
+      define_method(type) do
+        send(type.pluralize).order(:created_at).last
       end
     end
 

--- a/app/views/additional_document_validation_requests/_form.html.erb
+++ b/app/views/additional_document_validation_requests/_form.html.erb
@@ -2,7 +2,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@planning_application, @additional_document_validation_request], local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <%= form.govuk_fieldset legend: { text: "Request a new document", size: 'l' } do %>
-
+        <%= form.hidden_field(
+          :return_to,
+          value: local_assigns.fetch(:return_to, nil)
+        ) %>
         <%= render "shared/planning_application_address_and_reference" %>
 
         <%= form.govuk_text_field :document_request_type,

--- a/app/views/additional_document_validation_requests/new.html.erb
+++ b/app/views/additional_document_validation_requests/new.html.erb
@@ -6,4 +6,4 @@
 
 <% content_for :title, "Request a new document" %>
 
-<%= render "form" %>
+<%= render(partial: "form", locals: { return_to: @back_path }) %>

--- a/app/views/consistency_checklists/_description_matches_documents.html.erb
+++ b/app/views/consistency_checklists/_description_matches_documents.html.erb
@@ -7,17 +7,22 @@
       :description_matches_documents,
       :yes,
       label: { text: t(".yes") },
-      link_errors: true
+      link_errors: true,
+      disabled: form.object.open_description_change_requests?
     ) %>
     <%= form.govuk_radio_button(
       :description_matches_documents,
       :no,
-      label: { text: t(".no") }
+      label: { text: t(".no") },
+      checked: form.object.default_description_matches_documents_to_no?
     ) do %>
-      <% unless planning_application.description_change_validation_requests.open.any? %>
-        <%= form.submit(
+      <% unless form.object.open_description_change_requests? %>
+        <%= link_to(
           t("consistency_checklists.request_description_change"),
-          class: "button-as-link"
+          new_planning_application_description_change_validation_request_path(
+            planning_application
+          ),
+          class: "govuk-link"
         ) %>
       <% end %>
     <% end %>
@@ -34,7 +39,7 @@
   <%= render(
     partial: "description_change_validation_request",
     locals: {
-      request: planning_application.description_change_validation_request(post_validation: true),
+      request: planning_application.description_change_validation_request,
       planning_application: planning_application
     }
   ) %>

--- a/app/views/consistency_checklists/_documents_consistent.html.erb
+++ b/app/views/consistency_checklists/_documents_consistent.html.erb
@@ -7,16 +7,21 @@
       :documents_consistent,
       :yes,
       label: { text: t(".yes") },
-      link_errors: true
+      link_errors: true,
+      disabled: form.object.open_additional_document_requests?
     ) %>
     <%= form.govuk_radio_button(
       :documents_consistent,
       :no,
-      label: { text: t(".no") }
+      label: { text: t(".no") },
+      checked: form.object.default_documents_consistent_to_no?
     ) do %>
-      <%= form.submit(
+      <%= link_to(
         t("consistency_checklists.request_additional_document"),
-        class: "button-as-link"
+        new_planning_application_additional_document_validation_request_path(
+          planning_application
+        ),
+        class: "govuk-link"
       ) %>
     <% end %>
   <% else %>
@@ -27,7 +32,7 @@
       disabled: true
     ) %>
   <% end %>
-  <% planning_application.additional_document_validation_requests.post_validation.order(:created_at).each do |request| %>
+  <% planning_application.additional_document_validation_requests.order(:created_at).each do |request| %>
     <%= render(
       partial: "additional_document_validation_request",
       locals: { request: request, planning_application: planning_application }

--- a/app/views/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/consistency_checklists/_site_map_correct.html.erb
@@ -1,23 +1,28 @@
 <%= form.govuk_radio_buttons_fieldset(
   :site_map_correct,
-  legend: { text: t(".is_the_red"), size: "s" }
+  legend: { text: t(".is_the_red"), size: "s" },
 ) do %>
   <% if can_edit %>
     <%= form.govuk_radio_button(
       :site_map_correct,
       :yes,
       label: { text: t(".yes") },
-      link_errors: true
+      link_errors: true,
+      disabled: form.object.open_red_line_boundary_change_requests?
     ) %>
     <%= form.govuk_radio_button(
       :site_map_correct,
       :no,
-      label: { text: t(".no") }
+      label: { text: t(".no") },
+      checked: form.object.default_site_map_correct_to_no?
     ) do %>
-      <% unless planning_application.red_line_boundary_change_validation_requests.post_validation.open.any? %>
-        <%= form.submit(
+      <% unless form.object.open_red_line_boundary_change_requests? %>
+        <%= link_to(
           t("consistency_checklists.request_red_line_boundary_change"),
-          class: "button-as-link"
+          new_planning_application_red_line_boundary_change_validation_request_path(
+            planning_application
+          ),
+          class: "govuk-link"
         ) %>
       <% end %>
     <% end %>
@@ -32,7 +37,7 @@
   <%= render(
     partial: "red_line_boundary_change_validation_request",
     locals: {
-      request: planning_application.red_line_boundary_change_validation_request(post_validation: true),
+      request: planning_application.red_line_boundary_change_validation_request,
       planning_application: planning_application
     }
   ) %>

--- a/app/views/description_change_validation_requests/new.html.erb
+++ b/app/views/description_change_validation_requests/new.html.erb
@@ -55,6 +55,7 @@
             </span>
           </p>
         <% end %>
+        <%= form.hidden_field(:return_to, value: @back_path) %>
         <%= form.govuk_text_area :proposed_description,
       label: { text: 'Please suggest a new application description', class: 'govuk-label govuk-label--s'},
       rows: 5 %>

--- a/app/views/description_change_validation_requests/show.html.erb
+++ b/app/views/description_change_validation_requests/show.html.erb
@@ -32,9 +32,26 @@
         <%= @description_change_request.approved? ? 'Approved' : 'Rejected' %>
       <% end %>
     </p>
-    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button" %>
+
     <% if @description_change_request.open? %>
-      <%= link_to "Cancel this request", planning_application_description_change_validation_request_cancel_path(@planning_application, @description_change_request), class: "govuk-button govuk-button--secondary", method: :patch  %>
+      <%= form_with(
+        model: [@planning_application, @description_change_request],
+        url: planning_application_description_change_validation_request_cancel_path(
+          @planning_application,
+          @description_change_request
+        ),
+        method: :patch,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder
+      ) do |form| %>
+        <%= form.hidden_field(:return_to, value: @back_path) %>
+        <div class="govuk-button-group">
+          <%= link_to(t(".back"), @back_path, class: "govuk-button") %>
+          <%= form.submit(
+            t(".cancel_this_request"),
+            class: "govuk-button govuk-button--secondary"
+          ) %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_form.html.erb
@@ -21,6 +21,10 @@
           </div>
         </div>
       <% end %>
+      <%= form.hidden_field(
+        :return_to,
+        value: local_assigns.fetch(:return_to, nil)
+      ) %>
       <%= form.govuk_text_area :new_geojson,
                                label: { text: @planning_application.boundary_geojson ? "Applicant's existing red line boundary" : "No digital red line boundary has been previously set",
                                         size: 's',

--- a/app/views/red_line_boundary_change_validation_requests/new.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/new.html.erb
@@ -5,4 +5,4 @@
 <%= render "validation_requests/validation_requests_breadcrumbs" %>
 <% content_for :title, "Red line boundary change" %>
 
-<%= render "form" %>
+<%= render(partial: "form", locals: { return_to: @back_path }) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,7 +125,7 @@ en:
               not_determined: Determine whether the proposal details are consistent with the plans
             site_map_correct:
               not_determined: Determine whether the red line on the site map is correct
-              open_red_line_boundary_requests: Red line boundary change requests must be closed or cancelled
+              open_red_line_boundary_change_requests: Red line boundary change requests must be closed or cancelled
         document:
           attributes:
             file:
@@ -376,6 +376,9 @@ en:
       description_change: Description change
       new_description: 'New description:'
       proposed_description: 'Propsed description:'
+    show:
+      back: Back
+      cancel_this_request: Cancel this request
   documents:
     document_row_image:
       archive: Archive

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -17,7 +17,6 @@ Feature: Creating a description change on the application
 
   Scenario: I can add and view a new description change request after cancelling the previous one
     Given I create a description change request with "Its margarita time ole!"
-    When I press "Check and validate"
     And I press "Application information"
     And I press "View requested change"
     Then the page contains "Previous description"

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -14,7 +14,7 @@ end
 
 Given("I create a description change request with {string}") do |details|
   steps %(
-    I view the planning application
+    When I view the planning application
     And I press "Check and validate"
     And I press "Application information"
     And I press "Propose a change to the description"
@@ -29,7 +29,7 @@ end
 
 When("I cancel the existing description change request") do
   steps %(
-    I view the planning application
+    When I view the planning application
     And I press "Check and validate"
     And I press "Application information"
     And I press "View requested change"

--- a/features/step_definitions/validation_requests_steps.rb
+++ b/features/step_definitions/validation_requests_steps.rb
@@ -16,6 +16,7 @@ When("I create a new document validation request for a(n) {string} because {stri
     And I fill in "Please specify the new document type:" with "#{type}"
     And I fill in "the reason" with "#{reason}"
     And I save or send the request
+    And I press "Validation tasks"
     And I click link "Review validation requests"
   )
 end
@@ -65,6 +66,7 @@ Given("I create a(n) additional document validation request with {string}") do |
     And I fill in "Please specify the new document type:" with "#{details}"
     And I fill in "the reason" with "a valid reason"
     And I save or send the request
+    And I press "Validation tasks"
     And I click link "Review validation requests"
   )
 end

--- a/spec/models/consistency_checklist_spec.rb
+++ b/spec/models/consistency_checklist_spec.rb
@@ -336,4 +336,274 @@ RSpec.describe ConsistencyChecklist do
       end
     end
   end
+
+  describe "#open_red_line_boundary_change_requests?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(:consistency_checklist, planning_application: planning_application)
+    end
+
+    context "when there are no open requests" do
+      it "returns false" do
+        expect(
+          consistency_checklist.open_red_line_boundary_change_requests?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when there are open requests" do
+      before do
+        create(
+          :red_line_boundary_change_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.open_red_line_boundary_change_requests?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
+
+  describe "#open_additional_document_requests?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(:consistency_checklist, planning_application: planning_application)
+    end
+
+    context "when there are no open requests" do
+      it "returns false" do
+        expect(
+          consistency_checklist.open_additional_document_requests?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when there are open requests" do
+      before do
+        create(
+          :additional_document_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.open_additional_document_requests?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
+
+  describe "#open_description_change_requests?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(:consistency_checklist, planning_application: planning_application)
+    end
+
+    context "when there are no open requests" do
+      it "returns false" do
+        expect(
+          consistency_checklist.open_description_change_requests?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when there are open requests" do
+      before do
+        create(
+          :description_change_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.open_description_change_requests?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
+
+  describe "#default_description_matches_documents_to_no?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(
+        :consistency_checklist,
+        planning_application: planning_application,
+        description_matches_documents: description_matches_documents
+      )
+    end
+
+    context "when value is not 'no' and there are no open description change requests" do
+      let(:description_matches_documents) { :yes }
+
+      it "returns false" do
+        expect(
+          consistency_checklist.default_description_matches_documents_to_no?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when value is 'no'" do
+      let(:description_matches_documents) { :no }
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_description_matches_documents_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+
+    context "when there are open description change requests" do
+      let(:description_matches_documents) { :yes }
+
+      before do
+        create(
+          :description_change_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_description_matches_documents_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
+
+  describe "#default_documents_consistent_to_no?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(
+        :consistency_checklist,
+        planning_application: planning_application,
+        documents_consistent: documents_consistent
+      )
+    end
+
+    context "when value is not 'no' and there are no open description change requests" do
+      let(:documents_consistent) { :yes }
+
+      it "returns false" do
+        expect(
+          consistency_checklist.default_documents_consistent_to_no?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when value is 'no'" do
+      let(:documents_consistent) { :no }
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_documents_consistent_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+
+    context "when there are open description change requests" do
+      let(:documents_consistent) { :yes }
+
+      before do
+        create(
+          :additional_document_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_documents_consistent_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
+
+  describe "#default_site_map_correct_to_no?" do
+    let(:planning_application) { create(:planning_application) }
+
+    let(:consistency_checklist) do
+      create(
+        :consistency_checklist,
+        planning_application: planning_application,
+        site_map_correct: site_map_correct
+      )
+    end
+
+    context "when value is not 'no' and there are no open description change requests" do
+      let(:site_map_correct) { :yes }
+
+      it "returns false" do
+        expect(
+          consistency_checklist.default_site_map_correct_to_no?
+        ).to be(
+          false
+        )
+      end
+    end
+
+    context "when value is 'no'" do
+      let(:site_map_correct) { :no }
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_site_map_correct_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+
+    context "when there are open description change requests" do
+      let(:site_map_correct) { :yes }
+
+      before do
+        create(
+          :red_line_boundary_change_validation_request,
+          planning_application: planning_application
+        )
+      end
+
+      it "returns true" do
+        expect(
+          consistency_checklist.default_site_map_correct_to_no?
+        ).to be(
+          true
+        )
+      end
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1475,9 +1475,7 @@ RSpec.describe PlanningApplication do
   end
 
   describe "#red_line_boundary_change_validation_request" do
-    let(:planning_application) do
-      create(:planning_application, status: status)
-    end
+    let(:planning_application) { create(:planning_application) }
 
     let!(:request) do
       create(
@@ -1495,47 +1493,17 @@ RSpec.describe PlanningApplication do
       )
     end
 
-    context "when pre validation request is present" do
-      let(:status) { :not_started }
-
-      it "returns pre validation request" do
-        expect(
-          planning_application.red_line_boundary_change_validation_request
-        ).to eq(
-          request
-        )
-      end
-
-      it "does not return post validation request" do
-        expect(
-          planning_application.red_line_boundary_change_validation_request(post_validation: true)
-        ).to be_nil
-      end
-    end
-
-    context "when post validation request is present" do
-      let(:status) { :in_assessment }
-
-      it "does not return pre validation request" do
-        expect(
-          planning_application.red_line_boundary_change_validation_request
-        ).to be_nil
-      end
-
-      it "returns post validation request" do
-        expect(
-          planning_application.red_line_boundary_change_validation_request(post_validation: true)
-        ).to eq(
-          request
-        )
-      end
+    it "returns latest request" do
+      expect(
+        planning_application.red_line_boundary_change_validation_request
+      ).to eq(
+        request
+      )
     end
   end
 
   describe "#additional_document_validation_request" do
-    let(:planning_application) do
-      create(:planning_application, status: status)
-    end
+    let(:planning_application) { create(:planning_application) }
 
     let!(:request) do
       create(
@@ -1553,47 +1521,17 @@ RSpec.describe PlanningApplication do
       )
     end
 
-    context "when pre validation request is present" do
-      let(:status) { :not_started }
-
-      it "returns pre validation request" do
-        expect(
-          planning_application.additional_document_validation_request
-        ).to eq(
-          request
-        )
-      end
-
-      it "does not return post validation request" do
-        expect(
-          planning_application.additional_document_validation_request(post_validation: true)
-        ).to be_nil
-      end
-    end
-
-    context "when post validation request is present" do
-      let(:status) { :in_assessment }
-
-      it "does not return pre validation request" do
-        expect(
-          planning_application.additional_document_validation_request
-        ).to be_nil
-      end
-
-      it "returns post validation request" do
-        expect(
-          planning_application.additional_document_validation_request(post_validation: true)
-        ).to eq(
-          request
-        )
-      end
+    it "returns latest request" do
+      expect(
+        planning_application.additional_document_validation_request
+      ).to eq(
+        request
+      )
     end
   end
 
   describe "#description_change_validation_request" do
-    let(:planning_application) do
-      create(:planning_application, status: status)
-    end
+    let(:planning_application) { create(:planning_application) }
 
     let!(:request) do
       create(
@@ -1613,47 +1551,17 @@ RSpec.describe PlanningApplication do
       )
     end
 
-    context "when pre validation request is present" do
-      let(:status) { :not_started }
-
-      it "returns pre validation request" do
-        expect(
-          planning_application.description_change_validation_request
-        ).to eq(
-          request
-        )
-      end
-
-      it "does not return post validation request" do
-        expect(
-          planning_application.description_change_validation_request(post_validation: true)
-        ).to be_nil
-      end
-    end
-
-    context "when post validation request is present" do
-      let(:status) { :in_assessment }
-
-      it "does not return pre validation request" do
-        expect(
-          planning_application.description_change_validation_request
-        ).to be_nil
-      end
-
-      it "returns post validation request" do
-        expect(
-          planning_application.description_change_validation_request(post_validation: true)
-        ).to eq(
-          request
-        )
-      end
+    it "returns latest request" do
+      expect(
+        planning_application.description_change_validation_request
+      ).to eq(
+        request
+      )
     end
   end
 
   describe "#replacement_document_validation_request" do
-    let(:planning_application) do
-      create(:planning_application, :not_started)
-    end
+    let(:planning_application) { create(:planning_application, :not_started) }
 
     let!(:request) do
       create(
@@ -1671,25 +1579,17 @@ RSpec.describe PlanningApplication do
       )
     end
 
-    it "returns pre validation request" do
+    it "returns latest request" do
       expect(
         planning_application.replacement_document_validation_request
       ).to eq(
         request
       )
     end
-
-    it "does not return post validation request" do
-      expect(
-        planning_application.replacement_document_validation_request(post_validation: true)
-      ).to be_nil
-    end
   end
 
   describe "#other_change_validation_request" do
-    let(:planning_application) do
-      create(:planning_application, :not_started)
-    end
+    let(:planning_application) { create(:planning_application, :not_started) }
 
     let!(:request) do
       create(
@@ -1707,18 +1607,12 @@ RSpec.describe PlanningApplication do
       )
     end
 
-    it "returns pre validation request" do
+    it "returns latest request" do
       expect(
         planning_application.other_change_validation_request
       ).to eq(
         request
       )
-    end
-
-    it "does not return post validation request" do
-      expect(
-        planning_application.other_change_validation_request(post_validation: true)
-      ).to be_nil
     end
   end
 

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -217,14 +217,8 @@ RSpec.describe "Requesting a new document for a planning application" do
 
       expect(page).to have_content("Additional document request successfully created.")
 
-      within("#additional-documents-validation-task") do
-        expect(page).to have_content("Invalid")
-      end
-
       expect(planning_application.reload.documents_missing).to be_truthy
       expect(AdditionalDocumentValidationRequest.all.length).to eq(1)
-
-      click_link "Check required documents are on application"
 
       additional_document_validation_request = AdditionalDocumentValidationRequest.last
 

--- a/spec/system/planning_applications/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/checking_consistency_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "checking consistency" do
     )
 
     within(form_group) { choose("No") }
-    click_button("Request a change to the description")
+    click_link("Request a change to the description")
 
     fill_in(
       "Please suggest a new application description",
@@ -142,20 +142,26 @@ RSpec.describe "checking consistency" do
       "Description change request successfully sent."
     )
 
-    expect(page).not_to have_button("Request a change to the description")
+    expect(page).not_to have_link("Request a change to the description")
     expect(page).to have_content("Alice Smith requested a new description")
     expect(page).to have_content("Proposed description: New description")
     expect(page).to have_content("Proposed 15 September 2022 12:00")
 
     click_link("View and edit request")
-    click_link("Cancel this request")
+    click_button("Cancel this request")
 
     expect(page).to have_content("Description change request successfully cancelled.")
 
     expect(page).to have_content("Cancelled 15 September 2022 12:00")
 
     travel_to(Time.zone.local(2022, 9, 15, 13))
-    click_button("Request a change to the description")
+
+    form_group = form_group_with_legend(
+      "Does the description match the development or use in the plans?"
+    )
+
+    within(form_group) { choose("No") }
+    click_link("Request a change to the description")
 
     fill_in(
       "Please suggest a new application description",
@@ -168,7 +174,7 @@ RSpec.describe "checking consistency" do
       "Description change request successfully sent."
     )
 
-    expect(page).not_to have_button("Request a change to the description")
+    expect(page).not_to have_link("Request a change to the description")
     expect(page).to have_content("Proposed description: New description 2")
     expect(page).to have_content("Proposed 15 September 2022 13:00")
 
@@ -184,7 +190,13 @@ RSpec.describe "checking consistency" do
     expect(page).to have_content("Accepted 15 September 2022 13:00")
 
     travel_to(Time.zone.local(2022, 9, 15, 14))
-    click_button("Request a change to the description")
+
+    form_group = form_group_with_legend(
+      "Does the description match the development or use in the plans?"
+    )
+
+    within(form_group) { choose("No") }
+    click_link("Request a change to the description")
 
     fill_in(
       "Please suggest a new application description",
@@ -197,7 +209,7 @@ RSpec.describe "checking consistency" do
       "Description change request successfully sent."
     )
 
-    expect(page).not_to have_button("Request a change to the description")
+    expect(page).not_to have_link("Request a change to the description")
     expect(page).to have_content("Proposed description: New description 3")
     expect(page).to have_content("Proposed 15 September 2022 14:00")
 
@@ -218,7 +230,7 @@ RSpec.describe "checking consistency" do
     click_link("Description, documents and proposal details")
 
     expect(page).to have_content("Accepted 15 September 2022 14:00")
-    expect(page).to have_button("Request a change to the description")
+    expect(page).to have_link("Request a change to the description")
 
     click_button("Save and mark as complete")
 
@@ -237,7 +249,7 @@ RSpec.describe "checking consistency" do
     )
 
     within(form_group) { choose("No") }
-    click_button("Request a new document")
+    click_link("Request a new document")
 
     fill_in(
       "Please specify the new document type:",
@@ -310,7 +322,7 @@ RSpec.describe "checking consistency" do
     )
 
     within(form_group) { choose("No") }
-    click_button("Request a change to the red line boundary")
+    click_link("Request a change to the red line boundary")
 
     find(".govuk-visually-hidden", visible: false).set(
       {
@@ -351,7 +363,7 @@ RSpec.describe "checking consistency" do
     )
 
     within(form_group) { expect(find_field("No")).to be_checked }
-    expect(page).not_to have_button("Request a change to the red line boundary")
+    expect(page).not_to have_link("Request a change to the red line boundary")
     expect(page).to have_content("Alice Smith proposed a new red line boundary")
     expect(page).to have_content("Reason: request reason")
     expect(page).to have_content("Proposed 15 September 2022 12:00")

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -29,21 +29,34 @@ RSpec.describe "Requesting description changes to a planning application" do
     expect(page).to have_content(planning_application.reference)
   end
 
-  it "is possible to create a request to update description" do
-    visit new_planning_application_description_change_validation_request_path(planning_application)
+  it "lets user create and cancel request" do
+    visit(planning_application_assessment_tasks_path(planning_application))
+    click_button("Application information")
+    click_link("Propose a change to the description")
+    fill_in("Please suggest a new application description", with: "")
+    click_button("Send")
 
-    fill_in "Please suggest a new application description", with: "New description"
+    expect(page).to have_content("Proposed description can't be blank")
+
+    fill_in("Please suggest a new application description", with: "description")
     click_button "Send"
 
     expect(page).to have_text("Description change request successfully sent.")
-  end
 
-  it "only accepts a request that contains a proposed description" do
-    visit new_planning_application_description_change_validation_request_path(planning_application)
+    expect(page).to have_current_path(
+      planning_application_assessment_tasks_path(planning_application)
+    )
 
-    fill_in "Please suggest a new application description", with: " "
-    click_button "Send"
+    click_button("Application information")
+    click_link("View requested change")
+    click_button("Cancel this request")
 
-    expect(page).to have_content("Proposed description can't be blank")
+    expect(page).to have_content(
+      "Description change request successfully cancelled."
+    )
+
+    expect(page).to have_current_path(
+      planning_application_assessment_tasks_path(planning_application)
+    )
   end
 end

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "post validation requests" do
         "Additional document request successfully created."
       )
 
+      click_link("Application")
       click_link("Review non-validation requests")
 
       expect(page).to have_content(planning_application.full_address.upcase)

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -300,8 +300,14 @@ RSpec.describe "Drawing a sitemap on a planning application" do
       fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Amendment request"
       click_button "Send request"
       expect(page).to have_content("Validation request for red line boundary successfully created.")
+
+      expect(page).to have_current_path(
+        planning_application_assessment_tasks_path(planning_application)
+      )
+
       expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
 
+      click_link("Application")
       click_button "Audit log"
       click_link "View all audits"
 


### PR DESCRIPTION
### Description of change

As discussed with the design team, in order to avoid having 'links' that are really buttons:

- Change links on 'Description, documents and proposal details' page to actually BE links. Currently they look like links but submit the form before the user is taken to the expected path.
- Update the logic of the 'Description, documents and proposal details' page so that 'No' is automatically selected for a check if there are open requests associated with it.

As part of the work for [this ticket](https://trello.com/c/c2HVZjBV/1382-where-there-are-links-to-actions-from-the-accordion-users-should-return-to-the-same-place-they-left-from):

- Update the logic for redirecting back to the 'Description, documents and proposal details' page after a request has been made to use a value stored in the form, not the session. This means that if the user behaves unexpectedly we don't have confusing information hanging around in the session!
- Make updates so that the user is redirected back to the previous page by default, not to a hard-coded page. 