### PR TITLE
Allow editing consultee responses

### DIFF
--- a/app/controllers/consultees_controller.rb
+++ b/app/controllers/consultees_controller.rb
@@ -2,11 +2,26 @@
 
 class ConsulteesController < AuthenticationController
   before_action :set_planning_application
+  before_action :set_consultee, only: %i[edit update]
+
+  def edit
+    respond_to do |format|
+      format.html
+    end
+  end
 
   def create
     consultee = planning_application.consultees.new(consultee_params)
     consultee = planning_application.consultees.new if consultee.save
     render(json: { partial: consultees_partial(consultee) })
+  end
+
+  def update
+    if @consultee.update(consultee_params)
+      redirect_to after_update_consultees_path, notice: t(".success")
+    else
+      render :edit
+    end
   end
 
   def destroy
@@ -17,6 +32,20 @@ class ConsulteesController < AuthenticationController
   private
 
   attr_reader :planning_application
+
+  def after_update_consultees_path
+    # it's possible that the list of consultees is being edited before the
+    # consultation summary has been saved and so we can't link to the edit path
+    if (consultation_summary = planning_application.consultation_summary)
+      edit_planning_application_assessment_detail_path(planning_application, consultation_summary)
+    else
+      new_planning_application_assessment_detail_path(planning_application, category: "consultation_summary")
+    end
+  end
+
+  def set_consultee
+    @consultee = planning_application.consultees.find(Integer(params[:id]))
+  end
 
   def consultees_partial(consultee)
     render_to_string(
@@ -40,6 +69,6 @@ class ConsulteesController < AuthenticationController
   end
 
   def consultee_params
-    params.require(:consultee).permit(:name, :origin)
+    params.require(:consultee).permit(:name, :origin, :response)
   end
 end

--- a/app/views/consultees/edit.html.erb
+++ b/app/views/consultees/edit.html.erb
@@ -1,0 +1,45 @@
+<% content_for :page_title do %>
+  Edit consultee response - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Publicity", planning_application_path(@planning_application) %>
+<% content_for :title, "Edit neighbour response" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Edit consultee response" }
+    ) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-7">Edit the response</h2>
+<%= form_with(
+      model: [@planning_application, @consultee],
+      action: planning_application_consultee_path(@planning_application, @consultee),
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+      class: "govuk-!-margin-top-5",
+      method: :patch
+    ) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <% if @consultee.errors.any? %>
+    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <% @consultee.errors.full_messages.each do |error| %>
+            <li><%= error %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+  <%= form.govuk_text_field :name %>
+  <%= form.govuk_text_area :response, value: form.object.response %>
+  <%= form.submit(
+        "Update response",
+        class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
+      ) %>
+  <%= link_to "Back", planning_application_consultee_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+<% end %>

--- a/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
@@ -8,6 +8,9 @@
         </td>
         <% unless read_only %>
           <td class="govuk-table__cell">
+            <%= link_to "Edit response", edit_planning_application_consultee_path(planning_application, consultee), class: "govuk-link" %>
+          </td>
+          <td class="govuk-table__cell">
             <%= button_tag(
               t(".remove_from_list"),
               class: "button-as-link",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -462,6 +462,9 @@ en:
       update_constraints: Update constraints
     update:
       success: Constraints have been updated
+  consultees:
+    update:
+      success: Consultee response has been updated
   date:
     formats:
       default: "%-d %B %Y"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
 
   resources :planning_applications, only: %i[index show new edit create update] do
     resource :assessment_report_download, only: :show
-    resources :consultees, only: %i[create destroy]
+    resources :consultees, only: %i[create destroy edit update]
     resource(:consistency_checklist, only: %i[new create edit update show])
     resource :review_assessment_details, only: %i[show edit update]
 

--- a/db/migrate/20230905150942_add_response_to_consultee.rb
+++ b/db/migrate/20230905150942_add_response_to_consultee.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddResponseToConsultee < ActiveRecord::Migration[7.0]
+  def change
+    add_column :consultees, :response, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_25_082636) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -165,6 +165,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_25_082636) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "consultation_id"
+    t.text "response"
     t.index ["consultation_id"], name: "ix_consultees_on_consultation_id"
     t.index ["planning_application_id"], name: "ix_consultees_on_planning_application_id"
   end


### PR DESCRIPTION
### Description of change

In order to be able to view consultee responses we need to be able to track them, not just a summary of them.

### Story Link

https://trello.com/c/KYztoXq0/1888-view-all-comments-received-from-consultees

### Screenshots

Added "edit response" link to list of consultees:
<img width="649" alt="Screenshot 2023-09-06 at 10 11 38" src="https://github.com/unboxed/bops/assets/3986/7ab1540d-c3c9-4bb1-8812-1a5fccd4de50">

Which links to a form:
<img width="975" alt="Screenshot 2023-09-06 at 10 12 10" src="https://github.com/unboxed/bops/assets/3986/69f57365-8721-4a02-9a83-e67f371d8244">