### PR TITLE
Label application types with their work status

### DIFF
--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -34,7 +34,7 @@ module PlanningApplications
     end
 
     def your_application_attributes
-      %i[reference full_address application_type_name formatted_expiry_date remaining_days_status_tag status_tag]
+      %i[reference full_address application_type_with_status formatted_expiry_date remaining_days_status_tag status_tag]
     end
 
     def closed_attributes
@@ -51,7 +51,7 @@ module PlanningApplications
       %i[
         reference
         full_address
-        application_type_name
+        application_type_with_status
         formatted_expiry_date
         remaining_days_status_tag
         status_tag

--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -9,6 +9,7 @@ class PlanningApplicationPresenter
   include ProposalDetailsPresenter
   include ValidationTasksPresenter
   include AssessmentTasksPresenter
+  include ActionView::Helpers::SanitizeHelper
 
   def initialize(template, planning_application)
     @template = template
@@ -21,6 +22,18 @@ class PlanningApplicationPresenter
 
   def application_type_name
     I18n.t("application_types.#{application_type}")
+  end
+
+  def application_type_abbreviation
+    I18n.t("application_types.#{application_type}_abbr", default: application_type_name)
+  end
+
+  def application_type_with_status
+    status_title = work_status.titlecase
+    sanitize(
+      "<abbr title=\"#{application_type_name} #{status_title}\">" \
+      "#{application_type_abbreviation} #{status_title}</abbr>"
+    )
   end
 
   %i[awaiting_determination_at expiry_date outcome_date].each do |date|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -203,6 +203,7 @@ en:
   application_types:
     full: Full Householder Application
     lawfulness_certificate: Lawful Development Certificate
+    lawfulness_certificate_abbr: LDC
   archive_reasons:
     design: Revise design
     dimensions: Revise dimensions
@@ -638,6 +639,7 @@ en:
       all_applications: All applications
       all_your_applications: Your live applications
       application_type_name: Application type
+      application_type_with_status: Application type
       awaiting_correction: Corrections requested
       awaiting_determination: Awaiting determination
       closed: Closed

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -253,4 +253,24 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       end
     end
   end
+
+  describe "#application_type_with_status" do
+    let(:planning_application) { create(:planning_application) }
+    let(:presenter) { described_class.new(view, planning_application) }
+
+    context "when the status is proposed" do
+      it "is reflected in the type" do
+        expect(presenter.application_type_with_status).to include("LDC Proposed")
+        expect(presenter.application_type_with_status).to include("Lawful Development Certificate Proposed")
+      end
+    end
+
+    context "when the work status is existing" do
+      it "is reflected in the type" do
+        planning_application.work_status = "existing"
+        expect(presenter.application_type_with_status).to include("LDC Existing")
+        expect(presenter.application_type_with_status).to include("Lawful Development Certificate Existing")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Add the `work_status` (proposed, existing) to the "application type" column.
- Abbreviate the type but show the full name in a tooltip.
- Default to full name of type if no abbreviation defined.

### Story Link

https://trello.com/c/LRheh9Cn/1176-change-how-application-type-is-labelled-on-dashboard

### Screenshots

<img width="1000" alt="Screenshot 2023-03-16 at 15 15 11" src="https://user-images.githubusercontent.com/3986/225662392-a6a7f57e-9e26-48f2-afc0-07710d6d5cec.png">


### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
