### PR TITLE
Fix RSpec/NoExpectionExample errors

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -128,14 +128,6 @@ RSpec/LetSetup:
     - 'spec/system/planning_applications/validating_spec.rb'
     - 'spec/system/planning_applications/validation_banner_display_spec.rb'
 
-# Offense count: 2
-# Configuration parameters: AllowedPatterns.
-# AllowedPatterns: ^expect_, ^assert_
-RSpec/NoExpectationExample:
-  Exclude:
-    - 'spec/services/apis/mapit/client_spec.rb'
-    - 'spec/services/apis/paapi/client_spec.rb'
-
 # Offense count: 19
 # Configuration parameters: Database, Include.
 # SupportedDatabases: mysql, postgresql

--- a/spec/services/apis/mapit/client_spec.rb
+++ b/spec/services/apis/mapit/client_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Apis::Mapit::Client do
   let(:client) { described_class.new }
 
   describe "#call" do
-    let(:faraday_connection) { spy }
-    let(:url) { "https://mapit.mysociety.org" }
-
-    it "makes a Faraday connection" do
-      allow(Faraday).to receive(:new).with(url: url).and_yield(faraday_connection)
-
-      client.call("SE220HW")
+    it "is successfull" do
+      expect(client.call("SE220HW").status).to eq(200)
     end
 
     it "removes whitespace from the postcode" do

--- a/spec/services/apis/mapit/client_spec.rb
+++ b/spec/services/apis/mapit/client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Apis::Mapit::Client do
   let(:client) { described_class.new }
 
   describe "#call" do
-    it "is successfull" do
+    it "is successful" do
       expect(client.call("SE220HW").status).to eq(200)
     end
 

--- a/spec/services/apis/paapi/client_spec.rb
+++ b/spec/services/apis/paapi/client_spec.rb
@@ -6,13 +6,8 @@ RSpec.describe Apis::Paapi::Client do
   let(:client) { described_class.new }
 
   describe "#call" do
-    let(:faraday_connection) { spy }
-    let(:url) { "https://staging.paapi.services/api/v1" }
-
-    it "makes a Faraday connection" do
-      allow(Faraday).to receive(:new).with(url: url).and_yield(faraday_connection)
-
-      client.call("100081043511")
+    it "is successful" do
+      expect(client.call("100081043511").status).to eq(200)
     end
   end
 end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     WebMock.disable_net_connect!(
       allow_localhost: true,
       allow: "chromedriver.storage.googleapis.com",
-      net_http_connect_on_start: true
+      net_http_connect_on_start: false
     )
   end
 end


### PR DESCRIPTION
### Description of change

- Check that (stubbed) requests are successful, rather than stubbing Faraday, in client specs for Mapit and PAAPI APIs.

### Decisions

Alternatively we could change the `allow`s to `expects`, but I don't think it hurts to check Faraday actually makes the request!