### PR TITLE
Allow assessor to make a decision whether an application is immune from enforcement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Metrics/BlockLength:
     - spec/**/*
     - config/routes.rb
 
+Metrics/ClassLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Max: 20
 

--- a/app/controllers/planning_application/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_application/permitted_development_rights_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PlanningApplication
-  class PermittedDevelopmentRightsController < AuthenticationController # rubocop:disable Metrics/ClassLength
+  class PermittedDevelopmentRightsController < AuthenticationController
     include CommitMatchable
     include PlanningApplicationAssessable
     include PermittedDevelopmentRights

--- a/app/javascript/controllers/show_hide_controller.js
+++ b/app/javascript/controllers/show_hide_controller.js
@@ -1,11 +1,30 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["toggleable"]
+  static targets = ["toggleable", "toggleableWhenNo", "toggleableWhenYes"]
 
   handleEvent(_event) {
     this.toggleableTargets.forEach((element) => {
       element.classList.toggle("display-none")
+    })
+  }
+
+  handleEventForDecision(_event) {
+    const selectedDecisionHtml = document.querySelector(
+      'input[name="review_immunity_detail_permitted_development_right_form[review_immunity_detail][decision]"]:checked',
+    )
+    let selectedDecisionValue = selectedDecisionHtml.value
+    let oppositeValue = "Yes"
+
+    if (selectedDecisionValue === "Yes") {
+      oppositeValue = "No"
+    }
+
+    this[`toggleableWhen${selectedDecisionValue}Targets`].forEach((element) => {
+      element.classList.remove("display-none")
+    })
+    this[`toggleableWhen${oppositeValue}Targets`].forEach((element) => {
+      element.classList.add("display-none")
     })
   }
 }

--- a/app/models/review_immunity_detail.rb
+++ b/app/models/review_immunity_detail.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReviewImmunityDetail < ApplicationRecord
-  DECISIONS = %w[yes no].freeze
+  DECISIONS = %w[Yes No].freeze
 
   belongs_to :immunity_detail
 
@@ -18,6 +18,6 @@ class ReviewImmunityDetail < ApplicationRecord
   validates :decision, inclusion: { in: DECISIONS }
 
   def decision_is_immune?
-    decision == "yes"
+    decision == "Yes"
   end
 end

--- a/app/models/review_immunity_detail_permitted_development_right_form.rb
+++ b/app/models/review_immunity_detail_permitted_development_right_form.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+class ReviewImmunityDetailPermittedDevelopmentRightForm
+  include ActiveModel::Model
+  include CommitMatchable
+
+  attr_accessor :planning_application, :params
+
+  with_options presence: true do
+    validates :decision, :decision_reason
+    validates :summary, if: :decision_is_yes?
+    validates :removed_reason, if: :removed
+  end
+
+  validates :removed, inclusion: { in: [true, false], if: :decision_is_no? }
+
+  delegate(
+    :decision,
+    :decision_reason,
+    :decision_type,
+    :summary,
+    to: :review_immunity_detail
+  )
+
+  delegate(
+    :removed,
+    :removed_reason,
+    to: :permitted_development_right
+  )
+
+  def initialize(planning_application:, params: {})
+    @params = params
+    @review_immunity_detail_params = build_review_immunity_detail_params
+    @permitted_development_right_params = params[:permitted_development_right]
+
+    @review_immunity_detail = planning_application.immunity_detail.review_immunity_details.new(
+      review_immunity_detail_params
+    )
+    @permitted_development_right = planning_application.permitted_development_rights.new(
+      @permitted_development_right_params
+    )
+  end
+
+  def save
+    build_review_immunity_detail
+    build_permitted_development_right
+
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      review_immunity_detail.save!
+      permitted_development_right.save! if decision_is_no?
+
+      true
+    end
+  end
+
+  private
+
+  attr_reader :review_immunity_detail_params, :permitted_development_right_params,
+              :review_immunity_detail, :permitted_development_right
+
+  def decision_is_yes?
+    review_immunity_detail_params["decision"] == "Yes"
+  end
+
+  def decision_is_no?
+    review_immunity_detail_params["decision"] == "No"
+  end
+
+  def build_review_immunity_detail_params
+    return if params.blank?
+
+    review_immunity_detail_params = params[:review_immunity_detail]
+    review_immunity_detail_params["decision_reason"] = (review_immunity_detail_params["yes_decision_reason"].presence ||
+      review_immunity_detail_params["no_decision_reason"].presence)
+
+    review_immunity_detail_params.except("yes_decision_reason", "no_decision_reason")
+  end
+
+  def build_review_immunity_detail
+    review_immunity_detail.tap do |record|
+      record.assessor = Current.user
+      record.decision_reason = (decision_reason.presence || decision_type)
+    end
+  end
+
+  def build_permitted_development_right
+    return unless decision_is_no?
+
+    permitted_development_right.tap do |record|
+      record.assessor = Current.user
+      record.status = permitted_development_right_status
+    end
+  end
+
+  def permitted_development_right_status
+    return "in_progress" if save_progress?
+
+    case permitted_development_right_params[:removed]
+    when "true"
+      "removed"
+    when "false"
+      "checked"
+    end
+  end
+end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class PlanningApplicationCreationService # rubocop:disable Metrics/ClassLength
+class PlanningApplicationCreationService
   class CreateError < StandardError; end
 
   def initialize(planning_application: nil, **options)

