### PR TITLE
Show consultation deadline

### DIFF
--- a/app/components/accordion_sections/key_application_dates_component.html.erb
+++ b/app/components/accordion_sections/key_application_dates_component.html.erb
@@ -1,24 +1,28 @@
 <p class="govuk-body">
   <strong><%= t(".application_received") %></strong>
-  <%= planning_application.received_at.to_date.to_fs %>
+  <%= time_tag planning_application.received_at.to_date %>
 </p>
 <p class="govuk-body">
   <strong><%= t(".valid_from") %></strong>
+  <% if valid_from.respond_to?(:to_fs) %>
+  <%= time_tag valid_from %>
+  <% else %>
   <%= valid_from %>
+  <% end %>
 </p>
 <p class="govuk-body">
   <strong><%= t(".target_date") %></strong>
-  <%= planning_application.target_date.to_fs %>
+  <%= time_tag planning_application.target_date %>
 </p>
 <p class="govuk-body">
   <strong><%= t(".expiry_date") %></strong>
-  <%= planning_application.expiry_date.to_fs %>
+  <%= time_tag planning_application.expiry_date %>
 </p>
 <% if planning_application.consultation.present? %>
 <p class="govuk-body">
   <strong><%= t(".consultation_end_date") %></strong>
   <% if planning_application.consultation.end_date.present? %>
-    <%= planning_application.consultation.end_date.strftime("%-d %B %Y") %>
+    <%= time_tag planning_application.consultation.end_date %>
   <% else %>
     <%= t(".consultation_end_date_not_set") %>
   <% end %>

--- a/app/components/accordion_sections/key_application_dates_component.html.erb
+++ b/app/components/accordion_sections/key_application_dates_component.html.erb
@@ -14,3 +14,13 @@
   <strong><%= t(".expiry_date") %></strong>
   <%= planning_application.expiry_date.to_fs %>
 </p>
+<% if planning_application.consultation.present? %>
+<p class="govuk-body">
+  <strong><%= t(".consultation_end_date") %></strong>
+  <% if planning_application.consultation.end_date.present? %>
+    <%= planning_application.consultation.end_date.strftime("%-d %B %Y") %>
+  <% else %>
+    <%= t(".consultation_end_date_not_set") %>
+  <% end %>
+</p>
+<% end %>

--- a/app/components/accordion_sections/key_application_dates_component.html.erb
+++ b/app/components/accordion_sections/key_application_dates_component.html.erb
@@ -5,9 +5,9 @@
 <p class="govuk-body">
   <strong><%= t(".valid_from") %></strong>
   <% if valid_from.respond_to?(:to_fs) %>
-  <%= time_tag valid_from %>
+    <%= time_tag valid_from %>
   <% else %>
-  <%= valid_from %>
+    <%= valid_from %>
   <% end %>
 </p>
 <p class="govuk-body">

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -22,6 +22,10 @@ class Consultation < ApplicationRecord
 
   before_update :audit_letter_copy_sent!, if: :letter_copy_sent_at_changed?
 
+  def start_deadline
+    update!(end_date: end_date_from_now, start_date: 1.business_day.from_now)
+  end
+
   def end_date_from_now
     # Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday)
     # Second class letters are delivered 2 days after they’re dispatched.

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -33,6 +33,10 @@ class Consultation < ApplicationRecord
     1.business_day.from_now + 21.days
   end
 
