### PR TITLE
Pr np check the application page

### DIFF
--- a/app/components/accordion_sections/documents_component.html.erb
+++ b/app/components/accordion_sections/documents_component.html.erb
@@ -1,31 +1,33 @@
-<%= link_to(
-  t(".manage_documents"),
-  planning_application_documents_path(planning_application),
-  class: "govuk-link govuk-body"
-) %>
-<div class="scroll-docs">
-  <% documents.each do |document| %>
-    <hr>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third">
-        <%= render(
-          partial: "documents/document_row_image",
-          locals: {
-            planning_application: planning_application,
-            document: document,
-            resize: "200x110",
-            width: 90,
-            height: 110,
-            edit_and_archive: true
-          }
-        ) %>
+<div class="govuk-!-padding-left-2 govuk-!-padding-right-2">
+  <%= link_to(
+    t(".manage_documents"),
+    planning_application_documents_path(planning_application),
+    class: "govuk-button govuk-button--secondary"
+  ) %>
+  <div class="scroll-docs">
+    <% documents.each do |document| %>
+      <hr>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <%= render(
+            partial: "documents/document_row_image",
+            locals: {
+              planning_application: planning_application,
+              document: document,
+              resize: "200x110",
+              width: 90,
+              height: 110,
+              edit_and_archive: true
+            }
+          ) %>
+        </div>
+        <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+          <%= render(
+            partial: "documents/document_row_info",
+            locals: { document: document }
+          ) %>
+        </div>
       </div>
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
-        <%= render(
-          partial: "documents/document_row_info",
-          locals: { document: document }
-        ) %>
-      </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -24,4 +24,12 @@ module DocumentHelper
   def document_name_and_reference(document)
     "#{document.name}#{document.numbers? ? " - #{document.numbers}" : ''}"
   end
+
+  def titled_reference_or_file_name(document)
+    document.numbers? ? "Reference: #{document.numbers}" : "File name: #{document.name}"
+  end
+
+  def reference_or_file_name(document)
+    document.numbers.presence || document.name
+  end
 end

--- a/app/presenters/concerns/validation_tasks/documents_presenter.rb
+++ b/app/presenters/concerns/validation_tasks/documents_presenter.rb
@@ -4,6 +4,7 @@ module ValidationTasks
   extend ActiveSupport::Concern
 
   class DocumentsPresenter < PlanningApplicationPresenter
+    include DocumentHelper
     attr_reader :document
 
     def initialize(template, planning_application, document)
@@ -40,7 +41,7 @@ module ValidationTasks
     end
 
     def validate_document_link_text
-      "Check document - #{truncate document.name.to_s, length: 25}"
+      "Check document - #{truncate reference_or_file_name(document).to_s, length: 25}"
     end
 
     def validation_item_status

--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -21,7 +21,7 @@
     </p>
   <% end %>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    File name: <%= document.name %>
+    <%= titled_reference_or_file_name(document) %>
   </p>
   <p class="govuk-body govuk-!-margin-bottom-1">
     Date received: <%= document.received_at_or_created %>

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DocumentHelper do
+  describe "#titled_refrence_or_file_name" do
+    it "returns the document reference if present" do
+      document = create(:document, numbers: "REF123")
+
+      expect(titled_reference_or_file_name(document)).to eq "Reference: REF123"
+    end
+
+    it "returns if reference missing the document name" do
+      document = create(:document, numbers: "")
+
+      # I can't control the name of the document name so always proposed-flooplan.png
+      expect(titled_reference_or_file_name(document)).to eq "File name: proposed-floorplan.png"
+    end
+  end
+
+  describe "#refrence_or_file_name" do
+    it "returns the document reference if present" do
+      document = create(:document, numbers: "REF123")
+
+      expect(reference_or_file_name(document)).to eq "REF123"
+    end
+
+    it "returns if reference missing the document name" do
+      document = create(:document, numbers: "")
+
+      # I can't control the name of the document name so always proposed-flooplan.png
+      expect(reference_or_file_name(document)).to eq "proposed-floorplan.png"
+    end
+  end
+end

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Documents index page" do
         visit(planning_application_documents_path(planning_application))
 
         window1 = window_opened_by do
-          row = row_with_content("proposed-floorplan.png")
+          row = row_with_content("File name: proposed-floorplan.png")
           within(row) { click_link("View in new window") }
         end
 
@@ -82,7 +82,7 @@ RSpec.describe "Documents index page" do
         end
 
         window2 = window_opened_by do
-          row = row_with_content("proposed-roofplan.png")
+          row = row_with_content("File name: proposed-roofplan.png")
           within(row) { click_link("View in new window") }
         end
 


### PR DESCRIPTION
### Description of change
![check-all-others](https://user-images.githubusercontent.com/1710795/208987782-bee49201-0d92-4697-b479-c383ffa37924.jpg)

![pr-check-check-list](https://user-images.githubusercontent.com/1710795/208987816-352feeaa-c1ad-4ef3-8dc4-fdd0e5fe80e8.jpg)

- AC1 - Change "Manage document" from link to secondary CTA
- AC2 - On document accordion: If a reference has been added by the officer, use the "Document reference" instead the "Document name"
- AC3 - On Check supplied document list: If a reference has been added by the officer, use the "Document reference" instead the "Document name"
- AC4 - Document accordion: interline indented to the content

### Story Link

https://trello.com/c/VzSVWVoY/1270-check-the-application-page-check-list-changes