### PR TITLE
Link back button to application landing page

### DIFF
--- a/app/views/planning_application/neighbour_responses/edit.html.erb
+++ b/app/views/planning_application/neighbour_responses/edit.html.erb
@@ -52,5 +52,5 @@
     "Update response",
     class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
   ) %>
-  <%= link_to "Back", new_planning_application_consultation_neighbour_response_path(@planning_application, @consultation), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+  <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
 <% end %>

--- a/app/views/planning_application/neighbour_responses/new.html.erb
+++ b/app/views/planning_application/neighbour_responses/new.html.erb
@@ -59,9 +59,11 @@
     <%= form.govuk_radio_button :summary_tag, 'neutral', label: { text: 'Neutral' } %>
     <%= form.govuk_radio_button :summary_tag, 'objection', label: { text: 'An objection' } %>
   <% end %>
-  <%= form.submit(
-    "Save response",
-    class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
-  ) %>
-  <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+  <div class="govuk-button-group">
+    <%= form.submit(
+      "Save response",
+      class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
+    ) %>
+    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+  </div>
 <% end %>

--- a/spec/system/planning_applications/consulting/upload_neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/upload_neighbour_responses_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe "Upload neighbour responses" do
 
     expect(page).to have_content("08/07/2023")
     expect(page).to have_content("No neighbour responses yet")
+    expect(page).to have_link("Back", href: planning_application_path(planning_application))
 
     fill_in "Name", with: "Sarah Neighbour"
     fill_in "Email", with: "sarah@email.com"
@@ -132,6 +133,8 @@ RSpec.describe "Upload neighbour responses" do
     expect(page).to have_content("Email: sara@email.com")
     expect(page).to have_content("Address: 124 Made up Street")
     expect(page).to have_content("I think this proposal looks ****")
+
+    expect(page).to have_link("Back", href: planning_application_path(planning_application))
 
     # Check audit log
     visit planning_application_audits_path(planning_application)


### PR DESCRIPTION
### Description of change

Link back button to application landing page

### Story Link

https://trello.com/c/0Qhkgxde/1784-back-button-in-upload-neighbours-responses-sends-back-to-validation-page

