### PR TITLE
Update all constraints logic to use new db associations

### DIFF
--- a/app/components/accordion_sections/constraints_component.html.erb
+++ b/app/components/accordion_sections/constraints_component.html.erb
@@ -14,6 +14,6 @@
   partial: "constraints/info",
   locals: {
     planning_application: planning_application,
-    constraints: planning_application.old_constraints
+    constraints: planning_application.constraints
   }
 ) %>

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -18,4 +18,12 @@ class Constraint < ApplicationRecord
   }
 
   has_many :planning_application_constraints, dependent: :destroy
+
+  scope :options_for_local_authority, ->(local_authority_id) { where(local_authority_id: [local_authority_id, nil]) }
+
+  class << self
+    def grouped_by_category(local_authority_id)
+      options_for_local_authority(local_authority_id).group_by(&:category)
+    end
+  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -92,6 +92,7 @@ class PlanningApplication < ApplicationRecord
 
   accepts_nested_attributes_for :recommendations
   accepts_nested_attributes_for :documents
+  accepts_nested_attributes_for :constraints
 
   WORK_STATUSES = %w[proposed existing].freeze
 

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -1,7 +1,25 @@
 # frozen_string_literal: true
 
 class PlanningApplicationConstraint < ApplicationRecord
+  include Auditable
+
   belongs_to :planning_application
   belongs_to :planning_application_constraints_query, optional: true
   belongs_to :constraint
+
+  after_create :audit_constraint_added!
+  before_destroy :audit_constraint_removed!
+
+  delegate :name, to: :constraint
+  delegate :audits, to: :planning_application
+
+  private
+
+  def audit_constraint_added!
+    audit!(activity_type: "constraint_added", audit_comment: name)
+  end
+
+  def audit_constraint_removed!
+    audit!(activity_type: "constraint_removed", audit_comment: name)
+  end
 end

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ConstraintsCreationService
+  def initialize(planning_application:, constraints_params:)
+    @planning_application = planning_application
+    @constraints_params = constraints_params
+  end
+
+  def call # rubocop:disable Metrics/AbcSize
+    constraints.each do |constraint|
+      existing_constraint = Constraint.options_for_local_authority(planning_application.local_authority_id)
+                                      .find_by("LOWER(name)= ?", constraint.downcase)
+
+      if existing_constraint
+        planning_application.planning_application_constraints.create!(constraint_id: existing_constraint.id)
+      else
+        planning_application.constraints.find_or_create_by!(
+          name: constraint.titleize, category: "local", local_authority_id: planning_application.local_authority_id
+        )
+      end
+    end
+  rescue ActiveRecord::RecordInvalid, NoMethodError => e
+    Appsignal.send_error(e)
+  end
+
+  private
+
+  attr_reader :planning_application, :constraints_params
+
+  def constraints
+    if constraints_params.present?
+      constraints_params.to_unsafe_hash.filter_map do |key, value|
+        key.humanize if value
+      end
+    else
+      []
+    end
+  end
+end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -53,6 +53,7 @@ class PlanningApplicationCreationService
   def save_planning_application!(planning_application)
     PlanningApplication.transaction do
       if planning_application.save!
+        ConstraintsCreationService.new(planning_application:, constraints_params: params[:constraints]).call
         UploadDocumentsJob.perform_now(planning_application:, files: params[:files])
         CreateImmunityDetailsJob.perform_now(planning_application:) if possibly_immune?(planning_application)
       end

--- a/app/views/constraints/_info.html.erb
+++ b/app/views/constraints/_info.html.erb
@@ -5,7 +5,7 @@
 <% else %>
   <ul class="govuk-list govuk-list--bullet">
     <% constraints.each do |constraint| %>
-      <li><%= constraint %></li>
+      <li><%= constraint.name %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -14,40 +14,38 @@
 <div class="govuk-grid-row">
   <%= form_with model: @planning_application, url: planning_application_constraints_path(@planning_application), local: true do |form| %>
     <%= form.hidden_field(:return_to, value: @back_path) %>
-    <div class="govuk-grid-column-two-thirds">
-      <% t("constraint_list").each do |type, constraints| %>
-        <fieldset class="govuk-fieldset govuk-!-margin-top-3">
-          <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-            <h2 class="govuk-fieldset__heading">
-              <%= type.to_s.humanize %>
-            </h2>
-          </legend>
-          <div class="form-group">
-            <div class="govuk-checkboxes govuk-checkboxes--small">
-              <%= form.collection_check_boxes :old_constraints, constraints, :itself, :itself do |b| %>
-                <div class="govuk-checkboxes__item">
-                  <%= b.check_box class: "govuk-checkboxes__input" %>
-                  <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
-                </div>
-              <% end %>
-            </div>
-          </div>
-        </fieldset>
-      <% end %>
 
