### PR TITLE
Clear scroll position after use

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -27,6 +27,7 @@ window.addEventListener("DOMContentLoaded", () => {
 
   if (sessionStorage.getItem(scrollPositionKey)) {
     window.scrollTo(0, sessionStorage.getItem(scrollPositionKey))
+    sessionStorage.setItem(scrollPositionKey, 0)
   }
 
   window.onbeforeunload = function () {


### PR DESCRIPTION
### Description of change

The autoscroll code for the back button seems to sometimes be applied when it shouldn't. Clearing the value when it's been used might help to fix that.

### Story Link

https://link-to-issue

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
