### PR TITLE
Fix review immunity details to be specific for review_type

### DIFF
--- a/app/models/review_immunity_detail.rb
+++ b/app/models/review_immunity_detail.rb
@@ -36,7 +36,8 @@ class ReviewImmunityDetail < ApplicationRecord
 
   validates :decision, inclusion: { in: DECISIONS }, allow_blank: true
 
-  before_create :ensure_no_open_review_immunity_detail_response!
+  before_create :ensure_no_open_evidence_review_immunity_detail_response!
+  before_create :ensure_no_open_enforcement_review_immunity_detail_response!
   before_update :set_status_to_be_reviewed, if: :reviewer_comment?
   before_update :set_reviewer_edited, if: :decision_reason_changed?
 
@@ -86,14 +87,25 @@ class ReviewImmunityDetail < ApplicationRecord
     errors.add(:base, "Reviewer must be present when returning to officer with a comment")
   end
 
-  def ensure_no_open_review_immunity_detail_response!
-    return if evidence?
+  def ensure_no_open_evidence_review_immunity_detail_response!
+    return if enforcement?
 
-    last_review_immunity_detail = immunity_detail.current_enforcement_review_immunity_detail
-    return unless last_review_immunity_detail
-    return if last_review_immunity_detail.reviewed_at?
+    last_evidence_review_immunity_detail = immunity_detail.current_evidence_review_immunity_detail
+    return unless last_evidence_review_immunity_detail
+    return if last_evidence_review_immunity_detail.reviewed_at?
 
     raise NotCreatableError,
-          "Cannot create a review immunity detail response when there is already an open response"
+          "Cannot create an evidence review immunity detail response when there is already an open response"
+  end
+
+  def ensure_no_open_enforcement_review_immunity_detail_response!
+    return if evidence?
+
+    last_enforcement_review_immunity_detail = immunity_detail.current_enforcement_review_immunity_detail
+    return unless last_enforcement_review_immunity_detail
+    return if last_enforcement_review_immunity_detail.reviewed_at?
+
+    raise NotCreatableError,
+          "Cannot create an enforcement review immunity detail response when there is already an open response"
   end
 end

--- a/app/views/planning_application/review_immunity_enforcements/_shared_information.html.erb
+++ b/app/views/planning_application/review_immunity_enforcements/_shared_information.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  Review immunity enforcement - <%= t('page_title') %>
+  Review assessment of immunity - <%= t('page_title') %>
 <% end %>
 
 <%= render(
@@ -7,9 +7,9 @@
   locals: { planning_application: @planning_application  }
 ) %>
 
-<% content_for :title, "Review immunity enforcement" %>
+<% content_for :title, "Review assessment of immunity" %>
 
 <%= render(
   partial: "shared/proposal_header",
-  locals: { heading: "Review immunity enforcement" }
+  locals: { heading: "Review assessment of immunity" }
 ) %>

--- a/app/views/planning_application/review_tasks/index.html.erb
+++ b/app/views/planning_application/review_tasks/index.html.erb
@@ -25,14 +25,14 @@
       Review assessment
     </h2>
     <ul class="app-task-list__items" id="review-assessment-section">
-      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.any? %>
+      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.evidence.any? %>
           <%= render(
             TaskListItems::ReviewImmunityDetailsComponent.new(
               planning_application: @planning_application
             )
           ) %>
       <% end %>
