### PR TITLE
Add document tags endpoint to API

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -9,6 +9,16 @@ module Api
         document = PlanningApplication.find(params[:planning_application_id]).documents.for_publication.find(params[:id])
         redirect_to rails_blob_url(document.file)
       end
+
+      def tags
+        respond_to do |format|
+          format.json do
+            @tags = Document::TAGS
+            @evidence_tags = Document::EVIDENCE_TAGS
+            @plan_tags = Document::PLAN_TAGS
+          end
+        end
+      end
     end
   end
 end

--- a/app/views/api/v1/documents/tags.json.jbuilder
+++ b/app/views/api/v1/documents/tags.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+json.tags @tags
+json.evidence_tags @evidence_tags
+json.plan_tags @plan_tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -155,6 +155,10 @@ Rails.application.routes.draw do
         resources :other_change_validation_requests, only: %i[index update show]
         resources :red_line_boundary_change_validation_requests, only: %i[index update show]
       end
+
+      resources :documents, only: :show do
+        get :tags, on: :collection
+      end
     end
   end
 

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -576,6 +576,22 @@ paths:
                             - 51.50115276135022
                           - - -0.07716178894042969
                             - 51.50094238217541
+  /api/v1/documents/tags:
+    get:
+      summary: Retrieves permitted document tags
+      tags:
+        - Document tags
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Retrieves all the permitted document tags (evidence and plan)
+          content:
+            application/json:
+              example:
+                tags: []
+                evidence_tags: []
+                document_tags: []
   '/api/v1/planning_applications/{planning_application_id}/validation_requests':
     get:
       summary: Retrieves all validation requests for a given planning application

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -504,3 +504,20 @@ paths:
                           - [-0.07716178894042969, 51.50094238217541]
 
   $ref: './validation_requests.yaml'
+
+  '/api/v1/documents/tags':
+    get:
+      summary: Retrieves permitted document tags
+      tags:
+        - Document tags
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Retrieves all the permitted document tags (evidence and plan)
+          content:
+            application/json:
+              example:
+                tags: []
+                evidence_tags: []
+                document_tags: []

--- a/spec/requests/api/document_tags_spec.rb
+++ b/spec/requests/api/document_tags_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API request to show document tags", show_exceptions: true do
+  before do
+    create(:local_authority, :default)
+  end
+
+  describe "#tags" do
+    it "returns an object with an array of all the document tags, plan tags and evidence tags" do
+      get "/api/v1/documents/tags"
+
+      expect(response).to be_successful
+
+      expect(json).to eq({
+                           "tags" => Document::TAGS,
+                           "evidence_tags" => Document::EVIDENCE_TAGS,
+                           "plan_tags" => Document::PLAN_TAGS
+                         })
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Add document tags endpoint to API
- Dynamically fetch the tags we use to validate when persisting a document record and display this as an object of arrays on our endpoint

### Story Link

https://trello.com/c/SPaGhb8u/1098-add-accepted-document-tags-to-swagger-documentation

### Screenshots

![Screenshot 2023-03-29 at 12 03 41](https://user-images.githubusercontent.com/34001723/228514338-2485874f-d50f-4825-98f1-9ca063cdefdc.png)


