### PR TITLE
Change portal_name to section_name

### DIFF
--- a/app/components/proposal_details/groupable.rb
+++ b/app/components/proposal_details/groupable.rb
@@ -12,7 +12,7 @@ module ProposalDetails
 
     attr_reader :group
 
-    delegate :portal_name, :proposal_details, to: :group
+    delegate :section_name, :proposal_details, to: :group
 
     def auto_answered?
       proposal_details.all?(&:auto_answered?)
@@ -27,13 +27,13 @@ module ProposalDetails
     end
 
     def name
-      case portal_name
+      case section_name
       when "_root"
         t("proposal_details.main")
       when nil
         t("proposal_details.other")
       else
-        portal_name
+        section_name
       end
     end
   end

--- a/app/components/proposal_details/list_component.rb
+++ b/app/components/proposal_details/list_component.rb
@@ -12,10 +12,10 @@ module ProposalDetails
     attr_reader :proposal_details
 
     def groups
-      @groups ||= portal_names.map do |portal_name|
-        Struct.new(:portal_name, :proposal_details).new(
-          portal_name,
-          proposal_details_for_portal_name(portal_name)
+      @groups ||= section_names.map do |section_name|
+        Struct.new(:section_name, :proposal_details).new(
+          section_name,
+          proposal_details_for_section_name(section_name)
         )
       end
     end
@@ -26,14 +26,20 @@ module ProposalDetails
       end
     end
 
-    def proposal_details_for_portal_name(portal_name)
+    def proposal_details_for_section_name(section_name)
       proposal_details.select do |proposal_detail|
-        proposal_detail.portal_name == portal_name
+        proposal_detail.send(portal_or_section_name) == section_name
       end
     end
 
-    def portal_names
-      proposal_details.map(&:portal_name).uniq
+    def section_names
+      proposal_details.map(&portal_or_section_name.to_s.to_sym).uniq
+    end
+
+    def portal_or_section_name
+      # To handle older planning applications which came through with only portal_name
+      # instead of the new section_name
+      proposal_details.any?(&:section_name) ? "section_name" : "portal_name"
     end
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -308,7 +308,7 @@ class PlanningApplication < ApplicationRecord
 
   def immune_proposal_details
     proposal_details.select do |proposal_detail|
-      proposal_detail.portal_name == "immunity-check"
+      proposal_detail.flags == ["Planning permission / Immune"]
     end
   end
 

--- a/app/models/proposal_detail.rb
+++ b/app/models/proposal_detail.rb
@@ -27,6 +27,10 @@ class ProposalDetail
     metadata["policy_refs"] || []
   end
 
+  def section_name
+    metadata.fetch("section_name", nil)
+  end
+
   def portal_name
     metadata.fetch("portal_name", nil)
   end

--- a/app/presenters/concerns/proposal_details_presenter.rb
+++ b/app/presenters/concerns/proposal_details_presenter.rb
@@ -6,7 +6,7 @@ module ProposalDetailsPresenter
   included do
     def fee_related_proposal_details
       proposal_details.select do |proposal_detail|
-        proposal_detail.portal_name&.match(/(_|\b)fee(_|\b)/i)
+        proposal_detail.section_name&.match(/(_|\b)fee(_|\b)/i)
       end
     end
   end

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -271,7 +271,7 @@ paths:
                       metadata:
                         type: object
                         properties:
-                          portal_name:
+                          section_name:
                             type: string
                             example: Property details
                           notes:
@@ -403,32 +403,32 @@ paths:
                       responses:
                         - value: Modify or extend
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: What is the dwelling used as?
                       responses:
                         - value: A family home
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Is the property a house?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: How many storeys will the new structure have?
                       responses:
                         - value: '1'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Was the house always a house?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Will the structure include a satellite dish or antenna?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                         policy_refs:
                           - url: 'http://example.com/planning/policy/1/234/a.html'
                             text: GPDO 00.0000.000
@@ -436,38 +436,38 @@ paths:
                       responses:
                         - value: 50% or less
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: How high will the eaves of the new structure be?
                       responses:
                         - value: 2.5m or lower
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: What will the height of the new structure be?
                       responses:
                         - value: 2.5m or lower
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: How close will the new structure be to the site boundary?
                       responses:
                         - value: Within 2m
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: Will any part of the new structure be forward of the front of the original house?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: Will any part of the pool be forward of the front of the original house?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: What is the addition to the property?
                       responses:
                         - value: An outdoor pool
                         - value: An outbuilding
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                         policy_refs:
                           - url: 'http://example.com/planning/policy/1/234/b.html'
                             text: GPDO 00.0000.000
@@ -477,36 +477,36 @@ paths:
                       responses:
                         - value: '1'
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                           auto_answered: true
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                     - question: Is the property in an area of outstanding natural beauty?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in the broads?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in a world heritage site?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in a national park?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is any part of the property listed?
                       responses:
@@ -515,12 +515,12 @@ paths:
                             flags:
                               - Listed building consent / Not required
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                     - question: Will the works affect a protected tree?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?
                       responses:
@@ -530,19 +530,19 @@ paths:
                             flags:
                               - Planning permission / Permission needed
                       metadata:
-                        portal_name: Actitivies
+                        section_name: Actitivies
                     - question: What type of planning application are you making?
                       responses:
                         - value: Existing changes
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         policy_refs:
                           - url: 'http://example.com/planning/policy/1/234/a.html'
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         policy_refs:
                           - text: The Town and Country Planning (General Permitted Development) (England) Order 2015
                   constraints:
@@ -604,25 +604,25 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Existing changes I have made in the past
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         policy_refs:
                           - text: 'Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192'
                     - question: List the changes involved in the project
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                     - question: What type of changes were they?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         auto_answered: true
                     - question: Were the works carried out more than 4 years ago?
                       responses:
@@ -631,21 +631,21 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: Have the works been completed?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: When were the works completed?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: Has anyone ever attempted to conceal the changes?
@@ -655,7 +655,7 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Secretary of State for Communities and Local Government and another v Welwyn Hatfield Borough Council and Bonsall / Jackson v Secretary of State for Communities and Local Government
                     - question: Has enforcement action been taken about these changes?
@@ -665,7 +665,7 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: |-
                               Enforcement action is defined in the Town and Country Planning Act 1990 Section 171A.
@@ -674,7 +674,7 @@ paths:
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: permitteddevelopment
+                        section_name: permitteddevelopment
                         auto_answered: true
                         policy_refs:
                           - text: 'Town and Country Planning Act 1990 (Section 55), The Town and Country Planning (General Permitted Development) (England) Order 2015'
@@ -682,7 +682,7 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Alarms
+                        section_name: Alarms
                         auto_answered: true
                         policy_refs:
                           - text: 'Town and Country Planning Act 1990, Section 55 (2)'
@@ -693,14 +693,14 @@ paths:
                             flags:
                               - Planning permission / Not development
                       metadata:
-                        portal_name: Alarms
+                        section_name: Alarms
                         policy_refs:
                           - text: 'Town and Country Planning Act 1990, Section 55 (2)'
                     - question: Is any part of the property listed?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What do the proposals involve?
                       responses:
@@ -709,7 +709,7 @@ paths:
                             flags:
                               - Listed building consent / Required
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                         policy_refs:
                           - text: Planning (Listed Buildings and Conservation Areas) Act 1990
@@ -717,19 +717,19 @@ paths:
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Have you already told us that you are doing works to a tree or hedge?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Are there any protected trees on the property?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Do the works affect a protected tree?
                       responses:
@@ -738,44 +738,44 @@ paths:
                             flags:
                               - Works to trees & hedges / Not required
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         policy_refs:
                           - text: The Town and Country Planning (Tree Preservation)(England) Regulations 2012
                     - question: Should the applicant also apply for Works to Trees Consent?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Existing changes I have made in the past
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: What do the works involve?
                       responses:
                         - value: Alterations
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: What does the project involve?
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: Do the changes involve the creation of any new homes?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: Is the property in the Greater London Authority area?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                         policy_refs:
                           - text: Greater London Authority Act 1999
@@ -783,26 +783,26 @@ paths:
                       responses:
                         - value: Only one
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Do you know the title number of the property?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                     - question: Does the property have an Energy Performance Certificate (EPC)?
                       responses:
                         - value: I don't know
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: What type of application is this?
                       responses:
                         - value: Lawful Development Certificate - Existing
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         auto_answered: true
                         policy_refs:
                           - text: Greater London Authority Act 1999
@@ -810,66 +810,66 @@ paths:
                       responses:
                         - value: '2015-01-01'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: When were the works completed?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Does the site include parking spaces for any of these?
                       responses:
                         - value: None of these
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Are you applying on behalf of someone else?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which of these best describes you?
                       responses:
                         - value: Private individual
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Enter your contact details
                       responses:
                         - value: jessica@opensystemslab.io Test Jess 0123456789
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Is your contact address the same as the property address?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: 'If a planning officer needs to make a site visit, who should they contact?'
                       responses:
                         - value: 'Me, the applicant'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which of these best describes you?
                       responses:
                         - value: Applicant
                       metadata:
-                        portal_name: ownership
+                        section_name: ownership
                         auto_answered: true
                     - question: Which of these best describes your interest in the land?
                       responses:
                         - value: Sole owner
                       metadata:
-                        portal_name: ownership
+                        section_name: ownership
                         policy_refs:
                           - text: The Town and Country Planning (Development Management Procedure) (England) Order 2015
                     - question: What type of application is it?
                       responses:
                         - value: Lawful Development Certificate – Existing changes
                       metadata:
-                        portal_name: community-infrastructure-levy
+                        section_name: community-infrastructure-levy
                         auto_answered: true
                     - question: What does the project involve?
                       responses:
@@ -878,13 +878,13 @@ paths:
                             flags:
                               - Community infrastructure levy / Not liable
                       metadata:
-                        portal_name: CIL Liability check
+                        section_name: CIL Liability check
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Changes that have already been made in the past
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                         policy_refs:
                           - text: '[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)'
@@ -892,137 +892,137 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What types of changes did the project involve?
                       responses:
                         - value: Alterations
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                         auto_answered: true
                     - question: Did the works involve altering the appearance or layout of any roof?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any detail drawings?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Did the works involve any alterations to ground levels?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any photographs of the property as it is today?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any other additional drawings or documents?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Provide evidence of completion date
                       responses:
                         - value: Utility bills
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills start from?
                       responses:
                         - value: '2015-01-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills run until?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these utility bills show?
                       responses:
                         - value: 'Test evidence '
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What type of planning application are you making?
                       responses:
                         - value: Lawful Development Certificate
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         auto_answered: true
                     - question: What type of changes are you applying for?
                       responses:
                         - value: Existing changes
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         auto_answered: true
                     - question: Is the property a home?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: What types of changes does the application relate to?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: What did the alterations involve?
                       responses:
                         - value: Installation of plant equipment
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: The area of the site is
                       responses:
                         - value: 5 hectares or less
                       metadata:
-                        portal_name: LDC-E - Plant equipment or machinery
+                        section_name: LDC-E - Plant equipment or machinery
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2'
                     - question: Is the property a home?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         auto_answered: true
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         auto_answered: true
                     - question: Are the public allowed to access the building?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                     - question: Is this application a resubmission?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9'
                     - question: Does the application qualify for a disability exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Is the site a sports field?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         auto_answered: true
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 3'
@@ -1030,7 +1030,7 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         auto_answered: true
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11'
@@ -1038,20 +1038,20 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10'
                     - question: Does the application qualify for the sports club fee reduction?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Does the application qualify for the parish council reduction?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11'
@@ -1059,82 +1059,82 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Did you get any pre-application advice before making this application?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: pre-app-advice-check
+                        section_name: pre-app-advice-check
                     - question: Connections with Southwark Council
                       responses:
                         - value: None of the above apply to me
                       metadata:
-                        portal_name: declarations
+                        section_name: declarations
                     - question: 'I confirm that:'
                       responses:
                         - value: 'The information contained in this application is truthful, accurate and complete, to the best of my knowledge'
                       metadata:
-                        portal_name: declarations
+                        section_name: declarations
                     - question: What is the applicant's interest in the land?
                       responses:
                         - value: Southwark
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: What is the user's role?
                       responses:
                         - value: Applicant
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: What is the applicant's declared connections?
                       responses:
                         - value: None
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: Does the application qualify for a disability exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What do these photographs show?
                       responses:
                         - value: That it has happened
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills start from?
                       responses:
                         - value: '2013-03-02'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills run until?
                       responses:
                         - value: '2019-04-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these utility bills show?
                       responses:
                         - value: That i was paying water bills
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: When was this building control certificate issued?
                       responses:
                         - value: '2019-04-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these building control certificates show?
                       responses:
                         - value: that it was certified
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                   constraints:
                     conservation_area: true
@@ -1198,46 +1198,46 @@ paths:
                         - value: None of the above apply to me
                       metadata:
                         auto_answered: true
-                        portal_name: declarations
+                        section_name: declarations
                     - question: Has the house already been extended?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Select your project
                       responses:
                         - value: Add a rear extension
                       metadata:
-                        portal_name: Types of prior approval for houses
+                        section_name: Types of prior approval for houses
                     - question: Exactly how high are the eaves of the extension?
                       responses:
                         - value: '2.5'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class APermitted Development Rights for Householders Technical Guidance (PDF, 500KB)'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Are you applying on behalf of someone else?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Is any part of the extension within 2 metres of the boundary?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of house is it?
                       responses:
                         - value: Mid terrace
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and Side Extensions
+                        section_name: Rear and Side Extensions
                     - question: Is your contact address the same as the property address?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: How much of the property is covered by extensions and outbuildings?
                       responses:
                         - value: 50% or less of the available area around the original house
@@ -1247,12 +1247,12 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Connections with London Borough of Lambeth
                       responses:
                         - value: None of the above apply to me
                       metadata:
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: Was the house built before 2020?
                       responses:
                         - value: 'Yes, it was built before 2020'
@@ -1262,7 +1262,7 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class 1 A.'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: How far does the new addition extend beyond the back wall of the original house?
                       responses:
                         - value: 3 to 6m
@@ -1272,83 +1272,83 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (f)(i)'
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: Is the property in Lambeth?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: _root
+                        section_name: _root
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: What type of house is it?
                       responses:
                         - value: A terrace
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: What type of property is it?
                       responses:
                         - value: House
                       metadata:
                         auto_answered: true
-                        portal_name: property-types
+                        section_name: property-types
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Prior approval fees
+                        section_name: Prior approval fees
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-more-information
+                        section_name: prior-approval-more-information
                     - question: Has work already started?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                     - question: What is the exact height of the extension?
                       responses:
                         - value: '3'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of property is it?
                       responses:
                         - value: House
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-scope-check
+                        section_name: prior-approval-scope-check
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: 'Would you like to upload any additional drawings, documents or images?'
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Does the original house have a projection to the rear?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Will any part of the extension be higher than 4m?
                       responses:
                         - value: 'No'
@@ -1358,42 +1358,42 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (g)(ii)Permitted Development Rights for Householders Technical Guidance (PDF, 500KB)'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of house it is?
                       responses:
                         - value: Terrace
                       metadata:
                         auto_answered: true
-                        portal_name: property-types
+                        section_name: property-types
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Fee Exemptions check
+                        section_name: Fee Exemptions check
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What will you use the extension for?
                       responses:
                         - value: Kitchen
@@ -1403,30 +1403,30 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A  Town and Country Planning Act 1990, Section 55'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Describe the project.
                       responses:
                         - value: The new extension will be 4.5m in length beyond the original rear wall on the ground floor.nThe height of the new extension is 3 meters (measured from the ground to the highest point of the new extension)n
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                     - question: Is the property subject to any Article 4 directions?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: _root
+                        section_name: _root
                     - question: What works does the project involve?
                       responses:
                         - value: Extension
                       metadata:
                         auto_answered: true
-                        portal_name: Disability exemption check
+                        section_name: Disability exemption check
                     - question: Which Local Planning authority is it?
                       responses:
                         - value: Lambeth
                       metadata:
                         auto_answered: true
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: Are the materials of the extension similar to the original house?
                       responses:
                         - value: 'Yes'
@@ -1436,19 +1436,19 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property a site of special scientific interest?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: What type of prior approval application is it?application.type
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Lambeth confirmation page
+                        section_name: Lambeth confirmation page
                     - question: Does the application qualify to the same-day-planning-application exemption?
                       responses:
                         - value: 'No'
@@ -1456,44 +1456,44 @@ paths:
                         auto_answered: true
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14'
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: What type of planning application are you making?
                       responses:
                         - value: Prior approval
                       metadata:
                         auto_answered: true
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                     - question: Was the house always a house?
                       responses:
                         - value: 'Yes, it was built as a house'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: 'We may need to visit your site to assess your application. If we do, who should we contact to arrange the visit?'
                       responses:
                         - value: 'Me, the applicant'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Are you submitting a planning permission application as well as this prior approval application?
                       responses:
                         - value: 'No'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14'
-                        portal_name: Planning applications exemption
+                        section_name: Planning applications exemption
                     - question: Does the application qualify for a disability exemption?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: How high are the eaves of the extension?
                       responses:
                         - value: 3m or lower
@@ -1503,7 +1503,7 @@ paths:
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (i)Permitted Development Rights for Householders Technical Guidance (PDF, 500KB)'
-                        portal_name: Extensions - Two storey extensions
+                        section_name: Extensions - Two storey extensions
                     - question: What type of property is it?
                       responses:
                         - value: House
@@ -1511,109 +1511,109 @@ paths:
                         auto_answered: true
                         policy_refs:
                           - text: The Town and Country Planning (General Permitted Development) (England) Order 2015
-                        portal_name: Rear and Side Extensions
+                        section_name: Rear and Side Extensions
                     - question: Do you want to add drawings to show elevations?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Is the property a home?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Disability exemption check
+                        section_name: Disability exemption check
                     - question: Which of these best describes you (or your organisation)?
                       responses:
                         - value: Private individual
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: 'I confirm that:'
                       responses:
                         - value: 'The information contained in this application is truthful, accurate and complete, to the best of my knowledge'
                       metadata:
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: 'I confirm that:'
                       responses:
                         - value: 'The information contained in this application is truthful, accurate and complete, to the best of my knowledge'
                       metadata:
                         auto_answered: true
-                        portal_name: declarations
+                        section_name: declarations
                     - question: Which of these best describes your project?
                       responses:
                         - value: Rear only
                       metadata:
                         policy_refs:
                           - text: 'General Permitted Development Order 2015, Technical guidance (PDF)'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Your contact details
                       responses:
                         - value: joe@test.com Mr Blogs Joe 22211
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which Local Planning authority is it?
                       responses:
                         - value: Lambeth
                       metadata:
                         auto_answered: true
-                        portal_name: Confirmation pages
+                        section_name: Confirmation pages
                     - question: Which of these best describes the new extension?
                       responses:
                         - value: Single storey
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Section 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of roof does the extension have?
                       responses:
                         - value: Sloping
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is any part of the extension within 2 metres of the boundary?
                       responses:
                         - value: 'Yes'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A'
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: Is the sole purpose of the project to support the needs of a disabled resident?
                       responses:
                         - value: 'No'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14UK Statutory Instruments 2012 No. 2920 Regulation 4, Equalities Act 2010, Section 6 Children Act 1989, Part 3'
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                     - question: Does the original house have a projection to the rear?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: Exactly how far will the new addition extend beyond the back wall of the original house?
                       responses:
                         - value: '4.5'
                       metadata:
                         policy_refs:
                           - text: 'The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A'
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of roof does the extension have?
                       responses:
                         - value: Sloping
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -200,7 +200,7 @@ paths:
                       metadata:
                         type: object
                         properties:
-                          portal_name:
+                          section_name:
                             type: string
                             example: Property details
                           notes:
@@ -332,32 +332,32 @@ paths:
                       responses:
                         - value: 'Modify or extend'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: What is the dwelling used as?
                       responses:
                         - value: A family home
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Is the property a house?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: How many storeys will the new structure have?
                       responses:
                         - value: '1'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Was the house always a house?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                     - question: Will the structure include a satellite dish or antenna?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                         policy_refs:
                           - url: http://example.com/planning/policy/1/234/a.html
                             text: 'GPDO 00.0000.000'
@@ -365,38 +365,38 @@ paths:
                       responses:
                         - value: 50% or less
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: How high will the eaves of the new structure be?
                       responses:
                         - value: '2.5m or lower'
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: What will the height of the new structure be?
                       responses:
                         - value: '2.5m or lower'
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: How close will the new structure be to the site boundary?
                       responses:
                         - value: 'Within 2m'
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: Will any part of the new structure be forward of the front of the original house?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: Will any part of the pool be forward of the front of the original house?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Front of house
+                        section_name: Front of house
                     - question: What is the addition to the property?
                       responses:
                         - value: An outdoor pool
                         - value: An outbuilding
                       metadata:
-                        portal_name: Property details
+                        section_name: Property details
                         policy_refs:
                           - url: http://example.com/planning/policy/1/234/b.html
                             text: 'GPDO 00.0000.000'
@@ -406,36 +406,36 @@ paths:
                       responses:
                         - value: '1'
                       metadata:
-                        portal_name: Dimensions
+                        section_name: Dimensions
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                           auto_answered: true
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                     - question: Is the property in an area of outstanding natural beauty?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in the broads?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in a world heritage site?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is the property in a national park?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Is any part of the property listed?
                       responses:
@@ -444,12 +444,12 @@ paths:
                             flags:
                               - 'Listed building consent / Not required'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                     - question: Will the works affect a protected tree?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Surrounding Area
+                        section_name: Surrounding Area
                         auto_answered: true
                     - question: Will the new addition allow you to do an activity that most houses do not provide a dedicated space for?
                       responses:
@@ -459,19 +459,19 @@ paths:
                             flags:
                               - 'Planning permission / Permission needed'
                       metadata:
-                        portal_name: Actitivies
+                        section_name: Actitivies
                     - question: What type of planning application are you making?
                       responses:
                         - value: Existing changes
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         policy_refs:
                           - url: http://example.com/planning/policy/1/234/a.html
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         policy_refs:
                           - text: The Town and Country Planning (General Permitted Development) (England) Order 2015
                   constraints:
@@ -529,13 +529,13 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Existing changes I have made in the past
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         policy_refs:
                           - text: >-
                               Town and Country Planning Act 1990, Part 7, Section 191 &amp;
@@ -544,12 +544,12 @@ paths:
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                     - question: What type of changes were they?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         auto_answered: true
                     - question: Were the works carried out more than 4 years ago?
                       responses:
@@ -558,21 +558,21 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: Have the works been completed?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: When were the works completed?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: Town and Country Planning Act 1990 Section 171B
                     - question: Has anyone ever attempted to conceal the changes?
@@ -582,7 +582,7 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: >-
                               Secretary of State for Communities and Local Government and another
@@ -595,7 +595,7 @@ paths:
                             flags:
                               - Planning permission / Immune
                       metadata:
-                        portal_name: immunity-check
+                        section_name: immunity-check
                         policy_refs:
                           - text: >-
                               Enforcement action is defined in the Town and Country Planning Act
@@ -607,7 +607,7 @@ paths:
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: permitteddevelopment
+                        section_name: permitteddevelopment
                         auto_answered: true
                         policy_refs:
                           - text: >-
@@ -618,7 +618,7 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: Alarms
+                        section_name: Alarms
                         auto_answered: true
                         policy_refs:
                           - text: Town and Country Planning Act 1990, Section 55 (2)
@@ -629,14 +629,14 @@ paths:
                             flags:
                               - Planning permission / Not development
                       metadata:
-                        portal_name: Alarms
+                        section_name: Alarms
                         policy_refs:
                           - text: Town and Country Planning Act 1990, Section 55 (2)
                     - question: Is any part of the property listed?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What do the proposals involve?
                       responses:
@@ -645,7 +645,7 @@ paths:
                             flags:
                               - Listed building consent / Required
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                         policy_refs:
                           - text: Planning (Listed Buildings and Conservation Areas) Act 1990
@@ -653,19 +653,19 @@ paths:
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Have you already told us that you are doing works to a tree or hedge?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Are there any protected trees on the property?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         auto_answered: true
                     - question: Do the works affect a protected tree?
                       responses:
@@ -674,7 +674,7 @@ paths:
                             flags:
                               - Works to trees & hedges / Not required
                       metadata:
-                        portal_name: works-to-trees-filter
+                        section_name: works-to-trees-filter
                         policy_refs:
                           - text: >-
                               The Town and Country Planning (Tree Preservation)(England)
@@ -683,37 +683,37 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Existing changes I have made in the past
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: What do the works involve?
                       responses:
                         - value: Alterations
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: What does the project involve?
                       responses:
                         - value: Install a security alarm
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: Do the changes involve the creation of any new homes?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                     - question: Is the property in the Greater London Authority area?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: more-details
+                        section_name: more-details
                         auto_answered: true
                         policy_refs:
                           - text: Greater London Authority Act 1999
@@ -721,26 +721,26 @@ paths:
                       responses:
                         - value: Only one
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Do you know the title number of the property?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                     - question: Does the property have an Energy Performance Certificate (EPC)?
                       responses:
                         - value: I don't know
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: What type of application is this?
                       responses:
                         - value: Lawful Development Certificate - Existing
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         auto_answered: true
                         policy_refs:
                           - text: Greater London Authority Act 1999
@@ -748,59 +748,59 @@ paths:
                       responses:
                         - value: '2015-01-01'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: When were the works completed?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Does the site include parking spaces for any of these?
                       responses:
                         - value: None of these
                       metadata:
-                        portal_name: London Datahub
+                        section_name: London Datahub
                         policy_refs:
                           - text: Greater London Authority Act 1999
                     - question: Are you applying on behalf of someone else?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which of these best describes you?
                       responses:
                         - value: Private individual
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Enter your contact details
                       responses:
                         - value: jessica@opensystemslab.io Test Jess 0123456789
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Is your contact address the same as the property address?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: If a planning officer needs to make a site visit, who should they contact?
                       responses:
                         - value: Me, the applicant
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which of these best describes you?
                       responses:
                         - value: Applicant
                       metadata:
-                        portal_name: ownership
+                        section_name: ownership
                         auto_answered: true
                     - question: Which of these best describes your interest in the land?
                       responses:
                         - value: Sole owner
                       metadata:
-                        portal_name: ownership
+                        section_name: ownership
                         policy_refs:
                           - text: >-
                               The Town and Country Planning (Development Management Procedure)
@@ -809,7 +809,7 @@ paths:
                       responses:
                         - value: Lawful Development Certificate – Existing changes
                       metadata:
-                        portal_name: community-infrastructure-levy
+                        section_name: community-infrastructure-levy
                         auto_answered: true
                     - question: What does the project involve?
                       responses:
@@ -818,13 +818,13 @@ paths:
                             flags:
                               - Community infrastructure levy / Not liable
                       metadata:
-                        portal_name: CIL Liability check
+                        section_name: CIL Liability check
                         auto_answered: true
                     - question: What are you applying about?
                       responses:
                         - value: Changes that have already been made in the past
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                         policy_refs:
                           - text: >-
@@ -834,94 +834,94 @@ paths:
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What types of changes did the project involve?
                       responses:
                         - value: Alterations
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                         auto_answered: true
                     - question: Did the works involve altering the appearance or layout of any roof?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any detail drawings?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Did the works involve any alterations to ground levels?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any photographs of the property as it is today?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Would you like to upload any other additional drawings or documents?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: certificate-of-lawfulness-existing-drawings-immunity
+                        section_name: certificate-of-lawfulness-existing-drawings-immunity
                     - question: Provide evidence of completion date
                       responses:
                         - value: Utility bills
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills start from?
                       responses:
                         - value: '2015-01-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills run until?
                       responses:
                         - value: '2015-02-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these utility bills show?
                       responses:
                         - value: 'Test evidence '
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What type of planning application are you making?
                       responses:
                         - value: Lawful Development Certificate
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         auto_answered: true
                     - question: What type of changes are you applying for?
                       responses:
                         - value: Existing changes
                       metadata:
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                         auto_answered: true
                     - question: Is the property a home?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: What types of changes does the application relate to?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: What did the alterations involve?
                       responses:
                         - value: Installation of plant equipment
                       metadata:
-                        portal_name: LDC in Existing Use
+                        section_name: LDC in Existing Use
                         auto_answered: true
                     - question: The area of the site is
                       responses:
                         - value: 5 hectares or less
                       metadata:
-                        portal_name: LDC-E - Plant equipment or machinery
+                        section_name: LDC-E - Plant equipment or machinery
                         policy_refs:
                           - text: >-
                               The Town and Country Planning (Fees for Applications, Deemed
@@ -931,24 +931,24 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         auto_answered: true
                     - question: What type of changes does the project involve?
                       responses:
                         - value: Alteration
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         auto_answered: true
                     - question: Are the public allowed to access the building?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                     - question: Is this application a resubmission?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                         policy_refs:
                           - text: >-
                               The Town and Country Planning (Fees for Applications, Deemed
@@ -958,19 +958,19 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Is the site a sports field?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         auto_answered: true
                         policy_refs:
                           - text: >-
@@ -983,7 +983,7 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         auto_answered: true
                         policy_refs:
                           - text: >-
@@ -994,7 +994,7 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee Reductions
+                        section_name: Fee Reductions
                         policy_refs:
                           - text: >-
                               The Town and Country Planning (Fees for Applications, Deemed
@@ -1004,13 +1004,13 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Does the application qualify for the parish council reduction?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                         policy_refs:
                           - text: >-
@@ -1021,84 +1021,84 @@ paths:
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Fee exemptions and adjustments
+                        section_name: Fee exemptions and adjustments
                         auto_answered: true
                     - question: Did you get any pre-application advice before making this application?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: pre-app-advice-check
+                        section_name: pre-app-advice-check
                     - question: Connections with Southwark Council
                       responses:
                         - value: None of the above apply to me
                       metadata:
-                        portal_name: declarations
+                        section_name: declarations
                     - question: 'I confirm that:'
                       responses:
                         - value: >-
                             The information contained in this application is truthful, accurate
                             and complete, to the best of my knowledge
                       metadata:
-                        portal_name: declarations
+                        section_name: declarations
                     - question: What is the applicant's interest in the land?
                       responses:
                         - value: Southwark
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: What is the user's role?
                       responses:
                         - value: Applicant
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: What is the applicant's declared connections?
                       responses:
                         - value: None
                       metadata:
-                        portal_name: uniform-translator
+                        section_name: uniform-translator
                         auto_answered: true
                     - question: Does the application qualify for a disability exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                     - question: What do these photographs show?
                       responses:
                         - value: That it has happened
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills start from?
                       responses:
                         - value: '2013-03-02'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What date do these utility bills run until?
                       responses:
                         - value: '2019-04-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these utility bills show?
                       responses:
                         - value: That i was paying water bills
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: When was this building control certificate issued?
                       responses:
                         - value: '2019-04-01'
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: What do these building control certificates show?
                       responses:
                         - value: that it was certified
                       metadata:
-                        portal_name: certificate-of-lawfulness-documents-immunity
+                        section_name: certificate-of-lawfulness-documents-immunity
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                         auto_answered: true
                   constraints:
                     conservation_area: true
@@ -1158,17 +1158,17 @@ paths:
                         - value: None of the above apply to me
                       metadata:
                         auto_answered: true
-                        portal_name: declarations
+                        section_name: declarations
                     - question: Has the house already been extended?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Select your project
                       responses:
                         - value: Add a rear extension
                       metadata:
-                        portal_name: Types of prior approval for houses
+                        section_name: Types of prior approval for houses
                     - question: Exactly how high are the eaves of the extension?
                       responses:
                         - value: '2.5'
@@ -1178,29 +1178,29 @@ paths:
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class APermitted
                               Development Rights for Householders Technical Guidance (PDF, 500KB)
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Are you applying on behalf of someone else?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Is any part of the extension within 2 metres of the boundary?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of house is it?
                       responses:
                         - value: Mid terrace
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and Side Extensions
+                        section_name: Rear and Side Extensions
                     - question: Is your contact address the same as the property address?
                       responses:
                         - value: 'Yes'
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: How much of the property is covered by extensions and outbuildings?
                       responses:
                         - value: 50% or less of the available area around the original house
@@ -1212,12 +1212,12 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Connections with London Borough of Lambeth
                       responses:
                         - value: None of the above apply to me
                       metadata:
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: Was the house built before 2020?
                       responses:
                         - value: Yes, it was built before 2020
@@ -1229,7 +1229,7 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class 1 A.
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: >-
                         How far does the new addition extend beyond the back wall of the original
                         house?
@@ -1243,48 +1243,48 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A.1 (f)(i)
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: Is the property in Lambeth?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: _root
+                        section_name: _root
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: What type of house is it?
                       responses:
                         - value: A terrace
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: What type of property is it?
                       responses:
                         - value: House
                       metadata:
                         auto_answered: true
-                        portal_name: property-types
+                        section_name: property-types
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Prior approval fees
+                        section_name: Prior approval fees
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-more-information
+                        section_name: prior-approval-more-information
                     - question: Has work already started?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                     - question: What is the exact height of the extension?
                       responses:
                         - value: '3'
@@ -1293,35 +1293,35 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of property is it?
                       responses:
                         - value: House
                       metadata:
                         auto_answered: true
-                        portal_name: prior-approval-scope-check
+                        section_name: prior-approval-scope-check
                     - question: Does the application qualify for a resubmission exemption?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: Would you like to upload any additional drawings, documents or images?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Does the original house have a projection to the rear?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Will any part of the extension be higher than 4m?
                       responses:
                         - value: 'No'
@@ -1334,42 +1334,42 @@ paths:
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A.1 (g)(ii)Permitted
                               Development Rights for Householders Technical Guidance (PDF, 500KB)
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of house it is?
                       responses:
                         - value: Terrace
                       metadata:
                         auto_answered: true
-                        portal_name: property-types
+                        section_name: property-types
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is this a prior approval application for a larger rear extension?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of prior approval application is it?
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Fee Exemptions check
+                        section_name: Fee Exemptions check
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What will you use the extension for?
                       responses:
                         - value: Kitchen
@@ -1382,7 +1382,7 @@ paths:
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A  Town and Country
                               Planning Act 1990, Section 55
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Describe the project.
                       responses:
                         - value: >-
@@ -1390,25 +1390,25 @@ paths:
                             on the ground floor.nThe height of the new extension is 3 meters
                             (measured from the ground to the highest point of the new extension)n
                       metadata:
-                        portal_name: _root
+                        section_name: _root
                     - question: Is the property subject to any Article 4 directions?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: _root
+                        section_name: _root
                     - question: What works does the project involve?
                       responses:
                         - value: Extension
                       metadata:
                         auto_answered: true
-                        portal_name: Disability exemption check
+                        section_name: Disability exemption check
                     - question: Which Local Planning authority is it?
                       responses:
                         - value: Lambeth
                       metadata:
                         auto_answered: true
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: Are the materials of the extension similar to the original house?
                       responses:
                         - value: 'Yes'
@@ -1420,19 +1420,19 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property a site of special scientific interest?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: What type of prior approval application is it?application.type
                       responses:
                         - value: Larger extension to a house
                       metadata:
                         auto_answered: true
-                        portal_name: Lambeth confirmation page
+                        section_name: Lambeth confirmation page
                     - question: >-
                         Does the application qualify to the same-day-planning-application
                         exemption?
@@ -1445,13 +1445,13 @@ paths:
                               The Town and Country Planning (Fees for Applications, Deemed
                               Applications, Requests and Site Visits) (England) Regulations 2012,
                               Regulation 14
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: What type of planning application are you making?
                       responses:
                         - value: Prior approval
                       metadata:
                         auto_answered: true
-                        portal_name: fee-calculator
+                        section_name: fee-calculator
                     - question: Was the house always a house?
                       responses:
                         - value: Yes, it was built as a house
@@ -1460,20 +1460,20 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015, Schedule 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: >-
                         We may need to visit your site to assess your application. If we do, who
                         should we contact to arrange the visit?
                       responses:
                         - value: Me, the applicant
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: >-
                         Are you submitting a planning permission application as well as this prior
                         approval application?
@@ -1485,13 +1485,13 @@ paths:
                               The Town and Country Planning (Fees for Applications, Deemed
                               Applications, Requests and Site Visits) (England) Regulations 2012,
                               Regulation 14
-                        portal_name: Planning applications exemption
+                        section_name: Planning applications exemption
                     - question: Does the application qualify for a disability exemption?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Prior Approval Fee exemptions
+                        section_name: Prior Approval Fee exemptions
                     - question: How high are the eaves of the extension?
                       responses:
                         - value: 3m or lower
@@ -1504,7 +1504,7 @@ paths:
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A.1 (i)Permitted
                               Development Rights for Householders Technical Guidance (PDF, 500KB)
-                        portal_name: Extensions - Two storey extensions
+                        section_name: Extensions - Two storey extensions
                     - question: What type of property is it?
                       responses:
                         - value: House
@@ -1514,30 +1514,30 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015
-                        portal_name: Rear and Side Extensions
+                        section_name: Rear and Side Extensions
                     - question: Do you want to add drawings to show elevations?
                       responses:
                         - value: 'No'
                       metadata:
-                        portal_name: prior-approval-files
+                        section_name: prior-approval-files
                     - question: Is the property a home?
                       responses:
                         - value: 'Yes'
                       metadata:
                         auto_answered: true
-                        portal_name: Disability exemption check
+                        section_name: Disability exemption check
                     - question: Which of these best describes you (or your organisation)?
                       responses:
                         - value: Private individual
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: 'I confirm that:'
                       responses:
                         - value: >-
                             The information contained in this application is truthful, accurate
                             and complete, to the best of my knowledge
                       metadata:
-                        portal_name: apply-for-service-declarations
+                        section_name: apply-for-service-declarations
                     - question: 'I confirm that:'
                       responses:
                         - value: >-
@@ -1545,25 +1545,25 @@ paths:
                             and complete, to the best of my knowledge
                       metadata:
                         auto_answered: true
-                        portal_name: declarations
+                        section_name: declarations
                     - question: Which of these best describes your project?
                       responses:
                         - value: Rear only
                       metadata:
                         policy_refs:
                           - text: General Permitted Development Order 2015, Technical guidance (PDF)
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Your contact details
                       responses:
                         - value: joe@test.com Mr Blogs Joe 22211
                       metadata:
-                        portal_name: about-the-applicant
+                        section_name: about-the-applicant
                     - question: Which Local Planning authority is it?
                       responses:
                         - value: Lambeth
                       metadata:
                         auto_answered: true
-                        portal_name: Confirmation pages
+                        section_name: Confirmation pages
                     - question: Which of these best describes the new extension?
                       responses:
                         - value: Single storey
@@ -1572,18 +1572,18 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Section 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: How many storeys does the original house have?
                       responses:
                         - value: 2 or more
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of roof does the extension have?
                       responses:
                         - value: Sloping
                       metadata:
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is any part of the extension within 2 metres of the boundary?
                       responses:
                         - value: 'Yes'
@@ -1592,7 +1592,7 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: >-
                         Is the sole purpose of the project to support the needs of a disabled
                         resident?
@@ -1605,19 +1605,19 @@ paths:
                               Applications, Requests and Site Visits) (England) Regulations 2012,
                               Regulation 14UK Statutory Instruments 2012 No. 2920 Regulation 4,
                               Equalities Act 2010, Section 6 Children Act 1989, Part 3
-                        portal_name: Fee Exemptions
+                        section_name: Fee Exemptions
                     - question: Does the original house have a projection to the rear?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: Is the property on designated land?
                       responses:
                         - value: 'No'
                       metadata:
                         auto_answered: true
-                        portal_name: Extensions - No projection - Rear only
+                        section_name: Extensions - No projection - Rear only
                     - question: >-
                         Exactly how far will the new addition extend beyond the back wall of the
                         original house?
@@ -1628,13 +1628,13 @@ paths:
                           - text: >-
                               The Town and Country Planning (General Permitted Development)
                               (England) Order 2015 Schedule 2, Part 1, Class A
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                     - question: What type of roof does the extension have?
                       responses:
                         - value: Sloping
                       metadata:
                         auto_answered: true
-                        portal_name: Rear and side extensions to houses
+                        section_name: Rear and side extensions to houses
                   constraints:
                     conservation_area: true
                     protected_trees: false

--- a/spec/components/proposal_details/group_component_spec.rb
+++ b/spec/components/proposal_details/group_component_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe ProposalDetails::GroupComponent, type: :component do
     {
       question: "Test question 1",
       responses: [{ value: "Test response 1" }],
-      metadata: { portal_name: "group_x" }
+      metadata: { section_name: "group_x" }
     }.deep_stringify_keys
   end
 
   let(:group) do
-    Struct.new(:portal_name, :proposal_details).new(
+    Struct.new(:section_name, :proposal_details).new(
       "group_x",
       [ProposalDetail.new(proposal_detail_attributes, 1)]
     )

--- a/spec/components/proposal_details/link_component_spec.rb
+++ b/spec/components/proposal_details/link_component_spec.rb
@@ -7,15 +7,15 @@ RSpec.describe ProposalDetails::LinkComponent, type: :component do
     {
       question: "Test question 1",
       responses: [{ value: "Test response 1" }],
-      metadata: { portal_name: }
+      metadata: { section_name: }
     }.deep_stringify_keys
   end
 
-  let(:portal_name) { "group_x" }
+  let(:section_name) { "group_x" }
 
   let(:group) do
-    Struct.new(:portal_name, :proposal_details).new(
-      portal_name,
+    Struct.new(:section_name, :proposal_details).new(
+      section_name,
       [ProposalDetail.new(proposal_detail_attributes, 1)]
     )
   end
@@ -28,16 +28,8 @@ RSpec.describe ProposalDetails::LinkComponent, type: :component do
     expect(page).to have_link("Group x", href: "#groupx")
   end
 
-  context "when portal_name is '_root'" do
-    let(:portal_name) { "_root" }
-
-    it "renders link to 'Main'" do
-      expect(page).to have_link("Main", href: "#main")
-    end
-  end
-
-  context "when portal_name is nil" do
-    let(:portal_name) { nil }
+  context "when section_name is nil" do
+    let(:section_name) { nil }
 
     it "renders link to 'Other'" do
       expect(page).to have_link("Other", href: "#other")

--- a/spec/components/proposal_details/list_component_spec.rb
+++ b/spec/components/proposal_details/list_component_spec.rb
@@ -8,17 +8,17 @@ RSpec.describe ProposalDetails::ListComponent, type: :component do
       {
         question: "Test question 1",
         responses: [{ value: "Test response 1" }],
-        metadata: { auto_answered: true, portal_name: "group_a" }
+        metadata: { auto_answered: true, section_name: "group_a" }
       },
       {
         question: "Test question 2",
         responses: [{ value: "Test response 2" }],
-        metadata: { auto_answered: true, portal_name: "group_b" }
+        metadata: { auto_answered: true, section_name: "group_b" }
       },
       {
         question: "Test question 3",
         responses: [{ value: "Test response 3" }],
-        metadata: { auto_answered: true, portal_name: "group_a" }
+        metadata: { auto_answered: true, section_name: "group_a" }
       }
     ].to_json
   end

--- a/spec/components/proposal_details/summary_component_spec.rb
+++ b/spec/components/proposal_details/summary_component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProposalDetails::SummaryComponent, type: :component do
       question: "Test question 1",
       responses: [{ value: "Test response 1" }, { value: "Test response 2" }],
       metadata: {
-        portal_name: "group_x",
+        section_name: "group_x",
         notes: "Test note",
         auto_answered: true,
         policy_refs: [{ url: "www.example.com" }, { text: "Test ref" }]

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -304,19 +304,25 @@ FactoryBot.define do
         [
           {
             responses: [{
-              value: "Install a security alarm"
+              value: "Install a security alarm",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check"
+              section_name: "immunity-check"
             },
             question: "List the changes involved in the project"
           },
           {
             responses: [{
-              value: "Alteration"
+              value: "Alteration",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               auto_answered: true
             },
             question: "What type of changes were they?"
@@ -329,7 +335,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -338,10 +344,13 @@ FactoryBot.define do
           },
           {
             responses: [{
-              value: "Yes"
+              value: "Yes",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -353,7 +362,7 @@ FactoryBot.define do
               value: "that it was certified"
             }],
             metadata: {
-              portal_name: "certificate-of-lawfulness-documents-immunity"
+              section_name: "certificate-of-lawfulness-documents-immunity"
             },
             question: "What do these building control certificates show?"
           },
@@ -362,7 +371,7 @@ FactoryBot.define do
               value: "2016-02-01"
             }],
             metadata: {
-              portal_name: "certificate-of-lawfulness-documents-immunity"
+              section_name: "certificate-of-lawfulness-documents-immunity"
             },
             question: "When was this building control certificate issued?"
           },
@@ -371,7 +380,7 @@ FactoryBot.define do
               value: "2013-03-02"
             }],
             metadata: {
-              portal_name: "certificate-of-lawfulness-documents-immunity"
+              section_name: "certificate-of-lawfulness-documents-immunity"
             },
             question: "What date do these utility bills start from?"
           },
@@ -380,7 +389,7 @@ FactoryBot.define do
               value: "2019-04-01"
             }],
             metadata: {
-              portal_name: "certificate-of-lawfulness-documents-immunity"
+              section_name: "certificate-of-lawfulness-documents-immunity"
             },
             question: "What date do these utility bills run until?"
           },
