### PR TITLE
Add document evidence to immunity page

### DIFF
--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -1,0 +1,81 @@
+<div class="govuk-accordion" data-module="govuk-accordion">
+  <%= form_with model: [@planning_application, @planning_application.immunity_detail],
+        local: true,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        class: "govuk-!-margin-top-7",
+        id: "immunity-detail-evidence-groups" do |form| %>
+    <% sections.each_with_index do |section, index| %>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h3 class="govuk-accordion__section-heading">
+            <button type="button" class="govuk-accordion__section-button" id="accordion-default-heading-<%= "#{section}" %>">
+              <%= section.tag.humanize.pluralize %> (<%= section.documents.count %>)<br>
+              <%= section.start_date&.to_formatted_s(:day_month_year_slashes) %> to <%= section.end_date&.to_formatted_s(:day_month_year_slashes) %>
+            </button>
+            <span class="govuk-accordion__icon"></span>
+          </h3>
+        </div>
+        <div class="govuk-accordion__section-content">
+          <%= form.fields_for :evidence_groups, section do |ff| %>
+
+            <%= ff.govuk_date_field :start_date, legend: { text: "Starts from" } %>
+
+            <%= ff.govuk_date_field :end_date, legend: { text: "Runs until" } %>
+
+            <%= ff.govuk_check_boxes_fieldset :missing_evidence, multiple: false, legend: nil do %>
+              <%= ff.govuk_check_box :missing_evidence, 1, 0, multiple: false, label: { text: "Missing evidence (gap in time)" } do %>
+                <%= ff.govuk_text_field(
+                  :missing_evidence_entry, 
+                  label: { text: "List all the gap(s) in time" }
+                ) %>
+                <%= link_to(
+                  "Request a new document",
+                  new_planning_application_additional_document_validation_request_path(@planning_application),
+                  role: "button",
+                  class: "govuk-link govuk-!-margin-top-3",
+                  data: { module: "govuk-button" }
+                ) %>
+              <% end %>
+            <% end %>
+
+            <p class="govuk-body">
+              <strong>Applicant comment:</strong>
+              <%= section.applicant_comment %>
+            </p>
+
+            <% section.documents.each do |document| %>
+              <%= render(
+                EvidenceGroups::DocumentsComponent.new(
+                  documents: section.documents
+                )
+              ) %>
+            <% end %>
+            <hr>
+            <% section.comments.each do |comment| %>
+              <p><%= comment.text %></p>
+            <% end %>
+
+            <div class="govuk-form-group govuk-!-margin-bottom-2">
+              <%= label_tag(
+                "immunity-detail-evidence-groups-attributes-#{index}-comments-attributes-0-text",
+                "Add comment",
+                class: "govuk-label govuk-label--s"
+              ) %>
+              <%= text_area_tag(
+                "immunity_detail[evidence_groups_attributes][#{index}][comments_attributes][0][text]",
+                "",
+                id: "immunity-detail-evidence-groups-attributes-#{index}-comments-attributes-0-text",
+                class: "govuk-textarea govuk-!-margin-bottom-2",
+                rows: 1
+              ) %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<%= form_with model: [@planning_application, @planning_application.immunity_detail] do |form| %>
+  <%= render(partial: "shared/submit_buttons", locals: { form: form, id: "immunity-detail-evidence-groups" }) %>
+<% end %>

--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -10,7 +10,11 @@
           <h3 class="govuk-accordion__section-heading">
             <button type="button" class="govuk-accordion__section-button" id="accordion-default-heading-<%= "#{section}" %>">
               <%= section.tag.humanize.pluralize %> (<%= section.documents.count %>)<br>
-              <%= section.start_date&.to_formatted_s(:day_month_year_slashes) %> to <%= section.end_date&.to_formatted_s(:day_month_year_slashes) %>
+              <% if section.start_date.present? && section.end_date.present? %>
+                <%= section.start_date&.to_formatted_s(:day_month_year_slashes) %> to <%= section.end_date&.to_formatted_s(:day_month_year_slashes) %>
+              <% else %>
+                <%= section.start_date&.to_formatted_s(:day_month_year_slashes) %>
+              <% end %>
             </button>
             <span class="govuk-accordion__icon"></span>
           </h3>
@@ -32,7 +36,7 @@
                   "Request a new document",
                   new_planning_application_additional_document_validation_request_path(@planning_application),
                   role: "button",
-                  class: "govuk-link govuk-!-margin-top-3",
+                  class: "govuk-link govuk-!-margin-top-",
                   data: { module: "govuk-button" }
                 ) %>
               <% end %>
@@ -43,13 +47,12 @@
               <%= section.applicant_comment %>
             </p>
 
-            <% section.documents.each do |document| %>
-              <%= render(
-                EvidenceGroups::DocumentsComponent.new(
-                  documents: section.documents
-                )
-              ) %>
-            <% end %>
+            <%= render(
+              EvidenceGroups::DocumentsComponent.new(
+                documents: section.documents
+              )
+            ) %>
+
             <hr>
             <% section.comments.each do |comment| %>
               <p><%= comment.text %></p>

