### PR TITLE
Rename constraints.yml to avoid mixup

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -364,7 +364,7 @@ class PlanningApplication < ApplicationRecord
   # around it), just assume plain-text constraints rather than a
   # key-value mapping.
   def defined_constraints
-    I18n.t("constraints").values.flatten
+    I18n.t("constraint_list").values.flatten
   end
 
   def custom_constraints

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -15,7 +15,7 @@
   <%= form_with model: @planning_application, url: planning_application_constraints_path(@planning_application), local: true do |form| %>
     <%= form.hidden_field(:return_to, value: @back_path) %>
     <div class="govuk-grid-column-two-thirds">
-      <% t("constraints").each do |type, constraints| %>
+      <% t("constraint_list").each do |type, constraints| %>
         <fieldset class="govuk-fieldset govuk-!-margin-top-3">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h2 class="govuk-fieldset__heading">

--- a/config/locales/constraint_list.yml
+++ b/config/locales/constraint_list.yml
@@ -1,5 +1,5 @@
 en:
-  constraints:
+  constraint_list:
     flooding:
       - Flood zone
       - Flood zone 1


### PR DESCRIPTION
### Description of change

Rename constraints in constraints.yml to avoid confusion when listing out the constraints on the constraint edit page. 

### Story Link

https://trello.com/c/91yYQEwg/1462-review-the-list-of-constraints

### Decisions [OPTIONAL]

"Constraints" are defined in two places in the various yml files (constraints.yml and en.yml), resulting in when we iterate through the list of constraints for the constraint edit page we get some weird results - the success/update messages are listed as actual constraints.

Rename the constraint.yml file so this doesn't happen. Thought that was easier than trying to override the constraints controller to know to look for something different.

