### PR TITLE
Put node_modules in a docker volume

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 .git
 log/*
 tmp/*
-node_modules/*
+node_modules
 public/packs/*
 public/packs-test/*
 storage/*
@@ -11,3 +11,4 @@ docker-compose.yml
 bops-applicants
 deploy
 pkg
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,11 +34,15 @@ RUN yarn install
 
 WORKDIR /app
 
+RUN mkdir -p node_modules .cache
 RUN groupadd -r app && \
     useradd --no-log-init -r -g app -d /app app
+RUN chown -R app:app node_modules .cache
+
 USER app:app
 
 COPY . .
+
 
 # Sets an interactive shell as default command when the container starts
 CMD ["/bin/sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       - type: bind
         source: .
         target: /app
+      - type: volume
+        source: bops_node_modules
+        target: /app/node_modules
   applicants:
     build: ./bops-applicants
     entrypoint: ./docker-entrypoint.sh
@@ -84,7 +87,12 @@ services:
       - type: bind
         source: ./bops-applicants/
         target: /app
+      - type: volume
+        source: applicants_node_modules
+        target: /app/node_modules
 
 volumes:
   redis:
   db:
+  bops_node_modules:
+  applicants_node_modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,13 @@ services:
       - type: volume
         source: bops_node_modules
         target: /app/node_modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: yarn_cache
+        target: /app/.cache
+        volume:
+          nocopy: true
   applicants:
     build: ./bops-applicants
     entrypoint: ./docker-entrypoint.sh
@@ -90,9 +97,17 @@ services:
       - type: volume
         source: applicants_node_modules
         target: /app/node_modules
+        volume:
+          nocopy: true
+      - type: volume
+        source: yarn_cache
+        target: /app/.cache
+        volume:
+          nocopy: true
 
 volumes:
   redis:
   db:
   bops_node_modules:
   applicants_node_modules:
+  yarn_cache:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,9 +7,11 @@ echo "Bundling gems"
 bundle check || bundle install
 
 if [ -f /app/tmp/pids/server.pid ]; then
-  echo 'Deleting old server pid file ...'
-  rm -f /app/tmp/pids/server.pid
+	echo 'Deleting old server pid file ...'
+	rm -f /app/tmp/pids/server.pid
 fi
+
+yarn install
 
 # parameters will pass to bundle exec from docker-compose
 bundle exec "$@"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "rome": "^11.0.0"
   },
   "scripts": {
-    "build": "webpack --config ./config/webpack/webpack.config.js"
+    "build": "./node_modules/.bin/webpack --config ./config/webpack/webpack.config.js"
   }
 }


### PR DESCRIPTION
### Description of change

Use a docker volume for `node_modules`, so that this isn't shared with the host machine (which is probably a different OS and might be a different CPU architecture).