### PR TITLE
Show updated tab on view all applications page

### DIFF
--- a/app/components/planning_applications/panels_component.html.erb
+++ b/app/components/planning_applications/panels_component.html.erb
@@ -16,10 +16,8 @@
     )
   ) %>
 <% end %>
-<% if exclude_others %>
-  <%= render(
-    PlanningApplications::UpdatedPanelComponent.new(
-      audits: local_authority_most_recent_audits_for_planning_applications
-    )
-  ) %>
-<% end %>
+<%= render(
+  PlanningApplications::UpdatedPanelComponent.new(
+    audits: local_authority_most_recent_audits_for_planning_applications
+  )
+) %>

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -15,9 +15,6 @@
       <li class="govuk-tabs__list-item" role="presentation">
         <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 2 %>
       </li>
-      <li class="govuk-tabs__list-item" role="presentation">
-        <%= link_to "Updated", "#updated", class: "govuk-tabs__tab", role: "tab", "aria-controls": "updated", "aria-selected": false, tabindex: 3 %>
-      </li>
     <% else %>
       <li class="govuk-tabs__list-item" role="presentation">
         <%= link_to(
@@ -34,5 +31,8 @@
       </li>
       </li>
     <% end %>
+    <li class="govuk-tabs__list-item" role="presentation">
+      <%= link_to "Updated", "#updated", class: "govuk-tabs__tab", role: "tab", "aria-controls": "updated", "aria-selected": false, tabindex: 6 %>
+    </li>
   </ul>
 </div>

--- a/spec/system/planning_applications/updated_tab_spec.rb
+++ b/spec/system/planning_applications/updated_tab_spec.rb
@@ -135,4 +135,16 @@ RSpec.describe "Planning application updated tab spec" do
       expect(page).not_to have_css("#planning_application_#{other_planning_application.id}")
     end
   end
+
+  context "when viewing all applications" do
+    before do
+      click_link("View all applications")
+    end
+
+    it "shows the updated tab" do
+      within("#updated") do
+        expect(page).to have_content("Updated")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Show updated tab on view all applications page

### Story Link

https://trello.com/c/otGmyyo2/1503-add-updated-tab-to-all-applications-page

### Screenshots

This looks pretty bad as it stands but https://github.com/unboxed/bops/pull/978 should address the UI so the tabs fit in the grid

![Screenshot 2023-03-27 at 16 06 02](https://user-images.githubusercontent.com/34001723/227981876-c59d38e4-6046-45b1-b4e1-4f5dab43c892.png)