### PR TITLE
Allow cloning of planning applications for development / staging

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,11 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/models/review_policy_class_spec.rb
 
+Naming/VariableNumber:
+  Exclude:
+    - spec/**/*
+    - app/services/planning_application_creation_service.rb
+
 # we tend to use update_all in migrations
 Rails/SkipsModelValidations:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,6 +39,7 @@ Metrics/AbcSize:
     - 'app/helpers/planning_application_helper.rb'
     - 'app/helpers/validation_request_helper.rb'
     - 'app/presenters/concerns/validation_tasks/red_line_boundary_presenter.rb'
+    - 'app/services/planning_application_creation_service.rb'
     - 'db/migrate/20200419000000_create_initial_schema.rb'
 
 # Offense count: 5

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -505,6 +505,10 @@ class PlanningApplication < ApplicationRecord
     end
   end
 
+  def can_clone?
+    Rails.env.development? || ENV.fetch("STAGING_ENABLED", "false") == "true"
+  end
+
   private
 
   def set_reference

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+class PlanningApplicationCreationService
+  class CreateError < StandardError; end
+
+  def initialize(planning_application: nil, **options)
+    if planning_application
+      raise CreateError, "Cloning is not permitted in production" unless planning_application.can_clone?
+
+      audit_log = planning_application.audit_log
+      raise CreateError, "Planning application can not be cloned as it was not created via PlanX" unless audit_log
+
+      @params = ActionController::Parameters.new(JSON.parse(audit_log))
+      @local_authority = planning_application.local_authority
+      @api_user = planning_application.api_user
+    else
+      options.each { |k, v| instance_variable_set("@#{k}", v) unless v.nil? }
+    end
+  end
+
+  def call
+    save_planning_application!(build_planning_application)
+  end
+
+  private
+
+  attr_reader :local_authority, :params, :api_user
+
+  def build_planning_application
+    planning_application = PlanningApplication.new(
+      planning_application_params.merge!(
+        local_authority_id: local_authority.id,
+        boundary_geojson: (params[:boundary_geojson].to_json if params[:boundary_geojson].present?),
+        proposal_details: (params[:proposal_details].to_json if params[:proposal_details].present?),
+        constraints: constraints_array_from_param(params[:constraints]),
+        planx_data: (params[:planx_debug_data].to_json if params[:planx_debug_data].present?),
+        api_user: api_user,
+        audit_log: params.to_json,
+        user_role: params[:user_role].presence,
+        payment_amount: params[:payment_amount].presence && payment_amount_in_pounds(params[:payment_amount])
+      )
+    )
+
+    planning_application.assign_attributes(site_params) if site_params.present?
+    planning_application.assign_attributes(result_params) if result_params.present?
+
+    planning_application
+  end
+
+  def save_planning_application!(planning_application)
+    PlanningApplication.transaction do
+      if planning_application.save!
+        UploadDocumentsJob.perform_now(planning_application: planning_application, files: params[:files])
+
+        planning_application.send_receipt_notice_mail
+      end
+
+      planning_application
+    end
+  rescue Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid,
+         ArgumentError, NoMethodError => e
+    raise CreateError, e.message
+  end
+
+  def planning_application_params
+    permitted_keys = [:application_type,
+                      :description,
+                      :applicant_first_name,
+                      :applicant_last_name,
+                      :applicant_phone,
+                      :applicant_email,
+                      :agent_first_name,
+                      :agent_last_name,
+                      :agent_phone,
+                      :agent_email,
+                      :user_role,
+                      :proposal_details,
+                      :files,
+                      :payment_reference,
+                      :work_status,
+                      :planx_debug_data,
+                      { feedback: %i[result find_property planning_constraints] }]
+
+    params.permit permitted_keys
+  end
+
+  def constraints_array_from_param(constraints_params)
+    if constraints_params.present?
+      constraints_params.to_unsafe_hash.filter_map do |key, value|
+        key if value
+      end
+    else
+      []
+    end
+  end
+
+  def site_params
+    return unless params[:site]
+
+    { uprn: params[:site][:uprn],
+      address_1: params[:site][:address_1],
+      address_2: params[:site][:address_2],
+      town: params[:site][:town],
+      postcode: params[:site][:postcode],
+      latitude: params[:site][:latitude],
+      longitude: params[:site][:longitude] }
+  end
+
+  def result_params
+    return unless params[:result]
+
+    { result_flag: params[:result][:flag],
+      result_heading: params[:result][:heading],
+      result_description: params[:result][:description],
+      result_override: params[:result][:override] }
+  end
+
+  def payment_amount_in_pounds(amount)
+    amount.to_f / 100
+  end
+end

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -13,13 +13,21 @@
       sections: %i[key_application_dates contact_information audit_log notes]
     )
   ) %>
