### PR TITLE
Ensure docker versions match production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   db:
-    image: postgres:13.4
+    image: postgres:14.3
     volumes:
       - type: volume
         source: db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:latest
+    image: redis:7.0
     command: redis-server
     ports:
       - "6379:6379"


### PR DESCRIPTION
### Description of change

Ensure we use the same versions of Postgres and Redis as in production

Currently in development we're using an older version of Postgres which could lead to issues. We're also pinning to the `latest` version of Redis, which is currently the same as used in production but could change without our intending it.
