### PR TITLE
Retain information when replacing documents

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -49,7 +49,7 @@ class DocumentsController < AuthenticationController
   def update
     respond_to do |format|
       format.html do
-        if @document.update(document_params)
+        if @document.update_or_replace(document_params)
           if validate_document? && @document.validated == false
             redirect_to new_planning_application_replacement_document_validation_request_path(document: @document)
           else

--- a/app/models/replacement_document_validation_request.rb
+++ b/app/models/replacement_document_validation_request.rb
@@ -30,6 +30,19 @@ class ReplacementDocumentValidationRequest < ApplicationRecord
     raise ResetDocumentInvalidationError, e.message
   end
 
+  def replace_document!(file:, reason:)
+    transaction do
+      self.new_document = planning_application.documents.create!(
+        file: file,
+        tags: old_document.tags,
+        numbers: old_document.numbers
+      )
+
+      close!
+      old_document.update!(archive_reason: reason, archived_at: Time.zone.now)
+    end
+  end
+
   private
 
   def audit_api_comment

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -1,13 +1,7 @@
 <%= form_with model: [@planning_application, @document], local: true, class: "document", builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
   <%= render partial: 'documents/form_partials/upload', locals: {form: form} unless @validate_document %>
-
-  <div class="govuk-form-group <%= @document.errors.any? ? 'govuk-form-group--error' : '' %>">
-    <% if @document.errors[:numbers].any? %>
-      <% @document.errors[:numbers].each do |error| %>
-            <span id="status-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span><%= error %></span>
-      <% end %>
-    <% end %>
+  <div class="govuk-form-group">
     <%= render partial: 'documents/form_partials/received_at', locals: {form: form} unless @validate_document %>
     <%= render partial: 'documents/form_partials/tags', locals: {form: form} %>
     <%= render partial: 'documents/form_partials/privacy', locals: {form: form} %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -24,11 +24,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
-    <%= link_to image_tag(@document.file.representation(resize: "500x500"), style: 'max-width:100%'),
-                url_for_document(@document), target: :_blank %>
-    <p class="govuk-body">
-      <%= link_to "View in new window", url_for_document(@document), target: :_new, class: "govuk-link" %>
-    </p>
+    <% if @document.representable? %>
+      <%= link_to(
+        image_tag(
+          @document.file.representation(resize: "500x500"),
+          style: "max-width:100%"
+        ),
+        url_for_document(@document),
+        target: "_blank"
+      ) %>
+      <%= link_to(
+        t(".view_in_new"),
+        url_for_document(@document),
+        target: "_new",
+        class: "govuk-link govuk-body"
+      ) %>
+    <% end %>
   </div>
   <div class="govuk-grid-column-one-half">
     <p class="govuk-body">

--- a/app/views/documents/form_partials/_privacy.html.erb
+++ b/app/views/documents/form_partials/_privacy.html.erb
@@ -1,12 +1,9 @@
-<%= form.label :numbers, "Document reference(s)", class: "govuk-body govuk-!-font-weight-bold govuk-!-padding-top-3", for: "numbers" %>
-
-<div id="event-name-hint" class="govuk-hint">
-  Where documents contain multiple drawings, enter multiple references separated by a comma (e.g. "25A-V2, 25B-V2").
-</div>
-<div class="numbers">
-  <%= form.text_area :numbers, class: "govuk-input govuk-input--width-20", id: "numbers" %>
-</div>
-
+<%= form.govuk_text_field(
+  :numbers,
+  label: { text: t(".document_references"), tag: "strong", size: "s" },
+  hint: { text: t(".where_documents_contain") },
+  class: "govuk-input--width-20"
+) %>
 <div class="display govuk-!-padding-top-3">
   <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Do you want to list this document on the decision notice?' }) do %>
     <%= form.govuk_radio_button :referenced_in_decision_notice, 'true', label: { text: 'Yes' } %>

