### PR TITLE
Fix Selenium for local testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ group :development, :test do
   gem "rubocop-rails", require: false
   gem "rubocop-rspec", require: false
   gem "selenium-webdriver"
-  gem "webdrivers", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,10 +515,6 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -597,7 +593,6 @@ DEPENDENCIES
   strong_password (~> 0.0.9)
   view_component
   web-console
-  webdrivers
   webmock
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ docker run --rm -it -e DATABASE_URL=postgres://postgres@host.docker.internal:543
 ```sh
 $ bundle install
 $ yarn install
+$ brew install chromedriver  # as an admin user
 ```
 
 #### Create the databases

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -17,6 +17,11 @@ Capybara.register_driver :chrome_headless do |app|
   browser_options.args << "--window-size=1280,2800"
   browser_options.args << "--disable-gpu" if Gem.win_platform?
   browser_options.args << "--host-rules=MAP * 127.0.0.1"
+
+  if Gem::Platform.local.os == "darwin" && !(File.exist? "/Applications/Google Chrome for Testing.app")
+    browser_options.binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  end
+
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options).tap do |d|
     d.browser.download_path = download_path
   end


### PR DESCRIPTION
### Description of change

- Configure Selenium to use Chrome on MacOS
- Remove webdrivers gem which we no longer use

### Story Link

https://trello.com/c/U9dde5fb/1881-chromedriver-testing-is-broken