-      <% if @planning_application.local_constraints.any? %>
+    <div class="govuk-grid-column-two-thirds">
+      <% Constraint.grouped_by_category(@planning_application.local_authority_id).each do |category, constraints| %>
         <fieldset class="govuk-fieldset govuk-!-margin-top-3">
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
             <h2 class="govuk-fieldset__heading">
-              Local constraints
+              <% if category == "local" %>
+                Local constraints
+              <% else %>
+                <%= category.to_s.humanize %>
+              <% end %>
             </h2>
           </legend>
+
           <div class="form-group">
-            <div class="govuk-checkboxes govuk-checkboxes--small">
-              <%= form.collection_check_boxes :old_constraints, @planning_application.local_constraints, :itself, :itself do |b| %>
-                <div class="govuk-checkboxes__item">
-                  <%= b.check_box class: "govuk-checkboxes__input" %>
-                  <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+            <div class="govuk-checkboxes govuk-checkboxes--small">         
+              <% constraints.each do |constraint| %>
+                <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                  <div class="govuk-checkboxes__item">
+                    <%= check_box_tag(
+                      "constraint_ids[]",
+                      constraint.id,
+                      @constraint_ids.include?(constraint.id),
+                      class: "govuk-checkboxes__input",
+                      id: "constraint_id_#{constraint.id}",
+                      ) %>
+                    <%= label_tag(
+                      "constraint_id_#{constraint.id}",
+                      constraint.name,
+                      class: "govuk-label govuk-checkboxes__label",
+                    ) %>
+                  </div>
                 </div>
               <% end %>
             </div>
@@ -56,8 +54,8 @@
       <% end %>
 
       <div class="form-group">
-        <%= form.label :old_constraints, "Add a local constraint", class: 'govuk-heading-s govuk-!-margin-top-6' %>
-        <%= form.text_area :old_constraints, class: "govuk-textarea", rows: "3", "aria-describedby": "constraints-hint", multiple: true, value: "" %>
+        <%= form.label :name, "Add a local constraint", class: 'govuk-heading-s govuk-!-margin-top-6' %>
+        <%= form.text_area :name, class: "govuk-textarea", rows: "3", "aria-describedby": "constraints-hint" %>
       </div>
 
       <div class="govuk-button-group">

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -19,7 +19,7 @@
       partial: "constraints/info",
       locals: {
         planning_application: @planning_application,
-        constraints: @planning_application.old_constraints
+        constraints: @planning_application.constraints
       }
     ) %>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,3 +57,50 @@ local_authorities.each do |authority|
     end
   end
 end
+
+constraints_list = {
+  flooding: [
+    "Flood zone",
+    "Flood zone 1",
+    "Flood zone 2",
+    "Flood zone 3"
+  ],
+  military_and_defence: [
+    "Explosives & ordnance storage",
+    "Safeguarded land"
+  ],
+  ecology: [
+    "Special Area of Conservation (SAC)",
+    "Site of Special Scientific Interest (SSSI)",
+    "Ancient Semi-Natural Woodland (ASNW)",
+    "Local Wildlife / Biological notification site",
+    "Priority habitat"
+  ],
+  heritage_and_conservation: [
+    "Listed Building",
+    "Conservation Area",
+    "Area of Outstanding Natural Beauty",
+    "National Park",
+    "World Heritage Site",
+    "Broads"
+  ],
+  general_policy: [
+    "Article 4 area",
+    "Green belt"
+  ],
+  tree: [
+    "Tree Preservation Order"
+  ],
+  other: [
+    "Safety hazard area",
+    "Within 3km of the perimeter of an aerodrome"
+  ]
+}
+
+constraints_list.each do |category, names|
+  names.each do |name|
+    Constraint.create!(name:, category: category.to_s)
+  rescue ActiveRecord::RecordInvalid, ArgumentError => e
+    raise "Could not create constraint with category: '#{category}' and name: '#{name}' with error: #{e.message}"
+  end
+end

--- a/features/auditing.feature
+++ b/features/auditing.feature
@@ -37,18 +37,6 @@ Feature: Auditing a planning application
     Then there is an audit entry containing "Application returned"
     And there is an audit entry containing "Applicant sent selfies instead of floor plans"
 
