### PR TITLE
Add field to mark applications as public or not

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -96,6 +96,7 @@ class PlanningApplicationsController < AuthenticationController
       render "confirm_validation"
     else
       @planning_application.validated_at = date_from_params
+      @planning_application.update(planning_application_params)
       @planning_application.start!
       @planning_application.send_validation_notice_mail
 
@@ -170,6 +171,8 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def publish; end
+
+  def make_public; end
 
   def determine
     respond_to do |format|
@@ -264,7 +267,8 @@ class PlanningApplicationsController < AuthenticationController
                         received_at
                         town
                         uprn
-                        work_status]
+                        work_status
+                        make_public]
     # rubocop:enable Naming/VariableNumber
     params.require(:planning_application).permit permitted_keys
   end

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -66,3 +66,4 @@ if planning_application.consultation.present?
     json.summary_tag response.summary_tag
   end
 end
+json.make_public planning_application.make_public

--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -32,7 +32,10 @@
         </div>
       <% end %>
       <%= form.govuk_date_field :validated_at, legend: { size: 's' }, hint: { text: 'Enter valid date, for example, 28 12 2021' } %>
-      <%= form.govuk_check_box :make_public, 1, 0, multiple: false, label: { text: 'Publish application on BoPS applicants?'} %>
+      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BoPS Public Portal?' } do %>
+        <%= form.govuk_radio_button :make_public, true, label: { text: 'Yes' } %>
+        <%= form.govuk_radio_button :make_public, false, label: { text: 'No' } %>
+      <% end %>
       <p>
         <%= form.submit "Mark the application as valid", class: "govuk-button", data: { module: "govuk-button"} %>
       </p>

--- a/app/views/planning_applications/make_public.html.erb
+++ b/app/views/planning_applications/make_public.html.erb
@@ -1,22 +1,22 @@
 <% content_for :page_title do %>
-  <%= t('.validate_application') %> -  <%= t('page_title') %>
+  Make application public - <%= t('page_title') %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-<% content_for :title, t('.validate_application') %>
+
+<% content_for :title, "Make application public" %>
 
 <%= render(
   partial: "shared/proposal_header",
-  locals: { heading: t('.validate_application')  }
+  locals: { heading: "Make application public" }
 ) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">
-      When all parts of the application have been checked and are correct, mark the application as valid.
-    </p>
-    <%= form_with model: @planning_application, url: validate_planning_application_path(@planning_application), local:true, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+    <%= form_with model: @planning_application, 
+      url: planning_application_path(@planning_application), 
+      local: true,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
       <% if @planning_application.errors.any? %>
         <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
           <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -31,11 +31,11 @@
           </div>
         </div>
       <% end %>
-      <%= form.govuk_date_field :validated_at, legend: { size: 's' }, hint: { text: 'Enter valid date, for example, 28 12 2021' } %>
       <%= form.govuk_check_box :make_public, 1, 0, multiple: false, label: { text: 'Publish application on BoPS applicants?'} %>
       <p>
-        <%= form.submit "Mark the application as valid", class: "govuk-button", data: { module: "govuk-button"} %>
+        <%= form.submit "Update application", class: "govuk-button", data: { module: "govuk-button"} %>
       </p>
     <% end %>
   </div>
 </div>
+

--- a/app/views/planning_applications/make_public.html.erb
+++ b/app/views/planning_applications/make_public.html.erb
@@ -31,7 +31,10 @@
           </div>
         </div>
       <% end %>
-      <%= form.govuk_check_box :make_public, 1, 0, multiple: false, label: { text: 'Publish application on BoPS applicants?'} %>
+      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BoPS Public Portal?' } do %>
+        <%= form.govuk_radio_button :make_public, true, label: { text: 'Yes' } %>
+        <%= form.govuk_radio_button :make_public, false, label: { text: 'No' } %>
+      <% end %>
       <p>
         <%= form.submit "Update application", class: "govuk-button", data: { module: "govuk-button"} %>
       </p>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -27,5 +27,9 @@
         <strong>Note: application may be immune from enforcement</strong>
       </p>
     <% end %>
+
+    <p class="govuk-body">
+      Application is <%= @planning_application.make_public? ? "" : "not" %> public on BoPS applicants <span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
+    </p>
   </div>
 </div>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -29,7 +29,7 @@
     <% end %>
 
     <p class="govuk-body">
-      Application is <%= @planning_application.make_public? ? "" : "not" %> public on BoPS applicants <span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
+      Public on BoPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
     </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -68,6 +68,7 @@ Rails.application.routes.draw do
       get :validation_documents
       patch :validate_documents
       post :clone
+      get :make_public
     end
 
     resource :constraints, only: %i[show edit update] do

--- a/db/migrate/20230713142122_add_make_public_to_planning_application.rb
+++ b/db/migrate/20230713142122_add_make_public_to_planning_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMakePublicToPlanningApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :make_public, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_085643) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -436,6 +436,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_085643) do
     t.boolean "from_production", default: false
     t.text "changed_constraints", array: true
     t.bigint "application_type_id"
+    t.boolean "make_public", default: false
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -178,6 +178,8 @@ paths:
                               - Proposed
                             numbers: PLAN01
                             applicant_description: This is the proposed side elevation
+                        make_public: true
+
     post:
       summary: Create new planning application
       tags:

