### PR TITLE
Move release tagging into a separate job

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -150,36 +150,11 @@ jobs:
     strategy:
       matrix:
         service_type: ['console', 'worker', 'web']
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         if: matrix.service_type == 'web'
-
-      - name: Get current date
-        id: date
-        run: |
-          echo "date=$(date +%Y-%m-%dT%H.%M)" >>$GITHUB_OUTPUT
-
-      - name: Bump version and push tag
-        id: tag_version
-        uses: mathieudutour/github-tag-action@v6.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: ${{ inputs.environment-name }}-${{ steps.date.outputs.date }}
-          tag_prefix: ""
-        if: matrix.service_type == 'web'
-
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-
-        if: matrix.service_type == 'web' && inputs.environment-name == 'production'
 
       - name: Get github commit sha
         id: github
@@ -238,3 +213,36 @@ jobs:
           codedeploy-appspec: .aws/appspec.yml
           codedeploy-application: bops-${{ inputs.environment-name }}
           codedeploy-deployment-group: default
+
+  tag-release:
+    name: Tag release
+    runs-on: ubuntu-20.04
+    needs: [build-image, deploy-db-migrate-service]
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date +%Y-%m-%dT%H.%M)" >>$GITHUB_OUTPUT
+
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ inputs.environment-name }}-${{ steps.date.outputs.date }}
+          tag_prefix: ""
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+
+        if: inputs.environment-name == 'production'


### PR DESCRIPTION
### Description of change

Release tagging needs different (read/write) github credentials, which means that it's probably a good idea to keep those credentials separate (so that jobs which don't need write access don't have it).

There's also some errors with AWS credentials which appear to have begun when the credentials were configured, which might be because the setting affects both?

Finally, it's probably better if the tag is only created on a successful deploy (although actually we can make it tag even on a failed deploy if we wish).

### Story Link

https://trello.com/c/SavDuiTC/1661-add-github-releases-to-our-production-deployments
