### PR TITLE
Add ability to record site visits for consultations

### DIFF
--- a/app/components/task_list_items/site_visit_component.rb
+++ b/app/components/task_list_items/site_visit_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class SiteVisitComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+      @consultation = planning_application.consultation
+    end
+
+    private
+
+    attr_reader :consultation
+
+    delegate(:site_visit, to: :consultation)
+
+    def link_text
+      "Site visit"
+    end
+
+    def link_path
+      if @consultation.site_visits.any?
+        planning_application_consultation_site_visits_path(@planning_application, @consultation)
+      else
+        new_planning_application_consultation_site_visit_path(@planning_application, @consultation)
+      end
+    end
+
+    def status_tag_component
+      StatusTags::BaseComponent.new(
+        status: @consultation.site_visit&.status || "not_started"
+      )
+    end
+  end
+end

--- a/app/controllers/planning_application/site_visits_controller.rb
+++ b/app/controllers/planning_application/site_visits_controller.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class SiteVisitsController < AuthenticationController
+    before_action :set_planning_application
+    before_action :set_consultation
+    before_action :set_objected_neighbour_responses, only: %i[index new]
+    before_action :set_site_visit, only: [:show]
+
+    def index
+      @site_visits = @consultation.site_visits.by_created_at_desc.includes(:created_by)
+
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def show
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      @site_visit = @consultation.site_visits.new
+
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      @site_visit = @consultation.site_visits.new(site_visit_params)
+      @site_visit.created_by = current_user
+      @site_visit.status = "complete"
+
+      respond_to do |format|
+        if @site_visit.save
+          format.html do
+            redirect_to planning_application_path(@planning_application), notice: t(".success")
+          end
+        else
+          set_objected_neighbour_responses
+          format.html { render :new }
+        end
+      end
+    end
+
+    private
+
+    def set_planning_application
+      planning_application = planning_applications_scope.find(planning_application_id)
+
+      @planning_application = PlanningApplicationPresenter.new(view_context, planning_application)
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications
+    end
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+
+    def site_visit_params
+      params.require(:site_visit).permit(:decision, :comment, :visited_at).merge(documents_attributes:)
+    end
+
+    def documents_attributes
+      files = params.dig(:site_visit, :documents_attributes, "0", :files).compact_blank
+      files.map.with_index do |file, i|
+        [i.to_s, { file:, planning_application_id: @planning_application.id, tags: ["Site Visit"] }]
+      end.to_h
+    end
+
+    def set_consultation
+      @consultation = @planning_application.consultation
+    end
+
+    def set_objected_neighbour_responses
+      @objected_neighbour_responses = @consultation.neighbour_responses.objection
+    end
+
+    def set_site_visit
+      @site_visit = @consultation.site_visits.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/file_types_helper.rb
+++ b/app/helpers/file_types_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "file_types"
+
+module FileTypesHelper
+  def acceptable_file_mime_types
+    FileTypes::ACCEPTED.join(",")
+  end
+end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -2,8 +2,13 @@
 
 class Consultation < ApplicationRecord
   belongs_to :planning_application
-  has_many :consultees, dependent: :destroy
-  has_many :neighbours, dependent: :destroy
+
+  with_options dependent: :destroy do
+    has_many :consultees
+    has_many :neighbours
+    has_many :site_visits
+  end
+
   has_many :neighbour_letters, through: :neighbours
   has_many :neighbour_responses, through: :neighbours
 
@@ -36,6 +41,10 @@ class Consultation < ApplicationRecord
            max_height: planning_application&.proposal_measurement&.max_height,
            eaves_height: planning_application&.proposal_measurement&.eaves_height,
            application_link:)
+  end
+
+  def site_visit
+    site_visits.by_created_at_desc.first
   end
 
   private

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -5,7 +5,11 @@ class NeighbourResponse < ApplicationRecord
 
   validates :name, :response, :received_at, presence: true
 
+  enum(summary_tag: { supportive: "supportive", neutral: "neutral", objection: "objection" })
+
   scope :redacted, -> { where.not(redacted_response: "") }
 
-  enum(summary_tag: { supportive: "supportive", neutral: "neutral", objection: "objection" })
+  summary_tags.each do |tag|
+    scope :"#{tag}", -> { where(tag:) }
+  end
 end

