### PR TITLE
FIX if there's no comment previous summary crashes

### DIFF
--- a/app/components/assessment_details/previous_summary_component.html.erb
+++ b/app/components/assessment_details/previous_summary_component.html.erb
@@ -1,10 +1,12 @@
-<div class="govuk-!-margin-left-4">
-  <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-    <%= t(".user_marked_this", user: comment.user.name) %>
-  </p>
-  <p class="govuk-body govuk-!-margin-top-1"><%= comment.created_at.to_fs %></p>
-  <%= render(FormattedContentComponent.new(text: comment.text)) %>
-</div>
+<% if comment %>
+  <div class="govuk-!-margin-left-4">
+    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
+      <%= t(".user_marked_this", user: comment.user.name) %>
+    </p>
+    <p class="govuk-body govuk-!-margin-top-1"><%= comment.created_at.to_fs %></p>
+    <%= render(FormattedContentComponent.new(text: comment.text)) %>
+  </div>
+<% end %>
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
   <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
     <%= description %>

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -62,6 +62,16 @@ RSpec.describe "Reviewing assessment summaries" do
         entry: "site description"
       )
 
+      ## Created a second to show that previous summaries works
+      create(
+        :assessment_detail,
+        :site_description,
+        assessment_status: :complete,
+        planning_application:,
+        user: assessor,
+        entry: "site description"
+      )
+
       create(:consultee, planning_application:)
 
       create(


### PR DESCRIPTION
### Description of change

Previous summary was crashing if there wasn't a comment associated with the assessment detail

### Story Link

https://trello.com/c/X0cc6JJS/1667-previous-summary-component-no-comment
