### PR TITLE
Give Github workflow permission to modify the repository in order to tag it

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -150,6 +150,8 @@ jobs:
     strategy:
       matrix:
         service_type: ['console', 'worker', 'web']
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code
@@ -159,7 +161,7 @@ jobs:
       - name: Get current date
         id: date
         run: |
-          echo "date=$(date +%Y%m%d.%H%M)" >>$GITHUB_OUTPUT
+          echo "date=$(date +%Y-%m-%dT%H:%M)" >>$GITHUB_OUTPUT
 
       - name: Bump version and push tag
         id: tag_version
@@ -167,6 +169,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           custom_tag: ${{ inputs.environment-name }}-${{ steps.date.outputs.date }}
+          tag_prefix: ""
         if: matrix.service_type == 'web'
 
       - name: Create a GitHub release


### PR DESCRIPTION
### Description of change

Change made in #1187 fails with what appears to be a permissions error

### Story Link

https://trello.com/c/SavDuiTC/1661-add-github-releases-to-our-production-deployments
