### PR TITLE
Allow more time to enter 2FA code

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,6 +10,7 @@ class UserMailer < ApplicationMailer
 
   def otp_mail(user)
     @otp = user.current_otp
+    @expiry_minutes = Devise.otp_allowed_drift / 60
     view_mail(NOTIFY_TEMPLATE_ID, subject: subject(:otp_mail), to: user.email)
   end
 end

--- a/app/views/user_mailer/otp_mail.text.erb
+++ b/app/views/user_mailer/otp_mail.text.erb
@@ -1,1 +1,3 @@
 <%= t(".otp_is_your", otp: @otp) %>
+
+<%= t(".otp_expires", expires: @expires_minutes) %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -36,4 +36,6 @@ Devise.setup do |config|
   config.reset_password_within = 6.hours
 
   config.sign_out_via = :delete
+
+  config.otp_allowed_drift = 300
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -933,6 +933,7 @@ en:
     officer_role: Case Officer
   user_mailer:
     otp_mail:
+      otp_expires: It will expire in %{expires} minutes.
       otp_is_your: "%{otp} is your Back Office Planning System verification code."
     update_notification_mail:
       bops_case_reference: BoPS case %{reference} has a new update.


### PR DESCRIPTION
### Description of change

The default appears to be 30 seconds which is fine for app-based OTPs but not SMS/email. See [the devise-two-factor readme](https://rubydoc.info/github/tinfoil/devise-two-factor/main#enabling-two-factor-authentication).

### Story Link

https://trello.com/c/rHOOadWg/1576-allow-more-time-to-enter-2fa-code-on-bops-sign-in

### Known issues

There is [separate logic about how often the code can be resent](https://github.com/unboxed/bops/blob/main/app/controllers/users/sessions_controller.rb#L61-L63), which is currently one minute. I'm not sure that needs to be changed — it's now less likely that people will be re-requesting it so quickly, but it won't do any harm.

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
