### PR TITLE
Push directly to ECR repository to save time spent on exporting

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -66,9 +66,8 @@ jobs:
           DOCKER_BUILDKIT=1 docker buildx build \
             --cache-to type=gha,mode=max \
             --cache-from type=gha \
-            --load \
-            --build-arg RAILS_MASTER_KEY=$RAILS_MASTER_KEY -t bops:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+            --push \
+            --build-arg RAILS_MASTER_KEY=$RAILS_MASTER_KEY -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -f Dockerfile.production .
 
   deploy-db-migrate-service:
     name: Perform database migrations on ${{ inputs.environment-name }}


### PR DESCRIPTION
Export and then push is significantly slower. This saves over a minute on PAAPI.