### PR TITLE
Remove ruby version from Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y --no-install-recommends poppler-utils
 
 ## Install gems in a separate Docker fs layer
 WORKDIR /gems
-COPY Gemfile Gemfile.lock ./ .ruby-version ./
+COPY Gemfile Gemfile.lock ./
 RUN bundle
 
 ## Node

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").strip.split("-").last
-
 # Load environment variables
 gem "dotenv-rails", require: "dotenv/rails-now"
 


### PR DESCRIPTION
Remove ruby version from Gemfile and Dockerfile

- We keep the .ruby-version as GHA needs this