### PR TITLE
Add publicity summary as a type of assessment detail

### DIFF
--- a/app/form_models/review_assessment_details_form.rb
+++ b/app/form_models/review_assessment_details_form.rb
@@ -10,6 +10,7 @@ class ReviewAssessmentDetailsForm
     site_description
     consultation_summary
     additional_evidence
+    publicity_summary
   ].freeze
 
   define_model_callbacks :save
@@ -98,6 +99,15 @@ class ReviewAssessmentDetailsForm
     end
 
     true
+  end
+
+  def assessment_detail_types
+    case planning_application.application_type.name.to_sym
+    when :lawfulness_certificate
+      ASSESSMENT_DETAILS - ["publicity_summary"]
+    else
+      ASSESSMENT_DETAILS
+    end
   end
 
   private

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -63,6 +63,15 @@ class AssessmentDetail < ApplicationRecord
 
       categories.partition { |category| category != "additional_evidence" }.sum([])
     end
+
+    def categories_for(application_type)
+      case application_type
+      when :lawfulness_certificate
+        category_keys - ["publicity_summary"]
+      else
+        category_keys
+      end
+    end
   end
 
   def existing_or_new_comment

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -34,7 +34,8 @@ class AssessmentDetail < ApplicationRecord
     additional_evidence: "additional_evidence",
     site_description: "site_description",
     past_applications: "past_applications",
-    consultation_summary: "consultation_summary"
+    consultation_summary: "consultation_summary",
+    publicity_summary: "publicity_summary"
   }
 
   before_validation :set_user

--- a/app/views/planning_application/assessment_details/publicity_summary/_information.html.erb
+++ b/app/views/planning_application/assessment_details/publicity_summary/_information.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-body">
+  <% if action_name == "show" %>
+    <p><strong>Summary</strong></p>
+  <% end %>
+
+  <%= render "shared/warning_text",
+             message: "This information will be made publicly available." %>
+  <%= render(
+        partial: "comment",
+        locals: { comment: rejected_assessment_detail&.comment }
+      ) %>
+  <% unless action_name == "show" %>
+  <% end %>
+</div>

--- a/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
+++ b/app/views/planning_application/assessment_tasks/_assessment_information.html.erb
@@ -4,7 +4,7 @@
   </h2>
 
   <ul class="app-task-list__items">
