### PR TITLE
Send copy of neighbour consultation letter to applicant/agent by email

### DIFF
--- a/app/controllers/planning_application/consultations_controller.rb
+++ b/app/controllers/planning_application/consultations_controller.rb
@@ -58,6 +58,8 @@ class PlanningApplication
     def send_neighbour_letters
       return if @consultation.blank?
 
+      @planning_application.send_neighbour_consultation_letter_copy_mail
+
       @consultation.neighbours.reject(&:letter_created?).each do |neighbour|
         LetterSendingService.new(neighbour).deliver!
       end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -115,4 +115,16 @@ class PlanningApplicationMailer < ApplicationMailer
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
   end
+
+  def neighbour_consultation_letter_copy_mail(planning_application, email)
+    @planning_application = planning_application
+    @consultation = planning_application.consultation
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:neighbour_consultation_letter_copy_mail),
+      to: email,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+    )
+  end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -80,7 +80,8 @@ class Audit < ApplicationRecord
     replacement_document_validation_request_cancelled_post_validation:
       "replacement_document_validation_request_cancelled_post_validation",
     constraints_checked: "constraints_checked",
-    neighbour_letters_sent: "neighbour_letters_sent"
+    neighbour_letters_sent: "neighbour_letters_sent",
+    neighbour_letter_copy_mail_sent: "neighbour_letter_copy_mail_sent"
   }
 
   validates :activity_type, presence: true

--- a/app/models/concerns/planning_application/notification.rb
+++ b/app/models/concerns/planning_application/notification.rb
@@ -50,6 +50,16 @@ class PlanningApplication
       send_update_notification(reviewer_group_email)
     end
 
+    def send_neighbour_consultation_letter_copy_mail
+      downcase_and_unique(applicant_and_agent_email).each do |email|
+        PlanningApplicationMailer
+          .neighbour_consultation_letter_copy_mail(self, email)
+          .deliver_later
+      end
+
+      consultation.update!(letter_copy_sent_at: Time.current)
+    end
+
     private
 
     def send_update_notification(to)

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -75,14 +75,6 @@ class LetterSendingService
   end
 
   def message
-    planning_application = @neighbour.consultation.planning_application
-
-    I18n.t("neighbour_letter_template",
-           received_at: planning_application.received_at.to_fs(:day_month_year_slashes),
-           expiry_date: planning_application.expiry_date.to_fs(:day_month_year_slashes),
-           address: planning_application.full_address,
-           description: planning_application.description,
-           reference: planning_application.reference,
-           closing_date: planning_application.received_at.to_fs(:day_month_year_slashes))
+    consultation.neighbour_letter_content
   end
 end

--- a/app/views/planning_application/consultations/_form_actions.html.erb
+++ b/app/views/planning_application/consultations/_form_actions.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-inset-text">
+  <p class="govuk-body">A copy of the letter will also be sent by email to the applicant.</p>
+</div>
+
+<div class="govuk-button-group govuk-!-margin-top-5">
+  <%= form_with model: [planning_application, consultation], 
+    url: planning_application_consultation_send_neighbour_letters_path(planning_application: planning_application, consultation_id: consultation.id), 
+    method: 'post' do |form| %>
+      <%= form.submit "Print and send letters", class: "govuk-button govuk-button--primary", style: "margin-inline-end: 2rem;" %>
+    <% end %>
+
+    <%= form_with(
+      model: [planning_application, consultation],
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      class: "govuk-!-margin-top-5"
+    ) do |form| %>
+    <%= form.hidden_field :consultation_id %>
+    <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+    <%= link_to "Back", planning_application_path(planning_application), class: "govuk-button govuk-button--secondary" %>
+  <% end %>
+</div>

--- a/app/views/planning_application/consultations/edit.html.erb
+++ b/app/views/planning_application/consultations/edit.html.erb
@@ -28,21 +28,6 @@
 
     <%= render "selected_list", planning_application: @planning_application, consultation: @consultation %>
 
-    <div class="govuk-button-group">
-      <%= form_with model: [@planning_application, @consultation], url:
-  planning_application_consultation_send_neighbour_letters_path(planning_application: @planning_application, consultation_id: @consultation.id), method: 'post' do |form| %>
-        <%= form.submit "Print and send letters", class: "govuk-button govuk-button--primary", style: "margin-inline-end: 2rem;" %>
-      <% end %>
-
-      <%= form_with(
-          model: [@planning_application, @consultation],
-          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-          class: "govuk-!-margin-top-5"
-        ) do |form| %>
-        <%= form.hidden_field :consultation_id %>
-        <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
-        <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-      <% end %>
-    </div>
+    <%= render "form_actions", planning_application: @planning_application, consultation: @consultation %>
   </div>
 </div>