@@ -389,16 +398,19 @@ FactoryBot.define do
               value: "That i was paying water bills"
             }],
             metadata: {
-              portal_name: "certificate-of-lawfulness-documents-immunity"
+              section_name: "certificate-of-lawfulness-documents-immunity"
             },
             question: "What do these utility bills show?"
           },
           {
             responses: [{
-              value: "2015-02-01"
+              value: "2015-02-01",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -413,7 +425,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Secretary of State for Communities and Local Government and another v Welwyn Hatfield Borough Council and Bonsall / Jackson v Secretary of State for Communities and Local Government"
               }]
@@ -428,7 +440,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Enforcement action is defined in the Town and Country Planning Act 1990 Section 171A.\n'Lawful development' is defined in the Town and Country Planning Act 1990 Section 191."
               }]
@@ -452,19 +464,25 @@ FactoryBot.define do
         [
           {
             responses: [{
-              value: "Install a security alarm"
+              value: "Install a security alarm",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check"
+              section_name: "immunity-check"
             },
             question: "List the changes involved in the project"
           },
           {
             responses: [{
-              value: "Alteration"
+              value: "Alteration",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               auto_answered: true
             },
             question: "What type of changes were they?"
@@ -477,7 +495,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -486,10 +504,13 @@ FactoryBot.define do
           },
           {
             responses: [{
-              value: "Yes"
+              value: "Yes",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -498,10 +519,13 @@ FactoryBot.define do
           },
           {
             responses: [{
-              value: "2015-02-01"
+              value: "2015-02-01",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Town and Country Planning Act 1990 Section 171B"
               }]
@@ -516,7 +540,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Secretary of State for Communities and Local Government and another v Welwyn Hatfield Borough Council and Bonsall / Jackson v Secretary of State for Communities and Local Government"
               }]
@@ -531,7 +555,7 @@ FactoryBot.define do
               }
             }],
             metadata: {
-              portal_name: "immunity-check",
+              section_name: "immunity-check",
               policy_refs: [{
                 text: "Enforcement action is defined in the Town and Country Planning Act 1990 Section 171A.\n'Lawful development' is defined in the Town and Country Planning Act 1990 Section 191."
               }]

--- a/spec/fixtures/files/planx_params.json
+++ b/spec/fixtures/files/planx_params.json
@@ -44,7 +44,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details"
+        "section_name": "Property details"
       }
     },
     {
@@ -55,7 +55,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details"
+        "section_name": "Property details"
       }
     },
     {
@@ -66,7 +66,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details"
+        "section_name": "Property details"
       }
     },
     {
@@ -77,7 +77,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details"
+        "section_name": "Property details"
       }
     },
     {
@@ -88,7 +88,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details"
+        "section_name": "Property details"
       }
     },
     {
@@ -99,7 +99,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Property details",
+        "section_name": "Property details",
         "policy_refs": [
           {
             "url": "http://example.com/planning/policy/1/234/a.html",
@@ -116,7 +116,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Dimensions"
+        "section_name": "Dimensions"
       }
     },
     {
@@ -127,7 +127,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Dimensions"
+        "section_name": "Dimensions"
       }
     },
     {
@@ -138,7 +138,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Dimensions"
+        "section_name": "Dimensions"
       }
     },
     {
@@ -149,7 +149,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Front of house"
+        "section_name": "Front of house"
       }
     },
     {
@@ -160,7 +160,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Front of house"
+        "section_name": "Front of house"
       }
     },
     {
@@ -171,7 +171,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Front of house"
+        "section_name": "Front of house"
       }
     },
     {
@@ -186,7 +186,7 @@
       ],
       "metadata":
      {
-        "portal_name": "Property details",
+        "section_name": "Property details",
         "policy_refs": [
           {
             "url": "http://example.com/planning/policy/1/234/b.html",
@@ -207,7 +207,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Dimensions"
+        "section_name": "Dimensions"
       }
     },
     {
@@ -219,7 +219,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area"
+        "section_name": "Surrounding Area"
       }
     },
     {
@@ -230,7 +230,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area",
+        "section_name": "Surrounding Area",
         "auto_answered": true
       }
     },
