### PR TITLE
Show previous comments for evidence groups

### DIFF
--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -62,9 +62,10 @@
             ) %>
 
             <hr>
-            <% section.comments.each do |comment| %>
-              <p><%= comment.text %></p>
-            <% end %>
+            <%= render(
+              partial: "shared/policy_classes/previous_comments",
+              locals: { previous_comments: section.persisted_comments }
+            ) %>
 
             <div class="govuk-form-group govuk-!-margin-bottom-2">
               <%= label_tag(

--- a/app/models/evidence_group.rb
+++ b/app/models/evidence_group.rb
@@ -27,6 +27,14 @@ class EvidenceGroup < ApplicationRecord
     last_comment unless last_comment&.deleted?
   end
 
+  def previous_comments
+    persisted_comments
+  end
+
+  def persisted_comments
+    comments.select(&:persisted?).sort_by(&:created_at)
+  end
+
   private
 
   def last_comment
@@ -35,9 +43,5 @@ class EvidenceGroup < ApplicationRecord
 
   def reject_comment?(attributes)
     attributes[:text] == ""
-  end
-
-  def persisted_comments
-    comments.select(&:persisted?)
   end
 end

--- a/spec/system/planning_applications/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/evidence_of_immunity_spec.rb
@@ -85,6 +85,8 @@ RSpec.describe "Evidence of immunity" do
             fill_in "Month", with: "12"
             fill_in "Year", with: "2021"
           end
+
+          fill_in "Add comment", with: "This is my comment"
         end
 
         click_button "Save and come back later"
@@ -106,6 +108,10 @@ RSpec.describe "Evidence of immunity" do
             expect(page).to have_field("Month", with: "12")
             expect(page).to have_field("Year", with: "2021")
           end
+
+          find("span", text: "Previous comments").click
+
+          expect(page).to have_content("This is my comment")
         end
 
         click_link("Application")
@@ -149,6 +155,8 @@ RSpec.describe "Evidence of immunity" do
         within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
           expect(page).to have_field("List all the gap(s) in time", with: "May 2019")
           expect(page).to have_css(".govuk-warning-text__icon")
+
+          find("span", text: "Previous comments").click
           expect(page).to have_content("Not good enough")
         end
 
@@ -157,6 +165,7 @@ RSpec.describe "Evidence of immunity" do
         click_button "Building control certificates (1)"
 
         within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
+          find("span", text: "Previous comments").click
           expect(page).to have_content("This proves it")
         end
       end


### PR DESCRIPTION
### Description of change

Show previous comments added to an evidence group on the Evidence of Immunity page

### Story Link

https://trello.com/c/cd20dBJY/1534-enable-officer-to-add-comment-on-immunity-evidence-page

### Screenshots
<img width="1004" alt="Screenshot 2023-04-26 at 15 02 32" src="https://user-images.githubusercontent.com/35098639/234600311-a4234bcb-ff15-41c0-b6af-8b85f831db59.png">

<img width="1068" alt="Screenshot 2023-04-26 at 15 02 36" src="https://user-images.githubusercontent.com/35098639/234600323-cc789803-be27-4138-8b5a-c816bb36505a.png">
