### PR TITLE
Add warning icon when there's missing evidence

### DIFF
--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -16,6 +16,9 @@
                 <%= section.start_date&.to_formatted_s(:day_month_year_slashes) %>
               <% end %>
             </button>
+            <% if section.missing_evidence? %>
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <% end %>
             <span class="govuk-accordion__icon"></span>
           </h3>
         </div>
@@ -33,7 +36,7 @@
               <%= ff.govuk_check_boxes_fieldset :missing_evidence, multiple: false, legend: nil do %>
                 <%= ff.govuk_check_box :missing_evidence, 1, 0, multiple: false, label: { text: "Missing evidence (gap in time)" } do %>
                   <%= ff.govuk_text_field(
-                    :missing_evidence_entry, 
+                    :missing_evidence_entry,
                     label: { text: "List all the gap(s) in time" }
                   ) %>
                   <%= link_to(

--- a/spec/system/planning_applications/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/evidence_of_immunity_spec.rb
@@ -148,6 +148,7 @@ RSpec.describe "Evidence of immunity" do
 
         within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
           expect(page).to have_field("List all the gap(s) in time", with: "May 2019")
+          expect(page).to have_css(".govuk-warning-text__icon")
           expect(page).to have_content("Not good enough")
         end
 


### PR DESCRIPTION
### Description of change

Add warning icon when there's missing evidence

### Story Link

https://trello.com/c/f9tpRXRV

### Screenshot

![Screenshot 2023-04-28 at 17 27 03](https://user-images.githubusercontent.com/7561969/235175172-dac4a819-9915-4536-8477-369581b6f67c.jpg)
