### PR TITLE
Make back to top link go to back to top of section

### DIFF
--- a/app/components/accordion_component.html.erb
+++ b/app/components/accordion_component.html.erb
@@ -3,7 +3,7 @@
     <div class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h3 class="govuk-accordion__section-heading">
-          <button type="button" class="govuk-accordion__section-button">
+          <button type="button" class="govuk-accordion__section-button" id="accordion-default-heading-<%= "#{section}" %>">
             <%= t(".#{section}") %>
           </button>
           <span class="govuk-accordion__icon"></span>

--- a/app/components/proposal_details/group_component.html.erb
+++ b/app/components/proposal_details/group_component.html.erb
@@ -9,7 +9,7 @@
     <div>
       <%= render(
         partial: "shared/back_to_top_link",
-        locals: { target_id: "#accordion-default-heading-3" }
+        locals: { target_id: "#accordion-default-heading-proposal_details" }
       ) %>
     </div>
   </div>

--- a/app/views/shared/_accordian_section.html.erb
+++ b/app/views/shared/_accordian_section.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-accordion__section ">
   <div class="govuk-accordion__section-header">
     <h2 class="govuk-accordion__section-heading">
-      <span class="govuk-accordion__section-button" id="accordion-default-heading-1">
+      <span class="govuk-accordion__section-button">
         <%= heading %>
       </span>
     </h2>

--- a/spec/system/planning_applications/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessment_tasks_index_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "Assessment tasks" do
 
       first(:link, "Back to top").click
 
-      expect(current_url).to have_target_id("accordion-default-heading-3")
+      expect(current_url).to have_target_id("accordion-default-heading-proposal_details")
     end
   end
 end


### PR DESCRIPTION
### Description of change

Back to top links in the proposal details part of the accordion weren't working.

The ids were being set strangely on the accordion headings, so made them definitely unique and used the correct heading to navigate back to

### Story Link

https://trello.com/c/tnSUJDAf/1553-back-to-top-functionality-inside-proposal-detail-accordion-is-not-working
