### PR TITLE
Tag neighbour responses

### DIFF
--- a/app/assets/stylesheets/consultation.scss
+++ b/app/assets/stylesheets/consultation.scss
@@ -12,3 +12,11 @@
   border: 1px solid grey;
   padding: 50px;
 }
+
+.neighbour-response-section {
+  width: 50%;
+
+  .app-task-list__task-tag {
+    float: left
+  }
+}

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -28,11 +28,11 @@ module StatusTags
         "govuk-tag--grey"
       when :in_progress
         "govuk-tag--blue"
-      when :checked, :granted, :valid, :completed, :posted
+      when :checked, :granted, :valid, :completed, :posted, :supportive
         "govuk-tag--green"
-      when :updated, :to_be_reviewed, :submitted
+      when :updated, :to_be_reviewed, :submitted, :neutral
         "govuk-tag--yellow"
-      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected
+      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection
         "govuk-tag--red"
       when :printing
         "govuk-tag--purple"

--- a/app/controllers/planning_application/neighbour_responses_controller.rb
+++ b/app/controllers/planning_application/neighbour_responses_controller.rb
@@ -62,7 +62,7 @@ class PlanningApplication
 
     def neighbour_response_params
       params.require(:neighbour_response).permit(
-        :address, :name, :email, :received_at, :response, :new_address
+        :address, :name, :email, :received_at, :response, :new_address, :summary_tag
       )
     end
 

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -4,4 +4,6 @@ class NeighbourResponse < ApplicationRecord
   belongs_to :neighbour
 
   validates :name, :response, :received_at, presence: true
+
+  enum(summary_tag: { supportive: "supportive", neutral: "neutral", objection: "objection" })
 end

--- a/app/views/planning_application/neighbour_responses/new.html.erb
+++ b/app/views/planning_application/neighbour_responses/new.html.erb
@@ -20,7 +20,8 @@
   <hr>
   <% @neighbour_responses.each do |response| %>
     <div class="display-flex" style="align-items: baseline">
-      <div style="width: 50%;">
+      <div class="neighbour-response-section">
+        <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %><br><br>
         <ul class="govuk-list">
           <li>
             <strong>Date received:</strong> <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
@@ -77,6 +78,11 @@
   <%= form.govuk_text_field :new_address, label: { text: "Or add a new neighbour address" } %>
   <%= form.govuk_date_field :received_at, legend: { text: "Response received on", size: "s", tag: "p" } %>
   <%= form.govuk_text_area :response %>
+  <%= form.govuk_radio_buttons_fieldset :summary_tag, legend: { text: 'Is the response', size: 'm' } do %>
+    <%= form.govuk_radio_button :summary_tag, 'supportive', label: { text: 'Supportive' } %>
+    <%= form.govuk_radio_button :summary_tag, 'neutral', label: { text: 'Neutral' } %>
+    <%= form.govuk_radio_button :summary_tag, 'objection', label: { text: 'An objection' } %>
+  <% end %>
   <%= form.submit(
     "Save response",
     class: "govuk-button govuk-button--primary govuk-!-margin-top-5"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -954,7 +954,9 @@ en:
     granted: To grant
     in_progress: In progress
     invalid: Invalid
+    neutral: Neutral
     not_started: Not started
+    objection: Objection
     permanent_failure: Permanent failure
     posted: Posted
     printing: Printing
@@ -962,6 +964,7 @@ en:
     rejected: Rejected
     removed: Removed
     submitted: Submitted
+    supportive: Supportive
     technical_failure: Technical failure
     to_be_reviewed: To be reviewed
     updated: Updated

--- a/db/migrate/20230621150120_add_summary_tag_to_neighbour_responses.rb
+++ b/db/migrate/20230621150120_add_summary_tag_to_neighbour_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSummaryTagToNeighbourResponses < ActiveRecord::Migration[7.0]
+  def change
+    add_column :neighbour_responses, :summary_tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_113010) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_21_150120) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -277,6 +277,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_113010) do
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "summary_tag"
     t.index ["neighbour_id"], name: "ix_neighbour_responses_on_neighbour_id"
   end
 

--- a/spec/system/planning_applications/consulting/upload_neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/upload_neighbour_responses_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Upload neighbour responses" do
     fill_in "Month", with: "1"
     fill_in "Year", with: "2023"
     fill_in "Response", with: "I think this proposal looks great"
+    choose "Supportive"
 
     click_button "Save response"
 
@@ -42,6 +43,7 @@ RSpec.describe "Upload neighbour responses" do
     expect(page).to have_content("Email: sarah@email.com")
     expect(page).to have_content("Address: #{neighbour.address}")
     expect(page).to have_content("I think this proposal looks great")
+    expect(page).to have_content("Supportive")
 
     # Check audit log
     visit planning_application_audits_path(planning_application)
@@ -65,6 +67,7 @@ RSpec.describe "Upload neighbour responses" do
     fill_in "Month", with: "1"
     fill_in "Year", with: "2023"
     fill_in "Response", with: "I think this proposal looks great"
+    choose "An objection"
 
     click_button "Save response"
 
@@ -75,6 +78,7 @@ RSpec.describe "Upload neighbour responses" do
     expect(page).to have_content("Email: sarah@email.com")
     expect(page).to have_content("Address: 123 Street")
     expect(page).to have_content("I think this proposal looks great")
+    expect(page).to have_content("Objection")
 
     # Check audit log
     visit planning_application_audits_path(planning_application)


### PR DESCRIPTION
### Description of change

Allow planning officers to tag a response as either supportive, objection, or neutral

### Story Link

https://trello.com/c/1IHF5DLE/1640-indication-of-neighbour-response-objecting-neutral-or-supportive

### Screenshots

![screencapture-southwark-southwark-localhost-3000-planning-applications-3-consultations-1-neighbour-responses-new-2023-06-21-16_32_14](https://github.com/unboxed/bops/assets/35098639/bcbc3f88-c463-40e5-ad8e-fc5053b020df)
