### PR TITLE
Create database structure for constraints

### DIFF
--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Constraint < ApplicationRecord
+  validates :category, :name, presence: true
+
+  enum category: {
+    flooding: "flooding",
+    military_and_defence: "military_and_defence",
+    ecology: "ecology",
+    heritage_and_conservation: "heritage_and_conservation",
+    general_policy: "general_policy",
+    tree: "tree",
+    other: "other",
+    local: "local"
+  }
+
+  has_many :planning_application_constraints, dependent: :destroy
+end

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -2,6 +2,7 @@
 
 class Constraint < ApplicationRecord
   validates :category, :name, presence: true
+  validates :name, uniqueness: { scope: :local_authority }
 
   belongs_to :local_authority, optional: true
 

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -3,6 +3,8 @@
 class Constraint < ApplicationRecord
   validates :category, :name, presence: true
 
+  belongs_to :local_authority, optional: true
+
   enum category: {
     flooding: "flooding",
     military_and_defence: "military_and_defence",

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,6 +4,7 @@ class LocalAuthority < ApplicationRecord
   has_many :users, dependent: :destroy
   has_many :planning_applications, dependent: :destroy
   has_many :audits, through: :planning_applications
+  has_many :constraints, dependent: :destroy
   has_one :api_user, dependent: :destroy
 
   validates :council_code, :subdomain, :signatory_name, :signatory_job_title, :enquiries_paragraph, :email_address,

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -47,6 +47,8 @@ class PlanningApplication < ApplicationRecord
     has_many :requests, class_name: "ValidationRequest"
     has_many :assessment_details, -> { by_created_at_desc }, inverse_of: :planning_application
     has_many :permitted_development_rights, -> { order :created_at }, inverse_of: :planning_application
+    has_many :planning_application_constraints
+    has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_one :immunity_detail, required: false
     has_one :consultation, required: false
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -48,6 +48,7 @@ class PlanningApplication < ApplicationRecord
     has_many :assessment_details, -> { by_created_at_desc }, inverse_of: :planning_application
     has_many :permitted_development_rights, -> { order :created_at }, inverse_of: :planning_application
     has_many :planning_application_constraints
+    has_many :planning_application_constraints_queries
     has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_one :immunity_detail, required: false
     has_one :consultation, required: false

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PlanningApplicationConstraint < ApplicationRecord
+  belongs_to :planning_application
+  belongs_to :planning_application_constraints_query, optional: true
+  belongs_to :constraint
+end

--- a/app/models/planning_application_constraints_query.rb
+++ b/app/models/planning_application_constraints_query.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PlanningApplicationConstraintsQuery < ApplicationRecord
+  validates :geojson, :wkt, :planx_query, :planning_data_query, presence: true
+
+  belongs_to :planning_application
+  has_many :planning_application_constraints, dependent: :destroy
+  has_many :constraints, through: :planning_application_constraints
+end

--- a/db/migrate/20230602181048_create_constraints.rb
+++ b/db/migrate/20230602181048_create_constraints.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class CreateConstraints < ActiveRecord::Migration[7.0]
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
+  def change
+    create_table :constraints do |t|
+      t.string :name, null: false
+      t.string :category, null: false
+
+      t.timestamps
+    end
+
+    up_only do
+      constraints_list = {
+        flooding: [
+          "Flood zone",
+          "Flood zone 1",
+          "Flood zone 2",
+          "Flood zone 3"
+        ],
+        military_and_defence: [
+          "Explosives & ordnance storage",
+          "Safeguarded land"
+        ],
+        ecology: [
+          "Special Area of Conservation (SAC)",
+          "Site of Special Scientific Interest (SSSI)",
+          "Ancient Semi-Natural Woodland (ASNW)",
+          "Local Wildlife / Biological notification site",
+          "Priority habitat"
+        ],
+        heritage_and_conservation: [
+          "Listed Building",
+          "Conservation Area",
+          "Area of Outstanding Natural Beauty",
+          "National Park",
+          "World Heritage Site",
+          "Broads"
+        ],
+        general_policy: [
+          "Article 4 area",
+          "Green belt"
+        ],
+        tree: [
+          "Tree Preservation Order"
+        ],
+        other: [
+          "Safety hazard area",
+          "Within 3km of the perimeter of an aerodrome"
+        ]
+      }
+
+      constraints_list.each do |category, names|
+        names.each do |name|
+          Constraint.create!(name:, category: category.to_s)
+        rescue ActiveRecord::RecordInvalid, ArgumentError => e
+          raise "Could not create constraint with category: '#{category}' and name: '#{name}' with error: #{e.message}"
+        end
+      end
+
+      # Migrate local constraints from existing planning applications
+      constraint_names = PlanningApplication.pluck(:old_constraints).flatten.uniq
+
+      constraint_names.each do |name|
+        next if Constraint.find_by(name:)
+
+        Constraint.create!(name:, category: "local")
+      rescue ActiveRecord::RecordInvalid, ArgumentError => e
+        raise "Could not create constraint with category: '#{category}' and name: '#{name}' with error: #{e.message}"
+      end
+    end
+  end
+  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/migrate/20230602193038_create_planning_application_constraints_query.rb
+++ b/db/migrate/20230602193038_create_planning_application_constraints_query.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreatePlanningApplicationConstraintsQuery < ActiveRecord::Migration[7.0]
+  def change
+    create_table :planning_application_constraints_queries do |t|
+      t.json :geojson, null: false
+      t.text :wkt, null: false
+      t.string :planx_query, null: false
+      t.string :planning_data_query, null: false
+      t.references :planning_application, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230602193936_create_planning_application_constraint.rb
+++ b/db/migrate/20230602193936_create_planning_application_constraint.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class CreatePlanningApplicationConstraint < ActiveRecord::Migration[7.0]
+  def change
+    create_table :planning_application_constraints do |t|
+      t.references :planning_application, foreign_key: true
+      t.references :planning_application_constraints_query, foreign_key: true, null: true
+      t.references :constraint, foreign_key: true
+
+      t.timestamps
+    end
+
+    up_only do
+      constraints = PlanningApplication.pluck(:id, :old_constraints)
+
+      constraints.each do |planning_application_id, names|
+        names.each do |name|
+          constraint = Constraint.find_by!(name:)
+          PlanningApplicationConstraint.create!(
+            constraint:, planning_application: PlanningApplication.find(planning_application_id)
+          )
+        rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound, ArgumentError => e
+          raise "Could not create constraint with name: '#{name}' and planning_application_id: '#{planning_application_id}' with error: #{e.message}" # rubocop:disable Layout/LineLength
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20230602193937_add_local_authority_to_constraints.rb
+++ b/db/migrate/20230602193937_add_local_authority_to_constraints.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocalAuthorityToConstraints < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :constraints, :local_authority, index: true
+  end
+end

--- a/db/migrate/20230602193938_add_local_authority_foreign_key_to_constraints.rb
+++ b/db/migrate/20230602193938_add_local_authority_foreign_key_to_constraints.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLocalAuthorityForeignKeyToConstraints < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :constraints, :local_authorities
+  end
+end

--- a/db/migrate/20230602193939_add_unique_index_to_constraints_on_local_authority_and_name.rb
+++ b/db/migrate/20230602193939_add_unique_index_to_constraints_on_local_authority_and_name.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToConstraintsOnLocalAuthorityAndName < ActiveRecord::Migration[7.0]
+  def change
+    add_index :constraints, %i[local_authority_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_193936) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_193938) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_193936) do
     t.string "category", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "local_authority_id"
