### PR TITLE
Run update to constraints as background job

### DIFF
--- a/app/jobs/constraint_query_update_job.rb
+++ b/app/jobs/constraint_query_update_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ConstraintQueryUpdateJob < ApplicationJob
+  queue_as :high_priority
+
+  def perform(planning_application:)
+    ConstraintQueryUpdateService.new(
+      planning_application:
+    ).call
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -687,7 +687,7 @@ class PlanningApplication < ApplicationRecord
   def update_constraints
     return unless saved_changes.include? "boundary_geojson"
 
-    ConstraintQueryUpdateService.new(planning_application: self).call
+    ConstraintQueryUpdateJob.perform_later(planning_application: self)
   end
 
   def attribute_to_audit(attribute_name)

--- a/spec/jobs/constraint_query_update_job_spec.rb
+++ b/spec/jobs/constraint_query_update_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConstraintQueryUpdateJob do
+  let!(:planning_application) { create(:planning_application, :with_boundary_geojson) }
+
+  before do
+    stub_planx_api_response_for("POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))").to_return(
+      status: 200, body: "{}"
+    )
+  end
+
+  describe "#perform" do
+    it "calls ConstraintQueryUpdateService" do
+      expect_any_instance_of(ConstraintQueryUpdateService).to receive(:call)
+        .and_call_original
+
+      described_class.perform_now(planning_application:)
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -381,6 +381,48 @@ RSpec.describe PlanningApplication do
         end
       end
     end
+
+    describe "::after_update #update_constraints" do
+      let(:boundary_geojson) do
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [-0.054597, 51.537331],
+                [-0.054588, 51.537287],
+                [-0.054453, 51.537313],
+                [-0.054597, 51.537331]
+              ]
+            ]
+          }
+        }.to_json
+      end
+
+      before do
+        stub_planx_api_response_for("POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))").to_return(
+          status: 200, body: "{}"
+        )
+      end
+
+      context "when boundary_geojson is changed" do
+        it "calls the ConstraintQueryUpdateJob" do
+          expect do
+            planning_application.update!(boundary_geojson:)
+          end.to have_enqueued_job(ConstraintQueryUpdateJob).with(planning_application:)
+        end
+      end
+
+      context "when boundary_geojson is not changed" do
+        it "does not call the ConstraintQueryUpdateJob" do
+          expect do
+            planning_application.update!(address_1: "Address 1")
+          end.not_to have_enqueued_job(ConstraintQueryUpdateJob)
+        end
+      end
+    end
   end
 
   describe "constants" do


### PR DESCRIPTION
### Description of change

Run update to constraints as background job
- Since we are querying an API which queries its own data, there is risk of higher latency and a slow update action for changing red line boundaries.

### Story Link

https://trello.com/c/sTm72tgX/1783-run-constraints-update-as-a-background-task