--- a/app/views/planning_application/permitted_development_rights/_planning_history.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_planning_history.html.erb
@@ -1,4 +1,4 @@
-<section id="planning-history-section">
+<section id="planning-history-section" class="govuk-!-margin-bottom-7">
   <h2 class="govuk-heading-m govuk-!-margin-top-5">
     Planning history
   </h2>

--- a/app/views/planning_application/permitted_development_rights/_review_immunity_detail_form.html.erb
+++ b/app/views/planning_application/permitted_development_rights/_review_immunity_detail_form.html.erb
@@ -1,0 +1,101 @@
+<%= form_with(
+  model: @form, 
+  local: true,
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  url: planning_application_permitted_development_rights_path(@planning_application)
+  ) do |form| %>
+    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+    <div class="govuk-form-group <%= form.object.errors.any? ? 'govuk-form-group--error' : '' %>">
+      <%= form.fields_for :review_immunity_detail do |review_immunity_detail| %>
+        <%= review_immunity_detail.govuk_radio_buttons_fieldset(
+          :decision,
+          legend: { text: "Is the application immune from enforcement?", size: "s" },
+        ) do %>
+
+          <div data-controller="show-hide">
+            <div id="review-immunity-detail-section">
+              <%= review_immunity_detail.govuk_radio_button(
+                :decision, "Yes", 
+                label: { text: "Yes" },
+                link_errors: true,
+                data: {
+                  action: "change->show-hide#handleEventForDecision",
+                  show_hide_target: "toggleable"
+                }
+              ) do %>
+
+                <%= form.govuk_radio_buttons_fieldset(:decision_type, legend: nil) do %>
+                  <%= review_immunity_detail.govuk_radio_button(
+                    :decision_type, I18n.t("review_immunity_detail_permitted_development_right_form.four_years_substantial"), label: { text: I18n.t("review_immunity_detail_permitted_development_right_form.four_years_substantial") }, link_errors: true
+                  ) %>
+                  <%= review_immunity_detail.govuk_radio_button(
+                    :decision_type, I18n.t("review_immunity_detail_permitted_development_right_form.four_years_unauthorised"), label: { text: I18n.t("review_immunity_detail_permitted_development_right_form.four_years_unauthorised") }
+                  ) %>
+                  <%= review_immunity_detail.govuk_radio_button(
+                    :decision_type, I18n.t("review_immunity_detail_permitted_development_right_form.ten_years_other_breach"), label: { text: I18n.t("review_immunity_detail_permitted_development_right_form.ten_years_other_breach") }
+                  ) %>
+                  <%= review_immunity_detail.govuk_radio_button(
+                    :decision_type, I18n.t("review_immunity_detail_permitted_development_right_form.other"), label: { text: I18n.t("review_immunity_detail_permitted_development_right_form.other") }, link_errors: true
+                  ) do %>
+                    <%= review_immunity_detail.govuk_text_area :yes_decision_reason, label: { text: "Please provide a reason" }, link_errors: true %>
+                  <% end %>
+                <% end %>
+              <% end %>
+
+              <%= review_immunity_detail.govuk_radio_button(
+                :decision, "No", 
+                label: { text: "No" },
+                data: {
+                  action: "change->show-hide#handleEventForDecision",
+                  show_hide_target: "toggleableWhenNo"
+                },
+                link_errors: true
+              ) do %>
+                <%= review_immunity_detail.govuk_text_area(
+                  :no_decision_reason, rows: 6, label: { text: "Describe why the application is not immune from enforcement", link_errors: true }
+                ) %>
+              <% end %>
+
+              <div data-show-hide-target="toggleableWhenYes" class="display-none">
+                <%= review_immunity_detail.govuk_text_area(
+                  :summary, 
+                  rows: 6, 
+                  label: { text: "Immunity from enforcement summary", class: "govuk-label govuk-label--s" },
+                  hint: { text: "Refer to the evidences and history provided" }
+                ) %>
+              </div>
+            </div>
+
+            <div data-show-hide-target="toggleableWhenNo" class="display-none" id="permitted-development-right-section">  
+              <h3 class="govuk-heading-m govuk-!-padding-top-4">
+                Permitted development rights
+              </h3>
+
+              <%= form.fields_for :permitted_development_right do |permitted_development_right| %>
+                <%= permitted_development_right.govuk_radio_buttons_fieldset(
+                  :removed,
+                  legend: { text: "Have the permitted development rights relevant for this application been removed?", size: "s" }
+                ) do %>
+
+                  <%= permitted_development_right.govuk_radio_button(
+                    :removed, true, label: { text: "Yes" }
+                  ) do %>
+                    <%= permitted_development_right.govuk_text_area(
+                      :removed_reason, rows: 6, label: { text: "Describe how permitted development rights have been removed" }
+                    ) %>
+                  <% end %>
+
+                  <%= permitted_development_right.govuk_radio_button(
+                    :removed, false, label: { text: "No" }
+                  ) %>
+                <% end %>
+              <% end %>
+            </div>
+          <% end %>
+
+        <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/planning_application/permitted_development_rights/new.html.erb
+++ b/app/views/planning_application/permitted_development_rights/new.html.erb
@@ -24,6 +24,10 @@
 
     <%= render "previous", permitted_development_rights: @permitted_development_rights %>
 
