### PR TITLE
Create all necessary keys in first constraints migration

### DIFF
--- a/db/migrate/20230602181048_create_constraints.rb
+++ b/db/migrate/20230602181048_create_constraints.rb
@@ -7,6 +7,7 @@ class CreateConstraints < ActiveRecord::Migration[7.0]
     create_table :constraints do |t|
       t.string :name, null: false
       t.string :category, null: false
+      t.references :local_authority, null: true, index: true, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20230602193937_add_local_authority_to_constraints.rb
+++ b/db/migrate/20230602193937_add_local_authority_to_constraints.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddLocalAuthorityToConstraints < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :constraints, :local_authority, index: true
-  end
-end

--- a/db/migrate/20230602193938_add_local_authority_foreign_key_to_constraints.rb
+++ b/db/migrate/20230602193938_add_local_authority_foreign_key_to_constraints.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class AddLocalAuthorityForeignKeyToConstraints < ActiveRecord::Migration[7.0]
-  def change
-    add_foreign_key :constraints, :local_authorities
-  end
-end


### PR DESCRIPTION
These fields were being added later but were referenced earlier in the migration sequence