### PR TITLE
Add review type to review immunity detail

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,9 @@ RSpec/ContextWording:
     - with
     - without
 
+RSpec/LetSetup:
+  Enabled: false
+
 RSpec/MessageSpies:
   Enabled: false
 

--- a/app/components/planning_applications/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment_report_component.html.erb
@@ -10,7 +10,7 @@
     <%= render(FormattedContentComponent.new(text: past_applications.additional_information)) %>
   </section>
 <% end %>
-<% if planning_application.possibly_immune? && immunity_detail.current_review_immunity_detail %>
+<% if immunity_detail && review_immunity_detail = immunity_detail.current_enforcement_review_immunity_detail %>
   <section id="immunity-section">
     <%= render(
         PlanningApplications::ImmunityDetailsAssessmentComponent.new(planning_application: planning_application, evidence_groups: immunity_detail.evidence_groups)
@@ -18,10 +18,10 @@
     %>
     <p class="govuk-body"><strong>Is the application immune from enforcement?</strong></p>
     <p class="govuk-body">
-      <strong><%= immunity_detail.current_review_immunity_detail.decision %></strong><br>
-      <%= immunity_detail.current_review_immunity_detail.decision_reason %>
+      <strong><%= review_immunity_detail.decision %></strong><br>
+      <%= review_immunity_detail.decision_reason %>
     </p>
-    <p class="govuk-body"><%= immunity_detail.current_review_immunity_detail.summary %></p>
+    <p class="govuk-body"><%= review_immunity_detail.summary %></p>
   </section>
 <% end %>
 <% if permitted_development_right %>

--- a/app/components/task_list_items/assess_immunity_detail_permitted_development_right_component.rb
+++ b/app/components/task_list_items/assess_immunity_detail_permitted_development_right_component.rb
@@ -36,7 +36,7 @@ module TaskListItems
     end
 
     def status
-      if (review_immunity_detail = immunity_detail.current_review_immunity_detail)
+      if (review_immunity_detail = immunity_detail.current_enforcement_review_immunity_detail)
         review_immunity_detail.status.to_sym
       else
         :not_started

--- a/app/components/task_list_items/review_immunity_details_component.rb
+++ b/app/components/task_list_items/review_immunity_details_component.rb
@@ -17,11 +17,11 @@ module TaskListItems
     end
 
     def review_immunity_detail
-      immunity_detail.current_review_immunity_detail
+      immunity_detail.current_evidence_review_immunity_detail
     end
 
     def link_path
-      if immunity_detail.current_review_immunity_detail&.reviewed_at.present? &&
+      if immunity_detail.current_evidence_review_immunity_detail&.reviewed_at.present? &&
          immunity_detail.review_status == "review_complete"
         planning_application_review_immunity_detail_path(
           planning_application,

--- a/app/components/task_list_items/review_immunity_enforcement_component.rb
+++ b/app/components/task_list_items/review_immunity_enforcement_component.rb
@@ -17,7 +17,7 @@ module TaskListItems
     end
 
     def review_immunity_detail
-      immunity_detail.current_review_immunity_detail
+      immunity_detail.current_enforcement_review_immunity_detail
     end
 
     def link_path

--- a/app/controllers/planning_application/assess_immunity_detail_permitted_development_rights_controller.rb
+++ b/app/controllers/planning_application/assess_immunity_detail_permitted_development_rights_controller.rb
@@ -113,11 +113,12 @@ class PlanningApplication
     end
 
     def set_review_immunity_details
-      @review_immunity_details = @planning_application.immunity_detail.review_immunity_details.reviewer_not_accepted
+      @review_immunity_details =
+        @planning_application.immunity_detail.review_immunity_details.enforcement.reviewer_not_accepted
     end
 
     def set_review_immunity_detail
-      @review_immunity_detail = @planning_application.immunity_detail.current_review_immunity_detail
+      @review_immunity_detail = @planning_application.immunity_detail.current_enforcement_review_immunity_detail
     end
 
     def review_immunity_detail_status

--- a/app/controllers/planning_application/review_immunity_details_controller.rb
+++ b/app/controllers/planning_application/review_immunity_details_controller.rb
@@ -65,7 +65,7 @@ class PlanningApplication
     end
 
     def set_review_immunity_detail
-      @review_immunity_detail = @immunity_detail.current_review_immunity_detail
+      @review_immunity_detail = @immunity_detail.current_evidence_review_immunity_detail
     end
 
     def immunity_detail_status

--- a/app/controllers/planning_application/review_immunity_enforcements_controller.rb
+++ b/app/controllers/planning_application/review_immunity_enforcements_controller.rb
@@ -47,7 +47,7 @@ class PlanningApplication
     end
 
     def set_review_immunity_detail
-      @review_immunity_detail = @planning_application.immunity_detail.current_review_immunity_detail
+      @review_immunity_detail = @planning_application.immunity_detail.current_enforcement_review_immunity_detail
     end
 
     def status

--- a/app/views/planning_application/immunity_details/_previous.html.erb
+++ b/app/views/planning_application/immunity_details/_previous.html.erb
@@ -1,4 +1,4 @@
-<% if @immunity_detail.review_immunity_details.any? { |review_immunity_detail| review_immunity_detail.reviewer_comment.present? } %>
+<% if @immunity_detail.review_immunity_details.evidence.any? { |review_immunity_detail| review_immunity_detail.reviewer_comment.present? } %>
   <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
     <summary class="govuk-details__summary">
       <span class="govuk-details__summary-text">
@@ -6,7 +6,7 @@
       </span>
     </summary>
     <div class="govuk-details__text">
-      <% @immunity_detail.review_immunity_details.not_accepted.each do |review_immunity_detail| %>
+      <% @immunity_detail.review_immunity_details.evidence.not_accepted.each do |review_immunity_detail| %>
         <p><strong><%= review_immunity_detail.reviewer.name %> marked this for review</strong></p>
         <p><%= review_immunity_detail.reviewed_at %></p>
         <p><em>Reviewer comment: <%= review_immunity_detail.reviewer_comment %></em></p>

--- a/db/migrate/20230517102459_add_review_type_and_remove_not_null_constraints_on_review_immunity_details.rb
+++ b/db/migrate/20230517102459_add_review_type_and_remove_not_null_constraints_on_review_immunity_details.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class AddReviewTypeAndRemoveNotNullConstraintsOnReviewImmunityDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_column :review_immunity_details, :review_type, :string, default: "enforcement"
+
+    change_column_null :review_immunity_details, :decision, true
+    change_column_null :review_immunity_details, :decision_reason, true
+
+    up_only do
+      ReviewImmunityDetail.find_each do |review_immunity_detail|
+        review_immunity_detail.update(review_type: "enforcement")
+      end
+    end
+
+    change_column_null :review_immunity_details, :review_type, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_12_103706) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_17_102459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -436,8 +436,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_103706) do
     t.bigint "immunity_detail_id"
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
-    t.string "decision", null: false
-    t.text "decision_reason", null: false
+    t.string "decision"
+    t.text "decision_reason"
     t.text "summary"
     t.boolean "accepted", default: false, null: false
     t.text "reviewer_comment"