--- a/app/views/planning_application/consultations/show.html.erb
+++ b/app/views/planning_application/consultations/show.html.erb
@@ -23,7 +23,7 @@
     </div>
     <div class="govuk-notification-banner__content">
       <h3 class="govuk-notification-banner__heading">
-        Letters have been sent to neighbours
+        Letters have been sent to neighbours and a copy of the letter has been sent to the applicant.
       </h3>
       <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="https://www.notifications.service.gov.uk/support">GOV.UK Notify</a> if you think there’s a problem.</p>
     </div>
@@ -50,21 +50,6 @@
 
     <%= render "letter_template", planning_application: @planning_application, consultation: @consultation %>
 
-    <div class="govuk-button-group govuk-!-margin-top-5">
-      <%= form_with model: [@planning_application, @consultation], url:
-  planning_application_consultation_send_neighbour_letters_path(planning_application: @planning_application, consultation_id: @consultation.id), method: 'post' do |form| %>
-        <%= form.submit "Print and send letters", class: "govuk-button govuk-button--primary", style: "margin-inline-end: 2rem;" %>
-      <% end %>
-
-      <%= form_with(
-          model: [@planning_application, @consultation],
-          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-          class: "govuk-!-margin-top-5"
-        ) do |form| %>
-        <%= form.hidden_field :consultation_id %>
-        <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
-        <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-      <% end %>
-    </div>
+    <%= render "form_actions", planning_application: @planning_application, consultation: @consultation %>
   </div>
 </div>

--- a/app/views/planning_application_mailer/neighbour_consultation_letter_copy_mail.text.erb
+++ b/app/views/planning_application_mailer/neighbour_consultation_letter_copy_mail.text.erb
@@ -1,0 +1,11 @@
+Application reference number: <%= @planning_application.reference_in_full %>
+
+Application received: <%= @planning_application.received_at.strftime("%-d %B %Y") %>
+
+At: <%= @planning_application.full_address %>
+
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
+This is a copy of your neighbour consultation letter.
+
+<%= @consultation.neighbour_letter_content %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -320,6 +320,7 @@ en:
       document_invalidated: "%{args} was marked as invalid"
       document_received_at_changed: "%{args} received at date was modified"
       invalidated: Application invalidated
+      neighbour_letter_copy_mail_sent: Neighbour consultation letter copy email sent
       neighbour_letters_sent: Neighbour letters sent
       other_change_validation_request_added: 'Added: validation request (other validation#%{args})'
       other_change_validation_request_cancelled: 'Cancelled: validation request (other change from applicant#%{args})'
@@ -460,6 +461,7 @@ en:
       description_change_mail: Lawful Development Certificate application - suggested changes
       description_closure_notification_mail: Changes to your Lawful Development Certificate application
       invalidation_notice_mail: Lawful Development Certificate application - changes needed
+      neighbour_consultation_letter_copy_mail: Neighbour consultation letter copy
       otp_mail: Back Office Planning System verification code
       post_validation_request_mail: Lawful Development Certificate application  - changes needed
       receipt_notice_mail: Lawful Development Certificate application received

--- a/db/migrate/20230619170149_add_letter_copy_sent_at_to_consultations.rb
+++ b/db/migrate/20230619170149_add_letter_copy_sent_at_to_consultations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLetterCopySentAtToConsultations < ActiveRecord::Migration[7.0]
+  def change
+    add_column :consultations, :letter_copy_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_14_125702) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_19_170149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -148,9 +148,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_14_125702) do
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "neighbour_letter_text"
     t.string "status", default: "not_started", null: false
+    t.string "neighbour_letter_text"
     t.datetime "end_date"
+    t.datetime "letter_copy_sent_at"
     t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id"
   end
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -722,4 +722,63 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(mail.body.encoded).to include(planning_application.applicant_last_name)
     end
   end