--- a/app/models/site_visit.rb
+++ b/app/models/site_visit.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class SiteVisit < ApplicationRecord
+  belongs_to :created_by, class_name: "User"
+  belongs_to :consultation
+  has_many :documents, dependent: :destroy
+
+  validates :status, :comment, presence: true
+  validates :decision, inclusion: { in: [true, false] }
+
+  enum status: {
+    not_started: "not_started",
+    complete: "complete"
+  }
+
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+
+  accepts_nested_attributes_for :documents
+end

--- a/app/views/planning_application/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_application/neighbour_responses/_responses.html.erb
@@ -1,0 +1,32 @@
+<% neighbour_responses.each do |response| %>
+  <div class="display-flex" style="align-items: baseline">
+    <div class="neighbour-response-section">
+      <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %><br><br>
+      <ul class="govuk-list">
+        <li>
+          <strong>Date received:</strong> <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
+        </li>
+        <li>
+          <strong>Respondent:</strong> <%= response.name %>
+        </li>
+        <li>
+          <strong>Email:</strong> <%= response.email %>
+        </li>
+        <li>
+          <strong>Address:</strong> <%= response.neighbour.address %>
+        </li>
+      </ul>
+    </div>
+    <div style="width: 55%">
+      <p class="govuk-body-s"><strong>Original version:</strong></p>
+      <%= simple_format(response.response, class: "govuk-body") %>
+
+      <p class="govuk-body-s"><strong>Redacted version:</strong></p>
+      <%= simple_format(response.redacted_response, class: "govuk-body") %>
+
+    </div>
+    <div style="width: 4%;">
+      <%= link_to "Edit", edit_planning_application_consultation_neighbour_response_path(@planning_application, @consultation, response) %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/planning_application/neighbour_responses/new.html.erb
+++ b/app/views/planning_application/neighbour_responses/new.html.erb
@@ -18,39 +18,8 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-7">Responses</h2>
 <% if @neighbour_responses.any? %>
   <hr>
-  <% @neighbour_responses.each do |response| %>
-    <div class="display-flex" style="align-items: baseline">
-      <div class="neighbour-response-section">
-        <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %><br><br>
-        <ul class="govuk-list">
-          <li>
-            <strong>Date received:</strong> <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
-          </li>
-          <li>
-            <strong>Respondent:</strong> <%= response.name %>
-          </li>
-          <li>
-            <strong>Email:</strong> <%= response.email %>
-          </li>
-          <li>
-            <strong>Address:</strong> <%= response.neighbour.address %>
-          </li>
-        </ul>
-      </div>
-      <div style="width: 55%">
-        <p class="govuk-body-s"><strong>Original version:</strong></p>
-        <%= simple_format(response.response, class: "govuk-body") %>
-
-        <p class="govuk-body-s"><strong>Redacted version:</strong></p>
-        <%= simple_format(response.redacted_response, class: "govuk-body") %>
-
-      </div>
-      <div style="width: 4%;">
-        <%= link_to "Edit", edit_planning_application_consultation_neighbour_response_path(@planning_application, @consultation, response) %>
-      </div>
-    </div>
-    <hr>
-  <% end %>
+    <%= render "responses", neighbour_responses: @neighbour_responses %>
+  <hr>
 <% else %>
   <p class="govuk-body">No neighbour responses yet</p>
 <% end %>

