### PR TITLE
Show immunity details on permitted developments rights pages

### DIFF
--- a/app/views/planning_application/permitted_development_rights/_immunity_details.erb
+++ b/app/views/planning_application/permitted_development_rights/_immunity_details.erb
@@ -1,0 +1,23 @@
+<section class="immunity-section govuk-!-margin-top-5">
+  <h2 class="govuk-heading-m">
+    Immunity from enforcement
+  </h2>
+
+  <p class="govuk-body">
+    <strong>Note: application may be immune from enforcement</strong>
+  </p>
+
+  <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Applicant information</h3>
+  <ul class="govuk-body immunity-details-sub-list">
+    <% @planning_application.immune_proposal_details.each do |proposal_detail| %>
+      <li>
+        <%= proposal_detail.question %> 
+        <% proposal_detail.response_values.each do |response_value| %>
+          <strong>
+            <%= response_value.to_time.nil? ? response_value : response_value.to_time.to_formatted_s(:day_month_year_slashes) %>
+          </strong>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/planning_application/permitted_development_rights/edit.html.erb
+++ b/app/views/planning_application/permitted_development_rights/edit.html.erb
@@ -18,6 +18,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "information" %>
 
+    <% if @planning_application.possibly_immune? %>
+      <%= render "immunity_details", planning_application: @planning_application %>
+    <% end %>
+
     <%= render "previous", permitted_development_rights: @permitted_development_rights %>
 
     <%= render "form", planning_application: @planning_application %>

--- a/app/views/planning_application/permitted_development_rights/new.html.erb
+++ b/app/views/planning_application/permitted_development_rights/new.html.erb
@@ -18,6 +18,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "information" %>
 
+    <% if @planning_application.possibly_immune? %>
+      <%= render "immunity_details", planning_application: @planning_application %>
+    <% end %>
+
     <%= render "previous", permitted_development_rights: @permitted_development_rights %>
 
     <%= render "form", planning_application: @planning_application %>

--- a/app/views/planning_application/permitted_development_rights/show.html.erb
+++ b/app/views/planning_application/permitted_development_rights/show.html.erb
@@ -18,6 +18,10 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "information" %>
 
+    <% if @planning_application.possibly_immune? %>
+      <%= render "immunity_details", planning_application: @planning_application %>
+    <% end %>
+
     <%= render "previous", permitted_development_rights: @permitted_development_rights %>
 
     <p class="govuk-body govuk-!-padding-top-5">

--- a/app/views/planning_application/review_permitted_development_rights/_immunity_details.erb
+++ b/app/views/planning_application/review_permitted_development_rights/_immunity_details.erb
@@ -1,0 +1,23 @@
+<section class="immunity-section govuk-!-margin-top-5">
+  <h2 class="govuk-heading-m">
+    Immunity from enforcement
+  </h2>
+
+  <p class="govuk-body">
+    <strong>Note: application may be immune from enforcement</strong>
+  </p>
+
+  <h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Applicant information</h3>
+  <ul class="govuk-body immunity-details-sub-list">
+    <% @planning_application.immune_proposal_details.each do |proposal_detail| %>
+      <li>
+        <%= proposal_detail.question %> 
+        <% proposal_detail.response_values.each do |response_value| %>
+          <strong>
+            <%= response_value.to_time.nil? ? response_value : response_value.to_time.to_formatted_s(:day_month_year_slashes) %>
+          </strong>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/planning_application/review_permitted_development_rights/edit.html.erb
+++ b/app/views/planning_application/review_permitted_development_rights/edit.html.erb
@@ -30,6 +30,10 @@
 
     <%= render "planning_history" %>
 
+    <% if @planning_application.possibly_immune? %>
+      <%= render "immunity_details", planning_application: @planning_application %>
+    <% end %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <%= render "planning_application/permitted_development_rights/previous", permitted_development_rights: @permitted_development_rights %>

--- a/app/views/planning_application/review_permitted_development_rights/show.html.erb
+++ b/app/views/planning_application/review_permitted_development_rights/show.html.erb
@@ -30,6 +30,10 @@
 
     <%= render "planning_history" %>
 
+    <% if @planning_application.possibly_immune? %>
+      <%= render "immunity_details", planning_application: @planning_application %>
+    <% end %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <%= render "planning_application/permitted_development_rights/previous", permitted_development_rights: @permitted_development_rights %>

--- a/spec/system/planning_applications/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/permitted_development_right_spec.rb
@@ -327,6 +327,8 @@ RSpec.describe "Permitted development right" do
     end
 
     context "when planning application may be immune" do
+      let!(:planning_application) { create(:planning_application, :from_planx_immunity, :in_assessment, local_authority: default_local_authority) }
+
       it "I can view the information on the permitted development rights page" do
         create(:immunity_detail, planning_application:)
 
@@ -353,18 +355,12 @@ RSpec.describe "Permitted development right" do
         expect(page).to have_content("Application number: #{planning_application.reference}")
         expect(page).to have_content(planning_application.full_address)
 
-        within(".govuk-warning-text") do
-          expect(page).to have_content("This information will be made publicly available.")
-        end
-
-        within("#constraints-section") do
-          expect(page).to have_content("Constraints - including Article 4 direction(s)")
-          expect(page).to have_content("There are no planning constraints on the application site.")
-        end
-
-        within("#planning-history-section") do
-          expect(page).to have_content("Planning history")
-        end
+        expect(page).to have_content("Immunity from enforcement")
+        expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
+        expect(page).to have_content("Have the works been completed? Yes")
+        expect(page).to have_content("When were the works completed? 01/02/2015")
+        expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
+        expect(page).to have_content("Has enforcement action been taken about these changes? No")
       end
     end
   end
@@ -589,6 +585,8 @@ RSpec.describe "Permitted development right" do
     end
 
     context "when planning application may be immune" do
+      let!(:planning_application) { create(:planning_application, :from_planx_immunity, :awaiting_determination, local_authority: default_local_authority) }
+
       it "I can view the information on the review permitted development rights page" do
         create(:immunity_detail, planning_application:)
 
@@ -614,15 +612,12 @@ RSpec.describe "Permitted development right" do
         expect(page).to have_content("Application number: #{planning_application.reference}")
         expect(page).to have_content(planning_application.full_address)
 
-        expect(page).to have_content("Constraints and history")
-
-        within("#constraints-section") do
-          expect(page).to have_content("Constraints")
-        end
-
-        within("#planning-history-section") do
-          expect(page).to have_content("Historical information related to the property or to adjoining properties")
-        end
+        expect(page).to have_content("Immunity from enforcement")
+        expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
+        expect(page).to have_content("Have the works been completed? Yes")
+        expect(page).to have_content("When were the works completed? 01/02/2015")
+        expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
+        expect(page).to have_content("Has enforcement action been taken about these changes? No")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Show immunity details on the permitted development rights pages for assessors and reviewers

### Screenshots

![screencapture-southwark-southwark-localhost-3000-planning-applications-67-review-permitted-development-rights-9-edit-2023-04-21-13_37_59](https://user-images.githubusercontent.com/35098639/233638128-c5efb748-c3c7-495d-a659-c5c0b539b377.png)

