### PR TITLE
Allow requesting replacement documents at assessment stage

### DIFF
--- a/app/controllers/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/replacement_document_validation_requests_controller.rb
@@ -27,6 +27,7 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
     ActiveRecord::Base.transaction do
       @replacement_document_validation_request = @planning_application.replacement_document_validation_requests.new(replacement_document_validation_request_params).tap do |record|
         record.old_document = @document
+        record.post_validation = @planning_application.validated? unless @planning_application.validated?.nil?
         record.user = current_user
       end
 

--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -58,6 +58,8 @@ module AuditHelper
       "Cancelled: description change request (description##{args})"
     when "replacement_document_validation_request_sent"
       "Sent: validation request (replacement document##{args})"
+    when "replacement_document_validation_request_sent_post_validation"
+      "Sent: Post-validation request (replacement document##{args})"
     when "additional_document_validation_request_sent"
       "Sent: validation request (new document##{args})"
     when "additional_document_validation_request_sent_post_validation"

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -38,6 +38,7 @@ class Audit < ApplicationRecord
     description_change_validation_request_sent: "description_change_validation_request_sent",
     description_change_request_cancelled: "description_change_request_cancelled",
     replacement_document_validation_request_sent: "replacement_document_validation_request_sent",
+    replacement_document_validation_request_sent_post_validation: "replacement_document_validation_request_sent_post_validation",
     additional_document_validation_request_sent: "additional_document_validation_request_sent",
     additional_document_validation_request_sent_post_validation: "additional_document_validation_request_sent_post_validation",
     red_line_boundary_change_validation_request_sent: "red_line_boundary_change_validation_request_sent",
@@ -60,6 +61,7 @@ class Audit < ApplicationRecord
     red_line_boundary_change_validation_request_cancelled: "red_line_boundary_change_validation_request_cancelled",
     red_line_boundary_change_validation_request_cancelled_post_validation: "red_line_boundary_change_validation_request_cancelled_post_validation",
     replacement_document_validation_request_cancelled: "replacement_document_validation_request_cancelled",
+    replacement_document_validation_request_cancelled_post_validation: "replacement_document_validation_request_cancelled_post_validation",
     constraints_checked: "constraints_checked"
   }
 

--- a/app/models/replacement_document_validation_request.rb
+++ b/app/models/replacement_document_validation_request.rb
@@ -17,7 +17,6 @@ class ReplacementDocumentValidationRequest < ApplicationRecord
   delegate :invalidated_document_reason, to: :old_document
   delegate :validated?, :archived?, to: :new_document, prefix: :new_document
 
-  before_create :ensure_planning_application_not_validated!
   before_create :reset_replacement_document_validation_request_update_counter!
   before_destroy :reset_document_invalidation
 

--- a/app/views/audits/types/_replacement_document_validation_request_sent_post_validation.html.erb
+++ b/app/views/audits/types/_replacement_document_validation_request_sent_post_validation.html.erb
@@ -1,0 +1,6 @@
+<%= activity(locals[:item].activity_type, locals[:item].activity_information) %>
+<p class="govuk-body">
+  File name: <i><%= JSON.parse(locals[:item].audit_comment)["old_document"] %></i>
+<br/>
+  Invalid reason: <i><%= JSON.parse(locals[:item].audit_comment)["reason"] %></i>
+</p>

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -25,8 +25,9 @@
             <% if @planning_application.can_validate? %>
               <% if document.representable? %>
                 <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
-                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br/>
-                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %>
+                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br>
+                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
+                  <%= link_to "Request replacement", new_planning_application_replacement_document_validation_request_path(planning_application_id: @planning_application.id, document: document), class: "govuk-link" %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -24,6 +24,13 @@
         class: "govuk-link"
       ) %>
     </p>
+    <p class="govuk-body">
+      <%= link_to(
+        "Request replacement",
+        new_planning_application_replacement_document_validation_request_path(planning_application_id: planning_application.id, document: document),
+        class: "govuk-link"
+      ) %>
+    </p>
   <% end %>
 <% else %>
   <div class="govuk-grid-column-one-third">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,7 +189,7 @@ en:
     v1:
       replacement_document_validation_requests:
         update:
-          applicant_has_provided: Applicant has provived a replacement document.
+          applicant_has_provided: Applicant has provided a replacement document.
           error: Unable to update request
           success: Validation request updated
   application:

--- a/spec/models/replacement_document_validation_request_spec.rb
+++ b/spec/models/replacement_document_validation_request_spec.rb
@@ -101,11 +101,11 @@ RSpec.describe ReplacementDocumentValidationRequest do
           create(:replacement_document_validation_request, planning_application: planning_application)
         end
 
-        it "prevents a replacement_document_validation_request from being created" do
+        it "allows a replacement_document_validation_request to be created" do
           expect do
             replacement_document_validation_request
