### PR TITLE
Tweak dashboard remaining_days_status_tag

### DIFF
--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -33,7 +33,7 @@ module PlanningApplications
     end
 
     def your_application_attributes
-      %i[reference full_address application_type_with_status formatted_expiry_date remaining_days_status_tag status_tag]
+      %i[reference full_address application_type_with_status formatted_expiry_date days_status_tag status_tag]
     end
 
     def closed_attributes
@@ -52,7 +52,7 @@ module PlanningApplications
         full_address
         application_type_with_status
         formatted_expiry_date
-        remaining_days_status_tag
+        days_status_tag
         status_tag
         user_name
       ]

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -161,6 +161,10 @@ class PlanningApplication < ApplicationRecord
     update("#{aasm.to_state}_at": Time.zone.now)
   end
 
+  def days_from
+    created_at.to_date.business_days_until(Time.previous_business_day(Date.current))
+  end
+
   def days_left
     Date.current.business_days_until(expiry_date)
   end

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -28,7 +28,9 @@ module StatusPresenter
       classes = ["govuk-tag govuk-tag--#{status_date_tag_colour}"]
 
       tag.span class: classes do
-        if expiry_date.past?
+        if not_started?
+          I18n.t("planning_applications.days_from", count: days_from)
+        elsif expiry_date.past?
           I18n.t("planning_applications.overdue", count: days_overdue)
         else
           I18n.t("planning_applications.days_left", count: days_left)

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -24,7 +24,7 @@ module StatusPresenter
       end
     end
 
-    def remaining_days_status_tag
+    def days_status_tag
       classes = ["govuk-tag govuk-tag--#{status_date_tag_colour}"]
 
       tag.span class: classes do

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -94,6 +94,7 @@ module StatusPresenter
   end
 
   def status_date_tag_colour
+    return "orange" if @planning_application.not_started?
     return "grey" if @planning_application.determined?
 
     number = planning_application.days_left

--- a/app/views/planning_applications/_planning_application_tabs.erb
+++ b/app/views/planning_applications/_planning_application_tabs.erb
@@ -26,9 +26,9 @@
           aria_selected: false,
           tabindex: 1
         ) %>
+      </li>
       <li class="govuk-tabs__list-item" role="presentation">
         <%= link_to "Closed", "#closed", class: "govuk-tabs__tab", role: "tab", "aria-controls":"closed", "aria-selected": false, tabindex: 2 %>
-      </li>
       </li>
     <% end %>
     <li class="govuk-tabs__list-item" role="presentation">

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -5,7 +5,7 @@
 
       <% if @planning_application.in_progress? %>
         <span class="govuk-!-margin-left-1">
-          <%= @planning_application.remaining_days_status_tag %>
+          <%= @planning_application.days_status_tag %>
         </span>
       <% end %>
     </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -697,6 +697,7 @@ en:
       application_type_with_status: Application type
       awaiting_determination: Awaiting determination
       closed: Closed
+      days_status_tag: Days
       description: Description
       formatted_awaiting_determination_at: Recommendation date
       formatted_expiry_date: Expiry date
@@ -706,7 +707,6 @@ en:
       not_started_and_invalid: Not started
       outcome: Outcome
       reference: Application number
-      remaining_days_status_tag: Days left to expiry
       status_tag: Status
       to_be_reviewed: Corrections requested
       under_assessment: In assessment

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -671,6 +671,9 @@ en:
       validate_application: Validate application
     create:
       success: Planning application was successfully created.
+    days_from:
+      one: 1 day received
+      other: "%{count} days received"
     days_left:
       one: 1 day remaining
       other: "%{count} days remaining"

--- a/features/browsing_all_applications.feature
+++ b/features/browsing_all_applications.feature
@@ -8,7 +8,7 @@ Feature: As an assessor I can browse all applications
     And the application expires in 40 days
     Then I press "View all applications"
     Then I press "View my applications"
-    Then the page contains a "orange" tag containing "40 days remaining"
+    Then the page contains a "orange" tag containing "0 days received"
 
   Scenario Outline: I can see a colour-coded expiry date
     Given the time is 10:00 and the planning application is validated

--- a/features/browsing_all_applications.feature
+++ b/features/browsing_all_applications.feature
@@ -3,12 +3,19 @@ Feature: As an assessor I can browse all applications
     Given I am logged in as an assessor
     And a new planning application
 
+  Scenario: I can see an orange colour-tag when the application is not started
+    Given the time is 09:00
+    And the application expires in 40 days
+    Then I press "View all applications"
+    Then I press "View my applications"
+    Then the page contains a "orange" tag containing "40 days remaining"
+
   Scenario Outline: I can see a colour-coded expiry date
-    Given the time is 10:00
+    Given the time is 10:00 and the planning application is validated
     And the application expires in <days> days
     Then I press "View all applications"
     Then I press "View my applications"
-    Then the page contains a "<colour>" tag containing "<days> days"
+    Then the page contains a "<colour>" tag containing "<days> days remaining"
     Examples:
       | days | colour |
       |   12 | green  |
@@ -16,14 +23,14 @@ Feature: As an assessor I can browse all applications
       |    2 | red    |
 
   Scenario: I can see how many days is the application overdue during the working week
-    Given the date is 11-02-2022
+    Given the date is 11-02-2022 and the planning application is validated
     And the application expired 10 days ago
     Then I press "View all applications"
     Then I press "View my applications"
     Then the page contains a "red" tag containing "10 days overdue"
 
   Scenario: I can see how many days is the application overdue during the weekend
-    Given the date is 12-02-2022
+    Given the date is 12-02-2022 and the planning application is validated
     And the application expired 10 days ago
     Then I press "View all applications"
     Then I press "View my applications"

--- a/features/editing_documents.feature
+++ b/features/editing_documents.feature
@@ -1,7 +1,7 @@
 Feature: Editing documents for an application
   Background:
     Given I am logged in as an assessor
-    And a new planning application
+    And a validated planning application
     And the planning application has a document with reference "FOOBAR"
     And I view the planning application
     And I view the document with reference "FOOBAR"

--- a/features/step_definitions/datetime_steps.rb
+++ b/features/step_definitions/datetime_steps.rb
@@ -4,6 +4,14 @@ Given("the date is {int}-{int}-{int}") do |day, month, year|
   travel_to Time.zone.local(year, month, day)
 end
 
+Given("the date is {int}-{int}-{int} and the planning application is validated") do |day, month, year|
+  travel_to Time.zone.local(year, month, day)
+
+  steps("Given the planning application is validated")
+
+  visit root_path
+end
+
 Given("the time is {int}:{int} on the {int}-{int}-{int}") do |hour, minutes, day, month, year|
   travel_to Time.zone.local(year, month, day, hour, minutes)
 end
@@ -12,4 +20,14 @@ Given("the time is {int}:{int}") do |hour, minutes|
   now = Time.zone.now
 
   travel_to Time.zone.local(now.year, now.month, now.day, hour, minutes)
+end
+
+Given("the time is {int}:{int} and the planning application is validated") do |hour, minutes|
+  now = Time.zone.now
+
+  travel_to Time.zone.local(now.year, now.month, now.day, hour, minutes)
+
+  steps("Given the planning application is validated")
+
+  visit root_path
 end


### PR DESCRIPTION
### Description of change

Tweak dashboard remaining_days_status_tag as following:
- Change column `Days left to expiry` column to `Days`
- When a planning application has a state `not_started` should show `X days received`
- Any other state should have `X days remaining`
- If planning application's expire date is overdue should have `X days overdue`

### Story Link

https://trello.com/c/3jBdvqPw