### PR TITLE
Add immune status to application header

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -536,6 +536,10 @@ class PlanningApplication < ApplicationRecord
     errors.add(:user, "You cannot assign a planning application to an adminstrator")
   end
 
+  def possibly_immune?
+    false
+  end
+
   private
 
   def set_reference

--- a/app/views/shared/_proposal_header.html.erb
+++ b/app/views/shared/_proposal_header.html.erb
@@ -24,5 +24,11 @@
     <p class="govuk-body">
       <%= @planning_application.type_and_work_status %>: <%= @planning_application.description %>
     </p>
+
+    <% if @planning_application.possibly_immune? %>
+      <p class="govuk-body">
+        <strong>Note: application may be immune from enforcement</strong>
+      </p>
+    <% end %>
   </div>
 </div>

--- a/spec/system/planning_applications/immunity_spec.rb
+++ b/spec/system/planning_applications/immunity_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Validating the application" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  context "when not immune" do
+    before do
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    let(:planning_application) do
+      create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+    end
+
+    it "returns false from possibly_immune?" do
+      expect(planning_application.possibly_immune?).to be false
+    end
+
+    it "doesn't mention immunity in the page header" do
+      expect(page).not_to have_content("may be immune from enforcement")
+    end
+  end
+
+  context "when immune" do
+    let(:planning_application) do
+      create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+    end
+
+    before do
+      allow_any_instance_of(PlanningApplication).to receive(:possibly_immune?).and_return(true)
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    it "returns true from possibly_immune?" do
+      expect(planning_application.possibly_immune?).to be true
+    end
+
+    it "mentions immunity in the page header" do
+      expect(page).to have_content("may be immune from enforcement")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add immunity status to the page header

### Story Link

https://trello.com/c/EFwv89bN/1528-show-the-application-may-be-immune — only first screenshot

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Does not implement any kind of data structure for immunity status: just a dummy method for now.

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