+    t.index ["local_authority_id"], name: "ix_constraints_on_local_authority_id"
   end
 
   create_table "consultations", force: :cascade do |t|
@@ -576,6 +578,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_193936) do
   add_foreign_key "audits", "api_users"
   add_foreign_key "audits", "planning_applications"
   add_foreign_key "audits", "users"
+  add_foreign_key "constraints", "local_authorities"
   add_foreign_key "description_change_validation_requests", "planning_applications"
   add_foreign_key "description_change_validation_requests", "users"
   add_foreign_key "documents", "additional_document_validation_requests"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_31_150705) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_193936) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,6 +123,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_150705) do
     t.datetime "updated_at", null: false
     t.integer "site_map_correct", default: 0, null: false
     t.index ["planning_application_id"], name: "ix_consistency_checklists_on_planning_application_id"
+  end
+
+  create_table "constraints", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "category", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "consultations", force: :cascade do |t|
@@ -303,6 +310,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_150705) do
     t.index ["assessor_id"], name: "ix_permitted_development_rights_on_assessor_id"
     t.index ["planning_application_id"], name: "ix_permitted_development_rights_on_planning_application_id"
     t.index ["reviewer_id"], name: "ix_permitted_development_rights_on_reviewer_id"
+  end
+
+  create_table "planning_application_constraints", force: :cascade do |t|
+    t.bigint "planning_application_id"
+    t.bigint "planning_application_constraints_query_id"
+    t.bigint "constraint_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["constraint_id"], name: "ix_planning_application_constraints_on_constraint_id"
+    t.index ["planning_application_constraints_query_id"], name: "ix_planning_application_constraints_on_planning_application_con"
+    t.index ["planning_application_id"], name: "ix_planning_application_constraints_on_planning_application_id"
+  end
+
+  create_table "planning_application_constraints_queries", force: :cascade do |t|
+    t.json "geojson", null: false
+    t.text "wkt", null: false
+    t.string "planx_query", null: false
+    t.string "planning_data_query", null: false
+    t.bigint "planning_application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_planning_application_constraints_queries_on_planning_applica"
   end
 
   create_table "planning_applications", force: :cascade do |t|