-  <% if @planning_application.in_progress? %>
-    <%= link_to(
-      t(".close_or_cancel"),
-      close_or_cancel_confirmation_planning_application_path(
-        @planning_application
-      ),
-      class: "govuk-button govuk-button--warning"
-    ) %>
+  <% if @planning_application.in_progress? || @planning_application.can_clone? %>
+    <div class="govuk-button-group">
+      <% if @planning_application.in_progress? %>
+        <%= link_to(
+          t(".close_or_cancel"),
+          close_or_cancel_confirmation_planning_application_path(
+            @planning_application
+          ),
+          class: "govuk-button govuk-button--warning"
+        ) %>
+      <% end %>
+
+      <% if @planning_application.can_clone? %>
+        <%= link_to "Clone", clone_planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary", method: :post, data: { confirm: "This will clone the planning application identical to how it was created via PlanX. Are you sure?" } %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,7 @@ Rails.application.routes.draw do
       get :validation_decision
       get :validation_documents
       patch :validate_documents
+      post :clone
     end
 
     resource :constraints, only: %i[show edit update] do

--- a/spec/components/accordion_sections/application_information_component_spec.rb
+++ b/spec/components/accordion_sections/application_information_component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AccordionSections::ApplicationInformationComponent, type: :compon
       description: "Test description",
       application_type: :full,
       work_status: work_status,
-      address_1: "123 Long Lane", # rubocop:disable Naming/VariableNumber
+      address_1: "123 Long Lane",
       town: "Big City",
       postcode: "AB34EF",
       uprn: "123456789",

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -292,5 +292,9 @@ FactoryBot.define do
     factory :closed_planning_application do
       after(:create, &:close!)
     end
+
+    trait :from_planx do
+      audit_log { file_fixture("planx_params.json").read }
+    end
   end
 end

