### PR TITLE
Successfully redirect even when no policy classes have been added

### DIFF
--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -28,8 +28,7 @@ class PolicyClassesController < PlanningApplicationsController
     class_ids = planning_application_params[:policy_classes].compact_blank
 
     if class_ids.empty?
-      redirect_to new_planning_application_policy_class_path(@planning_application, part: params[:part]),
-                  alert: t(".failure")
+      success_redirect_url
       return
     end
 
@@ -40,8 +39,7 @@ class PolicyClassesController < PlanningApplicationsController
     @planning_application.policy_classes += classes
 
     if @planning_application.save
-      redirect_to planning_application_assessment_tasks_path(@planning_application),
-                  notice: t(".success")
+      success_redirect_url
     else
       redirect_to new_planning_application_policy_class_path(@planning_application, part: params[:part]),
                   alert: @planning_application.errors.full_messages
@@ -98,5 +96,10 @@ class PolicyClassesController < PlanningApplicationsController
 
   def status
     mark_as_complete? ? :complete : :in_assessment
+  end
+
+  def success_redirect_url
+    redirect_to planning_application_assessment_tasks_path(@planning_application),
+                notice: t(".success")
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -700,7 +700,6 @@ en:
       view_next_class: View next class
       view_previous_class: View previous class
     create:
-      failure: Please select at least one class
       success: Policy classes have been successfully added
     destroy:
       success: Policy class has been removed.

--- a/spec/requests/policy_classes_spec.rb
+++ b/spec/requests/policy_classes_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Policy classes", show_exceptions: true do
     expect(response.body).to include "Please choose one of the policy parts"
   end
 
-  it "validates selecting some classes" do
+  it "redirects successfully even when no classes are selected" do
     params = {
       part: policy_class.part,
       policy_classes: []
@@ -31,10 +31,10 @@ RSpec.describe "Policy classes", show_exceptions: true do
 
     post planning_application_policy_classes_path(planning_application), params: params
 
-    expect(response).to redirect_to new_planning_application_policy_class_path(planning_application, part: 1)
+    expect(response).to redirect_to planning_application_assessment_tasks_path(planning_application)
     follow_redirect!
 
-    expect(response.body).to include "Please select at least one class"
+    expect(response.body).to include "Policy classes have been successfully added"
   end
 
   context "when the application is past assessment" do


### PR DESCRIPTION
### Story Link

https://trello.com/c/WX9qjYrg/1409-unexpected-error-message-when-proceeding-with-add-assessment-area-if-all-areas-have-been-selected