--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -85,5 +85,19 @@
 </div>
 
 <%= form_with model: [@planning_application, @planning_application.immunity_detail] do |form| %>
-  <%= render(partial: "shared/submit_buttons", locals: { form: form, id: "immunity-detail-evidence-groups" }) %>
+  <div class="govuk-button-group">
+    <%= form.submit(
+      t("form_actions.save_and_mark_as_complete"),
+      class: "govuk-button",
+      data: { module: "govuk-button" },
+      form: "immunity-detail-evidence-groups"
+    ) %>
+    <%= form.submit(
+      t("form_actions.save_and_come_back_later"),
+      class: "govuk-button govuk-button--secondary",
+      data: { module: "govuk-button" },
+      form: "immunity-detail-evidence-groups"
+    ) %>
+    <%= back_link %>
+  </div>
 <% end %>

--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -21,24 +21,29 @@
         </div>
         <div class="govuk-accordion__section-content">
           <%= form.fields_for :evidence_groups, section do |ff| %>
+            <% if section.start_date.present? %>
+              <%= ff.govuk_date_field :start_date, legend: { text: "Starts from" } %>
+            <% end %>
 
-            <%= ff.govuk_date_field :start_date, legend: { text: "Starts from" } %>
+            <% if section.end_date.present? %>
+              <%= ff.govuk_date_field :end_date, legend: { text: "Runs until" } %>
+            <% end %>
 
-            <%= ff.govuk_date_field :end_date, legend: { text: "Runs until" } %>
-
-            <%= ff.govuk_check_boxes_fieldset :missing_evidence, multiple: false, legend: nil do %>
-              <%= ff.govuk_check_box :missing_evidence, 1, 0, multiple: false, label: { text: "Missing evidence (gap in time)" } do %>
-                <%= ff.govuk_text_field(
-                  :missing_evidence_entry, 
-                  label: { text: "List all the gap(s) in time" }
-                ) %>
-                <%= link_to(
-                  "Request a new document",
-                  new_planning_application_additional_document_validation_request_path(@planning_application),
-                  role: "button",
-                  class: "govuk-link govuk-!-margin-top-",
-                  data: { module: "govuk-button" }
-                ) %>
+            <% if section.end_date.present? || section.start_date.present? %>
+              <%= ff.govuk_check_boxes_fieldset :missing_evidence, multiple: false, legend: nil do %>
+                <%= ff.govuk_check_box :missing_evidence, 1, 0, multiple: false, label: { text: "Missing evidence (gap in time)" } do %>
+                  <%= ff.govuk_text_field(
+                    :missing_evidence_entry, 
+                    label: { text: "List all the gap(s) in time" }
+                  ) %>
+                  <%= link_to(
+                    "Request a new document",
+                    new_planning_application_additional_document_validation_request_path(@planning_application),
+                    role: "button",
+                    class: "govuk-link govuk-!-margin-top-",
+                    data: { module: "govuk-button" }
+                  ) %>
+                <% end %>
               <% end %>
             <% end %>
 

--- a/app/components/evidence_groups/accordion_component.rb
+++ b/app/components/evidence_groups/accordion_component.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module EvidenceGroups
+  class AccordionComponent < ViewComponent::Base
+    def initialize(planning_application:, sections: default_sections)
+      @planning_application = planning_application
+      @sections = sections
+    end
+
+    private
+
+    attr_reader :planning_application, :sections
+  end
+end

--- a/app/components/evidence_groups/accordion_component.rb
+++ b/app/components/evidence_groups/accordion_component.rb
@@ -2,6 +2,8 @@
 
 module EvidenceGroups
   class AccordionComponent < ViewComponent::Base
+    include ApplicationHelper
+
     def initialize(planning_application:, sections: default_sections)
       @planning_application = planning_application
       @sections = sections

--- a/app/components/evidence_groups/documents_component.html.erb
+++ b/app/components/evidence_groups/documents_component.html.erb
@@ -1,0 +1,26 @@
+<div class="govuk-!-padding-left-2 govuk-!-padding-right-2">
+  <div class="scroll-docs">
+    <% documents.each do |document| %>
+      <hr>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body govuk-!-margin-bottom-1">
+            <strong>Document reference: <%= document.numbers %></strong>
+          </p>
+          <p class="govuk-body">
+            File name: <%= document.name %>
+          </p>
+          <p class="govuk-body">
+            Date received: <%= document.received_at_or_created %>
+          </p>
+        </div>
+        <div class="govuk-grid-column-one-third govuk-!-margin-bottom-6">
+          <%= link_to "View document", url_for_document(document), target: :_new %><br>
+          <%= link_to "Edit", edit_planning_application_document_path(document.planning_application, document), class: "govuk-link" %><br>
+          <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
+          <%= link_to "Request replacement", new_planning_application_replacement_document_validation_request_path(planning_application_id: document.planning_application.id, document: document), class: "govuk-link" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/components/evidence_groups/documents_component.html.erb
+++ b/app/components/evidence_groups/documents_component.html.erb
@@ -7,7 +7,7 @@
           <p class="govuk-body govuk-!-margin-bottom-1">
             <strong>Document reference: <%= document.numbers %></strong>
           </p>
