### PR TITLE
Show planning officer the extension measurements

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -73,6 +73,7 @@ class Audit < ApplicationRecord
       "additional_document_validation_request_cancelled_post_validation",
     description_change_validation_request_cancelled: "description_change_validation_request_cancelled",
     other_change_validation_request_cancelled: "other_change_validation_request_cancelled",
+    proposal_measurements_updated: "proposal_measurements_updated",
     red_line_boundary_change_validation_request_cancelled: "red_line_boundary_change_validation_request_cancelled",
     red_line_boundary_change_validation_request_cancelled_post_validation:
     "red_line_boundary_change_validation_request_cancelled_post_validation",

--- a/app/models/consistency_checklist.rb
+++ b/app/models/consistency_checklist.rb
@@ -8,7 +8,12 @@ class ConsistencyChecklist < ApplicationRecord
     description_matches_documents
     documents_consistent
     proposal_details_match_documents
+    proposal_measurements_match_documents
     site_map_correct
+  ].freeze
+
+  PRIOR_APPROVAL_CHECKS = %i[
+    proposal_measurements_match_documents
   ].freeze
 
   REQUEST_TYPES = {
@@ -51,6 +56,7 @@ class ConsistencyChecklist < ApplicationRecord
 
   CHECKS.each do |check|
     define_method("#{check}_determined") do
+      return if planning_application.type == "Lawful Development Certificate" && PRIOR_APPROVAL_CHECKS.include?(check)
       return unless send("#{check}_to_be_determined?")
 
       errors.add(check, :not_determined)

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -32,9 +32,9 @@ class Consultation < ApplicationRecord
            description: planning_application.description,
            reference: planning_application.reference,
            closing_date: planning_application.received_at.to_fs(:day_month_year_slashes),
-           rear_wall: planning_application.rear_wall_length,
-           max_height: planning_application.max_height_extension,
-           eave_height: planning_application.eave_height_extension,
+           rear_wall: planning_application&.proposal_measurement&.depth,
+           max_height: planning_application&.proposal_measurement&.max_height,
+           eaves_height: planning_application&.proposal_measurement&.eaves_height,
            application_link:)
   end
 

--- a/app/models/proposal_measurement.rb
+++ b/app/models/proposal_measurement.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ProposalMeasurement < ApplicationRecord
+  belongs_to :planning_application
+
+  validates :depth, :max_height, :eaves_height, numericality: { only_float: true }
+end

--- a/app/views/consistency_checklists/_form.html.erb
+++ b/app/views/consistency_checklists/_form.html.erb
@@ -40,6 +40,16 @@
       consistency_checklist: consistency_checklist
     }
   ) %>
+  <% if @planning_application.proposal_measurement %>
+    <%= render(
+      partial: "proposal_measurements_match_documents",
+      locals: {
+        form: form,
+        can_edit: can_edit,
+        consistency_checklist: consistency_checklist
+      }
+    ) %>
+  <% end %>
   <% if can_edit %>
     <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
   <% else %>

