### PR TITLE
Add feedback fish widget

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -24,5 +24,9 @@
   <%= stylesheet_link_tag 'application', 'data-turbolinks-track': 'reload', media: 'all' %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
 
+  <% if ENV["FEEDBACK_FISH_ID"].present? %>
+    <script defer src="https://feedback.fish/ff.js?pid=<%= ENV['FEEDBACK_FISH_ID'] %>"></script>
+  <% end %>
+
   <meta property="og:image" content="&lt;YOUR-DOMAIN&gt;/images/govuk-opengraph-image.png">
 </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,11 +24,20 @@
           <strong class="govuk-tag govuk-phase-banner__content__tag">
             beta
           </strong>
-          <span class="govuk-phase-banner__text">
-            This is a new service – your
-            <%= mail_to current_local_authority.feedback_email, "feedback", class: "govuk-link" %>
-            will help us to improve it.
-          </span>
+
+          <% if ENV["FEEDBACK_FISH_ID"].present? %>
+            <span class="govuk-phase-banner__text">
+              This is a new service – your
+              <a class="govuk-link" href="#"
+                data-feedback-fish
+                data-feedback-fish-userid="<%= current_user.try(:email) %>"
+              >
+                feedback
+              </a>
+
+              will help us to improve it.
+            </span>
+          <% end %>
         </p>
       </div>
 

--- a/spec/system/feedback_fish_spec.rb
+++ b/spec/system/feedback_fish_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Feedback fish" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority: local_authority) }
+
+  before do
+    sign_in assessor
+  end
+
+  context "when FEEDBACK_FISH_ID env variable is set" do
+    before do
+      ENV["FEEDBACK_FISH_ID"] = "randomid123"
+    end
+
+    it "is displayed with a reference to the user's email" do
+      visit root_path
+
+      within find("a[data-feedback-fish][data-feedback-fish-userid='#{assessor.email}']") do
+        expect(page).to have_content "feedback"
+      end
+    end
+  end
+
+  context "when FEEDBACK_FISH_ID env variable is not set" do
+    before do
+      ENV["FEEDBACK_FISH_ID"] = nil
+    end
+
+    it "is not displayed" do
+      visit root_path
+
+      within(".govuk-phase-banner__content") do
+        expect(page).not_to have_content "feedback"
+      end
+    end
+  end
+end

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -127,12 +127,6 @@ RSpec.describe "Sign in" do
 
         expect(page).to have_text("Signed in successfully.")
       end
-
-      it "has the feedback email" do
-        visit root_path
-
-        expect(page).to have_link("feedback", href: "mailto:feedback_email@lambeth.gov.uk")
-      end
     end
   end
 


### PR DESCRIPTION
### Description of change

Embed[ feedback fish](https://feedback.fish/) widget

- Send user's email in feedback request
- Split pid id per environment so we can have a specific project for staging / production

### Story Link

https://trello.com/c/s24alR4w/1467-can-we-use-feedback-fish-on-bops-as-an-interim-solution


![Screenshot 2023-02-27 at 16 31 09](https://user-images.githubusercontent.com/34001723/221622591-a9f788f6-ac08-4837-9f40-873b92a6e084.png)
![Screenshot 2023-02-27 at 16 31 19](https://user-images.githubusercontent.com/34001723/221622598-79298808-a256-46a1-9827-913d74f344cd.png)

