### PR TITLE
Show both added and removed constraints

### DIFF
--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -13,6 +13,9 @@ class PlanningApplicationConstraint < ApplicationRecord
   delegate :name, to: :constraint
   delegate :audits, to: :planning_application
 
+  scope :active, -> { where({ removed_at: nil }) }
+  scope :removed, -> { where.not({ removed_at: nil }) }
+
   private
 
   def audit_constraint_added!

--- a/app/services/constraint_query_update_service.rb
+++ b/app/services/constraint_query_update_service.rb
@@ -27,6 +27,7 @@ class ConstraintQueryUpdateService
       [constraint_key.to_s.split(".").last.underscore, true]
     end
 
-    ConstraintsCreationService.new(planning_application: @planning_application, constraints_params:).call
+    ConstraintsCreationService.new(planning_application: @planning_application, constraints_params:,
+                                   constraints_query: query).call
   end
 end

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ConstraintsCreationService
-  def initialize(planning_application:, constraints_params:)
+  def initialize(planning_application:, constraints_params:, constraints_query: nil)
     @planning_application = planning_application
     @constraints_params = constraints_params
+    @constraints_query = constraints_query
   end
 
   def call
@@ -12,7 +13,10 @@ class ConstraintsCreationService
                                       .find_by("LOWER(name)= ?", constraint.downcase)
 
       if existing_constraint
-        planning_application.planning_application_constraints.create!(constraint_id: existing_constraint.id)
+        planning_application.planning_application_constraints.create!(
+          constraint_id: existing_constraint.id,
+          planning_application_constraints_query: @constraints_query
+        )
       else
         planning_application.constraints.find_or_create_by!(
           name: constraint.titleize, category: "local", local_authority_id: planning_application.local_authority_id

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -19,6 +19,10 @@ class ConstraintsCreationService
         )
       end
     end
+
+    planning_application.planning_application_constraints.active.each do |constraint|
+      constraint.update!(removed_at: Time.current) unless constraints.include?(constraint.constraint.name.humanize)
+    end
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
     Appsignal.send_error(e)
   end

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -24,7 +24,10 @@ class ConstraintsCreationService
       end
     end
 
-    planning_application.planning_application_constraints.active.each do |constraint|
+    previous_constraints =
+      planning_application.planning_application_constraints.active
+                          .where.not(planning_application_constraints_query: nil)
+    previous_constraints.each do |constraint|
       constraint.update!(removed_at: Time.current) unless constraints.include?(constraint.constraint.name.humanize)
     end
   rescue ActiveRecord::RecordInvalid, NoMethodError => e

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -13,10 +13,10 @@ class ConstraintsCreationService
                                       .find_by("LOWER(name)= ?", constraint.downcase)
 
       if existing_constraint
-        planning_application.planning_application_constraints.create!(
+        planning_application.planning_application_constraints.find_or_create_by!(
           constraint_id: existing_constraint.id,
           planning_application_constraints_query: @constraints_query
-        )
+        ).save!
       else
         planning_application.constraints.find_or_create_by!(
           name: constraint.titleize, category: "local", local_authority_id: planning_application.local_authority_id
@@ -26,7 +26,6 @@ class ConstraintsCreationService
 
     previous_constraints =
       planning_application.planning_application_constraints.active
-                          .where.not(planning_application_constraints_query: nil)
     previous_constraints.each do |constraint|
       constraint.update!(removed_at: Time.current) unless constraints.include?(constraint.constraint.name.humanize)
     end

--- a/app/views/constraints/_info.html.erb
+++ b/app/views/constraints/_info.html.erb
@@ -1,3 +1,5 @@
+<% show_update_button = local_assigns.fetch(:show_update_button, true) %>
+
 <% if constraints.empty? %>
   <p class="govuk-body audit_details">
     No constraints identified by PlanX
@@ -9,12 +11,12 @@
     <% end %>
   </ul>
 <% end %>
-<% if planning_application.can_validate? %>
+<% if planning_application.can_validate? && show_update_button %>
   <p class="govuk-body">
     <%= link_to(
-      t(".update_constraints"),
-      edit_planning_application_constraints_path(planning_application),
-      class: "govuk-link"
-    ) %>
+          t(".update_constraints"),
+          edit_planning_application_constraints_path(planning_application),
+          class: "govuk-link"
+        ) %>
   </p>
 <% end %>

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -1,12 +1,11 @@
 <% content_for :page_title do %>
-  Constraints - <%= t('page_title') %>
+  Constraints - <%= t("page_title") %>
 <% end %>
 
 <%= render(
-  partial: "shared/proposal_header",
-  locals: { heading: "Check the constraints"  }
-) %>
-
+      partial: "shared/proposal_header",
+      locals: { heading: "Check the constraints" }
+    ) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -20,6 +19,15 @@
           locals: {
             planning_application: @planning_application,
             constraints: @planning_application.planning_application_constraints.active
+          }
+        ) %>
+
+    <p class="govuk-body" id="constraints-removed">Removed constraints</p>
+    <%= render(
+          partial: "constraints/info",
+          locals: {
+            planning_application: @planning_application,
+            constraints: @planning_application.planning_application_constraints.removed
           }
         ) %>
 

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -27,7 +27,8 @@
           partial: "constraints/info",
           locals: {
             planning_application: @planning_application,
-            constraints: @planning_application.planning_application_constraints.removed
+            constraints: @planning_application.planning_application_constraints.removed,
+            show_update_button: false
           }
         ) %>
 

--- a/app/views/constraints/show.html.erb
+++ b/app/views/constraints/show.html.erb
@@ -16,12 +16,12 @@
 
     <p class="govuk-body" id="constraints-review">Review the following constraints and update as necessary.</p>
     <%= render(
-      partial: "constraints/info",
-      locals: {
-        planning_application: @planning_application,
-        constraints: @planning_application.constraints
-      }
-    ) %>
+          partial: "constraints/info",
+          locals: {
+            planning_application: @planning_application,
+            constraints: @planning_application.planning_application_constraints.active
+          }
+        ) %>
 
     <%= form_with model: @planning_application, url: check_planning_application_constraints_path(@planning_application), method: :patch do |form| %>
       <div class="govuk-button-group">

--- a/db/migrate/20230627083704_add_removal_to_planning_application_constraints.rb
+++ b/db/migrate/20230627083704_add_removal_to_planning_application_constraints.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRemovalToPlanningApplicationConstraints < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_application_constraints, :removed_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_153655) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_083704) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -345,6 +345,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_153655) do
     t.bigint "constraint_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "removed_at"
     t.index ["constraint_id"], name: "ix_planning_application_constraints_on_constraint_id"
     t.index ["planning_application_constraints_query_id"], name: "ix_planning_application_constraints_on_planning_application_con"
     t.index ["planning_application_id"], name: "ix_planning_application_constraints_on_planning_application_id"


### PR DESCRIPTION
### Description of change

Track when existing constraints are removed by a new redline query, and display those removed constraints alongside the existing constraints.

### Story Link

https://trello.com/c/JBSziiHI/1756-update-constraints-when-red-line-boundary-is-re-drawn-frontend

### Screenshots

![Screenshot 2023-06-28 at 8 55 06](https://github.com/unboxed/bops/assets/3986/527ae6ab-f125-4ddf-9807-bec773db5758)

### Known issues

UI could use improvement; in particular, we could display human-readable names once we start getting them from Planx.

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