-          <p class="govuk-body">
+          <p class="govuk-body govuk-!-margin-bottom-1">
             File name: <%= document.name %>
           </p>
           <p class="govuk-body">

--- a/app/components/evidence_groups/documents_component.rb
+++ b/app/components/evidence_groups/documents_component.rb
@@ -8,7 +8,7 @@ module EvidenceGroups
 
     attr_reader :documents
 
-    private 
+    private
 
     def url_for_document(document)
       if document.published?

--- a/app/components/evidence_groups/documents_component.rb
+++ b/app/components/evidence_groups/documents_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module EvidenceGroups
+  class DocumentsComponent < AccordionSections::BaseComponent
+    def initialize(documents:)
+      @documents = documents
+    end
+
+    attr_reader :documents
+
+    private 
+
+    def url_for_document(document)
+      if document.published?
+        api_v1_planning_application_document_url(document.planning_application, document)
+      else
+        rails_blob_url(document.file)
+      end
+    end
+  end
+end

--- a/app/controllers/planning_application/immunity_details_controller.rb
+++ b/app/controllers/planning_application/immunity_details_controller.rb
@@ -62,8 +62,18 @@ class PlanningApplication
 
     def immunity_details_params
       params.require(:immunity_detail)
-        .permit(evidence_groups_attributes: [:id, :start_date, :end_date, :missing_evidence, :missing_evidence_entry, { comments_attributes: [:text] }])
-        .merge(status:)
+            .permit(
+              evidence_groups_attributes:
+                [
+                  :id,
+                  :start_date,
+                  :end_date,
+                  :missing_evidence,
+                  :missing_evidence_entry,
+                  { comments_attributes: [:text] }
+                ]
+            )
+            .merge(status:)
     end
 
     def status

--- a/app/controllers/planning_application/immunity_details_controller.rb
+++ b/app/controllers/planning_application/immunity_details_controller.rb
@@ -29,7 +29,7 @@ class PlanningApplication
 
     def update
       respond_to do |format|
-        if @immunity_detail.update!(immunity_details_params)
+        if @immunity_detail.update(immunity_details_params)
           format.html do
             redirect_to planning_application_assessment_tasks_path(@planning_application),
                         notice: I18n.t("assessment_details.immunity_detail_successfully_updated")

--- a/app/controllers/planning_application/immunity_details_controller.rb
+++ b/app/controllers/planning_application/immunity_details_controller.rb
@@ -29,7 +29,7 @@ class PlanningApplication
 
     def update
       respond_to do |format|
-        if @immunity_detail.update(immunity_details_params)
+        if @immunity_detail.update!(immunity_details_params)
           format.html do
             redirect_to planning_application_assessment_tasks_path(@planning_application),
                         notice: I18n.t("assessment_details.immunity_detail_successfully_updated")
@@ -61,7 +61,9 @@ class PlanningApplication
     end
 
     def immunity_details_params
