### PR TITLE
Add back link to manage documents page

### DIFF
--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -142,7 +142,9 @@
     </tbody>
   </table>
 <% else %>
-    <p class="govuk-body">
-      <strong>No documents archived</strong>
-    </p>
+  <p class="govuk-body">
+    <strong>No documents archived</strong>
+  </p>
 <% end %>
+
+<%= back_link %>

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -95,6 +95,24 @@ RSpec.describe "Documents index page" do
         end
       end
     end
+
+    it "navigates back to the previous page I was on" do
+      click_link "Application"
+
+      # Navigate via validation tasks page
+      click_link "Check and validate"
+      click_button "Documents"
+      click_link "Manage documents"
+      click_link "Back"
+      expect(page).to have_current_path(planning_application_validation_tasks_path(planning_application))
+
+      # Navigate via archive document page
+      click_button "Documents"
+      click_link "Archive"
+      click_link "Cancel"
+      click_link "Back"
+      expect(page).to have_current_path(planning_application_document_archive_path(planning_application, document))
+    end
   end
 
   context "when handling invalid documents" do


### PR DESCRIPTION
### Description of change

Add back link to manage documents page
- This back link takes the user back to the previously visited page

### Story Link

https://trello.com/c/XqeJk5A8/1321-add-a-back-button-to-the-manage-documents-page