--- a/app/views/consistency_checklists/_proposal_measurements_match_documents.html.erb
+++ b/app/views/consistency_checklists/_proposal_measurements_match_documents.html.erb
@@ -1,0 +1,47 @@
+<%= form.govuk_radio_buttons_fieldset(
+  :proposal_measurements_match_documents,
+  legend: { text: t(".are_the_proposal"), size: "s" }
+  ) do %>
+  <p class="govuk-body govuk-!-margin-bottom-1">Applicant answers from PlanX</p>
+  <ul class="govuk-list">
+    <li>Maximum height: <%= @planning_application.max_height_extension %>m</li>
+    <li>Eaves height: <%= @planning_application.eave_height_extension %>m</li>
+    <li>Depth: <%= @planning_application.rear_wall_length %>m</li>
+  </ul>
+  <% if can_edit %>
+    <%= form.govuk_radio_button(
+      :proposal_measurements_match_documents,
+      :yes,
+      label: { text: t(".yes") },
+      link_errors: true
+    ) %>
+    <%= form.govuk_radio_button(
+      :proposal_measurements_match_documents,
+      :no,
+      label: { text: t(".no") }
+    ) do %>
+      <%= form.fields_for @planning_application.proposal_measurement do |ff| %>
+        <%= ff.govuk_text_field :max_height, label: { text: "Maximum height" } %>
+        <%= ff.govuk_text_field :eaves_height, label: { text: "Eaves height" } %>
+        <%= ff.govuk_text_field(:depth) %>
+      <% end  %>
+    <% end %>
+  <% else %>
+    <% if consistency_checklist.proposal_measurements_match_documents == "no" %>
+      <p class="govuk-body govuk-!-margin-bottom-1">Actual measurements according to plans</p>
+      <ul class="govuk-list">
+        <li>Maximum height: <%= @planning_application.proposal_measurement.max_height %>m</li>
+        <li>Eaves height: <%= @planning_application.proposal_measurement.eaves_height %>m</li>
+        <li>Depth: <%= @planning_application.proposal_measurement.depth %>m</li>
+      </ul>
+    <% end %>
+    <%= form.govuk_radio_button(
+      :proposal_measurements_match_documents,
+      consistency_checklist.proposal_measurements_match_documents,
+      label: {
+        text: t(".#{consistency_checklist.proposal_details_match_documents}")
+      },
+      disabled: true
+    ) %>
+  <% end %>
+<% end %>

--- a/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
+++ b/app/views/planning_application/assessment_details/summary_of_work/_information.html.erb
@@ -15,7 +15,15 @@
       <li>
         A list of the works involved in the project, such as alterations and extensions
       </li>
-      <li>Key dimensions</li>
+      <li>
+        Key dimensions
+        <% if @planning_application.proposal_measurement %>
+          <br>
+          Max height: <%= @planning_application.proposal_measurement.max_height %>m<br>
+          Eaves height: <%= @planning_application.proposal_measurement.eaves_height %>m<br>
+          Depth: <%= @planning_application.proposal_measurement.depth %>m<br>
+        <% end %>
+      </li>
       <li>Materials used in external works</li>
       <li>Specific features you want to draw attention to</li>
       <li>Details of a proposed use, such as opening hours</li>

--- a/app/views/planning_application/consultations/_letter_template.html.erb
+++ b/app/views/planning_application/consultations/_letter_template.html.erb
@@ -10,7 +10,9 @@ method: 'post'
   <%= form.text_area :neighbour_letter_content, rows: 25, class: "govuk-body neighbour-letter-template" %>
 
   <div class="govuk-inset-text">
-    <p class="govuk-body">Measurements in the letter have been taken from PlanX. Please amend if needed.</p>
+    <p class="govuk-body">
+      Measurements in the letter have been taken from PlanX. Please amend in the template or in the consistency checklist in the assessment task list.
+    </p>
     <p class="govuk-body">A copy of the letter will also be sent by email to the applicant.</p>
   </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,8 @@ en:
               open_additional_document_requests: Additional document requests must be closed or cancelled
             proposal_details_match_documents:
               not_determined: Determine whether the proposal details are consistent with the plans
+            proposal_measurements_match_documents:
+              not_determined: Determine whether the proposal measurements submitted by the applicant are consistent with the plans
             site_map_correct:
               not_determined: Determine whether the red line on the site map is correct
               open_red_line_boundary_change_requests: Red line boundary change requests must be closed or cancelled
@@ -331,6 +333,7 @@ en:
       other_change_validation_request_cancelled: 'Cancelled: validation request (other change from applicant#%{args})'
       other_change_validation_request_received: 'Received: request for change (other validation#%{args})'
       other_change_validation_request_sent: 'Sent: validation request (other validation#%{args})'
