### PR TITLE
Filter all my applications

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -76,6 +76,11 @@ Metrics/ModuleLength:
     - 'app/helpers/audit_helper.rb'
     - 'app/models/concerns/validation_requestable.rb'
 
+# Offense count: 1
+Metrics/ParameterLists:
+  Exclude: 
+    - 'app/components/planning_applications/panel_component.rb'
+
 # Offense count: 4
 # Configuration parameters: AllowedMethods, AllowedPatterns, IgnoredMethods, Max.
 Metrics/PerceivedComplexity:

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -307,3 +307,7 @@ html * {
 .italic {
   font-style: italic;
 }
+
+.display-flex {
+  display: flex;
+}

--- a/app/components/planning_applications/filter_component.html.erb
+++ b/app/components/planning_applications/filter_component.html.erb
@@ -1,0 +1,30 @@
+<div class="govuk-accordion single-section-accordion" data-module="govuk-accordion">
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h3 class="govuk-accordion__section-heading">
+        <button type="button" class="govuk-accordion__section-button">
+          Filter by status (<%= selected_filters_count %> of <%= filter_types.count %> selected)
+        </button>
+        <span class="govuk-accordion__icon"></span>
+      </h3>
+    </div>
+    <div class="govuk-accordion__section-content">
+      <%= form_with(
+        model: filter,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        method: :get,
+        url: planning_applications_path
+      ) do |form| %>
+        <div class="govuk-checkboxes--small" data-module="govuk-checkboxes" style="display:flex">
+          <% filter_types.each do |filter_type| %>
+            <div class="govuk-checkboxes__item">
+              <%= form.check_box filter_type, class: "govuk-checkboxes__input", checked: filter_checked_status(filter_type) %>
+              <%= form.label filter_type, class: "govuk-label govuk-checkboxes__label" %>
+            </div>
+          <% end %>
+        </div>
+        <%= form.submit "Apply filters", class: "govuk-button govuk-button--secondary" %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/components/planning_applications/filter_component.html.erb
+++ b/app/components/planning_applications/filter_component.html.erb
@@ -19,7 +19,7 @@
           <% filter_types.each do |filter_type| %>
             <div class="govuk-checkboxes__item">
               <%= form.check_box filter_type, class: "govuk-checkboxes__input", checked: filter_checked_status(filter_type) %>
-              <%= form.label (filter_type == :awaiting_correction ? "To be reviewed" : filter_type), class: "govuk-label govuk-checkboxes__label" %>
+              <%= form.label filter_type, class: "govuk-label govuk-checkboxes__label" %>
             </div>
           <% end %>
         </div>

--- a/app/components/planning_applications/filter_component.html.erb
+++ b/app/components/planning_applications/filter_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-accordion single-section-accordion" data-module="govuk-accordion">
+<div class="govuk-accordion single-section-accordion" data-module="govuk-accordion" data-controller="select-checkboxes">
   <div class="govuk-accordion__section">
     <div class="govuk-accordion__section-header">
       <h3 class="govuk-accordion__section-heading">
@@ -15,14 +15,8 @@
         method: :get,
         url: planning_applications_path
       ) do |form| %>
-        <div class="govuk-checkboxes--small" data-module="govuk-checkboxes" style="display:flex">
-          <% filter_types.each do |filter_type| %>
-            <div class="govuk-checkboxes__item">
-              <%= form.check_box filter_type, class: "govuk-checkboxes__input", checked: filter_checked_status(filter_type) %>
-              <%= form.label filter_type, class: "govuk-label govuk-checkboxes__label" %>
-            </div>
-          <% end %>
-        </div>
+        <%= hidden_field_tag(:q, "exclude_others") %>
+        <%= form.govuk_collection_check_boxes(:filter_options, filter_types, :to_s, :humanize, small: true, legend: nil, classes: "display-flex") %>
         <%= form.submit "Apply filters", class: "govuk-button govuk-button--secondary" %>
       <% end %>
     </div>

--- a/app/components/planning_applications/filter_component.html.erb
+++ b/app/components/planning_applications/filter_component.html.erb
@@ -19,7 +19,7 @@
           <% filter_types.each do |filter_type| %>
             <div class="govuk-checkboxes__item">
               <%= form.check_box filter_type, class: "govuk-checkboxes__input", checked: filter_checked_status(filter_type) %>
-              <%= form.label filter_type, class: "govuk-label govuk-checkboxes__label" %>
+              <%= form.label (filter_type == :awaiting_correction ? "To be reviewed" : filter_type), class: "govuk-label govuk-checkboxes__label" %>
             </div>
           <% end %>
         </div>

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -9,13 +9,13 @@ module PlanningApplications
     private
 
     def filter_types
-      [
-        :not_started,
-        :invalidated,
-        :in_assessment,
-        :awaiting_determination,
-        :to_be_reviewed,
-        :closed
+      %i[
+        not_started
+        invalidated
+        in_assessment
+        awaiting_determination
+        to_be_reviewed
+        closed
       ].compact
     end
 

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -2,25 +2,19 @@
 
 module PlanningApplications
   class FilterComponent < ViewComponent::Base
-    def initialize(filter:)
+    def initialize(filter:, current_user:)
       @filter = filter
+      @current_user = current_user
     end
 
     private
 
     def filter_types
-      %w[
-        not_started
-        invalidated
-        in_assessment
-        awaiting_determination
-        to_be_reviewed
-        closed
-      ]
+      @current_user.reviewer? ? PlanningApplication::FILTER_OPTIONS[3..4] : PlanningApplication::FILTER_OPTIONS
     end
 
     def selected_filters_count
-      filter.filter_options&.reject(&:empty?)&.count || 6
+      filter.filter_options&.reject(&:empty?)&.count || filter_types.count
     end
 
     attr_reader :filter

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -14,13 +14,13 @@ module PlanningApplications
         invalidated
         in_assessment
         awaiting_determination
-        awaiting_correction
+        to_be_reviewed
         closed
       ]
     end
 
     def selected_filters_count
-      filter.filter_options&.reject(&:empty?)&.count
+      filter.filter_options&.reject(&:empty?)&.count || 6
     end
 
     attr_reader :filter

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -10,7 +10,7 @@ module PlanningApplications
     private
 
     def filter_types
-      @current_user.reviewer? ? PlanningApplication::FILTER_OPTIONS[3..4] : PlanningApplication::FILTER_OPTIONS
+      @current_user.reviewer? ? PlanningApplication::REVIEWER_FILTER_OPTIONS : PlanningApplication::FILTER_OPTIONS
     end
 
     def selected_filters_count

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -11,10 +11,10 @@ module PlanningApplications
     def filter_types
       [
         :not_started,
-        :invalid,
+        :invalidated,
         :in_assessment,
         :awaiting_determination,
-        :awaiting_correction,
+        :to_be_reviewed,
         :closed
       ].compact
     end

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -9,26 +9,18 @@ module PlanningApplications
     private
 
     def filter_types
-      %i[
+      %w[
         not_started
         invalidated
         in_assessment
         awaiting_determination
-        to_be_reviewed
+        awaiting_correction
         closed
-      ].compact
+      ]
     end
 
     def selected_filters_count
-      filter.filter_options&.values&.count("1") || 6
-    end
-
-    def filter_checked_status(filter_type)
-      if filter.filter_options
-        filter.filter_options[filter_type] == "1"
-      else
-        true
-      end
+      filter.filter_options&.reject(&:empty?)&.count
     end
 
     attr_reader :filter

