### PR TITLE
Upgrade Rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,7 +358,7 @@ GEM
     puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails (7.0.4.2)


### PR DESCRIPTION
Fixing known vulnerability:
```
Name: rack
Version: 2.2.6.2
CVE: CVE-2023-27530
Criticality: Unknown
URL: https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388
Title: Possible DoS Vulnerability in Multipart MIME parsing
Solution: upgrade to ~> 2.0.9, >= 2.0.9.3, ~> 2.1.4, >= 2.1.4.3, ~> 2.2.6, >= 2.2.6.3, >= 3.0.4.2
```