@@ -449,6 +449,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_12_103706) do
     t.boolean "removed"
     t.boolean "reviewer_edited", default: false, null: false
     t.string "review_status", default: "review_not_started", null: false
+    t.string "review_type", default: "enforcement", null: false
     t.index ["assessor_id"], name: "ix_review_immunity_details_on_assessor_id"
     t.index ["immunity_detail_id"], name: "ix_review_immunity_details_on_immunity_detail_id"
     t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"

--- a/spec/components/task_list_items/review_immunity_details_component_spec.rb
+++ b/spec/components/task_list_items/review_immunity_details_component_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe TaskListItems::ReviewImmunityDetailsComponent, type: :component d
   let!(:review_immunity_detail) do
     create(
       :review_immunity_detail,
+      :evidence,
       immunity_detail:,
       reviewed_at: 1.day.ago
     )

--- a/spec/factories/review_immunity_detail.rb
+++ b/spec/factories/review_immunity_detail.rb
@@ -10,5 +10,9 @@ FactoryBot.define do
     trait :accepted do
       accepted { true }
     end
+
+    trait :evidence do
+      review_type { "evidence" }
+    end
   end
 end

--- a/spec/models/immunity_detail_spec.rb
+++ b/spec/models/immunity_detail_spec.rb
@@ -19,6 +19,37 @@ RSpec.describe ImmunityDetail do
     end
   end
 
+  describe "callbacks" do
+    describe "::after_update #create_evidence_review_immunity_detail" do
+      let!(:planning_application) do
+        create(:planning_application, :not_started)
+      end
+      let!(:immunity_detail) do
+        create(:immunity_detail, planning_application:)
+      end
+
+      context "when there is already an evidence review immunity detail record pending review" do
+        before do
+          create(:review_immunity_detail, :evidence, immunity_detail:)
+        end
+
+        it "does not create a new evidence review immunity detail record" do
+          expect do
+            immunity_detail.update(end_date: Time.zone.now)
+          end.not_to change(ReviewImmunityDetail, :count)
+        end
+      end
+
+      context "when there is no existing evidence review immunity detail" do
+        it "creates a new evidence review immunity detail record" do
+          expect do
+            immunity_detail.update(end_date: Time.zone.now)
+          end.to change(ReviewImmunityDetail, :count).by(1)
+        end
+      end
+    end
+  end
+
   describe "#add_document" do
     let(:immunity_detail) { create(:immunity_detail) }
     let(:document) { create(:document, tags: ["Council Tax Document"]) }

