### PR TITLE
Remove remaining instances of OpenStruct

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -217,7 +217,6 @@ Style/FormatStringToken:
 # Offense count: 45
 Style/OpenStructUse:
   Exclude:
-    - 'app/helpers/application_helper.rb'
     - 'spec/system/log_in_spec.rb'
 
 # Offense count: 74

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -214,11 +214,6 @@ Style/FetchEnvVar:
 Style/FormatStringToken:
   EnforcedStyle: unannotated
 
-# Offense count: 45
-Style/OpenStructUse:
-  Exclude:
-    - 'spec/system/log_in_spec.rb'
-
 # Offense count: 74
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, AllowedPatterns, IgnoredPatterns.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,9 +36,7 @@ module ApplicationHelper
   end
 
   def otp_delivery_method_options
-    User.otp_delivery_methods.keys.map do |key|
-      OpenStruct.new(id: key, name: t(".#{key}"))
-    end
+    User.otp_delivery_methods.keys.map { |key| [key, t(".#{key}")] }
   end
 
   def policy_comment_label(comment)

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -10,8 +10,8 @@
     <%= form.govuk_collection_select(
       :otp_delivery_method,
       otp_delivery_method_options,
-      :id,
-      :name
+      :first,
+      :last
     ) %>
     <% unless form.object == current_user %>
       <%= form.govuk_collection_select(

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -231,9 +231,11 @@ RSpec.describe "Sign in" do
 
       context "when there is an error from Notify" do
         before do
-          error_hash = OpenStruct.new(
-            body: "Notifications::Client::BadRequestError: ValidationError: phone_number Must not contain letters or symbols", code: 400
+          error_hash = Struct.new(:body, :code).new(
+            "Notifications::Client::BadRequestError: ValidationError: phone_number Must not contain letters or symbols",
+            400
           )
+
           allow_any_instance_of(TwoFactor::SmsNotification).to receive(:deliver!).and_raise(
             Notifications::Client::BadRequestError, error_hash
           )
@@ -309,9 +311,11 @@ RSpec.describe "Sign in" do
 
       context "when there is an error from Notify" do
         before do
-          error_hash = OpenStruct.new(
-            body: "Notifications::Client::ClientError: Exceeded rate limit", code: 429
+          error_hash = Struct.new(:body, :code).new(
+            "Notifications::Client::ClientError: Exceeded rate limit",
+            429
           )
+
           allow_any_instance_of(TwoFactor::SmsNotification).to receive(:deliver!).and_raise(
             Notifications::Client::ClientError, error_hash
           )


### PR DESCRIPTION
### Description of change

- Remove `OpenStruct` from form select helper.
- Remove `OpenStruct` from test stub.

### Story Link

https://trello.com/c/GjWdNTTK/1369-openstruct-refactoring