--- a/public/api-docs/v1/_build/swagger_doc.yaml
+++ b/public/api-docs/v1/_build/swagger_doc.yaml
@@ -96,6 +96,7 @@ paths:
                           - Proposed
                         numbers: PLAN01
                         applicant_description: This is the proposed side elevation
+                    make_public: true
   /api/v1/planning_applications:
     get:
       summary: Retrieves all determined planning applications

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -90,6 +90,7 @@ paths:
                         tags: ['Side', 'Elevation', 'Proposed']
                         numbers: PLAN01
                         applicant_description: 'This is the proposed side elevation'
+                    make_public: true
   '/api/v1/planning_applications':
     get:
       summary: Retrieves all determined planning applications

--- a/public/api-docs/v1/swagger_doc.yaml
+++ b/public/api-docs/v1/swagger_doc.yaml
@@ -71,6 +71,7 @@ paths:
                     result_heading: It looks like these changes will need planning permission
                     result_description: Based on the information you have provided, we do not think this is eligible for a Lawful Development Certificate
                     result_override: This was my reason for rejecting the result
+                    make_public: true
                     constraints:
                       - Conservation Area
                       - Listed Building
@@ -90,7 +91,6 @@ paths:
                         tags: ['Side', 'Elevation', 'Proposed']
                         numbers: PLAN01
                         applicant_description: 'This is the proposed side elevation'
-                    make_public: true
   '/api/v1/planning_applications':
     get:
       summary: Retrieves all determined planning applications

--- a/spec/fixtures/files/planx_params.json
+++ b/spec/fixtures/files/planx_params.json
@@ -758,7 +758,8 @@
       "result": "feedback about the result",
       "find_property": "feedback about the property",
       "planning_constraints": "feedback about the constraints"
-    }
+    },
+    "make_public": false 
   },
   "format": "json"
 }

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "making planning application public" do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  let!(:assessor) do
+    create(
+      :user,
+      :assessor,
+      local_authority:,
+      name: "Jane Smith"
+    )
+  end
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      local_authority:
+    )
+  end
+
+  it "lets a planning application be made public and not" do
+    travel_to("2022-01-01")
+    sign_in(assessor)
+
+    visit(planning_application_path(planning_application))
+
+    expect(page).to have_content("Application is not public on BoPS applicants")
+
+    visit(make_public_planning_application_path(planning_application))
+
+    expect(page).to have_content("Make application public")
+
+    check "Publish application on BoPS applicants?"
+
+    click_button "Update application"
+
+    expect(page).to have_content("Application is public on BoPS applicants")
+
+    visit(make_public_planning_application_path(planning_application))
+
+    uncheck "Publish application on BoPS applicants?"
+
+    click_button "Update application"
+
+    expect(page).to have_content("Application is not public on BoPS applicants")
+  end
+end

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -27,24 +27,24 @@ RSpec.describe "making planning application public" do
 
     visit(planning_application_path(planning_application))
 
-    expect(page).to have_content("Application is not public on BoPS applicants")
+    expect(page).to have_content("Public on BoPS Public Portal: No")
 
     visit(make_public_planning_application_path(planning_application))
 
     expect(page).to have_content("Make application public")
 
-    check "Publish application on BoPS applicants?"
+    choose "Yes"
 
     click_button "Update application"
 
-    expect(page).to have_content("Application is public on BoPS applicants")
+    expect(page).to have_content("Public on BoPS Public Portal: Yes")
 
     visit(make_public_planning_application_path(planning_application))
 
-    uncheck "Publish application on BoPS applicants?"
+    choose "No"
 
     click_button "Update application"
 
-    expect(page).to have_content("Application is not public on BoPS applicants")
+    expect(page).to have_content("Public on BoPS Public Portal: No")
   end
 end

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -25,12 +25,12 @@ RSpec.shared_examples "validate and invalidate" do
     fill_in "Month", with: "12"
     fill_in "Year", with: "2021"
 
-    check "Publish application on BoPS applicants?"
+    choose "Yes"
 
     click_button "Mark the application as valid"
 
     expect(page).to have_content("Application is ready for assessment")
-    expect(page).to have_content("Application is public on BoPS applicants")
+    expect(page).to have_content("Public on BoPS Public Portal: Yes")
 
     planning_application.reload
     expect(planning_application.status).to eq("in_assessment")

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -25,9 +25,12 @@ RSpec.shared_examples "validate and invalidate" do
     fill_in "Month", with: "12"
     fill_in "Year", with: "2021"
 
+    check "Publish application on BoPS applicants?"
+
     click_button "Mark the application as valid"
 
     expect(page).to have_content("Application is ready for assessment")
+    expect(page).to have_content("Application is public on BoPS applicants")
 
     planning_application.reload
     expect(planning_application.status).to eq("in_assessment")


### PR DESCRIPTION
### Description of change

- Add field to planning application to indicate whether it should be public on applicants or not
- Allow officer to change this when they make the case valid, but also on the application show page

### Story Link

https://trello.com/c/37TImALj/1785-restrict-cases-displayed-online

### Screenshots
<img width="934" alt="Screenshot 2023-07-14 at 12 17 46" src="https://github.com/unboxed/bops/assets/35098639/db71ffcd-44e0-4bfa-a45c-b789eec456bf">
<img width="735" alt="Screenshot 2023-07-14 at 12 18 02" src="https://github.com/unboxed/bops/assets/35098639/e3d0f75a-5943-47bc-ae8a-439755c8ba9d">


