### PR TITLE
If recommendation is complete, don't disable form

### DIFF
--- a/app/views/policy_classes/_form_controls.html.erb
+++ b/app/views/policy_classes/_form_controls.html.erb
@@ -30,10 +30,14 @@
     <% end %>
   </div>
 <% end %>
+
+<% if planning_application.submit_recommendation_complete? %>
+  <%= back_link %>
+<% else %>
 <%= render(
   partial: "shared/submit_buttons",
   locals: {
-    form: form,
-    disabled: planning_application.submit_recommendation_complete?
+    form: form
   }
 ) %>
+<% end %>


### PR DESCRIPTION
### Description of change

Currently, if a recommendation has been marked as submitted, the form gets disabled. However this locks it into a weird unfixable state in some cases.

Instead, it should show a back button if it's been submitted, or submit buttons if it hasn't.

### Story Link

https://trello.com/c/5Evc1vqs/1578-bug-cant-edit-see-reviewer-comment-on-legislation-page

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