+      proposal_measurements_updated: Proposal measurements were updated
       red_line_boundary_change_validation_request_added: 'Added: validation request (red line boundary#%{args})'
       red_line_boundary_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (red line boundary#%{sequence})'
@@ -399,6 +402,10 @@ en:
     proposal_details_match_documents:
       are_the_proposal: Are the proposal details consistent with the plans?
       how_are_the: How are the proposal details inconsistent?
+      'no': 'No'
+      'yes': 'Yes'
+    proposal_measurements_match_documents:
+      are_the_proposal: Do the measurements submitted by the applicant match the drawings?
       'no': 'No'
       'yes': 'Yes'
     red_line_boundary_change_validation_request:
@@ -568,7 +575,7 @@ en:
     %{description}
 
     Proposal dimensions
-    The new extension will extend %{rear_wall}m beyond the back wall of the original property, the maximum height of the extension is %{max_height}m, the eaves are %{eave_height}m high.
+    The new extension will extend %{rear_wall}m beyond the back wall of the original property, the maximum height of the extension is %{max_height}m, the eaves are %{eaves_height}m high.
 
     Application received: %{received_at}
 

--- a/db/migrate/20230710144801_create_proposal_measurements_table.rb
+++ b/db/migrate/20230710144801_create_proposal_measurements_table.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateProposalMeasurementsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :proposal_measurements do |t|
+      t.references :planning_application
+      t.float :eaves_height
+      t.float :depth
+      t.float :max_height
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230710150150_add_proposal_measurements_to_consistency_checklist.rb
+++ b/db/migrate/20230710150150_add_proposal_measurements_to_consistency_checklist.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddProposalMeasurementsToConsistencyChecklist < ActiveRecord::Migration[7.0]
+  def change
+    add_column :consistency_checklists, :proposal_measurements_match_documents, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20230711142759_add_proposal_measurements_to_existing_applications.rb
+++ b/db/migrate/20230711142759_add_proposal_measurements_to_existing_applications.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddProposalMeasurementsToExistingApplications < ActiveRecord::Migration[7.0]
+  def change
+    prior_approval = ApplicationType.find_by(name: "prior_approval")
+    PlanningApplication.where(application_type: prior_approval).each do |planning_application|
+      next if planning_application.proposal_measurement
+
+      ProposalMeasurement.create(
+        planning_application_id: planning_application.id,
+        max_height: planning_application.max_height_extension,
+        eaves_height: planning_application.eave_height_extension,
+        depth: planning_application.rear_wall_length
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_27_083704) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_142759) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,6 +130,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_083704) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "site_map_correct", default: 0, null: false
+    t.integer "proposal_measurements_match_documents", default: 0, null: false
     t.index ["planning_application_id"], name: "ix_consistency_checklists_on_planning_application_id"
   end
 
@@ -467,6 +468,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_083704) do
     t.datetime "updated_at", null: false
     t.integer "status", null: false
     t.index ["planning_application_id"], name: "ix_policy_classes_on_planning_application_id"
+  end
+
+  create_table "proposal_measurements", force: :cascade do |t|
+    t.bigint "planning_application_id"
+    t.float "eaves_height"
+    t.float "depth"
+    t.float "max_height"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_proposal_measurements_on_planning_application_id"
   end
 
   create_table "recommendations", force: :cascade do |t|

--- a/spec/factories/consistency_checklist.rb
+++ b/spec/factories/consistency_checklist.rb
@@ -17,6 +17,7 @@ FactoryBot.define do
       documents_consistent { :yes }
       proposal_details_match_documents { :yes }
       site_map_correct { :yes }
