### PR TITLE
Use consistent warning messages

### DIFF
--- a/app/views/planning_application/assessment_details/additional_evidence/_information.html.erb
+++ b/app/views/planning_application/assessment_details/additional_evidence/_information.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-body">
   <strong class="govuk-!-padding-bottom-3">What is the impact of any additional evidence on the application?</strong>
 
-  <p class="govuk-!-padding-bottom-3">This information will <strong>NOT</strong> be made public.</p>
+  <p class="govuk-!-padding-bottom-3">This information will <strong>NOT</strong> be made publicly available.</p>
   <%= render(
     partial: "comment",
     locals: { comment: rejected_assessment_detail&.comment }

--- a/app/views/planning_application/assessment_details/site_description/_information.html.erb
+++ b/app/views/planning_application/assessment_details/site_description/_information.html.erb
@@ -8,7 +8,7 @@
   <% end %>
 
   <%= render "shared/warning_text",
-      message: "This information WILL be made public" %>
+      message: "This information will be made publicly available." %>
   <%= render(
     partial: "comment",
     locals: { comment: rejected_assessment_detail&.comment }

--- a/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
+++ b/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
@@ -4,7 +4,7 @@
   <% end %>
 
   <%= render "shared/warning_text",
-      message: "This information WILL be made public" %>
+      message: "This information will be made publicly available." %>
   <%= render(
     partial: "comment",
     locals: { comment: rejected_assessment_detail&.comment }

--- a/app/views/planning_application/permitted_development_rights/_information.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_information.html.erb
@@ -1,5 +1,5 @@
 <%= render "shared/warning_text",
-    message: "This information WILL be made public" %>
+    message: "This information will be made publicly available." %>
 
 <section id="constraints-section">
   <h2 class="govuk-heading-m">

--- a/app/views/planning_application/withdraw_or_cancels/show.html.erb
+++ b/app/views/planning_application/withdraw_or_cancels/show.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "shared/warning_text",
-      message: "This information WILL be made public" %>
+      message: "This information will be made publicly available." %>
 
     <%= form_with model: @planning_application,
       url: planning_application_withdraw_or_cancel_path(@planning_application),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,7 @@ en:
       assessor_recommendation: The assessor recommends that the application should be %{decision}.
       assessor_remarks: Assessor's remarks
       review_assessment_summaries: Review assessment summaries
-      this_information_will: This information WILL be made public
+      this_information_will: This information will be made publicly available.
     saved: Review saved
   assessment_report_downloads:
     show:
@@ -461,7 +461,7 @@ en:
         reviewer_comment: Explain to the assessor why this needs reviewing
       planning_application:
         closed_or_cancellation_comment: Provide a reason
-        public_comment: 'This information will appear on the decision notice:'
+        public_comment: This information will appear on the decision notice.
       recommendation:
         reviewer_comment: Explain to the officer why the case is being returned
       red_line_boundary_change_validation_request:
@@ -528,17 +528,17 @@ en:
           list_who_was: List who was consulted about this application
         fields:
           summary_of_consultation: Summary of consultation responses
-          this_information_will: This information WILL be made public
+          this_information_will: This information will be made publicly available.
         form_fields:
           summary_of_consultation: Summary of consultation responses
-          this_information_will: This information WILL be made public
+          this_information_will: This information will be made publicly available.
       past_applications:
         form_fields:
           application_reference_numbers: Add any relevant reference numbers. You can separate the reference numbers with a comma.
           relevant_information: Provide relevant information about the planning history of the application site
         information:
           summary_of_the: Summary of the relevant historical applications
-          this_information_will: This information WILL be made public
+          this_information_will: This information will be made publicly available.
       show:
         edit_additional_evidence: Edit additional evidence
         edit_consultation_summary: Edit consultation details
@@ -755,7 +755,7 @@ en:
       recommendation: Recommendation
       review_changes: Review changes
       sign_off_recommendation: Sign off recommendation
-      this_information_will: 'This information will appear on the decision notice:'
+      this_information_will: This information will appear on the decision notice.
       you_have_not: You haven't suggested changes to be made by the officer.
       you_have_suggested: You have suggested changes to be made by the officer.
     event:
@@ -783,7 +783,7 @@ en:
       refer_to_the: Refer to specific permitted development legislation to support your recommendation.
       state_the_reason: State the reasons why this application is, or is not lawful.
       there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
-      this_information_will: This information WILL appear on the decision notice.
+      this_information_will: This information will appear on the decision notice.
       this_information_will_not: This information will not appear on the decision notice or the public register, but Freedom of Information requests will still apply.
       update_assessment: Update assessment
       'yes': 'Yes'

--- a/spec/system/planning_applications/additional_evidence_spec.rb
+++ b/spec/system/planning_applications/additional_evidence_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Additional evidence" do
       expect(page).to have_content(planning_application.full_address)
 
       expect(page).to have_content("What is the impact of any additional evidence on the application?")
-      expect(page).to have_content("This information will NOT be made public.")
+      expect(page).to have_content("This information will NOT be made publicly available.")
       expect(page).to have_content(
         "This task is optional. Provide any additional information that will impact the assessment of this application."
       )

--- a/spec/system/planning_applications/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/permitted_development_right_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Permitted development right" do
         expect(page).to have_content(planning_application.full_address)
 
         within(".govuk-warning-text") do
-          expect(page).to have_content("This information WILL be made public")
+          expect(page).to have_content("This information will be made publicly available.")
         end
 
         within("#constraints-section") do
@@ -104,7 +104,7 @@ RSpec.describe "Permitted development right" do
         click_link("Permitted development rights")
 
         within(".govuk-warning-text") do
-          expect(page).to have_content("This information WILL be made public")
+          expect(page).to have_content("This information will be made publicly available.")
         end
 
         within("#constraints-section") do

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe "Reviewing sign-off" do
       expect(page).to have_content("Sign off recommendation")
       expect(page).to have_content("To grant")
       within(".govuk-warning-text") do
-        expect(page).to have_content("This information will appear on the decision notice:")
+        expect(page).to have_content("This information will appear on the decision notice.")
       end
       expect(page).to have_content(planning_application.public_comment)
 
@@ -250,17 +250,17 @@ RSpec.describe "Reviewing sign-off" do
 
       expect(page).to have_content("Edit the information appearing on the decision notice")
       expect(page).to have_content("The planning officer recommends that the application is granted")
-      expect(page).to have_content("This information will appear on the decision notice:")
+      expect(page).to have_content("This information will appear on the decision notice.")
 
       # Attempt to save without any text input
-      fill_in "This information will appear on the decision notice:", with: ""
+      fill_in "This information will appear on the decision notice.", with: ""
       click_button "Save"
 
       within(".govuk-form-group--error") do
         expect(page).to have_content("Please state the reasons why this application is, or is not lawful")
       end
 
-      fill_in "This information will appear on the decision notice:", with: "This text will appear on the decision notice."
+      fill_in "This information will appear on the decision notice.", with: "This text will appear on the decision notice."
       click_button "Save"
       expect(page).to have_content("Planning application was successfully updated.")
 

--- a/spec/system/planning_applications/site_description_spec.rb
+++ b/spec/system/planning_applications/site_description_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Site description" do
       expect(page).to have_content("You can include:")
 
       within(".govuk-warning-text") do
-        expect(page).to have_content("This information WILL be made public")
+        expect(page).to have_content("This information will be made publicly available.")
       end
     end
 

--- a/spec/system/planning_applications/summary_of_works_spec.rb
+++ b/spec/system/planning_applications/summary_of_works_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Summary of works" do
       expect(page).to have_content("You can include:")
 
       within(".govuk-warning-text") do
-        expect(page).to have_content("This information WILL be made public")
+        expect(page).to have_content("This information will be made publicly available.")
       end
     end
 


### PR DESCRIPTION
### Description of change

- Use consistent warning messages
- Follow the GDS guide for warning messages https://design-system.service.gov.uk/components/warning-text/
- Do not capitalize "will"

### Story Link

https://trello.com/c/rc7DE8WN/1457-use-consistent-warning-this-information-will-be-made-public-notice