@@ -242,7 +242,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area",
+        "section_name": "Surrounding Area",
         "auto_answered": true
       }
     },
@@ -254,7 +254,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area",
+        "section_name": "Surrounding Area",
         "auto_answered": true
       }
     },
@@ -266,7 +266,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area",
+        "section_name": "Surrounding Area",
         "auto_answered": true
       }
     },
@@ -283,7 +283,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area"
+        "section_name": "Surrounding Area"
       }
     },
     {
@@ -294,7 +294,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Surrounding Area",
+        "section_name": "Surrounding Area",
         "auto_answered": true
       }
     },
@@ -312,7 +312,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Actitivies"
+        "section_name": "Actitivies"
       }
     },
     {
@@ -323,7 +323,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "fee-calculator",
+        "section_name": "fee-calculator",
         "policy_refs": [
           {
             "url": "http://example.com/planning/policy/1/234/a.html"
@@ -339,7 +339,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Fee Exemptions",
+        "section_name": "Fee Exemptions",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015"
@@ -406,7 +406,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details"
+          "section_name": "Property details"
         }
       },
       {
@@ -417,7 +417,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details"
+          "section_name": "Property details"
         }
       },
       {
@@ -428,7 +428,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details"
+          "section_name": "Property details"
         }
       },
       {
@@ -439,7 +439,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details"
+          "section_name": "Property details"
         }
       },
       {
@@ -450,7 +450,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details"
+          "section_name": "Property details"
         }
       },
       {
@@ -461,7 +461,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Property details",
+          "section_name": "Property details",
           "policy_refs": [
             {
               "url": "http://example.com/planning/policy/1/234/a.html",
@@ -478,7 +478,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Dimensions"
+          "section_name": "Dimensions"
         }
       },
       {
@@ -489,7 +489,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Dimensions"
+          "section_name": "Dimensions"
         }
       },
       {
@@ -500,7 +500,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Dimensions"
+          "section_name": "Dimensions"
         }
       },
       {
@@ -511,7 +511,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Front of house"
+          "section_name": "Front of house"
         }
       },
      {
@@ -522,7 +522,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Front of house"
+          "section_name": "Front of house"
         }
       },
       {
@@ -533,7 +533,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Front of house"
+          "section_name": "Front of house"
         }
       },
       {
@@ -548,7 +548,7 @@
         ],
         "metadata":
        {
-          "portal_name": "Property details",
+          "section_name": "Property details",
           "policy_refs": [
             {
               "url": "http://example.com/planning/policy/1/234/b.html",
@@ -569,7 +569,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Dimensions"
+          "section_name": "Dimensions"
         }
       },
       {
@@ -581,7 +581,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area"
+          "section_name": "Surrounding Area"
         }
       },
       {
@@ -592,7 +592,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area",
+          "section_name": "Surrounding Area",
           "auto_answered": true
         }
       },
