### PR TITLE
Change colour of 'In progress' tag

### DIFF
--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -22,7 +22,7 @@ module StatusTags
       case status
       when :not_started, :not_checked_yet
         "govuk-tag--grey"
-      when :complete
+      when :complete, :in_progress
         "govuk-tag--blue"
       when :checked, :granted
         "govuk-tag--green"


### PR DESCRIPTION
### Description of change

Change colour of 'In progress' tag.

### Story Link

https://trello.com/c/OFjNTM0t/1362-change-design-of-in-progress-tag-to-light-blue-fill-and-dark-blue-text

### Screenshot

<img width="629" alt="Screenshot 2022-12-19 at 14 08 09" src="https://user-images.githubusercontent.com/25392162/208444487-9301ee89-289e-401f-833c-1e86271affc2.png">