--- a/app/components/planning_applications/filter_component.rb
+++ b/app/components/planning_applications/filter_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  class FilterComponent < ViewComponent::Base
+    def initialize(filter:)
+      @filter = filter
+    end
+
+    private
+
+    def filter_types
+      [
+        :not_started,
+        :invalid,
+        :in_assessment,
+        :awaiting_determination,
+        :awaiting_correction,
+        :closed
+      ].compact
+    end
+
+    def selected_filters_count
+      filter.filter_options&.values&.count("1") || 6
+    end
+
+    def filter_checked_status(filter_type)
+      if filter.filter_options
+        filter.filter_options[filter_type] == "1"
+      else
+        true
+      end
+    end
+
+    attr_reader :filter
+  end
+end

--- a/app/components/planning_applications/panel_component.html.erb
+++ b/app/components/planning_applications/panel_component.html.erb
@@ -9,11 +9,14 @@
       )
     ) %>
   <% end %>
+  <% if filter.present? %>
     <%= render(
       PlanningApplications::FilterComponent.new(
+        panel_type: type,
         filter: filter
       )
     ) %>
+  <% end %>
   <% if search&.query && planning_applications.empty? %>
     <p class="govuk-body"><%= t(".no_planning_applications") %></p>
   <% else %>

--- a/app/components/planning_applications/panel_component.html.erb
+++ b/app/components/planning_applications/panel_component.html.erb
@@ -9,6 +9,11 @@
       )
     ) %>
   <% end %>
+    <%= render(
+      PlanningApplications::FilterComponent.new(
+        filter: filter
+      )
+    ) %>
   <% if search&.query && planning_applications.empty? %>
     <p class="govuk-body"><%= t(".no_planning_applications") %></p>
   <% else %>

--- a/app/components/planning_applications/panel_component.html.erb
+++ b/app/components/planning_applications/panel_component.html.erb
@@ -12,7 +12,8 @@
   <% if filter.present? %>
     <%= render(
       PlanningApplications::FilterComponent.new(
-        filter: filter
+        filter: filter,
+        current_user: current_user
       )
     ) %>
   <% end %>

--- a/app/components/planning_applications/panel_component.html.erb
+++ b/app/components/planning_applications/panel_component.html.erb
@@ -12,7 +12,6 @@
   <% if filter.present? %>
     <%= render(
       PlanningApplications::FilterComponent.new(
-        panel_type: type,
         filter: filter
       )
     ) %>

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -2,7 +2,7 @@
 
 module PlanningApplications
   class PanelComponent < ViewComponent::Base
-    def initialize(planning_applications:, type:, search: nil, exclude_others: nil, filter:)
+    def initialize(planning_applications:, type:, filter:, search: nil, exclude_others: nil)
       @planning_applications = planning_applications
       @type = type
       @search = search

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -2,14 +2,15 @@
 
 module PlanningApplications
   class PanelComponent < ViewComponent::Base
-    def initialize(planning_applications:, type:, search: nil, exclude_others: nil)
+    def initialize(planning_applications:, type:, search: nil, exclude_others: nil, filter:)
       @planning_applications = planning_applications
       @type = type
       @search = search
+      @filter = filter
       @exclude_others = exclude_others
     end
 
-    attr_reader :planning_applications, :type, :search, :exclude_others
+    attr_reader :planning_applications, :type, :search, :exclude_others, :filter
 
     def title
       type == :all ? all_title : t(".#{type}")

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -2,7 +2,7 @@
 
 module PlanningApplications
   class PanelComponent < ViewComponent::Base
-    def initialize(planning_applications:, type:, filter: nil, search: nil, exclude_others: nil, current_user:)
+    def initialize(planning_applications:, type:, current_user:, filter: nil, search: nil, exclude_others: nil)
       @planning_applications = planning_applications
       @type = type
       @search = search

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -2,15 +2,16 @@
 
 module PlanningApplications
   class PanelComponent < ViewComponent::Base
-    def initialize(planning_applications:, type:, filter:, search: nil, exclude_others: nil)
+    def initialize(planning_applications:, type:, filter: nil, search: nil, exclude_others: nil, current_user:)
       @planning_applications = planning_applications
       @type = type
       @search = search
       @filter = filter
       @exclude_others = exclude_others
+      @current_user = current_user
     end
 
-    attr_reader :planning_applications, :type, :search, :exclude_others, :filter
+    attr_reader :planning_applications, :type, :search, :exclude_others, :filter, :current_user
 
     def title
       type == :all ? all_title : t(".#{type}")
@@ -21,11 +22,19 @@ module PlanningApplications
     end
 
     def attributes
-      try("#{type}_attributes") || default_attributes
+      if exclude_others
+        your_application_attributes
+      else
+        try("#{type}_attributes") || default_attributes
+      end
     end
 
     def all_attributes
       %i[formatted_expiry_date reference status_tag full_address description]
+    end
+
+    def your_application_attributes
+      %i[reference full_address application_type_name formatted_expiry_date remaining_days_status_tag status_tag]
     end
 
     def closed_attributes

--- a/app/components/planning_applications/panels_component.html.erb
+++ b/app/components/planning_applications/panels_component.html.erb
@@ -2,7 +2,8 @@
   <%= render(
     PlanningApplications::PanelComponent.new(
       planning_applications: planning_applications.send(panel_type),
-      type: panel_type
+      type: panel_type,
+      filter: nil
     )
   ) %>
 <% end %>
@@ -11,7 +12,7 @@
     planning_applications: all_planning_applications,
     type: :all,
     search: search,
-    filter: filter,
+    filter: exclude_others ? filter : nil,
     exclude_others: exclude_others
   )
 ) %>

--- a/app/components/planning_applications/panels_component.html.erb
+++ b/app/components/planning_applications/panels_component.html.erb
@@ -3,7 +3,7 @@
     PlanningApplications::PanelComponent.new(
       planning_applications: planning_applications.send(panel_type),
       type: panel_type,
-      filter: nil
+      current_user: current_user
     )
   ) %>
 <% end %>
@@ -13,6 +13,7 @@
     type: :all,
     search: search,
     filter: exclude_others ? filter : nil,
-    exclude_others: exclude_others
+    exclude_others: exclude_others,
+    current_user: current_user
   )
 ) %>

--- a/app/components/planning_applications/panels_component.html.erb
+++ b/app/components/planning_applications/panels_component.html.erb
@@ -11,6 +11,7 @@
     planning_applications: all_planning_applications,
     type: :all,
     search: search,
+    filter: filter,
     exclude_others: exclude_others
   )
 ) %>

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -34,7 +34,7 @@ module PlanningApplications
       if search.query
         search.results
       elsif filter.filter_options
-        filter.results
+        filter.results.select { |pa| pa.user == @current_user }
       else
         planning_applications
       end

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -13,7 +13,17 @@ module PlanningApplications
     private
 
     def panel_types
-      [].compact
+      if @exclude_others
+        []
+      else
+        [
+          (:not_started_and_invalid unless reviewer_applications?),
+          (:under_assessment unless reviewer_applications?),
+          :awaiting_determination,
+          (:awaiting_correction unless current_user.assessor?),
+          :closed
+        ].compact
+      end
     end
 
     def reviewer_applications?

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -34,7 +34,7 @@ module PlanningApplications
       if search.query
         search.results
       elsif filter.filter_options
-        filter.results.select { |pa| pa.user == @current_user }
+        filter.results.select { |pa| pa.user == @current_user || pa.user == nil }
       else
         planning_applications
       end

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -34,7 +34,7 @@ module PlanningApplications
       if search.query
         search.results
       elsif filter.filter_options
