### PR TITLE
Add an alias_attribute for constraints to old_constraints

### DIFF
--- a/app/components/accordion_sections/constraints_component.html.erb
+++ b/app/components/accordion_sections/constraints_component.html.erb
@@ -14,6 +14,6 @@
   partial: "constraints/info",
   locals: {
     planning_application: planning_application,
-    constraints: planning_application.constraints
+    constraints: planning_application.old_constraints
   }
 ) %>

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -9,7 +9,7 @@ class ConstraintsController < AuthenticationController
   def edit; end
 
   def update
-    if @planning_application.update(constraints: constraints_params[:constraints].compact_blank)
+    if @planning_application.update(old_constraints: constraints_params[:constraints].compact_blank)
       redirect_to(after_update_path, notice: t(".success"))
     else
       render :edit

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -23,6 +23,8 @@ class PlanningApplication < ApplicationRecord
 
   enum user_role: { applicant: 0, agent: 1, proxy: 2 }
 
+  alias_attribute :old_constraints, :constraints
+
   with_options dependent: :destroy do
     has_many :audits, -> { by_created_at }, inverse_of: :planning_application
     has_many :documents, -> { by_created_at }, inverse_of: :planning_application
@@ -389,7 +391,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def custom_constraints
-    constraints.difference(defined_constraints)
+    old_constraints.difference(defined_constraints)
   end
 
   def valid_from

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -49,7 +49,7 @@ json.site do
 end
 json.received_date planning_application.received_at
 json.decision planning_application.decision if planning_application.determined?
-json.constraints planning_application.constraints if planning_application.constraints
+json.constraints planning_application.old_constraints if planning_application.old_constraints
 json.documents planning_application.documents.for_publication do |document|
   json.url api_v1_planning_application_document_url(planning_application, document)
   json.extract! document,

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -19,7 +19,7 @@
       partial: "constraints/info",
       locals: {
         planning_application: @planning_application,
-        constraints: @planning_application.constraints
+        constraints: @planning_application.old_constraints
       }
     ) %>
 

--- a/app/views/shared/_constraints.html.erb
+++ b/app/views/shared/_constraints.html.erb
@@ -1,4 +1,4 @@
-<% if @planning_application.constraints.empty? %>
+<% if @planning_application.old_constraints.empty? %>
   <p class="govuk-body">
     There are no planning constraints on the application site.
   </p>
@@ -7,7 +7,7 @@
     The application site has these constraints:
   </p>
   <ul class="govuk-list govuk-list--bullet">
-    <% @planning_application.constraints.each do |constraint| %>
+    <% @planning_application.old_constraints.each do |constraint| %>
       <li><%= constraint.humanize %></li>
     <% end %>
   </ul>

--- a/features/step_definitions/constraints_steps.rb
+++ b/features/step_definitions/constraints_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Given("the planning application has the {string} constraint") do |constraint|
-  @planning_application.constraints << constraint
+  @planning_application.old_constraints << constraint
 
   @planning_application.save!
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -714,13 +714,13 @@ RSpec.describe PlanningApplication do
     let(:planning_application) { build(:planning_application) }
 
     it "contains any custom constraint added" do
-      planning_application.constraints << "Foobar"
+      planning_application.old_constraints << "Foobar"
 
       expect(planning_application.custom_constraints).to contain_exactly "Foobar"
     end
 
     it "is empty when all constraints are predefined ones" do
-      planning_application.constraints << "Listed Building"
+      planning_application.old_constraints << "Listed Building"
 
       expect(planning_application.custom_constraints).to be_empty
     end
@@ -2108,7 +2108,7 @@ RSpec.describe PlanningApplication do
   end
 
   it "tracks changed constraints" do
-    planning_application.constraints << "test_constraint"
+    planning_application.old_constraints << "test_constraint"
     planning_application.save!
 
     expect(planning_application.changed_constraints).to include("test_constraint")

--- a/spec/requests/api/planning_application_list_spec.rb
+++ b/spec/requests/api/planning_application_list_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
         expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
         expect(planning_application_json["site"]["latitude"]).to eq(planning_application.latitude)
         expect(planning_application_json["site"]["longitude"]).to eq(planning_application.longitude)
-        expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
+        expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
         expect(planning_application_json["documents"]).to eq([])
       end
 
@@ -125,7 +125,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["site"]["county"]).to eq(planning_application.county)
           expect(planning_application_json["site"]["postcode"]).to eq(planning_application.postcode)
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
-          expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
+          expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
           expect(planning_application_json["documents"].size).to eq(1)
           expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(
                                                                               planning_application, document_with_number

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
         expect(planning_application_json["site"]["county"]).to eq(planning_application.county)
         expect(planning_application_json["site"]["postcode"]).to eq(planning_application.postcode)
         expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
-        expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
+        expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
         expect(planning_application_json["documents"]).to eq([])
       end
 
@@ -130,7 +130,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["site"]["uprn"]).to eq(planning_application.uprn)
           expect(planning_application_json["site"]["latitude"]).to eq(planning_application.latitude)
           expect(planning_application_json["site"]["longitude"]).to eq(planning_application.longitude)
-          expect(planning_application_json["constraints"]).to eq(planning_application.constraints)
+          expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
           expect(planning_application_json["documents"].size).to eq(1)
           expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(
                                                                               planning_application, document_with_number

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
             postcode: planning_application.postcode,
             uprn: planning_application.uprn,
             boundary_geojson: planning_application.boundary_geojson,
-            constraints: planning_application.constraints,
+            constraints: planning_application.old_constraints,
             agent_first_name: planning_application.agent_first_name,
             agent_email: planning_application.agent_email,
             applicant_email: planning_application.applicant_email,


### PR DESCRIPTION
### Description of change

We decided on renaming the filed of `constraints` to `old_constraints`, so we will make .Add an alias_attribute for constraints to old_constraints. [Discussion](https://github.com/unboxed/bops/pull/1089#discussion_r1202357956)