### PR TITLE
Prompt user to complete draft assessment before updating application details

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -9,6 +9,8 @@ class PlanningApplicationsController < AuthenticationController
 
   before_action :ensure_no_open_post_validation_requests, only: %i[submit]
 
+  before_action :ensure_draft_recommendation_complete, only: :update
+
   rescue_from PlanningApplication::WithdrawRecommendationError do |_exception|
     redirect_failed_withdraw_recommendation
   end
@@ -59,10 +61,6 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def update
-    if @planning_application.recommendation.present? && !@planning_application.recommendation.submitted
-      flash.now[:alert] = "Please complete in draft assessment before updating application fields."
-    end
-
     respond_to do |format|
       if @planning_application.update(planning_application_params)
         format.html { redirect_update_url }
@@ -380,5 +378,15 @@ class PlanningApplicationsController < AuthenticationController
         #{view_context.link_to 'review open requests',
                                post_validation_requests_planning_application_validation_requests_path(@planning_application)} and resolve them before submitting to your manager."
     render :submit_recommendation and return
+  end
+
+  def ensure_draft_recommendation_complete
+    return unless @planning_application.try(:assessment_in_progress?)
+
+    flash.now[:alert] = sanitize "Please save and mark as complete the
+        #{view_context.link_to 'draft recommendation',
+                               new_planning_application_recommendation_path(@planning_application)} before updating application fields."
+
+    render :edit and return
   end
 end

--- a/features/editing_a_planning_application.feature
+++ b/features/editing_a_planning_application.feature
@@ -63,4 +63,4 @@ Feature: Editing an application's details
     When I edit the planning application's details
     And I fill in "Address 2" with "Happy Buns"
     And I press "Save"
-    Then the page contains "Please complete in draft assessment before updating application fields."
+    Then the page contains "Please save and mark as complete the draft recommendation before updating application fields."

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -14,9 +14,12 @@ RSpec.describe "editing planning application" do
     )
   end
 
-  it "returns the user to the previous page after updating" do
+  before do
     sign_in(assessor)
     visit(planning_application_path(planning_application))
+  end
+
+  it "returns the user to the previous page after updating" do
     click_link("Check and assess")
     click_button("Application information")
     click_link("Edit details")
@@ -64,5 +67,28 @@ RSpec.describe "editing planning application" do
     expect(page).to have_current_path(
       new_planning_application_consistency_checklist_path(planning_application)
     )
+  end
+
+  context "when planning application status is assessment in progress" do
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :assessment_in_progress,
+        local_authority: local_authority
+      )
+    end
+
+    it "prompts the user to complete their draft assessment before updating" do
+      click_link("Check and assess")
+      click_button("Application information")
+      click_link("Edit details")
+
+      fill_in("Postcode", with: "123ABC")
+
+      click_button("Save")
+
+      expect(page).to have_content("Please save and mark as complete the draft recommendation before updating application fields.")
+      expect(page).to have_link("draft recommendation", href: new_planning_application_recommendation_path(planning_application))
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Investigated this and the planning application in question (as I write this) has a status of assessment_in_progress which means that validation had been lifted when saving the application.

Therefore, any subsequent update will run the validation checks and this application doesn't have an associated public comment so it is validating for this whenever we try to save the model.

Having had an audit of the way we are using assessment_in_progress i'm not confident with its implementation so there may be some rethinking here.

For now I will add a fix to suggest that the user will need to complete their draft assessment before updating the application details.

Once the application is out of assessment_in_progress i.e. now in just in_assessment after a public comment has been added, they should be able to proceed with editing application details.

### Story Link

https://trello.com/c/gDiAVNmi/1444-unexpected-error-message-when-updating-applicant-details-and-case-is-in-assessment

