### PR TITLE
Use parallel_tests gem to manage test parallelisation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,29 +41,9 @@ jobs:
 
   specs:
     uses: ./.github/workflows/testing.yml
-    strategy:
-      matrix:
-        specs:
-          - { group: "models", pattern: "[a-p]*_spec.rb" }
-          - { group: "models", pattern: "[q-z]*_spec.rb" }
-          - { group: "controllers", pattern: "*_spec.rb" }
-          - { group: "requests", pattern: "*_spec.rb", want_pdf: true }
-          - { group: "system", pattern: "a[a-s]*_spec.rb", want_pdf: true }
-          - { group: "system", pattern: "a[t-z]*_spec.rb" }
-          - { group: "system", pattern: "[b-f]*_spec.rb", want_pdf: true }
-          - { group: "system", pattern: "[g-k]*_spec.rb" }
-          - { group: "system", pattern: "[l-r]*_spec.rb" }
-          - { group: "system", pattern: "[s-z]*_spec.rb" }
-          - {
-              group: "other",
-              pattern: "*_spec.rb",
-              directories: "{components,form_models,helpers,presenters,mailer,jobs,services,translations}",
-            }
-      fail-fast: false
     with:
-      name: "${{matrix.specs.group}}: ${{matrix.specs.pattern }}"
-      include: "spec/${{matrix.specs.directories || matrix.specs.group}}/**/${{matrix.specs.pattern}}"
-      want-pdf: "${{ !!matrix.specs.want_pdf }}"
+      name: "rspec"
+      test-runner: "rspec"
     secrets: inherit
 
   cucumber:
@@ -71,7 +51,6 @@ jobs:
     with:
       name: "all"
       test-runner: "cucumber"
-      want-pdf: true
     secrets: inherit
 
   docker:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,10 +18,10 @@ on:
       test-runner:
         type: string
         default: rspec
-      want-pdf:
-        type: boolean
+      parallel-group:
+        type: string
         required: false
-        default: false
+        default: 1
       dockerfile:
         type: string
         required: false
@@ -74,7 +74,6 @@ jobs:
           yarn install --frozen-lockfile
 
       - name: Install file previewing tools
-        if: "${{ inputs.want-pdf }}"
         run: |
           sudo apt-get update
           sudo apt-get install -y ghostscript poppler-utils
@@ -87,9 +86,10 @@ jobs:
       - name: Setup test database
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
+          PARALLEL_TEST_PROCESSORS: 6
           RAILS_ENV: test
         run: |
-          bundle exec rake db:create db:schema:load
+          bundle exec rake "parallel:setup"
 
       - name: Build assets
         run: bundle exec rake assets:precompile
@@ -102,8 +102,9 @@ jobs:
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
           OTP_SECRET_ENCRYPTION_KEY: ${{ secrets.OTP_SECRET_ENCRYPTION_KEY }}
           SPEC_OPTS: '-f doc  --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}"'
+          PARALLEL_TEST_PROCESSORS: 6
         run: |
-          bundle exec rake spec
+          bundle exec parallel_rspec
 
       - name: Run cucumber specs
         if: ${{ inputs.test-runner == 'cucumber' }}

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem "guard", require: false
   gem "guard-cucumber", require: false
   gem "guard-rspec", require: false
+  gem "parallel_tests"
   gem "pry-byebug"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 4.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,8 @@ GEM
       commonmarker (~> 0.17)
     orm_adapter (0.5.0)
     parallel (1.23.0)
+    parallel_tests (4.2.1)
+      parallel
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
@@ -572,6 +574,7 @@ DEPENDENCIES
   mini_magick
   notifications-ruby-client
   openapi3_parser
+  parallel_tests
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 4)

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,7 +10,8 @@ development:
 
 test:
   <<: *default
-  database: bops_test
+  database: bops_test<%= ENV['TEST_ENV_NUMBER'] %>
+  url: <%= ENV["DATABASE_URL"] %><%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   <<: *default


### PR DESCRIPTION
### Description of change

Currently we define the parallel groups manually but several of these are significantly longer than others and they are likely to change over time.

The parallel-tests gem should handle this for us.

### Known issues

It would be possible to put each test in a separate matrix group but I'm not sure we'd get much value out of that; it also has the downside that we'd go back to having to install the PDF tools for all test groups even when they aren't needed.

This will by default estimate which files to run in which group as it won't have any data about which are slowest. It's possible to tune that but probably not worth it to begin with.
