### PR TITLE
Record gov.uk notify send failure reason for letters

### DIFF
--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -27,8 +27,8 @@ class LetterSendingService
         template_id: notify_template_id,
         personalisation:
       )
-    rescue Notifications::Client::RequestError
-      letter_record.update(status: "rejected")
+    rescue Notifications::Client::RequestError => e
+      letter_record.update(status: "rejected", failure_reason: e.message)
       return
     end
 

--- a/db/migrate/20230614101710_add_failure_reason_to_neighbour_letter.rb
+++ b/db/migrate/20230614101710_add_failure_reason_to_neighbour_letter.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFailureReasonToNeighbourLetter < ActiveRecord::Migration[7.0]
+  def change
+    add_column :neighbour_letters, :failure_reason, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_09_140723) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_14_101710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -148,8 +148,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_140723) do
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "not_started", null: false
     t.string "neighbour_letter_text"
+    t.string "status", default: "not_started", null: false
     t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id"
   end
 
@@ -263,6 +263,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_09_140723) do
     t.string "notify_id"
     t.string "status"
     t.string "status_updated_at"
+    t.string "failure_reason"
     t.index ["neighbour_id"], name: "ix_neighbour_letters_on_neighbour_id"
   end
 


### PR DESCRIPTION
### Description of change

Currently if Notify raises an exception we'll only see the 'rejected' message, which is impossible to debug. This PR will store the exception message too. (We can consider exposing that to users in future, but even having it in the database will make life a lot easier.)

### Story Link

https://link-to-issue

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
