### PR TITLE
Use db_migrate task exit code as workflow exit code

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -138,6 +138,8 @@ jobs:
              jq -r '.tasks[].taskArn')
           aws ecs wait tasks-stopped --cluster $CLUSTER --tasks "$task_arn"
           aws logs tail $LOG_GROUP --format short --since $start_time
+          exit_code=$(aws ecs describe-tasks --cluster $CLUSTER --task $task_arn | jq -r '.tasks[].containers[0].exitCode')
+          exit $exit_code
 
   deploy-services:
     name: Deploy services to ${{ inputs.environment-name }}


### PR DESCRIPTION
### Description of change

After waiting for the database migration command to complete, look up its exit code and exit from the Github workflow using that, so that if it has failed future steps will not run

### Story Link

https://trello.com/c/Q2woLPP2/1597-migrations-may-fail-silently-and-break-deploy