+  def days_left
+    (end_date - Time.zone.now).seconds.in_days.round
+  end
+
   def neighbour_letter_content
     I18n.t("neighbour_letter_template",
            received_at: planning_application.received_at.to_fs(:day_month_year_slashes),

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -23,7 +23,7 @@ class Consultation < ApplicationRecord
   before_update :audit_letter_copy_sent!, if: :letter_copy_sent_at_changed?
 
   def start_deadline
-    update!(end_date: end_date_from_now, start_date: 1.business_day.from_now)
+    update!(end_date: end_date_from_now, start_date: start_date || 1.business_day.from_now)
   end
 
   def end_date_from_now

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -109,4 +109,19 @@ module StatusPresenter
       "red"
     end
   end
+
+  def status_consultation_date_tag_colour
+    return "grey" if planning_application.consultation.blank?
+    return "grey" if planning_application.consultation.start_date.blank?
+
+    number = planning_application.consultation.days_left
+
+    if number > 11
+      "green"
+    elsif number.between?(6, 10)
+      "yellow"
+    else
+      "red"
+    end
+  end
 end

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -41,7 +41,7 @@ module StatusPresenter
     alias_method :outcome, :status_tag
 
     def next_relevant_date_tag
-      tag.strong(next_date_label) + tag.span(next_date.to_fs)
+      tag.strong(next_date_label) + tag.time(next_date.to_fs, datetime: next_date.iso8601)
     end
 
     def next_date_label

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -21,7 +21,7 @@ class LetterSendingService
 
     ActiveRecord::Base.transaction do
       letter_record.save!
-      consultation.update!(end_date: consultation.end_date_from_now, start_date: 1.business_day.from_now)
+      consultation.start_deadline
     end
 
     personalisation = { message: letter_content, heading: "Public consultation" }

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -5,6 +5,13 @@
         <strong>Consultation end date:</strong>
         <% if @planning_application.consultation.end_date.present? %>
           <%= time_tag @planning_application.consultation.end_date %>
+          <span class="govuk-tag govuk-tag--#{status_consultation_date_tag_colour}">
+            <% if @planning_application.consultation.days_left >0 %>
+              <%= t("planning_applications.days_left", count: @planning_application.consultation.days_left) %>
+            <% else %>
+             <%= t("planning_applications.overdue", count: @planning_application.consultation.days_left.abs) %>
+            <% end %>
+          </span>
         <% else %>
           <%= t(".consultation_end_date_not_set") %>
         <% end %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -1,5 +1,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="dates-and-assignment-details">
+      <% if @planning_application.consultation.present? %>
+      <p class="govuk-body">
+        <strong>Consultation end date:</strong>
+        <% if @planning_application.consultation.end_date.present? %>
+          <%= time_tag @planning_application.consultation.end_date %>
+        <% else %>
+          <%= t(".consultation_end_date_not_set") %>
+        <% end %>
+      </p>
+      <% end %>
+
     <p class="govuk-body">
       <%= @planning_application.next_relevant_date_tag %>
 

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -9,7 +9,7 @@
             <% if @planning_application.consultation.days_left >0 %>
               <%= t("planning_applications.days_left", count: @planning_application.consultation.days_left) %>
             <% else %>
-             <%= t("planning_applications.overdue", count: @planning_application.consultation.days_left.abs) %>
+              <%= t("planning_applications.overdue", count: @planning_application.consultation.days_left.abs) %>
             <% end %>
           </span>
         <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
       reason_given: <strong>Reason given:</strong> "%{feedback}"
     key_application_dates_component:
       application_received: 'Application received:'
+      consultation_end_date: 'Consultation deadline:'
+      consultation_end_date_not_set: Not yet started
       expiry_date: 'Expiry date:'
       not_yet_valid: Not yet valid
       target_date: 'Target date:'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -452,6 +452,10 @@ en:
       update_constraints: Update constraints
     update:
       success: Constraints have been updated
+  date:
+    formats:
+      default: "%-d %B %Y"
+      long: "%-d %B %Y"
   description_change_validation_requests:
     cancel:
       success: Description change request successfully cancelled.
@@ -1086,6 +1090,10 @@ en:
       upload_neighbour_responses: Upload neighbour responses
     validation_decision_component:
       send_validation_decision: Send validation decision
+  time:
+    formats:
+      default: "%-d %B %Y"
+      long: "%-d %B %Y"
   user:
     manager_role: Manager
     officer_role: Case Officer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -995,6 +995,8 @@ en:
       home: Home
     back_to_top_link:
       back_to_top: Back to top
+    dates_and_assignment_header:
+      consultation_end_date_not_set: Not yet started
     policy_classes:
       previous_comments:
         comment_deleted: Comment deleted %{time}

--- a/spec/components/accordion_sections/key_application_dates_component_spec.rb
+++ b/spec/components/accordion_sections/key_application_dates_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
     end
 
     it "renders consultation deadline" do
-      expect(page).to have_content("Consultation deadline:\n    14 August 2023")
+      expect(page).to have_content("Consultation deadline:\n    #{consultation.end_date.strftime('%d %B %Y')}")
     end
   end
 

--- a/spec/components/accordion_sections/key_application_dates_component_spec.rb
+++ b/spec/components/accordion_sections/key_application_dates_component_spec.rb
@@ -38,4 +38,41 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
       expect(page).to have_content("Not yet valid")
     end
   end
+
+  context "when there's a consultation" do
+    let(:consultation) { create(:consultation) }
+
+    before do
+      consultation.start_deadline
+      planning_application.consultation = consultation
+      planning_application.save!
+
+      render_inline(component)
+    end
+
+    it "renders consultation deadline" do
+      expect(page).to have_content("Consultation deadline:\n    14 August 2023")
+    end
+  end
+
+  context "when there's no consultation" do
+    it "does not render consultation deadline" do
+      expect(page).not_to have_content("Consultation deadline:")
+    end
+  end
+
+  context "when the consultation has not started" do
+    let(:consultation) { create(:consultation, start_date: nil) }
+
+    before do
+      planning_application.consultation = consultation
+      planning_application.save!
+
+      render_inline(component)
+    end
+
+    it "renders consultation deadline as not started" do
+      expect(page).to have_content("Consultation deadline:\n    Not yet started")
+    end
+  end
 end

--- a/spec/factories/consultation.rb
+++ b/spec/factories/consultation.rb
@@ -2,7 +2,11 @@
 
 FactoryBot.define do
   factory :consultation do
-    start_date { 2.days.ago }
     planning_application
+
+    trait :started do
+      start_date { 2.days.ago }
+      end_date { 2.days.ago + 21.days }
+    end
   end
 end

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Consultation do
     end
 
     context "when there isn't already a start date" do
-      let(:consultation) { create(:consultation, start_date: nil) }
+      let(:consultation) { create(:consultation) }
 
       before do
         consultation.start_deadline
@@ -108,7 +108,7 @@ RSpec.describe Consultation do
     end
 
     context "when the consultation is already started" do
-      let(:consultation) { create(:consultation, start_date: 2.days.ago) }
+      let(:consultation) { create(:consultation, :started) }
 
       before do
         consultation.start_deadline

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -83,4 +83,22 @@ RSpec.describe Consultation do
       end
     end
   end
+
+  describe "#start_deadline" do
+    let(:consultation) { create(:consultation) }
+    let(:date) { Time.zone.local(2023, 9, 20, 13) }
+
+    before do
+      travel_to date
+      consultation.start_deadline
+    end
+
+    it "sets the start date to tomorrow" do
+      expect(consultation.start_date).to eq(Time.zone.local(2023, 9, 21, 13))
+    end
+
+    it "sets the end date to the future" do
+      expect(consultation.end_date).to eq(Time.zone.local(2023, 10, 12, 13))
+    end
+  end
 end

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -85,20 +85,42 @@ RSpec.describe Consultation do
   end
 
   describe "#start_deadline" do
-    let(:consultation) { create(:consultation) }
     let(:date) { Time.zone.local(2023, 9, 20, 13) }
 
     before do
       travel_to date
-      consultation.start_deadline
     end
 
-    it "sets the start date to tomorrow" do
-      expect(consultation.start_date).to eq(Time.zone.local(2023, 9, 21, 13))
+    context "when there isn't already a start date" do
+      let(:consultation) { create(:consultation, start_date: nil) }
+
+      before do
+        consultation.start_deadline
+      end
+
+      it "sets the start date to tomorrow" do
+        expect(consultation.start_date).to eq(Time.zone.local(2023, 9, 21, 13))
+      end
+
+      it "sets the end date to the future" do
+        expect(consultation.end_date).to eq(Time.zone.local(2023, 10, 12, 13))
+      end
     end
 
-    it "sets the end date to the future" do
-      expect(consultation.end_date).to eq(Time.zone.local(2023, 10, 12, 13))
+    context "when the consultation is already started" do
+      let(:consultation) { create(:consultation, start_date: 2.days.ago) }
+
+      before do
+        consultation.start_deadline
+      end
+
+      it "leaves the start date alone" do
+        expect(consultation.start_date).to eq(2.days.ago)
+      end
+
+      it "sets the end date to the future" do
+        expect(consultation.end_date).to eq(Time.zone.local(2023, 10, 12, 13))
+      end
     end
   end
 end

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe LetterSendingService do
   let(:letter_sender) { described_class }
-  let(:neighbour) { create(:neighbour) }
+  let(:consultation) { create(:consultation, start_date: nil) }
+  let(:neighbour) { create(:neighbour, consultation:) }
 
   describe "#deliver!" do
     let(:user) { create(:user) }

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -4,8 +4,7 @@ require "rails_helper"
 
 RSpec.describe LetterSendingService do
   let(:letter_sender) { described_class }
-  let(:consultation) { create(:consultation, start_date: nil) }
-  let(:neighbour) { create(:neighbour, consultation:) }
+  let(:neighbour) { create(:neighbour) }
 
   describe "#deliver!" do
     let(:user) { create(:user) }


### PR DESCRIPTION
### Description of change

Show the consultation deadline in "key application dates"

### Story Link

https://trello.com/c/QKdZsZ9G/1713-display-end-date-of-consultation-prominently

### Screenshots
<img width="658" alt="Screenshot 2023-07-20 at 17 13 38" src="https://github.com/unboxed/bops/assets/3986/60add342-c38b-4f4d-ace7-cf20197731c8">

---

![Screenshot_2023-07-21_at_10 52 03](https://github.com/unboxed/bops/assets/3986/7ac1e301-446a-4cbe-83b0-674b24671d7c)

---

![Screenshot 2023-07-21 at 11 38 27](https://github.com/unboxed/bops/assets/3986/7943c597-4ce7-4ac3-ae33-f4b6a92be959)