### PR TITLE
Create tags and github releases on deploys

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -156,6 +156,28 @@ jobs:
         uses: actions/checkout@v3
         if: matrix.service_type == 'web'
 
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date +%Y%m%d.%H%M)" >>$GITHUB_OUTPUT
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ inputs.environment-name }}-${{ steps.date.outputs.date }}
+        if: matrix.service_type == 'web'
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+        if: matrix.service_type == 'web' && inputs.environment-name == 'production'
+
       - name: Get github commit sha
         id: github
         run: |


### PR DESCRIPTION
### Description of change

Create a tag containing the environment and date and time of deploy every time a deploy to staging or production happens.

Then, on deploys to production, create a Github release based on that tag.

### Story Link

https://trello.com/c/SavDuiTC/1661-add-github-releases-to-our-production-deployments

### Decisions [OPTIONAL]

The default is to use semver type tags, but that doesn't really make sense for our usecase. Some better format for the tag is obviously an option: using the environment name and timestamp was a first guess.

Potentially we can also create releases for deploys to staging, but that seems like it might be less useful/important — we'd still have tags to track those deploys. (Actually, I think tags might well cover most of our use cases anyway.)