### PR TITLE
Publish redacted comments on the BoPS API

### DIFF
--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -5,5 +5,7 @@ class NeighbourResponse < ApplicationRecord
 
   validates :name, :response, :received_at, presence: true
 
+  scope :redacted, -> { where.not(redacted_response: "") }
+
   enum(summary_tag: { supportive: "supportive", neutral: "neutral", objection: "objection" })
 end

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -59,3 +59,10 @@ json.documents planning_application.documents.for_publication do |document|
                 :numbers,
                 :applicant_description
 end
+if planning_application.consultation.present?
+  json.published_comments planning_application.consultation.neighbour_responses.redacted do |response|
+    json.comment response.redacted_response
+    json.received_at response.received_at
+    json.summary_tag response.summary_tag
+  end
+end

--- a/spec/factories/neighbour_response.rb
+++ b/spec/factories/neighbour_response.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :neighbour_response do
+    received_at { 1.day.ago }
+    response { "I like it rude word" }
+    redacted_response { "I like it *****" }
+    summary_tag { "supportive" }
+    name { "Neighbour" }
+    email { "neighbour@example.com" }
+    neighbour
+  end
+end

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
         let!(:document_with_number) { create(:document, :public, planning_application:) }
         let!(:document_without_number) { create(:document, planning_application:) }
         let!(:document_archived) { create(:document, :public, :archived, planning_application:) }
+        let!(:consultation) { create(:consultation, planning_application:) }
+        let!(:neighbour) { create(:neighbour, consultation:) }
+        let!(:neighbour_response) { create(:neighbour_response, neighbour:, redacted_response: "It's fine", received_at: 1.day.ago, summary_tag: "supportive") }
 
         it "returns the accurate data" do
           get "/api/v1/planning_applications/#{planning_application.id}"
@@ -147,6 +150,9 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["documents"].first["archive_reason"]).to eq(document_with_number.archive_reason)
           expect(planning_application_json["documents"].first["tags"]).to eq(document_with_number.tags)
           expect(planning_application_json["documents"].first["numbers"]).to eq(document_with_number.numbers)
+          expect(planning_application_json["published_comments"].first["comment"]).to eq(neighbour_response.redacted_response)
+          expect(planning_application_json["published_comments"].first["received_at"]).to eq(json_time_format(neighbour_response.received_at))
+          expect(planning_application_json["published_comments"].first["summary_tag"]).to eq(neighbour_response.summary_tag)
         end
       end
     end


### PR DESCRIPTION
### Description of change

Publish redacted comments with tag and date on the BoPS API

This is so bops-applicants can pick it up and show it

### Story Link

part 1 of https://trello.com/c/Xsc1xWiH/1653-publish-comments-so-everyone-can-see-the-comments