### PR TITLE
Check for legislation requirements

### DIFF
--- a/app/components/task_list_items/legislation_component.rb
+++ b/app/components/task_list_items/legislation_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class LegislationComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+    end
+
+    private
+
+    attr_reader :planning_application
+
+    def link_text
+      t(".check_legislation")
+    end
+
+    def link_path
+      planning_application_legislation_path(planning_application)
+    end
+
+    def status
+      if planning_application.legislation_checked?
+        :checked
+      else
+        :not_started
+      end
+    end
+  end
+end

--- a/app/controllers/legislations_controller.rb
+++ b/app/controllers/legislations_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class LegislationsController < AuthenticationController
+  include PlanningApplicationAssessable
+
+  before_action :set_planning_application
+  before_action :ensure_legislation_is_defined
+
+  def show
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def update
+    @planning_application.mark_legislation_as_checked!
+
+    respond_to do |format|
+      if @planning_application.legislation_checked?
+        format.html do
+          redirect_to planning_application_validation_tasks_path(@planning_application),
+                      notice: t(".success")
+        end
+      else
+        format.html do
+          redirect_failed_update
+        end
+      end
+    end
+  rescue ActiveRecord::ActiveRecordError
+    redirect_failed_update
+  end
+
+  private
+
+  def ensure_legislation_is_defined
+    return if @planning_application.application_type.legislation_description
+
+    render plain: "Not found", status: :not_found
+  end
+
+  def redirect_failed_update
+    redirect_to planning_application_validation_tasks_path(@planning_application), alert: t(".alert")
+  end
+end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -17,11 +17,33 @@ class ApplicationType < ApplicationRecord
     I18n.t("application_types.#{name}")
   end
 
+  def legislation_link
+    fetch_legislation_translation("link")
+  end
+
+  def legislation_link_text
+    fetch_legislation_translation("link_text")
+  end
+
+  def legislation_description
+    fetch_legislation_translation("description")
+  end
+
   class << self
     def menu(scope = all)
       scope.order(name: :asc).select(:name, :id).map do |application_type|
         [application_type.full_name, application_type.id]
       end
     end
+  end
+
+  private
+
+  def part_and_section
+    "#{part}#{section}"
+  end
+
+  def fetch_legislation_translation(key)
+    I18n.t("application_types.legislation.#{name}.#{part_and_section}.#{key}", default: false)
   end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -84,7 +84,8 @@ class Audit < ApplicationRecord
     neighbour_letters_sent: "neighbour_letters_sent",
     neighbour_letter_copy_mail_sent: "neighbour_letter_copy_mail_sent",
     neighbour_response_uploaded: "neighbour_response_uploaded",
-    neighbour_response_edited: "neighbour_response_edited"
+    neighbour_response_edited: "neighbour_response_edited",
+    legislation_checked: "legislation_checked"
   }
 
   validates :activity_type, presence: true

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -595,6 +595,13 @@ class PlanningApplication < ApplicationRecord
     end
   end
 
+  def mark_legislation_as_checked!
+    transaction do
+      update!(legislation_checked: true)
+      audit!(activity_type: "legislation_checked")
+    end
+  end
+
   delegate :name, to: :application_type, prefix: true
 
   private

