### PR TITLE
Do not audit when saved changes are all either nil, blank or zero

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -590,7 +590,7 @@ class PlanningApplication < ApplicationRecord
     return unless saved_changes?
 
     saved_changes.keys.intersection(PLANNING_APPLICATION_PERMITTED_KEYS).map do |attribute_name|
-      next if saved_change_to_attribute(attribute_name).all?(&:blank?)
+      next if saved_change_to_attribute(attribute_name).all? { |value| value.blank? || value.try(:zero?) }
 
       attribute_to_audit(attribute_name)
     end


### PR DESCRIPTION
### Description of change

Do not audit when saved changes are all either nil, blank or zero

- There was an issue where if we saved a nil payment amount as 0 it would create an audit with "payment amount changed from £0.00 to £0.00" which is obviously not helpful
- This change just means we ignore any non meaningful value change

