### PR TITLE
Remove duplicate heading from legislation review pages

### DIFF
--- a/app/views/shared/policy_classes/_table_head.html.erb
+++ b/app/views/shared/policy_classes/_table_head.html.erb
@@ -1,11 +1,3 @@
-<caption class="govuk-table__caption govuk-table__caption--l">
-  <%= t(
-    ".table_caption",
-    part: policy_class.part,
-    class: policy_class.section,
-    name: policy_class.name
-  ) %>
-</caption>
 <thead class="govuk-table__head">
   <tr class="govuk-table__row">
     <th scope="col" class="govuk-table__header govuk-!-width-one-half">

--- a/spec/system/planning_applications/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessment_against_legislation_spec.rb
@@ -112,15 +112,15 @@ RSpec.describe "assessment against legislation" do
 
       click_link("Part 1, Class A")
       expect(page).to have_content("Enlargement, improvement or other alteration of a dwellinghouse")
-      within(".govuk-table caption") do
-        expect(page).to have_content("Part 1, Class A - enlargement, improvement or other alteration of a dwellinghouse")
+      within("h1") do
+        expect(page).to have_content("Assess - Part 1, Class A")
       end
 
       click_link("Back")
       click_link("Part 1, Class B")
       expect(page).to have_content("Additions etc to the roof of a dwellinghouse")
-      within(".govuk-table caption") do
-        expect(page).to have_content("Part 1, Class B - additions etc to the roof of a dwellinghouse")
+      within("h1") do
+        expect(page).to have_content("Assess - Part 1, Class B")
       end
     end
 

--- a/spec/system/planning_applications/reviewing/policy_class_spec.rb
+++ b/spec/system/planning_applications/reviewing/policy_class_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Reviewing Policy Class" do
         visit(planning_application_review_tasks_path(planning_application))
         click_on "Review assessment of Part 1, Class A"
 
-        expect(page).to have_text("Part 1, Class A - Roof")
+        expect(page).to have_text("Review - Part1, Class A Roof")
         expect(page).to have_selector("p", text: "Policy description")
 
         expect(page).to have_text(


### PR DESCRIPTION
### Description of change

The title and subtitle of the legislation being reviewed was unnecessarily duplicated between the `policy_classes/_form` template and the `policy_classes/_table_head` partial. This removes the latter, which is not in the designs.

### Story Link

https://trello.com/c/6aswAGJq/1417-legislation-page-correct-h1-and-h2-and-remove-class-cta

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