-  Scenario: Updating constraints displays all updates in the audit log
-    When I press "Check and validate"
-    And I press "Check constraints"
-    And I press "Update constraints"
-    And I check "National Park"
-    And I check "Broads"
-    And I uncheck "Conservation Area"
-    And I press "Save"
-    Then there is an audit entry containing "Constraint added National Park"
-    And there is an audit entry containing "Constraint added Broads"
-    And there is an audit entry containing "Constraint removed Conservation Area"
-
   Scenario: I can view an entry in the audit log showing application updates
     Given I press "Check and validate"
     And I press "Application information"

--- a/features/editing_an_application_constraints.feature
+++ b/features/editing_an_application_constraints.feature
@@ -5,15 +5,6 @@ Feature: Editing an application's constraints
     And the planning application has the "Conservation Area" constraint
     And I view the planning application
 
-  Scenario: As an assessor I can view the existing constraints on the application
-    Given I press "Check and assess"
-    And I press "Constraints"
-    Then the page contains "Conservation Area"
-
-  Scenario: As an assessor I can view the existing constraints on the edit form
-    Given I visit the application's constraints form
-    Then the "Conservation Area" option is checked
-
   Scenario: As an assessor I can add custom constraints to the application
     Given I visit the application's constraints form
     And I fill in "Add a local constraint" with "Batcave"

