### PR TITLE
Show correct source of update in audits

### DIFF
--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -112,7 +112,9 @@ module AuditHelper
   end
 
   def audit_user_name(audit)
-    if audit.api_user.present?
+    if applicant_activity_types.include?(audit.activity_type)
+      t("audit_user_name.bops_applicants")
+    elsif audit.api_user.present?
       audit_api_user_name(audit)
     elsif audit.user.present?
       audit.user.name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,6 +293,7 @@ en:
       assessment_report: Assessment report
   audit_user_name:
     applicant: Applicant / Agent via %{api_user_name}
+    bops_applicants: Applicant / Agent via BoPS applicants
     deleted: User deleted
     system: Automated by the system
   audits:

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Requesting a new document for a planning application" do
 
     expect(page).to have_text("Received: request for change (new document#1)")
     expect(page).to have_text("roof_plan.pdf")
-    expect(page).to have_text("Applicant / Agent via Api Wizard")
+    expect(page).to have_text("Applicant / Agent via BoPS applicants")
   end
 
   context "when invalidation updates an additional document validation request" do

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Auditing changes to a planning application" do
     create(:planning_application, :invalidated, local_authority: default_local_authority)
   end
 
-  let!(:api_user) { create(:api_user, name: "Api Wizard") }
+  let!(:api_user) { create(:api_user) }
 
   before do
     create(:audit, planning_application_id: planning_application.id,
@@ -34,20 +34,20 @@ RSpec.describe "Auditing changes to a planning application" do
   it "displays details of other change validation request in the audit log" do
     expect(page).to have_text("Received: request for change (other validation#1)")
     expect(page).to have_text("I have sent the fee")
-    expect(page).to have_text("Applicant / Agent via Api Wizard")
+    expect(page).to have_text("Applicant / Agent via BoPS applicants")
   end
 
   it "displays the details of a red line boundary request in the audit log" do
     expect(page).to have_text("Received: request for change (red line boundary#1)")
     expect(page).to have_text("The boundary was too small")
     expect(page).to have_text("rejected")
-    expect(page).to have_text("Applicant / Agent via Api Wizard")
+    expect(page).to have_text("Applicant / Agent via BoPS applicants")
   end
 
   it "displays the details of replacement boundary requests in the audit log" do
     expect(page).to have_text("Received: request for change (replacement document#1)")
     expect(page).to have_text("floor_plan.pdf")
-    expect(page).to have_text("Applicant / Agent via Api Wizard")
+    expect(page).to have_text("Applicant / Agent via BoPS applicants")
   end
 
   context "when red line boundary change request is auto closed" do


### PR DESCRIPTION
### Description of change

We were incorrectly displaying that an update from BoPS applicants was via PlanX

### Screenshots

<img width="815" alt="Screenshot 2023-03-23 at 16 22 41" src="https://user-images.githubusercontent.com/34001723/227269379-7060efd4-17b8-4456-b1a5-d7e04a0cab17.png">