### PR TITLE
Include validation_request_added events to audits find query

### DIFF
--- a/app/models/concerns/validation_requestable.rb
+++ b/app/models/concerns/validation_requestable.rb
@@ -212,15 +212,16 @@ module ValidationRequestable
   end
 
   def sent_by
-    audits.find_by(activity_type: send_events, activity_information: sequence).user
+    audits.find_by(activity_type: send_and_add_events, activity_information: sequence).try(:user)
   end
 
   private
 
-  def send_events
+  def send_and_add_events
     [
       "#{self.class.name.underscore}_sent_post_validation",
-      "#{self.class.name.underscore}_sent"
+      "#{self.class.name.underscore}_sent",
+      "#{self.class.name.underscore}_added"
     ]
   end
 

--- a/spec/models/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/models/red_line_boundary_change_validation_request_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe RedLineBoundaryChangeValidationRequest do
     subject { create(:red_line_boundary_change_validation_request) }
   end
 
+  it_behaves_like("ValidationRequestable")
+
   describe "validations" do
     subject(:red_line_boundary_change_validation_request) { described_class.new }
 

--- a/spec/support/validation_requestable_shared_examples.rb
+++ b/spec/support/validation_requestable_shared_examples.rb
@@ -5,12 +5,24 @@ require "rails_helper"
 RSpec.shared_examples "ValidationRequestable" do
   describe "#sent_by" do
     let(:user) { create(:user) }
-    let(:request) { create(described_class.name.underscore) }
+    let(:request) { create(described_class.name.underscore, planning_application: planning_application) }
 
     before { Current.user = user }
 
-    it "returns user for audit associated with send event" do
-      expect(request.sent_by).to eq(user)
+    context "when a planning application has been invalidated" do
+      let(:planning_application) { create(:planning_application, :invalidated) }
+
+      it "returns user for audit associated with send event" do
+        expect(request.sent_by).to eq(user)
+      end
+    end
+
+    context "before a planning application is invalidated" do
+      let(:planning_application) { create(:planning_application, :not_started) }
+
+      it "returns user for audit associated with add event" do
+        expect(request.sent_by).to eq(user)
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

Fixes bug related to [issue](https://appsignal.com/southwark-bops/sites/5fce2dd55ac13f75e2b52bd7/exceptions/incidents/314?timestamp=2023-01-04T15%3A44%3A21Z)

- If a planning application hasn't been invalidated yet and there is a validation request added, this uses the "#{validation_request}_added" activity type for the audit.
- Only when a planning application has been invalidated and then a subsequent invalidation request is created, this uses the "#{validation_request}_sent" event
- This adds the "_added" activity type for the audits find query so that it doesn't return nil and then call user on it
- This also adds a safe navigator so that if the query does return nil we don't just blow up the page

### Story Link

https://trello.com/c/Jxe4UmKN/1413-actionviewtemplateerror-314-occurred-on-bops-preview-production-in-namespace-web