### PR TITLE
Ensure that the exit code from the db_migrate task is numeric

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -138,7 +138,9 @@ jobs:
              jq -r '.tasks[].taskArn')
           aws ecs wait tasks-stopped --cluster $CLUSTER --tasks "$task_arn"
           aws logs tail $LOG_GROUP --format short --since $start_time
-          exit_code=$(aws ecs describe-tasks --cluster $CLUSTER --task $task_arn | jq -r '.tasks[].containers[0].exitCode')
+          result_json=$(aws ecs describe-tasks --cluster $CLUSTER --task $task_arn)
+          exit_code=$(echo "$result_json" | jq -r '.tasks[].containers[0].exitCode // 1')
+          if [ $exit_code -gt 0 ]; then echo "$result_json" | jq -r; fi
           exit $exit_code
 
   deploy-services:


### PR DESCRIPTION
### Description of change

Also print the output json if it isn't, for debugging purposes.

Here I'm assuming that if the exit code is null, that's an error. I think that's safest as it will mean we won't deploy when we're uncertain.
