### PR TITLE
Respect business days when prepopulating the valid from date

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -431,11 +431,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def default_validated_at
-    self.validated_at ||= if closed_validation_requests.present?
-                            last_validation_request_date
-                          else
-                            created_at
-                          end
+    self.validated_at ||= Time.next_immediate_business_day(valid_from_date)
   end
 
   def assessment_submitted?
@@ -654,5 +650,13 @@ class PlanningApplication < ApplicationRecord
 
   def public_url_enabled?
     ENV.fetch("PUBLIC_URL_ENABLED", "false") == "true"
+  end
+
+  def valid_from_date
+    if closed_validation_requests.present?
+      last_validation_request_date
+    else
+      created_at
+    end
   end
 end

--- a/spec/system/planning_applications/validate_spec.rb
+++ b/spec/system/planning_applications/validate_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Validating the application" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  before do
+    sign_in assessor
+    visit root_path
+  end
+
+  describe "viewing the prepopulated valid from date field" do
+    let!(:planning_application) do
+      create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+    end
+
+    context "when there is a closed validation request" do
+      let!(:validation_request) do
+        create(:red_line_boundary_change_validation_request, planning_application: planning_application)
+      end
+
+      context "when the request was closed during work hours" do
+        before do
+          # 04/01/2023 12:00
+          travel_to(DateTime.new(2023, 1, 4, 12)) do
+            validation_request.close!
+            visit(confirm_validation_planning_application_path(planning_application))
+          end
+        end
+
+        it "prepopulates with the closed at date" do
+          expect(page).to have_field("Day", with: "4")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+
+      context "when the request was closed outside work hours" do
+        before do
+          # 04/01/2023 18:00
+          travel_to(DateTime.new(2023, 1, 4, 18)) do
+            validation_request.close!
+            visit(confirm_validation_planning_application_path(planning_application))
+          end
+        end
+
+        it "prepopulates with the business day after the closed at date" do
+          expect(page).to have_field("Day", with: "5")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+
+      context "when the request was closed on a non business day" do
+        before do
+          # 01/01/2023 12:00
+          travel_to(DateTime.new(2023, 1, 1, 12)) do
+            validation_request.close!
+            visit(confirm_validation_planning_application_path(planning_application))
+          end
+        end
+
+        it "prepopulates with the business day after the closed at date" do
+          expect(page).to have_field("Day", with: "3")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+    end
+
+    context "when there is no closed validation request" do
+      before { visit(confirm_validation_planning_application_path(planning_application)) }
+
+      context "when the planning application was created during work hours" do
+        let(:planning_application) do
+          travel_to(DateTime.new(2023, 1, 5, 12)) do
+            create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+          end
+        end
+
+        it "prepopulates with the created at date" do
+          expect(page).to have_field("Day", with: "5")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+
+      context "when the planning application was created outside work hours" do
+        let(:planning_application) do
+          travel_to(DateTime.new(2023, 1, 5, 18)) do
+            create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+          end
+        end
+
+        it "prepopulates with the business day after the created at date" do
+          expect(page).to have_field("Day", with: "6")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+
+      context "when the planning application was created on a non business day" do
+        let(:planning_application) do
+          travel_to(DateTime.new(2023, 1, 8)) do
+            create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+          end
+        end
+
+        it "prepopulates with the business day after the created at date" do
+          expect(page).to have_field("Day", with: "9")
+          expect(page).to have_field("Month", with: "1")
+          expect(page).to have_field("Year", with: "2023")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- If a planning application has a latest closed validation request after work hours (5pm) or a non business day then we treat this as a day after when prepopulating the valid from date field. When there is no closed validation request we use the created_at timestamp of the planning application and treat it in the same way

### Story Link

https://trello.com/c/Ebq66iiF/1377-valid-from-day-is-taking-date-of-last-action-but-seemingly-not-applying-the-rule-for-working-days

