### PR TITLE
Add conditions

### DIFF
--- a/app/components/accordion_sections/considerations_component.html.erb
+++ b/app/components/accordion_sections/considerations_component.html.erb
@@ -1,0 +1,12 @@
+<% if @planning_application.local_policy.present? %>
+  <% @planning_application.local_policy.local_policy_areas.each do |local_policy_area| %>
+    <p class="govuk-!-font-weight-bold govuk-body"><%= local_policy_area.area.humanize %></p>
+    <p class="govuk-body">Policies: <%= local_policy_area.policies %></p>
+    <% if local_policy_area.guidance.present? %>
+      <p class="govuk-body">Guidance: <%= local_policy_area.guidance %></p>
+    <% end %>
+    <p class="govuk-body">Assessment: <%= local_policy_area.assessment %></p>
+  <% end %>
+<% else %>
+  <p class="govuk-body">There are no considerations</p>
+<% end %>

--- a/app/components/accordion_sections/considerations_component.rb
+++ b/app/components/accordion_sections/considerations_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module AccordionSections
+  class ConsiderationsComponent < AccordionSections::BaseComponent
+  end
+end

--- a/app/components/task_list_items/conditions_component.rb
+++ b/app/components/task_list_items/conditions_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class ConditionsComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+    end
+
+    private
+
+    attr_reader :planning_application
+
+    def link_text
+      "Add conditions"
+    end
+
+    def link_path
+      if planning_application.conditions.any?
+        planning_application_conditions_path(@planning_application)
+      else
+        new_planning_application_condition_path(@planning_application)
+      end
+    end
+
+    def status_tag_component
+      StatusTags::BaseComponent.new(status:)
+    end
+
+    def status
+      planning_application.conditions.any? ? "complete" : "not_started"
+    end
+  end
+end

--- a/app/controllers/planning_applications/conditions_controller.rb
+++ b/app/controllers/planning_applications/conditions_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  class ConditionsController < AuthenticationController
+    include CommitMatchable
+
+    before_action :set_planning_application
+    before_action :set_conditions, only: :new
+
+    def new; end
+
+    def edit; end
+
+    def create
+      if @planning_application.update(condition_params)
+        respond_to do |format|
+          format.html do
+            redirect_to(planning_application_assessment_tasks_path(@planning_application),
+                        notice: I18n.t("conditions.create.success"))
+          end
+        end
+      else
+        set_conditions
+        render :new
+      end
+    end
+
+    private
+
+    def condition_params
+      params.require(:planning_application)
+            .permit(conditions_attributes: %i[text reason])
+    end
+
+    def set_conditions
+      @conditions = t("conditions").map do |condition|
+        Condition.new(text: condition.second[:condition], reason: condition.second[:reason])
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/conditions_controller.rb
+++ b/app/controllers/planning_applications/conditions_controller.rb
@@ -5,7 +5,10 @@ module PlanningApplications
     include CommitMatchable
 
     before_action :set_planning_application
-    before_action :set_conditions, only: :new
+    before_action :set_new_conditions, only: :new
+    before_action :set_conditions, only: :edit
+
+    def show; end
 
     def new; end
 
@@ -20,22 +23,66 @@ module PlanningApplications
           end
         end
       else
-        set_conditions
+        set_new_conditions
         render :new
+      end
+    end
+
+    def update
+      if update_conditions
+        respond_to do |format|
+          format.html do
+            redirect_to(planning_application_assessment_tasks_path(@planning_application),
+                        notice: I18n.t("conditions.update.success"))
+          end
+        end
+      else
+        set_conditions
+        render :edit
       end
     end
 
     private
 
-    def condition_params
-      params.require(:planning_application)
-            .permit(conditions_attributes: %i[text reason])
+    def update_conditions
+      ActiveRecord::Base.transaction do
+        @planning_application.update(condition_params) &&
+          @planning_application.conditions.each do |condition|
+            condition.destroy if irrelevant_conditions.include? condition.id
+          end
+      end
     end
 
-    def set_conditions
+    def condition_params
+      params.require(:planning_application)
+            .permit(conditions_attributes: %i[text reason id])
+    end
+
+    def set_new_conditions
       @conditions = t("conditions").map do |condition|
         Condition.new(text: condition.second[:condition], reason: condition.second[:reason])
       end
+    end
+
+    def set_conditions
+      new_conditions = t("conditions").map do |condition|
+        next if @planning_application.conditions.pluck(:text).include? condition.second[:condition]
+
+        Condition.new(text: condition.second[:condition], reason: condition.second[:reason])
+      end.compact_blank
+
+      @conditions = @planning_application.conditions + new_conditions
+    end
+
+    def irrelevant_conditions
+      conditions = []
+      params[:planning_application][:conditions_attributes].each do |_key, value|
+        next if value[:conditions] == ["true"]
+
+        conditions << value[:id].to_i
+      end
+
+      conditions
     end
   end
 end

--- a/app/controllers/planning_applications/conditions_controller.rb
+++ b/app/controllers/planning_applications/conditions_controller.rb
@@ -59,16 +59,16 @@ module PlanningApplications
     end
 
     def set_new_conditions
-      @conditions = t("conditions").map do |condition|
-        Condition.new(text: condition.second[:condition], reason: condition.second[:reason])
+      @conditions = t("conditions_list").map do |_key, value|
+        Condition.new(text: value[:condition], reason: value[:reason], title: value[:title])
       end
     end
 
     def set_conditions
-      new_conditions = t("conditions").map do |condition|
-        next if @planning_application.conditions.pluck(:text).include? condition.second[:condition]
+      new_conditions = t("conditions_list").map do |_key, value|
+        next if @planning_application.conditions.pluck(:text).include? value[:condition]
 
-        Condition.new(text: condition.second[:condition], reason: condition.second[:reason])
+        Condition.new(text: value[:condition], reason: value[:reason])
       end.compact_blank
 
       @conditions = @planning_application.conditions + new_conditions

