### PR TITLE
FIX: Saving payment_amount with none-digit chars + Max payment

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -125,13 +125,20 @@ class PlanningApplication < ApplicationRecord
   validates :review_documents_for_recommendation_status,
             inclusion: { in: PROGRESS_STATUSES }
   validates :application_type, :application_number, :reference, presence: true
-  validates :payment_amount, :invalid_payment_amount, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :payment_amount,
+            :invalid_payment_amount,
+            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1_000_000 },
+            allow_nil: true
 
   validate :applicant_or_agent_email
   validate :validated_at_date
   validate :public_comment_present
   validate :decision_with_recommendations
   validate :determination_date_is_not_in_the_future
+
+  def payment_amount=(amount)
+    self[:payment_amount] = amount.to_s.delete("^0-9.-").to_d
+  end
 
   def timestamp_status_change
     update("#{aasm.to_state}_at": Time.zone.now)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
               blank: Please select Yes or No
             payment_amount:
               greater_than_or_equal_to: Payment amount (£) must be greater than or equal to 0
+              less_than_or_equal_to: Payment amount (£) must be less than or equal to 1,000,000
               not_a_number: Payment amount must be a number not exceeding 2 decimal places
             public_comment:
               blank: Please state the reasons why this application is, or is not lawful

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -36,27 +36,26 @@ RSpec.describe PlanningApplication do
 
     describe "#payment_amount" do
       it "validates that it must be greater than or equal to 0" do
-        planning_application = build(:planning_application, payment_amount: -1)
+        planning_application = build(:planning_application, payment_amount: "-1")
 
-        expect { planning_application.valid? }.to change { planning_application.errors[:payment_amount] }.to ["Payment amount (£) must be greater than or equal to 0"]
+        expect { planning_application.valid? }.to change { planning_application.errors[:payment_amount] }
+          .to ["Payment amount (£) must be greater than or equal to 0"]
       end
 
-      it "validates that it must be a number" do
-        planning_application = build(:planning_application, payment_amount: "n")
+      it "validates that it must be less than maximum" do
+        planning_application = build(:planning_application, payment_amount: "1000001")
 
-        expect { planning_application.valid? }.to change { planning_application.errors[:payment_amount] }.to ["Payment amount must be a number not exceeding 2 decimal places"]
+        expect { planning_application.valid? }.to change { planning_application.errors[:payment_amount] }
+          .to ["Payment amount (£) must be less than or equal to 1,000,000"]
       end
 
-      it "does not raise a validation error if value is 0" do
-        planning_application = build(:planning_application, payment_amount: 0)
+      [0, 12.43, "0", "1,200.00", "n"].each do |value|
+        it "does not raise a validation error if value is #{value}" do
+          planning_application = build(:planning_application, payment_amount: value)
 
-        expect { planning_application.valid? }.not_to(change { planning_application.errors[:payment_amount] })
-      end
-
-      it "does not raise a validation error if value is a decimal" do
-        planning_application = build(:planning_application, payment_amount: 12.43)
-
-        expect { planning_application.valid? }.not_to(change { planning_application.errors[:payment_amount] })
+          expect { planning_application.valid? }
+            .not_to(change { planning_application.errors[:payment_amount] })
+        end
       end
     end
 

--- a/spec/system/planning_applications/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/fee_items_validation_spec.rb
@@ -461,11 +461,6 @@ RSpec.describe "FeeItemsValidation" do
         expect(page).to have_content("Check any extra fee has been received and update the total fee now paid.")
         expect(page).to have_field("planning_application[payment_amount]", with: "100.00")
 
-        # Fill in bad input
-        fill_in "planning_application[payment_amount]", with: "sss"
-        click_button("Continue")
-        expect(page).to have_content("Payment amount must be a number not exceeding 2 decimal places")
-
         fill_in "planning_application[payment_amount]", with: "350.22"
         click_button("Continue")
 


### PR DESCRIPTION
### Description of change

When editing anything in 'application information' and the application has a fee which includes a character not in a decimal then it errors with "Payment amount must be a number not exceeding 2 decimal places". Fee also shows as 1.00

- Actual issue is that it tries to save a "comma" character as part of a decimal. 

### Story Link

https://trello.com/c/bGGbpXHp/1258-issue-editing-saving-application-information-where-application-has-large-fee