### PR TITLE
Use dependabot security PRs instead of bundle-audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,16 @@
 version: 2
 updates:
+  - package-ecosystem: "bundle"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # security only
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0 # security only

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bundle-audit:
-    uses: ./.github/workflows/linters.yml
-    with:
-      bundler-audit: true
-
   brakeman:
     uses: ./.github/workflows/linters.yml
     with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,9 +4,6 @@ name: Verify
 on:
   workflow_call:
     inputs:
-      bundler-audit:
-        type: boolean
-        default: false
       brakeman:
         type: boolean
         default: false
@@ -41,11 +38,6 @@ jobs:
         with:
           node-version-file: .node-version
       - run: yarn install
-
-      - name: Check bundle for known CVEs
-        if: ${{ inputs.bundler-audit == true }}
-        run: |
-          bundle exec bundler-audit
 
       - name: Analyse code for vulnerabilities
         if: ${{ inputs.brakeman == true }}

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,6 @@ gem "view_component"
 group :development, :test do
   gem "brakeman", require: false
   gem "bullet"
-  gem "bundler-audit", require: false
   gem "guard", require: false
   gem "guard-cucumber", require: false
   gem "guard-rspec", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,9 +105,6 @@ GEM
     bullet (7.0.7)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    bundler-audit (0.9.1)
-      bundler (>= 1.2.0, < 3)
-      thor (~> 1.0)
     business_time (0.13.0)
       activesupport (>= 3.2.0)
       tzinfo
@@ -542,7 +539,6 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   brakeman
   bullet
-  bundler-audit
   business_time
   capybara
   cucumber-rails


### PR DESCRIPTION
The way we monitor using bundle-audit is suboptimal.

It flags up outdated gems in PRs, but first of all, we wouldn’t normally update the dependency in an unrelated PR anyway. We’d have to open a new PR, merge it, then rebase every PR onto main to get it to pass again. (Nothing wrong with rebasing in general, but this feels unnecessary because simply merging should be enough here, but bundle-audit can’t tell that.)

In particular, when there’s more than one vulnerability, a PR for either one will fail its checks because the other won’t have been updated. So we either do two upgrades in one PR, or we ignore the check and merge regardless.

Instead, we can configure Dependabot to automatically open PRs for security alerts. (It already does the alert but reducing manual steps seems positive.)
