### PR TITLE
Include correct application type name in email subjects and bodies

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -9,7 +9,7 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:decision_notice_mail),
+      subject: subject(:decision_notice_mail, application_type_name: @planning_application.application_type.human_name),
       to: user
     )
   end
@@ -19,7 +19,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:validation_notice_mail),
+      subject: subject(:validation_notice_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: email,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -30,7 +31,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:invalidation_notice_mail),
+      subject: subject(:invalidation_notice_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -41,7 +43,7 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:receipt_notice_mail),
+      subject: subject(:receipt_notice_mail, application_type_name: @planning_application.application_type.human_name),
       to: email,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -52,7 +54,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:validation_request_mail),
+      subject: subject(:validation_request_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -64,7 +67,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:post_validation_request_mail),
+      subject: subject(:post_validation_request_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -75,7 +79,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:cancelled_validation_request_mail),
+      subject: subject(:cancelled_validation_request_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -87,7 +92,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:description_change_mail),
+      subject: subject(:description_change_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -99,7 +105,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:description_closure_notification_mail),
+      subject: subject(:description_closure_notification_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -110,7 +117,8 @@ class PlanningApplicationMailer < ApplicationMailer
 
     view_mail(
       NOTIFY_TEMPLATE_ID,
-      subject: subject(:validation_request_closure_mail),
+      subject: subject(:validation_request_closure_mail,
+                       application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -13,6 +13,10 @@ class ApplicationType < ApplicationRecord
     name.humanize
   end
 
+  def human_name
+    I18n.t("application_types.#{name}")
+  end
+
   class << self
     def menu(scope = all)
       scope.order(name: :asc).select(:name, :id).map do |application_type|

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -5,13 +5,13 @@ Application reference number: <%= @planning_application.reference_in_full %>
 Address: <%= @planning_application.full_address %>
 
 <% if @planning_application.refused? %>
-  We regret to inform you that your application for a Lawful Development Certificate has been refused. For details of our decision, go to:
+  We regret to inform you that your application for a <%= @planning_application.application_type.human_name %> has been refused. For details of our decision, go to:
 
   <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
 
   To appeal this decision, read [Appeal a decision about a lawful development certificate on GOV.UK](https://www.gov.uk/appeal-lawful-development-certificate-decision).
 <% else %>
-  We are pleased to inform you that a decision has been made to grant you a Lawful Development Certificate. To see your certificate, go to:
+  We are pleased to inform you that a decision has been made to grant you a <%= @planning_application.application_type.human_name %>. To see your certificate, go to:
 
   <%= decision_notice_api_v1_planning_application_url(@planning_application, format: 'pdf', host: @host) %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -494,19 +494,19 @@ en:
   emails:
     subjects:
       assigned_notification_mail: You have been assigned to a prior approval case %{reference}
-      cancelled_validation_request_mail: Update on your application for a Lawful Development Certificate
-      decision_notice_mail: Decision on your Lawful Development Certificate  application
-      description_change_mail: Lawful Development Certificate application - suggested changes
-      description_closure_notification_mail: Changes to your Lawful Development Certificate application
-      invalidation_notice_mail: Lawful Development Certificate application - changes needed
+      cancelled_validation_request_mail: Update on your application for a %{application_type_name}
+      decision_notice_mail: Decision on your %{application_type_name}  application
+      description_change_mail: "%{application_type_name} application - suggested changes"
+      description_closure_notification_mail: Changes to your %{application_type_name} application
+      invalidation_notice_mail: "%{application_type_name} application - changes needed"
       neighbour_consultation_letter_copy_mail: Neighbour consultation letter copy
       otp_mail: Back Office Planning System verification code
-      post_validation_request_mail: Lawful Development Certificate application  - changes needed
-      receipt_notice_mail: Lawful Development Certificate application received
+      post_validation_request_mail: "%{application_type_name} application  - changes needed"
+      receipt_notice_mail: "%{application_type_name} application received"
       update_notification_mail: BoPS case %{reference} has a new update
-      validation_notice_mail: Your application for a Lawful Development Certificate
-      validation_request_closure_mail: Changes to your Lawful Development Certificate application
-      validation_request_mail: Lawful Development Certificate application  - further changes needed
+      validation_notice_mail: Your application for a %{application_type_name}
+      validation_request_closure_mail: Changes to your %{application_type_name} application
+      validation_request_mail: "%{application_type_name} application  - further changes needed"
   fee_items:
     fee_item_table:
       description: Description


### PR DESCRIPTION
### Description of change

Email subjects hardcode the string "lawful development certificate", which is not correct now that we support other application types. Change subject to include appropriate type name.

### Story Link

https://trello.com/c/tfL8zdkB/1836-bt-email-to-applicant-to-make-changes-refers-to-ldc-not-pa1a-23-00499-pa-lambeth

### Screenshots

If you have made changes to the frontend please add screenshots