@@ -604,7 +604,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area",
+          "section_name": "Surrounding Area",
           "auto_answered": true
         }
       },
@@ -616,7 +616,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area",
+          "section_name": "Surrounding Area",
           "auto_answered": true
         }
       },
@@ -628,7 +628,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area",
+          "section_name": "Surrounding Area",
           "auto_answered": true
         }
       },
@@ -645,7 +645,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area"
+          "section_name": "Surrounding Area"
         }
       },
       {
@@ -656,7 +656,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Surrounding Area",
+          "section_name": "Surrounding Area",
           "auto_answered": true
         }
       },
@@ -674,7 +674,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Actitivies"
+          "section_name": "Actitivies"
         }
       },
       {
@@ -685,7 +685,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "fee-calculator",
+          "section_name": "fee-calculator",
           "policy_refs": [
             {
               "url": "http://example.com/planning/policy/1/234/a.html"
@@ -701,7 +701,7 @@
           }
         ],
         "metadata": {
-          "portal_name": "Fee Exemptions",
+          "section_name": "Fee Exemptions",
           "policy_refs": [
             {
               "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015"

--- a/spec/fixtures/files/planx_params_immunity.json
+++ b/spec/fixtures/files/planx_params_immunity.json
@@ -38,7 +38,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Is the property in London Borough of Southwark?"
@@ -48,7 +48,7 @@
 				"value": "Existing changes I have made in the past"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192"
 				}]
@@ -57,19 +57,25 @@
 		},
 		{
 			"responses": [{
-				"value": "Install a security alarm"
+				"value": "Install a security alarm",
+        "metadata": {
+          "flags": ["Planning permission / Immune"]
+        }
 			}],
 			"metadata": {
-				"portal_name": "immunity-check"
+				"section_name": "immunity-check"
 			},
 			"question": "List the changes involved in the project"
 		},
 		{
 			"responses": [{
-				"value": "Alteration"
+				"value": "Alteration",
+        "metadata": {
+          "flags": ["Planning permission / Immune"]
+        }
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"auto_answered": true
 			},
 			"question": "What type of changes were they?"
@@ -82,7 +88,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990 Section 171B"
 				}]
@@ -91,10 +97,13 @@
 		},
 		{
 			"responses": [{
-				"value": "Yes"
+				"value": "Yes",
+        "metadata": {
+          "flags": ["Planning permission / Immune"]
+        }
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990 Section 171B"
 				}]
@@ -103,10 +112,13 @@
 		},
 		{
 			"responses": [{
-				"value": "2015-02-01"
+				"value": "2015-02-01",
+        "metadata": {
+          "flags": ["Planning permission / Immune"]
+        }
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990 Section 171B"
 				}]
@@ -121,7 +133,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"policy_refs": [{
 					"text": "Secretary of State for Communities and Local Government and another v Welwyn Hatfield Borough Council and Bonsall / Jackson v Secretary of State for Communities and Local Government"
 				}]
@@ -136,7 +148,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "immunity-check",
+				"section_name": "immunity-check",
 				"policy_refs": [{
 					"text": "Enforcement action is defined in the Town and Country Planning Act 1990 Section 171A.\n'Lawful development' is defined in the Town and Country Planning Act 1990 Section 191."
 				}]
@@ -148,7 +160,7 @@
 				"value": "Install a security alarm"
 			}],
 			"metadata": {
-				"portal_name": "permitteddevelopment",
+				"section_name": "permitteddevelopment",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990 (Section 55), The Town and Country Planning (General Permitted Development) (England) Order 2015"
@@ -161,7 +173,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "Alarms",
+				"section_name": "Alarms",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990, Section 55 (2)"
@@ -177,7 +189,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "Alarms",
+				"section_name": "Alarms",
 				"policy_refs": [{
 					"text": "Town and Country Planning Act 1990, Section 55 (2)"
 				}]
@@ -189,7 +201,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Is any part of the property listed?"
@@ -202,7 +214,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "Planning (Listed Buildings and Conservation Areas) Act 1990"
@@ -215,7 +227,7 @@
 				"value": "Alteration"
 			}],
 			"metadata": {
-				"portal_name": "works-to-trees-filter",
+				"section_name": "works-to-trees-filter",
 				"auto_answered": true
 			},
 			"question": "What types of changes does the project involve?"
