### PR TITLE
Show correct application type name in email bodies

### DIFF
--- a/app/views/planning_application_mailer/description_change_mail.text.erb
+++ b/app/views/planning_application_mailer/description_change_mail.text.erb
@@ -4,7 +4,7 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-We have suggested changes to the project description on your application for a Lawful Development Certificate.
+We have suggested changes to the project description on your application for a <%= @planning_application.application_type.human_name %>.
 
 You are invited to review and accept or reject the suggested changes. To review the changes, go to:
 

--- a/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
+++ b/app/views/planning_application_mailer/description_closure_notification_mail.text.erb
@@ -4,7 +4,7 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-We have changed the project description on your application for a Lawful Development Certificate. The changes were made automatically because you did not review them by <%= @description_change_request.request_expiry_date.strftime("%-d %B %Y") %>.
+We have changed the project description on your application for a <%= @planning_application.application_type.human_name %>. The changes were made automatically because you did not review them by <%= @description_change_request.request_expiry_date.strftime("%-d %B %Y") %>.
 
 To see the updated description, go to:
 

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -4,7 +4,7 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-Your application for a Lawful Development Certificate contains errors or missing information. We cannot continue with your application until you make the necessary changes.
+Your application for a <%= @planning_application.application_type.human_name %> contains errors or missing information. We cannot continue with your application until you make the necessary changes.
 
 To make changes, go to:
 

--- a/app/views/planning_application_mailer/receipt_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/receipt_notice_mail.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @planning_application.agent_or_applicant_name %>,
 
-We’ve received your application for a Lawful Development Certificate.
+We’ve received your application for a <%= @planning_application.application_type.human_name %>.
 
 Here are the details of your application:
 
@@ -17,14 +17,16 @@ We will check your application for errors and missing information. This can take
 If there are no issues with your application, we will start assessing it against the relevant planning policies and legislation.
 
 We may contact you or a person of your choosing to arrange a site visit.
+<% if @planning_application.application_type.name == 'lawfulness_certificate' %>
 
 You have the right to appeal to the Secretary of State if by <%= (@planning_application.received_at + 8.weeks).strftime("%-d %B %Y") %>:
 
 - you have not been told that the application is invalid
 - you have not been given a decision in writing
 - you have not agreed in writing to extend the decision period
+<% end %>
 
-To find out how to appeal an application for a Lawful Development Certificate, go to: https://www.gov.uk/appeal-lawful-development-certificate-decision.
+You can find advice about your rights of appeal at https://www.gov.uk/topic/planning-development/planning-permission-appeals.
 
 If you need help with your application, contact us at <%= @planning_application.local_authority.email_address %>.
 

--- a/app/views/planning_application_mailer/validation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_notice_mail.text.erb
@@ -4,11 +4,11 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-Your application for a Lawful Development Certificate contains no errors or missing information. We can now start assessing your application against the relevant planning policies and legislation.
+Your application for a <%= @planning_application.application_type.human_name %> contains no errors or missing information. We can now start assessing your application against the relevant planning policies and legislation.
 
 We aim to reach a decision about your application by <%= @planning_application.expiry_date.strftime("%-d %B %Y") %>. If we need more time, we will contact you. If you have not heard back from us by then, you have the right to appeal to the Secretary of State.
 
-Find out [how to appeal an application for a Lawful Development Certificate](https://www.gov.uk/appeal-lawful-development-certificate-decision).
+You can find advice about your rights of appeal at https://www.gov.uk/topic/planning-development/planning-permission-appeals.
 
 If you need help with your application, contact us at  <%= @planning_application.local_authority.email_address %>.
 

--- a/app/views/planning_application_mailer/validation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/validation_request_mail.text.erb
@@ -4,7 +4,7 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-We need you to make some more changes to your application for a Lawful Development Certificate. We cannot continue with your application until you make these changes.
+We need you to make some more changes to your application for a <%= @planning_application.application_type.human_name %>. We cannot continue with your application until you make these changes.
 
 To make the changes, go to:
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -495,18 +495,18 @@ en:
     subjects:
       assigned_notification_mail: You have been assigned to a prior approval case %{reference}
       cancelled_validation_request_mail: Update on your application for a %{application_type_name}
-      decision_notice_mail: Decision on your %{application_type_name}  application
+      decision_notice_mail: Decision on your %{application_type_name} application
       description_change_mail: "%{application_type_name} application - suggested changes"
       description_closure_notification_mail: Changes to your %{application_type_name} application
       invalidation_notice_mail: "%{application_type_name} application - changes needed"
       neighbour_consultation_letter_copy_mail: Neighbour consultation letter copy
       otp_mail: Back Office Planning System verification code
-      post_validation_request_mail: "%{application_type_name} application  - changes needed"
+      post_validation_request_mail: "%{application_type_name} application - changes needed"
       receipt_notice_mail: "%{application_type_name} application received"
       update_notification_mail: BoPS case %{reference} has a new update
       validation_notice_mail: Your application for a %{application_type_name}
       validation_request_closure_mail: Changes to your %{application_type_name} application
-      validation_request_mail: "%{application_type_name} application  - further changes needed"
+      validation_request_mail: "%{application_type_name} application - further changes needed"
   fee_items:
     fee_item_table:
       description: Description

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -875,10 +875,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         described_class.invalidation_notice_mail(planning_application)
       end
 
+      let(:mail_body) { invalidation_mail.body.encoded }
+
       it "sets the subject" do
         expect(invalidation_mail.subject).to eq(
           "Prior approval application - changes needed"
         )
+      end
+
+      it "includes the application type" do
+        expect(mail_body).to include("Prior approval")
+        expect(mail_body).not_to include("Lawful Development Certificate")
       end
     end
 
@@ -889,11 +896,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
           planning_application.agent_email
         )
       end
