### PR TITLE
Don't install file-preview tools unless necessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,25 +44,26 @@ jobs:
     strategy:
       matrix:
         specs:
-          - ["models", "[a-p]*_spec.rb"]
-          - ["models", "[q-z]*_spec.rb"]
-          - ["controllers", "*_spec.rb"]
-          - ["requests", "*_spec.rb"]
-          - ["system", "a[a-s]*_spec.rb"]
-          - ["system", "a[t-z]*_spec.rb"]
-          - ["system", "[b-f]*_spec.rb"]
-          - ["system", "[g-k]*_spec.rb"]
-          - ["system", "[l-r]*_spec.rb"]
-          - ["system", "[s-z]*_spec.rb"]
-          - [
-              "other",
-              "*_spec.rb",
-              "{components,form_models,helpers,presenters,mailer,jobs,services,translations}",
-            ]
+          - { group: "models", pattern: "[a-p]*_spec.rb" }
+          - { group: "models", pattern: "[q-z]*_spec.rb" }
+          - { group: "controllers", pattern: "*_spec.rb" }
+          - { group: "requests", pattern: "*_spec.rb" }
+          - { group: "system", pattern: "a[a-s]*_spec.rb", want_pdf: true }
+          - { group: "system", pattern: "a[t-z]*_spec.rb" }
+          - { group: "system", pattern: "[b-f]*_spec.rb", want_pdf: true }
+          - { group: "system", pattern: "[g-k]*_spec.rb" }
+          - { group: "system", pattern: "[l-r]*_spec.rb" }
+          - { group: "system", pattern: "[s-z]*_spec.rb" }
+          - {
+              group: "other",
+              pattern: "*_spec.rb",
+              directories: "{components,form_models,helpers,presenters,mailer,jobs,services,translations}",
+            }
       fail-fast: false
     with:
-      name: "${{matrix.specs[0]}}: ${{matrix.specs[1]}}"
-      include: "spec/${{matrix.specs[2] || matrix.specs[0]}}/**/${{matrix.specs[1]}}"
+      name: "${{matrix.specs.group}}: ${{matrix.specs.pattern }}"
+      include: "spec/${{matrix.specs.directories || matrix.specs.group}}/**/${{matrix.specs.pattern}}"
+      want-pdf: "${{ !!matrix.specs.want_pdf }}"
     secrets: inherit
 
   cucumber:
@@ -70,4 +71,5 @@ jobs:
     with:
       name: "all"
       test-runner: "cucumber"
+      want-pdf: true
     secrets: inherit

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,6 +18,10 @@ on:
       test-runner:
         type: string
         default: rspec
+      want-pdf:
+        type: boolean
+        required: false
+        default: false
 
     secrets:
       NOTIFY_API_KEY:
@@ -66,6 +70,7 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Install file previewing tools
+        if: "${{ inputs.want-pdf }}"
         run: |
           sudo apt-get update
           sudo apt-get install -y ghostscript poppler-utils


### PR DESCRIPTION
### Description of change

We install poppler and Ghostscript for every test group run, which takes a couple of minutes per test group; but only a few of the tests actually need it. This limits it to those groups.



### Known issues

It would be better yet if we could group the tests by those that actually need it and run all those together, and then be able to install it only once. But as there are only now two groups that do need it, plus cucumber, that feels like a minor gain relatively.