@@ -225,7 +237,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "works-to-trees-filter",
+				"section_name": "works-to-trees-filter",
 				"auto_answered": true
 			},
 			"question": "Have you already told us that you are doing works to a tree or hedge?"
@@ -235,7 +247,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "works-to-trees-filter",
+				"section_name": "works-to-trees-filter",
 				"auto_answered": true
 			},
 			"question": "Are there any protected trees on the property?"
@@ -248,7 +260,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "works-to-trees-filter",
+				"section_name": "works-to-trees-filter",
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Tree Preservation)(England) Regulations 2012"
 				}]
@@ -260,7 +272,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Should the applicant also apply for Works to Trees Consent?"
@@ -270,7 +282,7 @@
 				"value": "Existing changes I have made in the past"
 			}],
 			"metadata": {
-				"portal_name": "more-details",
+				"section_name": "more-details",
 				"auto_answered": true
 			},
 			"question": "What are you applying about?"
@@ -280,7 +292,7 @@
 				"value": "Alterations"
 			}],
 			"metadata": {
-				"portal_name": "more-details",
+				"section_name": "more-details",
 				"auto_answered": true
 			},
 			"question": "What do the works involve?"
@@ -290,7 +302,7 @@
 				"value": "Install a security alarm"
 			}],
 			"metadata": {
-				"portal_name": "more-details",
+				"section_name": "more-details",
 				"auto_answered": true
 			},
 			"question": "What does the project involve?"