-        filter.results.select { |pa| pa.user == @current_user || pa.user == nil }
+        filter.results.select { |pa| pa.user == @current_user || pa.user.nil? }
       else
         planning_applications
       end

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -14,7 +14,7 @@ module PlanningApplications
 
     def panel_types
       if @exclude_others
-        []
+        [:closed]
       else
         [
           (:not_started_and_invalid unless reviewer_applications?),

--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -2,23 +2,18 @@
 
 module PlanningApplications
   class PanelsComponent < ViewComponent::Base
-    def initialize(planning_applications:, exclude_others:, current_user:, search:)
+    def initialize(planning_applications:, exclude_others:, current_user:, search:, filter:)
       @planning_applications = planning_applications
       @exclude_others = exclude_others
       @current_user = current_user
       @search = search
+      @filter = filter
     end
 
     private
 
     def panel_types
-      [
-        (:not_started_and_invalid unless reviewer_applications?),
-        (:under_assessment unless reviewer_applications?),
-        :awaiting_determination,
-        (:awaiting_correction unless current_user.assessor?),
-        :closed
-      ].compact
+      [].compact
     end
 
     def reviewer_applications?
@@ -26,9 +21,15 @@ module PlanningApplications
     end
 
     def all_planning_applications
-      search.query ? search.results : planning_applications
+      if search.query
+        search.results
+      elsif filter.filter_options
+        filter.results
+      else
+        planning_applications
+      end
     end
 
-    attr_reader :planning_applications, :exclude_others, :current_user, :search
+    attr_reader :planning_applications, :exclude_others, :current_user, :search, :filter
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -11,6 +11,8 @@ class PlanningApplicationsController < AuthenticationController
 
   before_action :ensure_draft_recommendation_complete, only: :update
 
+  before_action :check_filter_params, only: :index
+
   rescue_from PlanningApplication::WithdrawRecommendationError do |_exception|
     redirect_failed_withdraw_recommendation
   end
@@ -383,5 +385,15 @@ class PlanningApplicationsController < AuthenticationController
                                new_planning_application_recommendation_path(@planning_application)} before updating application fields."
 
     render :edit and return
+  end
+
+  def check_filter_params
+    if current_user.reviewer? && params[:planning_application_filter]
+      params[:planning_application_filter][:filter_options] = filter_option_params.select { |a| a == "awaiting_determination" || a == "to_be_reviewed" }
+    end
+  end
+
+  def filter_option_params
+    params[:planning_application_filter][:filter_options]
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -389,7 +389,7 @@ class PlanningApplicationsController < AuthenticationController
 
   def check_filter_params
     if current_user.reviewer? && params[:planning_application_filter]
-      params[:planning_application_filter][:filter_options] = filter_option_params.select { |a| a == "awaiting_determination" || a == "to_be_reviewed" }
+      params[:planning_application_filter][:filter_options] = filter_option_params.select { |a| PlanningApplication::REVIEWER_FILTER_OPTIONS.include?(a) }
     end
   end
 

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -32,8 +32,7 @@ class PlanningApplicationsController < AuthenticationController
 
     @filter = if params[:planning_application_filter].present?
                 PlanningApplicationFilter.new(
-                  filter_options: planning_application_filter_params.except(:planning_applications),
-                  planning_applications: planning_application_filter_params[:planning_applications]
+                  planning_application_filter_params
                 )
               else
                 PlanningApplicationFilter.new
@@ -268,12 +267,7 @@ class PlanningApplicationsController < AuthenticationController
   def planning_application_filter_params
     params
       .require(:planning_application_filter)
-      .permit(:not_started,
-              :invalidated,
-              :in_assessment,
-              :awaiting_determination,
-              :to_be_reviewed,
-              :closed)
+      .permit(filter_options: [])
       .merge(planning_applications: @planning_applications)
   end
 

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -269,10 +269,10 @@ class PlanningApplicationsController < AuthenticationController
     params
       .require(:planning_application_filter)
       .permit(:not_started,
-        :invalid,
+        :invalidated,
         :in_assessment,
         :awaiting_determination,
-        :awaiting_correction,
+        :to_be_reviewed,
         :closed)
       .merge(planning_applications: @planning_applications)
   end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -29,6 +29,15 @@ class PlanningApplicationsController < AuthenticationController
                              else
                                planning_applications_scope
                              end
+  
+    @filter = if params[:planning_application_filter].present?
+                PlanningApplicationFilter.new(
+                  filter_options: planning_application_filter_params.except(:planning_applications), 
+                  planning_applications: planning_application_filter_params[:planning_applications]
+                )
+              else
+                PlanningApplicationFilter.new
+              end
 
     @search = if params[:planning_application_search].present?
                 PlanningApplicationSearch.new(
@@ -253,6 +262,18 @@ class PlanningApplicationsController < AuthenticationController
     params
       .require(:planning_application_search)
       .permit(:query)
+      .merge(planning_applications: @planning_applications)
+  end
+
+  def planning_application_filter_params
+    params
+      .require(:planning_application_filter)
+      .permit(:not_started,
+        :invalid,
+        :in_assessment,
+        :awaiting_determination,
+        :awaiting_correction,
+        :closed)
       .merge(planning_applications: @planning_applications)
   end
 

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -29,10 +29,10 @@ class PlanningApplicationsController < AuthenticationController
                              else
                                planning_applications_scope
                              end
-  
+
     @filter = if params[:planning_application_filter].present?
                 PlanningApplicationFilter.new(
-                  filter_options: planning_application_filter_params.except(:planning_applications), 
+                  filter_options: planning_application_filter_params.except(:planning_applications),
                   planning_applications: planning_application_filter_params[:planning_applications]
                 )
               else
@@ -269,11 +269,11 @@ class PlanningApplicationsController < AuthenticationController
     params
       .require(:planning_application_filter)
       .permit(:not_started,
-        :invalidated,
-        :in_assessment,
-        :awaiting_determination,
-        :to_be_reviewed,
-        :closed)
+              :invalidated,
+              :in_assessment,
+              :awaiting_determination,
+              :to_be_reviewed,
+              :closed)
       .merge(planning_applications: @planning_applications)
   end
 

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -388,9 +388,9 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def check_filter_params
-    if current_user.reviewer? && params[:planning_application_filter]
-      params[:planning_application_filter][:filter_options] = filter_option_params.select { |a| PlanningApplication::REVIEWER_FILTER_OPTIONS.include?(a) }
-    end
+    return unless current_user.reviewer? && params[:planning_application_filter]
+
+    params[:planning_application_filter][:filter_options] = filter_option_params.select { |a| PlanningApplication::REVIEWER_FILTER_OPTIONS.include?(a) }
   end
 
   def filter_option_params

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -121,6 +121,8 @@ class PlanningApplication < ApplicationRecord
 
   PROGRESS_STATUSES = %w[not_started in_progress complete].freeze
 
+  FILTER_OPTIONS = %w[not_started invalidated in_assessment awaiting_determination to_be_reviewed].freeze
+
   private_constant :PLANNING_APPLICATION_PERMITTED_KEYS
 
   validates :work_status,

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -122,6 +122,7 @@ class PlanningApplication < ApplicationRecord
   PROGRESS_STATUSES = %w[not_started in_progress complete].freeze
 
   FILTER_OPTIONS = %w[not_started invalidated in_assessment awaiting_determination to_be_reviewed].freeze
+  REVIEWER_FILTER_OPTIONS = %w[awaiting_determination to_be_reviewed].freeze
 
   private_constant :PLANNING_APPLICATION_PERMITTED_KEYS
 

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -3,14 +3,18 @@
 class PlanningApplicationFilter
   include ActiveModel::Model
 
