### PR TITLE
Do not send receipt notice email when cloning a planning application

### DIFF
--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -13,6 +13,7 @@ class PlanningApplicationCreationService
       @params = ActionController::Parameters.new(JSON.parse(audit_log))
       @local_authority = planning_application.local_authority
       @api_user = planning_application.api_user
+      @send_email = false
     else
       options.each { |k, v| instance_variable_set("@#{k}", v) unless v.nil? }
     end
@@ -56,7 +57,7 @@ class PlanningApplicationCreationService
       end
     end
 
-    planning_application.send_receipt_notice_mail unless params[:send_email] == "false"
+    planning_application.send_receipt_notice_mail unless skip_email?
 
     planning_application
   rescue Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid,
@@ -137,5 +138,9 @@ class PlanningApplicationCreationService
 
   def permitted_prior_approval_type?
     params[:planx_debug_data][:passport][:data][:"application.type"] == ["pa.part1.classA"]
+  end
+
+  def skip_email?
+    params[:send_email] == "false" || @send_email == false
   end
 end

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -32,6 +32,9 @@ RSpec.describe "cloning a planning application" do
 
   context "when I am able to clone a planning application" do
     it "I am successfully redirected to the cloned planning application" do
+      # It does not send a receipt notice mail
+      expect(PlanningApplicationMailer).not_to receive(:receipt_notice_mail)
+
       accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
         click_link("Clone")
       end


### PR DESCRIPTION
### Description of change

Do not send receipt notice email when cloning a planning application

### Story Link

https://trello.com/c/Ljv714Kg/1574-cloned-cases-on-staging-sends-emails-to-original-applicant-agent-find-solution