@@ -300,7 +312,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "more-details",
+				"section_name": "more-details",
 				"auto_answered": true
 			},
 			"question": "Do the changes involve the creation of any new homes?"
@@ -310,7 +322,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "more-details",
+				"section_name": "more-details",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
@@ -323,7 +335,7 @@
 				"value": "Only one"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
 				}]
@@ -335,7 +347,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub"
+				"section_name": "London Datahub"
 			},
 			"question": "Do you know the title number of the property?"
 		},
@@ -344,7 +356,7 @@
 				"value": "I don't know"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
 				}]
@@ -356,7 +368,7 @@
 				"value": "Lawful Development Certificate - Existing"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
@@ -369,7 +381,7 @@
 				"value": "2015-01-01"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
 				}]
@@ -381,7 +393,7 @@
 				"value": "2015-02-01"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
 				}]
@@ -393,7 +405,7 @@
 				"value": "None of these"
 			}],
 			"metadata": {
-				"portal_name": "London Datahub",
+				"section_name": "London Datahub",
 				"policy_refs": [{
 					"text": "Greater London Authority Act 1999"
 				}]
@@ -405,7 +417,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "about-the-applicant"
+				"section_name": "about-the-applicant"
 			},
 			"question": "Are you applying on behalf of someone else?"
 		},
@@ -414,7 +426,7 @@
 				"value": "Private individual"
 			}],
 			"metadata": {
-				"portal_name": "about-the-applicant"
+				"section_name": "about-the-applicant"
 			},
 			"question": "Which of these best describes you?"
 		},
@@ -423,7 +435,7 @@
 				"value": "jessica@opensystemslab.io Test Jess 0123456789"
 			}],
 			"metadata": {
-				"portal_name": "about-the-applicant"
+				"section_name": "about-the-applicant"
 			},
 			"question": "Enter your contact details"
 		},
@@ -432,7 +444,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "about-the-applicant"
+				"section_name": "about-the-applicant"
 			},
 			"question": "Is your contact address the same as the property address?"
 		},
@@ -441,7 +453,7 @@
 				"value": "Me, the applicant"
 			}],
 			"metadata": {
-				"portal_name": "about-the-applicant"
+				"section_name": "about-the-applicant"
 			},
 			"question": "If a planning officer needs to make a site visit, who should they contact?"
 		},
@@ -450,7 +462,7 @@
 				"value": "Applicant"
 			}],
 			"metadata": {
-				"portal_name": "ownership",
+				"section_name": "ownership",
 				"auto_answered": true
 			},
 			"question": "Which of these best describes you?"
@@ -460,7 +472,7 @@
 				"value": "Sole owner"
 			}],
 			"metadata": {
-				"portal_name": "ownership",
+				"section_name": "ownership",
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Development Management Procedure) (England) Order 2015"
 				}]
@@ -472,7 +484,7 @@
 				"value": "Lawful Development Certificate – Existing changes"
 			}],
 			"metadata": {
-				"portal_name": "community-infrastructure-levy",
+				"section_name": "community-infrastructure-levy",
 				"auto_answered": true
 			},
 			"question": "What type of application is it?"
@@ -485,7 +497,7 @@
 				}
 			}],
 			"metadata": {
-				"portal_name": "CIL Liability check",
+				"section_name": "CIL Liability check",
 				"auto_answered": true
 			},
 			"question": "What does the project involve?"
@@ -495,7 +507,7 @@
 				"value": "Changes that have already been made in the past"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)"
@@ -508,7 +520,7 @@
 				"value": "Yes"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Might the changes be immune?"
@@ -518,7 +530,7 @@
 				"value": "Alterations"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity",
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity",
 				"auto_answered": true
 			},
 			"question": "What types of changes did the project involve?"
@@ -528,7 +540,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity"
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity"
 			},
 			"question": "Did the works involve altering the appearance or layout of any roof?"
 		},
@@ -537,7 +549,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity"
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity"
 			},
 			"question": "Would you like to upload any detail drawings?"
 		},
@@ -546,7 +558,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity"
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity"
 			},
 			"question": "Did the works involve any alterations to ground levels?"
 		},
@@ -555,7 +567,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity"
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity"
 			},
 			"question": "Would you like to upload any photographs of the property as it is today?"
 		},
@@ -564,7 +576,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-existing-drawings-immunity"
+				"section_name": "certificate-of-lawfulness-existing-drawings-immunity"
 			},
 			"question": "Would you like to upload any other additional drawings or documents?"
 		},
@@ -573,7 +585,7 @@
 				"value": "Utility bills"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "Provide evidence of completion date"
 		},
@@ -582,7 +594,7 @@
 				"value": "2015-01-01"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What date do these utility bills start from?"
 		},
@@ -591,7 +603,7 @@
 				"value": "2015-02-01"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What date do these utility bills run until?"
 		},
@@ -600,7 +612,7 @@
 				"value": "Test evidence "
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What do these utility bills show?"
 		},
@@ -609,7 +621,7 @@
 				"value": "Lawful Development Certificate"
 			}],
 			"metadata": {
-				"portal_name": "fee-calculator",
+				"section_name": "fee-calculator",
 				"auto_answered": true
 			},
 			"question": "What type of planning application are you making?"
@@ -619,7 +631,7 @@
 				"value": "Existing changes"
 			}],
 			"metadata": {
-				"portal_name": "fee-calculator",
+				"section_name": "fee-calculator",
 				"auto_answered": true
 			},
 			"question": "What type of changes are you applying for?"
@@ -629,7 +641,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "LDC in Existing Use",
+				"section_name": "LDC in Existing Use",
 				"auto_answered": true
 			},
 			"question": "Is the property a home?"
@@ -639,7 +651,7 @@
 				"value": "Alteration"
 			}],
 			"metadata": {
-				"portal_name": "LDC in Existing Use",
+				"section_name": "LDC in Existing Use",
 				"auto_answered": true
 			},
 			"question": "What types of changes does the application relate to?"
@@ -649,7 +661,7 @@
 				"value": "Installation of plant equipment"
 			}],
 			"metadata": {
-				"portal_name": "LDC in Existing Use",
+				"section_name": "LDC in Existing Use",
 				"auto_answered": true
 			},
 			"question": "What did the alterations involve?"