-  attr_accessor :filter_options, :planning_applications
+  attr_accessor :filter_options, :planning_applications, :user
 
   def results
-    records_matching_query || []
+    records_matching_reference || []
   end
 
   def filter_types
     filter_options.reject(&:empty?)
+  end
+
+  def filtered_filter_types
+    filter_types.map { |x| x == "to_be_reviewed" ? "awaiting_correction" : x }
   end
 
   private
@@ -20,8 +24,6 @@ class PlanningApplicationFilter
   end
 
   def records_matching_reference
-    planning_applications.where(
-      status: [filter_types]
-    )
+    filtered_filter_types.map { |filter| planning_applications.send(filter) }.flatten
   end
 end

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -9,8 +9,8 @@ class PlanningApplicationFilter
     records_matching_query || []
   end
 
-  def filter_type
-    filter_options.keys.select { |key| filter_options[key] == "1" }
+  def filter_types
+    filter_options.keys.select { |key| filter_options[key] == "1" }.map { |x| x == "to_be_reviewed" ? "awaiting_correction" : x }
   end
 
   private
@@ -21,7 +21,7 @@ class PlanningApplicationFilter
 
   def records_matching_reference
     planning_applications.where(
-      status: [filter_type]
+      status: [filter_types]
     )
   end
 end

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -10,11 +10,7 @@ class PlanningApplicationFilter
   end
 
   def filter_types
-    filter_options.keys.select { |key| filter_options[key] == "1" }
-  end
-
-  def filtered_filter_types
-    filter_types.map { |x| x == "to_be_reviewed" ? "awaiting_correction" : x }
+    filter_options.reject(&:empty?)
   end
 
   private
@@ -25,7 +21,7 @@ class PlanningApplicationFilter
 
   def records_matching_reference
     planning_applications.where(
-      status: [filtered_filter_types]
+      status: [filter_types]
     )
   end
 end

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -24,6 +24,6 @@ class PlanningApplicationFilter
   end
 
   def records_matching_reference
-    filtered_filter_types.map { |filter| planning_applications.send(filter) }.flatten
+    planning_applications.where(status: [filtered_filter_types])
   end
 end

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class PlanningApplicationFilter
+  include ActiveModel::Model
+
+  attr_accessor :filter_options, :planning_applications
+
+  def results
+    records_matching_query || []
+  end
+
+  def filter_type
+    filter_options.keys.select { |key| filter_options[key] == "1" }
+  end
+
+  private
+
+  def records_matching_query
+    records_matching_reference.presence
+  end
+
+  def records_matching_reference
+    planning_applications.where(
+      status: [filter_type]
+    )
+  end
+end

--- a/app/services/planning_application_filter.rb
+++ b/app/services/planning_application_filter.rb
@@ -10,7 +10,11 @@ class PlanningApplicationFilter
   end
 
   def filter_types
-    filter_options.keys.select { |key| filter_options[key] == "1" }.map { |x| x == "to_be_reviewed" ? "awaiting_correction" : x }
+    filter_options.keys.select { |key| filter_options[key] == "1" }
+  end
+
+  def filtered_filter_types
+    filter_types.map { |x| x == "to_be_reviewed" ? "awaiting_correction" : x }
   end
 
   private
@@ -21,7 +25,7 @@ class PlanningApplicationFilter
 
   def records_matching_reference
     planning_applications.where(
-      status: [filter_types]
+      status: [filtered_filter_types]
     )
   end
 end

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -1,6 +1,21 @@
 <div>
   <ul class="govuk-tabs__list" id="planning_applications_statusTab" role="tablist">
-    <% unless exclude_others? %>
+    <% if exclude_others? %>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <%= link_to(
+          all_applications_tab_title,
+          "#all",
+          class: "govuk-tabs__tab",
+          role: "tab",
+          aria_controls: "all",
+          aria_selected: false,
+          tabindex: 5
+        ) %>
+      </li>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 4 %>
+      </li>
+    <% else %>
       <% unless current_user.reviewer? && exclude_others? %>
         <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
           <%= link_to "Not started", "#not_started_and_invalid", class: "govuk-tabs__tab", role: "tab", "aria-controls":"not_started_and_invalid", "aria-selected": true, tabindex: 0 %>
@@ -20,17 +35,17 @@
       <li class="govuk-tabs__list-item" role="presentation">
         <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 4 %>
       </li>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <%= link_to(
+          all_applications_tab_title,
+          "#all",
+          class: "govuk-tabs__tab",
+          role: "tab",
+          aria_controls: "all",
+          aria_selected: false,
+          tabindex: 5
+        ) %>
+      </li>
     <% end %>
-    <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to(
-         all_applications_tab_title,
-         "#all",
-         class: "govuk-tabs__tab",
-         role: "tab",
-         aria_controls: "all",
-         aria_selected: false,
-         tabindex: 5
-      ) %>
-    </li>
   </ul>
 </div>

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -1,5 +1,26 @@
 <div>
   <ul class="govuk-tabs__list" id="planning_applications_statusTab" role="tablist">
+    <% unless exclude_others? %>
+      <% unless current_user.reviewer? && exclude_others? %>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
+          <%= link_to "Not started", "#not_started_and_invalid", class: "govuk-tabs__tab", role: "tab", "aria-controls":"not_started_and_invalid", "aria-selected": true, tabindex: 0 %>
+        </li>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
+          <%= link_to "In assessment", "#under_assessment", class: "govuk-tabs__tab", role: "tab", "aria-controls":"under-assessment", "aria-selected": true, tabindex: 1 %>
+        </li>
+      <% end %>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <%= link_to "Awaiting determination", "#awaiting_determination", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
+      </li>
+      <% if current_user.reviewer?%>
+        <li class="govuk-tabs__list-item" role="presentation">
+          <%= link_to "Corrections requested", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting_correction", "aria-selected": false, tabindex: 3 %>
+        </li>
+      <% end %>
+      <li class="govuk-tabs__list-item" role="presentation">
+        <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 4 %>
+      </li>
+    <% end %>
     <li class="govuk-tabs__list-item" role="presentation">
       <%= link_to(
          all_applications_tab_title,

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -1,24 +1,5 @@
 <div>
   <ul class="govuk-tabs__list" id="planning_applications_statusTab" role="tablist">
-        <% unless current_user.reviewer? && exclude_others? %>
-          <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
-            <%= link_to "Not started", "#not_started_and_invalid", class: "govuk-tabs__tab", role: "tab", "aria-controls":"not_started_and_invalid", "aria-selected": true, tabindex: 0 %>
-          </li>
-          <li class="govuk-tabs__list-item govuk-tabs__list-item--selected" role="presentation">
-            <%= link_to "In assessment", "#under_assessment", class: "govuk-tabs__tab", role: "tab", "aria-controls":"under-assessment", "aria-selected": true, tabindex: 1 %>
-          </li>
-      <% end %>
-    <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to "Awaiting determination", "#awaiting_determination", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting-determination", "aria-selected": false, tabindex: 2 %>
-    </li>
-    <% if current_user.reviewer?%>
-      <li class="govuk-tabs__list-item" role="presentation">
-          <%= link_to "Corrections requested", "#awaiting_correction", class: "govuk-tabs__tab", role: "tab", "aria-controls":"awaiting_correction", "aria-selected": false, tabindex: 3 %>
-      </li>
-    <% end %>
-    <li class="govuk-tabs__list-item" role="presentation">
-      <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 4 %>
-    </li>
     <li class="govuk-tabs__list-item" role="presentation">
       <%= link_to(
          all_applications_tab_title,

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -29,8 +29,9 @@
         <%= 
           link_to filter_text, 
           planning_applications_path(
-            q: "exclude_others", 
-            planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'awaiting_correction', 'closed'] }
+            q: "exclude_others",
+            user_id: current_user.id,
+            planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'to_be_reviewed', 'closed'] }
           ), 
           class: "govuk-button" 
         %>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -26,12 +26,12 @@
         <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
       <p class="govuk-body">
