### PR TITLE
Add checklist for documents

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -34,6 +34,10 @@ class LocalAuthority < ApplicationRecord
     plan_x? ? council_code : subdomain.capitalize
   end
 
+  def document_checklist?
+    I18n.exists?("council_documents.#{subdomain}.document_checklist")
+  end
+
   private
 
   def council_code_exists

--- a/app/views/planning_applications/validation_documents.html.erb
+++ b/app/views/planning_applications/validation_documents.html.erb
@@ -21,11 +21,12 @@
           message: "One or more documents that the applicant submitted are not available due to a security issue. Ask the applicant or agent for replacements." %>
     <% end %>
 
-    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <p class="govuk-body">
-      <%= link_to "Add a request for a missing document",
-        new_planning_application_additional_document_validation_request_path(@planning_application), class: "govuk-link govuk-body-l" %>
-    </p>
+    <% if @planning_application.local_authority.document_checklist? %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <a href="<%= t("council_documents.#{@planning_application.local_authority.subdomain}.document_checklist")%>" target="_blank" class="govuk-link govuk-body-m">
+        Checklist for <%= @planning_application.application_type.name.humanize.downcase %> (opens in a new tab)
+      </a>
+    <% end %>
 
     <% if @additional_document_validation_requests.any? %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -39,6 +40,12 @@
     <% if @documents.any? %>
       <%= render "documents/active_documents_table", documents: @documents.with_file_attachment %>
     <% end %>
+
+    <p class="govuk-!-margin-bottom-6 govuk-!-margin-top-0">
+      <%= link_to "Add a request for a missing document",
+        new_planning_application_additional_document_validation_request_path(@planning_application), class: "govuk-link govuk-body-m" %>
+    </p>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <%= form_with model: @planning_application, url: validate_documents_planning_application_path(@planning_application), builder: GOVUKDesignSystemFormBuilder::FormBuilder, local: true do |form| %>
       <%= form.hidden_field :documents_missing, value: @additional_document_validation_requests.any? %>

--- a/config/locales/council_documents.yml
+++ b/config/locales/council_documents.yml
@@ -1,0 +1,9 @@
+en: 
+  council_documents:
+    lambeth: 
+      document_checklist: https://www.lambeth.gov.uk/sites/default/files/LAR_Final_22.07.2016.pdf
+    southwark: 
+      document_checklist: https://www.southwark.gov.uk/planning-and-building-control/planning-applications/how-to-prepare-a-valid-planning-application?chapter=7
+    buckinghamshire: 
+      document_checklist: https://www.buckinghamshire.gov.uk/planning-and-building-control/building-or-improving-your-property/how-to-prepare-a-valid-planning-application/
+


### PR DESCRIPTION
### Description of change

Add a link to the check documents page that opens the council's checklist for required documents 

### Story Link

https://trello.com/c/fhLWpWl8/1672-display-checklist-of-all-the-required-documents-and-view-them

### Screenshots

![screencapture-southwark-southwark-localhost-3000-planning-applications-9-validation-documents-2023-06-15-12_37_52](https://github.com/unboxed/bops/assets/35098639/7ba7b416-64d8-4ec8-b546-93d960758c74)