@@ -659,7 +671,7 @@
 				"value": "5 hectares or less"
 			}],
 			"metadata": {
-				"portal_name": "LDC-E - Plant equipment or machinery",
+				"section_name": "LDC-E - Plant equipment or machinery",
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2"
 				}]
@@ -671,7 +683,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Exemptions",
+				"section_name": "Fee Exemptions",
 				"auto_answered": true
 			},
 			"question": "Is the property a home?"
@@ -681,7 +693,7 @@
 				"value": "Alteration"
 			}],
 			"metadata": {
-				"portal_name": "Fee Exemptions",
+				"section_name": "Fee Exemptions",
 				"auto_answered": true
 			},
 			"question": "What type of changes does the project involve?"
@@ -691,7 +703,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Exemptions"
+				"section_name": "Fee Exemptions"
 			},
 			"question": "Are the public allowed to access the building?"
 		},
@@ -700,7 +712,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Exemptions",
+				"section_name": "Fee Exemptions",
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9"
 				}]
@@ -712,7 +724,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee exemptions and adjustments",
+				"section_name": "Fee exemptions and adjustments",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for a disability exemption?"
@@ -722,7 +734,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee exemptions and adjustments",
+				"section_name": "Fee exemptions and adjustments",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for a resubmission exemption?"
@@ -732,7 +744,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Reductions",
+				"section_name": "Fee Reductions",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 3"
@@ -745,7 +757,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Reductions",
+				"section_name": "Fee Reductions",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11"
@@ -758,7 +770,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee Reductions",
+				"section_name": "Fee Reductions",
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10"
 				}]
@@ -770,7 +782,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee exemptions and adjustments",
+				"section_name": "Fee exemptions and adjustments",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for the sports club fee reduction?"
@@ -780,7 +792,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee exemptions and adjustments",
+				"section_name": "Fee exemptions and adjustments",
 				"auto_answered": true,
 				"policy_refs": [{
 					"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11"
@@ -793,7 +805,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "Fee exemptions and adjustments",
+				"section_name": "Fee exemptions and adjustments",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for the alternative application reduction?"
@@ -803,7 +815,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "pre-app-advice-check"
+				"section_name": "pre-app-advice-check"
 			},
 			"question": "Did you get any pre-application advice before making this application?"
 		},
@@ -812,7 +824,7 @@
 				"value": "None of the above apply to me"
 			}],
 			"metadata": {
-				"portal_name": "declarations"
+				"section_name": "declarations"
 			},
 			"question": "Connections with Southwark Council"
 		},
@@ -821,7 +833,7 @@
 				"value": "The information contained in this application is truthful, accurate and complete, to the best of my knowledge"
 			}],
 			"metadata": {
-				"portal_name": "declarations"
+				"section_name": "declarations"
 			},
 			"question": "I confirm that:"
 		},
@@ -830,7 +842,7 @@
 				"value": "Southwark"
 			}],
 			"metadata": {
-				"portal_name": "uniform-translator",
+				"section_name": "uniform-translator",
 				"auto_answered": true
 			},
 			"question": "What is the applicant's interest in the land?"
@@ -840,7 +852,7 @@
 				"value": "Applicant"
 			}],
 			"metadata": {
-				"portal_name": "uniform-translator",
+				"section_name": "uniform-translator",
 				"auto_answered": true
 			},
 			"question": "What is the user's role?"
@@ -850,7 +862,7 @@
 				"value": "None"
 			}],
 			"metadata": {
-				"portal_name": "uniform-translator",
+				"section_name": "uniform-translator",
 				"auto_answered": true
 			},
 			"question": "What is the applicant's declared connections?"
@@ -860,7 +872,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for a disability exemption?"
@@ -870,7 +882,7 @@
 				"value": "2013-03-02"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What date do these utility bills start from?"
 		},
@@ -879,7 +891,7 @@
 				"value": "2019-04-01"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What date do these utility bills run until?"
 		},
@@ -888,7 +900,7 @@
 				"value": "That i was paying water bills"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What do these utility bills show?"
 		},
@@ -897,7 +909,7 @@
 				"value": "2016-02-01"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "When was this building control certificate issued?"
 		},
@@ -906,7 +918,7 @@
 				"value": "that it was certified"
 			}],
 			"metadata": {
-				"portal_name": "certificate-of-lawfulness-documents-immunity"
+				"section_name": "certificate-of-lawfulness-documents-immunity"
 			},
 			"question": "What do these building control certificates show?"
 		},
@@ -915,7 +927,7 @@
 				"value": "No"
 			}],
 			"metadata": {
-				"portal_name": "_root",
+				"section_name": "_root",
 				"auto_answered": true
 			},
 			"question": "Does the application qualify for a resubmission exemption?"

--- a/spec/fixtures/files/planx_params_prior_approval.json
+++ b/spec/fixtures/files/planx_params_prior_approval.json
@@ -233,7 +233,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root",
+        "section_name": "_root",
         "auto_answered": true
       },
       "question": "Is the property in Lambeth?"
@@ -245,7 +245,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types",
+        "section_name": "property-types",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -257,7 +257,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types",
+        "section_name": "property-types",
         "auto_answered": true
       },
       "question": "Which of these best describes the use of the property?"
@@ -269,7 +269,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types"
+        "section_name": "property-types"
       },
       "question": "Is it any of these?"
     },
@@ -280,7 +280,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types"
+        "section_name": "property-types"
       },
       "question": "What type of property is it?"
     },
@@ -291,7 +291,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root"
+        "section_name": "_root"
       },
       "question": "Has work already started?"
     },
@@ -302,7 +302,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root"
+        "section_name": "_root"
       },
       "question": "Describe the project."
     },
@@ -313,7 +313,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-scope-check",
+        "section_name": "prior-approval-scope-check",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -325,7 +325,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -337,7 +337,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats"
+        "section_name": "Solar panels to a house or flats"
       },
       "question": "What do you want to install?"
     },
@@ -348,7 +348,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats",
+        "section_name": "Solar panels to a house or flats",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class A\nThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -367,7 +367,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats",
+        "section_name": "Solar panels to a house or flats",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class A"
@@ -386,7 +386,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -406,7 +406,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -423,7 +423,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels"
+        "section_name": "Solar panels"
       },
       "question": "Where are the new solar panels?"
     },
@@ -437,7 +437,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -456,7 +456,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -475,7 +475,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class BThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -494,7 +494,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class BThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -513,7 +513,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class B"
@@ -529,7 +529,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "Is the property in a conservation area?"
@@ -541,7 +541,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "Is the property in a world heritage site?"
@@ -556,7 +556,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class AThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -572,7 +572,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Types of Prior Approval for commercial buildings",
+        "section_name": "Types of Prior Approval for commercial buildings",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -584,7 +584,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Types of Prior Approval for commercial buildings"
+        "section_name": "Types of Prior Approval for commercial buildings"
       },
       "question": "Select your project"
     },
@@ -595,7 +595,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-more-information",
+        "section_name": "prior-approval-more-information",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -607,7 +607,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Are you applying on behalf of someone else?"
     },
@@ -618,7 +618,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Which of these best describes you (or your organisation)?"
     },
@@ -629,7 +629,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Your contact details"
     },
@@ -640,7 +640,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Is your contact address the same as the property address?"
     },
@@ -651,7 +651,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "We may need to visit your site to assess your application. If we do, who should we contact to arrange the visit?"
     },
@@ -662,7 +662,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files",
+        "section_name": "prior-approval-files",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -674,7 +674,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files",
+        "section_name": "prior-approval-files",
         "auto_answered": true
       },
       "question": "Where will the solar panels be installed?"
@@ -686,7 +686,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Your planning officer will need to check how far the solar panels stick out beyond the surface of the roof. What do you have that shows this?"
     },
@@ -697,7 +697,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Do you want to upload any photographs?"
     },
@@ -708,7 +708,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Would you like to upload any additional drawings, documents or images?"
     },
@@ -719,7 +719,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "fee-calculator",
+        "section_name": "fee-calculator",
         "auto_answered": true
       },
       "question": "What type of planning application are you making?"
@@ -731,7 +731,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Fee Exemptions"
+        "section_name": "Fee Exemptions"
       },
       "question": "Are the public allowed to access the building?"
     },
@@ -742,7 +742,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior approval fees",
+        "section_name": "Prior approval fees",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -754,7 +754,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Disability exemption check",
+        "section_name": "Disability exemption check",
         "auto_answered": true
       },
       "question": "Is the property a home?"
@@ -766,7 +766,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Disability exemption check",
+        "section_name": "Disability exemption check",
         "auto_answered": true
       },
       "question": "What type of changes does the project involve?"
@@ -778,7 +778,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Fee Exemptions check",
+        "section_name": "Fee Exemptions check",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -790,7 +790,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true
       },
       "question": "Does the application qualify for a disability exemption?"
@@ -802,7 +802,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true
       },
       "question": "Does the application qualify for a resubmission exemption?"
@@ -814,7 +814,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -831,7 +831,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations",
+        "section_name": "apply-for-service-declarations",
         "auto_answered": true
       },
       "question": "Which Local Planning authority is it?"
@@ -843,7 +843,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations"
+        "section_name": "apply-for-service-declarations"
       },
       "question": "Connections with London Borough of Lambeth"
     },
@@ -854,7 +854,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations"
+        "section_name": "apply-for-service-declarations"
       },
       "question": "I confirm that:"
     },
@@ -865,7 +865,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "declarations",
+        "section_name": "declarations",
         "auto_answered": true
       },
       "question": "Connections with London Borough of Lambeth"
@@ -877,7 +877,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "declarations",
+        "section_name": "declarations",
         "auto_answered": true
       },
       "question": "I confirm that:"
@@ -889,7 +889,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Confirmation pages",
+        "section_name": "Confirmation pages",
         "auto_answered": true
       },
       "question": "Which Local Planning authority is it?"
@@ -901,7 +901,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Lambeth confirmation page",
+        "section_name": "Lambeth confirmation page",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?application.type"

--- a/spec/fixtures/files/planx_params_prior_approval_not_accepted.json
+++ b/spec/fixtures/files/planx_params_prior_approval_not_accepted.json
@@ -233,7 +233,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root",
+        "section_name": "_root",
         "auto_answered": true
       },
       "question": "Is the property in Lambeth?"
@@ -245,7 +245,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types",
+        "section_name": "property-types",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -257,7 +257,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types",
+        "section_name": "property-types",
         "auto_answered": true
       },
       "question": "Which of these best describes the use of the property?"
@@ -269,7 +269,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types"
+        "section_name": "property-types"
       },
       "question": "Is it any of these?"
     },
@@ -280,7 +280,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "property-types"
+        "section_name": "property-types"
       },
       "question": "What type of property is it?"
     },
@@ -291,7 +291,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root"
+        "section_name": "_root"
       },
       "question": "Has work already started?"
     },
