### PR TITLE
Show a warning when constraints have changed

### DIFF
--- a/app/components/accordion_sections/constraints_component.html.erb
+++ b/app/components/accordion_sections/constraints_component.html.erb
@@ -1,4 +1,4 @@
-<% if planning_application.updated_address_or_boundary_geojson %>
+<% if planning_application.updated_address_or_boundary_geojson || planning_application.changed_constraints.present? %>
   <%= render(
     partial: "shared/warning_text",
     locals: { message: t(".this_application_has") }

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -79,6 +79,7 @@ class PlanningApplication < ApplicationRecord
   before_update -> { reset_validation_requests_update_counter!(fee_item_validation_requests) }, if: :valid_fee?
   after_update :audit_updated!
   after_update :address_or_boundary_geojson_updated?
+  after_update :constraints_updated?
 
   accepts_nested_attributes_for :recommendations
   accepts_nested_attributes_for :documents
@@ -616,6 +617,13 @@ class PlanningApplication < ApplicationRecord
     return unless saved_changes.keys.intersection(ADDRESS_AND_BOUNDARY_GEOJSON_FIELDS).any?
 
     update!(updated_address_or_boundary_geojson: true)
+  end
+
+  def constraints_updated?
+    return unless saved_changes.include? "constraints"
+    return if constraints.blank?
+
+    update!(changed_constraints: ((changed_constraints.presence || []) + constraints).uniq)
   end
 
   def attribute_to_audit(attribute_name)

--- a/db/migrate/20230413104408_add_changed_constraints_to_planning_application.rb
+++ b/db/migrate/20230413104408_add_changed_constraints_to_planning_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddChangedConstraintsToPlanningApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :changed_constraints, :text, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_12_102829) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_13_104408) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -340,6 +340,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_12_102829) do
     t.datetime "received_at"
     t.boolean "from_production", default: false
     t.string "review_documents_for_recommendation_status", default: "not_started", null: false
+    t.text "changed_constraints", array: true
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2019,4 +2019,11 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  it "tracks changed constraints" do
+    planning_application.constraints << "test_constraint"
+    planning_application.save!
+
+    expect(planning_application.changed_constraints).to include("test_constraint")
+  end
 end

--- a/spec/system/planning_applications/updating_constraints_spec.rb
+++ b/spec/system/planning_applications/updating_constraints_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "updating constraints" do
     click_button("Constraints")
 
     expect(page).to have_content("Conservation Area")
+    expect(page).to have_content("This application has been updated. Please check the constraints are correct.")
 
     click_link("Application")
     click_button("Audit log")


### PR DESCRIPTION
### Description of change

Currently a warning is displayed if certain fields change, notifying the user that it may no longer be valid.

This extends that to include the constraints field.

### Story Link

https://trello.com/c/5SgiA53g/1169-show-application-has-been-updated-warning-in-accordion-after-any-constraints-have-been-changed

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