+      proposal_measurements_match_documents { :yes }
     end
   end
 end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -213,6 +213,54 @@ FactoryBot.define do
             ]
           },
           {
+            question: "Exactly how far will the new addition extend beyond the back wall of the original house?",
+            responses: [
+              {
+                value: "4.5"
+              }
+            ],
+            metadata: {
+              policy_refs: [
+                {
+                  text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A"
+                }
+              ],
+              section_name: "Rear and side extensions to houses"
+            }
+          },
+          {
+            question: "Exactly how high are the eaves of the extension?",
+            responses: [
+              {
+                value: "2.5"
+              }
+            ],
+            metadata: {
+              policy_ref: [
+                {
+                  text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class APermitted Development Rights for Householders Technical Guidance (PDF, 500KB)"
+                }
+              ],
+              section_name: "Rear and side extensions to houses"
+            }
+          },
+          {
+            question: "What is the exact height of the extension?",
+            responses: [
+              {
+                value: "3"
+              }
+            ],
+            metadata: {
+              policy_refs: [
+                {
+                  text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A"
+                }
+              ],
+              section_name: "Rear and side extensions to houses"
+            }
+          },
+          {
             question: "The height of the new roof will be higher than the old roof by",
             responses: [
               {
@@ -229,6 +277,10 @@ FactoryBot.define do
       end
 
       application_type { association :application_type, :prior_approval }
+
+      after(:create) do |planning_application|
+        create(:proposal_measurement, planning_application:)
+      end
     end
 
     trait :with_consultees do

--- a/spec/factories/proposal_measurement.rb
+++ b/spec/factories/proposal_measurement.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :proposal_measurement do
+    max_height { 2.0 }
+    eaves_height { 2.0 }
+    depth { 2.0 }
+  end
+end

--- a/spec/models/consistency_checklist_spec.rb
+++ b/spec/models/consistency_checklist_spec.rb
@@ -120,6 +120,7 @@ RSpec.describe ConsistencyChecklist do
             description_matches_documents: :to_be_determined,
             documents_consistent: :yes,
             proposal_details_match_documents: :yes,
+            proposal_measurements_match_documents: :yes,
             site_map_correct: :yes
           )
         end
@@ -147,6 +148,7 @@ RSpec.describe ConsistencyChecklist do
             description_matches_documents: :yes,
             documents_consistent: :yes,
             proposal_details_match_documents: :to_be_determined,
+            proposal_measurements_match_documents: :yes,
             site_map_correct: :yes
           )
         end
@@ -163,6 +165,47 @@ RSpec.describe ConsistencyChecklist do
           ).to contain_exactly(
             "Determine whether the proposal details are consistent with the plans"
           )
+        end
+      end
+
+      context "when proposal_measurements_match_documents is not determined" do
+        let(:consistency_checklist) do
+          build(
+            :consistency_checklist,
+            :complete,
+            description_matches_documents: :yes,
+            documents_consistent: :yes,
+            proposal_details_match_documents: :yes,
+            proposal_measurements_match_documents: :to_be_determined,
+            site_map_correct: :yes
+          )
+        end
+
+        context "when needed" do
+          before do
+            planning_application = create(:planning_application, :prior_approval)
+            consistency_checklist.update(planning_application:)
+          end
+
+          it "returns false" do
+            expect(consistency_checklist.valid?).to be(false)
+          end
+
+          it "sets error message" do
+            consistency_checklist.valid?
+
+            expect(
+              consistency_checklist.errors.messages[:proposal_measurements_match_documents]
+            ).to contain_exactly(
+              "Determine whether the proposal measurements submitted by the applicant are consistent with the plans"
+            )
+          end
+        end
+
+        context "when not needed" do
+          it "returns true" do
+            expect(consistency_checklist.valid?).to be(true)
+          end
         end
       end
 
@@ -201,6 +244,7 @@ RSpec.describe ConsistencyChecklist do
             description_matches_documents: :yes,
             documents_consistent: :to_be_determined,
             proposal_details_match_documents: :yes,
+            proposal_measurements_match_documents: :yes,
             site_map_correct: :to_be_determined
           )
         end

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -27,96 +27,215 @@ RSpec.describe "checking consistency" do
     visit(planning_application_path(planning_application))
   end
 
-  it "lets user save draft or mark as complete" do
-    expect(list_item("Check and assess")).to have_content("Not started")
-    click_link("Check and assess")
-    click_link("Check description, documents and proposal details")
-    click_button("Save and mark as complete")
+  context "when the application is an LDC" do
+    it "lets user save draft or mark as complete" do
+      expect(list_item("Check and assess")).to have_content("Not started")
+      click_link("Check and assess")
+      click_link("Check description, documents and proposal details")
+      click_button("Save and mark as complete")
 
-    expect(page).to have_content(
-      "Determine whether the description matches the development or use in the plans"
-    )
+      expect(page).to have_content(
+        "Determine whether the description matches the development or use in the plans"
+      )
 
-    expect(page).to have_content(
-      "Determine whether the proposal details are consistent with the plans"
-    )
+      expect(page).to have_content(
+        "Determine whether the proposal details are consistent with the plans"
+      )
 
