### PR TITLE
Show document count on site visit

### DIFF
--- a/app/views/planning_application/site_visits/index.html.erb
+++ b/app/views/planning_application/site_visits/index.html.erb
@@ -33,6 +33,7 @@
           <p class="govuk-body">Visited at: <%= site_visit.visited_at&.strftime("%-d %B %Y") %></p>
         <% end %>
         <p class="govuk-body">Comment: <%= site_visit.comment %></p>
+        <p class="govuk-body"><%= site_visit.documents.count %> document<%= site_visit.documents.count == 1 ? "" : "s" %> added</p>
         
         <p><%= link_to "View", planning_application_consultation_site_visit_path(@planning_application, @consultation, site_visit), class: "govuk-link" %></p>
         <hr>

--- a/app/views/planning_application/site_visits/show.html.erb
+++ b/app/views/planning_application/site_visits/show.html.erb
@@ -18,7 +18,7 @@
 <p class="govuk-body">Response created by: <%= @site_visit.created_by.name %></p>
 <p class="govuk-body">Response created at: <%= @site_visit.created_at.to_fs %></p>
 <% if @site_visit.decision? %>
-  <p class="govuk-body">Visited at: <%= @site_visit.visited_at&.to_fs %></p>
+  <p class="govuk-body">Visited at: <%= @site_visit.visited_at&.to_date.to_fs %></p>
 <% end %>
 <p class="govuk-body">Comment: <%= @site_visit.comment %></p>
 

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe "Site visit" do
           expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
           expect(page).to have_content("Visited at: 20 July 2023")
           expect(page).to have_content("Comment: Site visit is needed")
+          expect(page).to have_content("1 document added")
 
           click_link "View"
         end


### PR DESCRIPTION
### Description of change

- Show count of documents on site visit element
- Remove time from when site visit happened on show page. User doesn't input this so it always shows as midnight which isn't very helpful

### Story Link

https://trello.com/c/RPMVpWMw/1852-bt-make-it-clear-if-there-are-photographs-associated-with-a-site-visit-response

### Screenshots

<img width="635" alt="Screenshot 2023-08-09 at 11 20 28" src="https://github.com/unboxed/bops/assets/35098639/c7ff4f1a-f23a-44c8-9b57-8c2b042b7b85">
