### PR TITLE
Show basic map of neighbours on consultations page

### DIFF
--- a/app/controllers/planning_application/consultations_controller.rb
+++ b/app/controllers/planning_application/consultations_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class ConsultationsController < AuthenticationController
+    before_action :set_planning_application
+
+    def new; end
+
+    private
+
+    def set_planning_application
+      planning_application = planning_applications_scope.find(planning_application_id)
+
+      @planning_application = PlanningApplicationPresenter.new(view_context, planning_application)
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications
+    end
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+  end
+end

--- a/app/views/planning_application/consultations/new.html.erb
+++ b/app/views/planning_application/consultations/new.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  Send letters to neighbours - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path(filter_options: PlanningApplication::FILTER_OPTIONS) %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_path(@planning_application) %>
+<% content_for :title, "Send letters to neighbours" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Send letters to neighbours" }
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">   
+    <%= render(
+      partial: "shared/location_map",
+      locals: {
+        locals: {
+          in_accordion: false,
+          geojson: @planning_application.boundary_geojson
+        }
+      }
+    ) %>
+
+    <br>
+    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
+</div>

--- a/app/views/planning_applications/_application_steps.html.erb
+++ b/app/views/planning_applications/_application_steps.html.erb
@@ -1,3 +1,4 @@
 <%= render 'planning_applications/steps/validation' %>
+<%= render 'planning_applications/steps/consultation' %>
 <%= render 'planning_applications/steps/assessment' %>
 <%= render 'planning_applications/steps/review' %>

--- a/app/views/planning_applications/steps/_assessment.html.erb
+++ b/app/views/planning_applications/steps/_assessment.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">2. Assessment</h2>
+<h2 class="govuk-heading-m">3. Assessment</h2>
 <ul class="app-task-list__items" id="assess-section">
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">

--- a/app/views/planning_applications/steps/_consultation.html.erb
+++ b/app/views/planning_applications/steps/_consultation.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-6">2. Consultation</h2>
+<ul class="app-task-list__items" id="consultation-section">
+  <li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+        <%= link_to(
+           "Send letters to neighbours",
+           new_planning_application_consultation_path(@planning_application),
+           aria: { describedby: "consultation-completed" },
+           class: "govuk-link"
+        ) %>
+    </span>
+    <div class="app-task-list__task-tag">
+      <%= render(
+        StatusTags::BaseComponent.new(
+          ## Needs fixing - don't have any models to base this on yet
+          status: @planning_application.validation_status
+        )
+      ) %>
+    </div>
+  </li>
+</ul>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -1,5 +1,5 @@
 <div id="review-section">
-  <h2 class="govuk-heading-m">3. Review</h2>
+  <h2 class="govuk-heading-m">4. Review</h2>
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,8 @@ Rails.application.routes.draw do
         patch :update, on: :collection
       end
 
+      resources :consultations, only: %i[new create edit update show]
+
       resource :withdraw_or_cancel, only: %i[show update]
 
       resources :assign_users, only: %i[index] do

--- a/spec/system/planning_applications/consulting_spec.rb
+++ b/spec/system/planning_applications/consulting_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Consulting" do
+  let!(:api_user) { create(:api_user, name: "PlanX") }
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, local_authority: default_local_authority, api_user:)
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  it "displays the planning application address and reference" do
+    expect(page).to have_content("2. Consultation")
+
+    click_link "Send letters to neighbours"
+
+    expect(page).to have_content("Send letters to neighbours")
+
+    expect(page).to have_content(planning_application.full_address)
+    expect(page).to have_content(planning_application.reference)
+
+    map_selector = find("my-map")
+    expect(map_selector["latitude"]).to eq(planning_application.latitude)
+    expect(map_selector["longitude"]).to eq(planning_application.longitude)
+    expect(map_selector["showMarker"]).to eq("true")
+  end
+end


### PR DESCRIPTION
### Description of change

- Creates "Consultation" task in application workflow
- Creates "Send letters to neighbours" task under consultation
- Has basic map we're using currently on it

### Story Link

https://trello.com/c/pt0xSQyb/1615-see-the-application-site-on-a-map

### Screenshots
<img width="1027" alt="Screenshot 2023-05-19 at 16 01 00" src="https://github.com/unboxed/bops/assets/35098639/c6458433-ae31-405d-8a2a-a7033c1c8947">

![screencapture-southwark-southwark-localhost-3000-planning-applications-1-consultations-new-2023-05-19-16_01_14](https://github.com/unboxed/bops/assets/35098639/89487d62-9d3d-471a-b93c-045ece870568)

### Decisions [OPTIONAL]

Ideally, the map would show neighbours addresses on it - i.e. click a pin and it gives you the exact one. This would mean extending our current map or making a PR against https://github.com/theopensystemslab/map. I've separated into a different story as I'm expecting that's quite a lot of work and seems better to get this started quickly