+        <% options = current_user.reviewer? ?  PlanningApplication::FILTER_OPTIONS[3..4] : PlanningApplication::FILTER_OPTIONS %>
         <%= 
           link_to filter_text, 
           planning_applications_path(
             q: "exclude_others",
-            user_id: current_user.id,
-            planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'to_be_reviewed', 'closed'] }
+            planning_application_filter: { filter_options: options }
           ), 
           class: "govuk-button" 
         %>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -25,7 +25,16 @@
       <p class="govuk-body">
         <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
-      <p class="govuk-body"><%= link_to filter_text, planning_applications_path(q: "exclude_others"), class: "govuk-button" %></p>
+      <p class="govuk-body">
+        <%= 
+          link_to filter_text, 
+          planning_applications_path(
+            q: "exclude_others", 
+            planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'awaiting_correction', 'closed'] }
+          ), 
+          class: "govuk-button" 
+        %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -26,12 +26,11 @@
         <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
       </p>
       <p class="govuk-body">
-        <% options = current_user.reviewer? ?  PlanningApplication::FILTER_OPTIONS[3..4] : PlanningApplication::FILTER_OPTIONS %>
         <%= 
           link_to filter_text, 
           planning_applications_path(
             q: "exclude_others",
-            planning_application_filter: { filter_options: options }
+            planning_application_filter: { filter_options: current_user.reviewer? ?  PlanningApplication::REVIEWER_FILTER_OPTIONS : PlanningApplication::FILTER_OPTIONS }
           ), 
           class: "govuk-button" 
         %>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -48,6 +48,7 @@
         PlanningApplications::PanelsComponent.new(
           planning_applications: @planning_applications,
           search: @search,
+          filter: @filter,
           current_user: current_user,
           exclude_others: exclude_others?
         )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -636,7 +636,7 @@ en:
     panel_component:
       all: All
       all_applications: All applications
-      all_your_applications: Your applications
+      all_your_applications: Your live applications
       application_type_name: Application type
       awaiting_correction: Corrections requested
       awaiting_determination: Awaiting determination
@@ -644,6 +644,7 @@ en:
       description: Description
       formatted_awaiting_determination_at: Recommendation date
       formatted_expiry_date: Expiry date
+      application_type_name: Application type
       formatted_outcome_date: Outcome date
       full_address: Site address
       no_planning_applications: No planning applications match your search
@@ -685,7 +686,7 @@ en:
       download_assessment_report: Download assessment report as PDF
     tabs:
       all_applications: All applications
-      all_your_applications: Your applications
+      all_your_applications: Your live applications
     update:
       success: Planning application was successfully updated.
     validate:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -636,7 +636,7 @@ en:
     panel_component:
       all: All
       all_applications: All applications
-      all_your_applications: All your applications
+      all_your_applications: Your applications
       application_type_name: Application type
       awaiting_correction: Corrections requested
       awaiting_determination: Awaiting determination
@@ -685,7 +685,7 @@ en:
       download_assessment_report: Download assessment report as PDF
     tabs:
       all_applications: All applications
-      all_your_applications: All your applications
+      all_your_applications: Your applications
     update:
       success: Planning application was successfully updated.
     validate:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -644,7 +644,6 @@ en:
       description: Description
       formatted_awaiting_determination_at: Recommendation date
       formatted_expiry_date: Expiry date
-      application_type_name: Application type
       formatted_outcome_date: Outcome date
       full_address: Site address
       no_planning_applications: No planning applications match your search

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root to: "planning_applications#index", defaults: 
     { 
       q: "exclude_others",
-      planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'to_be_reviewed', 'closed'] }
+      planning_application_filter: { filter_options: PlanningApplication::FILTER_OPTIONS }
     }
 
   mount Rswag::Ui::Engine => "api-docs"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,11 @@
 # require "rswag-api"
 
 Rails.application.routes.draw do
-  root to: "planning_applications#index", defaults: { q: "exclude_others" }
+  root to: "planning_applications#index", defaults: 
+    { 
+      q: "exclude_others",
+      planning_application_filter: { filter_options: ['not_started', 'invalidated', 'in_assessment', 'awaiting_determination', 'to_be_reviewed', 'closed'] }
+    }
 
   mount Rswag::Ui::Engine => "api-docs"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@
 # require "rswag-api"
 
 Rails.application.routes.draw do
-  root to: "planning_applications#index", defaults: 
-    { 
+  root to: "planning_applications#index", defaults:
+    {
       q: "exclude_others",
       planning_application_filter: { filter_options: PlanningApplication::FILTER_OPTIONS }
     }

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "filtering planning applications" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :assessor, local_authority: local_authority) }
+
+  let!(:not_started_planning_application) do
+    create(
+      :planning_application,
+      :not_started,
+      user: user,
+      local_authority: local_authority,
+      description: "Add a chimney stack"
+    )
+  end
+
+  let!(:invalid_planning_application) do
+    create(
+      :planning_application,
+      :invalidated,
+      user: nil,
+      local_authority: local_authority,
+      description: "Add a patio"
+    )
+  end
+
+  let!(:in_assessment_planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      user: other_user,
+      local_authority: local_authority,
+      description: "Add a skylight"
+    )
+  end
+
+  let!(:awaiting_determination_planning_application) do
+    create(
+      :planning_application,
+      :awaiting_determination,
+      user: other_user,
+      local_authority: local_authority,
+      description: "Add a skylight"
+    )
+  end
+
+  let!(:awaiting_correction_planning_application) do
+    create(
+      :planning_application,
+      :awaiting_correction,
+      user: other_user,
+      local_authority: local_authority,
+      description: "Add a skylight"
+    )
+  end
+
+  let!(:closed_planning_application) do
+    create(
+      :planning_application,
+      :closed,
+      user: other_user,
+      local_authority: local_authority,
+      description: "Add a skylight"
+    )
+  end
+
+  before { sign_in(user) }
+
+  context "when user views her own planning applications" do
+    before do
+      visit(planning_applications_path)
+    end
+
+    it "allows user to filter by different statuses" do
+      within(selected_govuk_tab) do
+        expect(page).to have_content("All applications")
+        expect(page).to have_content(not_started_planning_application.reference)
+        expect(page).to have_content(invalid_planning_application.reference)
+        expect(page).to have_content(in_assessment_planning_application.reference)
+        expect(page).to have_content(awaiting_determination_planning_application.reference)
+        expect(page).to have_content(awaiting_correction_planning_application.reference)
+        expect(page).to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (6 of 6 selected)")
+      uncheck("Invalid")
+      uncheck("In assessment")
+      uncheck("Awaiting determination")
+      uncheck("To be reviewed")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 6 selected)")
+      check("Invalid")
+      uncheck("Not started")
+      uncheck("In assessment")
+      uncheck("Awaiting determination")
+      uncheck("To be reviewed")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 6 selected)")
+      check("In assessment")
+      uncheck("Not started")
+      uncheck("Invalid")
+      uncheck("Awaiting determination")
+      uncheck("To be reviewed")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 6 selected)")
+      check("Awaiting determination")
+      uncheck("Not started")
+      uncheck("Invalid")
+      uncheck("In assessment")
+      uncheck("To be reviewed")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 6 selected)")
+      check("To be reviewed")
+      uncheck("Not started")
+      uncheck("Invalid")
+      uncheck("In assessment")
+      uncheck("Awaiting determination")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 6 selected)")
+      check("Closed")
+      uncheck("Not started")
+      uncheck("Invalid")
+      uncheck("In assessment")
+      uncheck("Awaiting determination")
+      uncheck("To be reviewed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content(closed_planning_application.reference)
+        expect(page).not_to have_content(not_started_planning_application.reference)
+        expect(page).not_to have_content(invalid_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+      end
+    end
+
+    it "allows user to filter by many different statuses" do
+      click_button("Filter by status (6 of 6 selected)")
+      uncheck("Awaiting determination")
+      uncheck("To be reviewed")
+      uncheck("Closed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(3 of 6 selected)")
+        expect(page).to have_content(not_started_planning_application.reference)
+        expect(page).to have_content(invalid_planning_application.reference)
+        expect(page).to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+      end
+    end
+  end
+end

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "filtering planning applications" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :assessor, local_authority: local_authority) }
 
