### PR TITLE
Update Node to 16.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle
 
 ## Node
-RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get install -y nodejs
 
 ## Yarn

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -18,7 +18,7 @@ ENV LANG=en_US.UTF-8
 RUN locale-gen
 
 # Install NODE_MAJOR
-ARG NODE_MAJOR=14
+ARG NODE_MAJOR=16
 RUN bash -c "export DEBIAN_FRONTEND=noninteractive && \
     curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash - && \
     apt-get update && apt-get install -y nodejs"


### PR DESCRIPTION
### Description of change

We are using a very outdated version of Node. We should use a supported version when possible.