### PR TITLE
Specify certain requests to not log

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "boot"
+require_relative "../lib/quiet_logger"
 
 require "rails"
 # Pick the frameworks you want:
@@ -46,5 +47,8 @@ module Bops
     config.action_mailer.preview_path = Rails.root.join("spec/mailer/previews")
 
     config.active_storage.variant_processor = :mini_magick
+
+    # Don't log certain requests that spam the log files
+    config.middleware.insert_before Rails::Rack::Logger, QuietLogger, paths: ["/healthcheck"]
   end
 end

--- a/lib/quiet_logger.rb
+++ b/lib/quiet_logger.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class QuietLogger
+  PATH_INFO = "PATH_INFO"
+
+  attr_reader :app, :options, :paths
+
+  def initialize(app, options = {})
+    @app = app
+    @options = options
+    @paths = Array(options[:paths])
+  end
+
+  def call(env)
+    if silence_request?(env)
+      logger.silence { app.call(env) }
+    else
+      app.call(env)
+    end
+  end
+
+  private
+
+  def silence_request?(env)
+    paths.any? { |path| path === env[PATH_INFO] } # rubocop:disable Style/CaseEquality
+  end
+
+  def logger
+    Rails.logger
+  end
+end


### PR DESCRIPTION
### Description of change

The CloudWatch logs fill up with ELB health checks whichmakes it much harder to find meaningful logs.

This middleware should silence logging these requests.