-    expect(page).to have_content(
-      "Determine whether the plans are consistent with each other"
-    )
+      expect(page).to have_content(
+        "Determine whether the plans are consistent with each other"
+      )
 
-    form_group1 = form_group_with_legend(
-      "Is the red line on the site map correct for the site and proposed works?"
-    )
+      form_group1 = form_group_with_legend(
+        "Is the red line on the site map correct for the site and proposed works?"
+      )
 
-    within(form_group1) { choose("Yes") }
+      within(form_group1) { choose("Yes") }
 
-    form_group2 = form_group_with_legend(
-      "Does the description match the development or use in the plans?"
-    )
+      form_group2 = form_group_with_legend(
+        "Does the description match the development or use in the plans?"
+      )
 
-    within(form_group2) { choose("Yes") }
+      within(form_group2) { choose("Yes") }
 
-    form_group3 = form_group_with_legend(
-      "Are the plans consistent with each other?"
-    )
+      form_group3 = form_group_with_legend(
+        "Are the plans consistent with each other?"
+      )
 
-    within(form_group3) { choose("Yes") }
-    click_button("Save and come back later")
+      within(form_group3) { choose("Yes") }
+      click_button("Save and come back later")
 
-    expect(page).to have_content("Successfully updated application checklist")
+      expect(page).to have_content("Successfully updated application checklist")
 
-    expect(task_list_item).to have_content("In progress")
+      expect(task_list_item).to have_content("In progress")
 
-    click_link("Check description, documents and proposal details")
+      click_link("Check description, documents and proposal details")
 
-    form_group4 = form_group_with_legend(
-      "Are the proposal details consistent with the plans?"
-    )
+      form_group4 = form_group_with_legend(
+        "Are the proposal details consistent with the plans?"
+      )
 
-    within(form_group4) { choose("No") }
+      within(form_group4) { choose("No") }
 
-    fill_in(
-      "How are the proposal details inconsistent?",
-      with: "Reason for inconsistencty"
-    )
+      fill_in(
+        "How are the proposal details inconsistent?",
+        with: "Reason for inconsistencty"
+      )
 
-    click_button("Save and mark as complete")
+      click_button("Save and mark as complete")
 
-    expect(page).to have_content("Successfully updated application checklist")
+      expect(page).to have_content("Successfully updated application checklist")
 
-    expect(task_list_item).to have_content("Completed")
+      expect(task_list_item).to have_content("Completed")
 
-    click_link("Check description, documents and proposal details")
+      click_link("Check description, documents and proposal details")
 
-    field1 = find_by_id(
-      "consistency-checklist-description-matches-documents-yes-field"
-    )
+      field1 = find_by_id(
+        "consistency-checklist-description-matches-documents-yes-field"
+      )
 
-    field2 = find_by_id("consistency-checklist-documents-consistent-yes-field")
+      field2 = find_by_id("consistency-checklist-documents-consistent-yes-field")
 
-    field3 = find_by_id(
-      "consistency-checklist-proposal-details-match-documents-no-field"
-    )
+      field3 = find_by_id(
+        "consistency-checklist-proposal-details-match-documents-no-field"
+      )
 
-    expect(field1).to be_disabled
-    expect(field1).to be_checked
-    expect(field2).to be_disabled
-    expect(field2).to be_checked
-    expect(field3).to be_disabled
-    expect(field3).to be_checked
+      expect(field1).to be_disabled
+      expect(field1).to be_checked
+      expect(field2).to be_disabled
+      expect(field2).to be_checked
+      expect(field3).to be_disabled
+      expect(field3).to be_checked
 
-    expect(page).not_to have_field(
-      "How are the proposal details inconsistent?",
-      with: "Reason for inconsistencty"
-    )
+      expect(page).not_to have_field(
+        "How are the proposal details inconsistent?",
+        with: "Reason for inconsistencty"
+      )
 
-    expect(page).to have_content("How are the proposal details inconsistent?")
-    expect(page).to have_content("Reason for inconsistencty")
+      expect(page).to have_content("How are the proposal details inconsistent?")
+      expect(page).to have_content("Reason for inconsistencty")
 
-    click_link("Application")
+      click_link("Application")
 