@@ -560,6 +589,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_150705) do
   add_foreign_key "other_change_validation_requests", "users"
   add_foreign_key "permitted_development_rights", "users", column: "assessor_id"
   add_foreign_key "permitted_development_rights", "users", column: "reviewer_id"
+  add_foreign_key "planning_application_constraints", "constraints"
+  add_foreign_key "planning_application_constraints", "planning_application_constraints_queries"
+  add_foreign_key "planning_application_constraints", "planning_applications"
+  add_foreign_key "planning_application_constraints_queries", "planning_applications"
   add_foreign_key "planning_applications", "api_users"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_193938) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_193939) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -131,6 +131,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_193938) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "local_authority_id"
+    t.index ["local_authority_id", "name"], name: "ix_constraints_on_local_authority_id__name", unique: true
     t.index ["local_authority_id"], name: "ix_constraints_on_local_authority_id"
   end
 

--- a/spec/factories/constraint.rb
+++ b/spec/factories/constraint.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :constraint do
+    name { "Flood zone" }
+    category { "flooding" }
+  end
+end

--- a/spec/factories/planning_application_constraint.rb
+++ b/spec/factories/planning_application_constraint.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :planning_application_constraint do
+    planning_application
+    constraint
+    planning_application_constraints_query
+  end
+end

--- a/spec/factories/planning_application_constraints_query.rb
+++ b/spec/factories/planning_application_constraints_query.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :planning_application_constraints_query do
+    planning_application
+
+    geojson do
+      '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}'
+    end
+    wkt { "POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))" }
+    planx_query { "https://api.editor.planx.uk/gis/opensystemslab?geom=POLYGON+%28%28-0.07629275321961124+51.48596289289142%2C+-0.0763061642646857+51.48591028066045%2C+-0.07555112242699404+51.48584764697301%2C+-0.07554173469544191+51.48590192950712%2C+-0.07629275321961124+51.48596289289142%29%29&analytics=false" }
+    planning_data_query { "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=POLYGON+%28%28-0.07629275321961124+51.48596289289142%2C+-0.0763061642646857+51.48591028066045%2C+-0.07555112242699404+51.48584764697301%2C+-0.07554173469544191+51.48590192950712%2C+-0.07629275321961124+51.48596289289142%29%29&geometry_relation=intersects&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=listed-building&dataset=listed-building-outline&dataset=locally-listed-building&dataset=park-and-garden&dataset=conservation-area&dataset=area-of-outstanding-natural-beauty&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=special-protection-area&dataset=scheduled-monument&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone&dataset=site-of-special-scientific-interest&dataset=special-area-of-conservation&dataset=ancient-woodland" }
+  end
+end