-    <%= render "form", planning_application: @planning_application %>
+    <% if @planning_application.possibly_immune? %>
+      <%= render "review_immunity_detail_form", planning_application: @planning_application %>
+    <% else %>
+      <%= render "form", planning_application: @planning_application %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,6 +100,18 @@ en:
               blank: Please select Yes or No
             public_comment:
               blank: Please state the reasons why this application is, or is not lawful
+        review_immunity_detail_permitted_development_right_form:
+          attributes:
+            decision:
+              blank: Please select Yes or No for whether the application is immune from enforcement
+            decision_reason:
+              blank: Decision reason for why the application is immune can't be blank
+            removed:
+              inclusion: Please select Yes or No for the permitted development rights
+            removed_reason:
+              blank: Removed reason for the permitted development rights can't be blank
+            summary:
+              blank: Immunity from enforcement summary can't be blank
   activerecord:
     errors:
       models:
@@ -806,6 +818,11 @@ en:
       success: Replacement document validation request successfully created.
     update:
       success: Replacement document reason successfully updated.
+  review_immunity_detail_permitted_development_right_form:
+    four_years_substantial: no action is taken within 4 years of substantial completion for a breach of planning control consisting of operational development
+    four_years_unauthorised: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse
+    other: other
+    ten_years_other_breach: no action is taken within 10 years for any other breach of planning control (essentially other changes of use)
   review_policy_classes:
     navigation_component:
       view_next_class: View next class