--- a/spec/fixtures/files/planx_params.json
+++ b/spec/fixtures/files/planx_params.json
@@ -350,7 +350,8 @@
   ],
   "constraints": {
     "conservation_area": true,
-    "protected_trees": false
+    "protected_trees": false,
+    "national_park": true
   },
   "files": [
     {

--- a/spec/models/constraint_spec.rb
+++ b/spec/models/constraint_spec.rb
@@ -30,4 +30,45 @@ RSpec.describe Constraint do
       end
     end
   end
+
+  describe "scopes" do
+    describe ".options_for_local_authority" do
+      let!(:local_authority1) { create(:local_authority) }
+      let!(:local_authority2) { create(:local_authority, :southwark) }
+
+      let!(:constraint1) { create(:constraint, local_authority: local_authority1) }
+      let!(:constraint2) { create(:constraint, local_authority: nil) }
+      let!(:constraint3) { create(:constraint, local_authority: local_authority2) }
+
+      it "returns available constraint options for a local authority" do
+        expect(described_class.options_for_local_authority(local_authority1)).to match_array([constraint1, constraint2])
+        expect(described_class.options_for_local_authority(local_authority2)).to match_array([constraint2, constraint3])
+      end
+    end
+  end
+
+  describe "class methods" do
+    describe "#grouped_by_category" do
+      let!(:local_authority1) { create(:local_authority) }
+      let!(:local_authority2) { create(:local_authority, :southwark) }
+
+      let!(:constraint1) { create(:constraint, category: "tree", local_authority: local_authority1) }
+      let!(:constraint2) { create(:constraint, category: "ecology", local_authority: nil) }
+      let!(:constraint3) { create(:constraint, category: "local", local_authority: local_authority2) }
+
+      it "returns all constraint options for a local authority grouped by category" do
+        expect(described_class.grouped_by_category(local_authority1)).to eq(
+          {
+            "tree" => [constraint1], "ecology" => [constraint2]
+          }
+        )
+
+        expect(described_class.grouped_by_category(local_authority2)).to eq(
+          {
+            "ecology" => [constraint2], "local" => [constraint3]
+          }
+        )
+      end
+    end
+  end
 end

--- a/spec/services/constraints_creation_service_spec.rb
+++ b/spec/services/constraints_creation_service_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConstraintsCreationService, type: :service do
+  describe "#call" do
+    let!(:local_authority1) { create(:local_authority) }
+    let!(:local_authority2) { create(:local_authority, :southwark) }
+
+    let!(:planning_application) { create(:planning_application, local_authority: local_authority1) }
+    let!(:constraints_params) do
+      ActionController::Parameters.new(
+        {
+          "conservation_area" => true,
+          "protected_trees" => true,
+          "national_park" => true,
+          "listed_building" => true
+        }
+      )
+    end
+
+    let(:create_constraints) do
+      described_class.new(
+        planning_application:,
+        constraints_params:
+      ).call
+    end
+
+    context "when new constraints are added" do
+      it "creates the constraint and planning application constraints for the local authority" do
+        expect do
+          create_constraints
+        end.to change(Constraint, :count).by(4).and change(PlanningApplicationConstraint, :count).by(4)
+
+        expect(Constraint.pluck(:name, :category, :local_authority_id)).to eq(
+          [
+            ["Conservation Area", "local", local_authority1.id],
+            ["Protected Trees", "local", local_authority1.id],
+            ["National Park", "local", local_authority1.id],
+            ["Listed Building", "local", local_authority1.id]
+          ]
+        )
+
+        expect(planning_application.planning_application_constraints.length).to eq(4)
+        expect(planning_application.constraints.length).to eq(4)
+      end
+    end
+
+    context "when existing constraints are added" do
+      let!(:constraint1) { create(:constraint, name: "conservation area", local_authority: local_authority1) }
+      let!(:constraint2) { create(:constraint, name: "Protected trees") }
+      let!(:constraint3) { create(:constraint, name: "National Park") }
+      # Constraint for another local authority
+      let!(:constraint4) { create(:constraint, name: "Listed building", local_authority: local_authority2) }
+
+      it "creates planning application constraints using the existing constraint for the local authority" do
+        expect do
+          create_constraints
+        end.to change(Constraint, :count).by(1).and change(PlanningApplicationConstraint, :count).by(4)
+
+        expect(planning_application.planning_application_constraints.length).to eq(4)
+        expect(planning_application.constraints.length).to eq(4)
+      end
+    end
+
+    context "when existing and new constraints are added" do
+      let!(:constraint1) { create(:constraint, name: "conservation area") }
+      let!(:constraint2) { create(:constraint, name: "Protected trees") }
+
+      it "creates the non existing constraints and planning application constraints" do
+        expect do
+          create_constraints
+        end.to change(Constraint, :count).by(2).and change(PlanningApplicationConstraint, :count).by(4)
+
+        expect(planning_application.planning_application_constraints.length).to eq(4)
+        expect(planning_application.constraints.length).to eq(4)
+      end
+    end
+
+    [ActiveRecord::RecordInvalid, NoMethodError].each do |error|
+      context "when there is an error of type: #{error} creating the constraints" do
+        before { allow_any_instance_of(Constraint).to receive(:save!).and_raise(error) }
+
+        it "raises an error" do
+          expect(Appsignal).to receive(:send_error)
+
+          create_constraints
+        end
+      end
+
+      context "when there is an error of type: #{error} creating the planning application constraints" do
+        before { allow_any_instance_of(PlanningApplicationConstraint).to receive(:save!).and_raise(error) }
+
+        it "raises an error" do
+          expect(Appsignal).to receive(:send_error)
+
+          create_constraints
+        end
+      end
+    end
+  end
+end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -181,6 +181,10 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         it "creates a new planning application from the params" do
           expect { create_planning_application }.to change(PlanningApplication, :count).by(1)
         end
+
+        it "calls the constraints creation service" do
+          expect { create_planning_application }.to change(Constraint, :count).by(2).and change(PlanningApplicationConstraint, :count).by(2)
+        end
       end
     end
   end

--- a/spec/system/planning_applications/updating_constraints_spec.rb
+++ b/spec/system/planning_applications/updating_constraints_spec.rb
@@ -8,8 +8,14 @@ RSpec.describe "updating constraints" do
   let(:planning_application) do
     create(
       :planning_application,
-      local_authority:,
-      old_constraints: []
+      local_authority:
+    )
+  end
+
+  let!(:constraint) do
+    create(
+      :constraint,
+      name: "Conservation Area"
     )
   end
 
@@ -22,6 +28,7 @@ RSpec.describe "updating constraints" do
     visit(planning_application_assessment_tasks_path(planning_application))
     click_button("Constraints")
     click_link("Update constraints")
+
     check("Conservation Area")
     click_button("Save")
 
@@ -38,8 +45,13 @@ RSpec.describe "updating constraints" do
 
     click_link("Application")
     click_button("Audit log")
+    click_link("View all audits")
 
-    expect(page).to have_content("Constraint added")
+    within("#audit_#{Audit.last.id}") do
+      expect(page).to have_content("Conservation Area")
+      expect(page).to have_content("Constraint added")
+      expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    end
 
     visit(planning_application_assessment_tasks_path(planning_application))
     click_link("Check description, documents and proposal details")


### PR DESCRIPTION
### Description of change

- Manually add/update/remove constraints using new associations
- Update PlanningApplicationCreationService to use the new db structure
- Add audit creation callback for adding/removing constraints

Todo: Once this is up and working, we can remove all references to the `old_constraints` array field and drop this column

### Story Link

https://trello.com/c/aQagsxTg/1742-use-new-constraints-database-structure-for-manually-adding-constraints
https://trello.com/c/J9djmvZq/1738-update-planning-application-creation-service-to-use-new-constraints-database-structure