### PR TITLE
Add immunity detail answers to draft recommendations 

### DIFF
--- a/app/components/planning_applications/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment_report_component.html.erb
@@ -10,6 +10,12 @@
     <%= render(FormattedContentComponent.new(text: past_applications.additional_information)) %>
   </section>
 <% end %>
+<% if planning_application.possibly_immune? %>
+  <section id="immunity-section" class="govuk-!-padding-bottom-5">
+    <h3 class="govuk-heading-s"><%= t(".immunity_from_enforcement") %></h3>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: planning_application.immune_proposal_details)) %>
+  </section>
+<% end %>
 <% if permitted_development_right %>
   <section id="permitted-development-rights-section" class="govuk-!-padding-bottom-5">
     <h3 class="govuk-heading-s"><%= t(".have_the_permitted_development_rights") %></h3>

--- a/app/components/planning_applications/immunity_details_component.html.erb
+++ b/app/components/planning_applications/immunity_details_component.html.erb
@@ -1,6 +1,6 @@
-<h3 class="govuk-heading-s govuk-!-margin-top-5 govuk-!-margin-bottom-1">Applicant information</h3>
+<h3 class="govuk-heading-s govuk-!-margin-bottom-1 govuk-!-margin-top-5">Applicant information</h3>
 <ul class="govuk-body immunity-details-sub-list">
-  <% @planning_application.immune_proposal_details.each do |proposal_detail| %>
+  <% immunity_details.each do |proposal_detail| %>
     <li>
       <%= proposal_detail.question %> 
       <% proposal_detail.response_values.each do |response_value| %>

--- a/app/components/planning_applications/immunity_details_component.rb
+++ b/app/components/planning_applications/immunity_details_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  class ImmunityDetailsComponent < ViewComponent::Base
+    def initialize(immunity_details:)
+      @immunity_details = immunity_details
+    end
+
+    attr_reader :immunity_details
+  end
+end

--- a/app/views/planning_application/immunity_details/edit.html.erb
+++ b/app/views/planning_application/immunity_details/edit.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
     <%= render "form", planning_application: @planning_application %>
   </div>

--- a/app/views/planning_application/immunity_details/new.html.erb
+++ b/app/views/planning_application/immunity_details/new.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
     <%= render "form", planning_application: @planning_application %>
   </div>

--- a/app/views/planning_application/immunity_details/show.html.erb
+++ b/app/views/planning_application/immunity_details/show.html.erb
@@ -16,6 +16,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
+
+    <%#= render "applicant_answers", planning_application: @planning_application %>
   </div>
 </div>

--- a/app/views/planning_application/review_immunity_details/edit.html.erb
+++ b/app/views/planning_application/review_immunity_details/edit.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
     <%= render "form", editable: true %>
   </div>

--- a/app/views/planning_application/review_immunity_details/show.html.erb
+++ b/app/views/planning_application/review_immunity_details/show.html.erb
@@ -16,7 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
     <%= render "form", editable: false %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -610,6 +610,7 @@ en:
       consultation_documents: Consultation documents
       documents_included_in: Documents included in the decision notice
       have_the_permitted_development_rights: Have the permitted development rights relevant for this application been removed?
+      immunity_from_enforcement: Immunity from enforcement
       legislation: Legislation
       location_description: Location description
       no_documents_listed: There are no documents listed on the decision notice.


### PR DESCRIPTION
### Description of change

- Show applicant answers to immunity on draft recommendation page for assessors
- Small refactor to turn it into a component

### Screenshots

![screencapture-southwark-southwark-localhost-3000-planning-applications-65-recommendations-new-2023-04-21-15_54_58](https://user-images.githubusercontent.com/35098639/233667874-88dc670e-cbcc-4295-b312-2bc3db51b0f5.png)
