### PR TITLE
Add ReviewImmunityDetails

### DIFF
--- a/app/controllers/planning_application/review_immunity_details_controller.rb
+++ b/app/controllers/planning_application/review_immunity_details_controller.rb
@@ -23,7 +23,7 @@ class PlanningApplication
 
     def update
       @immunity_detail.assign_attributes(
-        review_status: status, reviewer: current_user, reviewed_at: Time.current
+        review_status: status
       )
 
       respond_to do |format|

--- a/app/models/immunity_detail.rb
+++ b/app/models/immunity_detail.rb
@@ -3,6 +3,8 @@
 class ImmunityDetail < ApplicationRecord
   belongs_to :planning_application
 
+  has_many :review_immunity_details, dependent: :destroy
+
   enum(
     status: {
       not_started: "not_started",
@@ -17,11 +19,6 @@ class ImmunityDetail < ApplicationRecord
     review_in_progress: "review_in_progress",
     review_complete: "review_complete"
   }
-
-  with_options class_name: "User", optional: true do
-    belongs_to :assessor
-    belongs_to :reviewer
-  end
 
   with_options presence: true do
     validates :status, :review_status

--- a/app/models/review_immunity_detail.rb
+++ b/app/models/review_immunity_detail.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class ReviewImmunityDetail < ApplicationRecord
+  DECISIONS = %w[yes no].freeze
+
+  belongs_to :immunity_detail
+
+  with_options class_name: "User", optional: true do
+    belongs_to :assessor
+    belongs_to :reviewer
+  end
+
+  with_options presence: true do
+    validates :decision, :decision_reason
+    validates :summary, if: :decision_is_immune?
+  end
+
+  validates :decision, inclusion: { in: DECISIONS }
+
+  def decision_is_immune?
+    decision == "yes"
+  end
+end

--- a/db/migrate/20230418103900_add_review_immunity_details.rb
+++ b/db/migrate/20230418103900_add_review_immunity_details.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class AddReviewImmunityDetails < ActiveRecord::Migration[7.0]
+  def up
+    create_table :review_immunity_details do |t|
+      t.references :immunity_details
+      t.references :assessor, foreign_key: { to_table: :users }
+      t.references :reviewer, foreign_key: { to_table: :users }
+      t.string :decision
+      t.text :decision_reason
+      t.text :summary
+      t.boolean :accepted, default: false, null: false
+      t.text :reviewer_comment
+      t.datetime :reviewed_at
+
+      t.timestamps
+    end
+
+    remove_reference :immunity_details, :reviewer
+    remove_reference :immunity_details, :assessor
+    remove_column :immunity_details, :reviewed_at, :datetime
+  end
+
+  def down
+    drop_table :review_immunity_details if table_exists?(:review_immunity_details)
+
+    change_table :immunity_details, bulk: true do |t|
+      t.references :assessor, foreign_key: { to_table: :users }
+      t.references :reviewer, foreign_key: { to_table: :users }
+      t.datetime :reviewed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_103900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -203,12 +203,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "review_status", default: "review_not_started", null: false
-    t.bigint "assessor_id"
-    t.bigint "reviewer_id"
-    t.datetime "reviewed_at", precision: nil
-    t.index ["assessor_id"], name: "ix_immunity_details_on_assessor_id"
     t.index ["planning_application_id"], name: "ix_immunity_details_on_planning_application_id"
-    t.index ["reviewer_id"], name: "ix_immunity_details_on_reviewer_id"
   end
 
   create_table "local_authorities", force: :cascade do |t|
@@ -437,6 +432,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
     t.index ["user_id"], name: "index_document_change_requests_on_user_id"
   end
 
+  create_table "review_immunity_details", force: :cascade do |t|
+    t.bigint "immunity_details_id"
+    t.bigint "assessor_id"
+    t.bigint "reviewer_id"
+    t.string "decision"
+    t.text "decision_reason"
+    t.text "summary"
+    t.boolean "accepted", default: false, null: false
+    t.text "reviewer_comment"
+    t.datetime "reviewed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessor_id"], name: "ix_review_immunity_details_on_assessor_id"
+    t.index ["immunity_details_id"], name: "ix_review_immunity_details_on_immunity_details_id"
+    t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"
+  end
+
   create_table "review_policy_classes", force: :cascade do |t|
     t.bigint "policy_class_id", null: false
     t.integer "mark", null: false
@@ -499,8 +511,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "replacement_document_validation_requests"
   add_foreign_key "documents", "users"
-  add_foreign_key "immunity_details", "users", column: "assessor_id"
-  add_foreign_key "immunity_details", "users", column: "reviewer_id"
   add_foreign_key "notes", "planning_applications"
   add_foreign_key "notes", "users"
   add_foreign_key "other_change_validation_requests", "planning_applications"
@@ -517,6 +527,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_13_104701) do
   add_foreign_key "replacement_document_validation_requests", "documents", column: "old_document_id"
   add_foreign_key "replacement_document_validation_requests", "planning_applications"
   add_foreign_key "replacement_document_validation_requests", "users"
+  add_foreign_key "review_immunity_details", "users", column: "assessor_id"
+  add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "validation_requests", "planning_applications"
 end


### PR DESCRIPTION
### Description of change
Add ReviewImmunityDetails table

- Create immunity_detail has_many review_immunity_details association so we can capture any decision and reasons/comments made by both assessor and reviewer. We have a has_many relation so we can keep track of historical exchanges and display this in the frontend if an assessor needs to create a new decision and reason again.

