### PR TITLE
Select application type when creating/editing a planning application

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -2,4 +2,18 @@
 
 class ApplicationType < ApplicationRecord
   has_many :planning_applications, dependent: :restrict_with_exception
+
+  validates :name, presence: true
+
+  def full_name
+    name.humanize
+  end
+
+  class << self
+    def menu(scope = all)
+      scope.order(name: :asc).select(:name, :id).map do |application_type|
+        [application_type.full_name, application_type.id]
+      end
+    end
+  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -86,6 +86,8 @@ class PlanningApplication < ApplicationRecord
                   reset_validation_requests_update_counter!(red_line_boundary_change_validation_requests)
                 }, if: :valid_red_line_boundary?
   before_update -> { reset_validation_requests_update_counter!(fee_item_validation_requests) }, if: :valid_fee?
+  before_update :audit_update_application_type!, if: :application_type_id_changed?
+
   after_update :audit_updated!
   after_update :address_or_boundary_geojson_updated?
   after_update :old_constraints_updated?
@@ -98,7 +100,6 @@ class PlanningApplication < ApplicationRecord
 
   PLANNING_APPLICATION_PERMITTED_KEYS = %w[address_1
                                            address_2
-                                           application_type
                                            applicant_first_name
                                            applicant_last_name
                                            applicant_phone
@@ -705,6 +706,17 @@ class PlanningApplication < ApplicationRecord
 
     attr_added.each { |attr| audit!(activity_type: "constraint_added", audit_comment: attr) }
     attr_removed.each { |attr| audit!(activity_type: "constraint_removed", audit_comment: attr) }
+  end
+
+  def audit_update_application_type!
+    old_application_type = ApplicationType.find(changes["application_type_id"].first)
+
+    audit!(
+      activity_type: "updated",
+      activity_information: "Application type",
+      audit_comment:
+        "Application type changed from: #{old_application_type.full_name} / Changed to: #{application_type.full_name}"
+    )
   end
 
   def determination_date_is_not_in_the_future

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -1,27 +1,16 @@
 <%= form_with model: @planning_application, local: true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
- <% if @planning_application.errors.any? %>
-    <span id="status-error" class="govuk-error-message">
-      <span class="govuk-visually-hidden">
-        <h2>
-          <%= pluralize(@planning_application.errors.count, "error") %>
-          prohibited this @planning_application from being saved:
-        </h2>
-      </span>
-      <ul>
-        <% @planning_application.errors.map do |error| %>
-          <li><%= error.message %></li>
-        <% end %>
-      </ul>
-    </span>
-  <% end %>
   <%= form.hidden_field(
     :return_to,
     value: local_assigns.fetch(:return_to, nil)
   ) %>
-  <%= form.hidden_field :application_type_id, value: ApplicationType.find_by(name: "lawfulness_certificate").id %>
   <div class="govuk-form-group">
     <% if action_name == "new" || action_name == "create" %>
+      <div class="govuk-form-group govuk-!-margin-bottom-4">
+        <%= form.govuk_select(:application_type_id, ApplicationType.menu, options: { include_blank: true }, label: { text: "Application type" }) %>
+      </div>
+      
       <p class="govuk-body">
         <%= form.label :description, "Description", class: "govuk-heading-m govuk-!-margin-bottom-1" %>
         <%= form.text_area :description, class: "govuk-textarea", rows: "5" %>
@@ -34,6 +23,8 @@
           <%= link_to "Propose a change to the description", new_planning_application_description_change_validation_request_path(@planning_application), class: "govuk-link" %>
         <% end %>
       </p>
+
+      <%= form.govuk_select(:application_type_id, ApplicationType.menu, label: { text: "Application type" }) %>
     <% end %>
   </div>
   <div class="govuk-form-group govuk-!-margin-top-8">

--- a/app/views/planning_applications/new.html.erb
+++ b/app/views/planning_applications/new.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l govuk-!-margin-top-7">
-      New Application: Residential Lawful Development Certificate
+      New Application
     </h1>
     <%= render 'form', planning_application: @planning_application %>
   </div>

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationType do
+  describe "#validations" do
+    subject(:application_type) { described_class.new }
+
+    describe "#name" do
+      it "validates presence" do
+        expect { application_type.valid? }.to change { application_type.errors[:name] }.to ["can't be blank"]
+      end
+    end
+  end
+
+  describe "class methods" do
+    describe "#menu" do
+      let!(:lawfulness_certificate) { create(:application_type, name: "lawfulness_certificate") }
+      let!(:prior_approval) { create(:application_type, name: "prior_approval") }
+
+      it "returns an array of application type names (humanized) and ids" do
+        expect(described_class.menu).to eq(
+          [["Lawfulness certificate", lawfulness_certificate.id], ["Prior approval", prior_approval.id]]
+        )
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe PlanningApplication do
       end
     end
 
-    describe "::after_update" do
+    describe "::before_update" do
       context "when there is an update to any address or boundary geojson fields" do
         it "sets the updated_address_or_boundary_geojson to true" do
           planning_application.update!(address_1: "")

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "Creating a planning application" do
   it "allows for an application to be created by an assessor, using minimum details" do
     click_link "Add new application"
 
-    expect(page).to have_text("New Application: Residential Lawful Development Certificate")
+    expect(page).to have_text("New Application")
 
+    select("Lawfulness certificate")
     fill_in "Description", with: "Back shack"
 
     within_fieldset "Applicant information" do
@@ -42,8 +43,7 @@ RSpec.describe "Creating a planning application" do
   it "displays an error when both agent and applicant emails are missing" do
     click_link "Add new application"
 
-    expect(page).to have_text("New Application: Residential Lawful Development Certificate")
-
+    select("Lawfulness certificate")
     fill_in "Description", with: "Bad bad application"
 
     click_button "Save"
@@ -59,6 +59,13 @@ RSpec.describe "Creating a planning application" do
     expect(page).to have_text("Description: Bad bad application")
   end
 
+  it "displays an error when application type is not selected" do
+    click_link "Add new application"
+
+    click_button "Save"
+    expect(page).to have_text("Application type must exist")
+  end
+
   it "allows for an application to be created by a reviewer, using minimum details" do
     click_link "Log out"
     sign_in reviewer1
@@ -66,6 +73,7 @@ RSpec.describe "Creating a planning application" do
 
     click_link "Add new application"
 
+    select("Lawfulness certificate")
     fill_in "Description", with: "Bird house"
     within_fieldset "Applicant information" do
       fill_in "Email address", with: "mah@mah.com"
@@ -83,6 +91,7 @@ RSpec.describe "Creating a planning application" do
     before do
       click_link "Add new application"
 
+      select("Lawfulness certificate")
       fill_in "Description", with: "Backyard bird hotel"
       fill_in "Day", with: "3"
       fill_in "Month", with: "3"


### PR DESCRIPTION
### Description of change

Allow officers to select application type when creating a new application or editing an existing one.
Previously there was the `lawfulness_certificate` application type hardcoded in the form and therefore any subsequent updates using this form would revert any application type back to this one.

```form.hidden_field :application_type_id, value: ApplicationType.find_by(name: "lawfulness_certificate").id```

A select dropdown had been chosen instead of radio buttons as we expect to add several more application types in the near future

### Story Link
https://trello.com/c/9mCWMBJN/1767-pa-shows-ldc-in-application-info-propose-a-change-to-the-description
https://trello.com/c/FSFaQslL/1776-allow-officers-to-select-application-type-on-planning-application-form
https://trello.com/c/Ra6Sn7eD/1779-add-audit-entry-when-selecting-the-application-type

### Screenshots

### **Creating a new application**
![Screenshot 2023-07-07 at 11 40 54](https://github.com/unboxed/bops/assets/34001723/66ffaf0a-bd98-47ba-a429-dd372e91a67b)

### **Editing an application**
![Screenshot 2023-07-07 at 11 39 31](https://github.com/unboxed/bops/assets/34001723/163341dc-9e6c-4b14-a95e-abeea69559d2)

### **Audit log entry**
![Screenshot 2023-07-07 at 12 51 52](https://github.com/unboxed/bops/assets/34001723/e35c45f6-7861-4915-9043-988d1c8ac048)

