### PR TITLE
Silence deprecation warnings in sass dependencies

### DIFF
--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+# govuk-frontend triggers sass deprecation warnings that we can't control
+Rails.application.config.dartsass.build_options << " --quiet-deps"


### PR DESCRIPTION
### Description of change

govuk-frontend triggers sass deprecation warnings that we can't control; this silences them so we can more easily see warnings/errors that we can control.

### Story Link

https://link-to-issue

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
