### PR TITLE
Anonymise planning application personal information when cloned from production

### DIFF
--- a/app/services/planning_application_anonymisation_service.rb
+++ b/app/services/planning_application_anonymisation_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class PlanningApplicationAnonymisationService
+  class AnonymiseError < StandardError; end
+
+  ANONYMISATION_TEXT = "XXXXX"
+
+  def initialize(planning_application:)
+    @planning_application = planning_application
+  end
+
+  def call!
+    unless planning_application.from_production?
+      raise AnonymiseError, "Anonymizing is only permitted for production cases."
+    end
+
+    anonymize_personal_information.tap(&:save!)
+  rescue ActiveRecord::ActiveRecordError => e
+    raise AnonymiseError, e.message
+  end
+
+  private
+
+  attr_reader :planning_application
+
+  def anonymize_personal_information
+    planning_application.tap do |record|
+      record.applicant_first_name = ANONYMISATION_TEXT
+      record.applicant_last_name = ANONYMISATION_TEXT
+      record.applicant_phone = ANONYMISATION_TEXT
+      record.applicant_email = "applicant@example.com"
+      record.agent_first_name = ANONYMISATION_TEXT
+      record.agent_last_name = ANONYMISATION_TEXT
+      record.agent_phone = ANONYMISATION_TEXT
+      record.agent_email = "agent@example.com"
+    end
+  end
+end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -53,6 +53,9 @@ class PlanningApplicationCreationService
   def save_planning_application!(planning_application)
     PlanningApplication.transaction do
       if planning_application.save!
+        if planning_application.from_production?
+          PlanningApplicationAnonymisationService.new(planning_application:).call!
+        end
         ConstraintsCreationService.new(planning_application:,
                                        constraints_params: params[:constraints]&.to_unsafe_hash).call
         UploadDocumentsJob.perform_now(planning_application:, files: params[:files])

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -95,7 +95,20 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
 
         perform_enqueued_jobs
 
-        expect(PlanningApplication.last.from_production).to be true
+        planning_application = PlanningApplication.last
+        expect(planning_application.from_production).to be true
+
+        expect(planning_application).to have_attributes(
+          from_production: true,
+          applicant_first_name: "XXXXX",
+          applicant_last_name: "XXXXX",
+          applicant_phone: "XXXXX",
+          applicant_email: "applicant@example.com",
+          agent_first_name: "XXXXX",
+          agent_last_name: "XXXXX",
+          agent_phone: "XXXXX",
+          agent_email: "agent@example.com"
+        )
       end
 
       it "doesn't post to staging if in staging env" do

--- a/spec/services/planning_application_anonymisation_service_spec.rb
+++ b/spec/services/planning_application_anonymisation_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplicationAnonymisationService, type: :service do
+  describe "#call!" do
+    let!(:local_authority) { create(:local_authority) }
+
+    let(:anonymise_planning_application) do
+      described_class.new(planning_application:).call!
+    end
+
+    context "when planning application is from production" do
+      let!(:planning_application) { create(:planning_application, local_authority:, from_production: true) }
+
+      it "anonymises the personal information on a planning application" do
+        anonymise_planning_application
+
+        expect(planning_application).to have_attributes(
+          from_production: true,
+          applicant_first_name: "XXXXX",
+          applicant_last_name: "XXXXX",
+          applicant_phone: "XXXXX",
+          applicant_email: "applicant@example.com",
+          agent_first_name: "XXXXX",
+          agent_last_name: "XXXXX",
+          agent_phone: "XXXXX",
+          agent_email: "agent@example.com"
+        )
+      end
+
+      context "when there is an ActiveRecord::RecordInvalid error saving the new planning application" do
+        before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
+
+        it "raises an error" do
+          expect { anonymise_planning_application }.to raise_error(described_class::AnonymiseError)
+        end
+      end
+    end
+
+    context "when planning application is not from production" do
+      let!(:planning_application) { create(:planning_application, local_authority:, from_production: false) }
+
+      it "raises an error" do
+        expect { anonymise_planning_application }.to raise_error(described_class::AnonymiseError, "Anonymizing is only permitted for production cases.")
+      end
+    end
+  end
+end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         it "creates a new planning application identical to how it came via planx using the audit_log value as the params" do
           planning_application = PlanningApplication.last
 
+          expect(PlanningApplicationAnonymisationService).not_to receive(:new)
+
           expect do
             described_class.new(
               planning_application:


### PR DESCRIPTION
### Description of change

- We need to anonymise sensitive information from production cases when cloning them into staging

Need to call this service on staging for all planning applications with `from_production = true`

### Story Link

https://trello.com/c/Z3TdzZsV/1782-for-production-clone-cases-in-staging-remove-personal-data-from-planx

