### PR TITLE
Reduce duplication in deploy job

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -181,30 +181,11 @@ jobs:
           aws ecs describe-task-definition --task-definition bops-${{ matrix.service_type }}-${{ inputs.environment-name }} --query taskDefinition | \
           jq -r 'del(.compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .status, .registeredAt, .registeredBy)' > ${{ matrix.service_type }}.json
 
-      - name: Generate task definition for console
-        if: matrix.service_type == 'console'
-        id: task-def-console
+      - name: Generate task definition for ${{ inputs.environment-name }}
+        id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: console.json
-          container-name: bops
-          image: ${{ steps.ecr-image.outputs.uri }}
-
-      - name: Generate task definition for worker
-        if: matrix.service_type == 'worker'
-        id: task-def-worker
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: worker.json
-          container-name: bops
-          image: ${{ steps.ecr-image.outputs.uri }}
-
-      - name: Generate task definition for web
-        if: matrix.service_type == 'web'
-        id: task-def-web
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: web.json
+          task-definition: ${{ inputs.environment-name }}.json
           container-name: bops
           image: ${{ steps.ecr-image.outputs.uri }}
 
@@ -212,7 +193,7 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         if: matrix.service_type != 'web'
         with:
-          task-definition: ${{ steps[format('task-def-{0}', matrix.service_type)].outputs.task-definition }}
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: bops-${{ matrix.service_type }}-${{ inputs.environment-name }}
           cluster: bops-${{ inputs.environment-name }}
           wait-for-service-stability: true
@@ -221,7 +202,7 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         if: matrix.service_type == 'web'
         with:
-          task-definition: ${{ steps[format('task-def-{0}', matrix.service_type)].outputs.task-definition }}
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: bops-${{ matrix.service_type }}-${{ inputs.environment-name }}
           cluster: bops-${{ inputs.environment-name }}
           wait-for-service-stability: true

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -145,9 +145,13 @@ jobs:
     needs: [build-image, deploy-db-migrate-service]
     strategy:
       matrix:
-        service_type: ['console', 'worker']
+        service_type: ['console', 'worker', 'web']
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        if: matrix.service_type == 'web'
+
       - name: Get github commit sha
         id: github
         run: |
@@ -195,53 +199,8 @@ jobs:
           container-name: bops
           image: ${{ steps.ecr-image.outputs.uri }}
 
-      - name: Deploy ${{ matrix.service_type }}
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-        with:
-          task-definition: ${{ steps[format('task-def-{0}', matrix.service_type)].outputs.task-definition }}
-          service: bops-${{ matrix.service_type }}-${{ inputs.environment-name }}
-          cluster: bops-${{ inputs.environment-name }}
-          wait-for-service-stability: true
-
-  deploy-web-service:
-    name: Deploy web service to ${{ inputs.environment-name }}
-    runs-on: ubuntu-20.04
-    needs: [build-image, deploy-db-migrate-service, deploy-services]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Get github commit sha
-        id: github
-        run: |
-          echo "sha=$(echo ${GITHUB_SHA::7})" >>$GITHUB_OUTPUT
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/bops_github_deploy_${{ inputs.environment-name }}
-          aws-region: eu-west-2
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Get image URI
-        id: ecr-image
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: bops/${{ inputs.environment-name }}
-          IMAGE_TAG: ${{ steps.github.outputs.sha }}
-        run: |
-          echo "uri=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >>$GITHUB_OUTPUT
-
-      - name: Download task definition for web and strip unused properties
-        run: |
-          aws ecs describe-task-definition --task-definition bops-web-${{ inputs.environment-name }} --query taskDefinition | \
-          jq -r 'del(.compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .status, .registeredAt, .registeredBy)' > web.json
-
       - name: Generate task definition for web
+        if: matrix.service_type == 'web'
         id: task-def-web
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
@@ -249,11 +208,21 @@ jobs:
           container-name: bops
           image: ${{ steps.ecr-image.outputs.uri }}
 
+      - name: Deploy ${{ matrix.service_type }}
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        if: matrix.service_type != 'web'
+        with:
+          task-definition: ${{ steps[format('task-def-{0}', matrix.service_type)].outputs.task-definition }}
+          service: bops-${{ matrix.service_type }}-${{ inputs.environment-name }}
+          cluster: bops-${{ inputs.environment-name }}
+          wait-for-service-stability: true
+
       - name: Deploy web
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        if: matrix.service_type == 'web'
         with:
-          task-definition: ${{ steps.task-def-web.outputs.task-definition }}
-          service: bops-web-${{ inputs.environment-name }}
+          task-definition: ${{ steps[format('task-def-{0}', matrix.service_type)].outputs.task-definition }}
+          service: bops-${{ matrix.service_type }}-${{ inputs.environment-name }}
           cluster: bops-${{ inputs.environment-name }}
           wait-for-service-stability: true
           codedeploy-appspec: .aws/appspec.yml


### PR DESCRIPTION
### Description of change

The deploy-web job is almost identical to the deploy-services job, it should be possible to reduce duplication by including it in the matrix.

Additionally, the generation of task definitions is identical but for the service name. It's possible to use one step for this; the ID `task-def` will refer to the instance of the task within _this_ branch of the matrix, so it'll get the right one.

### Story Link

https://link-to-issue

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
