### PR TITLE
Redirect document updates correctly

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -144,6 +144,8 @@ class DocumentsController < AuthenticationController
   end
 
   def set_return_to_session
+    return unless request.referer&.include?(@planning_application.id.to_s)
+
     session[:return_to] ||= request.referer
   end
 

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -239,5 +239,33 @@ RSpec.describe "Edit document" do
         expect(page).to have_current_path(planning_application_documents_path(planning_application))
       end
     end
+
+    context "when visitng the edit/archive url directly after viewing another planning application" do
+      let!(:other_planning_application) do
+        create(
+          :planning_application,
+          local_authority: default_local_authority
+        )
+      end
+      let!(:other_document) do
+        create(:document, :with_file, planning_application: other_planning_application)
+      end
+
+      it "edit returns to the documents index page" do
+        visit edit_planning_application_document_path(planning_application, document)
+        visit edit_planning_application_document_path(other_planning_application, other_document)
+
+        click_button "Save"
+        expect(page).to have_current_path(planning_application_documents_path(other_planning_application))
+      end
+
+      it "archive returns to the documents index page" do
+        visit edit_planning_application_document_path(other_planning_application, other_document)
+        visit planning_application_document_archive_path(planning_application, document)
+
+        click_button "Archive"
+        expect(page).to have_current_path(planning_application_documents_path(planning_application))
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Redirect document updates correctly

- If the request.referer contains a url from another planning application, the document redirect can end up in a weird place. Therefore, check if the planning application id is within the referer url otherwise default to the planning application documents page

### Story Link

https://trello.com/c/E5gkkz68/1493-updating-documents-takes-me-to-the-documents-of-a-different-application