--- a/spec/models/constraint_spec.rb
+++ b/spec/models/constraint_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Constraint do
+  describe "validations" do
+    subject(:constraint) { described_class.new }
+
+    describe "#name" do
+      it "validates presence" do
+        expect { constraint.valid? }.to change { constraint.errors[:name] }.to ["can't be blank"]
+      end
+
+      it "validates uniqueness" do
+        create(:constraint, name: "Flood zone")
+
+        expect { described_class.create!(name: "Flood zone") }.to raise_error(
+          ActiveRecord::RecordInvalid, "Validation failed: Category can't be blank, Name has already been taken"
+        )
+      end
+    end
+
+    describe "#category" do
+      it "validates presence" do
+        expect { constraint.valid? }.to change { constraint.errors[:category] }.to ["can't be blank"]
+      end
+
+      it "validates enum type" do
+        expect { described_class.new(category: "random") }.to raise_error(ArgumentError, "'random' is not a valid category")
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_constraint_spec.rb
+++ b/spec/models/planning_application_constraint_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplicationConstraint do
+  describe "validations" do
+    subject(:planning_application_constraint) { described_class.new }
+
+    describe "#constraint" do
+      it "validates presence" do
+        expect { planning_application_constraint.valid? }.to change { planning_application_constraint.errors[:constraint] }.to ["must exist"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { planning_application_constraint.valid? }.to change { planning_application_constraint.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_constraints_query_spec.rb
+++ b/spec/models/planning_application_constraints_query_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplicationConstraintsQuery do
+  describe "validations" do
+    subject(:planning_application_constraints_query) { described_class.new }
+
+    describe "#geojson" do
+      it "validates presence" do
+        expect { planning_application_constraints_query.valid? }.to change { planning_application_constraints_query.errors[:geojson] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#wkt" do
+      it "validates presence" do
+        expect { planning_application_constraints_query.valid? }.to change { planning_application_constraints_query.errors[:wkt] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planx_query" do
+      it "validates presence" do
+        expect { planning_application_constraints_query.valid? }.to change { planning_application_constraints_query.errors[:planx_query] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planning_data_query" do
+      it "validates presence" do
+        expect { planning_application_constraints_query.valid? }.to change { planning_application_constraints_query.errors[:planning_data_query] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { planning_application_constraints_query.valid? }.to change { planning_application_constraints_query.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -109,6 +109,45 @@ RSpec.describe PlanningApplication do
         expect(planning_application.fee_item_validation_requests).to eq([other_change_validation_request2])
       end
     end
+
+    describe "constraints" do
+      let!(:planning_application) { create(:planning_application) }
+
+      let!(:constraint1) { create(:constraint, name: "Constraint 1", category: "other") }
+      let!(:constraint2) { create(:constraint, name: "Constraint 2", category: "other") }
+
+      let!(:planning_application_constraints_query) { create(:planning_application_constraints_query, planning_application:) }
+      let!(:planning_application_constraint1) { create(:planning_application_constraint, planning_application_constraints_query:, planning_application:, constraint: constraint1) }
+      let!(:planning_application_constraint2) { create(:planning_application_constraint, planning_application_constraints_query:, planning_application:, constraint: constraint2) }
+
+      it "returns the associations for constraints" do
+        expect(constraint1.planning_application_constraints).to eq([planning_application_constraint1])
+        expect(constraint2.planning_application_constraints).to eq([planning_application_constraint2])
+      end
+
+      it "returns the associations for planning_application_constraints_query" do
+        expect(planning_application_constraints_query.constraints).to match_array([constraint1, constraint2])
+        expect(planning_application_constraints_query.planning_application_constraints).to match_array([planning_application_constraint1, planning_application_constraint2])
+        expect(planning_application_constraints_query.planning_application).to eq(planning_application)
+      end
+
+      it "returns the associations for planning_application" do
+        expect(planning_application.planning_application_constraints).to match_array([planning_application_constraint1, planning_application_constraint2])
+        # To change to "constraints" when we update the code to use the new association and are able to drop the "constraints" array field
+        expect(planning_application.constraints).to match_array([constraint1, constraint2])
+      end
+
+      it "returns the associations for planning_application_constraint" do
+        expect(planning_application_constraint1.planning_application).to eq(planning_application)
+        expect(planning_application_constraint2.planning_application).to eq(planning_application)
+
+        expect(planning_application_constraint1.planning_application_constraints_query).to eq(planning_application_constraints_query)
+        expect(planning_application_constraint2.planning_application_constraints_query).to eq(planning_application_constraints_query)
+
+        expect(planning_application_constraint1.constraint).to eq(constraint1)
+        expect(planning_application_constraint2.constraint).to eq(constraint2)
+      end
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
### Description of change

Create [database structure](https://miro.com/app/board/uXjVMZhLyKE=/) for constraints

- Adds Constraints table
- Adds PlanningApplicationConstraintsQuery table
- Adds PlanningApplicationConstraint table

Currently we have constraints as an array field on planning applications. However, since we will be making an API request to retrieve the updated constraints from planx/planning data, we need to modify the schema to allow a relation with the query made and constraints returned.

This commit does not yet migrate the existing constraints array on planning applications to the new association and the constraints_list.yml has been kept in for now.

Since custom constraints can be added, we need to iterate and migrate the existing items in all the planning application constraints array that include a name that hasn't been seeded and create a new Constraint entry in the database. This needs to be done before we can switch the code to use the new has_many constraints association for planning applications.


I've not added any indexes for performance (better searching) as this can be added when needed after

### Story Link

https://trello.com/c/BIRiwVeV/1664-create-constraints-database-structure
https://trello.com/c/tu2RHkaV/1610-update-constraints-when-red-line-boundary-is-re-drawn