--- a/app/controllers/planning_applications/conditions_controller.rb
+++ b/app/controllers/planning_applications/conditions_controller.rb
@@ -15,7 +15,7 @@ module PlanningApplications
     def edit; end
 
     def create
-      if @planning_application.update(condition_params)
+      if @planning_application.update(assign_params)
         respond_to do |format|
           format.html do
             redirect_to(planning_application_assessment_tasks_path(@planning_application),
@@ -46,43 +46,72 @@ module PlanningApplications
 
     def update_conditions
       ActiveRecord::Base.transaction do
-        @planning_application.update(condition_params) &&
-          @planning_application.conditions.each do |condition|
-            condition.destroy if irrelevant_conditions.include? condition.id
-          end
+        @planning_application.update(assign_params) && destroy_old_conditions
       end
     end
 
     def condition_params
       params.require(:planning_application)
-            .permit(conditions_attributes: %i[text reason id])
+            .permit(
+              conditions_attributes: [:title, :text, :reason, :id, :standard, :new_condition, { conditions: [] }]
+            )
+    end
+
+    def assign_params
+      new_params = condition_params
+      new_params[:conditions_attributes] = condition_params[:conditions_attributes].select do |_key, value|
+        value[:conditions].present? ||
+          (value[:standard] == "false" && (value[:text].present? || value[:reason].present?))
+      end
+      new_params
     end
 
     def set_new_conditions
       @conditions = t("conditions_list").map do |_key, value|
-        Condition.new(text: value[:condition], reason: value[:reason], title: value[:title])
+        construct_condition(value)
       end
     end
 
     def set_conditions
       new_conditions = t("conditions_list").map do |_key, value|
-        next if @planning_application.conditions.pluck(:text).include? value[:condition]
+        next if @planning_application.conditions.pluck(:title).include? value[:title]
 
-        Condition.new(text: value[:condition], reason: value[:reason])
+        construct_condition(value)
       end.compact_blank
 
       @conditions = @planning_application.conditions + new_conditions
     end
 
-    def irrelevant_conditions
+    def irrelevant_condition_ids
       conditions = []
       params[:planning_application][:conditions_attributes].each do |_key, value|
         next if value[:conditions] == ["true"]
 
         conditions << value[:id].to_i
       end
-
       conditions
+    end
+
+    def relevant_condition_ids
+      conditions = []
+      params[:planning_application][:conditions_attributes].each do |_key, value|
+        conditions << value[:id].to_i if value[:standard] == "false"
+      end
+      conditions
+    end
+
+    def construct_condition(value)
+      Condition.new(text: value[:condition], reason: value[:reason], standard: true, title: value[:title])
+    end
+
+    def destroy_old_conditions
+      @planning_application.conditions.each do |condition|
+        if condition.standard?
+          condition.destroy if irrelevant_condition_ids.include?(condition.id)
+        else
+          condition.destroy unless relevant_condition_ids.include?(condition.id) || condition.id_previously_changed?
+        end
+      end
     end
   end
 end

--- a/app/javascript/controllers/add_condition_controller.js
+++ b/app/javascript/controllers/add_condition_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  handleClick(event) {
+    event.preventDefault()
+    const form = event.currentTarget
+  }
+}

