### PR TITLE
Don't validate 'consultation_summary' assessment details on presence of consultees

### DIFF
--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -42,8 +42,6 @@ class AssessmentDetail < ApplicationRecord
   validates :assessment_status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
 
-  validate :consultees_added, if: :consultation_summary?
-
   scope :by_created_at_desc, -> { order(created_at: :desc) }
 
   delegate :consultees, to: :planning_application
@@ -72,12 +70,6 @@ class AssessmentDetail < ApplicationRecord
     summary_of_work? ||
       site_description? ||
       (assessment_complete? && (past_applications? || consultation_summary?))
-  end
-
-  def consultees_added
-    return if !assessment_complete? || consultees.any?
-
-    errors.add(:base, :no_consultees_added)
   end
 
   def set_user

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe AssessmentDetail do
         create(
           :assessment_detail,
           :consultation_summary,
-          :with_consultees,
           entry: "",
           assessment_status: assessment_status
         )
@@ -93,13 +92,7 @@ RSpec.describe AssessmentDetail do
       end
 
       describe "scopes" do
-        let(:planning_application) do
-          if category_type == "consultation_summary"
-            create(:planning_application, :with_consultees)
-          else
-            create(:planning_application)
-          end
-        end
+        let(:planning_application) { create(:planning_application) }
 
         describe ".by_created_at_desc" do
           let!("#{category_type}1") do
@@ -191,61 +184,6 @@ RSpec.describe AssessmentDetail do
             "can't be blank"
           )
         end
-      end
-    end
-
-    context "when assessment_status is 'complete'" do
-      let(:assessment_status) { :complete }
-
-      context "when category is 'consultation_summary'" do
-        let(:category) { :consultation_summary }
-
-        context "when there are no consultees" do
-          let(:planning_application) { create(:planning_application) }
-
-          it "returns false" do
-            expect(assessment_detail.valid?).to be(false)
-          end
-
-          it "sets error message" do
-            assessment_detail.valid?
-
-            expect(
-              assessment_detail.errors.messages[:base]
-            ).to contain_exactly(
-              "Consultees must be added"
-            )
-          end
-        end
-
-        context "when there are consultees" do
-          let(:planning_application) do
-            create(:planning_application, :with_consultees)
-          end
-
-          it "returns true" do
-            expect(assessment_detail.valid?).to be(true)
-          end
-        end
-      end
-
-      context "when category is not 'consultation_summary' and there are no consultees" do
-        let(:category) { :summary_of_work }
-        let(:planning_application) { create(:planning_application) }
-
-        it "returns true" do
-          expect(assessment_detail.valid?).to be(true)
-        end
-      end
-    end
-
-    context "when assessment_status is 'progress', category is 'consultation_summary' and there are no consultees" do
-      let(:assessment_status) { :in_progress }
-      let(:category) { :summary_of_work }
-      let(:planning_application) { create(:planning_application) }
-
-      it "returns true" do
-        expect(assessment_detail.valid?).to be(true)
       end
     end
 

--- a/spec/system/planning_applications/adding_consultation_summary_spec.rb
+++ b/spec/system/planning_applications/adding_consultation_summary_spec.rb
@@ -27,8 +27,6 @@ RSpec.describe "adding consultation summary" do
     click_link("Summary of consultation")
     click_button("Save and mark as complete")
 
-    expect(page).to have_content("Consultees must be added")
-
     expect(page).to have_content(
       "Summary of consultation responses can't be blank"
     )


### PR DESCRIPTION
### Description of change

- Don't validate 'consultation_summary' assessment details on presence of consultees.

### Story Link

https://trello.com/c/zeactQ4n/1352-allow-users-to-save-and-mark-as-complete-the-consultation-task-when-there-is-no-data-entered-for-consultees