-      params.permit.merge(status:)
+      params.require(:immunity_detail)
+        .permit(evidence_groups_attributes: [:id, :start_date, :end_date, :missing_evidence, :missing_evidence_entry, { comments_attributes: [:text] }])
+        .merge(status:)
     end
 
     def status

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -58,39 +58,39 @@ class Document < ApplicationRecord
 
   ## Needs to be better
   EVIDENCE_QUESTIONS = {
-    "utility_bill": [
-    "What do these utility bills show?",
-    "What date do these utility bills start from?",
-    "What date do these utility bills run until?"
+    utility_bill: [
+      "What do these utility bills show?",
+      "What date do these utility bills start from?",
+      "What date do these utility bills run until?"
     ],
-    "photograph": ["What do these photographs show?"],
-    "building_control_certificate": [
+    photograph: ["What do these photographs show?"],
+    building_control_certificate: [
       "When was this building control certificate issued?",
       "What do these building control certificates show?"
     ],
-    "construction_invoice": ["What do these construction invoices show?"],
-    "council_task_document": [
+    construction_invoice: ["What do these construction invoices show?"],
+    council_task_document: [
       "What date do these council tax bills start from?",
       "When do these councils tax bills run until?",
       "What do these Council Tax documents show?"
     ],
-    "tenancy_agreement": [
+    tenancy_agreement: [
       "What date do these tenancy agreements start from?",
       "When do these tenancy agreements run until?",
       "What do these tenancy agreements show?"
     ],
-    "tenancy_invoice": [
+    tenancy_invoice: [
       "What date do these tenancy invoices start from?",
       "When do these tenancy invoices run until?",
       "What do these tenancy invoices show?"
     ],
-    "bank_statement": [
+    bank_statement: [
       "What date do these bank statements start from?",
       "When do these bank statements run until?",
       "What do these bank statements show?"
     ],
-    "other": ["What do these documents show?"] 
-  }
+    other: ["What do these documents show?"]
+  }.freeze
 
   TAGS = PLAN_TAGS + EVIDENCE_TAGS
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -56,11 +56,40 @@ class Document < ApplicationRecord
     "Other"
   ].freeze
 
+  ## Needs to be better
   EVIDENCE_QUESTIONS = {
     "utility_bill": [
     "What do these utility bills show?",
     "What date do these utility bills start from?",
-    "What date do these utility bills run until?"]
+    "What date do these utility bills run until?"
+    ],
+    "photograph": ["What do these photographs show?"],
+    "building_control_certificate": [
+      "When was this building control certificate issued?",
+      "What do these building control certificates show?"
+    ],
+    "construction_invoice": ["What do these construction invoices show?"],
+    "council_task_document": [
+      "What date do these council tax bills start from?",
+      "When do these councils tax bills run until?",
+      "What do these Council Tax documents show?"
+    ],
+    "tenancy_agreement": [
+      "What date do these tenancy agreements start from?",
+      "When do these tenancy agreements run until?",
+      "What do these tenancy agreements show?"
+    ],
+    "tenancy_invoice": [
+      "What date do these tenancy invoices start from?",
+      "When do these tenancy invoices run until?",
+      "What do these tenancy invoices show?"
+    ],
+    "bank_statement": [
+      "What date do these bank statements start from?",
+      "When do these bank statements run until?",
+      "What do these bank statements show?"
+    ],
+    "other": ["What do these documents show?"] 
   }
 
   TAGS = PLAN_TAGS + EVIDENCE_TAGS

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -56,6 +56,13 @@ class Document < ApplicationRecord
     "Other"
   ].freeze
 
+  EVIDENCE_QUESTIONS = {
+    "utility_bill": [
+    "What do these utility bills show?",
+    "What date do these utility bills start from?",
+    "What date do these utility bills run until?"]
+  }
+
   TAGS = PLAN_TAGS + EVIDENCE_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze

--- a/app/models/evidence_group.rb
+++ b/app/models/evidence_group.rb
@@ -5,6 +5,11 @@ class EvidenceGroup < ApplicationRecord
   has_many :documents, dependent: :destroy
   has_many :comments, as: :commentable, dependent: :destroy
 
+  accepts_nested_attributes_for(
+    :comments,
+    reject_if: :reject_comment?
+  )
+
   enum tag: {
     photograph: 0,
     utility_bill: 1,
@@ -17,4 +22,23 @@ class EvidenceGroup < ApplicationRecord
     statutory_declaration: 8,
     other: 9
   }
+
+  def comment
+    last_comment unless last_comment&.deleted?
+  end
+
+
+  private
+
+  def last_comment
+    @last_comment ||= persisted_comments.last
+  end
+
+  def reject_comment?(attributes)
+    attributes[:text] == ""
+  end
+
+  def persisted_comments
+    comments.select(&:persisted?)
+  end
 end

--- a/app/models/evidence_group.rb
+++ b/app/models/evidence_group.rb
@@ -27,7 +27,6 @@ class EvidenceGroup < ApplicationRecord
     last_comment unless last_comment&.deleted?
   end
 
-
   private
 
   def last_comment

--- a/app/models/immunity_detail.rb
+++ b/app/models/immunity_detail.rb
@@ -3,8 +3,12 @@
 class ImmunityDetail < ApplicationRecord
   belongs_to :planning_application
   has_many :evidence_groups, dependent: :destroy
+  has_many :comments, as: :commentable, through: :evidence_groups, dependent: :destroy
 
   has_many :review_immunity_details, dependent: :destroy
+
+  accepts_nested_attributes_for :evidence_groups
+  accepts_nested_attributes_for :comments
 
   enum(
     status: {

--- a/app/services/immunity_details_creation_service.rb
+++ b/app/services/immunity_details_creation_service.rb
@@ -11,6 +11,7 @@ class ImmunityDetailsCreationService
       immunity_detail.end_date = application_end_date
       immunity_detail.save!
     end
+    create_evidence_groups
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
     Appsignal.send_error(e)
   end
@@ -21,5 +22,28 @@ class ImmunityDetailsCreationService
 
   def application_end_date
     @planning_application.find_proposal_detail("When were the works completed?").first.response_values.first
+  end
+
+  def create_evidence_groups
+    Document::EVIDENCE_TAGS.each do |tag|
+      next if @planning_application.documents.with_tag(tag).empty?
+
+      @planning_application.documents.with_tag(tag).each do |doc|
+        @planning_application.immunity_detail.add_document(doc)
+      end
+    end
+
+    @planning_application.immunity_detail.evidence_groups.each do |eg|
+      Document::EVIDENCE_QUESTIONS[eg.tag.to_sym].each do |question|
+        if question.include? "show"
+          eg.applicant_comment = @planning_application.find_proposal_detail(question).first.response_values.first
+        elsif (question.include?("start") || question.include?("issued"))
+          eg.start_date = @planning_application.find_proposal_detail(question).first.response_values.first
+        elsif question.include? "run"
+          eg.end_date = @planning_application.find_proposal_detail(question).first.response_values.first
+        end
+        eg.save
+      end
+    end
   end
 end

--- a/app/services/immunity_details_creation_service.rb
+++ b/app/services/immunity_details_creation_service.rb
@@ -12,6 +12,7 @@ class ImmunityDetailsCreationService
       immunity_detail.save!
     end
     create_evidence_groups
+    fill_in_evidence_group_information
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
     Appsignal.send_error(e)
   end
@@ -32,7 +33,9 @@ class ImmunityDetailsCreationService
         @planning_application.immunity_detail.add_document(doc)
       end
     end
+  end
 
+  def fill_in_evidence_group_information # rubocop:disable Metrics/AbcSize
     @planning_application.immunity_detail.evidence_groups.each do |eg|
       Document::EVIDENCE_QUESTIONS[eg.tag.to_sym].each do |question|
         case question

--- a/app/services/immunity_details_creation_service.rb
+++ b/app/services/immunity_details_creation_service.rb
@@ -35,14 +35,15 @@ class ImmunityDetailsCreationService
 
     @planning_application.immunity_detail.evidence_groups.each do |eg|
       Document::EVIDENCE_QUESTIONS[eg.tag.to_sym].each do |question|
-        if question.include? "show"
+        case question
+        when /show/
           eg.applicant_comment = @planning_application.find_proposal_detail(question).first.response_values.first
-        elsif (question.include?("start") || question.include?("issued"))
+        when /(start|issued)/
           eg.start_date = @planning_application.find_proposal_detail(question).first.response_values.first
-        elsif question.include? "run"
+        when /run/
           eg.end_date = @planning_application.find_proposal_detail(question).first.response_values.first
         end
-        eg.save
+        eg.save!
       end
     end
   end

--- a/app/views/planning_application/immunity_details/_form.html.erb
+++ b/app/views/planning_application/immunity_details/_form.html.erb
@@ -1,8 +1,0 @@
-<%= form_with model: [@planning_application, @immunity_detail],
-              local: true,
-              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-              class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-
-  <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
-<% end %>

--- a/app/views/planning_application/immunity_details/edit.html.erb
+++ b/app/views/planning_application/immunity_details/edit.html.erb
@@ -18,6 +18,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
-    <%= render "form", planning_application: @planning_application %>
+    <%= render(
+      EvidenceGroups::AccordionComponent.new(
+        planning_application: @planning_application,
+        sections: @planning_application.immunity_detail.evidence_groups
+      )
+    ) %>
   </div>
 </div>

--- a/app/views/planning_application/immunity_details/new.html.erb
+++ b/app/views/planning_application/immunity_details/new.html.erb
@@ -18,6 +18,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
-    <%= render "form", planning_application: @planning_application %>
+    <%= render(
+      EvidenceGroups::AccordionComponent.new(
+        planning_application: @planning_application,
+        sections: @planning_application.immunity_detail.evidence_groups
+      )
+    ) %>
   </div>
 </div>

--- a/app/views/planning_application/immunity_details/show.html.erb
+++ b/app/views/planning_application/immunity_details/show.html.erb
@@ -18,6 +18,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(PlanningApplications::ImmunityDetailsComponent.new(immunity_details: @planning_application.immune_proposal_details)) %>
 
-    <%#= render "applicant_answers", planning_application: @planning_application %>
+    <%= render(
+      EvidenceGroups::AccordionComponent.new(
+        planning_application: @planning_application,
+        sections: @planning_application.immunity_detail.evidence_groups
+      )
+    ) %>
   </div>
 </div>

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-button-group">
-  <% if local_assigns.fetch(:id, nil) %>
+  <% if local_assigns.fetch(:id) %>
     <%= form.submit(
       t("form_actions.save_and_mark_as_complete"),
       class: "govuk-button",

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -3,13 +3,15 @@
     t("form_actions.save_and_mark_as_complete"),
     class: "govuk-button",
     data: { module: "govuk-button" },
-    disabled: local_assigns.fetch(:disabled, false)
+    disabled: local_assigns.fetch(:disabled, false),
+    form: id
   ) %>
   <%= form.submit(
     t("form_actions.save_and_come_back_later"),
     class: "govuk-button govuk-button--secondary",
     data: { module: "govuk-button" },
-    disabled: local_assigns.fetch(:disabled, false)
+    disabled: local_assigns.fetch(:disabled, false),
+    form: id
   ) %>
   <%= back_link %>
 </div>

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-button-group">
-  <% if id %>
+  <% if local_assigns.fetch(:id, nil) %>
     <%= form.submit(
       t("form_actions.save_and_mark_as_complete"),
       class: "govuk-button",
@@ -15,7 +15,7 @@
       form: id
     ) %>
   <% else %>
-     <%= form.submit(
+    <%= form.submit(
       t("form_actions.save_and_mark_as_complete"),
       class: "govuk-button",
       data: { module: "govuk-button" },
@@ -25,8 +25,7 @@
       t("form_actions.save_and_come_back_later"),
       class: "govuk-button govuk-button--secondary",
       data: { module: "govuk-button" },
-      disabled: local_assigns.fetch(:disabled, false),
-      form: id
+      disabled: local_assigns.fetch(:disabled, false)
     ) %>
   <% end %>
   <%= back_link %>

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -1,32 +1,15 @@
 <div class="govuk-button-group">
-  <% if local_assigns.fetch(:id) %>
-    <%= form.submit(
-      t("form_actions.save_and_mark_as_complete"),
-      class: "govuk-button",
-      data: { module: "govuk-button" },
-      disabled: local_assigns.fetch(:disabled, false),
-      form: id
-    ) %>
-    <%= form.submit(
-      t("form_actions.save_and_come_back_later"),
-      class: "govuk-button govuk-button--secondary",
-      data: { module: "govuk-button" },
-      disabled: local_assigns.fetch(:disabled, false),
-      form: id
-    ) %>
-  <% else %>
-    <%= form.submit(
-      t("form_actions.save_and_mark_as_complete"),
-      class: "govuk-button",
-      data: { module: "govuk-button" },
-      disabled: local_assigns.fetch(:disabled, false)
-    ) %>
-    <%= form.submit(
-      t("form_actions.save_and_come_back_later"),
-      class: "govuk-button govuk-button--secondary",
-      data: { module: "govuk-button" },
-      disabled: local_assigns.fetch(:disabled, false)
-    ) %>
-  <% end %>
+  <%= form.submit(
+    t("form_actions.save_and_mark_as_complete"),
+    class: "govuk-button",
+    data: { module: "govuk-button" },
+    disabled: local_assigns.fetch(:disabled, false)
+  ) %>
+  <%= form.submit(
+    t("form_actions.save_and_come_back_later"),
+    class: "govuk-button govuk-button--secondary",
+    data: { module: "govuk-button" },
+    disabled: local_assigns.fetch(:disabled, false)
+  ) %>
   <%= back_link %>
 </div>

--- a/app/views/shared/_submit_buttons.html.erb
+++ b/app/views/shared/_submit_buttons.html.erb
@@ -1,17 +1,33 @@
 <div class="govuk-button-group">
-  <%= form.submit(
-    t("form_actions.save_and_mark_as_complete"),
-    class: "govuk-button",
-    data: { module: "govuk-button" },
-    disabled: local_assigns.fetch(:disabled, false),
-    form: id
-  ) %>
-  <%= form.submit(
-    t("form_actions.save_and_come_back_later"),
-    class: "govuk-button govuk-button--secondary",
-    data: { module: "govuk-button" },
-    disabled: local_assigns.fetch(:disabled, false),
-    form: id
-  ) %>
+  <% if id %>
+    <%= form.submit(
+      t("form_actions.save_and_mark_as_complete"),
+      class: "govuk-button",
+      data: { module: "govuk-button" },
+      disabled: local_assigns.fetch(:disabled, false),
+      form: id
+    ) %>
+    <%= form.submit(
+      t("form_actions.save_and_come_back_later"),
+      class: "govuk-button govuk-button--secondary",
+      data: { module: "govuk-button" },
+      disabled: local_assigns.fetch(:disabled, false),
+      form: id
+    ) %>
+  <% else %>
+     <%= form.submit(
+      t("form_actions.save_and_mark_as_complete"),
+      class: "govuk-button",
+      data: { module: "govuk-button" },
+      disabled: local_assigns.fetch(:disabled, false)
+    ) %>
+    <%= form.submit(
+      t("form_actions.save_and_come_back_later"),
+      class: "govuk-button govuk-button--secondary",
+      data: { module: "govuk-button" },
+      disabled: local_assigns.fetch(:disabled, false),
+      form: id
+    ) %>
+  <% end %>
   <%= back_link %>
 </div>

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -37,4 +37,8 @@ FactoryBot.define do
   trait :public do
     publishable { true }
   end
+
+  trait :evidence do
+    tags { ["Proposed", "Utility Bill"] }
+  end
 end

--- a/spec/factories/evidence_groups.rb
+++ b/spec/factories/evidence_groups.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :evidence_group do
+    immunity_detail
+    start_date { 6.years.ago }
+    end_date { 4.years.ago }
+    tag { "utility_bill" }
+    applicant_comment { "This is my proof" }
+
+    trait :with_document do
+      after :create do |evidence_group|
+        create(:document, :evidence, evidence_group:)
+      end
+    end
+  end
+end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -350,6 +350,51 @@ FactoryBot.define do
           },
           {
             responses: [{
+              value: "that it was certified"
+            }],
+            metadata: {
+              portal_name: "certificate-of-lawfulness-documents-immunity"
+            },
+            question: "What do these building control certificates show?"
+          },
+          {
+            responses: [{
+              value: "2016-02-01"
+            }],
+            metadata: {
+              portal_name: "certificate-of-lawfulness-documents-immunity"
+            },
+            question: "When was this building control certificate issued?"
+          },
+          {
+            responses: [{
+              value: "2013-03-02"
+            }],
+            metadata: {
+              portal_name: "certificate-of-lawfulness-documents-immunity"
+            },
+            question: "What date do these utility bills start from?"
+          },
+          {
+            responses: [{
+              value: "2019-04-01"
+            }],
+            metadata: {
+              portal_name: "certificate-of-lawfulness-documents-immunity"
+            },
+            question: "What date do these utility bills run until?"
+          },
+          {
+            responses: [{
+              value: "That i was paying water bills"
+            }],
+            metadata: {
+              portal_name: "certificate-of-lawfulness-documents-immunity"
+            },
+            question: "What do these utility bills show?"
+          },
+          {
+            responses: [{
               value: "2015-02-01"
             }],
             metadata: {

--- a/spec/fixtures/files/planx_params_immunity.json
+++ b/spec/fixtures/files/planx_params_immunity.json
@@ -50,7 +50,7 @@
 			"metadata": {
 				"portal_name": "_root",
 				"policy_refs": [{
-					"text": "Town and Country Planning Act 1990, Part 7, Section 191 & Section 192"
+					"text": "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192"
 				}]
 			},
 			"question": "What are you applying about?"
@@ -867,6 +867,51 @@
 		},
 		{
 			"responses": [{
+				"value": "2013-03-02"
+			}],
+			"metadata": {
+				"portal_name": "certificate-of-lawfulness-documents-immunity"
+			},
+			"question": "What date do these utility bills start from?"
+		},
+    {
+			"responses": [{
+				"value": "2019-04-01"
+			}],
+			"metadata": {
+				"portal_name": "certificate-of-lawfulness-documents-immunity"
+			},
+			"question": "What date do these utility bills run until?"
+		},
+    {
+			"responses": [{
+				"value": "That i was paying water bills"
+			}],
+			"metadata": {
+				"portal_name": "certificate-of-lawfulness-documents-immunity"
+			},
+			"question": "What do these utility bills show?"
+		},
+    {
+			"responses": [{
+				"value": "2016-02-01"
+			}],
+			"metadata": {
+				"portal_name": "certificate-of-lawfulness-documents-immunity"
+			},
+			"question": "When was this building control certificate issued?"
+		},
+    {
+			"responses": [{
+				"value": "that it was certified"
+			}],
+			"metadata": {
+				"portal_name": "certificate-of-lawfulness-documents-immunity"
+			},
+			"question": "What do these building control certificates show?"
+		},
+		{
+			"responses": [{
 				"value": "No"
 			}],
 			"metadata": {
@@ -881,12 +926,25 @@
 		"protected_trees": false
 	},
 	"files": [{
-		"filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
-		"applicant_description": "This is the side plan",
-		"tags": [
-			"Side"
-		]
-	}],
+			"filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+			"tags": [
+				"Utility Bill"
+			]
+		},
+		{
+			"filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+			"tags": [
+				"Utility Bill"
+			]
+		}
+,
+		{
+			"filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+			"tags": [
+				"Building Control Certificate"
+			]
+		}
+	],
 	"boundary_geojson": {
 		"type": "Feature",
 		"geometry": {

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -16,4 +16,8 @@ module SystemSpecHelpers
   def find_checkbox_by_id(id)
     find(".govuk-checkboxes__item ##{id}")
   end
+
+  def open_accordion_section
+    find(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']")
+  end
 end

--- a/spec/system/planning_applications/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/evidence_of_immunity_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe "Evidence of immunity" do
     create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
   end
 
+  let(:evidence_group1) { create(:evidence_group, :with_document, tag: "utility_bill", immunity_detail: planning_application.immunity_detail) }
+  let(:evidence_group2) { create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail) }
+
   before do
     sign_in assessor
     visit planning_application_path(planning_application)
@@ -52,11 +55,41 @@ RSpec.describe "Evidence of immunity" do
         expect(page).to have_content("When were the works completed? 01/02/2015")
         expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
         expect(page).to have_content("Has enforcement action been taken about these changes? No")
+
+        click_button "Utility bills (1)"
+
+        within(open_accordion_section) do
+          within_fieldset("Starts from") do
+            expect(page).to have_field("Day", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%-d"))
+            expect(page).to have_field("Month", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%-m"))
+            expect(page).to have_field("Year", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%Y"))
+          end
+
+          within_fieldset("Runs until") do
+            expect(page).to have_field("Day", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%-d"))
+            expect(page).to have_field("Month", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%-m"))
+            expect(page).to have_field("Year", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%Y"))
+          end
+
+          expect(page).to have_content("This is my proof")
+
+          expect(page).to have_content(planning_application.immunity_detail.evidence_groups.first.documents.first.numbers)
+        end
       end
 
       it "I can save and come back later when adding or editing the immunity evidence" do
         click_link "Check and assess"
         click_link "Evidence of immunity"
+
+        click_button "Utility bills (1)"
+
+        within(open_accordion_section) do
+          within_fieldset("Runs until") do
+            fill_in "Day", with: "03"
+            fill_in "Month", with: "12"
+            fill_in "Year", with: "2021"
+          end
+        end
 
         click_button "Save and come back later"
 
@@ -69,13 +102,13 @@ RSpec.describe "Evidence of immunity" do
 
         click_link("Evidence of immunity")
 
-        click_button "Save and come back later"
-        expect(page).to have_content("Evidence of immunity successfully updated")
-
-        expect(page).to have_list_item_for(
-          "Evidence of immunity",
-          with: "In progress"
-        )
+        within(open_accordion_section) do
+          within_fieldset("Runs until") do
+            expect(page).to have_field("Day", with: "3")
+            expect(page).to have_field("Month", with: "12")
+            expect(page).to have_field("Year", with: "2021")
+          end
+        end
 
         click_link("Application")
 
@@ -86,6 +119,22 @@ RSpec.describe "Evidence of immunity" do
         click_link "Check and assess"
         click_link "Evidence of immunity"
 
+        click_button "Utility bills (1)"
+
+        within(open_accordion_section) do
+          check "Missing evidence (gap in time)"
+          fill_in "List all the gap(s) in time", with: "May 2019"
+          fill_in "Add comment", with: "Not good enough"
+        end
+
+        click_button "Utility bills (1)"
+
+        click_button "Building control certificates (1)"
+
+        within(open_accordion_section) do
+          fill_in "Add comment", with: "This proves it"
+        end
+
         click_button "Save and mark as complete"
 
         expect(page).to have_content("Evidence of immunity successfully updated")
@@ -94,6 +143,23 @@ RSpec.describe "Evidence of immunity" do
           "Evidence of immunity",
           with: "Completed"
         )
+
+        click_link "Evidence of immunity"
+
+        click_button "Utility bills (1)"
+
+        within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
+          expect(page).to have_field("List all the gap(s) in time", with: "May 2019")
+          expect(page).to have_content("Not good enough")
+        end
+
+        click_button "Utility bills (1)"
+
+        click_button "Building control certificates (1)"
+
+        within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
+          expect(page).to have_content("This proves it")
+        end
       end
     end
   end

--- a/spec/system/planning_applications/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/evidence_of_immunity_spec.rb
@@ -11,16 +11,11 @@ RSpec.describe "Evidence of immunity" do
     create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
   end
 
-  let(:evidence_group1) { create(:evidence_group, :with_document, tag: "utility_bill", immunity_detail: planning_application.immunity_detail) }
-  let(:evidence_group2) { create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail) }
-
-  before do
-    sign_in assessor
-    visit planning_application_path(planning_application)
-  end
-
   context "when signed in as an assessor" do
     before do
+      create(:evidence_group, :with_document, tag: "utility_bill", immunity_detail: planning_application.immunity_detail)
+      create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
+
       sign_in assessor
       visit planning_application_path(planning_application)
     end
@@ -57,23 +52,24 @@ RSpec.describe "Evidence of immunity" do
         expect(page).to have_content("Has enforcement action been taken about these changes? No")
 
         click_button "Utility bills (1)"
+        utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
 
         within(open_accordion_section) do
           within_fieldset("Starts from") do
-            expect(page).to have_field("Day", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%-d"))
-            expect(page).to have_field("Month", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%-m"))
-            expect(page).to have_field("Year", with: planning_application.immunity_detail.evidence_groups.first.start_date.strftime("%Y"))
+            expect(page).to have_field("Day", with: utility_bill_group.start_date.strftime("%-d"))
+            expect(page).to have_field("Month", with: utility_bill_group.start_date.strftime("%-m"))
+            expect(page).to have_field("Year", with: utility_bill_group.start_date.strftime("%Y"))
           end
 
           within_fieldset("Runs until") do
-            expect(page).to have_field("Day", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%-d"))
-            expect(page).to have_field("Month", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%-m"))
-            expect(page).to have_field("Year", with: planning_application.immunity_detail.evidence_groups.first.end_date.strftime("%Y"))
+            expect(page).to have_field("Day", with: utility_bill_group.end_date.strftime("%-d"))
+            expect(page).to have_field("Month", with: utility_bill_group.end_date.strftime("%-m"))
+            expect(page).to have_field("Year", with: utility_bill_group.end_date.strftime("%Y"))
           end
 
           expect(page).to have_content("This is my proof")
 
-          expect(page).to have_content(planning_application.immunity_detail.evidence_groups.first.documents.first.numbers)
+          expect(page).to have_content(utility_bill_group.documents.first.numbers)
         end
       end
 
@@ -101,6 +97,8 @@ RSpec.describe "Evidence of immunity" do
         )
 
         click_link("Evidence of immunity")
+
+        click_button "Utility bills (1)"
 
         within(open_accordion_section) do
           within_fieldset("Runs until") do


### PR DESCRIPTION
### Description of change

Add accordion of document evidence to immunity page 

### Story Link

https://trello.com/c/LFI7E28g/1532-add-list-of-documents-to-evidence-of-immunity-page-assessment

### Screenshots
![screencapture-southwark-southwark-localhost-3000-planning-applications-65-immunity-details-1-edit-2023-04-24-15_39_49](https://user-images.githubusercontent.com/35098639/234030561-29edcc69-9160-47b4-8b77-07ec26a0f813.png)
