### PR TITLE
Planning data

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -14,13 +14,6 @@ class LocalAuthority < ApplicationRecord
     allow_blank: true
   )
 
-  enum subdomain: {
-    lambeth: "lambeth",
-    southwark: "southwark",
-    buckinghamshire: "buckinghamshire",
-    ripa: "ripa"
-  }
-
   def signatory
     "#{signatory_name}, #{signatory_job_title}"
   end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -14,6 +14,8 @@ class LocalAuthority < ApplicationRecord
     allow_blank: true
   )
 
+  validate :council_code_exists
+
   def signatory
     "#{signatory_name}, #{signatory_job_title}"
   end
@@ -24,5 +26,26 @@ class LocalAuthority < ApplicationRecord
 
   def staging?
     ENV.fetch("STAGING_ENABLED", "false") == "true"
+  end
+
+  private
+
+  def council_code_exists
+    return true if ripa?
+    return true unless council_code_changed?
+
+    errors.add(:council_code, "Please enter a valid council code") unless council_code == planning_data
+  end
+
+  def ripa?
+    council_code == "RIPA"
+  end
+
+  def planning_data
+    @planning_data ||= Apis::PlanningData::Query.new.fetch(council_code)
+  end
+
+  def planning_data?
+    !planning_data.nil?
   end
 end

--- a/app/services/apis/planning_data/client.rb
+++ b/app/services/apis/planning_data/client.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module Apis
+  module PlanningData
+    class Client
+      HOST = "https://www.planning.data.gov.uk"
+      TIMEOUT = 5
+
+      def call(reference)
+        faraday.get("/entity.json?reference=#{reference}") do |request|
+          request.options[:timeout] = TIMEOUT
+        end
+      end
+
+      private
+
+      def faraday
+        @faraday ||= Faraday.new(url: HOST) do |f|
+          f.response :raise_error
+        end
+      end
+    end
+  end
+end

--- a/app/services/apis/planning_data/query.rb
+++ b/app/services/apis/planning_data/query.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "faraday"
+
+module Apis
+  module PlanningData
+    class Query
+      def fetch(reference)
+        response = client.call(reference)
+
+        if response.success?
+          parse(JSON.parse(response.body))
+        else
+          []
+        end
+      rescue Faraday::ResourceNotFound, Faraday::ClientError
+        []
+      rescue Faraday::Error => e
+        Appsignal.send_exception(e)
+        []
+      end
+
+      private
+
+      def parse(body)
+        body["count"] == 1 && body["end-date"].blank? ? body["entities"].first["reference"] : nil
+      end
+
+      def client
+        @client ||= Apis::PlanningData::Client.new
+      end
+    end
+  end
+end

--- a/features/support/stub_requests.rb
+++ b/features/support/stub_requests.rb
@@ -2,15 +2,22 @@
 
 require Rails.root.join "spec/support/api/mapit_helpers"
 require Rails.root.join "spec/support/api/paapi_helpers"
+require Rails.root.join "spec/support/api/planning_data_helpers"
 require Rails.root.join "spec/support/notify_helpers"
 
 World(MapitHelper)
 World(PaapiHelper)
+World(PlanningDataHelper)
 World(NotifyHelper)
 
 Before do
   stub_any_mapit_api_request.to_return(mapit_api_response(:ok))
   stub_paapi_api_request_for("100081043511").to_return(paapi_api_response(:ok))
+
+  stub_planning_data_api_request_for("BUC").to_return(planning_data_api_response(:ok, "BUC"))
+  stub_planning_data_api_request_for("LBH").to_return(planning_data_api_response(:ok, "LBH"))
+  stub_planning_data_api_request_for("SWK").to_return(planning_data_api_response(:ok, "SWK"))
+  stub_planning_data_api_request_for("TEST").to_return(planning_data_api_response(:ok, "TEST"))
 
   stub_any_post_sms_notification.to_return(sms_notification_api_response(:ok))
 end

--- a/spec/fixtures/planning_data/BUC.json
+++ b/spec/fixtures/planning_data/BUC.json
@@ -1,0 +1,25 @@
+{
+  "entities": [{
+    "entry-date": "2022-12-12",
+    "start-date": "2020-04-01",
+    "end-date": "",
+    "entity": 67,
+    "name": "Buckinghamshire Council",
+    "dataset": "local-authority",
+    "typology": "organisation",
+    "reference": "BUC",
+    "prefix": "local-authority",
+    "organisation-entity": "600001",
+    "geometry": "",
+    "point": "",
+    "twitter": "buckscouncil",
+    "website": "https://www.buckinghamshire.gov.uk/",
+    "wikidata": "Q65052846",
+    "wikipedia": "Buckinghamshire_Council",
+    "local-authority-type": "UA",
+    "parliament-thesaurus": "474721",
+    "statistical-geography": "E06000060"
+  }],
+  "links": {},
+  "count": 1
+}

--- a/spec/fixtures/planning_data/LBH.json
+++ b/spec/fixtures/planning_data/LBH.json
@@ -1,0 +1,25 @@
+{
+  "entities": [{
+    "entry-date": "2022-12-12",
+    "start-date": "",
+    "end-date": "",
+    "entity": 192,
+    "name": "London Borough of Lambeth",
+    "dataset": "local-authority",
+    "typology": "organisation",
+    "reference": "LBH",
+    "prefix": "local-authority",
+    "organisation-entity": "600001",
+    "geometry": "",
+    "point": "",
+    "twitter": "lambeth_council",
+    "website": "https://www.lambeth.gov.uk",
+    "wikidata": "Q6481450",
+    "wikipedia": "Lambeth_London_Borough_Council",
+    "local-authority-type": "LBO",
+    "parliament-thesaurus": "42273",
+    "statistical-geography": "E09000022"
+  }],
+  "links": {},
+  "count": 1
+}

