### PR TITLE
Return to the review recommendation page after editing decision notice text

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -349,8 +349,11 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def redirect_update_url
-    if params[:edit_action] == "edit_payment_amount"
+    case params[:edit_action]&.to_sym
+    when :edit_payment_amount
       redirect_to planning_application_fee_items_path(@planning_application, validate_fee: "yes"), notice: "Planning application payment amount was successfully updated."
+    when :edit_public_comment
+      redirect_to edit_planning_application_recommendations_path(@planning_application), notice: "The information appearing on the decision notice was successfully updated."
     else
       redirect_to(after_update_url, notice: t(".success"))
     end

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -262,9 +262,10 @@ RSpec.describe "Reviewing sign-off" do
 
       fill_in "This information will appear on the decision notice.", with: "This text will appear on the decision notice."
       click_button "Save"
-      expect(page).to have_content("Planning application was successfully updated.")
+      expect(page).to have_content("The information appearing on the decision notice was successfully updated.")
+      expect(page).to have_current_path(edit_planning_application_recommendations_path(planning_application))
 
-      click_link "Review and sign-off"
+      click_link "Review"
       click_link "Sign-off recommendation"
 
       expect(page).to have_content("This text will appear on the decision notice.")


### PR DESCRIPTION
### Story Link

https://trello.com/c/6x6y4fEv/1086-when-a-manager-is-reviewing-recommendation-and-updates-the-text-for-the-decision-notice-return-them-to-review-recommendation-pag