### PR TITLE
Don't show review evidence of immunity if table doesn't exist

### DIFF
--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -25,7 +25,7 @@
       Review assessment
     </h2>
     <ul class="app-task-list__items" id="review-assessment-section">
-      <% if @planning_application.possibly_immune? %>
+      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.any? %>
           <%= render(
             TaskListItems::ImmunityDetailsReviewComponent.new(
               planning_application: @planning_application


### PR DESCRIPTION
### Description of change

Page was erroring because the ReviewImmunityTable didn't exist. 

This follows the pattern of BoPS and doesn't show the link in the Review task list if the table doesn't exist