--- a/app/views/legislations/show.html.erb
+++ b/app/views/legislations/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  Legislation - <%= t("page_title") %>
+<% end %>
+
+<%= render "validation_requests/validation_requests_breadcrumbs" %>
+<% content_for :title, "Check legislative requirements" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Check legislative requirements" }
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <p class="govuk-body"><%= @planning_application.application_type.legislation_description %></p>
+    <p class="govuk-body"><%= link_to @planning_application.application_type.legislation_link_text, @planning_application.application_type.legislation_link, target: "_blank" %></p>
+    
+    <%= render(
+      AccordionComponent.new(planning_application: @planning_application, sections: ["proposal_details"])
+    ) %>
+
+    <%= form_with model: @planning_application, url: planning_application_legislation_path(@planning_application), method: :patch do |form| %>
+      <div class="govuk-button-group">
+        <%= form.submit "Mark as checked", class: "govuk-button", data: { module: "govuk-button" } unless @planning_application.legislation_checked? %>
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_application/validation_tasks/_legislation.html.erb
+++ b/app/views/planning_application/validation_tasks/_legislation.html.erb
@@ -1,0 +1,20 @@
+<li id="check-legislation-task">
+  <h2 class="app-task-list__section">
+    Legislation
+  </h2>
+  <ul class="app-task-list__items">
+    <% if @planning_application.validated? %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          Planning application has already been validated
+        </span>
+      </li>
+    <% else %>
+      <%= render(
+        TaskListItems::LegislationComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
+    <% end %>
+  </ul>
+</li>

--- a/app/views/planning_application/validation_tasks/index.html.erb
+++ b/app/views/planning_application/validation_tasks/index.html.erb
@@ -36,6 +36,8 @@
 
       <%= render "additional_document_validation" %>
 
+      <%= render "legislation" if @planning_application.application_type.legislation_description %>
+
       <%= render "other_validation_request" %>
 
       <%= render "review" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -228,6 +228,12 @@ en:
   application_types:
     lawfulness_certificate: Lawful Development Certificate
     lawfulness_certificate_abbr: LDC
+    legislation:
+      prior_approval:
+        1A:
+          description: Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A.
+          link: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made
+          link_text: The Town and Country Planning (General Permitted Development) (England) Order 2015
     prior_approval: Prior approval
     prior_approval_abbr: PA
   archive_reasons:
@@ -344,6 +350,7 @@ en:
       document_invalidated: "%{args} was marked as invalid"
       document_received_at_changed: "%{args} received at date was modified"
       invalidated: Application invalidated
+      legislation_checked: Legislative requirements checked
       neighbour_letter_copy_mail_sent: Neighbour consultation letter copy email sent
       neighbour_letters_sent: Neighbour letters sent
       neighbour_response_edited: Neighbour response edited
@@ -582,6 +589,10 @@ en:
         removed: Is the application immune from enforcement?
   immunity_details:
     successfully_updated: Review immunity details was successfully updated
+  legislations:
+    update:
+      alert: Couldn't mark legislative requirements as checked - please contact support.
+      success: Legislative requirements have been marked as checked.
   local_authorities:
     edit:
       edit_local_authority: Edit council information
@@ -1089,6 +1100,8 @@ en:
       check_fee: Check fee
     immunity_details_component:
       evidence_of_immunity: Evidence of immunity
+    legislation_component:
+      check_legislation: Check legislative requirements
     other_change_request_component:
       view_other_validation: 'View other validation request #%{number}'
     permitted_development_right_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,8 @@ Rails.application.routes.draw do
 
     resource :planning_history, only: :show
 
+    resource :legislation, only: %i[show update]
+
     scope module: :planning_application do
       resources :notes, only: %i[index create]
 

--- a/db/migrate/20230809135315_add_legislation_checked_to_planning_applications.rb
+++ b/db/migrate/20230809135315_add_legislation_checked_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLegislationCheckedToPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :legislation_checked, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_134342) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_135315) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -439,6 +439,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_134342) do
     t.text "changed_constraints", array: true
     t.bigint "application_type_id"
     t.boolean "make_public", default: false
+    t.boolean "legislation_checked", default: false, null: false
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -25,4 +25,40 @@ RSpec.describe ApplicationType do
       end
     end
   end
+
+  describe "legislation details" do
+    context "when planning application type has legislation details defined in en.yml translation" do
+      let!(:application_type) { create(:application_type, name: "prior_approval", part: 1, section: "A") }
+
+      describe "legislation_link" do
+        it "returns the legislation link" do
+          expect(application_type.legislation_link).to eq("https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made")
+        end
+      end
+
+      describe "legislation_link_text" do
+        it "returns the legislation link text" do
+          expect(application_type.legislation_link_text).to eq("The Town and Country Planning (General Permitted Development) (England) Order 2015")
+        end
+      end
+
+      describe "legislation_description" do
+        it "returns the legislation description" do
+          expect(application_type.legislation_description).to eq("Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A.")
+        end
+      end
+    end
+
+    context "when planning application type has no legislation details defined in en.yml translation" do
+      let!(:application_type) { create(:application_type) }
+
+      %w[legislation_link legislation_link_text legislation_description].each do |translation|
+        describe translation.to_s do
+          it "returns false" do
+            expect(application_type.send(translation)).to be(false)
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2274,4 +2274,20 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  describe "#mark_legislation_as_checked!" do
+    let(:planning_application) { create(:planning_application) }
+
+    it "sets legislation_checked as true and adds an audit record" do
+      expect { planning_application.mark_legislation_as_checked! }
+        .to change(planning_application, :legislation_checked)
+        .from(false)
+        .to(true)
+
+      expect(Audit.last).to have_attributes(
+        planning_application_id: planning_application.id,
+        activity_type: "legislation_checked"
+      )
+    end
+  end
 end