--- a/app/javascript/controllers/add_condition_controller.js
+++ b/app/javascript/controllers/add_condition_controller.js
@@ -21,28 +21,28 @@ export default class extends Controller {
   changeIds(form, length) {
     const inputs = form.getElementsByTagName("input")
 
-    for (let a = 0; a < inputs.length; a++) {
+    for (const input of inputs) {
       const formCount = 3 + length
-      inputs[a].name = inputs[a].name.replace(/\d/g, `${formCount}`)
-      inputs[a].id = inputs[a].id.replace(/\d/g, `${formCount}`)
+      input.name = input.name.replace(/\d/g, `${formCount}`)
+      input.id = input.id.replace(/\d/g, `${formCount}`)
     }
 
     const divs = form.getElementsByTagName("div")
 
-    for (let b = 0; b < divs.length; b++) {
+    for (const div of divs) {
       const count = 3 + length
-      const children = divs[b].childNodes
+      const children = div.childNodes
 
-      for (let k = 0; k < children.length; k++) {
-        if (children[k].hasAttribute("for")) {
-          children[k].setAttribute(
+      for (const child of children) {
+        if (child.hasAttribute("for")) {
+          child.setAttribute(
             "for",
-            children[k].getAttribute("for").replace(/\d/g, `${count}`),
+            child.getAttribute("for").replace(/\d/g, `${count}`),
           )
         }
-        if (children[k].hasAttribute("name")) {
-          children[k].name = children[k].name.replace(/\d/g, `${count}`)
-          children[k].id = children[k].id.replace(/\d/g, `${count}`)
+        if (child.hasAttribute("name")) {
+          child.name = child.name.replace(/\d/g, `${count}`)
+          child.id = child.id.replace(/\d/g, `${count}`)
         }
       }
     }

--- a/app/javascript/controllers/add_condition_controller.js
+++ b/app/javascript/controllers/add_condition_controller.js
@@ -1,16 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["form", "newForms"]
+
   addCondition(event) {
     event.preventDefault()
-    const form = document.getElementById("add-condition-form")
-    const clone = form.cloneNode(true)
+    const clone = this.formTarget.cloneNode(true)
     const length = document.querySelectorAll(".condition-form").length
     this.changeIds(clone, length)
     clone.id = `add-condition-form-${length}`
     clone.classList.remove("display-none")
-    const place = document.getElementById("new-forms")
-    place.appendChild(clone)
+    clone.data = {} // to remove the stimulus target
+    this.newFormsTarget.appendChild(clone)
   }
 
   removeCondition(event) {

--- a/app/javascript/controllers/add_condition_controller.js
+++ b/app/javascript/controllers/add_condition_controller.js
@@ -1,8 +1,50 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  handleClick(event) {
+  addCondition(event) {
     event.preventDefault()
-    const form = event.currentTarget
+    const form = document.getElementById("add-condition-form")
+    const clone = form.cloneNode(true)
+    const length = document.querySelectorAll(".condition-form").length
+    this.changeIds(clone, length)
+    clone.id = `add-condition-form-${length}`
+    clone.classList.remove("display-none")
+    const place = document.getElementById("new-forms")
+    place.appendChild(clone)
+  }
+
+  removeCondition(event) {
+    event.preventDefault()
+    event.srcElement.parentNode.remove()
+  }
+
+  changeIds(form, length) {
+    const inputs = form.getElementsByTagName("input")
+
+    for (let a = 0; a < inputs.length; a++) {
+      const formCount = 3 + length
+      inputs[a].name = inputs[a].name.replace(/\d/g, `${formCount}`)
+      inputs[a].id = inputs[a].id.replace(/\d/g, `${formCount}`)
+    }
+
+    const divs = form.getElementsByTagName("div")
+
+    for (let b = 0; b < divs.length; b++) {
+      const count = 3 + length
+      const children = divs[b].childNodes
+
+      for (let k = 0; k < children.length; k++) {
+        if (children[k].hasAttribute("for")) {
+          children[k].setAttribute(
+            "for",
+            children[k].getAttribute("for").replace(/\d/g, `${count}`),
+          )
+        }
+        if (children[k].hasAttribute("name")) {
+          children[k].name = children[k].name.replace(/\d/g, `${count}`)
+          children[k].id = children[k].id.replace(/\d/g, `${count}`)
+        }
+      }
+    }
   }
 }

--- a/app/javascript/controllers/add_condition_controller.js
+++ b/app/javascript/controllers/add_condition_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["form", "newForms"]
+  static targets = ["form", "newForms", "standardConditions"]
 
   addCondition(event) {
     event.preventDefault()
@@ -21,9 +21,13 @@ export default class extends Controller {
 
   changeIds(form, length) {
     const inputs = form.getElementsByTagName("input")
+    const standardConditionsCount =
+      this.standardConditionsTarget.querySelectorAll(
+        ".govuk-checkboxes__item",
+      ).length
 
     for (const input of inputs) {
-      const formCount = 3 + length
+      const formCount = standardConditionsCount + length
       input.name = input.name.replace(/\d/g, `${formCount}`)
       input.id = input.id.replace(/\d/g, `${formCount}`)
     }
@@ -31,7 +35,7 @@ export default class extends Controller {
     const divs = form.getElementsByTagName("div")
 
     for (const div of divs) {
-      const count = 3 + length
+      const count = standardConditionsCount + length
       const children = div.childNodes
 
       for (const child of children) {

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,5 +1,8 @@
 import { application } from "./application"
 
+import AddConditionController from "./add_condition_controller.js"
+application.register("add-condition", AddConditionController)
+
 import AddressFillController from "./address_fill_controller.js"
 application.register("address-fill", AddressFillController)
 

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Condition < ApplicationRecord
+  validates :text, :reason, presence: true
+
+  belongs_to :planning_application
+
+  attr_accessor :new_condition, :conditions
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -53,6 +53,7 @@ class PlanningApplication < ApplicationRecord
     has_many :planning_application_constraints_queries
     has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_many :site_notices
+    has_many :conditions
     has_one :immunity_detail, required: false
     has_one :consultation, required: false
     has_one :proposal_measurement, required: false
@@ -115,6 +116,7 @@ class PlanningApplication < ApplicationRecord
   accepts_nested_attributes_for :documents
   accepts_nested_attributes_for :constraints
   accepts_nested_attributes_for :proposal_measurement
+  accepts_nested_attributes_for :conditions
 
   WORK_STATUSES = %w[proposed existing].freeze
 

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -21,7 +21,7 @@ class ErrorPresenter
     if message.match?(/\A[A-Z].+\Z/)
       message
     else
-      "#{attribute.to_s.humanize} #{message}"
+      "#{attribute.to_s.humanize.tr('.', ' ')} #{message}"
     end
   end
 

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -106,6 +106,15 @@
   </div>
 
   <h3 class="govuk-heading-s">
+    Conditions:
+  </h3>
+  <ul class="govuk-list">
+    <% @planning_application.conditions.each do |condition| %>
+      <li><%= condition.text %></li>
+    <% end %>
+  </p>
+
+  <h3 class="govuk-heading-s">
     Notes:
   </h3>
   <p class="govuk-body">

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -58,6 +58,17 @@
       </p>
     <% end %>
     <h3 class="govuk-heading-s">
+      Conditions:
+    </h3>
+    <ul class="govuk-list">
+      <% @planning_application.conditions.each do |condition| %>
+        <li>
+          <%= condition.text %><br>
+          <%= condition.reason %>
+        </li>
+      <% end %>
+    </p>
+    <h3 class="govuk-heading-s">
       This decision is based on the following approved plans:
     </h3>
     <% if planning_application.documents_for_decision_notice.any? %>
@@ -104,15 +115,6 @@
       <p class="govuk-body">No digital sitemap provided</p>
     <% end %>
   </div>
-
-  <h3 class="govuk-heading-s">
-    Conditions:
-  </h3>
-  <ul class="govuk-list">
-    <% @planning_application.conditions.each do |condition| %>
-      <li><%= condition.text %></li>
-    <% end %>
-  </p>
 
   <h3 class="govuk-heading-s">
     Notes:

--- a/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
@@ -23,7 +23,7 @@
         )
       ) %>
     </li>
-    <% if @planning_application.type == "Householder Application for Planning Permission" && @planning_application.decision == "granted" %>
+    <% if @planning_application.type == "Householder Application for Planning Permission" %>
       <%= render(
         TaskListItems::ConditionsComponent.new(
           planning_application: @planning_application

--- a/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
@@ -23,6 +23,23 @@
         )
       ) %>
     </li>
+    <% if @planning_application.type == "Householder Application for Planning Permission" && @planning_application.decision == "granted" %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= link_to_if(
+            @planning_application.can_assess?,
+            "Add conditions",
+            new_planning_application_condition_path(@planning_application),
+            class: "govuk-link"
+          ) %>
+        </span>
+        <%= render(
+          StatusTags::AssessRecommendationComponent.new(
+            planning_application: @planning_application
+          )
+        ) %>
+      </li>
+    <% end %>
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
         <% if @planning_application.can_submit_recommendation? %>

--- a/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment_tasks/_complete_assessment.html.erb
@@ -24,21 +24,11 @@
       ) %>
     </li>
     <% if @planning_application.type == "Householder Application for Planning Permission" && @planning_application.decision == "granted" %>
-      <li class="app-task-list__item">
-        <span class="app-task-list__task-name">
-          <%= link_to_if(
-            @planning_application.can_assess?,
-            "Add conditions",
-            new_planning_application_condition_path(@planning_application),
-            class: "govuk-link"
-          ) %>
-        </span>
-        <%= render(
-          StatusTags::AssessRecommendationComponent.new(
-            planning_application: @planning_application
-          )
-        ) %>
-      </li>
+      <%= render(
+        TaskListItems::ConditionsComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
     <% end %>
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -7,7 +7,8 @@
   <%= form.govuk_check_boxes_fieldset :conditions, multiple: true do %>
     <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
     <%= form.fields_for :conditions, @conditions do |ff| %>
-      <%= ff.govuk_check_box :text, ff.object.text.to_s, label: { text: ff.object.text.to_s }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
+      <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.text.to_s }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
+        <%= ff.hidden_field :id, value: ff.object.id %>
         <%= ff.hidden_field :text, value: ff.object.text %>
         <%= ff.govuk_text_area :reason, value: ff.object.reason %>
       <% end %>

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -6,27 +6,45 @@
               method: method.to_sym do |form| %>
   <%= form.govuk_check_boxes_fieldset :conditions, legend: { text: "Suggested conditions" }, multiple: true do %>
     <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-    <%= form.fields_for :conditions, @conditions do |ff| %>
-      <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.title }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
+    <%= form.fields_for(:conditions, @conditions.select(&:standard?)) do |ff| %>
+      <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.title }, checked: @planning_application.conditions.where(title: ff.object.title).any? do %>
         <%= ff.hidden_field :id, value: ff.object.id %>
-        <%= ff.govuk_text_area :text, value: ff.object.text %>
-        <%= ff.govuk_text_area :reason, value: ff.object.reason %>
+        <%= ff.hidden_field :standard, value: true %>
+        <%= ff.hidden_field :title, value: ff.object.title %>
+        <%= ff.govuk_text_area :text, label: { text: "Condition", size: "s" }, value: ff.object.text %>
+        <%= ff.govuk_text_area :reason, label: { text: "Reason", size: "s" }, value: ff.object.reason %>
       <% end %>
     <% end %>
+
     <div data-controller="add-condition">
       <h2>Other conditions</h2>
-      <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#handleClick" %>
+      <%= form.fields_for(:conditions, @conditions.reject(&:standard?)) do |ff| %>
+        <div class="condition-form govuk-!-margin-bottom-5">
+          <%= ff.hidden_field :id, value: ff.object.id %>
+          <%= ff.hidden_field :standard, value: false %>
+          <%= ff.hidden_field :new_condition, value: true %>
+          <%= ff.govuk_text_area :text, label: { text: "Condition", size: "s" } %>
+          <%= ff.govuk_text_area :reason, label: { text: "Reason", size: "s" } %>
+          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
+        </div>
+      <% end %>
+      <div class="display-none govuk-!-margin-bottom-5 condition-form" id="add-condition-form">
+        <%= form.fields_for :conditions, Condition.new(planning_application: @planning_application.planning_application) do |ff| %>
+          <%= ff.hidden_field :standard, value: false %>
+          <%= ff.hidden_field :new_condition, value: true %>
+          <%= ff.govuk_text_area :text, label: { text: "Condition", size: "s" } %>
+          <%= ff.govuk_text_area :reason, label: { text: "Reason", size: "s" } %>
+          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
+        <% end %>
+       </div>
+      <div id="new-forms"></div>
+      <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#addCondition" %>
     </div>
   <% end %>
   <div class="govuk-button-group">
     <%= form.submit(
           t("form_actions.save_and_mark_as_complete"),
           class: "govuk-button",
-          data: { module: "govuk-button" }
-        ) %>
-    <%= form.submit(
-          t("form_actions.save_and_come_back_later"),
-          class: "govuk-button govuk-button--secondary",
           data: { module: "govuk-button" }
         ) %>
     <%= back_link %>

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -1,0 +1,31 @@
+<%= form_with model: [@planning_application],
+              local: true,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              class: "govuk-!-margin-top-7",
+              url:,
+              method: method.to_sym do |form| %>
+  <%= form.govuk_check_boxes_fieldset :conditions, multiple: true do %>
+    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.fields_for :conditions, @conditions do |ff| %>
+      <%= ff.govuk_check_box :text, ff.object.text.to_s, label: { text: ff.object.text.to_s }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
+        <%= ff.hidden_field :text, value: ff.object.text %>
+        <%= ff.govuk_text_area :reason, value: ff.object.reason %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <div class="govuk-button-group">
+    <%= form.submit(
+          t("form_actions.save_and_mark_as_complete"),
+          class: "govuk-button",
+          data: { module: "govuk-button" },
+          disabled: local_assigns.fetch(:disabled, false)
+        ) %>
+    <%= form.submit(
+          t("form_actions.save_and_come_back_later"),
+          class: "govuk-button govuk-button--secondary",
+          data: { module: "govuk-button" },
+          disabled: local_assigns.fetch(:disabled, false)
+        ) %>
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -3,6 +3,7 @@
               builder: GOVUKDesignSystemFormBuilder::FormBuilder,
               class: "govuk-!-margin-top-7",
               url:,
+              html: { data: { controller: "add-condition" } },
               method: method.to_sym do |form| %>
   <%= form.govuk_check_boxes_fieldset :conditions, legend: { text: "Suggested conditions" }, multiple: true do %>
     <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
@@ -16,7 +17,7 @@
       <% end %>
     <% end %>
 
-    <div data-controller="add-condition">
+    <div>
       <h2>Other conditions</h2>
       <%= form.fields_for(:conditions, @conditions.reject(&:standard?)) do |ff| %>
         <div class="condition-form govuk-!-margin-bottom-5">

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -26,7 +26,7 @@
           <%= ff.hidden_field :new_condition, value: true %>
           <%= ff.govuk_text_area :text, label: { text: "Condition", size: "s" } %>
           <%= ff.govuk_text_area :reason, label: { text: "Reason", size: "s" } %>
-          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
+          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", data: { action: "add-condition#removeCondition" } %>
         </div>
       <% end %>
       <div class="display-none govuk-!-margin-bottom-5 condition-form" id="add-condition-form" data-add-condition-target="form">
@@ -35,11 +35,11 @@
           <%= ff.hidden_field :new_condition, value: true %>
           <%= ff.govuk_text_area :text, label: { text: "Condition", size: "s" } %>
           <%= ff.govuk_text_area :reason, label: { text: "Reason", size: "s" } %>
-          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
+          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", data: { action: "add-condition#removeCondition" } %>
         <% end %>
        </div>
       <div id="new-forms" data-add-condition-target="newForms"></div>
-      <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#addCondition" %>
+      <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", data: { action: "add-condition#addCondition" } %>
     </div>
   <% end %>
   <div class="govuk-button-group">

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -5,7 +5,7 @@
               url:,
               html: { data: { controller: "add-condition" } },
               method: method.to_sym do |form| %>
-  <%= form.govuk_check_boxes_fieldset :conditions, legend: { text: "Suggested conditions" }, multiple: true do %>
+  <%= form.govuk_check_boxes_fieldset :conditions, legend: { text: "Suggested conditions" }, multiple: true, form_group: { data: { "add-condition-target": "standardConditions" } } do %>
     <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
     <%= form.fields_for(:conditions, @conditions.select(&:standard?)) do |ff| %>
       <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.title }, checked: @planning_application.conditions.where(title: ff.object.title).any? do %>

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -28,7 +28,7 @@
           <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
         </div>
       <% end %>
-      <div class="display-none govuk-!-margin-bottom-5 condition-form" id="add-condition-form">
+      <div class="display-none govuk-!-margin-bottom-5 condition-form" id="add-condition-form" data-add-condition-target="form">
         <%= form.fields_for :conditions, Condition.new(planning_application: @planning_application.planning_application) do |ff| %>
           <%= ff.hidden_field :standard, value: false %>
           <%= ff.hidden_field :new_condition, value: true %>
@@ -37,7 +37,7 @@
           <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#removeCondition" %>
         <% end %>
        </div>
-      <div id="new-forms"></div>
+      <div id="new-forms" data-add-condition-target="newForms"></div>
       <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#addCondition" %>
     </div>
   <% end %>

--- a/app/views/planning_applications/conditions/_form.html.erb
+++ b/app/views/planning_applications/conditions/_form.html.erb
@@ -4,28 +4,30 @@
               class: "govuk-!-margin-top-7",
               url:,
               method: method.to_sym do |form| %>
-  <%= form.govuk_check_boxes_fieldset :conditions, multiple: true do %>
+  <%= form.govuk_check_boxes_fieldset :conditions, legend: { text: "Suggested conditions" }, multiple: true do %>
     <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
     <%= form.fields_for :conditions, @conditions do |ff| %>
-      <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.text.to_s }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
+      <%= ff.govuk_check_box :conditions, true, label: { text: ff.object.title }, checked: @planning_application.conditions.where(text: ff.object.text).any? do %>
         <%= ff.hidden_field :id, value: ff.object.id %>
-        <%= ff.hidden_field :text, value: ff.object.text %>
+        <%= ff.govuk_text_area :text, value: ff.object.text %>
         <%= ff.govuk_text_area :reason, value: ff.object.reason %>
       <% end %>
     <% end %>
+    <div data-controller="add-condition">
+      <h2>Other conditions</h2>
+      <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", "data-action": "click->add-condition#handleClick" %>
+    </div>
   <% end %>
   <div class="govuk-button-group">
     <%= form.submit(
           t("form_actions.save_and_mark_as_complete"),
           class: "govuk-button",
-          data: { module: "govuk-button" },
-          disabled: local_assigns.fetch(:disabled, false)
+          data: { module: "govuk-button" }
         ) %>
     <%= form.submit(
           t("form_actions.save_and_come_back_later"),
           class: "govuk-button govuk-button--secondary",
-          data: { module: "govuk-button" },
-          disabled: local_assigns.fetch(:disabled, false)
+          data: { module: "govuk-button" }
         ) %>
     <%= back_link %>
   </div>

--- a/app/views/planning_applications/conditions/edit.html.erb
+++ b/app/views/planning_applications/conditions/edit.html.erb
@@ -16,6 +16,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render(
+          AccordionComponent.new(
+            planning_application: @planning_application,
+            sections: %w[constraints considerations]
+          )
+        ) %>
     <p class="govuk-body govuk-!-margin-top-5">
       Select all the conditions that apply, to support your approval
     </p>

--- a/app/views/planning_applications/conditions/edit.html.erb
+++ b/app/views/planning_applications/conditions/edit.html.erb
@@ -21,6 +21,6 @@
     </p>
     <%= render "shared/warning_text", message: "This information WILL be made publicly available." %>
 
-    <%= render "form", url: update_planning_application_conditions_path(@planning_application), method: "patch" %>
+    <%= render "form", url: planning_application_conditions_path(@planning_application), method: "patch" %>
   </div>
 </div>

--- a/app/views/planning_applications/conditions/edit.html.erb
+++ b/app/views/planning_applications/conditions/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  Add conditions - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Add conditions" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Add conditions" }
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-top-5">
+      Select all the conditions that apply, to support your approval
+    </p>
+    <%= render "shared/warning_text", message: "This information WILL be made publicly available." %>
+
+    <%= render "form", url: update_planning_application_conditions_path(@planning_application), method: "patch" %>
+  </div>
+</div>

--- a/app/views/planning_applications/conditions/new.html.erb
+++ b/app/views/planning_applications/conditions/new.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  Add conditions - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Add conditions" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Add conditions" }
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-top-5">
+      Select all the conditions that apply, to support your approval
+    </p>
+    <%= render "shared/warning_text", message: "This information WILL be made publicly available." %>
+
+    <%= render "form", url: planning_application_conditions_path(@planning_application), method: "post" %>
+  </div>
+</div>

--- a/app/views/planning_applications/conditions/new.html.erb
+++ b/app/views/planning_applications/conditions/new.html.erb
@@ -17,7 +17,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-!-margin-top-5">
-      Select all the conditions that apply, to support your approval
+      Select and add the relevant conditions
     </p>
     <%= render "shared/warning_text", message: "This information WILL be made publicly available." %>
 

--- a/app/views/planning_applications/conditions/new.html.erb
+++ b/app/views/planning_applications/conditions/new.html.erb
@@ -16,6 +16,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render(
+          AccordionComponent.new(
+            planning_application: @planning_application,
+            sections: %w[constraints considerations]
+          )
+        ) %>
     <p class="govuk-body govuk-!-margin-top-5">
       Select and add the relevant conditions
     </p>

--- a/app/views/planning_applications/conditions/show.html.erb
+++ b/app/views/planning_applications/conditions/show.html.erb
@@ -18,7 +18,12 @@
 <ol class="govuk-list govuk-list--number">
   <% @planning_application.conditions.each do |condition| %>
     <li>
-      <span class="govuk-!-font-weight-bold"><%= condition.text %></span><br>
+      <% if condition.title %>
+        <span class="govuk-!-font-weight-bold"><%= condition&.title %></span><br>
+        <%= condition.text %><br>
+      <% else %>
+        <span class="govuk-!-font-weight-bold"><%= condition.text %></span><br>
+      <% end %>
       <%= condition.reason %>
     </li>
   <% end %>

--- a/app/views/planning_applications/conditions/show.html.erb
+++ b/app/views/planning_applications/conditions/show.html.erb
@@ -14,22 +14,32 @@
       locals: { heading: "Add conditions" }
     ) %>
 
-<h2 class="govuk-heading-m">Conditions</h2>
-<ol class="govuk-list govuk-list--number">
-  <% @planning_application.conditions.each do |condition| %>
-    <li>
-      <% if condition.title %>
-        <span class="govuk-!-font-weight-bold"><%= condition&.title %></span><br>
-        <%= condition.text %><br>
-      <% else %>
-        <span class="govuk-!-font-weight-bold"><%= condition.text %></span><br>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(
+          AccordionComponent.new(
+            planning_application: @planning_application,
+            sections: %w[constraints considerations]
+          )
+        ) %>
+    <h2 class="govuk-heading-m">Conditions</h2>
+    <ol class="govuk-list govuk-list--number">
+      <% @planning_application.conditions.each do |condition| %>
+        <li>
+          <% if condition.title %>
+            <span class="govuk-!-font-weight-bold"><%= condition&.title %></span><br>
+            <%= condition.text %><br>
+          <% else %>
+            <span class="govuk-!-font-weight-bold"><%= condition.text %></span><br>
+          <% end %>
+          <%= condition.reason %>
+        </li>
       <% end %>
-      <%= condition.reason %>
-    </li>
-  <% end %>
-</ol>
+    </ol>
 
-<div class="govuk-button-group">
-  <%= back_link %>
-  <%= link_to "Edit conditions", edit_planning_application_conditions_path(@planning_application), class: "govuk-link govuk-body" %>
+    <div class="govuk-button-group">
+      <%= back_link %>
+      <%= link_to "Edit conditions", edit_planning_application_conditions_path(@planning_application), class: "govuk-link govuk-body" %>
+    </div>
+  </div>
 </div>

--- a/app/views/planning_applications/conditions/show.html.erb
+++ b/app/views/planning_applications/conditions/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  Add conditions - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Add conditions" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Add conditions" }
+    ) %>
+
+<h2 class="govuk-heading-m">Conditions</h2>
+<ol class="govuk-list govuk-list--number">
+  <% @planning_application.conditions.each do |condition| %>
+    <li>
+      <span class="govuk-!-font-weight-bold"><%= condition.text %></span><br>
+      <%= condition.reason %>
+    </li>
+  <% end %>
+</ol>
+
+<div class="govuk-button-group">
+  <%= back_link %>
+  <%= link_to "Edit conditions", edit_planning_application_conditions_path(@planning_application), class: "govuk-link govuk-body" %>
+</div>

--- a/config/locales/conditions.yml
+++ b/config/locales/conditions.yml
@@ -1,0 +1,8 @@
+en: 
+  conditions:
+    time:
+      condition: The development herby permitted shall be commenced within three years of the date of this permission
+      reason: To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended).
+    plans:
+      condition: The development herby permitted must be undertaken in accordance with the approved plans and documents.
+      reason: For the avoidance of doubt and in the interests of proper planning.

--- a/config/locales/conditions_list.yml
+++ b/config/locales/conditions_list.yml
@@ -1,8 +1,15 @@
 en: 
-  conditions:
+  conditions_list:
     time:
+      title: Time limit
       condition: The development herby permitted shall be commenced within three years of the date of this permission
       reason: To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended).
     plans:
+      title: In accordance with approved plans
       condition: The development herby permitted must be undertaken in accordance with the approved plans and documents.
       reason: For the avoidance of doubt and in the interests of proper planning.
+    materials: 
+      title: Materials to match
+      condition: Fill in
+      reason: Fill in
+

--- a/config/locales/conditions_list.yml
+++ b/config/locales/conditions_list.yml
@@ -2,7 +2,7 @@ en:
   conditions_list:
     time:
       title: Time limit
-      condition: The development herby permitted shall be commenced within three years of the date of this permission
+      condition: The development herby permitted shall be commenced within three years of the date of this permission.
       reason: To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended).
     plans:
       title: In accordance with approved plans