-    <% AssessmentDetail.category_keys.each do |category| %>
+    <% AssessmentDetail.categories_for(@planning_application.application_type.name.to_sym).each do |category| %>
       <%= render(
         TaskListItems::AssessmentDetailComponent.new(
           planning_application: @planning_application,

--- a/app/views/review_assessment_details/_form.html.erb
+++ b/app/views/review_assessment_details/_form.html.erb
@@ -5,7 +5,7 @@
   builder: GOVUKDesignSystemFormBuilder::FormBuilder
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <% ReviewAssessmentDetailsForm::ASSESSMENT_DETAILS.each_with_index do |assessment_detail, index| %>
+  <% @form.assessment_detail_types.each_with_index do |assessment_detail, index| %>
     <% unless index == 0 %>
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -245,12 +245,14 @@ en:
     edit_additional_evidence: Edit additional evidence
     edit_consultation_summary: Add consultation details
     edit_past_applications: History
+    edit_publicity_summary: Edit summary of neighbour responses
     edit_site_description: Edit site description
     edit_summary_of_work: Edit summary of works
     immunity_detail_successfully_updated: Evidence of immunity successfully updated
     new_additional_evidence: Add detail of additional evidence
     new_consultation_summary: Add consultation details
     new_past_applications: History
+    new_publicity_summary: Add summary of neighbour responses
     new_site_description: Create a description of the site
     new_summary_of_work: Create a summary of the works
     not_started: Not started
@@ -269,9 +271,13 @@ en:
       user_updated_consultation_summary: "%{user} updated consultation summary"
       user_updated_site_description: "%{user} updated site description"
       user_updated_summary_of_work: "%{user} updated summary of works"
+    publicity_summary: Summary of neighbour responses
+    publicity_summary_successfully_created: Summary of neighbour responses was successfully created.
+    publicity_summary_successfully_updated: Summary of neighbour responses was successfully updated.
     show_additional_evidence: Detail of additional evidence
     show_consultation_summary: Consultation details
     show_past_applications: History
+    show_publicity_summary: Summary of neighbour responses
     show_site_description: Site description
     show_summary_of_work: Summary of works
     site_description: Site description
@@ -634,6 +640,7 @@ en:
         edit_additional_evidence: Edit additional evidence
         edit_consultation_summary: Edit consultation details
         edit_past_applications: Edit history
+        edit_publicity_summary: Edit summary of neighbour responses
         edit_site_description: Edit site description
         edit_summary_of_work: Edit summary of work
     assessment_tasks:
@@ -1018,6 +1025,7 @@ en:
       additional_evidence: Summary of additional evidence
       consultation_summary: Summary of consultation
       past_applications: History (manual)
+      publicity_summary: Summary of neighbour responses
       site_description: Site description
       summary_of_work: Summary of works
     check_red_line_boundary_component:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,6 +108,8 @@ en:
               recommendation_accepted: You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen
             consultation_summary_entry:
               not_changed: must be edited
+            publicity_summary_entry:
+              not_changed: must be edited
             site_description_entry:
               not_changed: must be edited
             summary_of_work_entry:
@@ -922,12 +924,14 @@ en:
       edit_review: Edit review
       edit_to_accept: Edit to accept
       explain_to_the: Explain to the assessor why this needs reviewing
+      publicity_summary: Summary of neighbour responses
       return_to_officer: Return to officer with comment
       site_description: Site description
       summary_of_consultee: Summary of consultee responses
       summary_of_work: Summary of works
       update_additional_evidence: Update additional evidence
       update_consultation_summary: Update consultation summary
+      update_publicity_summary: Update summary of neighbour responses
       update_site_description: Update site description
       update_summary_of_work: Update summary of works
     information:

--- a/spec/form_models/review_assessment_details_form_spec.rb
+++ b/spec/form_models/review_assessment_details_form_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe ReviewAssessmentDetailsForm do
         )
       end
 
+      let!(:publicity_summary) do
+        create(
+          :assessment_detail,
+          :publicity_summary,
+          planning_application:,
+          entry: "publicity summary",
+          assessment_status: :complete
+        )
+      end
+
       let!(:site_description) do
         create(
           :assessment_detail,
@@ -76,7 +86,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: :accepted,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -107,6 +118,13 @@ RSpec.describe ReviewAssessmentDetailsForm do
               review_status: "in_progress"
             )
           end
+
+          it "updates publicity summmary" do
+            expect(publicity_summary.reload).to have_attributes(
+              reviewer_verdict: "accepted",
+              review_status: "in_progress"
+            )
+          end
         end
 
         context "when reviewer verdict 'rejected' and comment text is present" do
@@ -120,7 +138,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_comment_text: "summary of work comment",
               site_description_comment_text: "site description comment",
               additional_evidence_comment_text: "additional evidence comment",
-              consultation_summary_comment_text: "consultation summary comment"
+              consultation_summary_comment_text: "consultation summary comment",
+              publicity_summary_comment_text: "publicity summary comment"
             }
           end
 
@@ -188,7 +207,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_comment_text: "",
               site_description_comment_text: "",
               additional_evidence_comment_text: "",
-              consultation_summary_comment_text: ""
+              consultation_summary_comment_text: "",
+              publicity_summary_comment_text: ""
             }
           end
 
@@ -233,10 +253,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :edited_and_accepted,
               additional_evidence_reviewer_verdict: :edited_and_accepted,
               consultation_summary_reviewer_verdict: :edited_and_accepted,
+              publicity_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "edited summary of work",
               site_description_entry: "edited site description",
               additional_evidence_entry: "edited additional evidence",
-              consultation_summary_entry: "edited consultation summary"
+              consultation_summary_entry: "edited consultation summary",
+              publicity_summary_entry: "edited publicity summary"
             }
           end
 
@@ -271,6 +293,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
               entry: "edited consultation summary"
             )
           end
+
+          it "updates publicity summary" do
+            expect(publicity_summary.reload).to have_attributes(
+              reviewer_verdict: "edited_and_accepted",
+              review_status: "in_progress",
+              entry: "edited publicity summary"
+            )
+          end
         end
 
         context "when reviewer verdict 'edited and accepted' and entry is blank" do
@@ -281,10 +311,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :edited_and_accepted,
               additional_evidence_reviewer_verdict: :edited_and_accepted,
               consultation_summary_reviewer_verdict: :edited_and_accepted,
