### PR TITLE
Only specify environment for first job to trigger manual approval for prod deploy

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -75,7 +75,6 @@ jobs:
     name: Perform database migrations on ${{ inputs.environment-name }}
     runs-on: ubuntu-20.04
     needs: [build-image]
-    environment: ${{ inputs.environment-name }}
 
     steps:
       - name: Get github commit sha
@@ -131,7 +130,6 @@ jobs:
     name: Deploy services to ${{ inputs.environment-name }}
     runs-on: ubuntu-20.04
     needs: [build-image, deploy-db-migrate-service]
-    environment: ${{ inputs.environment-name }}
     strategy:
       matrix:
         service_type: [ 'console', 'worker' ]
@@ -197,7 +195,6 @@ jobs:
     name: Deploy web service to ${{ inputs.environment-name }}
     runs-on: ubuntu-20.04
     needs: [build-image, deploy-db-migrate-service, deploy-services]
-    environment: ${{ inputs.environment-name }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
### Description of change

We don't need to specify the environment each time for all jobs as this will result in us having to manually approve each step. We add a dependency on the workflow by using "needs:" which means any subsequent job needs the previous ones to run successfully