--- a/spec/system/planning_applications/validating/check_legislation_spec.rb
+++ b/spec/system/planning_applications/validating/check_legislation_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check legislation" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  context "when planning application type is prior approval 1A" do
+    let!(:planning_application) do
+      create(:planning_application, :prior_approval, :not_started, local_authority: default_local_authority)
+    end
+
+    before do
+      planning_application.application_type.update(part: 1, section: "A")
+
+      sign_in assessor
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link("Check legislative requirements")
+    end
+
+    it "displays the application information" do
+      within("#planning-application-details") do
+        expect(page).to have_content("Check legislative requirements")
+        expect(page).to have_content(planning_application.full_address)
+        expect(page).to have_content(planning_application.reference)
+        expect(page).to have_content(planning_application.description)
+      end
+
+      expect(page).to have_link(
+        "Back",
+        href: planning_application_validation_tasks_path(planning_application)
+      )
+    end
+
+    it "displays the legislation information" do
+      expect(page).to have_content("Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A.")
+      expect(page).to have_link(
+        "The Town and Country Planning (General Permitted Development) (England) Order 2015",
+        href: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made"
+      )
+    end
+
+    it "displays the proposal details" do
+      expect(page).to have_button("Proposal details")
+    end
+
+    it "I can mark the legislative requirements as checked" do
+      click_button "Mark as checked"
+
+      expect(page).to have_content("Legislative requirements have been marked as checked.")
+
+      within("#check-legislation-task") do
+        expect(page).to have_content("Checked")
+      end
+
+      click_link "Application"
+
+      # Check audit logs
+      click_button "Audit log"
+      click_link "View all audits"
+      within("#audit_#{Audit.last.id}") do
+        expect(page).to have_content("Legislative requirements checked")
+        expect(page).to have_content(assessor.name)
+        expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      end
+    end
+
+    context "when there is an ActiveRecord Error" do
+      before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
+
+      it "present an error message" do
+        click_button "Mark as checked"
+
+        expect(page).to have_content("Couldn't mark legislative requirements as checked - please contact support.")
+
+        within("#check-legislation-task") do
+          expect(page).to have_content("Not started")
+        end
+      end
+    end
+  end
+
+  context "when planning application type has no legislation en.yml translation details" do
+    let!(:planning_application) do
+      create(:planning_application, :not_started, local_authority: default_local_authority)
+    end
+
+    before do
+      sign_in assessor
+      visit planning_application_validation_tasks_path(planning_application)
+    end
+
+    it "does not show the check legislation tasklist" do
+      expect(page).not_to have_css("#check-legislation-task")
+    end
+
+    it "shows forbidden when navigating to the page directly" do
+      visit planning_application_legislation_path(planning_application)
+      expect(page).to have_content("Not found")
+    end
+  end
+end

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -103,6 +103,8 @@ RSpec.describe "Validation tasks" do
           )
         end
 
+        expect(page).not_to have_css("#check-legislation-task")
+
         within("#review-tasks") do
           expect(page).to have_content("Review")
           expect(page).to have_link(
@@ -113,6 +115,27 @@ RSpec.describe "Validation tasks" do
       end
 
       expect(page).to have_link("Back", href: planning_application_path(planning_application))
+    end
+
+    context "when planning application type is prior approval 1A" do
+      let!(:planning_application) do
+        create(:planning_application, :prior_approval, :not_started, local_authority: default_local_authority)
+      end
+
+      before do
+        planning_application.application_type.update(part: 1, section: "A")
+
+        sign_in assessor
+        visit planning_application_validation_tasks_path(planning_application)
+      end
+
+      it "shows the check legislation task" do
+        within("#check-legislation-task") do
+          expect(page).to have_content("Legislation")
+          expect(page).to have_content("Check legislative requirements")
+          expect(page).to have_content("Not started")
+        end
+      end
     end
   end
 
@@ -171,6 +194,8 @@ RSpec.describe "Validation tasks" do
           )
         end
 
+        expect(page).not_to have_css("#check-legislation-task")
+
         within("#review-tasks") do
           expect(page).to have_content("Review")
           expect(page).to have_link(
@@ -181,6 +206,26 @@ RSpec.describe "Validation tasks" do
       end
 
       expect(page).to have_link("Back", href: planning_application_path(planning_application))
+    end
+
+    context "when planning application type is prior approval 1A" do
+      let!(:planning_application) do
+        create(:planning_application, :prior_approval, :in_assessment, local_authority: default_local_authority)
+      end
+
+      before do
+        planning_application.application_type.update(part: 1, section: "A")
+
+        sign_in assessor
+        visit planning_application_validation_tasks_path(planning_application)
+      end
+
+      it "shows the check legislation task" do
+        within("#check-legislation-task") do
+          expect(page).to have_content("Legislation")
+          expect(page).to have_content("Planning application has already been validated")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

- Add legislation requirements check for validation stage
- Add link to relevant legislation for prior approvals 1A
- Add proposal details accordion
- Allow officer to mark this section as checked
- Do not render this check if there is no legislation details set in en.yml translations

### Story Link

https://trello.com/c/AmWutGkw/1795-bt-add-tasks-for-assessor-to-check-requirements-specific-to-larger-householder-prior-approval-were-provided

### Screenshots

![Screenshot 2023-08-10 at 09 38 32](https://github.com/unboxed/bops/assets/34001723/e5ad4484-40f9-46a2-87cb-1672a6f881be)
![Screenshot 2023-08-11 at 12 32 34](https://github.com/unboxed/bops/assets/34001723/497b0fff-b8f8-46d9-909b-938b2db3ee94)


