### PR TITLE
Call constraints query update service only if boundary_geojson has changed

### DIFF
--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2186,11 +2186,4 @@ RSpec.describe PlanningApplication do
       end
     end
   end
-
-  it "tracks changed constraints" do
-    planning_application.old_constraints << "test_constraint"
-    planning_application.save!
-
-    expect(planning_application.changed_constraints).to include("test_constraint")
-  end
 end

--- a/spec/services/constraint_query_update_service_spec.rb
+++ b/spec/services/constraint_query_update_service_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe ConstraintQueryUpdateService, type: :service do
       it "creates some constraints" do
         planning_application.boundary_geojson = '{"type":"Polygon","coordinates":[[[-0.07629275321961124,51.48596289289142],[-0.07630616426468570,51.48591028066045],[-0.07555112242699404,51.48584764697301],[-0.07554173469544191,51.48590192950712],[-0.07629275321961124,51.48596289289142]]]}'
         planning_application.save!
+
         expect(planning_application.constraints).not_to be_empty
       end
     end


### PR DESCRIPTION
### Description of change

We should call the constraints query update service only if the boundary_geojson has changed.
This also should fix an issue where edits made to the planning application were not persisting (exact reason to still be identified)

### Story Link

https://trello.com/c/2BsTKOTu/1781-updated-site-map-not-saved

