### PR TITLE
Filter by planning application type

### DIFF
--- a/app/components/planning_applications/search_component.html.erb
+++ b/app/components/planning_applications/search_component.html.erb
@@ -3,7 +3,7 @@
   scope: '',
   builder: GOVUKDesignSystemFormBuilder::FormBuilder,
   method: :get,
-  url: planning_applications_path(anchor: panel_type, status: selected_status),
+  url: planning_applications_path(anchor: panel_type, status: selected_status, application_type: selected_application_type),
   data: { controller: "clear-form" }
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
@@ -34,13 +34,25 @@
         <div class="govuk-accordion__section-header">
           <h3 class="govuk-accordion__section-heading">
             <button type="button" class="govuk-accordion__section-button">
-              <%= t(".status_filter", selected: selected_status_count, total: total_status_count) %>
+              Filters
             </button>
             <span class="govuk-accordion__icon"></span>
           </h3>
         </div>
+
         <div class="govuk-accordion__section-content">
+          <p class="govuk-body"><strong>Application type</strong></p>
+          <%= form.govuk_collection_check_boxes(:application_type, all_application_types, :to_s, :humanize, small: true, legend: nil, classes: "display-flex") %>
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        </div>
+
+        <div class="govuk-accordion__section-content">
+          <p class="govuk-body"><strong>Status</strong></p>
           <%= form.govuk_collection_check_boxes(:status, all_statuses, :to_s, :humanize, small: true, legend: nil, classes: "display-flex") %>
+          <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+        </div>
+        
+        <div class="govuk-accordion__section-content">
           <%= form.govuk_submit "Apply filters", class: "govuk-button govuk-button--secondary" %>
         </div>
       </div>

--- a/app/components/planning_applications/search_component.rb
+++ b/app/components/planning_applications/search_component.rb
@@ -20,12 +20,16 @@ module PlanningApplications
       search&.statuses
     end
 
-    def selected_status_count
-      selected_status&.count || total_status_count
-    end
-
     def total_status_count
       all_statuses.count
+    end
+
+    def selected_application_type
+      search&.application_type
+    end
+
+    def all_application_types
+      search&.application_types
     end
 
     def view
@@ -36,7 +40,8 @@ module PlanningApplications
       planning_applications_path(
         anchor: panel_type,
         view:,
-        status: all_statuses
+        status: all_statuses,
+        application_type: all_application_types
       )
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -758,7 +758,6 @@ en:
       clear_search: Clear search
       find_an_application: Find an application
       search: Search
-      status_filter: Filter by status (%{selected} of %{total} selected)
       you_can_search: You can search by application number or description
     steps:
       assessment:

--- a/db/migrate/20230713085643_add_indexes_to_planning_applications.rb
+++ b/db/migrate/20230713085643_add_indexes_to_planning_applications.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddIndexesToPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_index :planning_applications, %i[status application_type_id]
+    add_index :planning_applications, [:status]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_142759) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_085643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -444,7 +444,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_142759) do
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["reference", "local_authority_id"], name: "ix_planning_applications_on_reference__local_authority_id", unique: true
-    t.index ["user_id"], name: "index_planning_applications_on_user_id"
+    t.index ["status", "application_type_id"], name: "ix_planning_applications_on_status__application_type_id"
+    t.index ["status"], name: "ix_planning_applications_on_status"
+    t.index ["user_id"], name: "ix_planning_applications_on_user_id"
   end
 
   create_table "policies", force: :cascade do |t|

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(closed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 
-          click_button("Filter by status (5 of 5 selected)")
+          click_button("Filter")
           uncheck("Invalid")
           uncheck("In assessment")
           uncheck("Awaiting determination")
@@ -117,7 +117,6 @@ RSpec.describe "filtering planning applications" do
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 5 selected)")
           expect(page).to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(invalid_planning_application.reference)
           expect(page).not_to have_content(in_assessment_planning_application.reference)
@@ -125,7 +124,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
-          click_button("Filter by status (1 of 5 selected)")
+          click_button("Filter")
           check("Invalid")
           uncheck("Not started")
           uncheck("In assessment")
@@ -134,7 +133,6 @@ RSpec.describe "filtering planning applications" do
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 5 selected)")
           expect(page).to have_content(invalid_planning_application.reference)
           expect(page).not_to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(in_assessment_planning_application.reference)
@@ -142,7 +140,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
-          click_button("Filter by status (1 of 5 selected)")
+          click_button("Filter")
           check("In assessment")
           uncheck("Not started")
           uncheck("Invalid")
