### PR TITLE
Allow marking applications as CIL-liable

### DIFF
--- a/app/components/task_list_items/cil_liability_component.rb
+++ b/app/components/task_list_items/cil_liability_component.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class CilLiabilityComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+    end
+
+    private
+
+    attr_reader :planning_application
+
+    delegate(:cil_liable, to: :planning_application)
+
+    def link_text
+      t(".link_text")
+    end
+
+    def link_path
+      edit_planning_application_cil_liability_path(
+        planning_application
+      )
+    end
+
+    def status
+      case cil_liable
+      when TrueClass
+        :cil_liable
+      when FalseClass
+        :not_cil_liable
+      when NilClass
+        :not_started
+      else
+        raise "Unexpected value for `cil_liable': #{cil_liable.inspect}"
+      end
+    end
+  end
+end

--- a/app/controllers/planning_application/cil_liability_controller.rb
+++ b/app/controllers/planning_application/cil_liability_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class CilLiabilityController < ApplicationController
+    include PlanningApplicationAssessable
+    before_action :set_planning_application
+    before_action :ensure_planning_application_is_validated
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      if @planning_application.update(cil_liability_params)
+        redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def planning_application_id
+      Integer(params[:planning_application_id])
+    end
+
+    def planning_applications_scope
+      current_local_authority.planning_applications
+    end
+
+    def set_planning_application
+      planning_application = planning_applications_scope.find(planning_application_id)
+
+      @planning_application = PlanningApplicationPresenter.new(view_context, planning_application)
+    end
+
+    def cil_liability_params
+      params.require(:planning_application).permit([:cil_liable])
+    end
+  end
+end

--- a/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_application/assessment_tasks/_check_consistency.html.erb
@@ -54,5 +54,10 @@
         )
       ) %>
     <% end %>
+    <%= render(
+      TaskListItems::CilLiabilityComponent.new(
+        planning_application: @planning_application
+      )
+    ) %>
   </ul>
 </li>

--- a/app/views/planning_application/cil_liability/_form.html.erb
+++ b/app/views/planning_application/cil_liability/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with model: [@planning_application],
+              url: planning_application_cil_liability_url(@planning_application),
+              local: true,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+              class: "govuk-!-margin-top-7" do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+        :cil_liability,
+        legend: { text: "Is the application liable for CIL?", size: "s" }
+      ) do %>
+    <%= form.govuk_radio_button(
+          :cil_liable, true, checked: @planning_application.cil_liable, label: { text: "Yes" }
+        ) %>
+
+    <%= form.govuk_radio_button(
+          :cil_liable, false, checked: !@planning_application.cil_liable.nil? && !@planning_application.cil_liable, label: { text: "No" }
+        ) %>
+  <% end %>
+
+  <%= render(partial: "shared/submit_buttons", locals: { form: }) %>
+<% end %>

--- a/app/views/planning_application/cil_liability/edit.html.erb
+++ b/app/views/planning_application/cil_liability/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title do %>
+  CIL Liability - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "CIL Liability" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "CIL Liability" }
+    ) %>
+
+<%= render partial: "form" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -691,6 +691,9 @@ en:
         permitted_development_rights: Permitted development rights
       index:
         application_details: Application details
+    cil_liability:
+      update:
+        success: CIL liability updated
     consultation_neighbour_addresses:
       create:
         success: Addresses have been successfully added.
@@ -1054,6 +1057,7 @@ en:
     accepted: Printing
     awaiting_determination: Awaiting determination
     checked: Checked
+    cil_liable: Liable
     complete: Completed
     failed: Failed
     granted: To grant
@@ -1061,6 +1065,7 @@ en:
     in_progress: In progress
     invalid: Invalid
     neutral: Neutral
+    not_cil_liable: Not liable
     not_started: Not started
     objection: Objection
     permanent_failure: Permanent failure
@@ -1100,6 +1105,8 @@ en:
       summary_of_work: Summary of works
     check_red_line_boundary_component:
       check_red_line: Check red line boundary