-          end.to raise_error(ValidationRequestable::ValidationRequestNotCreatableError,
-                             "Cannot create Replacement Document Validation Request when planning application has been validated")
+          end.not_to raise_error(ValidationRequestable::ValidationRequestNotCreatableError,
+                                 "Cannot create Replacement Document Validation Request when planning application has been validated")
         end
       end
     end

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     expect(replacement_document_validation_request.state).to eq("closed")
     expect(replacement_document_validation_request.new_document).to be_a(Document)
     expect(document.archived_at).not_to be_nil
-    expect(document.archive_reason).to eq("Applicant has provived a replacement document.")
+    expect(document.archive_reason).to eq("Applicant has provided a replacement document.")
   end
 
   it "copies old document tags and reference to new document" do

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -501,6 +501,19 @@ RSpec.describe "Requesting document changes to a planning application" do
       end
     end
 
+    it "sends an email notification" do
+      delivered_emails = ActionMailer::Base.deliveries.count
+
+      click_link "Check and assess"
+      click_button "Documents"
+      click_link "Request replacement"
+
+      fill_in "List all issues with the document.", with: "This is very invalid"
+      click_button "Send request"
+
+      expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
+    end
+
     it "allows new replacement requests to be responded to" do
       click_link "Check and assess"
       click_button "Documents"

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -101,7 +101,11 @@ RSpec.describe "Requesting document changes to a planning application" do
       click_button "Save request"
 
       expect(page).to have_content("Replacement document validation request successfully created.")
-      expect(document1.reload.replacement_document_validation_request).to eq(ReplacementDocumentValidationRequest.last)
+
+      document1.reload
+      expect(document1.replacement_document_validation_request).to eq(ReplacementDocumentValidationRequest.last)
+      expect(document1.replacement_document_validation_request.post_validation).to be_falsey
+
       within("#invalid-items-count") do
         expect(page).to have_content("Invalid items 1")
       end
@@ -476,7 +480,10 @@ RSpec.describe "Requesting document changes to a planning application" do
       click_button "Send request"
 
       expect(page).to have_content("Replacement document validation request successfully created.")
-      expect(document1.reload.replacement_document_validation_request).to eq(ReplacementDocumentValidationRequest.last)
+
+      document1.reload
+      expect(document1.replacement_document_validation_request).to eq(ReplacementDocumentValidationRequest.last)
+      expect(document1.replacement_document_validation_request.post_validation).to be true
     end
   end
 

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -486,6 +486,21 @@ RSpec.describe "Requesting document changes to a planning application" do
       expect(document1.replacement_document_validation_request.post_validation).to be true
     end
 
+    it "appears in the post validation requests table" do
+      click_link "Check and assess"
+      click_button "Documents"
+      click_link "Request replacement"
+
+      fill_in "List all issues with the document.", with: "This is very invalid"
+      click_button "Send request"
+      click_link "Application"
+      click_link "Review non-validation requests"
+
+      within ".validation-requests-table" do
+        expect(page).to have_content(document1.name)
+      end
+    end
+
     it "allows new replacement requests to be responded to" do
       click_link "Check and assess"
       click_button "Documents"

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -466,6 +466,18 @@ RSpec.describe "Requesting document changes to a planning application" do
         expect(page).to have_content("Planning application has already been validated")
       end
     end
+
+    it "allows new replacement requests" do
+      click_link "Check and assess"
+      click_button "Documents"
+      click_link "Request replacement"
+
+      fill_in "List all issues with the document.", with: "This is very invalid"
+      click_button "Send request"
+
+      expect(page).to have_content("Replacement document validation request successfully created.")
+      expect(document1.reload.replacement_document_validation_request).to eq(ReplacementDocumentValidationRequest.last)
+    end
   end
 
   context "when document is archived" do


### PR DESCRIPTION
### Description of change

Currently, replacement documents can only be requested at the validation stage. This adds UI for creating them from the assessment stage and alters the database validation to permit that.

### Story Link

https://trello.com/c/KnZEB2t8/1470-request-replacement-document-at-assessment-stage

### Screenshots

![Screenshot 2023-03-06 at 16 20 37](https://user-images.githubusercontent.com/3986/223173962-b862bb2e-b479-485d-af39-7e11877d630f.png)
![Screenshot 2023-03-06 at 16 20 26](https://user-images.githubusercontent.com/3986/223173969-f0fdcf19-be8e-4020-b074-d663c7a50509.png)

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

There's a couple of things that it'd be good to check with someone more familiar:

- [x]  I'm passing `post_validation: true` when creating the request, and this is being reflected in the document, but I hadn't found where this affects the UI (a list of open post-validation requests somewhere?). Presumably it does but I haven't visually confirmed this.

- [x] I need to double check whether the changes I've made to the document management views affect the UI in the validation stage as well as the assessment stage — it's possible I'm passing `post_validation: true` when it shouldn't be.

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