--- a/app/views/planning_application/site_visits/_form.html.erb
+++ b/app/views/planning_application/site_visits/_form.html.erb
@@ -1,0 +1,43 @@
+<%= form_with(
+  model: [@planning_application, @consultation, @site_visit],
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  class: "govuk-!-margin-top-5",
+  method: :post
+) do |form| %>
+
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <%= form.govuk_radio_buttons_fieldset(
+        :decision,
+        legend: { text: "Add site visit", size: "s" }
+      ) do %>
+        <%= form.govuk_radio_button(
+          :decision, true, label: { text: "Yes" }
+        ) do %>
+          <%= form.govuk_date_field(:visited_at, rows: 6, legend: { text: "Site visited at" }) %>
+
+          <%= form.fields_for :documents, @site_visit.documents.new do |document_attributes| %>
+            <%= document_attributes.govuk_file_field :files, 
+              multiple: true, 
+              label: { text: "Upload photo(s)", 
+              class: "govuk-label govuk-!-font-weight-bold" }, 
+              accept: acceptable_file_mime_types
+            %>
+          <% end %>
+        <% end %>
+
+        <%= form.govuk_radio_button(:decision, false, label: { text: "No" }) %>
+
+        <%= form.govuk_text_area(:comment, rows: 6, label: { text: "Comment" }) %>
+      <% end %>
+    </fieldset>
+
+    <div class="govuk-button-group govuk-!-padding-top-7">
+      <%= form.submit "Save", class: "govuk-button govuk-button--primary" %>
+
+      <%= back_link %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/planning_application/site_visits/index.html.erb
+++ b/app/views/planning_application/site_visits/index.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title do %>
+  Site visit - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_path(@planning_application) %>
+<% content_for :title, "Site visit" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "View site visits" }
+) %>
+
+<h2 class="govuk-heading-m">Objected neighbour responses</h2>
+<%= render "planning_application/neighbour_responses/responses", neighbour_responses: @objected_neighbour_responses %>
+
+<% if @site_visits.any? %>
+  <h2 class="govuk-heading-m">Site visits</h2>
+  
+  <details class="govuk-details govuk-!-padding-top-5" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        See previous site visit responses
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <% @site_visits.each do |site_visit| %>
+        <p class="govuk-body">Site visit needed: <%= site_visit.decision? ? "Yes" : "No" %></p>
+        <p class="govuk-body">Response created by: <%= site_visit.created_by.name %></p>
+        <p class="govuk-body">Response created at: <%= site_visit.created_at.to_fs %></p>
+        <% if site_visit.decision? %>
+          <p class="govuk-body">Visited at: <%= site_visit.visited_at&.strftime("%-d %B %Y") %></p>
+        <% end %>
+        <p class="govuk-body">Comment: <%= site_visit.comment %></p>
+        
+        <p><%= link_to "View", planning_application_consultation_site_visit_path(@planning_application, @consultation, site_visit), class: "govuk-link" %></p>
+        <hr>
+      <% end %>
+    </div>
+  </details>
+<% else %>
+  <p class="govuk-body">
+    No site visit responses have been added yet.
+  </p>
+<% end %>
+
+<%= link_to "Add site visit response", new_planning_application_consultation_site_visit_path(@planning_application, @consultation), class: "govuk-link" %>
+
+<div class="govuk-button-group govuk-!-padding-top-7">
+  <%= back_link %>
+</div>

--- a/app/views/planning_application/site_visits/new.html.erb
+++ b/app/views/planning_application/site_visits/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  Site visit - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_path(@planning_application) %>
+<% content_for :title, "Site visit" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Add a site visit" }
+) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-7">Objected neighbour responses</h2>
+<%= render "planning_application/neighbour_responses/responses", neighbour_responses: @objected_neighbour_responses %>
+
+<%= render "form" %>

--- a/app/views/planning_application/site_visits/show.html.erb
+++ b/app/views/planning_application/site_visits/show.html.erb
@@ -1,0 +1,65 @@
+<% content_for :page_title do %>
+  Site visit - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_path(@planning_application) %>
+<% content_for :title, "View site visit" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "View site visit" }
+) %>
+
+<h2 class="govuk-heading-m">Site visit response</h2>
+
+<p class="govuk-body">Site visit needed: <%= @site_visit.decision? ? "Yes" : "No" %></p>
+<p class="govuk-body">Response created by: <%= @site_visit.created_by.name %></p>
+<p class="govuk-body">Response created at: <%= @site_visit.created_at.to_fs %></p>
+<% if @site_visit.decision? %>
+  <p class="govuk-body">Visited at: <%= @site_visit.visited_at&.to_fs %></p>
+<% end %>
+<p class="govuk-body">Comment: <%= @site_visit.comment %></p>
+
+<% if @site_visit.documents.any? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Document</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Tags</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Date uploaded</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @site_visit.documents.with_file_attachment.each do |document| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= link_to image_tag(document.file.representation(resize: "300x212")),
+                          url_for_document(document), target: :_blank %>
+            </p>
+            <p class="govuk-body">
+              <%= truncate(document.name.to_s, length: 50) %><br>
+              <%= link_to "View in new window", url_for_document(document), target: :_new %>
+            </p>
+          </td>
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <% document.tags.each do |tag| %>
+              <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= document.created_at.to_fs %>
+            </p>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<div class="govuk-button-group govuk-!-padding-top-7">
+  <%= back_link %>
+</div>

