### PR TITLE
Add review immunity details table

### DIFF
--- a/db/migrate/20230417094650_add_reviewer_comment_to_immunity_detail.rb
+++ b/db/migrate/20230417094650_add_reviewer_comment_to_immunity_detail.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class AddReviewerCommentToImmunityDetail < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :immunity_details, :reviewer_id
+    remove_column :immunity_details, :assessor_id
+    remove_column :immunity_details, :reviewed_at
+
+    create_table :review_immunity_details do |t|
+      t.references :immunity_details
+      t.text :assessor_comment
+      t.references :assessor, foreign_key: { to_table: :users }
+      t.text :reviewer_comment
+      t.references :reviewer, foreign_key: { to_table: :users }
+      t.string :assessor_decision
+      t.string :reviewer_decision
+      t.datetime :assessor_decision_updated_at
+      t.datetime :reviewer_decision_updated_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -203,12 +203,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "review_status", default: "review_not_started", null: false
+<<<<<<< Updated upstream
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
     t.datetime "reviewed_at", precision: nil
     t.index ["assessor_id"], name: "ix_immunity_details_on_assessor_id"
+=======
+>>>>>>> Stashed changes
     t.index ["planning_application_id"], name: "ix_immunity_details_on_planning_application_id"
-    t.index ["reviewer_id"], name: "ix_immunity_details_on_reviewer_id"
   end
 
   create_table "local_authorities", force: :cascade do |t|
@@ -437,6 +439,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
     t.index ["user_id"], name: "index_document_change_requests_on_user_id"
   end
 
+  create_table "review_immunity_details", force: :cascade do |t|
+    t.bigint "immunity_details_id"
+    t.text "assessor_comment"
+    t.bigint "assessor_id"
+    t.text "reviewer_comment"
+    t.bigint "reviewer_id"
+    t.string "assessor_decision"
+    t.string "reviewer_decision"
+    t.datetime "assessor_decision_updated_at"
+    t.datetime "reviewer_decision_updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessor_id"], name: "ix_review_immunity_details_on_assessor_id"
+    t.index ["immunity_details_id"], name: "ix_review_immunity_details_on_immunity_details_id"
+    t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"
+  end
+
   create_table "review_policy_classes", force: :cascade do |t|
     t.bigint "policy_class_id", null: false
     t.integer "mark", null: false
@@ -499,8 +518,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "replacement_document_validation_requests"
   add_foreign_key "documents", "users"
-  add_foreign_key "immunity_details", "users", column: "assessor_id"
-  add_foreign_key "immunity_details", "users", column: "reviewer_id"
   add_foreign_key "notes", "planning_applications"
   add_foreign_key "notes", "users"
   add_foreign_key "other_change_validation_requests", "planning_applications"
@@ -517,6 +534,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
   add_foreign_key "replacement_document_validation_requests", "documents", column: "old_document_id"
   add_foreign_key "replacement_document_validation_requests", "planning_applications"
   add_foreign_key "replacement_document_validation_requests", "users"
+  add_foreign_key "review_immunity_details", "users", column: "assessor_id"
+  add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "validation_requests", "planning_applications"
 end


### PR DESCRIPTION
This will allow us to keep an audit log of what goes on with immunity details, i.e. multiple back and forths between assessor and reviewer