@@ -10,6 +10,6 @@ en:
       reason: For the avoidance of doubt and in the interests of proper planning.
     materials: 
       title: Materials to match
-      condition: Fill in
-      reason: Fill in
+      condition: All new external work and finishes and work of making good shall match the original work in respect of the materials, colour, texture, profile and finished appearance, except where indicated otherwise on the drawings hereby approved or unless otherwise required by condition.
+      reason: To preserve the character and appearance of the local area.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -420,6 +420,11 @@ en:
       destroy:
         failure: Couldn't delete validation request — please contact support.
         success: Validation request was successfully deleted.
+  conditions:
+    create:
+      success: Conditions successfully created
+    update:
+      success: Conditions successfully updated
   consistency_checklists:
     additional_document_validation_request:
       cancelled: Cancelled %{time}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
   accordion_component:
     application_information: Application information
     audit_log: Audit log
+    considerations: Considerations
     constraints: Constraints
     consultation: Consultation
     contact_information: Contact information

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,7 +174,11 @@ Rails.application.routes.draw do
         patch :update, on: :collection
       end
 
-      resources :conditions, only: %i[new create show edit update]
+      resources :conditions, only: %i[new create] do
+        get :edit, on: :collection
+        get :show, on: :collection
+        patch :update, on: :collection
+      end
 
       resource :withdraw_or_cancel, only: %i[show update]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -174,6 +174,8 @@ Rails.application.routes.draw do
         patch :update, on: :collection
       end
 