--- a/spec/fixtures/planning_data/SWK.json
+++ b/spec/fixtures/planning_data/SWK.json
@@ -1,0 +1,25 @@
+{
+  "entities": [{
+    "entry-date": "2022-12-12",
+    "start-date": "",
+    "end-date": "",
+    "entity": 329,
+    "name": "London Borough of Southwark",
+    "dataset": "local-authority",
+    "typology": "organisation",
+    "reference": "SWK",
+    "prefix": "local-authority",
+    "organisation-entity": "600001",
+    "geometry": "",
+    "point": "",
+    "twitter": "lb_southwark",
+    "website": "https://www.southwark.gov.uk",
+    "wikidata": "Q7571153",
+    "wikipedia": "Southwark_London_Borough_Council",
+    "local-authority-type": "LBO",
+    "parliament-thesaurus": "70632",
+    "statistical-geography": "E09000028"
+  }],
+  "links": {},
+  "count": 1
+}

--- a/spec/fixtures/planning_data/TEST.json
+++ b/spec/fixtures/planning_data/TEST.json
@@ -1,0 +1,5 @@
+{
+  "entities": [],
+  "links": {},
+  "count": 0
+}

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UserMailer, type: :mailer do
     let(:mail_body) { mail.body.encoded }
 
     it "sets subject" do
-      travel_to("2022-01-01") do
+      travel_to("2022-01-01 00:00:00 GMT") do
         expect(mail.subject).to eq(
           "BoPS case BUC-22-00100-LDCP has a new update"
         )
@@ -28,7 +28,7 @@ RSpec.describe UserMailer, type: :mailer do
     end
 
     it "includes planning application reference" do
-      travel_to("2022-01-01") do
+      travel_to("2022-01-01 00:00:00 GMT") do
         expect(mail_body).to include(
           "BoPS case BUC-22-00100-LDCP has a new update."
         )

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -42,12 +42,6 @@ RSpec.describe LocalAuthority do
       it "validates presence" do
         expect { local_authority.valid? }.to change { local_authority.errors[:subdomain] }.to ["can't be blank"]
       end
-
-      it "raises an error with wrong type" do
-        expect { build(:local_authority, subdomain: "new_name") }
-          .to raise_error(ArgumentError)
-          .with_message(/is not a valid subdomain/)
-      end
     end
 
     describe "#signatory_name" do

--- a/spec/services/apis/planning_data/client_spec.rb
+++ b/spec/services/apis/planning_data/client_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Apis::PlanningData::Client do
+  let(:client) { described_class.new }
+
+  describe "#call" do
+    it "is successful" do
+      expect(client.call("LBH").status).to eq(200)
+    end
+  end
+end

--- a/spec/services/apis/planning_data/query_spec.rb
+++ b/spec/services/apis/planning_data/query_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Apis::PlanningData::Query do
+  let(:query) { described_class.new }
+
+  describe "#fetch" do
+    context "when the request is successful" do
+      context "when a valid council code reference is supplied" do
+        before do
+          stub_planning_data_api_request_for("BUC").to_return(planning_data_api_response(:ok, "BUC"))
+          stub_planning_data_api_request_for("LBH").to_return(planning_data_api_response(:ok, "LBH"))
+          stub_planning_data_api_request_for("SWK").to_return(planning_data_api_response(:ok, "SWK"))
+        end
+
+        it "returns buckinghamshire council's reference code" do
+          expect(query.fetch("BUC")).to eq("BUC")
+        end
+
+        it "returns lambeth council's reference code" do
+          expect(query.fetch("LBH")).to eq("LBH")
+        end
+
+        it "returns southwark council's reference code" do
+          expect(query.fetch("SWK")).to eq("SWK")
+        end
+      end
+
+      context "when an invalid council code reference is supplied" do
+        before do
+          stub_planning_data_api_request_for("TEST").to_return(planning_data_api_response(:ok, "TEST"))
+        end
+
+        it "returns nil" do
+          expect(query.fetch("TEST")).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/support/api/planning_data_helpers.rb
+++ b/spec/support/api/planning_data_helpers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module PlanningDataHelper
+  BASE_URL = "https://www.planning.data.gov.uk"
+
+  def stub_planning_data_api_request_for(reference)
+    stub_request(:get, "#{BASE_URL}/entity.json?reference=#{reference}")
+  end
+
+  def planning_data_api_response(status, body = "LBH")
+    status = Rack::Utils.status_code(status)
+
+    body = Rails.root.join("spec", "fixtures", "planning_data", "#{body}.json").read
+
+    { status: status, body: body }
+  end
+end
+
+if RSpec.respond_to?(:configure)
+  RSpec.configure do |config|
+    config.include(PlanningDataHelper)
+
+    config.before do
+      stub_planning_data_api_request_for("BUC").to_return(planning_data_api_response(:ok, "BUC"))
+      stub_planning_data_api_request_for("LBH").to_return(planning_data_api_response(:ok, "LBH"))
+      stub_planning_data_api_request_for("SWK").to_return(planning_data_api_response(:ok, "SWK"))
+      stub_planning_data_api_request_for("TEST").to_return(planning_data_api_response(:ok, "TEST"))
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Drop enum subdomain
- Add a validation which will call the planning.data.gov.uk API and compare whether the provided council code match

### Story Link

https://trello.com/c/57PS42eE