### PR TITLE
Present helpful error message when using expired password reset link

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -4,8 +4,14 @@
 
 <h1 class="govuk-heading-l">Change your password</h1>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= form_with(
+  model: resource,
+  as: resource_name,
+  url: password_path(resource_name),
+  method: :put,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder
+) do |f| %>
+  <%= f.govuk_error_summary(presenter: ErrorPresenter) %>
   <%= f.hidden_field :reset_password_token %>
   <div class="govuk-form-group govuk-!-margin-top-8">
     <%= f.label :password, "New password", class: "govuk-heading-s govuk-!-margin-bottom-1" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,10 @@ en:
           attributes:
             base:
               recommendation_accepted: You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen
+        user:
+          attributes:
+            reset_password_token:
+              invalid: The reset password link you used no longer works. Please request a new link and try again.
   additional_document_validation_requests:
     create:
       success: Additional document request successfully created.

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -466,4 +466,34 @@ RSpec.describe "Sign in" do
       end
     end
   end
+
+  context "when recovering a password" do
+    it "presents a helpful error message when using an expired link" do
+      visit root_path
+
+      click_link("Forgot your password?")
+      fill_in("user[email]", with: assessor.email)
+
+      click_button("Send me reset password instructions")
+      expect(page).to have_content("You will receive an email with instructions on how to reset your password in a few minutes.")
+
+      assessor.reload
+      url = edit_user_password_path(assessor, subdomain: assessor.local_authority.subdomain, reset_password_token: assessor.reset_password_token)
+
+      # Now request another link
+      click_link("Forgot your password?")
+      fill_in("user[email]", with: assessor.email)
+      click_button("Send me reset password instructions")
+
+      # Visit old expired link
+      visit url
+      fill_in("user[password]", with: "password")
+      fill_in("user[password_confirmation]", with: "password")
+      click_button("Change password")
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("The reset password link you used no longer works. Please request a new link and try again.")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Story Link

https://trello.com/c/M8pegXZo/1356-what-does-reset-password-token-is-invalid-mean

An error "Reset password token is invalid" is presented when a user has clicked on an expired reset password link (perhaps a more recent reset password request was made). This PR updates that message to something a bit more helpful.