--- a/spec/models/review_immunity_detail_spec.rb
+++ b/spec/models/review_immunity_detail_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ReviewImmunityDetail do
 
     describe "#decision" do
       it "validates presence for decision" do
-        expect { review_immunity_detail.valid? }.to change { review_immunity_detail.errors[:decision] }.to ["can't be blank", "is not included in the list"]
+        expect { review_immunity_detail.valid? }.to change { review_immunity_detail.errors[:decision] }.to ["can't be blank"]
       end
 
       it "validates inclusion in list ['Yes', 'No']" do

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -20,4 +20,8 @@ module SystemSpecHelpers
   def open_accordion_section
     find(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']")
   end
+
+  def expand_span_item(text)
+    find("span", text:).click
+  end
 end

--- a/spec/system/planning_applications/immunity_spec.rb
+++ b/spec/system/planning_applications/immunity_spec.rb
@@ -2,9 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe "Validating the application" do
+RSpec.describe "Immunity" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
   context "when not immune" do
     before do
@@ -42,6 +43,175 @@ RSpec.describe "Validating the application" do
 
     it "mentions immunity in the page header" do
       expect(page).to have_content("may be immune from enforcement")
+    end
+  end
+
+  context "when there is both an assessment and review for the immunity of an application" do
+    let(:planning_application) do
+      create(:planning_application, :in_assessment, local_authority: default_local_authority)
+    end
+
+    let!(:immunity_detail) { create(:immunity_detail, planning_application:) }
+
+    before do
+      create(:evidence_group, :with_document, tag: "utility_bill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: planning_application.immunity_detail)
+
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    it "shows the assessment and review stages for immunity" do
+      click_link("Check and assess")
+      expect(page).to have_content("Note: application may be immune from enforcement")
+
+      click_link("Evidence of immunity")
+      click_button "Utility bills (1)"
+
+      within(open_accordion_section) do
+        check "Missing evidence (gap in time)"
+        fill_in "List all the gap(s) in time", with: "May 2020"
+        fill_in "Add comment", with: "Not good enough"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Evidence of immunity successfully updated")
+
+      click_link("Immunity/permitted development rights")
+
+      within("#assess-immunity-detail-section") do
+        choose "Yes"
+
+        within(".govuk-radios") do
+          choose "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse"
+        end
+
+        fill_in "Immunity from enforcement summary", with: "A summary"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Immunity/permitted development rights response was successfully created")
+
+      click_link "Make draft recommendation"
+      choose "Yes"
+      fill_in "State the reasons why this application is, or is not lawful.", with: "A public comment"
+      fill_in "Provide supporting information for your manager.", with: "A private comment"
+      click_button "Save and mark as complete"
+
+      click_on("Review and submit recommendation")
+      click_on("Submit recommendation")
+
+      sign_in(reviewer)
+      visit planning_application_path(planning_application)
+      click_link "Review and sign-off"
+
+      click_link "Review evidence of immunity"
+      click_button "Utility bills (1)"
+
+      within(open_accordion_section) do
+        expect(page).to have_content("Missing evidence (gap in time): May 2020")
+        expect(page).to have_content("Not good enough")
+      end
+
+      choose "Return to officer with comment"
+      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess the evidence of immunity"
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Review immunity details was successfully updated")
+
+      click_link "Review immunity enforcement"
+      expect(page).to have_content("Assessor decision: Yes")
+      expect(page).to have_content("Reason: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
+      expect(page).to have_content("Summary: A summary")
+
+      choose "Return to officer with comment"
+      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess immunity enforcement response"
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Review immunity details was successfully updated for enforcement")
+
+      sign_in(assessor)
+      visit planning_application_path(planning_application)
+      click_link("Check and assess")
+      click_link("Evidence of immunity")
+
+      # Fill in evidence of immunity again
+      expand_span_item("See immunity detail checks")
+      expect(page).to have_content("#{reviewer.name} marked this for review")
+      expect(page).to have_content("Reviewer comment: Please re-assess the evidence of immunity")
+
+      # Modify evidence group input
+      click_button "Utility bills (1)"
+
+      within(open_accordion_section) do
+        check "Missing evidence (gap in time)"
+        fill_in "List all the gap(s) in time", with: "June 2020"
+        fill_in "Add comment", with: "Never good enough"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Evidence of immunity successfully updated")
+
+      within("#immunity-permitted-development-rights") do
+        expect(page).to have_content("To be reviewed")
+        click_link("Immunity/permitted development rights")
+      end
+
+      expand_span_item("See previous review immunity detail responses")
+      expect(page).to have_content("Assessor decision: Yes")
+      expect(page).to have_content("Reason: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
+      expect(page).to have_content("Summary: A summary")
+      expect(page).to have_content("Reviewer comment: Please re-assess immunity enforcement response")
+
+      # Fill in immunity response again
+      within("#assess-immunity-detail-section") do
+        choose "No"
+
+        fill_in "Describe why the application is not immune from enforcement", with: "Application is not immune"
+      end
+
+      within("#permitted-development-right-section") do
+        choose "Yes"
+
+        fill_in "Describe how permitted development rights have been removed", with: "A reason"
+      end
+
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Immunity/permitted development rights response was successfully created")
+
+      sign_in(reviewer)
+      visit planning_application_path(planning_application)
+      click_link "Review and sign-off"
+
+      click_link "Review evidence of immunity"
+      click_button "Utility bills (1)"
+
+      within(open_accordion_section) do
+        expect(page).to have_content("Missing evidence (gap in time): June 2020")
+        expect(page).to have_content("Never good enough")
+      end
+
+      click_link "Edit review immunity details"
+      choose "Accept"
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Review immunity details was successfully updated")
+
+      click_link "Review immunity enforcement"
+      expect(page).to have_content("Assessor decision: No")
+      expect(page).to have_content("Reason: Application is not immune")
+
+      choose("Accept", match: :first)
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Review immunity details was successfully updated for enforcement")
+
+      click_link "Review permitted development rights"
+      expect(page).to have_content("Have the permitted development rights relevant for this application been removed?")
+      expect(page).to have_content("Yes")
+      expect(page).to have_content("A reason")
+
+      choose("Accept", match: :first)
+      click_button "Save and mark as complete"
+      expect(page).to have_content("Permitted development rights response was successfully updated")
+
+      expect(immunity_detail.current_evidence_review_immunity_detail.accepted).to be(true)
+      expect(immunity_detail.current_enforcement_review_immunity_detail.accepted).to be(true)
     end
   end
 end

--- a/spec/system/planning_applications/reviewing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/reviewing/evidence_of_immunity_spec.rb
@@ -27,9 +27,10 @@ RSpec.describe "Reviewing evidence of immunity" do
     )
   end
 
-  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) } # rubocop:disable RSpec/LetSetup
+  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) }
 
   before do
