### PR TITLE
Include google map link on site description sections

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -50,4 +50,8 @@ module PlanningApplicationHelper
       planning_application.latitude.present? &&
       planning_application.longitude.present?
   end
+
+  def map_link(full_address)
+    "https://google.co.uk/maps/place/#{CGI.escape(full_address)}"
+  end
 end

--- a/app/views/assessment_details_reviews/_form.html.erb
+++ b/app/views/assessment_details_reviews/_form.html.erb
@@ -19,6 +19,9 @@
           assessment_detail: form.object.send(assessment_detail)
         )
       ) %>
+      <% if assessment_detail == :site_description %>
+        <p><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></p>
+      <% end %>
       <% if assessment_detail == :consultation_summary %>
         <%= render(
           partial: "consultees",

--- a/app/views/planning_application/assessment_details/site_description/_information.html.erb
+++ b/app/views/planning_application/assessment_details/site_description/_information.html.erb
@@ -1,4 +1,6 @@
 <div class="govuk-body">
+  <%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %>
+
   <% unless action_name == "show" %>
     <p><strong>Create a desciption of the site</strong></p>
   <% else %>

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -130,6 +130,10 @@ RSpec.describe "Reviewing assessment summaries" do
       click_link("Review assessment summaries")
 
       within(find("fieldset", text: "Site description")) do
+        expect(page).to have_link(
+          "View site on Google Maps",
+          href: "https://google.co.uk/maps/place/#{CGI.escape(planning_application.full_address)}"
+        )
         choose("Edit to accept")
       end
 

--- a/spec/system/planning_applications/site_description_spec.rb
+++ b/spec/system/planning_applications/site_description_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe "Site description" do
         new_planning_application_assessment_detail_path(planning_application, category: "site_description")
       )
 
+      expect(page).to have_link(
+        "View site on Google Maps",
+        href: "https://google.co.uk/maps/place/#{CGI.escape(planning_application.full_address)}"
+      )
+
       expect(page).to have_content("Create a desciption of the site")
       expect(page).to have_content(planning_application.reference)
       expect(page).to have_content(planning_application.full_address.upcase)


### PR DESCRIPTION
### Story Link

https://trello.com/c/SwGNpAne/1430-review-assessment-summaries-include-google-map-link-to-be-open-in-new-tab-on-site-description-section