+      resources :conditions, only: %i[new create show edit update]
+
       resource :withdraw_or_cancel, only: %i[show update]
 
       resources :assign_users, only: %i[index] do

--- a/db/migrate/20231009145226_create_conditions.rb
+++ b/db/migrate/20231009145226_create_conditions.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class CreateConditions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :conditions do |t|
+      t.string :title
+      t.text :text
+      t.text :reason
+      t.boolean :standard
+      t.references :planning_application, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_09_093157) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_09_145226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -121,6 +121,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_09_093157) do
     t.datetime "deleted_at", precision: nil
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "ix_comments_on_user_id"
+  end
+
+  create_table "conditions", force: :cascade do |t|
+    t.string "title"
+    t.text "text"
+    t.text "reason"
+    t.boolean "standard"
+    t.bigint "planning_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "index_conditions_on_planning_application_id"
   end
 
   create_table "consistency_checklists", force: :cascade do |t|

--- a/spec/factories/condition.rb
+++ b/spec/factories/condition.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :condition do
+    title { "Time limit" }
+    text { "The development herby permitted shall be commenced within three years of the date of this permission." }
+    reason { "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)." }
+  end
+end

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe "Add conditions" do
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
   let!(:planning_application) do
-    create(:planning_application, :invalidated, local_authority: default_local_authority, api_user:)
+    create(:planning_application, :planning_permission, :in_assessment, local_authority: default_local_authority, api_user:, decision: "granted")
   end