-  let(:other_user) { create(:user, :assessor, local_authority: local_authority) }
+  let(:other_user) { create(:user, :reviewer, local_authority: local_authority) }
 
   let!(:not_started_planning_application) do
     create(
@@ -44,11 +44,29 @@ RSpec.describe "filtering planning applications" do
     )
   end
 
+  let!(:other_awaiting_determination_planning_application) do
+    create(
+      :planning_application,
+      :awaiting_determination,
+      user: other_user,
+      local_authority: local_authority,
+    )
+  end
+
   let!(:awaiting_correction_planning_application) do
     create(
       :planning_application,
       :awaiting_correction,
       user: user,
+      local_authority: local_authority,
+    )
+  end
+
+  let!(:other_awaiting_correction_planning_application) do
+    create(
+      :planning_application,
+      :awaiting_correction,
+      user: other_user,
       local_authority: local_authority,
     )
   end
@@ -71,37 +89,34 @@ RSpec.describe "filtering planning applications" do
     )
   end
 
-  before { sign_in(user) }
-
-  context "when user views her own planning applications" do
+  context "when user is assessor" do
     before do
-      visit(planning_applications_path)
-      click_on "View my applications"
+      sign_in(user)
+      visit(root_path)
     end
 
     it "allows user to filter by different statuses" do
       within(selected_govuk_tab) do
