### PR TITLE
Show adjoining neighbour addresses submitted by applicant

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -582,6 +582,16 @@ class PlanningApplication < ApplicationRecord
     find_proposal_detail("Exactly how high are the eaves of the extension?")&.first&.response_values&.first
   end
 
+  def neighbour_addresses
+    proposal_details.select { |detail| detail.question.include? "adjoining property" }&.map(&:response_values)&.flatten
+  end
+
+  def neighbour_addresses_inline
+    neighbour_addresses.map do |address|
+      address.gsub(/[,\s]{2,}/, ", ")
+    end
+  end
+
   delegate :name, to: :application_type, prefix: true
 
   private

--- a/app/views/planning_application/consultations/_neighbours_added.html.erb
+++ b/app/views/planning_application/consultations/_neighbours_added.html.erb
@@ -1,0 +1,6 @@
+<h3 class="govuk-heading-s govuk-!-margin-top-5">Neighbours submitted by applicant</h3>
+<ul class="govuk-list">
+  <% @planning_application.neighbour_addresses_inline.each do |address| %>
+    <li><%= address %></li>
+  <% end %>
+</ul>

--- a/app/views/planning_application/consultations/new.html.erb
+++ b/app/views/planning_application/consultations/new.html.erb
@@ -24,6 +24,8 @@
       }
     ) %>
 
+    <%= render "neighbours_added", planning_application: @planning_application, consultation: @consultation %>
+    
     <%= render "form", planning_application: @planning_application, consultation: @consultation %>
 
     <%= render "selected_list", planning_application: @planning_application, consultation: @consultation %>

--- a/app/views/planning_application/consultations/show.html.erb
+++ b/app/views/planning_application/consultations/show.html.erb
@@ -42,6 +42,8 @@
       }
     ) %>
 
+    <%= render "neighbours_added", planning_application: @planning_application, consultation: @consultation %>
+
     <%= render "form", planning_application: @planning_application, consultation: @consultation %>
 
     <%= render "selected_list", planning_application: @planning_application, consultation: @consultation %>

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -60,6 +60,22 @@ FactoryBot.define do
             ]
           }
         },
+        {
+          question: "Enter the address of the first adjoining property",
+          responses: [
+            {
+              value: "London, 80 Underhill Road , , , , SE22 0QU"
+            }
+          ]
+        },
+        {
+          question: "Enter the address of the second adjoining property",
+          responses: [
+            {
+              value: "London, 78 Underhill Road, , , , SE22 0QU"
+            }
+          ]
+        },
         question: "Is this a listed building?",
         responses: [
           {

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Send letters to neighbours", js: true do
     visit planning_application_path(planning_application)
   end
 
-  it "displays the planning application address and reference" do
+  it "displays the planning application address, reference, and addresses submitted by applicant" do
     expect(page).to have_content("2. Consultation")
 
     click_link "Send letters to neighbours"
@@ -34,6 +34,10 @@ RSpec.describe "Send letters to neighbours", js: true do
     expect(map_selector["latitude"]).to eq(planning_application.latitude)
     expect(map_selector["longitude"]).to eq(planning_application.longitude)
     expect(map_selector["showMarker"]).to eq("true")
+
+    expect(page).to have_content("Neighbours submitted by applicant")
+    expect(page).to have_content("London, 80 Underhill Road, SE22 0QU")
+    expect(page).to have_content("London, 78 Underhill Road, SE22 0QU")
   end
 
   it "allows me to add addresses" do


### PR DESCRIPTION
### Description of change

Show the adjoining neighbour addresses that the applicant has submitted on the letters page

### Story Link

https://trello.com/c/b0S95VJF/1619-display-the-application-form-for-adjoining-neighbour-addresses-and-check-that-they-are-correct

### Screenshots

![screencapture-southwark-southwark-localhost-3000-planning-applications-9-consultations-new-2023-07-06-11_16_25](https://github.com/unboxed/bops/assets/35098639/5f961aac-d2e4-4a30-8c25-ca0dac6cf2af)