-
-  let!(:condtion) { create(:condition) }
 
   before do
     sign_in assessor
@@ -19,13 +17,26 @@ RSpec.describe "Add conditions" do
     click_link "Check and assess"
   end
 
-  context "when adding conditions" do
-    it "displays the constraints" do
-      click_link "Add conditions"
+  context "when planning application is planning permission" do
+    context "when it's been granted" do
+      it "you can add conditions" do
+        click_link "Add conditions"
 
-      expect(page).to have_content("Add conditions")
+        expect(page).to have_content("Add conditions")
 
-      check condition.title.to_s
+        check "The development herby permitted shall be commenced within three years of the date of this permission"
+        check "The development herby permitted must be undertaken in accordance with the approved plans and documents."
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "Conditions successfully created"
+
+        within("#add-conditions") do
+          expect(page).to have_content "Completed"
+        end
+
+        expect(planning_application.conditions.count).to eq 2
+      end
     end
   end
 end

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -18,25 +18,164 @@ RSpec.describe "Add conditions" do
   end
 
   context "when planning application is planning permission" do
-    context "when it's been granted" do
-      it "you can add conditions" do
-        click_link "Add conditions"
+    it "you can add conditions" do
+      click_link "Add conditions"
 
-        expect(page).to have_content("Add conditions")
+      expect(page).to have_content("Add conditions")
 
