### PR TITLE
Return any planning application on the API

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -16,7 +16,7 @@ module Api
 
       def show
         @planning_application = current_local_authority.planning_applications.where(id: params[:id]).first
-        if @planning_application&.validated?
+        if @planning_application
           respond_to(:json)
         else
           send_not_found_response

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -47,12 +47,6 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
       expect(planning_application_json).to eq({ "message" => "Unable to find record" })
     end
 
-    it "returns 404 if planning application is not validated" do
-      get "/api/v1/planning_applications/#{planning_application_not_validated.id}"
-      expect(response.code).to eq("404")
-      expect(planning_application_json).to eq({ "message" => "Unable to find record" })
-    end
-
     context "with a new planning application" do
       it "returns the accurate data" do
         get "/api/v1/planning_applications/#{planning_application.id}"


### PR DESCRIPTION
This breaks validation requests on bops applicants, because they haven't been validated! Quick fix for now