--- a/spec/fixtures/files/planx_params.json
+++ b/spec/fixtures/files/planx_params.json
@@ -1,0 +1,763 @@
+{
+  "application_type": "lawfulness_certificate",
+  "site": {
+    "uprn": "100081043511",
+    "address_1": "12 Test Abbey Gardens",
+    "address_2": "Southwark",
+    "town": "London",
+    "postcode": "SE16 3RQ",
+    "latitude": "51.4842536",
+    "longitude": "-0.0764165"
+  },
+  "description": "Add a chimney stack",
+  "payment_reference": "PAY1",
+  "payment_amount": 10300,
+  "work_status": "proposed",
+  "applicant_first_name": "Albert",
+  "applicant_last_name": "Manteras",
+  "applicant_phone": "23432325435",
+  "applicant_email": "applicant@example.com",
+  "agent_first_name": "Jennifer",
+  "agent_last_name": "Harper",
+  "agent_phone": "237878889",
+  "agent_email": "agent@example.com",
+  "user_role": "agent",
+  "feedback": {
+    "result": "feedback about the result",
+    "find_property": "feedback about the property",
+    "planning_constraints": "feedback about the constraints"
+  },
+  "result":
+  {
+    "flag": "Planning permission / Permission needed",
+    "heading": "It looks like these changes will need planning permission",
+    "description": "Based on the information you have provided, we do not think this is eligible for a Lawful Development Certificate",
+    "override": "This was my reason for rejecting the result"
+  },
+  "proposal_details":
+  [
+    {
+      "question": "What do you want to do?",
+      "responses": [
+        {
+          "value": "Modify or extend"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details"
+      }
+    },
+    {
+      "question": "What is the dwelling used as?",
+      "responses": [
+        {
+          "value": "A family home"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details"
+      }
+    },
+    {
+      "question": "Is the property a house?",
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details"
+      }
+    },
+    {
+      "question": "How many storeys will the new structure have?",
+      "responses": [
+        {
+          "value": "1"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details"
+      }
+    },
+    {
+      "question": "Was the house always a house?",
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details"
+      }
+    },
+    {
+      "question": "Will the structure include a satellite dish or antenna?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Property details",
+        "policy_refs": [
+          {
+            "url": "http://example.com/planning/policy/1/234/a.html",
+            "text": "GPDO 00.0000.000"
+          }
+        ]
+      }
+    },
+    {
+      "question": "What will be the total footprint of all additions of the available area around the original house?",
+      "responses": [
+        {
+          "value": "50% or less"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Dimensions"
+      }
+    },
+    {
+      "question": "How high will the eaves of the new structure be?",
+      "responses": [
+        {
+          "value": "2.5m or lower"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Dimensions"
+      }
+    },
+    {
+      "question": "What will the height of the new structure be?",
+      "responses": [
+        {
+          "value": "2.5m or lower"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Dimensions"
+      }
+    },
+    {
+      "question": "How close will the new structure be to the site boundary?",
+      "responses": [
+        {
+          "value": "Within 2m"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Front of house"
+      }
+    },
+    {
+      "question": "Will any part of the new structure be forward of the front of the original house?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Front of house"
+      }
+    },
+    {
+      "question": "Will any part of the pool be forward of the front of the original house?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Front of house"
+      }
+    },
+    {
+      "question": "What is the addition to the property?",
+      "responses": [
+        {
+          "value": "An outdoor pool"
+        },
+        {
+          "value": "An outbuilding"
+        }
+      ],
+      "metadata":
+     {
+        "portal_name": "Property details",
+        "policy_refs": [
+          {
+            "url": "http://example.com/planning/policy/1/234/b.html",
+            "text": "GPDO 00.0000.000"
+          },
+          {
+            "url": "http://example.com/planning/policy/1/234/c.html",
+            "text": "GPDO 00.0000.000"
+          }
+        ]
+      }
+    },
+    {
+      "question": "How many storeys will the new structure have?",
+      "responses": [
+        {
+          "value": "1"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Dimensions"
+      }
+    },
+    {
+      "question": "Is the property on designated land?",
+      "responses": [
+        {
+          "value": "No",
+          "auto_answered": true
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area"
+      }
+    },
+    {
+      "question": "Is the property in an area of outstanding natural beauty?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area",
+        "auto_answered": true
+      }
+    },
+    {
+      "question": "Is the property in the broads?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area",
+        "auto_answered": true
+      }
+    },
+    {
+      "question": "Is the property in a world heritage site?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area",
+        "auto_answered": true
+      }
+    },
+    {
+      "question": "Is the property in a national park?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area",
+        "auto_answered": true
+      }
+    },
+    {
+      "question": "Is any part of the property listed?",
+      "responses": [
+        {
+          "value": "No",
+          "metadata": {
+            "flags": [
+              "Listed building consent / Not required"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area"
+      }
+    },
+    {
+      "question": "Will the works affect a protected tree?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Surrounding Area",
+        "auto_answered": true
+      }
+    },
+    {
+      "question": "Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?",
+      "responses": [
+        {
+          "value": "Yes",
+          "metadata": {
+            "notes": "It will allow me to exercise on a regular basis and generate energy",
+            "flags": [
+              "Planning permission / Permission needed"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "portal_name": "Actitivies"
+      }
+    },
+    {
+      "question": "What type of planning application are you making?",
+      "responses": [
+        {
+          "value": "Existing changes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "fee-calculator",
+        "policy_refs": [
+          {
+            "url": "http://example.com/planning/policy/1/234/a.html"
+          }
+        ]
+      }
+    },
+    {
+      "question": "What type of changes does the project involve?",
+      "responses": [
+        {
+          "value": "Alteration"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015"
+          }
+        ]
+      }
+    }
+  ],
+  "constraints": {
+    "conservation_area": true,
+    "protected_trees": false
+  },
+  "files": [
+    {
+      "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+      "applicant_description": "This is the side plan",
+      "tags": [
+        "Side"
+      ]
+    }
+  ],
+  "boundary_geojson":
+  {
+    "type": "Feature",
+    "geometry":
+    {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -0.07716178894042969,
+            51.50094238217541
+          ],
+          [
+            -0.07645905017852783,
+            51.50053497847238
+          ],
+          [
+            -0.07615327835083008,
+            51.50115276135022
+          ],
+          [
+            -0.07716178894042969,
+            51.50094238217541
+          ]
+        ]
+      ]
+    }
+  },
+  "controller": "api/v1/planning_applications",
+  "action": "create",
+  "planning_application":
+  {
+    "application_type": "lawfulness_certificate",
+    "description": "Add a chimney stack",
+    "proposal_details":
+    [
+      {
+        "question": "What do you want to do?",
+        "responses": [
+          {
+            "value": "Modify or extend"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details"
+        }
+      },
+      {
+        "question": "What is the dwelling used as?",
+        "responses": [
+          {
+            "value": "A family home"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details"
+        }
+      },
+      {
+        "question": "Is the property a house?",
+        "responses": [
+          {
+            "value": "Yes"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details"
+        }
+      },
+      {
+        "question": "How many storeys will the new structure have?",
+        "responses": [
+          {
+            "value": "1"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details"
+        }
+      },
+      {
+        "question": "Was the house always a house?",
+        "responses": [
+          {
+            "value": "Yes"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details"
+        }
+      },
+      {
+        "question": "Will the structure include a satellite dish or antenna?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Property details",
+          "policy_refs": [
+            {
+              "url": "http://example.com/planning/policy/1/234/a.html",
+              "text": "GPDO 00.0000.000"
+            }
+          ]
+        }
+      },
+      {
+        "question": "What will be the total footprint of all additions of the available area around the original house?",
+        "responses": [
+          {
+            "value": "50% or less"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Dimensions"
+        }
+      },
+      {
+        "question": "How high will the eaves of the new structure be?",
+        "responses": [
+          {
+            "value": "2.5m or lower"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Dimensions"
+        }
+      },
+      {
+        "question": "What will the height of the new structure be?",
+        "responses": [
+          {
+            "value": "2.5m or lower"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Dimensions"
+        }
+      },
+      {
+        "question": "How close will the new structure be to the site boundary?",
+        "responses": [
+          {
+            "value": "Within 2m"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Front of house"
+        }
+      },
+     {
+        "question": "Will any part of the new structure be forward of the front of the original house?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Front of house"
+        }
+      },
+      {
+        "question": "Will any part of the pool be forward of the front of the original house?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Front of house"
+        }
+      },
+      {
+        "question": "What is the addition to the property?",
+        "responses": [
+          {
+            "value": "An outdoor pool"
+          },
+          {
+            "value": "An outbuilding"
+          }
+        ],
+        "metadata":
+       {
+          "portal_name": "Property details",
+          "policy_refs": [
+            {
+              "url": "http://example.com/planning/policy/1/234/b.html",
+              "text": "GPDO 00.0000.000"
+            },
+            {
+              "url": "http://example.com/planning/policy/1/234/c.html",
+              "text": "GPDO 00.0000.000"
+            }
+          ]
+        }
+      },
+      {
+        "question": "How many storeys will the new structure have?",
+        "responses": [
+          {
+            "value": "1"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Dimensions"
+        }
+      },
+      {
+        "question": "Is the property on designated land?",
+        "responses": [
+          {
+            "value": "No",
+            "auto_answered": true
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area"
+        }
+      },
+      {
+        "question": "Is the property in an area of outstanding natural beauty?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area",
+          "auto_answered": true
+        }
+      },
+      {
+        "question": "Is the property in the broads?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area",
+          "auto_answered": true
+        }
+      },
+      {
+        "question": "Is the property in a world heritage site?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area",
+          "auto_answered": true
+        }
+      },
+      {
+        "question": "Is the property in a national park?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area",
+          "auto_answered": true
+        }
+      },
+      {
+        "question": "Is any part of the property listed?",
+        "responses": [
+          {
+            "value": "No",
+            "metadata": {
+              "flags": [
+                "Listed building consent / Not required"
+              ]
+            }
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area"
+        }
+      },
+      {
+        "question": "Will the works affect a protected tree?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Surrounding Area",
+          "auto_answered": true
+        }
+      },
+      {
+        "question": "Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?",
+        "responses": [
+          {
+            "value": "Yes",
+            "metadata": {
+              "notes": "It will allow me to exercise on a regular basis and generate energy",
+              "flags": [
+                "Planning permission / Permission needed"
+              ]
+            }
+          }
+        ],
+        "metadata": {
+          "portal_name": "Actitivies"
+        }
+      },
+      {
+        "question": "What type of planning application are you making?",
+        "responses": [
+          {
+            "value": "Existing changes"
+          }
+        ],
+        "metadata": {
+          "portal_name": "fee-calculator",
+          "policy_refs": [
+            {
+              "url": "http://example.com/planning/policy/1/234/a.html"
+            }
+          ]
+        }
+      },
+      {
+        "question": "What type of changes does the project involve?",
+        "responses": [
+          {
+            "value": "Alteration"
+          }
+        ],
+        "metadata": {
+          "portal_name": "Fee Exemptions",
+          "policy_refs": [
+            {
+              "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015"
+            }
+          ]
+        }
+      }
+    ],
+    "agent_first_name": "Jennifer",
+    "agent_last_name": "Harper",
+    "agent_phone": "237878889",
+    "agent_email": "agent@example.com",
+    "applicant_first_name": "Albert",
+    "applicant_last_name": "Manteras",
+    "applicant_email": "applicant@example.com",
+    "applicant_phone": "23432325435",
+    "payment_reference": "PAY1",
+    "work_status": "proposed",
+    "boundary_geojson":
+    {
+      "type": "Feature",
+      "geometry":
+      {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -0.07716178894042969,
+              51.50094238217541
+            ],
+            [
+              -0.07645905017852783,
+              51.50053497847238
+            ],
+            [
+              -0.07615327835083008,
+              51.50115276135022
+            ],
+            [
+              -0.07716178894042969,
+              51.50094238217541
+            ]
+          ]
+        ]
+      }
+    },
+    "constraints": {
+      "conservation_area": true,
+      "protected_trees": false
+    },
+    "payment_amount": 10300,
+    "user_role": "agent",
+    "feedback": {
+      "result": "feedback about the result",
+      "find_property": "feedback about the property",
+      "planning_constraints": "feedback about the constraints"
+    }
+  },
+  "format": "json"
+}

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       applicant_email: "cookie_crumbs@example.com",
       local_authority: local_authority,
       decision: "granted",
-      address_1: "123 High Street", # rubocop:disable Naming/VariableNumber
+      address_1: "123 High Street",
       town: "Big City",
       postcode: "AB3 4EF",
       description: "Add a chimney stack",
@@ -154,7 +154,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         :planning_application,
         :invalidated,
         local_authority: local_authority,
-        address_1: "123 High Street", # rubocop:disable Naming/VariableNumber
+        address_1: "123 High Street",
         town: "Big City",
         postcode: "AB3 4EF",
         invalidated_at: DateTime.new(2022, 6, 5)
@@ -536,7 +536,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         :planning_application,
         agent_email: "agent@example.com",
         local_authority: local_authority,
-        address_1: "123 High Street", # rubocop:disable Naming/VariableNumber
+        address_1: "123 High Street",
         town: "Big City",
         postcode: "AB3 4EF"
       )

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1862,4 +1862,36 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  describe "#can_clone?" do
+    let(:planning_application) { create(:planning_application) }
+
+    context "when in the dev environment" do
+      before { allow(Rails.env).to receive(:development?).and_return(true) }
+
+      it "returns true" do
+        expect(planning_application.can_clone?).to be(true)
+      end
+    end
+
+    context "when STAGING_ENABLED env variable is set to true" do
+      before do
+        allow(ENV).to receive(:fetch).with("STAGING_ENABLED", "false").and_return("true")
+      end
+
+      it "returns true" do
+        expect(planning_application.can_clone?).to be(true)
+      end
+    end
+
+    context "when not in the dev environment and STAGING_ENABLED env variable is not set" do
+      before do
+        allow(ENV).to receive(:fetch).with("STAGING_ENABLED", "false").and_return("false")
+      end
+
+      it "returns false" do
+        expect(planning_application.can_clone?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplicationCreationService, type: :service do
+  describe "#call" do
+    let(:api_user) { create(:api_user) }
+
+    before do
+      stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+        .to_return(
+          status: 200,
+          body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
+          headers: { "Content-Type" => "application/pdf" }
+        )
+    end
+
+    context "when a planning application is provided" do
+      let!(:planning_application) { create(:planning_application, :from_planx, api_user: api_user) }
+
+      let(:create_planning_application) do
+        described_class.new(
+          planning_application: planning_application
+        ).call
+      end
+
+      before do
+        allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(true)
+      end
+
+      context "when successful" do
+        before do
+          # Create the planning application to be cloned using the audit_log value from planx params
+          described_class.new(
+            planning_application: planning_application
+          ).call
+        end
+
+        it "creates a new planning application identical to how it came via planx using the audit_log value as the params" do
+          planning_application = PlanningApplication.last
+
+          expect do
+            described_class.new(
+              planning_application: planning_application
+            ).call
+          end.to change(PlanningApplication, :count).by(1)
+
+          cloned_planning_application = PlanningApplication.last
+
+          expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
+
+          expect(cloned_planning_application).to have_attributes(
+            id: planning_application.id + 1,
+            local_authority_id: planning_application.local_authority.id,
+            api_user_id: planning_application.api_user.id,
+            planx_data: planning_application.planx_data,
+            audit_log: planning_application.audit_log,
+            address_1: planning_application.address_1,
+            address_2: planning_application.address_2,
+            town: planning_application.town,
+            county: planning_application.county,
+            postcode: planning_application.postcode,
+            uprn: planning_application.uprn,
+            boundary_geojson: planning_application.boundary_geojson,
+            constraints: planning_application.constraints,
+            agent_first_name: planning_application.agent_first_name,
+            agent_email: planning_application.agent_email,
+            applicant_email: planning_application.applicant_email,
+            result_flag: planning_application.result_flag,
+            description: planning_application.description
+          )
+
+          # Proposal details have their own object id i.e. ProposalDetail:0x00007fe42a8476a8 so compare the json value instead
+          proposal_details = planning_application.proposal_details.map(&:to_json)
+          cloned_proposal_details = cloned_planning_application.proposal_details.map(&:to_json)
+          expect(proposal_details).to eq(cloned_proposal_details)
+        end
+      end
+
+      context "when can_clone? is false" do
+        before { allow(planning_application).to receive(:can_clone?).and_return(false) }
+
+        it "raises an error" do
+          expect { create_planning_application }.to raise_error(described_class::CreateError, "Cloning is not permitted in production")
+        end
+      end
+
+      context "when planning application was not created via PlanX i.e. there is no audit_log value" do
+        let(:planning_application) { create(:planning_application) }
+
+        it "raises an error" do
+          expect { create_planning_application }.to raise_error(described_class::CreateError, "Planning application can not be cloned as it was not created via PlanX")
+        end
+      end
+
+      [Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError, NoMethodError].each do |error|
+        context "when there is an error of type: #{error} saving the new planning application" do
+          before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(error) }
+
+          it "raises an error" do
+            expect { create_planning_application }.to raise_error(described_class::CreateError)
+          end
+        end
+      end
+    end
+
+    context "when no planning application is provided" do
+      let(:local_authority) { create(:local_authority) }
+      let(:params) { ActionController::Parameters.new(JSON.parse(file_fixture("planx_params.json").read)) }
+
+      let(:create_planning_application) do
+        described_class.new(
+          local_authority: local_authority, params: params, api_user: api_user
+        ).call
+      end
+
+      context "when successful" do
+        it "creates a new planning application from the params" do
+          expect { create_planning_application }.to change(PlanningApplication, :count).by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "cloning a planning application" do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority: local_authority) }
+  let(:api_user) { create(:api_user) }
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :from_planx,
+      local_authority: local_authority,
+      api_user: api_user
+    )
+  end
+
+  before do
+    allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(true)
+
+    stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+      .to_return(
+        status: 200,
+        body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
+        headers: { "Content-Type" => "application/pdf" }
+      )
+
+    sign_in(assessor)
+    visit(planning_application_path(planning_application))
+  end
+
+  context "when I am able to clone a planning application" do
+    it "I am successfully redirected to the cloned planning application" do
+      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+        click_link("Clone")
+      end
+
+      expect(page).to have_content("Planning application was successfully cloned")
+
+      expect(PlanningApplication.all.count).to eq(2)
+
+      cloned_planning_application = PlanningApplication.last
+      expect(page).to have_current_path(planning_application_path(cloned_planning_application))
+      expect(page).to have_content("Planning application was successfully cloned")
+
+      expect(JSON.parse(planning_application.audit_log)).to eq(JSON.parse(cloned_planning_application.audit_log))
+      expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
+    end
+  end
+
+  context "when there is an error cloning a planning application" do
+    before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
+
+    it "I am presented with the error" do
+      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+        click_link("Clone")
+      end
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Error cloning application with message: Record invalid.")
+      end
+
+      expect(PlanningApplication.all.count).to eq(1)
+    end
+  end
+
+  context "when can_clone? returns false" do
+    before { allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(false) }
+
+    it "I am unable to clone and presented with an error" do
+      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+        click_link("Clone")
+      end
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Cloning is not permitted in production")
+      end
+
+      expect(PlanningApplication.all.count).to eq(1)
+    end
+  end
+
+  context "when planning application was not created via PlanX i.e. there is no audit_log value" do
+    let(:planning_application) { create(:planning_application, local_authority: local_authority) }
+
+    it "I am unable to clone and presented with an error" do
+      visit(planning_application_path(planning_application))
+
+      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+        click_link("Clone")
+      end
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Planning application can not be cloned as it was not created via PlanX")
+      end
+
+      expect(PlanningApplication.all.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

**Allow cloning of planning applications for development / staging**
- This clone feature just replicates the POST request that PlanX makes into our API
- Extract the planning application API create action into a service so that we can repurpose this for both cloning internally and external API requests
- This is only supported on development and staging environments
- Cloning will only work on planning applications where there is an audit_log value storing the params we get from the PlanX post request. This is used to mimic the same request when cloning
- If a planning application has been processed further along within BOPS then the cloned application will not have these updates

### Story Link

https://trello.com/c/ckdkEHkj/1427-add-the-ability-to-clone-a-planning-application-staging-only