+    create(:review_immunity_detail, :evidence, immunity_detail: planning_application.immunity_detail, assessor:)
     create(:evidence_group, :with_document, tag: "utility_bill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: planning_application.immunity_detail)
     create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
 

--- a/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
@@ -27,9 +27,11 @@ RSpec.describe "Reviewing immunity enforcement" do
     )
   end
 
-  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) } # rubocop:disable RSpec/LetSetup
+  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) }
 
   before do
+    create(:review_immunity_detail, :evidence, immunity_detail: planning_application.immunity_detail, assessor:)
+
     sign_in reviewer
     visit(planning_application_review_tasks_path(planning_application))
   end
@@ -49,7 +51,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       end
 
       expect(page).to have_current_path(
-        edit_planning_application_review_immunity_enforcement_path(planning_application, ReviewImmunityDetail.last)
+        edit_planning_application_review_immunity_enforcement_path(planning_application, review_immunity_detail)
       )
 
       expect(page).to have_content("Review immunity enforcement")

--- a/spec/system/planning_applications/reviewing/permitted_development_rights_spec.rb
+++ b/spec/system/planning_applications/reviewing/permitted_development_rights_spec.rb
@@ -236,6 +236,7 @@ RSpec.describe "Permitted development right" do
       it "I can view the information on the review permitted development rights page" do
         immunity_detail = create(:immunity_detail, planning_application:)
         create(:review_immunity_detail, immunity_detail:)
+        create(:review_immunity_detail, :evidence, immunity_detail:)
         evidence_group = create(:evidence_group, missing_evidence: true, immunity_detail:)
         create(:document, evidence_group:)
 


### PR DESCRIPTION
### Description of change

- This change fixes a bug where review evidence of immunity and review immunity enforcement were updating the same instance instead of storing the reviewer comment separately
- Adding a review type means we can distinguish between the different types of review (evidence / enforcement)

- This also adds a complete e2e test for assessing and reviewing an immunity case going back and forth between the assessor and reviewer

### Story Link

https://trello.com/c/FzhpuW0E/1599-end-to-end-automated-test-for-immunity-assessment
https://trello.com/c/f2sRt6yX/1601-reviewing-evidence-of-immunity-overwrites-the-review-immunity-enforcement-response

