### PR TITLE
Keep Dockerfile updated with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### Description of change

On ECS,  ruby images under tags get rebuilt when the base images receive updates. We need to come up with a plan for ensuring these get applied.

Use dependabot to check daily whether any base images are out of date
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker