### PR TITLE
Make 'send letters' status in list reflect state of letters

### DIFF
--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -32,7 +32,7 @@ module StatusTags
         "govuk-tag--green"
       when :updated, :to_be_reviewed, :submitted, :neutral
         "govuk-tag--yellow"
-      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection
+      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection, :failed
         "govuk-tag--red"
       when :printing
         "govuk-tag--purple"

--- a/app/components/task_list_items/send_letters_to_neighbours_component.rb
+++ b/app/components/task_list_items/send_letters_to_neighbours_component.rb
@@ -31,7 +31,13 @@ module TaskListItems
 
     def status_tag_component
       StatusTags::BaseComponent.new(
-        status: @planning_application.consultation&.status || "not_started"
+        status: if @planning_application.consultation&.neighbour_letters_failed?
+                  "failed"
+                elsif @planning_application.consultation&.neighbour_letters_sent?
+                  "complete"
+                else
+                  "not_started"
+                end
       )
     end
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -37,6 +37,14 @@ class Consultation < ApplicationRecord
     (end_date - Time.zone.now).seconds.in_days.round
   end
 
+  def neighbour_letters_failed?
+    neighbour_letters.failed.present?
+  end
+
+  def neighbour_letters_sent?
+    neighbour_letters.sent.present?
+  end
+
   def neighbour_letter_content
     I18n.t("neighbour_letter_template",
            received_at: planning_application.received_at.to_fs(:day_month_year_slashes),

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -13,6 +13,11 @@ class NeighbourLetter < ApplicationRecord
     cancelled: "cancelled"
   }.freeze
 
+  FAILURE_STATUSES = %i[technical_failure permanent_failure rejected].freeze
+
+  scope :failed, -> { where(status: FAILURE_STATUSES) }
+  scope :sent, -> { where.not(status: FAILURE_STATUSES) }
+
   def update_status
     return false if notify_id.blank?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1038,6 +1038,7 @@ en:
     awaiting_determination: Awaiting determination
     checked: Checked
     complete: Completed
+    failed: Failed
     granted: To grant
     in_progress: In progress
     invalid: Invalid

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -197,4 +197,45 @@ RSpec.describe "Send letters to neighbours", js: true do
 
     expect(page).to have_content("60-62 Commercial Street")
   end
+
+  describe "showing the status on the dashboard" do
+    let(:consultation) { create(:consultation, planning_application:) }
+
+    before do
+      sign_in assessor
+    end
+
+    context "when there are no letters" do
+      it "shows 'not started'" do
+        visit planning_application_path(planning_application)
+        expect(page).to have_content "Send letters to neighbours Not started"
+      end
+    end
+
+    context "when there are only successful letters" do
+      before do
+        neighbour = create(:neighbour, consultation:)
+        create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
+      end
+
+      it "shows 'completed'" do
+        visit planning_application_path(planning_application)
+        expect(page).to have_content "Send letters to neighbours Completed"
+      end
+    end
+
+    context "when there are failed letters" do
+      before do
+        neighbour1 = create(:neighbour, consultation:)
+        neighbour2 = create(:neighbour, consultation:)
+        create(:neighbour_letter, neighbour: neighbour1, status: "submitted", notify_id: "123")
+        create(:neighbour_letter, neighbour: neighbour2, status: "rejected", notify_id: "123")
+      end
+
+      it "shows 'failed'" do
+        visit planning_application_path(planning_application)
+        expect(page).to have_content "Send letters to neighbours Failed"
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

"Send letters to neighbours" step status previously reflected the state of the consultation as a whole: it would only show as complete when the consultation was marked as complete. (I don't know when this actually happens, incidentally.)

It is now marked as complete when any letters have been sent.

### Story Link

https://trello.com/c/G1ONu15P/1840-bt-when-letters-sent-show-send-letters-to-neighbours-task-as-complete-not-in-progress

### Decisions

The actual state I've used for the letters here is that they are _created_, i.e., sent _to Notify_ — this is regardless of whether Notify has posted them, because that seems like something the user has no control over and thus irrelevant.

There's no really practical way of distinguishing between "some letters have been sent" and "all letters have been sent", because we don't have a concept of what "all letters" means. If the user sends a letter to only one neighbour it will be marked as complete, even if they need to send letters to more neighbours later. This is the user's responsibility, I think.
