### PR TITLE
Add neighbour comments in responses summary page

### DIFF
--- a/app/helpers/assessment_detail_helper.rb
+++ b/app/helpers/assessment_detail_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module AssessmentDetailHelper
+  def neighbour_responses_summary_text(neighbour_responses_by_summary_tag)
+    return "There are no neighbour responses" unless neighbour_responses_by_summary_tag.any?
+
+    summary_text = neighbour_responses_by_summary_tag.map do |tag, count|
+      "#{count} #{tag}"
+    end
+
+    "There is #{summary_text.join(', ')}."
+  end
+end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -55,6 +55,10 @@ class Consultation < ApplicationRecord
     site_visits.by_created_at_desc.first
   end
 
+  def neighbour_responses_by_summary_tag
+    neighbour_responses.group(:summary_tag).count
+  end
+
   private
 
   def application_link

--- a/app/views/planning_application/assessment_details/publicity_summary/_information.html.erb
+++ b/app/views/planning_application/assessment_details/publicity_summary/_information.html.erb
@@ -1,4 +1,16 @@
 <div class="govuk-body">
+  <% if consultation = @planning_application.consultation %>
+    <%= render "shared/notification_banner", 
+      banner_class: "govuk-notification-banner",
+      role: "region",
+      title: "Neighbour responses",
+      heading: neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %>
+      
+    <p><%= link_to "Upload neighbour responses", new_planning_application_consultation_neighbour_response_path(@planning_application, consultation) %></p>
+  <% else %>
+    <p>There is no existing consultation for this planning application.</p>
+  <% end %>
+
   <% if action_name == "show" %>
     <p><strong>Summary</strong></p>
   <% end %>

--- a/app/views/shared/_notification_banner.html.erb
+++ b/app/views/shared/_notification_banner.html.erb
@@ -1,0 +1,14 @@
+<div class=<%= banner_class %> role=<%= role %>
+  aria-labelledby="govuk-notification-banner-title"
+  data-module="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      <%= title %>
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      <%= heading %>
+    </p>
+  </div>
+</div>

--- a/spec/helpers/assessment_detail_helper_spec.rb
+++ b/spec/helpers/assessment_detail_helper_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessmentDetailHelper do
+  describe ".neighbour_responses_summary_text" do
+    it "generates the correct text from a given hash" do
+      summary_hash = { "objection" => 1, "supportive" => 2, "neutral" => 1 }
+
+      result = neighbour_responses_summary_text(summary_hash)
+      expect(result).to eq("There is 1 objection, 2 supportive, 1 neutral.")
+    end
+  end
+end

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -123,4 +123,19 @@ RSpec.describe Consultation do
       end
     end
   end
+
+  describe "#neighbour_responses_by_summary_tag" do
+    let!(:consultation) { create(:consultation) }
+    let!(:neighbour1) { create(:neighbour, consultation:) }
+    let!(:neighbour2) { create(:neighbour, consultation:) }
+    let!(:neighbour3) { create(:neighbour, consultation:) }
+    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
+    let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+    let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+    let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
+
+    it "returns correct count of summary tags" do
+      expect(consultation.neighbour_responses_by_summary_tag).to eq({ "objection" => 1, "supportive" => 2, "neutral" => 1 })
+    end
+  end
 end

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -18,6 +18,15 @@ RSpec.describe "neighbour responses" do
   end
 
   context "when planning application is in assessment" do
+    let!(:consultation) { create(:consultation, end_date: Time.zone.now, planning_application:) }
+    let!(:neighbour1) { create(:neighbour, consultation:) }
+    let!(:neighbour2) { create(:neighbour, consultation:) }
+    let!(:neighbour3) { create(:neighbour, consultation:) }
+    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
+    let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+    let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+    let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
+
     it "I can view the information on the neighbour responses page" do
       click_link "Check and assess"
 
@@ -27,6 +36,16 @@ RSpec.describe "neighbour responses" do
       within("#summary-of-neighbour-responses") do
         expect(page).to have_content("Not started")
         click_link "Summary of neighbour responses"
+      end
+
+      expect(page).to have_link(
+        "Upload neighbour responses",
+        href: new_planning_application_consultation_neighbour_response_path(planning_application, consultation)
+      )
+
+      within(".govuk-notification-banner") do
+        expect(page).to have_content("Neighbour responses")
+        expect(page).to have_content("There is 1 neutral, 1 objection, 2 supportive.")
       end
 
       expect(page).to have_current_path(
@@ -65,6 +84,11 @@ RSpec.describe "neighbour responses" do
 
       within(".govuk-breadcrumbs__list") do
         expect(page).to have_content("Edit summary of neighbour responses")
+      end
+
+      within(".govuk-notification-banner") do
+        expect(page).to have_content("Neighbour responses")
+        expect(page).to have_content("There is 1 neutral, 1 objection, 2 supportive.")
       end
 
       click_button "Save and come back later"


### PR DESCRIPTION
### Story Link

https://trello.com/c/mi78dxri/1853-bt-assessor-can-see-if-there-were-neighbour-comments-in-add-summary-of-neighbour-responses

### Screenshots

![Screenshot 2023-08-03 at 15 27 55](https://github.com/unboxed/bops/assets/34001723/2ae4560f-79dd-4f0a-991d-b1b88e37fdda)