@@ -302,7 +302,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "_root"
+        "section_name": "_root"
       },
       "question": "Describe the project."
     },
@@ -313,7 +313,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-scope-check",
+        "section_name": "prior-approval-scope-check",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -325,7 +325,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -337,7 +337,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats"
+        "section_name": "Solar panels to a house or flats"
       },
       "question": "What do you want to install?"
     },
@@ -348,7 +348,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats",
+        "section_name": "Solar panels to a house or flats",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class A\nThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -367,7 +367,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels to a house or flats",
+        "section_name": "Solar panels to a house or flats",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class A"
@@ -386,7 +386,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -406,7 +406,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -423,7 +423,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels"
+        "section_name": "Solar panels"
       },
       "question": "Where are the new solar panels?"
     },
@@ -437,7 +437,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -456,7 +456,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -475,7 +475,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class BThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -494,7 +494,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class BThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -513,7 +513,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class B"
@@ -529,7 +529,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "Is the property in a conservation area?"
@@ -541,7 +541,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "auto_answered": true
       },
       "question": "Is the property in a world heritage site?"
@@ -556,7 +556,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Solar panels",
+        "section_name": "Solar panels",
         "policy_refs": [
           {
             "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class AThe Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 14, Class K"
@@ -572,7 +572,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Types of Prior Approval for commercial buildings",
+        "section_name": "Types of Prior Approval for commercial buildings",
         "auto_answered": true
       },
       "question": "What type of property is it?"
@@ -584,7 +584,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Types of Prior Approval for commercial buildings"
+        "section_name": "Types of Prior Approval for commercial buildings"
       },
       "question": "Select your project"
     },
@@ -595,7 +595,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-more-information",
+        "section_name": "prior-approval-more-information",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -607,7 +607,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Are you applying on behalf of someone else?"
     },
@@ -618,7 +618,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Which of these best describes you (or your organisation)?"
     },
@@ -629,7 +629,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Your contact details"
     },
@@ -640,7 +640,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "Is your contact address the same as the property address?"
     },
@@ -651,7 +651,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "about-the-applicant"
+        "section_name": "about-the-applicant"
       },
       "question": "We may need to visit your site to assess your application. If we do, who should we contact to arrange the visit?"
     },
@@ -662,7 +662,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files",
+        "section_name": "prior-approval-files",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -674,7 +674,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files",
+        "section_name": "prior-approval-files",
         "auto_answered": true
       },
       "question": "Where will the solar panels be installed?"
@@ -686,7 +686,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Your planning officer will need to check how far the solar panels stick out beyond the surface of the roof. What do you have that shows this?"
     },
@@ -697,7 +697,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Do you want to upload any photographs?"
     },
@@ -708,7 +708,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "prior-approval-files"
+        "section_name": "prior-approval-files"
       },
       "question": "Would you like to upload any additional drawings, documents or images?"
     },
@@ -719,7 +719,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "fee-calculator",
+        "section_name": "fee-calculator",
         "auto_answered": true
       },
       "question": "What type of planning application are you making?"
@@ -731,7 +731,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Fee Exemptions"
+        "section_name": "Fee Exemptions"
       },
       "question": "Are the public allowed to access the building?"
     },
@@ -742,7 +742,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior approval fees",
+        "section_name": "Prior approval fees",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -754,7 +754,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Disability exemption check",
+        "section_name": "Disability exemption check",
         "auto_answered": true
       },
       "question": "Is the property a home?"
@@ -766,7 +766,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Disability exemption check",
+        "section_name": "Disability exemption check",
         "auto_answered": true
       },
       "question": "What type of changes does the project involve?"
@@ -778,7 +778,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Fee Exemptions check",
+        "section_name": "Fee Exemptions check",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?"
@@ -790,7 +790,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true
       },
       "question": "Does the application qualify for a disability exemption?"
@@ -802,7 +802,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true
       },
       "question": "Does the application qualify for a resubmission exemption?"
@@ -814,7 +814,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Prior Approval Fee exemptions",
+        "section_name": "Prior Approval Fee exemptions",
         "auto_answered": true,
         "policy_refs": [
           {
@@ -831,7 +831,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations",
+        "section_name": "apply-for-service-declarations",
         "auto_answered": true
       },
       "question": "Which Local Planning authority is it?"
@@ -843,7 +843,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations"
+        "section_name": "apply-for-service-declarations"
       },
       "question": "Connections with London Borough of Lambeth"
     },
@@ -854,7 +854,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "apply-for-service-declarations"
+        "section_name": "apply-for-service-declarations"
       },
       "question": "I confirm that:"
     },
@@ -865,7 +865,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "declarations",
+        "section_name": "declarations",
         "auto_answered": true
       },
       "question": "Connections with London Borough of Lambeth"
@@ -877,7 +877,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "declarations",
+        "section_name": "declarations",
         "auto_answered": true
       },
       "question": "I confirm that:"
@@ -889,7 +889,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Confirmation pages",
+        "section_name": "Confirmation pages",
         "auto_answered": true
       },
       "question": "Which Local Planning authority is it?"
@@ -901,7 +901,7 @@
         }
       ],
       "metadata": {
-        "portal_name": "Lambeth confirmation page",
+        "section_name": "Lambeth confirmation page",
         "auto_answered": true
       },
       "question": "What type of prior approval application is it?application.type"

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -681,7 +681,14 @@ RSpec.describe PlanningApplication do
       [
         {
           question: "Test question?",
-          responses: [{ value: "Test response" }],
+          responses: [
+            {
+              value: "Test response",
+              metadata: {
+                flags: ["Planning permission / Immune"]
+              }
+            }
+          ],
           metadata: {
             auto_answered: true,
             portal_name: "immunity-check",

--- a/spec/models/proposal_detail_spec.rb
+++ b/spec/models/proposal_detail_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProposalDetail do
       ],
       metadata: {
         auto_answered: auto_asnwered,
-        portal_name: "Test portal",
+        section_name: "Test portal",
         policy_refs: [
           { text: "Test ref text", url: "https://www.exampleref.com" }
         ],
@@ -82,9 +82,9 @@ RSpec.describe ProposalDetail do
     end
   end
 
-  describe "#portal_name" do
+  describe "#section_name" do
     it "returns portal name" do
-      expect(proposal_detail.portal_name).to eq("Test portal")
+      expect(proposal_detail.section_name).to eq("Test portal")
     end
   end
 

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -153,27 +153,27 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
         {
           question: "Question 1",
           responses: [{ value: "Answer 1" }],
-          metadata: { portal_name: "Fee Related Group" }
+          metadata: { section_name: "Fee Related Group" }
         },
         {
           question: "Question 2",
           responses: [{ value: "Answer 2" }],
-          metadata: { portal_name: "group-about-fee" }
+          metadata: { section_name: "group-about-fee" }
         },
         {
           question: "Question 3",
           responses: [{ value: "Answer 3" }],
-          metadata: { portal_name: "a_fee_group" }
+          metadata: { section_name: "a_fee_group" }
         },
         {
           question: "Question 4",
           responses: [{ value: "Answer 4" }],
-          metadata: { portal_name: "Other Group" }
+          metadata: { section_name: "Other Group" }
         },
         {
           question: "Question 5",
           responses: [{ value: "Answer 5" }],
-          metadata: { portal_name: "Birdfeed Related" }
+          metadata: { section_name: "Birdfeed Related" }
         }
       ].to_json
     end
@@ -184,7 +184,7 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
 
     it "returns proposal details with 'fee' in the portal name" do
       expect(
-        presenter.fee_related_proposal_details.map(&:portal_name)
+        presenter.fee_related_proposal_details.map(&:section_name)
       ).to contain_exactly(
         "Fee Related Group",
         "group-about-fee",

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -94,17 +94,17 @@ RSpec.describe "Assessment tasks" do
         {
           question: "Question 1",
           responses: [{ value: "Answer 1" }],
-          metadata: { portal_name: "_root", auto_answered: true }
+          metadata: { section_name: "About the property", auto_answered: true }
         },
         {
           question: "Question 2",
           responses: [{ value: "Answer 2" }],
-          metadata: { portal_name: "_root" }
+          metadata: { section_name: "About the property" }
         },
         {
           question: "Question 3",
           responses: [{ value: "Answer 3" }],
-          metadata: { portal_name: "group_1", auto_answered: true }
+          metadata: { section_name: "group_1", auto_answered: true }
         },
         {
           question: "Question 4",
@@ -115,9 +115,9 @@ RSpec.describe "Assessment tasks" do
 
     it "displays the proposal details by group" do
       click_button("Proposal details")
-      click_link("Main")
+      click_link("About the property")
 
-      expect(current_url).to have_target_id("main")
+      expect(current_url).to have_target_id("abouttheproperty")
 
       within(find_all(".proposal-details-sub-list")[0]) do
         expect(page).to have_content("1.  Question 1")
@@ -149,7 +149,7 @@ RSpec.describe "Assessment tasks" do
       click_button("Proposal details")
       check("View ONLY applicant answers, hide 'Auto-answered by PlanX")
 
-      expect(page).to have_text(:visible, "Main")
+      expect(page).to have_text(:visible, "About the property")
       expect(page).not_to have_text(:visible, "Group 1")
       expect(page).to have_text(:visible, "Other")
 

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -12,17 +12,17 @@ RSpec.describe "Planning Application show page" do
       {
         question: "What do you want to do?",
         responses: [{ value: "Modify or extend" }],
-        metadata: { portal_name: "_root", auto_answered: true }
+        metadata: { section_name: "_root", auto_answered: true }
       },
       {
         question: "Is the property a house?",
         responses: [{ value: "Yes" }],
-        metadata: { portal_name: "_root" }
+        metadata: { section_name: "_root" }
       },
       {
         question: "What will the height of the new structure be?",
         responses: [{ value: "2.5m" }],
-        metadata: { portal_name: "Dimensions", auto_answered: true }
+        metadata: { section_name: "Dimensions", auto_answered: true }
       },
       {
         question: "Is the property in a world heritage site?",

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe "FeeItemsValidation" do
         {
           question: "What type of planning application are you making?",
           responses: [{ value: "Existing changes" }],
-          metadata: { portal_name: "fee-related" }
+          metadata: { section_name: "fee-related" }
         },
         {
           question: "What type of changes does the project involve?",
           responses: [{ value: "Alteration" }],
           metadata: {
-            portal_name: "fee-related",
+            section_name: "fee-related",
             policy_refs: [
               { text: "The Town and Country Planning Order 2015" },
               { url: "https://www.example.com/planning/policy/1" }


### PR DESCRIPTION
PlanX have changed the name because it was buggy on their end.

They want to switch off `portal_name` altogether so we need to change it on our end

https://trello.com/c/WVyDS17G/1761-chore-change-sectionname-to-portalname-in-proposaldetails