--- a/db/migrate/20230421180115_add_decision_type_to_review_immunity_details.rb
+++ b/db/migrate/20230421180115_add_decision_type_to_review_immunity_details.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDecisionTypeToReviewImmunityDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :review_immunity_details, :decision_type, :string
+
+    change_column_null :review_immunity_details, :decision, false
+    change_column_null :review_immunity_details, :decision_reason, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_18_103900) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_21_180115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -436,14 +436,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_18_103900) do
     t.bigint "immunity_detail_id"
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
-    t.string "decision"
-    t.text "decision_reason"
+    t.string "decision", null: false
+    t.text "decision_reason", null: false
     t.text "summary"
     t.boolean "accepted", default: false, null: false
     t.text "reviewer_comment"
     t.datetime "reviewed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "decision_type"
     t.index ["assessor_id"], name: "ix_review_immunity_details_on_assessor_id"
     t.index ["immunity_detail_id"], name: "ix_review_immunity_details_on_immunity_detail_id"
     t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"

--- a/spec/system/planning_applications/review_immunity_detail_permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/review_immunity_detail_permitted_development_right_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Review immunity detail permitted development right" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let(:planning_application) do
+    create(:planning_application, :in_assessment, local_authority: default_local_authority)
+  end
+  let!(:immunity_detail) { create(:immunity_detail, planning_application:) }
+
+  before do
+    Capybara.ignore_hidden_elements = true
+    sign_in assessor
+    visit planning_application_path(planning_application)
+    click_link("Check and assess")
+    click_link("Immunity/permitted development rights")
+  end
+
+  after do
+    Capybara.ignore_hidden_elements = false
+  end
+
+  context "when there are validation errors" do
+    it "displays an error if an option for the decision has not been selected" do
+      click_button "Save and mark as complete"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("Please select Yes or No for whether the application is immune from enforcement")
+        expect(page).to have_content("Decision reason for why the application is immune can't be blank")
+      end
+    end
+
+    it "displays an error if no reason for a 'Yes' decision has been given" do
+      within("#review-immunity-detail-section") do
+        choose "Yes"
+      end
+      click_button "Save and mark as complete"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Decision reason for why the application is immune can't be blank")
+        expect(page).to have_content("Immunity from enforcement summary can't be blank")
+      end
+    end
+
+    it "displays an error if no reason or response to permitted development rights for a 'No' decision has been given" do
+      within("#review-immunity-detail-section") do
+        choose "No"
+      end
+      click_button "Save and mark as complete"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Decision reason for why the application is immune can't be blank")
+        expect(page).to have_content("Please select Yes or No for the permitted development rights")
+      end
+    end
+
+    it "displays an error if no reason for removing permitted development rights has been given" do
+      within("#review-immunity-detail-section") do
+        choose "No"
+      end
+      within("#permitted-development-right-section") do
+        choose "Yes"
+      end
+      click_button "Save and mark as complete"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Removed reason for the permitted development rights can't be blank")
+      end
+    end
+  end
+
+  context "when viewing the content" do
+    it "I see the relevant information" do
+      expect(page).to have_content("Immunity/permitted development rights")
+      expect(page).to have_css("#planning-application-details")
+      expect(page).to have_css("#constraints-section")
+      expect(page).to have_css("#planning-history-section")
+
+      expect(page).to have_content("Is the application immune from enforcement?")
+      # Does not show summary field until decision is chosen
+      expect(page).not_to have_content("Immunity from enforcement summary")
+
+      within("#review-immunity-detail-section") do
+        choose "Yes"
+        # Does not show permitted development rights section when decision is "Yes"
+        expect(page).not_to have_css("#permitted-development-right-section")
+      end
+
+      within("#review-immunity-detail-section") do
+        choose "No"
+        # Does not show summary field
+        expect(page).not_to have_content("Immunity from enforcement summary")
+      end
+    end
+  end
+
+  context "when the the application is immune from enforcement" do
+    it "I can choose 'Yes' and select a reason" do
+      within("#review-immunity-detail-section") do
+        choose "Yes"
+
+        within(".govuk-radios") do
+          expect(page).to have_content("no action is taken within 4 years of substantial completion for a breach of planning control consisting of operational development")
+          expect(page).to have_content("no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
+          expect(page).to have_content("no action is taken within 10 years for any other breach of planning control (essentially other changes of use)")
+
+          choose "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse"
+        end
+
+        fill_in "Immunity from enforcement summary", with: "A summary"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      expect(ReviewImmunityDetail.last).to have_attributes(
+        immunity_detail_id: immunity_detail.id,
+        assessor_id: assessor.id,
+        decision: "Yes",
+        decision_reason: "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse",
+        decision_type: "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse",
+        summary: "A summary"
+      )
+    end
+
+    it "I can choose 'Yes' and give an other reason" do
+      within("#review-immunity-detail-section") do
+        choose "Yes"
+
+        within(".govuk-radios") do
+          choose "other"
+          fill_in "Please provide a reason", with: "A reason for my decision"
+        end
+
+        fill_in "Immunity from enforcement summary", with: "A summary"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      expect(ReviewImmunityDetail.last).to have_attributes(
+        immunity_detail_id: immunity_detail.id,
+        assessor_id: assessor.id,
+        decision: "Yes",
+        decision_reason: "A reason for my decision",
+        decision_type: "other",
+        summary: "A summary"
+      )
+      expect(PermittedDevelopmentRight.all.length).to eq(0)
+    end
+
+    it "I choose 'Yes' after originally selecting 'No'" do
+      within("#review-immunity-detail-section") do
+        choose "No"
+
+        fill_in "Describe why the application is not immune from enforcement", with: "Application is not immune"
+      end
+
+      within("#permitted-development-right-section") do
+        choose "Yes"
+
+        fill_in "Describe how permitted development rights have been removed", with: "A reason"
+      end
+
+      within("#review-immunity-detail-section") do
+        choose "Yes"
+
+        within(".govuk-radios") do
+          choose "other"
+          fill_in "Please provide a reason", with: "A reason for my decision"
+        end
+
+        fill_in "Immunity from enforcement summary", with: "A summary"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      expect(ReviewImmunityDetail.all.length).to eq(1)
+      # No permitted development right response is created
+      expect(PermittedDevelopmentRight.all.length).to eq(0)
+    end
+
+    it "I can choose 'No' and respond to the permitted development rights" do
+      within("#review-immunity-detail-section") do
+        choose "No"
+
+        fill_in "Describe why the application is not immune from enforcement", with: "Application is not immune"
+      end
+
+      within("#permitted-development-right-section") do
+        choose "Yes"
+
+        fill_in "Describe how permitted development rights have been removed", with: "A reason"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully created")
+
+      expect(ReviewImmunityDetail.last).to have_attributes(
+        immunity_detail_id: immunity_detail.id,
+        assessor_id: assessor.id,
+        decision: "No",
+        decision_reason: "Application is not immune"
+      )
+      expect(PermittedDevelopmentRight.last).to have_attributes(
+        assessor_id: assessor.id,
+        removed: true,
+        removed_reason: "A reason",
+        status: "removed"
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Allow assessor to make a decision whether an application is immune from enforcement

- If decision is "Yes" then a decision reason and summary must be provided but no permitted development right response is required
- If decision is "No" then only a reason is required but the assessor must respond also to the permitted development rights

### Story Link

https://trello.com/c/DOzhSrrk/1543-allow-assessor-to-decide-whether-application-is-immune-or-not

### Screenshots

![Screenshot 2023-04-24 at 17 38 26](https://user-images.githubusercontent.com/34001723/234064683-46c65cd0-0a84-40af-9f9c-9ed0bd3e678b.png)
![Screenshot 2023-04-24 at 17 39 02](https://user-images.githubusercontent.com/34001723/234064687-b9ab9bd8-45e7-41d4-9850-814b54fffa15.png)
![Screenshot 2023-04-24 at 17 58 03](https://user-images.githubusercontent.com/34001723/234065216-e6044b24-8783-4806-8fd3-8753d3f23c96.png)


### Decisions [OPTIONAL]

The way this has been implemented is a bit unideal: 

- This feature probably should have split the update of review immunity detail and permitted development rights into two stages rather than using conditional form rendering (and JS to hide/display fields). I've created a form object to handle the updates to both models and tried to cover as best as possible with tests.
- If this becomes an issue, we can revisit this functionality and try to split the steps into two different forms which may be preferable.