### PR TITLE
Add warning message if consultation is still ongoing

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -67,6 +67,12 @@ class Consultation < ApplicationRecord
     neighbour_responses.group(:summary_tag).count
   end
 
+  def publicity_active?
+    return false unless end_date
+
+    end_date > Time.zone.now || (end_date.to_date == Time.zone.now.to_date)
+  end
+
   private
 
   def application_link

--- a/app/views/recommendations/edit.html.erb
+++ b/app/views/recommendations/edit.html.erb
@@ -58,6 +58,14 @@
         <%= t(".you_have_not") %>
       </p>
     <% end %>
+    <% if @planning_application.consultation.try(:publicity_active?) %>
+      <%= render(
+        partial: "shared/alert_banner",
+        locals: {
+          message: "The consultation is still ongoing. It will end on the #{@planning_application.consultation.end_date.to_fs(:day_month_year_slashes)}. Are you sure you still want to make the recommendation?"
+        }
+      ) %>
+    <% end %>
     <%= render(
       partial: "form",
       locals: {

--- a/app/views/recommendations/new.html.erb
+++ b/app/views/recommendations/new.html.erb
@@ -41,6 +41,14 @@
         }
       ) %>
     <% end %>
+    <% if @planning_application.consultation.try(:publicity_active?) %>
+      <%= render(
+        partial: "shared/alert_banner",
+        locals: {
+          message: "The consultation is still ongoing. It will end on the #{@planning_application.consultation.end_date.to_fs(:day_month_year_slashes)}. Are you sure you still want to make the recommendation?"
+        }
+      ) %>
+    <% end %>
     <%= form_with(
       model: @recommendation,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1040,6 +1040,7 @@ en:
     complete: Completed
     failed: Failed
     granted: To grant
+    granted_not_required: Prior approval not required
     in_progress: In progress
     invalid: Invalid
     neutral: Neutral

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -138,4 +138,45 @@ RSpec.describe Consultation do
       expect(consultation.neighbour_responses_by_summary_tag).to eq({ "objection" => 1, "supportive" => 2, "neutral" => 1 })
     end
   end
+
+  describe "publicity_active?" do
+    let(:consultation) { create(:consultation, end_date: Time.zone.local(2023, 9, 23, 13)) }
+
+    before do
+      travel_to date
+    end
+
+    context "when the consultation end date is not present" do
+      let(:consultation) { create(:consultation) }
+      let(:date) { Time.zone.local(2023, 9, 23, 13) }
+
+      it "returns false" do
+        expect(consultation.publicity_active?).to be(false)
+      end
+    end
+
+    context "when the consultation end date is after now" do
+      let(:date) { Time.zone.local(2023, 9, 20, 13) }
+
+      it "returns true" do
+        expect(consultation.publicity_active?).to be(true)
+      end
+    end
+
+    context "when the consultation end date is before now" do
+      let(:date) { Time.zone.local(2023, 9, 27, 13) }
+
+      it "returns false" do
+        expect(consultation.publicity_active?).to be(false)
+      end
+    end
+
+    context "when the consultation end date is today" do
+      let(:date) { Time.zone.local(2023, 9, 23, 13) }
+
+      it "returns true" do
+        expect(consultation.publicity_active?).to be(true)
+      end
+    end
+  end
 end

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -900,5 +900,31 @@ RSpec.describe "Planning Application Assessment" do
         end
       end
     end
+
+    context "when consultation is still ongoing" do
+      let!(:consultation) do
+        create(:consultation, end_date: 10.days.from_now, planning_application:)
+      end
+
+      it "displays a warning message with the consultation end date" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        within(".moj-banner__message") do
+          expect(page).to have_content("The consultation is still ongoing. It will end on the #{consultation.end_date.to_fs(:day_month_year_slashes)}. Are you sure you still want to make the recommendation?")
+        end
+      end
+    end
+
+    context "when consultation hasn't begun" do
+      let!(:consultation) do
+        create(:consultation, planning_application:)
+      end
+
+      it "does not display a warning message" do
+        visit new_planning_application_recommendation_path(planning_application)
+
+        expect(page).not_to have_css(".moj-banner__message")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Story Link

https://trello.com/c/awbPSSDk/1842-bt-warn-assessor-reviewer-if-recommendation-is-before-21-days-publicity-time-expired

### Screenshots

![Screenshot 2023-08-07 at 14 39 44](https://github.com/unboxed/bops/assets/34001723/05658b3a-bc7f-4e74-8f72-8be81dc70209)

