### PR TITLE
Fix date (year) specific test expectations

### DIFF
--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )
@@ -189,7 +189,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )
@@ -234,7 +234,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )
@@ -283,7 +283,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )
@@ -390,7 +390,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application number: RIPA-22-00100-LDCP"
         )
@@ -456,7 +456,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include("Application number: RIPA-22-00100-LDCP")
       end
     end
@@ -506,7 +506,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )
@@ -574,7 +574,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
 
       it "includes the reference" do
-        travel_to(Date.new(2022)) do
+        travel_to("2022-01-01") do
           expect(mail_body).to include(
             "Application reference number: RIPA-22-00100-LDCP"
           )
@@ -621,7 +621,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       end
 
       it "includes the reference" do
-        travel_to(Date.new(2022)) do
+        travel_to("2022-01-01") do
           expect(mail_body).to include(
             "Application reference number: RIPA-22-00100-LDCP"
           )
@@ -677,7 +677,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     it "includes the reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "Application reference number: RIPA-22-00100-LDCP"
         )

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail_body) { mail.body.encoded }
 
     it "sets subject" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail.subject).to eq(
           "BoPS case BUC-22-00100-LDCP has a new update"
         )
@@ -28,7 +28,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it "includes planning application reference" do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         expect(mail_body).to include(
           "BoPS case BUC-22-00100-LDCP has a new update."
         )

--- a/spec/services/planning_application_search_spec.rb
+++ b/spec/services/planning_application_search_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PlanningApplicationSearch do
   describe "#results" do
     let!(:planning_application1) do
-      travel_to(Date.new(2022)) do
+      travel_to("2022-01-01") do
         create(
           :planning_application,
           work_status: "proposed",

--- a/spec/services/planning_application_search_spec.rb
+++ b/spec/services/planning_application_search_spec.rb
@@ -5,12 +5,13 @@ require "rails_helper"
 RSpec.describe PlanningApplicationSearch do
   describe "#results" do
     let!(:planning_application1) do
-      create(
-        :planning_application,
-        work_status: "proposed",
-        created_at: DateTime.new(2022, 1, 1),
-        description: "Add a chimney stack."
-      )
+      travel_to(Date.new(2022)) do
+        create(
+          :planning_application,
+          work_status: "proposed",
+          description: "Add a chimney stack."
+        )
+      end
     end
 
     let!(:planning_application2) do

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "assigning planning application" do
   end
 
   it "lets a planning application be assigned to a user" do
-    travel_to(Date.new(2022))
+    travel_to("2022-01-01")
     sign_in(reviewer)
     visit(assign_planning_application_path(planning_application))
     choose("Jane Smith")

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Planning Application Assessment" do
   end
 
   let!(:planning_application) do
-    travel_to(Date.new(2022)) do
+    travel_to("2022-01-01") do
       create(
         :planning_application,
         local_authority: default_local_authority,

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -30,12 +30,13 @@ RSpec.describe "Planning Application Assessment" do
   end
 
   let!(:planning_application) do
-    create(
-      :planning_application,
-      local_authority: default_local_authority,
-      created_at: DateTime.new(2022, 1, 1),
-      public_comment: nil
-    )
+    travel_to(Date.new(2022)) do
+      create(
+        :planning_application,
+        local_authority: default_local_authority,
+        public_comment: nil
+      )
+    end
   end
 
   before do
@@ -46,7 +47,6 @@ RSpec.describe "Planning Application Assessment" do
   context "when clicking Save and mark as complete" do
     context "with no previous recommendations" do
       it "can create a new recommendation, edit it, and submit it" do
-        travel_to(Date.new(2022))
         click_link "In assessment"
 
         within(selected_govuk_tab) do
@@ -126,8 +126,6 @@ RSpec.describe "Planning Application Assessment" do
         expect(page).to have_text(assessor.name)
         expect(page).to have_text("Assessor comment: Edited private assessor comment")
         expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
-
-        travel_back
       end
     end
 

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Reviewing sign-off" do
   let(:user) { create(:user) }
 
   let!(:planning_application) do
-    travel_to(Date.new(2022)) do
+    travel_to("2022-01-01") do
       create(
         :planning_application,
         :awaiting_determination,

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -18,14 +18,15 @@ RSpec.describe "Reviewing sign-off" do
   let(:user) { create(:user) }
 
   let!(:planning_application) do
-    create(
-      :planning_application,
-      :awaiting_determination,
-      local_authority: default_local_authority,
-      decision: "granted",
-      created_at: DateTime.new(2022, 1, 1),
-      user: user
-    )
+    travel_to(Date.new(2022)) do
+      create(
+        :planning_application,
+        :awaiting_determination,
+        local_authority: default_local_authority,
+        decision: "granted",
+        user: user
+      )
+    end
   end
 
   before do
@@ -96,7 +97,6 @@ RSpec.describe "Reviewing sign-off" do
            assessor_comment: "New assessor comment",
            submitted: true)
 
-    travel_to(Date.new(2022))
     visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
 
@@ -147,8 +147,6 @@ RSpec.describe "Reviewing sign-off" do
     expect(page).to have_text("Recommendation challenged")
     expect(page).to have_text("Reviewer private comment")
     expect(page).to have_text(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
-
-    travel_back
   end
 
   it "cannot be rejected without a review comment" do


### PR DESCRIPTION
### Description of change

Fix date (year) specific test expectations

- Before a planning application is created, we have a `before_create` callback that invokes `set_reference`
```ruby
  def set_reference
    self.reference = [
      Date.current.strftime("%y"),
      application_number,
      application_type_code
    ].join("-")
  end
```

The date used here is dynamic so the test needs to be set up in a way so that at the exact point we create the planning application it has the year we expect.

Previously we would create the planning application with it being the current date (i.e. year 2023) and then in the test itself we travel to a specified date

### Story Link

https://trello.com/c/5LZZ9vkT/1407-fix-all-date-sensitive-tests-that-relied-on-the-year-being-2022

