### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -6,7 +6,7 @@ module SystemSpecHelpers
   end
 
   def selected_govuk_tab
-    find("div[class='govuk-tabs__panel']")
+    find("div[class='govuk-tabs__panel']:not(.govuk-tabs__panel--hidden)")
   end
 
   def list_item(text, element = page)


### PR DESCRIPTION
The helper searches within any govuk tab panel, but appears to be intended only to search within the current (i.e., not hidden) one.