-        check "The development herby permitted shall be commenced within three years of the date of this permission"
-        check "The development herby permitted must be undertaken in accordance with the approved plans and documents."
-
-        click_button "Save and mark as complete"
-
-        expect(page).to have_content "Conditions successfully created"
-
-        within("#add-conditions") do
-          expect(page).to have_content "Completed"
-        end
-
-        expect(planning_application.conditions.count).to eq 2
+      check "Time limit"
+      within(:xpath, "//div[@id='planning-application-conditions-attributes-0-conditions-true-conditional']") do
+        fill_in "Condition", with: "New condition"
       end
+      check "Materials to match"
+
+      click_link "+ Add condition"
+      within(:xpath, "//div[@id='add-condition-form-1']") do
+        fill_in "Condition", with: "Custom condition 1"
+        fill_in "Reason", with: "Custom reason 1"
+      end
+
+      click_link "+ Add condition"
+      within(:xpath, "//div[@id='add-condition-form-2']") do
+        fill_in "Condition", with: "Custom condition 2"
+        fill_in "Reason", with: "Custom reason 2"
+      end
+
+      click_link "+ Add condition"
+      within(:xpath, "//div[@id='add-condition-form-3']") do
+        fill_in "Condition", with: "Custom condition 3"
+        fill_in "Reason", with: "Custom reason 3"
+        click_link "Remove condition"
+      end
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Conditions successfully created"
+
+      within("#add-conditions") do
+        expect(page).to have_content "Completed"
+        click_link "Add conditions"
+      end
+
+      expect(page).to have_content "Time limit"
+      expect(page).to have_content "New condition"
+      expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
+      expect(page).to have_content "Materials to match"
+      expect(page).to have_content "All new external work and finishes and work of making good shall match the original work in respect of the materials, colour, texture, profile and finished appearance, except where indicated otherwise on the drawings hereby approved or unless otherwise required by condition."
+      expect(page).to have_content "To preserve the character and appearance of the local area."
+      expect(page).to have_content "Custom condition 1"
+      expect(page).to have_content "Custom reason 1"
+      expect(page).to have_content "Custom condition 2"
+      expect(page).to have_content "Custom condition 2"
+      expect(page).not_to have_content "Custom condition 3"
+    end
+
+    it "you can edit conditions" do
+      create(:condition, planning_application:, standard: true)
+      create(:condition, planning_application:, standard: false, title: "Condition 1", text: "This is the condition", reason: "Reason 1")
+
+      visit planning_application_path(planning_application)
+      click_link "Check and assess"
+
+      click_link "Add conditions"
+
+      expect(page).to have_content "Time limit"
+      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
+      expect(page).to have_content "Condition 1"
+      expect(page).to have_content "Reason 1"
+
+      click_link "Edit conditions"
+
+      check "In accordance with approved plans"
+
+      click_link "+ Add condition"
+      within(:xpath, "//div[@id='add-condition-form-2']") do
+        fill_in "Condition", with: "Custom condition 1"
+        fill_in "Reason", with: "Custom reason 1"
+      end
+
+      click_button "Save and mark as complete"
+
+      click_link "Add conditions"
+
+      expect(page).to have_content "Time limit"
+      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
+      expect(page).to have_content "In accordance with approved plans"
+      expect(page).to have_content "The development herby permitted must be undertaken in accordance with the approved plans and documents."
+      expect(page).to have_content "For the avoidance of doubt and in the interests of proper planning."
+      expect(page).to have_content "Condition 1"
+      expect(page).to have_content "Reason 1"
+      expect(page).to have_content "Custom condition 1"
+      expect(page).to have_content "Custom reason 1"
+
+      click_link "Edit conditions"
+
+      uncheck "Time limit"
+
+      within(:xpath, "(//div[@class='condition-form govuk-!-margin-bottom-5'])[1]") do
+        click_link "Remove condition"
+      end
+
+      click_button "Save and mark as complete"
+
+      click_link "Add conditions"
+
+      expect(page).to have_content "In accordance with approved plans"
+      expect(page).to have_content "The development herby permitted must be undertaken in accordance with the approved plans and documents."
+      expect(page).to have_content "For the avoidance of doubt and in the interests of proper planning."
+      expect(page).to have_content "Custom condition 1"
+      expect(page).to have_content "Custom reason 1"
+
+      expect(page).not_to have_content "Time limit"
+      expect(page).not_to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).not_to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
+      expect(page).not_to have_content "Condition 1"
+      expect(page).not_to have_content "Reason 1"
+    end
+
+    it "shows errors" do
+      click_link "Add conditions"
+
+      check "Time limit"
+      within(:xpath, "//div[@id='planning-application-conditions-attributes-0-conditions-true-conditional']") do
+        fill_in "Condition", with: ""
+      end
+
+      click_link "+ Add condition"
+      within(:xpath, "//div[@id='add-condition-form-1']") do
+        fill_in "Condition", with: "Custom condition 1"
+      end
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Conditions reason can't be blank"
+    end
+
+    it "shows conditions on the decision notice" do
+      create(:recommendation, :assessment_in_progress, planning_application:)
+      create(:condition, planning_application:, standard: true)
+
+      visit planning_application_path(planning_application)
+      click_link "Check and assess"
+      click_link "Review and submit recommendation"
+
+      expect(page).to have_content "Conditions"
+      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
+    end
+  end
+
+  context "when planning application is not planning permission" do
+    it "you cannot add conditions" do
+      type = create(:application_type)
+      planning_application.update(application_type: type)
+
+      visit planning_application_path(planning_application)
+      click_link "Check and assess"
+
+      expect(page).not_to have_content("Add conditions")
     end
   end
 end

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Add conditions" do
       expect(page).to have_content "Custom condition 1"
       expect(page).to have_content "Custom reason 1"
       expect(page).to have_content "Custom condition 2"