+              publicity_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "",
               site_description_entry: "",
               additional_evidence_entry: "",
-              consultation_summary_entry: ""
+              consultation_summary_entry: "",
+              publicity_summary_entry: ""
             }
           end
 
@@ -315,6 +347,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
           it "sets consultation summary error message" do
             expect(
               review_assessment_details.errors.messages[:consultation_summary_entry]
+            ).to contain_exactly(
+              "can't be blank"
+            )
+          end
+
+          it "sets publicity summary error message" do
+            expect(
+              review_assessment_details.errors.messages[:publicity_summary_entry]
             ).to contain_exactly(
               "can't be blank"
             )
@@ -329,10 +369,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :edited_and_accepted,
               additional_evidence_reviewer_verdict: :edited_and_accepted,
               consultation_summary_reviewer_verdict: :edited_and_accepted,
+              publicity_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "summary of work",
               site_description_entry: "site description",
               additional_evidence_entry: "additional evidence",
-              consultation_summary_entry: "consultation summary"
+              consultation_summary_entry: "consultation summary",
+              publicity_summary_entry: "publicity summary"
             }
           end
 
@@ -367,6 +409,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
               "must be edited"
             )
           end
+
+          it "sets publicity summary error message" do
+            expect(
+              review_assessment_details.errors.messages[:publicity_summary_entry]
+            ).to contain_exactly(
+              "must be edited"
+            )
+          end
         end
 
         context "when reviewer verdict is nil" do
@@ -376,7 +426,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: nil,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -394,7 +445,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: :accepted,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -413,7 +465,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: nil,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -439,7 +492,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: :accepted,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -478,6 +532,15 @@ RSpec.describe ReviewAssessmentDetailsForm do
               review_status: "in_progress"
             )
           end
+
+          it "creates publicity summmary" do
+            expect(
+              planning_application.reload.publicity_summary
+            ).to have_attributes(
+              reviewer_verdict: "accepted",
+              review_status: "in_progress"
+            )
+          end
         end
 
         context "when reviewer verdict is 'rejected' and comment text is present" do
@@ -488,10 +551,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :rejected,
               additional_evidence_reviewer_verdict: :rejected,
               consultation_summary_reviewer_verdict: :rejected,
+              publicity_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "summary of work comment",
               site_description_comment_text: "site description comment",
               additional_evidence_comment_text: "additional evidence comment",
-              consultation_summary_comment_text: "consultation summary comment"
+              consultation_summary_comment_text: "consultation summary comment",
+              publicity_summary_comment_text: "publicity summary comment"
             }
           end
 
@@ -562,6 +627,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
               text: "consultation summary comment"
             )
           end
+
+          it "creates comment for publicity summary" do
+            expect(
+              planning_application.reload.publicity_summary.comment
+            ).to have_attributes(
+              text: "publicity summary comment"
+            )
+          end
         end
 
         context "when reviewer verdict is 'rejected' and comment text is blank" do
@@ -572,10 +645,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :rejected,
               additional_evidence_reviewer_verdict: :rejected,
               consultation_summary_reviewer_verdict: :rejected,
+              publicity_summary_reviewer_verdict: :rejected,
               summary_of_work_comment_text: "",
               site_description_comment_text: "",
               additional_evidence_comment_text: "",
-              consultation_summary_comment_text: ""
+              consultation_summary_comment_text: "",
+              publicity_summary_comment_text: ""
             }
           end
 
@@ -610,6 +685,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
               "can't be blank"
             )
           end
+
+          it "sets publicity summary error message" do
+            expect(
+              review_assessment_details.errors.messages[:publicity_summary_comment_text]
+            ).to contain_exactly(
+              "can't be blank"
+            )
+          end
         end
 
         context "when reviewer verdict is 'edited and accepted' and entry is present" do
@@ -620,10 +703,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :edited_and_accepted,
               additional_evidence_reviewer_verdict: :edited_and_accepted,
               consultation_summary_reviewer_verdict: :edited_and_accepted,
+              publicity_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "edited summary of work",
               site_description_entry: "edited site description",
               additional_evidence_entry: "edited additional evidence",
-              consultation_summary_entry: "edited consultation summary"
+              consultation_summary_entry: "edited consultation summary",
+              publicity_summary_entry: "edited publicity summary"
             }
           end
 