@@ -151,7 +149,6 @@ RSpec.describe "filtering planning applications" do
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 5 selected)")
           expect(page).to have_content(in_assessment_planning_application.reference)
           expect(page).not_to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(invalid_planning_application.reference)
@@ -159,7 +156,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
-          click_button("Filter by status (1 of 5 selected)")
+          click_button("Filter")
           check("Awaiting determination")
           uncheck("Not started")
           uncheck("Invalid")
@@ -168,7 +165,6 @@ RSpec.describe "filtering planning applications" do
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 5 selected)")
           expect(page).to have_content(awaiting_determination_planning_application.reference)
           expect(page).not_to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(invalid_planning_application.reference)
@@ -176,7 +172,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
-          click_button("Filter by status (1 of 5 selected)")
+          click_button("Filter")
           check("To be reviewed")
           uncheck("Not started")
           uncheck("Invalid")
@@ -185,7 +181,6 @@ RSpec.describe "filtering planning applications" do
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 5 selected)")
           expect(page).to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(invalid_planning_application.reference)
@@ -209,13 +204,12 @@ RSpec.describe "filtering planning applications" do
 
       it "allows user to filter by many different statuses" do
         within(selected_govuk_tab) do
-          click_button("Filter by status (5 of 5 selected)")
+          click_button("Filter")
           uncheck("Awaiting determination")
           uncheck("To be reviewed")
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(3 of 5 selected)")
           expect(page).to have_content(not_started_planning_application.reference)
           expect(page).to have_content(invalid_planning_application.reference)
           expect(page).to have_content(in_assessment_planning_application.reference)
@@ -237,7 +231,7 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
-          click_button("Filter by status (5 of 5 selected)")
+          click_button("Filter")
           uncheck("Invalidated")
           uncheck("To be reviewed")
 
@@ -273,13 +267,12 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(closed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 
-          click_button("Filter by status (5 of 5 selected)")
+          click_button("Filter")
           uncheck("Invalid")
           uncheck("In assessment")
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(3 of 5 selected)")
           expect(page).to have_content(awaiting_determination_planning_application.reference)
           expect(page).to have_content(other_awaiting_determination_planning_application.reference)
           expect(page).to have_content(to_be_reviewed_planning_application.reference)
@@ -321,23 +314,21 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(closed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 
-          click_button("Filter by status (2 of 2 selected)")
+          click_button("Filter")
           uncheck("To be reviewed")
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 2 selected)")
           expect(page).to have_content(other_awaiting_determination_planning_application.reference)
           expect(page).not_to have_content(other_to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 
-          click_button("Filter by status (1 of 2 selected)")
+          click_button("Filter")
           check("To be reviewed")
           uncheck("Awaiting determination")
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(1 of 2 selected)")
           expect(page).to have_content(other_to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(other_awaiting_determination_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
@@ -373,13 +364,12 @@ RSpec.describe "filtering planning applications" do
           expect(page).not_to have_content(closed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 
-          click_button("Filter by status (5 of 5 selected)")
+          click_button("Filter")
           uncheck("Invalid")
           uncheck("In assessment")
 
           click_button("Apply filters")
 
-          expect(page).to have_content("(3 of 5 selected)")
           expect(page).to have_content(awaiting_determination_planning_application.reference)
           expect(page).to have_content(other_awaiting_determination_planning_application.reference)
           expect(page).to have_content(to_be_reviewed_planning_application.reference)

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "searching planning applications" do
 
     it "allows user to search on filtered results", skip: "flaky" do
       within(selected_govuk_tab) do
-        click_button("Filter by status (5 of 5 selected)")
+        click_button("Filter")
         uncheck("Invalid")
         uncheck("Not started")
         uncheck("Awaiting determination")
@@ -229,7 +229,7 @@ RSpec.describe "searching planning applications" do
 
     it "allows user to search on filtered results", skip: "flaky" do
       within(selected_govuk_tab) do
-        click_button("Filter by status (5 of 5 selected)")
+        click_button("Filter")
         uncheck("Invalid")
         uncheck("Not started")
         uncheck("Awaiting determination")


### PR DESCRIPTION
### Description of change

- Filter by planning application type
- Also adds indexes for better search/filtering optimisation

### Story Link

https://trello.com/c/DDBkmVaD/1744-add-filters-for-planning-application-type

### Screenshots

![Screenshot 2023-07-13 at 12 11 52](https://github.com/unboxed/bops/assets/34001723/31d6a8b0-fcff-41a4-af18-3fc40dc2f335)