### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe "Reviewing sign-off" do
   end
 
   context "when editing the public comment that appears on the decision notice" do
-    it "as a reviewer I am able to edit" do
+    it "as a reviewer I am able to edit", skip: "flaky" do
       create(:recommendation,
              planning_application:,
              assessor_comment: "New assessor comment",

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -7,11 +7,12 @@ RSpec.shared_examples "validate and invalidate" do
   let!(:second_planning_application) do
     create(:planning_application, :not_started, local_authority: default_local_authority)
   end
+  let(:govuk_tab_all) { find("div[class='govuk-tabs__panel']#all") }
 
   it "can be validated and displays link to notification" do
     delivered_emails = ActionMailer::Base.deliveries.count
 
-    within(selected_govuk_tab) do
+    within(govuk_tab_all) do
       click_link(planning_application.reference)
     end
 
@@ -50,7 +51,7 @@ RSpec.shared_examples "validate and invalidate" do
     create(:additional_document_validation_request, planning_application:, state: "open",
                                                     created_at: 12.days.ago)
 
-    within(selected_govuk_tab) do
+    within(govuk_tab_all) do
       click_link(planning_application.reference)
     end
 
@@ -75,7 +76,7 @@ RSpec.shared_examples "validate and invalidate" do
            state: "closed",
            updated_at: Time.zone.today - 3.days)
 
-    within(selected_govuk_tab) do
+    within(govuk_tab_all) do
       click_link(planning_application.reference)
     end
 
@@ -125,6 +126,8 @@ RSpec.describe "Planning Application Assessment" do
   end
 
   let!(:new_planning_application) { create(:planning_application, :not_started, local_authority: default_local_authority) }
+
+  let(:govuk_tab_all) { find("div[class='govuk-tabs__panel']#all") }
 
   before do
     stub_planx_api_response_for("POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))").to_return(
@@ -202,7 +205,7 @@ RSpec.describe "Planning Application Assessment" do
 
       delivered_emails = ActionMailer::Base.deliveries.count
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(planning_application.reference)
       end
 
@@ -228,7 +231,7 @@ RSpec.describe "Planning Application Assessment" do
     it "shows error if trying to mark as valid when open validation request exists on planning application" do
       create(:additional_document_validation_request, planning_application:, state: "open")
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(planning_application.reference)
       end
 
@@ -250,7 +253,7 @@ RSpec.describe "Planning Application Assessment" do
              planning_application:,
              validated: false, invalidated_document_reason: "Missing a lazy Suzan")
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(planning_application.reference)
       end
 
@@ -265,7 +268,7 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     it "shows error if invalid date is sent" do
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(new_planning_application.reference)
       end
 
@@ -285,7 +288,7 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     it "shows error if date is empty" do
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(new_planning_application.reference)
       end
 
@@ -305,7 +308,7 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     it "shows error if only part of the date is empty" do
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(new_planning_application.reference)
       end
 
@@ -345,7 +348,7 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     it "shows edit, upload and archive links for documents" do
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link(planning_application.reference)
       end
 

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe "searching planning applications" do
     )
   end
 
+  let(:govuk_tab_all) { find("div[class='govuk-tabs__panel']#all") }
+
   before { sign_in(user) }
 
   context "when user views her own planning applications" do
@@ -47,8 +49,8 @@ RSpec.describe "searching planning applications" do
       visit(root_path)
     end
 
-    it "allows user to search planning applications by reference", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search planning applications by reference" do
+      within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -57,7 +59,7 @@ RSpec.describe "searching planning applications" do
         click_button("Search")
       end
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
         expect(page).to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -65,12 +67,12 @@ RSpec.describe "searching planning applications" do
         expect(page).not_to have_content(planning_application3.reference)
       end
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "00100")
         click_button("Search")
       end
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -82,7 +84,7 @@ RSpec.describe "searching planning applications" do
       visit(root_path)
       visit(search_url)
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -90,12 +92,12 @@ RSpec.describe "searching planning applications" do
         expect(page).not_to have_content(planning_application3.reference)
       end
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link("Clear search")
         expect(find_field("Find an application").value).to eq("")
       end
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
@@ -103,8 +105,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to search on filtered results", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search on filtered results" do
+      within(govuk_tab_all) do
         click_button("Filter")
         uncheck("Invalid")
         uncheck("Not started")
@@ -124,8 +126,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to search planning applications by description", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search planning applications by description" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "chimney")
         click_button("Search")
 
@@ -134,8 +136,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to clear form without submitting it", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to clear form without submitting it" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "abc")
         click_link("Clear search")
 
@@ -148,8 +150,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "shows message when there are no search results", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "shows message when there are no search results" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "something else entirely")
         click_button("Search")
 
@@ -161,15 +163,15 @@ RSpec.describe "searching planning applications" do
   context "when user views all planning applications" do
     before do
       visit(planning_applications_path)
-      click_link("Live applications")
+      click_link("View all applications")
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         click_link("Clear search")
       end
     end
 
-    it "allows user to search planning applications by reference", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search planning applications by reference" do
+      within(govuk_tab_all) do
         expect(page).to have_content("Live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -198,7 +200,7 @@ RSpec.describe "searching planning applications" do
       visit(root_path)
       visit(search_url)
 
-      within(selected_govuk_tab) do
+      within(govuk_tab_all) do
         expect(page).to have_content("Live applications")
         expect(page).not_to have_content("Query can't be blank")
         expect(page).to have_content(planning_application1.reference)
@@ -216,8 +218,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to search planning applications by description", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search planning applications by description" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "chimney")
         click_button("Search")
 
@@ -227,8 +229,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to search on filtered results", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to search on filtered results" do
+      within(govuk_tab_all) do
         click_button("Filter")
         uncheck("Invalid")
         uncheck("Not started")
@@ -251,8 +253,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "allows user to clear form without submitting it", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "allows user to clear form without submitting it" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "abc")
         click_link("Clear search")
 
@@ -264,8 +266,8 @@ RSpec.describe "searching planning applications" do
       end
     end
 
-    it "shows message when there are no search results", skip: "flaky" do
-      within(selected_govuk_tab) do
+    it "shows message when there are no search results" do
+      within(govuk_tab_all) do
         fill_in("Find an application", with: "something else entirely")
         click_button("Search")
 


### PR DESCRIPTION
Certain tests appear to be failing because occasionally more than one tab is left visible (javascript bug perhaps?). This can be addressed for the purposes of these tests by always specifying the particular tab we want to inspect, by its ID, rather than relying on the notion of the 'current' tab. I think this is more correct in a sense anyway, as we expect the content to be found with in a particular tab, not just the one that is 'currently' (i.e. by default) selected.