@@ -666,6 +751,16 @@ RSpec.describe ReviewAssessmentDetailsForm do
               entry: "edited consultation summary"
             )
           end
+
+          it "creates publicity summary" do
+            expect(
+              planning_application.reload.publicity_summary
+            ).to have_attributes(
+              reviewer_verdict: "edited_and_accepted",
+              review_status: "in_progress",
+              entry: "edited publicity summary"
+            )
+          end
         end
 
         context "when reviewer verdict is 'edited and accepted' and entry is blank" do
@@ -676,10 +771,12 @@ RSpec.describe ReviewAssessmentDetailsForm do
               site_description_reviewer_verdict: :edited_and_accepted,
               additional_evidence_reviewer_verdict: :edited_and_accepted,
               consultation_summary_reviewer_verdict: :edited_and_accepted,
+              publicity_summary_reviewer_verdict: :edited_and_accepted,
               summary_of_work_entry: "",
               site_description_entry: "",
               additional_evidence_entry: "",
-              consultation_summary_entry: ""
+              consultation_summary_entry: "",
+              publicity_summary_entry: ""
             }
           end
 
@@ -714,6 +811,14 @@ RSpec.describe ReviewAssessmentDetailsForm do
               "can't be blank"
             )
           end
+
+          it "sets publicity summary error message" do
+            expect(
+              review_assessment_details.errors.messages[:publicity_summary_entry]
+            ).to contain_exactly(
+              "can't be blank"
+            )
+          end
         end
 
         context "when any reviewer verdict is nil" do
@@ -723,7 +828,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: nil,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -741,7 +847,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
               summary_of_work_reviewer_verdict: :accepted,
               additional_evidence_reviewer_verdict: :accepted,
               site_description_reviewer_verdict: :accepted,
-              consultation_summary_reviewer_verdict: :accepted
+              consultation_summary_reviewer_verdict: :accepted,
+              publicity_summary_reviewer_verdict: :accepted
             }
           end
 
@@ -785,7 +892,8 @@ RSpec.describe ReviewAssessmentDetailsForm do
           additional_evidence_reviewer_verdict: :accepted,
           site_description_reviewer_verdict: :accepted,
           consultation_summary_reviewer_verdict: :rejected,
-          consultation_summary_comment_text: "consultation summary comment"
+          consultation_summary_comment_text: "consultation summary comment",
+          publicity_summary_comment_text: "publicity summary comment"
         }
       end
 

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe AssessmentDetail do
     describe "#category_keys" do
       it "returns an array of categories with additional_evidence as the last item" do
         expect(described_class.category_keys).to eq(
-          %w[summary_of_work site_description consultation_summary additional_evidence]
+          %w[summary_of_work site_description consultation_summary publicity_summary additional_evidence]
         )
       end
     end

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -6,8 +6,10 @@ RSpec.describe "neighbour responses" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
+  let!(:application_type) { create(:application_type, name: :prior_approval) }
   let!(:planning_application) do
-    create(:planning_application, :in_assessment, local_authority: default_local_authority)
+    create(:planning_application, :in_assessment, :from_planx_immunity, application_type:,
+                                                                        local_authority: default_local_authority)
   end
 
   before do
@@ -113,6 +115,21 @@ RSpec.describe "neighbour responses" do
       visit new_planning_application_assessment_detail_path(planning_application)
 
       expect(page).to have_content("forbidden")
