### PR TITLE
BUG Add missing translations for Prior Approvals

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,11 +213,13 @@ en:
       existing: LDCE
       proposed: LDCP
     prior_approval:
-      proposed: ''
+      existing: PA
+      proposed: PA
   application_types:
     lawfulness_certificate: Lawful Development Certificate
     lawfulness_certificate_abbr: LDC
     prior_approval: Prior approval
+    prior_approval_abbr: PA
   archive_reasons:
     design: Revise design
     dimensions: Revise dimensions

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -247,6 +247,18 @@ RSpec.describe PlanningApplication do
               .to("22-00100-LDCP")
           end
         end
+
+        it "works for other planning application types" do
+          prior_approval_type = create(:application_type, name: "prior_approval")
+          planning_application = build(:planning_application, work_status: "proposed", application_type: prior_approval_type)
+
+          travel_to(DateTime.new(2022, 1, 1)) do
+            expect { planning_application.save }
+              .to change(planning_application, :reference)
+              .from(nil)
+              .to("22-00100-PA")
+          end
+        end
       end
     end
 


### PR DESCRIPTION
### Description of change

The reference creation on planning applications wasn't working because we were missing some translations for Prior Approvals