### PR TITLE
Update decision notice page for PA1A

### DIFF
--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -5,8 +5,7 @@
     </span>
     <br/>
     <h3 class="govuk-heading-s">
-      Town and Country Planning Act 1990 (as amended): sections 191 and 192 <br>
-      Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39
+      <%= t("recommendation.#{planning_application.application_type.name}.legislation_html") %>
     </h3>
     <h2 class="govuk-heading-m">
       <%= t("recommendation.#{planning_application.application_type.name}.#{planning_application.decision}_html") %>

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -56,7 +56,7 @@
       ) %>
       <div class="govuk-form-group <%= "govuk-form-group--error" if form.object.errors[:public_comment].any? %>">
         <%= form.label(:public_comment, @recommendation.reason_text, class: "govuk-label govuk-label--s") %>
-        <div class="govuk-hint"><%= t(".refer_to_the") %></div>
+        <div class="govuk-hint"><%= t(".refer_to_the.#{@planning_application.application_type.name}") %></div>
         <%= render(
           partial: "shared/warning_text",
           locals: { message: t(".this_information_will") }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -878,12 +878,14 @@ en:
   recommendation:
     lawfulness_certificate:
       granted_html: Certificate of Lawful Use or Development <br> <strong>Granted</strong>
+      legislation_html: 'Town and Country Planning Act 1990 (as amended): sections 191 and 192<br>Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39'
       refused_html: Certificate of Lawful Use or Development <br> Decision Notice <strong>Refused</strong>
     prior_approval:
       granted: Prior approval required and approved
       granted_html: "<strong>Prior approval required and approved</strong>"
       granted_not_required: Prior approval not required
       granted_not_required_html: "<strong>Prior approval not required</strong>"
+      legislation_html: Town and Country Planning Act 1990 (as amended)
       refused: Prior approval required and refused
       refused_html: "<strong>Prior approval required and refused</strong>"
   recommendations:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -929,7 +929,9 @@ en:
       pa_is_the_use: What is your recommendation?
       pa_state_the_reason: State the reasons for your recommendation.
       please_provide_supporting: Provide supporting information for your manager.
-      refer_to_the: Refer to specific permitted development legislation to support your recommendation.
+      refer_to_the:
+        lawfulness_certificate: Refer to specific permitted development legislation to support your recommendation.
+        prior_approval: Refer to specific permitted development legislation, and Local Plan policies in relation to impact on neighbouring amenity.
       there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
       this_information_will: This information will appear on the decision notice.
       this_information_will_not: This information will not appear on the decision notice or the public register, but Freedom of Information requests will still apply.

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe "Planning Application Assessment" do
           "Certificate of Lawful Use or Development Granted"
         )
 
+        expect(page).to have_content("Town and Country Planning Act 1990 (as amended): sections 191 and 192")
+        expect(page).to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39")
+
         expect(page).to have_content("Jane Smith, Director")
 
         visit planning_application_path(planning_application)
@@ -156,6 +159,34 @@ RSpec.describe "Planning Application Assessment" do
           click_button("Publish determination")
 
           expect(page).to have_content("Decision Notice sent to applicant")
+        end
+      end
+
+      context "when the application is for a prior approval" do
+        let(:application_type) { create(:application_type, name: "prior_approval") }
+        let!(:planning_application) do
+          create(:planning_application, :awaiting_determination,
+                 :from_planx_prior_approval,
+                 application_type:,
+                 local_authority: default_local_authority,
+                 decision: "granted")
+        end
+
+        it "lists different legislation in the decision notice" do
+          click_link("Publish determination")
+
+          within("#determination-date") do
+            # Enter date today
+            fill_in "Day", with: "2"
+            fill_in "Month", with: "1"
+            fill_in "Year", with: "2024"
+          end
+
+          click_button("Publish determination")
+
+          click_link("View decision notice")
+          expect(page).to have_content("Town and Country Planning Act 1990 (as amended)")
+          expect(page).not_to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39")
         end
       end
     end


### PR DESCRIPTION
### Description of change

This needs to show different text in several locations depending on the application type. Until now it's been statically defined as the text for LDCs.

### Story Link

https://trello.com/c/zfBtkVmv/1809-show-assessor-correct-guidance-at-make-draft-recommendation-page

https://trello.com/c/8kWUkXGg/1848-show-correct-legislation-on-decision-notices-for-pa1a

### Screenshots

If you have made changes to the frontend please add screenshots