+    end
+  end
+
+  context "when it's an LDC application" do
+    let!(:application_type) { create(:application_type, name: :lawfulness_certificate) }
+    let!(:planning_application) do
+      create(:planning_application, :in_assessment, application_type:, local_authority: default_local_authority)
+    end
+
+    it "does not show neighbour responses as an option" do
+      click_link "Check and assess"
+
+      within("#assessment-information-tasks") do
+        expect(page).not_to have_content("Summary of neighbour responses")
+      end
     end
   end
 end

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "neighbour responses" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, :in_assessment, local_authority: default_local_authority)
+  end
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  context "when planning application is in assessment" do
+    it "I can view the information on the neighbour responses page" do
+      click_link "Check and assess"
+
+      within("#assessment-information-tasks") do
+        expect(page).to have_content("Summary of neighbour responses")
+      end
+      within("#summary-of-neighbour-responses") do
+        expect(page).to have_content("Not started")
+        click_link "Summary of neighbour responses"
+      end
+
+      expect(page).to have_current_path(
+        new_planning_application_assessment_detail_path(planning_application, category: "publicity_summary")
+      )
+
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Summary of neighbour responses")
+      end
+
+      expect(page).to have_content("Add summary of neighbour responses")
+      expect(page).to have_content(planning_application.reference)
+      expect(page).to have_content(planning_application.full_address)
+
+      expect(page).to have_content("This information will be made publicly available.")
+    end
+
+    it "I can save and come back later when adding or editing neighbour responses" do
+      expect(list_item("Check and assess")).to have_content("Not started")
+
+      click_link "Check and assess"
+      click_link "Summary of neighbour responses"
+
+      fill_in "assessment_detail[entry]", with: "A draft entry for the neighbour responses"
+      click_button "Save and come back later"
+
+      expect(page).to have_content("neighbour responses was successfully created.")
+
+      within("#summary-of-neighbour-responses") do
+        expect(page).to have_content("In progress")
+      end
+
+      click_link "Summary of neighbour responses"
+      expect(page).to have_content("Edit summary of neighbour responses")
+      expect(page).to have_content("A draft entry for the neighbour responses")
+
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Edit summary of neighbour responses")
+      end
+
+      click_button "Save and come back later"
+      expect(page).to have_content("neighbour responses was successfully updated.")
+
+      within("#summary-of-neighbour-responses") do
+        expect(page).to have_content("In progress")
+      end
+
+      click_link("Application")
+
+      expect(list_item("Check and assess")).to have_content("In progress")
+    end
+
+    it "I can save and mark as complete when adding neighbour responses" do
+      click_link "Check and assess"
+      click_link "Summary of neighbour responses"
+
+      fill_in "assessment_detail[entry]", with: "A complete entry for the neighbour responses"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("neighbour responses was successfully created.")
+
+      within("#summary-of-neighbour-responses") do
+        expect(page).to have_content("Completed")
+      end
+
+      click_link "Summary of neighbour responses"
+      expect(page).to have_content("Summary of neighbour responses")
+      expect(page).to have_content("A complete entry for the neighbour responses")
+
+      expect(page).to have_link(
+        "Edit summary of neighbour responses",
+        href: edit_planning_application_assessment_detail_path(planning_application,
+                                                               AssessmentDetail.publicity_summary.last)
+      )
+    end
+  end
+
+  context "when planning application has not been validated yet" do
+    let!(:planning_application) do
+      create(:planning_application, :not_started, local_authority: default_local_authority)
+    end
+
+    it "does not allow me to visit the page" do
+      expect(page).not_to have_link("neighbour responses")
+
+      visit new_planning_application_assessment_detail_path(planning_application)
+
+      expect(page).to have_content("forbidden")
+    end
+  end
+end

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -202,6 +202,10 @@ RSpec.describe "Reviewing assessment summaries" do
         choose("Accept")
       end
 
+      within(find("fieldset", text: "Summary of neighbour responses")) do
+        choose("Accept")
+      end
+
       click_button("Save and mark as complete")
 
       expect(page).to have_list_item_for(
@@ -453,6 +457,10 @@ RSpec.describe "Reviewing assessment summaries" do
       click_link("Review assessment summaries")
 
       within(find("fieldset", text: "Summary of additional evidence")) do
+        choose("Accept")
+      end
+
+      within(find("fieldset", text: "Summary of neighbour responses")) do
         choose("Accept")
       end
 


### PR DESCRIPTION
### Description of change

Add a `publicity_summary` type to AssessmentDetail and the associated views to create this option in the list of assessor remarks options.

### Story Link

https://trello.com/c/gvvCrMug/1702-text-box-for-assessment-of-proposal-follow-objections

### Screenshots
<img width="689" alt="Screenshot 2023-07-20 at 13 51 16" src="https://github.com/unboxed/bops/assets/3986/6a85b891-fbf4-4adf-a395-b9a54a9486d2">
<img width="662" alt="Screenshot 2023-07-20 at 13 51 49" src="https://github.com/unboxed/bops/assets/3986/33ad3690-5260-46d5-8180-0d99ac05593d">
<img width="668" alt="Screenshot 2023-07-20 at 13 52 07" src="https://github.com/unboxed/bops/assets/3986/9a24210e-7d1b-4c7e-8628-a09d02b9ffa3">