-      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.any? %>
+      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.enforcement.any? %>
           <%= render(
             TaskListItems::ReviewImmunityEnforcementComponent.new(
               planning_application: @planning_application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -936,7 +936,7 @@ en:
     review_immunity_details_component:
       evidence_of_immunity: Review evidence of immunity
     review_immunity_enforcement_component:
-      review_immunity_enforcement: Review immunity enforcement
+      review_immunity_enforcement: Review assessment of immunity
     review_permitted_development_right_component:
       review_permitted_development_rights: Review permitted development rights
     validation_decision_component:

--- a/spec/components/task_list_items/review_immunity_enforcement_component_spec.rb
+++ b/spec/components/task_list_items/review_immunity_enforcement_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TaskListItems::ReviewImmunityEnforcementComponent, type: :compone
 
     it "renders link to permitted development right review page" do
       expect(page).to have_link(
-        "Review immunity enforcement",
+        "Review assessment of immunity",
         href: "/planning_applications/#{planning_application.id}/review_immunity_enforcements/#{review_immunity_detail.id}"
       )
     end
@@ -43,7 +43,7 @@ RSpec.describe TaskListItems::ReviewImmunityEnforcementComponent, type: :compone
 
     it "renders link to edit permitted development right review page" do
       expect(page).to have_link(
-        "Review immunity enforcement",
+        "Review assessment of immunity",
         href: "/planning_applications/#{planning_application.id}/review_immunity_enforcements/#{review_immunity_detail.id}/edit"
       )
     end

--- a/spec/factories/review_immunity_detail.rb
+++ b/spec/factories/review_immunity_detail.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
     trait :evidence do
       review_type { "evidence" }
     end
+
+    trait :enforcement do
+      review_type { "enforcement" }
+    end
   end
 end

--- a/spec/models/review_immunity_detail_spec.rb
+++ b/spec/models/review_immunity_detail_spec.rb
@@ -44,25 +44,53 @@ RSpec.describe ReviewImmunityDetail do
   end
 
   describe "callbacks" do
-    describe "::before_create #ensure_no_open_review_immunity_detail_response!" do
+    describe "::before_create #ensure_no_open_evidence_review_immunity_detail_response!" do
       let(:immunity_detail) { create(:immunity_detail) }
 
-      context "when there is already an open review immunity detail response" do
-        let(:new_review_immunity_detail) { create(:review_immunity_detail, immunity_detail:) }
+      context "when there is already an open evidence review immunity detail response" do
+        let(:new_review_immunity_detail) { create(:review_immunity_detail, :evidence, immunity_detail:) }
 
-        before { create(:review_immunity_detail, immunity_detail:) }
+        before { create(:review_immunity_detail, :evidence, immunity_detail:) }
 
         it "raises an error" do
           expect do
             new_review_immunity_detail
-          end.to raise_error(described_class::NotCreatableError, "Cannot create a review immunity detail response when there is already an open response")
+          end.to raise_error(described_class::NotCreatableError, "Cannot create an evidence review immunity detail response when there is already an open response")
         end
       end
 
-      context "when there is no open review immunity detail response to be reviewed" do
-        let(:new_review_immunity_detail) { create(:review_immunity_detail, immunity_detail:) }
+      context "when there is no open evidence review immunity detail response to be reviewed" do
+        let(:new_review_immunity_detail) { create(:review_immunity_detail, :evidence, immunity_detail:) }
 
-        before { create(:review_immunity_detail, immunity_detail:, reviewed_at: Time.current) }
+        before { create(:review_immunity_detail, :evidence, immunity_detail:, reviewed_at: Time.current) }
+
+        it "does not raise an error" do
+          expect do
+            new_review_immunity_detail
+          end.not_to raise_error
+        end
+      end
+    end
+
+    describe "::before_create #ensure_no_open_enforcement_review_immunity_detail_response!" do
+      let(:immunity_detail) { create(:immunity_detail) }
+
+      context "when there is already an open enforcement review immunity detail response" do
+        let(:new_review_immunity_detail) { create(:review_immunity_detail, :enforcement, immunity_detail:) }
+
+        before { create(:review_immunity_detail, :enforcement, immunity_detail:) }
+
+        it "raises an error" do
+          expect do
+            new_review_immunity_detail
+          end.to raise_error(described_class::NotCreatableError, "Cannot create an enforcement review immunity detail response when there is already an open response")
+        end
+      end
+
+      context "when there is no open enforcement review immunity detail response to be reviewed" do
+        let(:new_review_immunity_detail) { create(:review_immunity_detail, :enforcement, immunity_detail:) }
+
+        before { create(:review_immunity_detail, :enforcement, immunity_detail:, reviewed_at: Time.current) }
 
         it "does not raise an error" do
           expect do

--- a/spec/system/planning_applications/assess_immunity_detail_permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assess_immunity_detail_permitted_development_right_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe "Assess immunity detail permitted development right" do
       end
 
       click_button "Save and mark as complete"
-      expect(page).to have_text("Cannot create a review immunity detail response when there is already an open response")
+      expect(page).to have_text("Cannot create an enforcement review immunity detail response when there is already an open response")
 
       expect(ReviewImmunityDetail.count).to eq(1)
     end

--- a/spec/system/planning_applications/immunity_spec.rb
+++ b/spec/system/planning_applications/immunity_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Immunity" do
       click_button "Save and mark as complete"
       expect(page).to have_content("Review immunity details was successfully updated")
 
-      click_link "Review immunity enforcement"
+      click_link "Review assessment of immunity"
       expect(page).to have_content("Assessor decision: Yes")
       expect(page).to have_content("Reason: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
       expect(page).to have_content("Summary: A summary")
@@ -193,7 +193,7 @@ RSpec.describe "Immunity" do
       click_button "Save and mark as complete"
       expect(page).to have_content("Review immunity details was successfully updated")
 
-      click_link "Review immunity enforcement"
+      click_link "Review assessment of immunity"
       expect(page).to have_content("Assessor decision: No")
       expect(page).to have_content("Reason: Application is not immune")
 

--- a/spec/system/planning_applications/reviewing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/reviewing/evidence_of_immunity_spec.rb
@@ -27,181 +27,192 @@ RSpec.describe "Reviewing evidence of immunity" do
     )
   end
 
-  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) }
+  context "when there's not an evidence of immunity" do
+    before do
+      sign_in reviewer
+      visit(planning_application_review_tasks_path(planning_application))
+    end
 
