### PR TITLE
Fix dashboard table view

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -3,6 +3,7 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 @import "components/buttons";
 @import "components/flashes";
+@import "components/table";
 @import "components/task_list";
 @import "proposal";
 @import "consultation";

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -1,0 +1,3 @@
+.govuk-table__cell.description {
+  overflow-wrap: anywhere;
+}

--- a/app/components/planning_applications/row_component.html.erb
+++ b/app/components/planning_applications/row_component.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row" id=<%= dom_id(planning_application) %>>
   <% attributes.each do |attribute| %>
-    <td class="govuk-table__cell<%= " bottom-border-none" if audit %>">
+    <td class="govuk-table__cell<%= " bottom-border-none" if audit %><%= " #{attribute}" %>">
       <%= link_to_if(
         attribute == :reference,
         planning_application.send(attribute),


### PR DESCRIPTION
### Description of change

- When there is a long string for the description, the table format goes wrong since we do not have any rule in place to break it onto a separate line -The css rule added should avoid breaking apart shorter words unnecessarily but still will result in long strings to break across lines as needed.

### Story Link

https://trello.com/c/g4KGNXku/1796-dashboard-view-bug-clicked-on-view-all-applications-button-and-it-displays-strangely

### Screenshots

**BEFORE**
![Screenshot 2023-08-02 at 14 20 52](https://github.com/unboxed/bops/assets/34001723/60b68673-847a-400f-85eb-5c07d63e8821)
![Screenshot 2023-08-02 at 14 21 02](https://github.com/unboxed/bops/assets/34001723/9e19951f-b144-4bbe-875f-1c34f43c2f22)

**After**
![Screenshot 2023-08-02 at 14 32 22](https://github.com/unboxed/bops/assets/34001723/a9494b84-c8cc-43f7-9cc4-c1ffd7f54151)
