### PR TITLE
Change colour of 'Completed' tag

### DIFF
--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -22,7 +22,7 @@ module StatusTags
       case status
       when :not_started, :not_checked_yet
         "govuk-tag--grey"
-      when :complete, :in_progress
+      when :in_progress
         "govuk-tag--blue"
       when :checked, :granted
         "govuk-tag--green"

--- a/spec/components/status_tags/review_policy_class_components_spec.rb
+++ b/spec/components/status_tags/review_policy_class_components_spec.rb
@@ -16,6 +16,6 @@ RSpec.describe StatusTags::ReviewPolicyClassComponent, type: :component do
 
     render_inline(described_class.new(review_policy_class: review_policy_class))
 
-    expect(page).to have_css ".govuk-tag--blue", text: "Completed"
+    expect(page).to have_css(".govuk-tag", text: "Completed")
   end
 end


### PR DESCRIPTION
### Description of change

- Make 'Completed' tag the default tag colour.

### Story Link

https://trello.com/c/irWJtop9/1363-replace-any-instances-of-the-complete-tag-with-the-completed-tag

### Screenshot

<img width="631" alt="Screenshot 2022-12-21 at 10 43 37" src="https://user-images.githubusercontent.com/25392162/208886927-891b4768-5d30-4c6c-a374-fa10d9a02ca2.png">
