### PR TITLE
Use letter template ID from dummy account in staging

### DIFF
--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -56,7 +56,11 @@ class LetterSendingService
   end
 
   def notify_template_id
-    @notify_template_id ||= @local_authority.notify_letter_template || DEFAULT_NOTIFY_TEMPLATE_ID
+    if production?
+      @notify_template_id ||= @local_authority.notify_letter_template || DEFAULT_NOTIFY_TEMPLATE_ID
+    else
+      @notify_template_id = DEFAULT_NOTIFY_TEMPLATE_ID
+    end
   end
 
   def address


### PR DESCRIPTION
This is necessary because the template ID is required to be found in the given account. We ovveride the account used in staging but use the template ID from the real account, leading to errors.

- Encountered in https://trello.com/c/G1ONu15P/1840-bt-when-letters-sent-show-send-letters-to-neighbours-task-as-complete-not-in-progress
- Required in https://trello.com/c/MOybr8vo/1855-set-up-notify-for-lambeth