--- a/app/views/planning_applications/steps/_consultation.html.erb
+++ b/app/views/planning_applications/steps/_consultation.html.erb
@@ -10,4 +10,13 @@
       planning_application: @planning_application
     )
   ) %>
+  <% if consultation = @planning_application.consultation %>
+    <% if consultation.site_visits.any? || consultation.neighbour_responses.objection.any? %>
+      <%= render(
+        TaskListItems::SiteVisitComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
+    <% end %>
+  <% end %>
 </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -184,6 +184,10 @@ en:
           attributes:
             base:
               recommendation_accepted: You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen
+        site_visit:
+          attributes:
+            decision:
+              inclusion: You must choose 'Yes' or 'No'
         user:
           attributes:
             reset_password_token:
@@ -679,6 +683,9 @@ en:
       index:
         application_details: Application details
         review_and_sign_off: Review and sign-off
+    site_visits:
+      create:
+        success: Site visit was successfully created.
     validation_tasks:
       index:
         application_details: Application details
@@ -1044,6 +1051,8 @@ en:
       review_permitted_development_rights: Review permitted development rights
     send_letters_to_neighbours_component:
       send_letters_to_neighbours: Send letters to neighbours
+    site_visit_component:
+      site_visit: Site visit
     upload_neighbour_responses_component:
       upload_neighbour_responses: Upload neighbour responses
     validation_decision_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,7 @@ Rails.application.routes.draw do
       resources :consultations, only: %i[new create edit update show destroy] do
         post :send_neighbour_letters
         resources :neighbour_responses, only: %i[new create edit update]
+        resources :site_visits, only: %i[index new create edit show update]
       end
 
       resource :withdraw_or_cancel, only: %i[show update]

--- a/db/migrate/20230718134342_create_site_visits.rb
+++ b/db/migrate/20230718134342_create_site_visits.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateSiteVisits < ActiveRecord::Migration[7.0]
+  def change
+    create_table :site_visits do |t|
+      t.references :consultation, foreign_key: true
+      t.references :created_by, null: false, foreign_key: { to_table: :users }
+      t.string :status, default: "not_started", null: false
+      t.text :comment, null: false
+      t.boolean :decision, null: false
+      t.datetime :visited_at
+
+      t.timestamps
+    end
+
+    add_reference :documents, :site_visit, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_134342) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -208,11 +208,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
     t.bigint "replacement_document_validation_request_id"
     t.boolean "redacted", default: false, null: false
     t.bigint "evidence_group_id"
+    t.bigint "site_visit_id"
     t.index ["additional_document_validation_request_id"], name: "ix_documents_on_additional_document_validation_request_id"
     t.index ["api_user_id"], name: "ix_documents_on_api_user_id"
     t.index ["evidence_group_id"], name: "ix_documents_on_evidence_group_id"
     t.index ["planning_application_id"], name: "index_documents_on_planning_application_id"
     t.index ["replacement_document_validation_request_id"], name: "ix_documents_on_replacement_document_validation_request_id"
+    t.index ["site_visit_id"], name: "ix_documents_on_site_visit_id"
     t.index ["user_id"], name: "ix_documents_on_user_id"
   end
 
@@ -573,6 +575,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
     t.index ["policy_class_id"], name: "ix_review_policy_classes_on_policy_class_id"
   end
 
+  create_table "site_visits", force: :cascade do |t|
+    t.bigint "consultation_id"
+    t.bigint "created_by_id", null: false
+    t.string "status", default: "not_started", null: false
+    t.text "comment", null: false
+    t.boolean "decision", null: false
+    t.datetime "visited_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["consultation_id"], name: "ix_site_visits_on_consultation_id"
+    t.index ["created_by_id"], name: "ix_site_visits_on_created_by_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -626,6 +641,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "evidence_groups"
   add_foreign_key "documents", "replacement_document_validation_requests"
+  add_foreign_key "documents", "site_visits"
   add_foreign_key "documents", "users"
   add_foreign_key "notes", "planning_applications"
   add_foreign_key "notes", "users"
@@ -650,5 +666,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_13_142122) do
   add_foreign_key "review_immunity_details", "users", column: "assessor_id"
   add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
+  add_foreign_key "site_visits", "consultations"
+  add_foreign_key "site_visits", "users", column: "created_by_id"
   add_foreign_key "validation_requests", "planning_applications"
 end

--- a/lib/file_types.rb
+++ b/lib/file_types.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module FileTypes
+  ACCEPTED = %w[.png image/png .jpeg .jpg image/jpeg .pdf].freeze
+end

