### PR TITLE
Don't show assessor remarks for consultation on PAs

### DIFF
--- a/app/form_models/review_assessment_details_form.rb
+++ b/app/form_models/review_assessment_details_form.rb
@@ -15,7 +15,6 @@ class ReviewAssessmentDetailsForm
   PRIOR_APPROVAL_ASSESSMENT_DETAILS = %i[
     summary_of_work
     site_description
-    consultation_summary
     additional_evidence
     publicity_summary
     amenity

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -69,6 +69,8 @@ class AssessmentDetail < ApplicationRecord
       case application_type
       when :lawfulness_certificate
         category_keys - %w[publicity_summary amenity]
+      when :prior_approval
+        category_keys - %w[consultation_summary]
       else
         category_keys
       end

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Assessment tasks" do
             expect(page).to have_link("Summary of works")
             expect(page).to have_link("Summary of additional evidence")
             expect(page).to have_link("Site description")
-            expect(page).to have_link("Summary of consultation")
+            expect(page).not_to have_link("Summary of consultation")
             expect(page).to have_link("Amenity")
           end
 

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -83,18 +83,6 @@ RSpec.describe "Reviewing assessment summaries" do
           entry: "site description"
         )
 
-        create(:consultee, planning_application:)
-
-        create(
-          :assessment_detail,
-          :consultation_summary,
-          assessment_status: :complete,
-          planning_application:,
-          user: assessor,
-          entry: "consultation summary",
-          created_at: Time.zone.local(2022, 11, 27, 12, 15)
-        )
-
         create(
           :assessment_detail,
           :additional_evidence,
@@ -157,14 +145,6 @@ RSpec.describe "Reviewing assessment summaries" do
         )
 
         expect(page).to have_content(
-          "Consultation summary reviewer verdict can't be blank"
-        )
-
-        expect(page).to have_content(
-          "Consultation summary reviewer verdict can't be blank"
-        )
-
-        expect(page).to have_content(
           "Amenity reviewer verdict can't be blank"
         )
 
@@ -210,27 +190,6 @@ RSpec.describe "Reviewing assessment summaries" do
           "Review assessment summaries", with: "In progress"
         )
 
-        click_link("Review assessment summaries")
-
-        within(find("fieldset", text: "Consultation")) do
-          choose("Return to officer with comment")
-        end
-
-        click_button("Save and come back later")
-
-        expect(page).to have_content(
-          "Consultation summary comment text can't be blank"
-        )
-
-        within(find("fieldset", text: "Consultation")) do
-          fill_in(
-            "Explain to the assessor why this needs reviewing",
-            with: "consultation comment"
-          )
-        end
-
-        click_button("Save and come back later")
-
         within("ul#review-assessment-section") do
           expect(page).to have_list_item_for(
             "Review assessment summaries", with: "In progress"
@@ -275,10 +234,6 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
         click_link("Review assessment summaries")
 
-        within(find("fieldset", text: "Consultation")) do
-          expect(find(".govuk-tag")).to have_content("To be reviewed")
-        end
-
         click_link("Log out")
         sign_in(assessor)
         visit(planning_application_path(planning_application))
@@ -286,38 +241,6 @@ RSpec.describe "Reviewing assessment summaries" do
         expect(page).to have_list_item_for(
           "Check and assess", with: "To be reviewed"
         )
-
-        click_link("Check and assess")
-
-        expect(page).to have_list_item_for(
-          "Summary of consultation", with: "To be reviewed"
-        )
-
-        click_link("Summary of consultation")
-
-        expect(page).to have_content("Bella Jones marked this for review")
-        expect(page).to have_content("28 November 2022 12:30")
-        expect(page).to have_content("consultation comment")
-
-        expect(page).to have_field(
-          "assessment-detail-entry-field",
-          with: "consultation summary"
-        )
-
-        fill_in(
-          "assessment-detail-entry-field",
-          with: "updated consultation summary"
-        )
-
-        click_button("Save and mark as complete")
-
-        expect(page).to have_content("Consultation summary successfully updated.")
-
-        expect(page).to have_list_item_for(
-          "Summary of consultation", with: "Completed"
-        )
-
-        click_link("Application")
 
         click_link("Check and assess")
         click_link("Make draft recommendation")
@@ -329,92 +252,11 @@ RSpec.describe "Reviewing assessment summaries" do
         sign_in(reviewer)
         visit(planning_application_path(planning_application))
 
-        expect(page).to have_list_item_for(
-          "Review and sign-off", with: "Updated"
-        )
-
         click_link("Review and sign-off")
-
-        expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Updated"
-        )
-
-        click_link("Review assessment summaries")
-        expect(page).to have_content("updated consultation summary")
-
-        within(find("fieldset", text: "Consultation")) do
-          expect(find(".govuk-tag")).to have_content("Updated")
-
-          find("span", text: "See previous summaries").click
-
-          expect(page).to have_content("Alice Smith created consultation summary")
-          expect(page).to have_content("27 November 2022 12:15")
-          expect(page).to have_content("Bella Jones marked this for review")
-          expect(page).to have_content("28 November 2022 12:30")
-
-          choose("Accept")
-        end
-
-        click_button("Save and mark as complete")
-
-        expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
-        )
-
-        click_link("Review assessment summaries")
-
-        within(find("fieldset", text: "Consultation")) do
-          expect(find(".govuk-tag")).to have_content("Completed")
-        end
-
-        click_link("Review")
         click_link("Sign-off recommendation")
         choose("Yes")
         click_button("Save and mark as complete")
