### PR TITLE
Add end date to consultations

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -13,4 +13,11 @@ class Consultation < ApplicationRecord
     in_progress: "in_progress",
     complete: "complete"
   }
+
+  def end_date_from_now
+    # Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday)
+    # Second class letters are delivered 2 days after they’re dispatched.
+    # Royal Mail delivers from Monday to Saturday, excluding bank holidays.
+    1.business_day.from_now + 21.days
+  end
 end

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -9,7 +9,8 @@ class NeighbourLetter < ApplicationRecord
     rejected: "rejected",
     submitted: "submitted",
     accepted: "printing",
-    received: "posted"
+    received: "posted",
+    cancelled: "cancelled"
   }.freeze
 
   def update_status
@@ -25,6 +26,8 @@ class NeighbourLetter < ApplicationRecord
     self.status_updated_at = response.sent_at || response.created_at
     save
   end
+
+  private
 
   def notify_api_key
     neighbour.consultation.planning_application.local_authority.notify_api_key || ENV.fetch("NOTIFY_API_KEY")

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -21,7 +21,7 @@ class LetterSendingService
 
     ActiveRecord::Base.transaction do
       letter_record.save!
-      consultation.update!(end_date: consultation.end_date_from_now)
+      consultation.update!(end_date: consultation.end_date_from_now, start_date: 1.business_day.from_now)
     end
 
     personalisation = { message:, heading: consultation.planning_application.reference }

--- a/db/migrate/20230614125702_add_end_date_to_consultations.rb
+++ b/db/migrate/20230614125702_add_end_date_to_consultations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEndDateToConsultations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :consultations, :end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_14_101710) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_14_125702) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -150,6 +150,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_14_101710) do
     t.datetime "updated_at", null: false
     t.string "neighbour_letter_text"
     t.string "status", default: "not_started", null: false
+    t.datetime "end_date"
     t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id"
   end
 

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -10,4 +10,41 @@ RSpec.describe Consultation do
       expect(consultation.valid?).to be(true)
     end
   end
+
+  describe "#end_date_from_now" do
+    let(:consultation) { create(:consultation) }
+
+    before do
+      travel_to date
+    end
+
+    context "when tomorrow is not a working day" do
+      context "when it is saturday" do
+        # Sat, 23 Sep 2023 13:00:00
+        let(:date) { Time.zone.local(2023, 9, 23, 13) }
+
+        it "returns the day 21 days after the next working day" do
+          expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 17, 9))
+        end
+      end
+
+      context "when it is sunday" do
+        # Sun, 24 Sep 2023 13:00:00
+        let(:date) { Time.zone.local(2023, 9, 24, 13) }
+
+        it "returns the day 21 days after the next working day" do
+          expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 17, 9))
+        end
+      end
+    end
+
+    context "when tomorrow is a working day" do
+      # Wed, 20 Sep 2023 13:00:00
+      let(:date) { Time.zone.local(2023, 9, 20, 13) }
+
+      it "returns the day 21 days after the next working day" do
+        expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 12, 13))
+      end
+    end
+  end
 end

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe LetterSendingService do
         expect(letter.id).not_to be_nil
         expect(letter.status).not_to be_nil
         expect(neighbour.consultation.end_date).to eq(DateTime.new(2023, 1, 27, 9))
+        expect(neighbour.consultation.start_date).to eq(DateTime.new(2023, 1, 6, 9))
       end
     end
 

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe LetterSendingService do
     context "when the request is successful" do
       let(:status) { 200 }
 
+      before do
+        travel_to(DateTime.new(2023, 1, 5, 5))
+      end
+
       it "makes a request and records it in the model" do
         notify_request = stub_send_letter(message: "hello world", status: 200)
         letter_sender.new(neighbour, "hello world").deliver!
@@ -24,6 +28,7 @@ RSpec.describe LetterSendingService do
         expect(letter.sent_at).not_to be_nil
         expect(letter.id).not_to be_nil
         expect(letter.status).not_to be_nil
+        expect(neighbour.consultation.end_date).to eq(DateTime.new(2023, 1, 27, 9))
       end
     end
 
@@ -31,6 +36,8 @@ RSpec.describe LetterSendingService do
       let(:status) { 500 }
 
       it "makes a request but does not record a sending date" do
+        expect(Appsignal).to receive(:send_error)
+
         notify_request = stub_send_letter(message: "hello world", status:)
         letter_sender.new(neighbour, "hello world").deliver!
 
@@ -41,6 +48,7 @@ RSpec.describe LetterSendingService do
         expect(letter.notify_response).to be_nil
         expect(letter.sent_at).to be_nil
         expect(letter.status).to eq("rejected")
+        expect(letter.failure_reason).to eq("Exception: Internal server error")
       end
     end
   end


### PR DESCRIPTION
### Description of change

- Set end_date to 21 days after the next business day as the deadline for neighbours to respond

### Story Link

https://trello.com/c/DYJD2Ugi/1624-automatically-calculate-21-days-from-the-day-letters-are-sent-and-auto-populate-the-letter-and-display-it-on-the-page

