### PR TITLE
Install and use systemwide chromedriver in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ docker-compose.yml
 bops-applicants
 deploy
 pkg
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN gem install bundler -v 2.3.26
 RUN apt-get update -y
 
 # Install Chromium for the feature tests
-RUN apt-get install -y --no-install-recommends chromium
+RUN apt-get install -y --no-install-recommends chromium chromium-driver
 
 # Install Poppler to generate PDF previews
 RUN apt-get install -y --no-install-recommends poppler-utils

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -22,6 +22,17 @@ Capybara.register_driver :chrome_headless do |app|
     browser_options.binary = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
   end
 
+  if Gem::Platform.local.os != "darwin"
+    # Probably Docker/GHA
+    %w[/usr/local/bin /usr/bin].each do |path|
+      driver_path = "#{path}/chromedriver"
+      if File.exist? driver_path
+        Selenium::WebDriver::Chrome::Service.driver_path = driver_path
+        break
+      end
+    end
+  end
+
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: browser_options).tap do |d|
     d.browser.download_path = download_path
   end


### PR DESCRIPTION
### Description of change

Install and use Chromedriver in the dev docker container.

### Story Link

https://trello.com/c/U9dde5fb/1881-chromedriver-testing-is-broken