### PR TITLE
Add an association between api_users and local_authority

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApiUser < ApplicationRecord
+  belongs_to :local_authority, optional: true
+
   validates :name, :token, presence: true
   has_many :audits, dependent: :nullify
 end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -3,6 +3,8 @@
 class ApiUser < ApplicationRecord
   belongs_to :local_authority, optional: true
 
-  validates :name, :token, presence: true
+  validates :name, presence: true
   has_many :audits, dependent: :nullify
+
+  has_secure_token :token, length: 36
 end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -3,7 +3,7 @@
 class ApiUser < ApplicationRecord
   belongs_to :local_authority, optional: true
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
   has_many :audits, dependent: :nullify
 
   has_secure_token :token, length: 36

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -3,6 +3,7 @@
 class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
+  has_one :api_user, dependent: :destroy
 
   validates :subdomain, :signatory_name, :signatory_job_title, :enquiries_paragraph, :email_address, :feedback_email,
             presence: true

--- a/db/migrate/20221227150720_add_local_authorities_reference_to_api_users.rb
+++ b/db/migrate/20221227150720_add_local_authorities_reference_to_api_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocalAuthoritiesReferenceToApiUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :api_users, :local_authority, index: true
+  end
+end

--- a/db/migrate/20221228155440_add_unique_index_to_api_use_on_name_and_token.rb
+++ b/db/migrate/20221228155440_add_unique_index_to_api_use_on_name_and_token.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToApiUseOnNameAndToken < ActiveRecord::Migration[6.1]
+  def change
+    change_table :api_users, bulk: true do |t|
+      t.change_default(:name, from: "", to: nil)
+      t.change_default(:token, from: "", to: nil)
+    end
+
+    add_index :api_users, :name, unique: true
+    add_index :api_users, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_16_173005) do
+ActiveRecord::Schema.define(version: 2022_12_27_150720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,8 @@ ActiveRecord::Schema.define(version: 2022_12_16_173005) do
     t.string "token", default: "", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "local_authority_id"
+    t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"
   end
 
   create_table "assessment_details", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_27_150720) do
+ActiveRecord::Schema.define(version: 2022_12_28_155440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,12 +61,14 @@ ActiveRecord::Schema.define(version: 2022_12_27_150720) do
   end
 
   create_table "api_users", force: :cascade do |t|
-    t.string "name", default: "", null: false
-    t.string "token", default: "", null: false
+    t.string "name", null: false
+    t.string "token", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "local_authority_id"
     t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"
+    t.index ["name"], name: "ix_api_users_on_name", unique: true
+    t.index ["token"], name: "ix_api_users_on_token", unique: true
   end
 
   create_table "assessment_details", force: :cascade do |t|

--- a/spec/factories/api_users.rb
+++ b/spec/factories/api_users.rb
@@ -3,6 +3,5 @@
 FactoryBot.define do
   factory :api_user do
     name { Faker::Name.name }
-    token { "dsafdsaf87897dsf8" }
   end
 end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -20,5 +20,13 @@ RSpec.describe ApiUser do
       api_user = build(:api_user, name: nil)
       expect(api_user).not_to be_valid
     end
+
+    it "must have a unique name and token" do
+      create(:api_user, name: "test")
+      api_user = build(:api_user, name: "test")
+      api_user.save
+
+      expect(api_user.errors.messages[:name][0]).to eq("has already been taken")
+    end
   end
 end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -3,18 +3,22 @@
 require "rails_helper"
 
 RSpec.describe ApiUser do
-  it "creates api user successfully" do
-    api_consumer = create(:api_user)
-    expect(api_consumer).to be_valid
-  end
+  describe "#validations" do
+    it "creates api user successfully" do
+      api_user = create(:api_user)
+      expect(api_user).to be_valid
+    end
 
-  it "is not created without a token" do
-    api_user_without_token = build(:api_user, token: nil)
-    expect(api_user_without_token).not_to be_valid
-  end
+    it "generates a new client secret" do
+      api_user = build(:api_user)
+      api_user.save
 
-  it "is not created without a name" do
-    api_user_without_name = build(:api_user, name: nil)
-    expect(api_user_without_name).not_to be_valid
+      expect(api_user.token).not_to be_empty
+    end
+
+    it "is not created without a name" do
+      api_user = build(:api_user, name: nil)
+      expect(api_user).not_to be_valid
+    end
   end
 end


### PR DESCRIPTION
### Description of change

- Add an association between api_users and local_authority
- Move token to has_secure_token
- Add uniqueness on api_user's name and token
- Drop defaults on api_user's name and token

### Story Link

https://trello.com/c/hAx0QAYq