-      expect(page).to have_content "Custom condition 2"
+      expect(page).to have_content "Custom reason 2"
       expect(page).not_to have_content "Custom condition 3"
     end
 

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add conditions" do
+  let!(:api_user) { create(:api_user, name: "PlanX") }
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, :invalidated, local_authority: default_local_authority, api_user:)
+  end
+
+  let!(:condtion) { create(:condition) }
+
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+    click_link "Check and assess"
+  end
+
+  context "when adding conditions" do
+    it "displays the constraints" do
+      click_link "Add conditions"
+
+      expect(page).to have_content("Add conditions")
+
+      check condition.title.to_s
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add conditions to a planning application.

### Story card
https://trello.com/c/2jl8SvO8/1704-add-conditions-to-go-on-the-decision-notice

### Decisions

- Using a yml file for now to pre-populate rather than storing them as structured data. This is probably a stop-gap until we can get more structured data for conditions
- The javascript for adding new conditions at the bottom of the page is pretty intense, sorry
- There is no save_and_come_back_later button on the form for now because there's no way to save progress using a status across the planning_application has_many conditions relationship. Could be saved on a join table, but didn't have time to do that so could be added if the POs want it

### Screenshots
![Screenshot 2023-10-13 at 14 22 03](https://github.com/unboxed/bops/assets/35098639/f2eceeb3-1150-4538-ab6c-090384aa0d45)