+
+  describe "#neighbour_consultation_letter_copy_mail" do
+    let!(:consultation) do
+      travel_to("2022-01-01") { create(:consultation, planning_application:) }
+    end
+
+    let(:neighbour_consultation_letter_copy_mail) do
+      described_class.neighbour_consultation_letter_copy_mail(planning_application, planning_application.agent_email)
+    end
+
+    let(:mail_body) { neighbour_consultation_letter_copy_mail.body.encoded }
+
+    it "sets the subject" do
+      expect(neighbour_consultation_letter_copy_mail.subject).to eq(
+        "Neighbour consultation letter copy"
+      )
+    end
+
+    it "sets the recipient" do
+      expect(neighbour_consultation_letter_copy_mail.to).to contain_exactly(
+        "cookie_crackers@example.com"
+      )
+    end
+
+    it "includes the reference" do
+      expect(mail_body).to include(
+        "Application reference number: PlanX-22-00100-LDCP"
+      )
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include(
+        "At: 123 High Street, Big City, AB3 4EF"
+      )
+    end
+
+    it "includes the main text body" do
+      expect(mail_body).to include(
+        "This is a copy of your neighbour consultation letter."
+      )
+      expect(mail_body).to include(
+        "We are writing to notify you that we have received a prior approval application for a larger extension at the address:"
+      )
+      expect(mail_body).to include(
+        "To view more details about this application or to make a comment"
+      )
+      expect(mail_body).to include(
+        "search for it on the council's planning register using the application number 22-00100-LDCP"
+      )
+      expect(mail_body).to include(
+        "You can comment on this application until 03/05/2022"
+      )
+    end
+
+    it "includes the name of the agent in the body if agent is present" do
+      expect(neighbour_consultation_letter_copy_mail.body.encoded).to include(planning_application.agent_first_name)
+      expect(neighbour_consultation_letter_copy_mail.body.encoded).to include(planning_application.agent_last_name)
+    end
+  end
 end

--- a/spec/models/concerns/planning_application/notification_spec.rb
+++ b/spec/models/concerns/planning_application/notification_spec.rb
@@ -3,9 +3,12 @@
 require "rails_helper"
 
 RSpec.describe PlanningApplication::Notification do
-  let(:planning_application) { create(:planning_application) }
+  let(:planning_application) { create(:planning_application, agent_email: "agent@example.com", applicant_email: "applicant@example.com") }
   let(:planning_application_with_same_agent_and_applicant_email) do
     create(:planning_application, applicant_email: "email@example.com", agent_email: "Email@example.com")
+  end
+  let(:planning_application_with_only_agent_email) do
+    create(:planning_application, applicant_email: nil, agent_email: "Email@example.com")
   end
 
   describe "#send_decision_notice_mail" do
@@ -58,6 +61,39 @@ RSpec.describe PlanningApplication::Notification do
         expect(PlanningApplicationMailer).to receive(:receipt_notice_mail).once.and_call_original
 
         planning_application_with_same_agent_and_applicant_email.send_receipt_notice_mail
+      end
+    end
+  end
+
+  describe "#send_neighbour_consultation_letter_copy" do
+    context "when there is an applicant an agent email" do
+      let!(:consultation) { create(:consultation, planning_application:) }
+
+      it "sends an email to both applicant and agent" do
+        expect(PlanningApplicationMailer).to receive(:neighbour_consultation_letter_copy_mail).with(planning_application, "agent@example.com").and_call_original
+        expect(PlanningApplicationMailer).to receive(:neighbour_consultation_letter_copy_mail).with(planning_application, "applicant@example.com").and_call_original
+
+        planning_application.send_neighbour_consultation_letter_copy_mail
+      end
+    end
+
+    context "when applicant and agent email are the same" do
+      let!(:consultation) { create(:consultation, planning_application: planning_application_with_same_agent_and_applicant_email) }
+
+      it "sends only one email" do
+        expect(PlanningApplicationMailer).to receive(:neighbour_consultation_letter_copy_mail).with(planning_application_with_same_agent_and_applicant_email, "email@example.com").and_call_original
+
+        planning_application_with_same_agent_and_applicant_email.send_neighbour_consultation_letter_copy_mail
+      end
+    end
+
+    context "when there is only an agent email" do
+      let!(:consultation) { create(:consultation, planning_application: planning_application_with_only_agent_email) }
+
+      it "sends only one email" do
+        expect(PlanningApplicationMailer).to receive(:neighbour_consultation_letter_copy_mail).with(planning_application_with_only_agent_email, "email@example.com").and_call_original
+
+        planning_application_with_only_agent_email.send_neighbour_consultation_letter_copy_mail
       end
     end
   end


### PR DESCRIPTION
### Description of change

- Send a copy of the letter sent to the neighbours to the person who submitted the application
- Add audit log entry for email being sent
- Update content on send letters page to indicate that this email will also be sent

### Story Link

https://trello.com/c/MzPV9ng4/1631-send-a-copy-of-the-letter-sent-to-the-neighbours-to-the-person-who-submitted-the-application

### Screenshots

**Content above print and send letters CTA**
![Screenshot 2023-06-20 at 11 53 45](https://github.com/unboxed/bops/assets/34001723/3d41d755-ea30-4eba-97cb-3519a8ffd5cf)

----------------------

**Success banner**
![Screenshot 2023-06-20 at 11 53 51](https://github.com/unboxed/bops/assets/34001723/f747efc9-f334-444f-871d-aad15eb4c368)

----------------------

**Audit log entry**
![Screenshot 2023-06-20 at 11 53 32](https://github.com/unboxed/bops/assets/34001723/88a02aed-b3d5-4f86-8930-a15e12426ff0)