### PR TITLE
Limit PlanningData API queries to local-authority dataset

### DIFF
--- a/app/services/apis/planning_data/client.rb
+++ b/app/services/apis/planning_data/client.rb
@@ -9,7 +9,7 @@ module Apis
       TIMEOUT = 5
 
       def call(reference)
-        faraday.get("/entity.json?reference=#{reference}") do |request|
+        faraday.get("/entity.json?reference=#{reference}&dataset=local-authority") do |request|
           request.options[:timeout] = TIMEOUT
         end
       end

--- a/spec/support/api/planning_data_helpers.rb
+++ b/spec/support/api/planning_data_helpers.rb
@@ -4,7 +4,7 @@ module PlanningDataHelper
   BASE_URL = "https://www.planning.data.gov.uk"
 
   def stub_planning_data_api_request_for(reference)
-    stub_request(:get, "#{BASE_URL}/entity.json?reference=#{reference}")
+    stub_request(:get, "#{BASE_URL}/entity.json?reference=#{reference}&dataset=local-authority")
   end
 
   def planning_data_api_response(status, body = "LBH")


### PR DESCRIPTION
### Description of change

Different datasets can contain entities with the same reference; in particular BUC is local authority Buckinghamshire but also conservation area Buckland. The query will fail if more than one result is returned, and we know we only want local authorities anyway.
