### PR TITLE
Validate 'past_applications' assessment details on 'additional_information'

### DIFF
--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -42,6 +42,12 @@ class AssessmentDetail < ApplicationRecord
   validates :assessment_status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
 
+  validates(
+    :additional_information,
+    presence: true,
+    if: :validate_additional_information_presence?
+  )
+
   scope :by_created_at_desc, -> { order(created_at: :desc) }
 
   delegate :consultees, to: :planning_application
@@ -64,12 +70,16 @@ class AssessmentDetail < ApplicationRecord
 
   private
 
+  def validate_additional_information_presence?
+    past_applications? && assessment_complete?
+  end
+
   def validate_entry_presence?
     return false if accepted? || rejected?
 
     summary_of_work? ||
       site_description? ||
-      (assessment_complete? && (past_applications? || consultation_summary?))
+      (assessment_complete? && consultation_summary?)
   end
 
   def set_user

--- a/spec/factories/assessment_detail.rb
+++ b/spec/factories/assessment_detail.rb
@@ -9,10 +9,15 @@ FactoryBot.define do
     assessment_status { :complete }
     entry { "This is a description about the summary of works" }
 
-    AssessmentDetail.categories.each_key do |category|
+    AssessmentDetail.categories.except(:past_applications).each_key do |category|
       trait category do
         category { category }
       end
+    end
+
+    trait :past_applications do
+      category { :past_applications }
+      additional_information { "Additional information" }
     end
 
     trait :with_consultees do

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -42,13 +42,6 @@ RSpec.describe AssessmentDetail do
       context "when assessment_status is complete" do
         let(:assessment_status) { :complete }
 
-        it "validates presence for past_applications" do
-          expect { past_applications }.to raise_error(
-            ActiveRecord::RecordInvalid,
-            "Validation failed: Entry can't be blank"
-          )
-        end
-
         it "validates presence for consultation_summary" do
           expect { consultation_summary }.to raise_error(
             ActiveRecord::RecordInvalid,
@@ -140,7 +133,8 @@ RSpec.describe AssessmentDetail do
         category: category,
         planning_application: planning_application,
         reviewer_verdict: reviewer_verdict,
-        entry: entry
+        entry: entry,
+        additional_information: additional_information
       )
     end
 
@@ -148,6 +142,48 @@ RSpec.describe AssessmentDetail do
     let(:category) { :summary_of_work }
     let(:reviewer_verdict) { nil }
     let(:entry) { "entry" }
+    let(:additional_information) { "additional details" }
+
+    context "when additional_information is blank" do
+      let(:additional_information) { nil }
+
+      context "when category is 'past_applications' and assessment status is 'complete'" do
+        let(:category) { :past_applications }
+        let(:assessment_status) { :complete }
+
+        it "returns false" do
+          expect(assessment_detail.valid?).to be(false)
+        end
+
+        it "sets error" do
+          assessment_detail.valid?
+
+          expect(
+            assessment_detail.errors.messages[:additional_information]
+          ).to contain_exactly(
+            "can't be blank"
+          )
+        end
+      end
+
+      context "when category is not past_applications and assessment status is 'complete'" do
+        let(:category) { :summary_of_work }
+        let(:assessment_status) { :complete }
+
+        it "returns true" do
+          expect(assessment_detail.valid?).to be(true)
+        end
+      end
+
+      context "when category is past_applications and assessment status is not 'complete'" do
+        let(:category) { :past_applications }
+        let(:assessment_status) { :in_progress }
+
+        it "returns true" do
+          expect(assessment_detail.valid?).to be(true)
+        end
+      end
+    end
 
     context "when entry is blank" do
       let(:entry) { nil }

--- a/spec/system/planning_applications/adding_past_application_references_spec.rb
+++ b/spec/system/planning_applications/adding_past_application_references_spec.rb
@@ -25,12 +25,10 @@ RSpec.describe "adding past application references" do
     expect(list_item("History (manual)")).to have_content("Not started")
 
     click_link("History (manual)")
-    fill_in("Relevant information", with: "Application granted.")
+    fill_in("Application reference number(s)", with: "22-00107-LDCP")
     click_button("Save and mark as complete")
 
-    expect(page).to have_content(
-      "Application reference numbers can't be blank"
-    )
+    expect(page).to have_content("Relevant information can't be blank")
 
     click_button("Save and come back later")
 
@@ -38,7 +36,7 @@ RSpec.describe "adding past application references" do
     expect(list_item("History (manual)")).to have_content("In progress")
 
     click_link("History (manual)")
-    fill_in("Application reference number(s)", with: "22-00107-LDCP")
+    fill_in("Relevant information", with: "Application granted.")
     click_button("Save and mark as complete")
 
     expect(page).to have_content("History successfully updated.")


### PR DESCRIPTION
### Description of change

- When `assessment_status` is 'complete' validate on presence of `additional_information`, not `entry`.

### Story Link

https://trello.com/c/NxuwrZMx/1353-allow-users-to-save-and-mark-as-complete-the-history-manual-task-when-there-is-no-data-entered

### Screenshots

<img width="60%" alt="Screenshot 2022-12-15 at 15 38 32" src="https://user-images.githubusercontent.com/25392162/207903422-c4dbbb8e-80ac-4c27-815c-b3c3b975b3ad.png">