+      let(:mail_body) { validation_mail.body.encoded }
 
       it "sets the subject" do
         expect(validation_mail.subject).to eq(
           "Your application for a Prior approval"
         )
+      end
+
+      it "includes the application type" do
+        expect(mail_body).to include("Prior approval")
+        expect(mail_body).not_to include("Lawful Development Certificate")
       end
     end
 
@@ -901,11 +914,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       let(:validation_request_mail) do
         described_class.validation_request_mail(planning_application)
       end
+      let(:mail_body) { validation_request_mail.body.encoded }
 
       it "sets the subject" do
         expect(validation_request_mail.subject).to eq(
           "Prior approval application  - further changes needed"
         )
+      end
+
+      it "includes the application type" do
+        expect(mail_body).to include("Prior approval")
+        expect(mail_body).not_to include("Lawful Development Certificate")
       end
     end
 
@@ -944,11 +963,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
           planning_application.agent_email
         )
       end
+      let(:mail_body) { mail.body.encoded }
 
       it "sets the subject" do
         expect(mail.subject).to eq(
           "Prior approval application received"
         )
+      end
+
+      it "includes the application type" do
+        expect(mail_body).to include("Prior approval")
+        expect(mail_body).not_to include("Lawful Development Certificate")
       end
     end
 
@@ -983,10 +1008,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
           )
         end
 
+        let(:mail_body) { description_change_mail.body.encoded }
+
         it "sets the subject" do
           expect(description_change_mail.subject).to eq(
             "Prior approval application - suggested changes"
           )
+        end
+
+        it "includes the application type" do
+          expect(mail_body).to include("Prior approval")
+          expect(mail_body).not_to include("Lawful Development Certificate")
         end
       end
 
@@ -998,10 +1030,17 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
           )
         end
 
+        let(:mail_body) { description_closure_mail.body.encoded }
+
         it "sets the subject" do
           expect(description_closure_mail.subject).to eq(
             "Changes to your Prior approval application"
           )
+        end
+
+        it "includes the application type" do
+          expect(mail_body).to include("Prior approval")
+          expect(mail_body).not_to include("Lawful Development Certificate")
         end
       end
     end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "sets the subject" do
       expect(mail.subject).to eq(
-        "Decision on your Lawful Development Certificate  application"
+        "Decision on your Lawful Development Certificate application"
       )
     end
 
@@ -273,7 +273,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "sets the subject" do
       expect(validation_request_mail.subject).to eq(
-        "Lawful Development Certificate application  - further changes needed"
+        "Lawful Development Certificate application - further changes needed"
       )
     end
 
@@ -381,7 +381,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "sets the subject" do
       expect(post_validation_request_mail.subject).to eq(
-        "Lawful Development Certificate application  - changes needed"
+        "Lawful Development Certificate application - changes needed"
       )
     end
 
@@ -822,7 +822,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "sets the subject" do
         expect(mail.subject).to eq(
-          "Decision on your Prior approval  application"
+          "Decision on your Prior approval application"
         )
       end
 
@@ -918,7 +918,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "sets the subject" do
         expect(validation_request_mail.subject).to eq(
-          "Prior approval application  - further changes needed"
+          "Prior approval application - further changes needed"
         )
       end
 
@@ -939,7 +939,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "sets the subject" do
         expect(post_validation_request_mail.subject).to eq(
-          "Prior approval application  - changes needed"
+          "Prior approval application - changes needed"
         )
       end
     end


### PR DESCRIPTION
### Description of change

The body of some emails incorrectly hardcoded "Lawful Development Certificate". Following on from #1201, these should list the correct application type.

In addition, links to advice and details of appeal rights should be correct for the application type. For now the listing of rights is simply restricted to LDCs.

### Story Link

https://trello.com/c/tfL8zdkB/1836-bt-email-to-applicant-to-make-changes-refers-to-ldc-not-pa1a-23-00499-pa-lambeth