-  before do
-    create(:review_immunity_detail, :evidence, immunity_detail: planning_application.immunity_detail, assessor:)
-    create(:evidence_group, :with_document, tag: "utility_bill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: planning_application.immunity_detail)
-    create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
-
-    sign_in reviewer
-    visit(planning_application_review_tasks_path(planning_application))
+    it "I cannot view the link of Review evidence of immunity page" do
+      expect(page).not_to have_link("Review evidence of immunity")
+    end
   end
 
-  context "when planning application is awaiting determination" do
-    it "I can view the information on the review evidence of immunity page" do
-      expect(page).to have_list_item_for(
-        "Review evidence of immunity",
-        with: "Not started"
-      )
+  context "when there's an evidence of immunity" do
+    before do
+      create(:review_immunity_detail, :evidence, immunity_detail: planning_application.immunity_detail, assessor:)
+      create(:evidence_group, :with_document, tag: "utility_bill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: planning_application.immunity_detail)
+      create(:evidence_group, :with_document, tag: "building_control_certificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
 
-      click_link "Review evidence of immunity"
+      sign_in reviewer
+      visit(planning_application_review_tasks_path(planning_application))
+    end
 
-      within(".govuk-breadcrumbs__list") do
-        expect(page).to have_content("Review")
+    context "when planning application is awaiting determination" do
+      it "I can view the information on the review evidence of immunity page" do
+        expect(page).to have_list_item_for(
+          "Review evidence of immunity",
+          with: "Not started"
+        )
+
+        click_link "Review evidence of immunity"
+
+        within(".govuk-breadcrumbs__list") do
+          expect(page).to have_content("Review")
+          expect(page).to have_content("Review evidence of immunity")
+        end
+
+        expect(page).to have_current_path(
+          edit_planning_application_review_immunity_detail_path(planning_application, ReviewImmunityDetail.last)
+        )
+
         expect(page).to have_content("Review evidence of immunity")
+        expect(page).to have_content("Application number: #{planning_application.reference}")
+        expect(page).to have_content(planning_application.full_address)
+
+        expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
+        expect(page).to have_content("Have the works been completed? Yes")
+        expect(page).to have_content("When were the works completed? 01/02/2015")
+        expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
+        expect(page).to have_content("Has enforcement action been taken about these changes? No")
+
+        click_button "Utility bills (1)"
+        utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
+
+        within(open_accordion_section) do
+          expect(page).to have_content(utility_bill_group.start_date.to_fs(:day_month_year_slashes))
+          expect(page).to have_content(utility_bill_group.end_date.to_fs(:day_month_year_slashes))
+
+          expect(page).to have_content("Missing evidence (gap in time): gaps everywhere")
+
+          expect(page).to have_content("This is my proof")
+
+          expect(page).to have_content(utility_bill_group.documents.first.numbers)
+        end
       end
 
-      expect(page).to have_current_path(
-        edit_planning_application_review_immunity_detail_path(planning_application, ReviewImmunityDetail.last)
-      )
+      it "I can save and come back later when adding my review or editing the evidence of immunity" do
+        click_link "Review evidence of immunity"
 
-      expect(page).to have_content("Review evidence of immunity")
-      expect(page).to have_content("Application number: #{planning_application.reference}")
-      expect(page).to have_content(planning_application.full_address)
+        choose "Accept"
 
-      expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
-      expect(page).to have_content("Have the works been completed? Yes")
-      expect(page).to have_content("When were the works completed? 01/02/2015")
-      expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
-      expect(page).to have_content("Has enforcement action been taken about these changes? No")
+        click_button "Save and come back later"
+        expect(page).to have_content("Review immunity details was successfully updated")
 
-      click_button "Utility bills (1)"
-      utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
+        expect(page).to have_list_item_for(
+          "Review evidence of immunity",
+          with: "In progress"
+        )
 
-      within(open_accordion_section) do
-        expect(page).to have_content(utility_bill_group.start_date.to_fs(:day_month_year_slashes))
-        expect(page).to have_content(utility_bill_group.end_date.to_fs(:day_month_year_slashes))
+        click_link "Review evidence of immunity"
 
-        expect(page).to have_content("Missing evidence (gap in time): gaps everywhere")
+        expect(page).to have_checked_field("Accept")
 
-        expect(page).to have_content("This is my proof")
+        choose "Return to officer with comment"
 
-        expect(page).to have_content(utility_bill_group.documents.first.numbers)
-      end
-    end
+        fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
 
-    it "I can save and come back later when adding my review or editing the evidence of immunity" do
-      click_link "Review evidence of immunity"
+        click_button "Save and come back later"
+        expect(page).to have_content("Review immunity details was successfully updated")
 
-      choose "Accept"
+        expect(page).to have_list_item_for(
+          "Review evidence of immunity",
+          with: "In progress"
+        )
 
-      click_button "Save and come back later"
-      expect(page).to have_content("Review immunity details was successfully updated")
+        click_link "Review evidence of immunity"
 
-      expect(page).to have_list_item_for(
-        "Review evidence of immunity",
-        with: "In progress"
-      )
+        expect(page).to have_checked_field("Return to officer with comment")
 
-      click_link "Review evidence of immunity"
-
-      expect(page).to have_checked_field("Accept")
-
-      choose "Return to officer with comment"
-
-      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
-
-      click_button "Save and come back later"
-      expect(page).to have_content("Review immunity details was successfully updated")
-
-      expect(page).to have_list_item_for(
-        "Review evidence of immunity",
-        with: "In progress"
-      )
-
-      click_link "Review evidence of immunity"
-
-      expect(page).to have_checked_field("Return to officer with comment")
-
-      expect(page).to have_content("Please re-assess")
-    end
-
-    it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
-      click_link "Review evidence of immunity"
-
-      choose "Accept"
-
-      click_button "Save and mark as complete"
-
-      expect(page).to have_list_item_for(
-        "Review evidence of immunity",
-        with: "Completed"
-      )
-
-      click_link "Review evidence of immunity"
-
-      expect(page).not_to have_content("Save and mark as complete")
-    end
-
-    it "when I return it to officer with comments, they can see my comments" do
-      click_link "Review evidence of immunity"
-
-      choose "Return to officer with comment"
-
-      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
-
-      click_button "Save and mark as complete"
-
-      click_link "Application"
-      click_link "Check and assess"
-
-      expect(page).to have_list_item_for(
-        "Evidence of immunity",
-        with: "To be reviewed"
-      )
-
-      click_link "Evidence of immunity"
-      find("span", text: "See immunity detail checks").click
-
-      expect(page).to have_content("Please re-assess")
-    end
-
-    it "I can edit comments" do
-      utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
-
-      comment = create(
-        :comment,
-        commentable: utility_bill_group,
-        created_at: DateTime.new(2022, 12, 19),
-        text: "test"
-      )
-
-      click_link "Review evidence of immunity"
-
-      click_button "Utility bills (1)"
-
-      within(open_accordion_section) do
-        expect(page).to have_content("test")
-
-        click_button "Edit comment"
-
-        fill_in "Comment added on #{comment.created_at.strftime('%d %b %Y')} by",
-                with: ""
-
-        click_button "Update"
-
-        expect(page).to have_content "Text can't be blank"
-
-        fill_in "Comment added on #{comment.created_at.strftime('%d %b %Y')} by",
-                with: "This is a new comment now"
-
-        click_button "Update"
-
-        expect(page).to have_content("This is a new comment now")
+        expect(page).to have_content("Please re-assess")
       end
 
-      click_link "Review"
-      click_link "Review evidence of immunity"
+      it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
+        click_link "Review evidence of immunity"
 
-      click_button "Utility bills (1)"
+        choose "Accept"
 
-      within(open_accordion_section) do
-        expect(page).to have_content("This is a new comment now")
+        click_button "Save and mark as complete"
 
-        find("span", text: "Previous comments").click
+        expect(page).to have_list_item_for(
+          "Review evidence of immunity",
+          with: "Completed"
+        )
 
-        expect(page).to have_content("test")
+        click_link "Review evidence of immunity"
+
+        expect(page).not_to have_content("Save and mark as complete")
+      end
+
+      it "when I return it to officer with comments, they can see my comments" do
+        click_link "Review evidence of immunity"
+
+        choose "Return to officer with comment"
+
+        fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
+
+        click_button "Save and mark as complete"
+
+        click_link "Application"
+        click_link "Check and assess"
+
+        expect(page).to have_list_item_for(
+          "Evidence of immunity",
+          with: "To be reviewed"
+        )
+
+        click_link "Evidence of immunity"
+        find("span", text: "See immunity detail checks").click
+
+        expect(page).to have_content("Please re-assess")
+      end
+
+      it "I can edit comments" do
+        utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
+
+        comment = create(
+          :comment,
+          commentable: utility_bill_group,
+          created_at: DateTime.new(2022, 12, 19),
+          text: "test"
+        )
+
+        click_link "Review evidence of immunity"
+
+        click_button "Utility bills (1)"
+
+        within(open_accordion_section) do
+          expect(page).to have_content("test")
+
+          click_button "Edit comment"
+
+          fill_in "Comment added on #{comment.created_at.strftime('%d %b %Y')} by",
+                  with: ""
+
+          click_button "Update"
+
+          expect(page).to have_content "Text can't be blank"
+
+          fill_in "Comment added on #{comment.created_at.strftime('%d %b %Y')} by",
+                  with: "This is a new comment now"
+
+          click_button "Update"
+
+          expect(page).to have_content("This is a new comment now")
+        end
+
+        click_link "Review"
+        click_link "Review evidence of immunity"
+
+        click_button "Utility bills (1)"
+
+        within(open_accordion_section) do
+          expect(page).to have_content("This is a new comment now")
+
+          find("span", text: "Previous comments").click
+
+          expect(page).to have_content("test")
+        end
       end
     end
   end

--- a/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
@@ -27,130 +27,141 @@ RSpec.describe "Reviewing immunity enforcement" do
     )
   end
 
-  let!(:review_immunity_detail) { create(:review_immunity_detail, immunity_detail: planning_application.immunity_detail, assessor:) }
+  context "when there's not an immunity enforcement" do
+    before do
+      sign_in reviewer
+      visit(planning_application_review_tasks_path(planning_application))
+    end
 
-  before do
-    create(:review_immunity_detail, :evidence, immunity_detail: planning_application.immunity_detail, assessor:)
-
-    sign_in reviewer
-    visit(planning_application_review_tasks_path(planning_application))
+    it "I cannot view the link of Review immunity enforcement page" do
+      expect(page).not_to have_link("Review immunity enforcement")
+    end
   end
 
-  context "when planning application is awaiting determination" do
-    it "I can view the information on the review immunity enforcement page" do
-      expect(page).to have_list_item_for(
-        "Review immunity enforcement",
-        with: "Not started"
-      )
+  context "when there's an immunity enforcement" do
+    before do
+      create(:review_immunity_detail, :enforcement, immunity_detail: planning_application.immunity_detail, assessor:)
 
-      click_link "Review immunity enforcement"
+      sign_in reviewer
+      visit(planning_application_review_tasks_path(planning_application))
+    end
 
-      within(".govuk-breadcrumbs__list") do
-        expect(page).to have_content("Review")
+    context "when planning application is awaiting determination" do
+      it "I can view the information on the review immunity enforcement page" do
+        expect(page).to have_list_item_for(
+          "Review immunity enforcement",
+          with: "Not started"
+        )
+
+        click_link "Review immunity enforcement"
+
+        within(".govuk-breadcrumbs__list") do
+          expect(page).to have_content("Review")
+          expect(page).to have_content("Review immunity enforcement")
+        end
+
+        expect(page).to have_current_path(
+          edit_planning_application_review_immunity_enforcement_path(planning_application, ReviewImmunityDetail.last)
+        )
+
         expect(page).to have_content("Review immunity enforcement")
+        expect(page).to have_content("Application number: #{planning_application.reference}")
+        expect(page).to have_content(planning_application.full_address)
+
+        expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
+        expect(page).to have_content("Have the works been completed? Yes")
+        expect(page).to have_content("When were the works completed? 01/02/2015")
+        expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
+        expect(page).to have_content("Has enforcement action been taken about these changes? No")
+
+        expect(page).to have_content("Is the application immune from enforcement?")
+        expect(page).not_to have_content("Immunity from enforcement summary")
+        expect(page).to have_content("Assessor decision: Yes")
+        expect(page).to have_content("Reason: it looks immune to me")
+        expect(page).to have_content("Summary: they have enough bills to show it's immune")
       end
 
-      expect(page).to have_current_path(
-        edit_planning_application_review_immunity_enforcement_path(planning_application, review_immunity_detail)
-      )
+      it "I can save and come back later when adding my review or editing the immunity enforcement" do
+        click_link "Review immunity enforcement"
 
-      expect(page).to have_content("Review immunity enforcement")
-      expect(page).to have_content("Application number: #{planning_application.reference}")
-      expect(page).to have_content(planning_application.full_address)
+        radio_buttons = find_all(".govuk-radios__item")
+        within(radio_buttons[1]) do
+          choose "Accept"
+        end
 
-      expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
-      expect(page).to have_content("Have the works been completed? Yes")
-      expect(page).to have_content("When were the works completed? 01/02/2015")
-      expect(page).to have_content("Has anyone ever attempted to conceal the changes? No")
-      expect(page).to have_content("Has enforcement action been taken about these changes? No")
+        click_button "Save and come back later"
+        expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
-      expect(page).to have_content("Is the application immune from enforcement?")
-      expect(page).not_to have_content("Immunity from enforcement summary")
-      expect(page).to have_content("Assessor decision: Yes")
-      expect(page).to have_content("Reason: it looks immune to me")
-      expect(page).to have_content("Summary: they have enough bills to show it's immune")
-    end
+        expect(page).to have_list_item_for(
+          "Review immunity enforcement",
+          with: "In progress"
+        )
 
-    it "I can save and come back later when adding my review or editing the immunity enforcement" do
-      click_link "Review immunity enforcement"
+        click_link "Review immunity enforcement"
 
-      radio_buttons = find_all(".govuk-radios__item")
-      within(radio_buttons[1]) do
-        choose "Accept"
+        expect(page).to have_checked_field("Accept")
+
+        choose "Return to officer with comment"
+
+        fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
+
+        click_button "Save and come back later"
+        expect(page).to have_content("Review immunity details was successfully updated for enforcement")
+
+        expect(page).to have_list_item_for(
+          "Review immunity enforcement",
+          with: "In progress"
+        )
+
+        click_link "Review immunity enforcement"
+
+        expect(page).to have_checked_field("Return to officer with comment")
+
+        expect(page).to have_content("Please re-assess")
       end
 
-      click_button "Save and come back later"
-      expect(page).to have_content("Review immunity details was successfully updated for enforcement")
+      it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
+        click_link "Review immunity enforcement"
 
-      expect(page).to have_list_item_for(
-        "Review immunity enforcement",
-        with: "In progress"
-      )
+        radio_buttons = find_all(".govuk-radios__item")
+        within(radio_buttons[1]) do
+          choose "Accept"
+        end
 
-      click_link "Review immunity enforcement"
+        click_button "Save and mark as complete"
 
-      expect(page).to have_checked_field("Accept")
+        expect(page).to have_list_item_for(
+          "Review immunity enforcement",
+          with: "Completed"
+        )
 
-      choose "Return to officer with comment"
+        click_link "Review immunity enforcement"
 
-      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
-
-      click_button "Save and come back later"
-      expect(page).to have_content("Review immunity details was successfully updated for enforcement")
-
-      expect(page).to have_list_item_for(
-        "Review immunity enforcement",
-        with: "In progress"
-      )
-
-      click_link "Review immunity enforcement"
-
-      expect(page).to have_checked_field("Return to officer with comment")
-
-      expect(page).to have_content("Please re-assess")
-    end
-
-    it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
-      click_link "Review immunity enforcement"
-
-      radio_buttons = find_all(".govuk-radios__item")
-      within(radio_buttons[1]) do
-        choose "Accept"
+        expect(page).not_to have_content("Save and mark as complete")
       end
 
-      click_button "Save and mark as complete"
+      it "when I return it to officer with comments, they can see my comments" do
+        click_link "Review immunity enforcement"
 
-      expect(page).to have_list_item_for(
-        "Review immunity enforcement",
-        with: "Completed"
-      )
+        choose "Return to officer with comment"
 
-      click_link "Review immunity enforcement"
+        fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
 
-      expect(page).not_to have_content("Save and mark as complete")
-    end
+        click_button "Save and mark as complete"
 
-    it "when I return it to officer with comments, they can see my comments" do
-      click_link "Review immunity enforcement"
+        click_link "Application"
+        click_link "Check and assess"
 
-      choose "Return to officer with comment"
+        expect(page).to have_list_item_for(
+          "Immunity/permitted development rights",
+          with: "To be reviewed"
+        )
 
-      fill_in "Explain to the assessor why this needs reviewing", with: "Please re-assess"
+        click_link "Immunity/permitted development rights"
+        find("span", text: "See previous review immunity detail responses").click
 
-      click_button "Save and mark as complete"
-
-      click_link "Application"
-      click_link "Check and assess"
-
-      expect(page).to have_list_item_for(
-        "Immunity/permitted development rights",
-        with: "To be reviewed"
-      )
-
-      click_link "Immunity/permitted development rights"
-      find("span", text: "See previous review immunity detail responses").click
-
-      expect(page).to have_content("Please re-assess")
+        expect(page).to have_content("Please re-assess")
+      end
     end
   end
 end

--- a/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/reviewing/immunity_enforcement_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "Reviewing immunity enforcement" do
       visit(planning_application_review_tasks_path(planning_application))
     end
 
-    it "I cannot view the link of Review immunity enforcement page" do
-      expect(page).not_to have_link("Review immunity enforcement")
+    it "I cannot view the link of Review assessment of immunity page" do
+      expect(page).not_to have_link("Review assessment of immunity")
     end
   end
 
@@ -47,24 +47,24 @@ RSpec.describe "Reviewing immunity enforcement" do
     end
 
     context "when planning application is awaiting determination" do
-      it "I can view the information on the review immunity enforcement page" do
+      it "I can view the information on the Review assessment of immunity page" do
         expect(page).to have_list_item_for(
-          "Review immunity enforcement",
+          "Review assessment of immunity",
           with: "Not started"
         )
 
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         within(".govuk-breadcrumbs__list") do
           expect(page).to have_content("Review")
-          expect(page).to have_content("Review immunity enforcement")
+          expect(page).to have_content("Review assessment of immunity")
         end
 
         expect(page).to have_current_path(
           edit_planning_application_review_immunity_enforcement_path(planning_application, ReviewImmunityDetail.last)
         )
 
-        expect(page).to have_content("Review immunity enforcement")
+        expect(page).to have_content("Review assessment of immunity")
         expect(page).to have_content("Application number: #{planning_application.reference}")
         expect(page).to have_content(planning_application.full_address)
 
@@ -82,7 +82,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       end
 
       it "I can save and come back later when adding my review or editing the immunity enforcement" do
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         radio_buttons = find_all(".govuk-radios__item")
         within(radio_buttons[1]) do
@@ -93,11 +93,11 @@ RSpec.describe "Reviewing immunity enforcement" do
         expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
         expect(page).to have_list_item_for(
-          "Review immunity enforcement",
+          "Review assessment of immunity",
           with: "In progress"
         )
 
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         expect(page).to have_checked_field("Accept")
 
@@ -109,11 +109,11 @@ RSpec.describe "Reviewing immunity enforcement" do
         expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
         expect(page).to have_list_item_for(
-          "Review immunity enforcement",
+          "Review assessment of immunity",
           with: "In progress"
         )
 
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         expect(page).to have_checked_field("Return to officer with comment")
 
@@ -121,7 +121,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       end
 
       it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         radio_buttons = find_all(".govuk-radios__item")
         within(radio_buttons[1]) do
@@ -131,17 +131,17 @@ RSpec.describe "Reviewing immunity enforcement" do
         click_button "Save and mark as complete"
 
         expect(page).to have_list_item_for(
-          "Review immunity enforcement",
+          "Review assessment of immunity",
           with: "Completed"
         )
 
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         expect(page).not_to have_content("Save and mark as complete")
       end
 
       it "when I return it to officer with comments, they can see my comments" do
-        click_link "Review immunity enforcement"
+        click_link "Review assessment of immunity"
 
         choose "Return to officer with comment"
 


### PR DESCRIPTION
### Description of change

After the #1082 pr, we introduced the `review_type` on the `review_immunity_details` table. But we miss fixing these page to be based on the `review_type`.