-
         click_link("Review assessment summaries")
-        click_link("Edit review")
-
-        within(find("fieldset", text: "Consultation")) do
-          choose("Return to officer with comment")
-
-          fill_in(
-            "Explain to the assessor why this needs reviewing",
-            with: "new consultation comment"
-          )
-        end
-
-        click_button("Save and mark as complete")
-
-        expect(page).to have_content(
-          "You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen"
-        )
-
-        click_link("Review")
-        click_link("Sign-off recommendation")
-        choose("No (return the case for assessment)")
-
-        fill_in(
-          "Explain to the officer why the case is being returned",
-          with: "recommendation challenged again"
-        )
-
-        click_button("Save and mark as complete")
-        click_link("Review assessment summaries")
-        click_link("Edit review")
-
-        within(find("fieldset", text: "Consultation")) do
-          choose("Return to officer with comment")
-
-          fill_in(
-            "Explain to the assessor why this needs reviewing",
-            with: "new consultation comment"
-          )
-        end
-
-        click_button("Save and mark as complete")
-
-        expect(page).to have_content("Review saved")
       end
     end
 
@@ -451,10 +293,6 @@ RSpec.describe "Reviewing assessment summaries" do
           "Site description reviewer verdict can't be blank"
         )
 
-        expect(page).to have_content(
-          "Consultation summary reviewer verdict can't be blank"
-        )
-
         click_button("Save and come back later")
 
         expect(page).to have_list_item_for(
@@ -473,31 +311,6 @@ RSpec.describe "Reviewing assessment summaries" do
 
         within(find("fieldset", text: "Site description")) do
           fill_in("Update site description", with: "edited site description")
-        end
-
-        click_button("Save and come back later")
-
-        expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "In progress"
-        )
-
-        click_link("Review assessment summaries")
-
-        within(find("fieldset", text: "Consultation")) do
-          choose("Return to officer with comment")
-        end
-
-        click_button("Save and come back later")
-
-        expect(page).to have_content(
-          "Consultation summary comment text can't be blank"
-        )
-
-        within(find("fieldset", text: "Consultation")) do
-          fill_in(
-            "Explain to the assessor why this needs reviewing",
-            with: "consultation comment"
-          )
         end
 
         click_button("Save and come back later")


### PR DESCRIPTION
### Description of change

PAs don't have consultations so offering an option to comment on the outcome will never be useful.

### Story Link

https://trello.com/c/1oReFtn1/1856-bt-consultations-should-not-be-visible-in-assessment-and-review-if-no-consultation-has-taken-place