-    expect(list_item("Check and assess")).to have_content("In progress")
+      expect(list_item("Check and assess")).to have_content("In progress")
+    end
+  end
+
+  context "when the application is a prior approval" do
+    before do
+      type = create(:application_type, :prior_approval)
+      planning_application.update(application_type: type)
+      create(:proposal_measurement, planning_application:)
+    end
+
+    it "lets user save draft or mark as complete" do
+      expect(list_item("Check and assess")).to have_content("Not started")
+      click_link("Check and assess")
+      click_link("Check description, documents and proposal details")
+      click_button("Save and mark as complete")
+
+      expect(page).to have_content(
+        "Determine whether the description matches the development or use in the plans"
+      )
+
+      expect(page).to have_content(
+        "Determine whether the proposal details are consistent with the plans"
+      )
+
+      expect(page).to have_content(
+        "Determine whether the plans are consistent with each other"
+      )
+
+      form_group1 = form_group_with_legend(
+        "Is the red line on the site map correct for the site and proposed works?"
+      )
+
+      within(form_group1) { choose("Yes") }
+
+      form_group2 = form_group_with_legend(
+        "Does the description match the development or use in the plans?"
+      )
+
+      within(form_group2) { choose("Yes") }
+
+      form_group3 = form_group_with_legend(
+        "Are the plans consistent with each other?"
+      )
+
+      within(form_group3) { choose("Yes") }
+      click_button("Save and come back later")
+
+      expect(page).to have_content("Successfully updated application checklist")
+
+      expect(task_list_item).to have_content("In progress")
+
+      click_link("Check description, documents and proposal details")
+
+      form_group4 = form_group_with_legend(
+        "Are the proposal details consistent with the plans?"
+      )
+
+      within(form_group4) { choose("No") }
+
+      fill_in(
+        "How are the proposal details inconsistent?",
+        with: "Reason for inconsistencty"
+      )
+
+      form_group5 = form_group_with_legend(
+        "Do the measurements submitted by the applicant match the drawings?"
+      )
+
+      within(form_group5) { choose("No") }
+
+      fill_in(
+        "Eaves height",
+        with: "6.0"
+      )
+
+      click_button("Save and mark as complete")
+
+      expect(page).to have_content("Successfully updated application checklist")
+
+      expect(task_list_item).to have_content("Completed")
+
+      click_link("Check description, documents and proposal details")
+
+      field1 = find_by_id(
+        "consistency-checklist-description-matches-documents-yes-field"
+      )
+
+      field2 = find_by_id("consistency-checklist-documents-consistent-yes-field")
+
+      field3 = find_by_id(
+        "consistency-checklist-proposal-details-match-documents-no-field"
+      )
+
+      field4 = find_by_id(
+        "consistency-checklist-proposal-measurements-match-documents-no-field"
+      )
+
+      expect(field1).to be_disabled
+      expect(field1).to be_checked
+      expect(field2).to be_disabled
+      expect(field2).to be_checked
+      expect(field3).to be_disabled
+      expect(field3).to be_checked
+      expect(field4).to be_checked
+      expect(field4).to be_checked
+
+      expect(page).not_to have_field(
+        "How are the proposal details inconsistent?",
+        with: "Reason for inconsistencty"
+      )
+
+      expect(page).to have_content("How are the proposal details inconsistent?")
+      expect(page).to have_content("Reason for inconsistencty")
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
+    end
   end
 
   it "lets the user request a description change" do


### PR DESCRIPTION
### Description of change

- Planning officer can edit measurements sent by applicant using new table `proposal_measurement`
- The measurements are shown to the officer when they write a summary of work

### Story Link

https://trello.com/c/yBytePhg/1697-view-key-dimensions-on-the-proposal

### Screenshots
![screencapture-southwark-southwark-localhost-3000-planning-applications-17-consistency-checklist-edit-2023-07-11-13_48_42](https://github.com/unboxed/bops/assets/35098639/bc0b7189-02ae-4be1-b26e-9f025ae76f76)

### Decisions
I've used a new table called `proposal_measurements` to save the data in for now. Not sure how it might look in the future but think it's useful