-        expect(page).to have_content("Your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).to have_content(not_started_planning_application.reference)
         expect(page).to have_content(invalid_planning_application.reference)
         expect(page).to have_content(in_assessment_planning_application.reference)
         expect(page).to have_content(awaiting_determination_planning_application.reference)
         expect(page).to have_content(awaiting_correction_planning_application.reference)
-        expect(page).to have_content(closed_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
         expect(page).not_to have_content(other_closed_planning_application.reference)
       end
 
-      click_button("Filter by status (6 of 6 selected)")
+      click_button("Filter by status (5 of 5 selected)")
       uncheck("Invalid")
       uncheck("In assessment")
       uncheck("Awaiting determination")
       uncheck("To be reviewed")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content("(1 of 5 selected)")
         expect(page).to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(invalid_planning_application.reference)
         expect(page).not_to have_content(in_assessment_planning_application.reference)
@@ -110,18 +125,17 @@ RSpec.describe "filtering planning applications" do
         expect(page).not_to have_content(closed_planning_application.reference)
       end
 
-      click_button("Filter by status (1 of 6 selected)")
+      click_button("Filter by status (1 of 5 selected)")
       check("Invalid")
       uncheck("Not started")
       uncheck("In assessment")
       uncheck("Awaiting determination")
       uncheck("To be reviewed")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content("(1 of 5 selected)")
         expect(page).to have_content(invalid_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(in_assessment_planning_application.reference)
@@ -130,18 +144,17 @@ RSpec.describe "filtering planning applications" do
         expect(page).not_to have_content(closed_planning_application.reference)
       end
 
-      click_button("Filter by status (1 of 6 selected)")
+      click_button("Filter by status (1 of 5 selected)")
       check("In assessment")
       uncheck("Not started")
       uncheck("Invalid")
       uncheck("Awaiting determination")
       uncheck("To be reviewed")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content("(1 of 5 selected)")
         expect(page).to have_content(in_assessment_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(invalid_planning_application.reference)
@@ -150,18 +163,17 @@ RSpec.describe "filtering planning applications" do
         expect(page).not_to have_content(closed_planning_application.reference)
       end
 
-      click_button("Filter by status (1 of 6 selected)")
+      click_button("Filter by status (1 of 5 selected)")
       check("Awaiting determination")
       uncheck("Not started")
       uncheck("Invalid")
       uncheck("In assessment")
       uncheck("To be reviewed")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content("(1 of 5 selected)")
         expect(page).to have_content(awaiting_determination_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(invalid_planning_application.reference)
@@ -170,18 +182,17 @@ RSpec.describe "filtering planning applications" do
         expect(page).not_to have_content(closed_planning_application.reference)
       end
 
-      click_button("Filter by status (1 of 6 selected)")
+      click_button("Filter by status (1 of 5 selected)")
       check("To be reviewed")
       uncheck("Not started")
       uncheck("Invalid")
       uncheck("In assessment")
       uncheck("Awaiting determination")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
+        expect(page).to have_content("(1 of 5 selected)")
         expect(page).to have_content(awaiting_correction_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(invalid_planning_application.reference)
@@ -190,18 +201,9 @@ RSpec.describe "filtering planning applications" do
         expect(page).not_to have_content(closed_planning_application.reference)
       end
 
-      click_button("Filter by status (1 of 6 selected)")
-      check("Closed")
-      uncheck("Not started")
-      uncheck("Invalid")
-      uncheck("In assessment")
-      uncheck("Awaiting determination")
-      uncheck("To be reviewed")
-
-      click_button("Apply filters")
+      click_link("Closed")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(1 of 6 selected)")
         expect(page).to have_content(closed_planning_application.reference)
         expect(page).not_to have_content(other_closed_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
@@ -213,21 +215,71 @@ RSpec.describe "filtering planning applications" do
     end
 
     it "allows user to filter by many different statuses" do
-      click_button("Filter by status (6 of 6 selected)")
+      click_button("Filter by status (5 of 5 selected)")
       uncheck("Awaiting determination")
       uncheck("To be reviewed")
-      uncheck("Closed")
 
       click_button("Apply filters")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("(3 of 6 selected)")
+        expect(page).to have_content("(3 of 5 selected)")
         expect(page).to have_content(not_started_planning_application.reference)
         expect(page).to have_content(invalid_planning_application.reference)
         expect(page).to have_content(in_assessment_planning_application.reference)
         expect(page).not_to have_content(awaiting_determination_planning_application.reference)
         expect(page).not_to have_content(awaiting_correction_planning_application.reference)
         expect(page).not_to have_content(closed_planning_application.reference)
+      end
+    end
+  end
+
+  context "when user is reviewer" do
+    before do
+      sign_in(other_user)
+      visit(root_path)
+    end
+
+    it "allows user to filter by different statuses" do
+      within(selected_govuk_tab) do
+        expect(page).to have_content("Your live applications")
+        expect(page).to have_content(other_awaiting_determination_planning_application.reference)
+        expect(page).to have_content(other_awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(in_assessment_planning_application.reference)
+        expect(page).not_to have_content(closed_planning_application.reference)
+        expect(page).not_to have_content(other_closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (2 of 2 selected)")
+      uncheck("To be reviewed")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 2 selected)")
+        expect(page).to have_content(other_awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(other_awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(other_closed_planning_application.reference)
+      end
+
+      click_button("Filter by status (1 of 2 selected)")
+      check("To be reviewed")
+      uncheck("Awaiting determination")
+
+      click_button("Apply filters")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content("(1 of 2 selected)")
+        expect(page).to have_content(other_awaiting_correction_planning_application.reference)
+        expect(page).not_to have_content(other_awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(other_closed_planning_application.reference)
+      end
+
+      click_link("Closed")
+
+      within(selected_govuk_tab) do
+        expect(page).to have_content(other_closed_planning_application.reference)
+        expect(page).not_to have_content(other_awaiting_determination_planning_application.reference)
+        expect(page).not_to have_content(other_awaiting_correction_planning_application.reference)
       end
     end
   end

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "filtering planning applications" do
       :not_started,
       user: user,
       local_authority: local_authority,
-      description: "Add a chimney stack"
     )
   end
 
@@ -22,9 +21,8 @@ RSpec.describe "filtering planning applications" do
     create(
       :planning_application,
       :invalidated,
-      user: nil,
+      user: user,
       local_authority: local_authority,
-      description: "Add a patio"
     )
   end
 
@@ -32,9 +30,8 @@ RSpec.describe "filtering planning applications" do
     create(
       :planning_application,
       :in_assessment,
-      user: other_user,
+      user: user,
       local_authority: local_authority,
-      description: "Add a skylight"
     )
   end
 
@@ -42,9 +39,8 @@ RSpec.describe "filtering planning applications" do
     create(
       :planning_application,
       :awaiting_determination,
-      user: other_user,
+      user: user,
       local_authority: local_authority,
-      description: "Add a skylight"
     )
   end
 
@@ -52,9 +48,8 @@ RSpec.describe "filtering planning applications" do
     create(
       :planning_application,
       :awaiting_correction,
-      user: other_user,
+      user: user,
       local_authority: local_authority,
-      description: "Add a skylight"
     )
   end
 
@@ -62,9 +57,17 @@ RSpec.describe "filtering planning applications" do
     create(
       :planning_application,
       :closed,
+      user: user,
+      local_authority: local_authority,
+    )
+  end
+
+  let!(:other_closed_planning_application) do
+    create(
+      :planning_application,
+      :closed,
       user: other_user,
       local_authority: local_authority,
-      description: "Add a skylight"
     )
   end
 
@@ -73,6 +76,7 @@ RSpec.describe "filtering planning applications" do
   context "when user views her own planning applications" do
     before do
       visit(planning_applications_path)
+      click_on "View my applications"
     end
 
     it "allows user to filter by different statuses" do
@@ -84,6 +88,7 @@ RSpec.describe "filtering planning applications" do
         expect(page).to have_content(awaiting_determination_planning_application.reference)
         expect(page).to have_content(awaiting_correction_planning_application.reference)
         expect(page).to have_content(closed_planning_application.reference)
+        expect(page).not_to have_content(other_closed_planning_application.reference)
       end
 
       click_button("Filter by status (6 of 6 selected)")
@@ -198,6 +203,7 @@ RSpec.describe "filtering planning applications" do
       within(selected_govuk_tab) do
         expect(page).to have_content("(1 of 6 selected)")
         expect(page).to have_content(closed_planning_application.reference)
+        expect(page).not_to have_content(other_closed_planning_application.reference)
         expect(page).not_to have_content(not_started_planning_application.reference)
         expect(page).not_to have_content(invalid_planning_application.reference)
         expect(page).not_to have_content(in_assessment_planning_application.reference)

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :not_started,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -22,7 +22,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :invalidated,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -31,7 +31,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :in_assessment,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -40,7 +40,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :awaiting_determination,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -49,7 +49,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :awaiting_determination,
       user: other_user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -58,7 +58,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :awaiting_correction,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -67,7 +67,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :awaiting_correction,
       user: other_user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -76,7 +76,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :closed,
       user: user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 
@@ -85,7 +85,7 @@ RSpec.describe "filtering planning applications" do
       :planning_application,
       :closed,
       user: other_user,
-      local_authority: local_authority,
+      local_authority: local_authority
     )
   end
 

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe "filtering planning applications" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :assessor, local_authority: local_authority) }
 
+  let(:other_user) { create(:user, :assessor, local_authority: local_authority) }
+
   let!(:not_started_planning_application) do
     create(
       :planning_application,
@@ -75,7 +77,7 @@ RSpec.describe "filtering planning applications" do
 
     it "allows user to filter by different statuses" do
       within(selected_govuk_tab) do
-        expect(page).to have_content("All applications")
+        expect(page).to have_content("Your applications")
         expect(page).to have_content(not_started_planning_application.reference)
         expect(page).to have_content(invalid_planning_application.reference)
         expect(page).to have_content(in_assessment_planning_application.reference)

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -12,6 +12,9 @@ RSpec.describe "Planning Application index page" do
   let!(:planning_application_started) do
     create(:planning_application, :awaiting_determination, user: assessor, local_authority: default_local_authority)
   end
+  let!(:reviewer_planning_application_started) do
+    create(:planning_application, :awaiting_determination, user: reviewer, local_authority: default_local_authority)
+  end
   let!(:planning_application_completed) do
     create(:planning_application, :determined, local_authority: default_local_authority)
   end
@@ -62,38 +65,40 @@ RSpec.describe "Planning Application index page" do
     context "when viewing tabs" do
       it "Planning Application status bar is present" do
         within(:planning_applications_status_tab) do
-          expect(page).to have_link "Your applications"
+          expect(page).to have_link "Your live applications"
         end
       end
 
       it "Only Planning Applications that are in_assessment are present when filtered" do
-        click_on "Filter by status (6 of 6 selected)"
+        click_on "Filter by status (5 of 5 selected)"
         uncheck "Not started"
         uncheck "Invalidated"
         uncheck "Awaiting determination"
         uncheck "To be reviewed"
-        uncheck "Closed"
         click_button "Apply filters"
 
-        expect(page).to have_link(planning_application_1.reference)
-        expect(page).to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_started.reference)
-        expect(page).not_to have_link(planning_application_completed.reference)
+        within(selected_govuk_tab) do
+          expect(page).to have_link(planning_application_1.reference)
+          expect(page).to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(planning_application_started.reference)
+          expect(page).not_to have_link(planning_application_completed.reference)
+        end
       end
 
       it "Only Planning Applications that are awaiting_determination are present when filtered" do
-        click_on "Filter by status (6 of 6 selected)"
+        click_on "Filter by status (5 of 5 selected)"
         uncheck "Not started"
         uncheck "Invalidated"
         uncheck "In assessment"
         uncheck "To be reviewed"
-        uncheck "Closed"
         click_button "Apply filters"
 
-        expect(page).to have_link(planning_application_started.reference)
-        expect(page).not_to have_link(planning_application_1.reference)
-        expect(page).not_to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_completed.reference)
+        within(selected_govuk_tab) do
+          expect(page).to have_link(planning_application_started.reference)
+          expect(page).not_to have_link(planning_application_1.reference)
+          expect(page).not_to have_link(planning_application_2.reference)
+          expect(page).not_to have_link(planning_application_completed.reference)
+        end
       end
 
       context "when I view the closed tab" do
@@ -154,15 +159,23 @@ RSpec.describe "Planning Application index page" do
           )
         end
 
+        let!(:other_closed_planning_application) do
+          create(
+            :planning_application,
+            :closed,
+            closed_at: DateTime.new(2022, 8, 4),
+            address_1: "4 Long Lane",
+            town: "London",
+            postcode: "AB3 4EF",
+            description: "Add an attic",
+            local_authority: default_local_authority,
+            user: reviewer
+          )
+        end
+
         before do
           visit(root_path)
-          click_on "Filter by status (6 of 6 selected)"
-          uncheck "Not started"
-          uncheck "Invalidated"
-          uncheck "Awaiting determination"
-          uncheck "To be reviewed"
-          uncheck "In assessment"
-          click_button "Apply filters"
+          click_on "Closed"
         end
 
         it "shows determined application" do
@@ -200,6 +213,12 @@ RSpec.describe "Planning Application index page" do
             expect(row).to have_content("4 Aug")
             expect(row).to have_content("4 Long Lane, London, AB3 4EF")
             expect(row).to have_content("Add an attic")
+          end
+        end
+
+        it "only shows your own applications" do
+          within(selected_govuk_tab) do
+            expect(page).not_to have_content(other_closed_planning_application.reference)
           end
         end
       end
@@ -249,15 +268,13 @@ RSpec.describe "Planning Application index page" do
 
         it "shows relevant application details" do
           visit(planning_applications_path(q: "exclude_others"))
-          click_link("All your applications")
 
           within(selected_govuk_tab) do
-            expect(page).to have_content("All your applications")
+            expect(page).to have_content("Your live applications")
             row = row_with_content(planning_application.reference)
             expect(row).to have_content("Not started")
             expect(row).to have_content("1 Mar")
             expect(row).to have_content("1 Long Lane, London, AB3 4EF")
-            expect(row).to have_content("Add a fence")
           end
         end
       end
@@ -281,10 +298,11 @@ RSpec.describe "Planning Application index page" do
       end
       let(:recommendation) { create(:recommendation, planning_application: other_assessor_planning_application) }
 
-      it "On login, assessor gets redirected to a view with its own and unassigned Planning Applications" do
-        within("#under_assessment") do
+      it "On login, assessor gets redirected to a view with all their Planning Applications" do
+        within(selected_govuk_tab) do
           expect(page).to have_link(planning_application_1.reference)
           expect(page).to have_link(planning_application_2.reference)
+          expect(page).to have_link(planning_application_started.reference)
           expect(page).not_to have_link(other_assessor_planning_application.reference)
         end
       end
@@ -304,7 +322,7 @@ RSpec.describe "Planning Application index page" do
 
         click_on "View my applications"
 
-        within("#under_assessment") do
+        within(selected_govuk_tab) do
           expect(page).to have_link(planning_application_1.reference)
           expect(page).to have_link(planning_application_2.reference)
           expect(page).not_to have_link(other_assessor_planning_application.reference)
@@ -380,9 +398,8 @@ RSpec.describe "Planning Application index page" do
 
     it "Planning Application status bar is present and does not show In Assessment by default" do
       within(:planning_applications_status_tab) do
-        expect(page).to have_link "Awaiting determination"
+        expect(page).to have_link "Your live applications"
         expect(page).to have_link "Closed"
-        expect(page).not_to have_link "In assessment"
       end
     end
 
@@ -398,18 +415,18 @@ RSpec.describe "Planning Application index page" do
       click_link "View assessed applications"
 
       within(:planning_applications_status_tab) do
-        expect(page).to have_link "Awaiting determination"
+        expect(page).to have_link "Your live applications"
         expect(page).to have_link "Closed"
-        expect(page).not_to have_link "In assessment"
       end
     end
 
     it "Only Planning Applications that are awaiting_determination are present in this tab" do
-      click_link "Awaiting determination"
+      click_on "Filter by status (2 of 2 selected)"
+      uncheck "To be reviewed"
+      click_button "Apply filters"
 
-      within("#awaiting_determination") do
-        expect(page).to have_text("Awaiting determination")
-        expect(page).to have_link(planning_application_started.reference)
+      within(selected_govuk_tab) do
+        expect(page).to have_link(reviewer_planning_application_started.reference)
         expect(page).not_to have_link(planning_application_1.reference)
         expect(page).not_to have_link(planning_application_2.reference)
         expect(page).not_to have_link(planning_application_completed.reference)

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Planning Application index page" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
-  
+
   let!(:planning_application_1) { create(:planning_application, :in_assessment, user: assessor, local_authority: default_local_authority) }
   let!(:planning_application_2) { create(:planning_application, :in_assessment, user: assessor, local_authority: default_local_authority) }
   let!(:planning_application_started) do

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -4,11 +4,8 @@ require "rails_helper"
 
 RSpec.describe "Planning Application index page" do
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
-  let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
-
-  let!(:planning_application_1) { create(:planning_application, :in_assessment, user: assessor, local_authority: default_local_authority) }
-  let!(:planning_application_2) { create(:planning_application, :in_assessment, user: assessor, local_authority: default_local_authority) }
+  let!(:planning_application_1) { create(:planning_application, :in_assessment, local_authority: default_local_authority) }
+  let!(:planning_application_2) { create(:planning_application, :in_assessment, local_authority: default_local_authority) }
   let!(:planning_application_started) do
     create(:planning_application, :awaiting_determination, user: assessor, local_authority: default_local_authority)
   end
@@ -18,6 +15,8 @@ RSpec.describe "Planning Application index page" do
   let!(:planning_application_completed) do
     create(:planning_application, :determined, local_authority: default_local_authority)
   end
+  let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
   context "as an assessor" do
     before do

--- a/spec/system/planning_applications/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Planning Application Assessment" do
 
   before do
     sign_in assessor
-    visit root_path
+    visit planning_applications_path
   end
 
   context "when clicking Save and mark as complete" do

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -41,13 +41,12 @@ RSpec.describe "searching planning applications" do
 
   context "when user views her own planning applications" do
     before do
-      visit(planning_applications_path(q: "exclude_others"))
-      click_link("All your applications")
+      visit(root_path)
     end
 
     it "allows user to search planning applications by reference" do
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
@@ -57,7 +56,7 @@ RSpec.describe "searching planning applications" do
       click_button("Search")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
@@ -68,7 +67,7 @@ RSpec.describe "searching planning applications" do
       click_button("Search")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
@@ -80,7 +79,7 @@ RSpec.describe "searching planning applications" do
       visit(search_url)
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
@@ -92,7 +91,7 @@ RSpec.describe "searching planning applications" do
       expect(find_field("Find an application").value).to eq("")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
@@ -116,7 +115,7 @@ RSpec.describe "searching planning applications" do
       expect(find_field("Find an application").value).to eq("")
 
       within(selected_govuk_tab) do
-        expect(page).to have_content("All your applications")
+        expect(page).to have_content("Your live applications")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)


### PR DESCRIPTION
### Description of change

Changing how we use the tabs on the frontend 
- One tab for now "Your applications" when looking at only your applications, another for closed applications
- You can filter on this tab based on status
- Reviewer has a different view which only has two filters

### Story Link

https://trello.com/c/DBXZ8Omv/1298-1-2-create-a-filter-for-the-all-my-application-tab-to-reduce-the-number-of-tabs-on-officer-view

### Screenshots

<img width="1119" alt="Screenshot 2023-03-08 at 16 11 25" src="https://user-images.githubusercontent.com/35098639/223767095-97ab8231-ad61-42ee-b6f1-2b578d9abf75.png">

<img width="1068" alt="Screenshot 2023-03-08 at 16 11 32" src="https://user-images.githubusercontent.com/35098639/223767105-32dcbb0d-bea7-484c-a3b5-df1378cf1c3e.png">