--- a/spec/factories/site_visit.rb
+++ b/spec/factories/site_visit.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_visit do
+    association :created_by, factory: :user
+    consultation
+
+    decision { "Yes" }
+    comment { "A comment about the site visit" }
+    visited_at { 1.day.ago }
+
+    trait :with_documents do
+      before(:create) do |request|
+        documents = create_list(
+          :document,
+          2,
+          planning_application: request.planning_application,
+          tags: ["Site Visit"]
+        )
+
+        request.documents << documents
+      end
+    end
+  end
+end

--- a/spec/models/neighbour_response_spec.rb
+++ b/spec/models/neighbour_response_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NeighbourResponse do
+  describe "validations" do
+    subject(:neighbour_response) { described_class.new }
+
+    describe "#received_at" do
+      it "validates presence" do
+        expect { neighbour_response.valid? }.to change { neighbour_response.errors[:received_at] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#response" do
+      it "validates presence" do
+        expect { neighbour_response.valid? }.to change { neighbour_response.errors[:response] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#name" do
+      it "validates presence" do
+        expect { neighbour_response.valid? }.to change { neighbour_response.errors[:name] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#neighbour" do
+      it "validates presence" do
+        expect { neighbour_response.valid? }.to change { neighbour_response.errors[:neighbour] }.to ["must exist"]
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".redacted" do
+      let!(:neighbour_responses1) { create(:neighbour_response, redacted_response: "") }
+      let!(:neighbour_responses2) { create(:neighbour_response, redacted_response: "redacted") }
+      let!(:neighbour_responses3) { create(:neighbour_response, redacted_response: "redacted") }
+
+      it "returns neighbour_responses with redactions" do
+        expect(described_class.redacted).to eq([neighbour_responses2, neighbour_responses3])
+      end
+    end
+
+    describe ".objection" do
+      let!(:neighbour_responses1) { create(:neighbour_response, summary_tag: "supportive") }
+      let!(:neighbour_responses2) { create(:neighbour_response, summary_tag: "neutral") }
+      let!(:neighbour_responses3) { create(:neighbour_response, summary_tag: "objection") }
+
+      it "returns neighbour_responses with redactions" do
+        expect(described_class.objection).to eq([neighbour_responses3])
+      end
+    end
+  end
+end

--- a/spec/models/site_visit_spec.rb
+++ b/spec/models/site_visit_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SiteVisit do
+  describe "validations" do
+    subject(:site_visit) { described_class.new }
+
+    describe "#consultation" do
+      it "validates presence" do
+        expect { site_visit.valid? }.to change { site_visit.errors[:consultation] }.to ["must exist"]
+      end
+    end
+
+    describe "#created_by" do
+      it "validates presence" do
+        expect { site_visit.valid? }.to change { site_visit.errors[:created_by] }.to ["must exist"]
+      end
+    end
+
+    describe "#decision" do
+      it "validates inclusion in [true, false]" do
+        expect { site_visit.valid? }.to change { site_visit.errors[:decision] }.to ["You must choose 'Yes' or 'No'"]
+      end
+    end
+
+    describe "#comment" do
+      it "validates presence" do
+        expect { site_visit.valid? }.to change { site_visit.errors[:comment] }.to ["can't be blank"]
+      end
+    end
+  end
+
+  describe "scopes" do
+    describe ".by_created_at_desc" do
+      let!(:site_visits1) { create(:site_visit, created_at: 1.day.ago) }
+      let!(:site_visits2) { create(:site_visit, created_at: Time.zone.now) }
+      let!(:site_visits3) { create(:site_visit, created_at: 2.days.ago) }
+
+      it "returns site_visits sorted by created at desc (i.e. most recent first)" do
+        expect(described_class.by_created_at_desc).to eq([site_visits2, site_visits1, site_visits3])
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Site visit" do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority:) }
+
+  let!(:planning_application) do
+    create(:planning_application, local_authority:)
+  end
+
+  let!(:consultation) { create(:consultation, end_date: "2023-07-08 16:17:35 +0100", planning_application:) }
+  let!(:neighbour) { create(:neighbour, consultation:) }
+
+  before do
+    sign_in assessor
+  end
+
+  describe "viewing the consultations tasklist" do
+    context "when there is an objection from a neighbour" do
+      let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:) }
+
+      it "shows the site visit item in the tasklist" do
+        visit planning_application_path(planning_application)
+        expect(page).to have_css("#site-visit")
+      end
+    end
+
+    context "when a site visit response exists" do
+      let!(:site_visit) { create(:site_visit, consultation:) }
+
+      it "shows the site visit item in the tasklist" do
+        visit planning_application_path(planning_application)
+        expect(page).to have_css("#site-visit")
+      end
+    end
+
+    context "when there is no objection from a neighbour or existing site visit response" do
+      let!(:neighbour_response1) { create(:neighbour_response, summary_tag: "neutral", neighbour:) }
+      let!(:neighbour_response2) { create(:neighbour_response, summary_tag: "supportive", neighbour:) }
+
+      it "does not show the site visit item in the tasklist" do
+        visit planning_application_path(planning_application)
+        expect(page).not_to have_css("#site-visit")
+      end
+    end
+  end
+
+  describe "viewing site visits" do
+    let!(:site_visit1) { create(:site_visit, consultation:, comment: "Site visit 1") }
+    let!(:site_visit2) { create(:site_visit, decision: false, consultation:, comment: "Site visit 2") }
+    let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:) }
+
+    before do
+      visit planning_application_path(planning_application)
+      click_link "Site visit"
+    end
+
+    it "I can see the application information" do
+      within("#planning-application-details") do
+        expect(page).to have_content("View site visits")
+        expect(page).to have_content(planning_application.reference)
+        expect(page).to have_content(planning_application.full_address)
+        expect(page).to have_content(planning_application.description)
+      end
+    end
+
+    it "I can view the objected neighbour responses" do
+      expect(page).to have_content("Objected neighbour responses")
+      expect(page).to have_content("Objection")
+      expect(page).to have_content("Date received: 20/07/2023")
+      expect(page).to have_content("Respondent:")
+      expect(page).to have_content("Email: neighbour@example.com")
+      expect(page).to have_content("Address: #{neighbour.address}")
+      expect(page).to have_content("Original version: I like it rude word")
+      expect(page).to have_content("Redacted version: I like it *****")
+    end
+
+    context "when there are site visit responses" do
+      it "I can see the previous responses and their details" do
+        find("span", text: "See previous site visit responses").click
+        within(".govuk-details__text") do
+          expect(page).to have_content("Site visit needed: Yes")
+          expect(page).to have_content("Response created by: #{site_visit1.created_by.name}")
+          expect(page).to have_content("Response created at: #{site_visit1.created_at.to_fs}")
+          expect(page).to have_content("Comment: Site visit 1")
+
+          expect(page).to have_content("Site visit needed: No")
+          expect(page).to have_content("Response created by: #{site_visit2.created_by.name}")
+          expect(page).to have_content("Response created at: #{site_visit2.created_at.to_fs}")
+          expect(page).to have_content("Comment: Site visit 2")
+        end
+
+        expect(page).to have_link("Add site visit response")
+      end
+    end
+  end
+
+  describe "adding a new site visit response" do
+    let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:) }
+
+    before do
+      visit planning_application_path(planning_application)
+      within("#site-visit") do
+        click_link "Site visit"
+      end
+    end
+
+    it "there is a validation error when saving" do
+      click_button "Save"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("You must choose 'Yes' or 'No'")
+        expect(page).to have_content("Comment can't be blank")
+      end
+      within("#site-visit-decision-error") do
+        expect(page).to have_content("You must choose 'Yes' or 'No'")
+      end
+      within("#site-visit-comment-error") do
+        expect(page).to have_content("can't be blank")
+      end
+
+      choose "Yes"
+      attach_file("Upload photo(s)", "spec/fixtures/images/image.gif")
+      click_button("Save")
+
+      expect(page).to have_content("The selected file must be a PDF, JPG or PNG")
+    end
+
+    it "I can view the objected neighbour responses" do
+      expect(page).to have_content("Objected neighbour responses")
+      expect(page).to have_content("Objection")
+      expect(page).to have_content("Date received: 20/07/2023")
+      expect(page).to have_content("Respondent:")
+      expect(page).to have_content("Email: neighbour@example.com")
+      expect(page).to have_content("Address: #{neighbour.address}")
+      expect(page).to have_content("Original version: I like it rude word")
+      expect(page).to have_content("Redacted version: I like it *****")
+    end
+
+    context "when a site visit is taking place" do
+      it "I choose yes and provide some information" do
+        choose "Yes"
+        fill_in "Day", with: "20"
+        fill_in "Month", with: "7"
+        fill_in "Year", with: "2023"
+
+        attach_file("Upload photo(s)", "spec/fixtures/images/proposed-floorplan.png")
+
+        fill_in "Comment", with: "Site visit is needed"
+        click_button "Save"
+
+        expect(page).to have_content("Site visit was successfully created.")
+
+        within("#site-visit") do
+          expect(page).to have_link(
+            "Site visit",
+            href: "/planning_applications/#{planning_application.id}/consultations/#{consultation.id}/site_visits"
+          )
+          expect(page).to have_content("Completed")
+
+          click_link "Site visit"
+        end
+
+        find("span", text: "See previous site visit responses").click
+        within(".govuk-details__text") do
+          expect(page).to have_content("Site visit needed: Yes")
+          expect(page).to have_content("Response created by: #{assessor.name}")
+          expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
+          expect(page).to have_content("Visited at: 20 July 2023")
+          expect(page).to have_content("Comment: Site visit is needed")
+
+          click_link "View"
+        end
+
+        expect(page).to have_content("View site visit")
+        expect(page).to have_content("Site visit response")
+
+        expect(page).to have_content("Site visit needed: Yes")
+        expect(page).to have_content("Response created by: #{assessor.name}")
+        expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
+        expect(page).to have_content("Visited at: 20 July 2023")
+        expect(page).to have_content("Comment: Site visit is needed")
+
+        within(".govuk-table") do
+          document = SiteVisit.last.documents.first
+          expect(page).to have_content(document.name.to_s)
+          expect(page).to have_link("View in new window")
+          expect(page).to have_content("Site Visit")
+          expect(page).to have_content(document.created_at.to_fs)
+        end
+
+        click_link "Back"
+        expect(current_url).to include(
+          "/planning_applications/#{planning_application.id}/consultations/#{consultation.id}/site_visits"
+        )
+      end
+    end
+
+    context "when a site visit is not taking place" do
+      it "I choose no and give a reason why" do
+        choose "No"
+
+        fill_in "Comment", with: "Site visit not needed"
+        click_button "Save"
+
+        within("#site-visit") do
+          expect(page).to have_content("Completed")
+
+          click_link "Site visit"
+        end
+
+        find("span", text: "See previous site visit responses").click
+        within(".govuk-details__text") do
+          expect(page).to have_content("Site visit needed: No")
+          expect(page).to have_content("Response created by: #{assessor.name}")
+          expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
+          expect(page).not_to have_content("Visited at")
+          expect(page).to have_content("Comment: Site visit not needed")
+
+          click_link "View"
+        end
+
+        expect(page).to have_content("Site visit needed: No")
+        expect(page).to have_content("Response created by: #{assessor.name}")
+        expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
+        expect(page).not_to have_content("Visited at")
+        expect(page).to have_content("Comment: Site visit not needed")
+
+        expect(page).not_to have_css(".govuk-table")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Allow officers to record a site visit response whether it is required or not
- Only reveal option to add this response if there is a neighbour objection
- Allow officers to upload supporting photos to a site visit
- Allow officer to add more than one site visit

### Story Link

https://trello.com/c/n9XMUfd2/1698-site-visit-if-there-are-objections

### Screenshots

### **Consultations tasklist**
![Screenshot 2023-07-21 at 12 53 15](https://github.com/unboxed/bops/assets/34001723/d92ad6f8-cec7-45a2-921b-e30a4a134cb8)

------------------

### Add a site visit (YES)**
![Screenshot 2023-07-21 at 12 53 55](https://github.com/unboxed/bops/assets/34001723/861b7fa7-4b32-4eca-b8eb-2c0ae3a3bf83)

------------------

### **Add a site visit (NO)**
![Screenshot 2023-07-21 at 12 54 00](https://github.com/unboxed/bops/assets/34001723/28298cdc-bfdb-4f2b-bc71-24b31841aa50)

------------------

### **View site visits**
![Screenshot 2023-07-21 at 12 53 42](https://github.com/unboxed/bops/assets/34001723/b6ea54fc-778d-4919-af2e-38e875058bea)

------------------

### **View a site visit**
![Screenshot 2023-07-21 at 12 56 29](https://github.com/unboxed/bops/assets/34001723/02e9b473-014f-4930-a2c5-58676cdd44d6)