+    cil_liability_component:
+      link_text: CIL Liability
     document_component:
       check_document: Check document - %{document}
     fee_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,7 @@ Rails.application.routes.draw do
       resources :review_immunity_details, only: %i[edit update show]
 
       resources :permitted_development_rights, only: %i[new create edit update show]
+      resource :cil_liability, only: %i[edit update], controller: :cil_liability
 
       resources :review_immunity_enforcements, only: %i[show edit update]
 

--- a/db/migrate/20230822145120_add_cil_liable_to_planning_application.rb
+++ b/db/migrate/20230822145120_add_cil_liable_to_planning_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCilLiableToPlanningApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :cil_liable, :boolean, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -443,6 +443,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_082636) do
     t.bigint "application_type_id"
     t.boolean "make_public", default: false
     t.boolean "legislation_checked", default: false, null: false
+    t.boolean "cil_liable"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/spec/system/planning_applications/assessing/cil_liability_spec.rb
+++ b/spec/system/planning_applications/assessing/cil_liability_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Permitted development right" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, :in_assessment, old_constraints: [], local_authority: default_local_authority)
+  end
+
+  context "when signed in as an assessor" do
+    before do
+      sign_in assessor
+      visit planning_application_path(planning_application)
+    end
+
+    context "when planning application is in assessment" do
+      it "is listed as incomplete by default" do
+        visit planning_application_assessment_tasks_path(planning_application)
+
+        within "#check-consistency-assessment-tasks" do
+          expect(page).to have_content "CIL Liability Not started"
+        end
+      end
+
+      it "can be marked as liable" do
+        visit planning_application_assessment_tasks_path(planning_application)
+        click_link "CIL Liability"
+        choose "Yes"
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "CIL liability updated"
+        within "#check-consistency-assessment-tasks" do
+          expect(page).to have_content "CIL Liability Liable"
+        end
+      end
+
+      it "can be marked as not liable" do
+        visit planning_application_assessment_tasks_path(planning_application)
+        click_link "CIL Liability"
+        choose "No"
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "CIL liability updated"
+        within "#check-consistency-assessment-tasks" do
+          expect(page).to have_content "CIL Liability Not liable"
+        end
+      end
+
+      context "when revisiting the edit page" do
+        it "is marked as true when liable" do
+          visit planning_application_assessment_tasks_path(planning_application)
+          click_link "CIL Liability"
+          choose "Yes"
+          click_button "Save and mark as complete"
+
+          click_link "CIL Liability"
+
+          expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
+          expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+        end
+
+        it "is marked as false when not liable" do
+          visit planning_application_assessment_tasks_path(planning_application)
+          click_link "CIL Liability"
+          choose "No"
+          click_button "Save and mark as complete"
+
+          click_link "CIL Liability"
+
+          expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+          expect(find_by_id("planning-application-cil-liable-field")).to be_selected
+        end
+      end
+    end
+  end
+
+  context "when planning application has not been validated yet" do
+    let!(:planning_application) do
+      create(:planning_application, :not_started, local_authority: default_local_authority)
+    end
+
+    it "does not allow me to visit the page" do
+      sign_in assessor
+      visit planning_application_path(planning_application)
+
+      expect(page).not_to have_link("CIL Liability")
+
+      visit edit_planning_application_cil_liability_path(planning_application)
+
+      expect(page).to have_content("forbidden")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add database field and form for editing CIL liability status.

### Story Link

https://trello.com/c/bJFCoQ00/1803-record-an-application-if-its-cil-liable

### Screenshots

<img width="664" alt="Screenshot 2023-08-30 at 16 53 54" src="https://github.com/unboxed/bops/assets/3986/859ddf1a-1698-4acf-8b9d-f08af9618c1f">

<img width="688" alt="Screenshot 2023-08-30 at 16 54 38" src="https://github.com/unboxed/bops/assets/3986/06508ecb-8915-42c5-a282-cdfc9bfe606f">


### Known issues [OPTIONAL]

The "Save and come back later" button might actually be meaningless for this.