### PR TITLE
Fix broken test

### DIFF
--- a/spec/components/accordion_sections/key_application_dates_component_spec.rb
+++ b/spec/components/accordion_sections/key_application_dates_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
     end
 
     it "renders consultation deadline" do
-      expect(page).to have_content("Consultation deadline:\n    #{consultation.end_date.strftime('%d %B %Y')}")
+      expect(page).to have_content("Consultation deadline:\n    #{consultation.end_date.strftime('%-d %B %Y')}")
     end
   end
 


### PR DESCRIPTION
This comes from mismatched date formats (zero-padded versus space-padded/unpadded) and only showed up today because it's representing a date three weeks in the future, which is now 1 September (whereas when the bug was introduced, 3 weeks in the future was >= 10 August).