--- a/app/views/documents/form_partials/_upload.html.erb
+++ b/app/views/documents/form_partials/_upload.html.erb
@@ -1,16 +1,14 @@
-<div class="govuk-form-group <%= form.object.errors[:file].any? ? 'govuk-form-group--error' : '' %>">
-  <% if @document.new_record? %>
-    <%= form.label :file, "Upload a file", class: "govuk-label" %>
-  <% else %>
-    <%= form.label :file, "Upload a replacement file", class: "govuk-label" %>
-  <% end %>
-
-  <% if form.object.errors[:file].any? %>
-    <% form.object.errors[:file].each do |error| %>
-      <span id="status-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span><%= error %></span>
-    <% end %>
-  <% end %>
-
-  <%= form.file_field :file, direct_upload: true, class: "govuk-file-upload" %>
-</div>
+<% if @document.new_record? %>
+  <%= form.govuk_file_field(
+    :file,
+    label: { text: t(".upload_a_file") },
+    direct_upload: true
+  ) %>
+<% else %>
+  <%= form.govuk_file_field(
+    :file,
+    label: { text: t(".upload_a_replacement") , size: "m" },
+    hint: { text: t(".a_replacement_file")  },
+    direct_upload: true
+  ) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,6 +130,7 @@ en:
           attributes:
             file:
               missing_file: Please choose a file
+              open_replacement_request: You cannot replace the file when there is an open document replacement request
               unsupported_file_type: The selected file must be a PDF, JPG or PNG
             numbers:
               missing_numbers: All documents listed on the decision notice must have a document number
@@ -184,6 +185,13 @@ en:
       local_authority_successfully_updated: Council information successfully updated
       user_successfully_created: User successfully created
       user_successfully_updated: User successfully updated
+  api:
+    v1:
+      replacement_document_validation_requests:
+        update:
+          applicant_has_provided: Applicant has provived a replacement document.
+          error: Unable to update request
+          success: Validation request updated
   application:
     header:
       back_office_planning: Back-office Planning System
@@ -382,11 +390,23 @@ en:
     show:
       back: Back
       cancel_this_request: Cancel this request
+  document:
+    replacement_document_uploaded: Replacement document uploaded
   documents:
     document_row_image:
       archive: Archive
       edit: Edit
       view_in_new: View in new window
+    edit:
+      view_in_new: View in new window
+    form_partials:
+      privacy:
+        document_references: Document reference(s)
+        where_documents_contain: Where documents contain multiple drawings, enter multiple references separated by a comma (e.g. "25A-V2, 25B-V2").
+      upload:
+        a_replacement_file: A replacement file will automatically archive the existing file
+        upload_a_file: Upload a file
+        upload_a_replacement: Upload a replacement file
     index:
       request_a_new: Request a new document
       upload_document: Upload document

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -19,8 +19,16 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   let!(:document) do
-    create(:document, :with_file, :public, planning_application: planning_application, validated: false,
-                                           invalidated_document_reason: "Not readable")
+    create(
+      :document,
+      :with_file,
+      :public,
+      planning_application: planning_application,
+      validated: false,
+      invalidated_document_reason: "Not readable",
+      tags: ["Front"],
+      numbers: "DOC123"
+    )
   end
 
   let!(:replacement_document_validation_request) do
@@ -61,6 +69,17 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     expect(replacement_document_validation_request.new_document).to be_a(Document)
     expect(document.archived_at).not_to be_nil
     expect(document.archive_reason).to eq("Applicant has provived a replacement document.")
+  end
+
+  it "copies old document tags and reference to new document" do
+    patch(path, params: params, headers: headers)
+
+    expect(
+      replacement_document_validation_request.reload.new_document
+    ).to have_attributes(
+      tags: ["Front"],
+      numbers: "DOC123"
+    )
   end
 
   it "creates request received audit associated with API user" do

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -66,7 +66,10 @@ RSpec.describe "Edit document numbers page" do
           click_link "Edit"
         end
         # the submitted values are re-presented in the form
-        expect(find_field("numbers")).to have_content "new_number_1, new_number_2"
+        expect(page).to have_field(
+          "Document reference(s)",
+          with: "new_number_1, new_number_2"
+        )
 
         click_link "Documents"
 
@@ -98,7 +101,10 @@ RSpec.describe "Edit document numbers page" do
           click_link "Edit"
         end
         # the submitted values are re-presented in the form
-        expect(page).to have_field("numbers", with: "new_number_1, new_number_2")
+        expect(page).to have_field(
+          "Document reference(s)",
+          with: "new_number_1, new_number_2"
+        )
 
         click_link "Documents"
 


### PR DESCRIPTION
### Description of change

- Update API so that when applicant submits a replacement document the `tags` and `numbers` attributes are copied over from the old document.
- Update logic when assessor submits edit documents form so that if they have uploaded a new file the existing document record is archived with the old file, and a new document record is created with the new file 😅 
- Tidy up the edit document form a bit.

### Story Link

https://trello.com/c/Nek3QKHF/1287-archive-document-when-user-upload-a-replacement-file