### PR TITLE
COPY fails in multistage build: layer does not exist

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -117,6 +117,9 @@ COPY --chown=app:app ./config.ru /app/config.ru
 COPY --chown=app:app ./db/ /app/db/
 COPY --chown=app:app ./lib/ /app/lib/
 COPY --chown=app:app ./public/ /app/public/
+
+RUN true
+
 COPY --chown=app:app ./babel.config.js /app/babel.config.js
 COPY --chown=app:app ./config.ru /app/config.ru
 COPY --chown=app:app ./postcss.config.js /app/postcss.config.js


### PR DESCRIPTION
### Description of change

COPY fails in multistage build: layer does not exist

https://github.com/moby/moby/issues/37965