### PR TITLE
Show PlanX response relating to CIL liability when assessing

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -314,6 +314,17 @@ class PlanningApplication < ApplicationRecord
     proposal_details.select { |detail| detail.question == question }
   end
 
+  def cil_liability_proposal_detail
+    [
+      "How much new floor area is being added to the house?",
+      "How much new floor area is being created?"
+    ].filter_map { |q| find_proposal_detail(q) }.first&.first
+  end
+
+  def likely_cil_liable?
+    cil_liability_proposal_detail&.response_values&.first != "Less than 100m²"
+  end
+
   def secure_change_url
     protocol = Rails.env.production? ? "https" : "http"
 

--- a/app/views/planning_application/cil_liability/_form.html.erb
+++ b/app/views/planning_application/cil_liability/_form.html.erb
@@ -10,11 +10,11 @@
         legend: { text: "Is the application liable for CIL?", size: "s" }
       ) do %>
     <%= form.govuk_radio_button(
-          :cil_liable, true, checked: @planning_application.cil_liable, label: { text: "Yes" }
+          :cil_liable, true, checked: @planning_application.cil_liable.nil? ? @planning_application.cil_liable : @planning_application.likely_cil_liable?, label: { text: "Yes" }
         ) %>
 
     <%= form.govuk_radio_button(
-          :cil_liable, false, checked: !@planning_application.cil_liable.nil? && !@planning_application.cil_liable, label: { text: "No" }
+          :cil_liable, false, checked: @planning_application.cil_liable.nil? ? !@planning_application.likely_cil_liable? : !@planning_application.cil_liable, label: { text: "No" }
         ) %>
   <% end %>
 

--- a/app/views/planning_application/cil_liability/edit.html.erb
+++ b/app/views/planning_application/cil_liability/edit.html.erb
@@ -14,4 +14,19 @@
       locals: { heading: "CIL Liability" }
     ) %>
 
+<p class="govuk-body">
+  <% if @planning_application.cil_liability_proposal_detail.present? %>
+      According to PlanX the new floor area being added is:
+      <strong><%= @planning_application.cil_liability_proposal_detail.response_values.to_sentence %></strong>.
+      <br>
+      This might mean that the application is
+      <% unless @planning_application.likely_cil_liable? %>
+        not
+      <% end %>
+      liable for CIL.
+  <% else %>
+    No information on potential CIL liability from PlanX.
+  <% end %>
+</p>
+
 <%= render partial: "form" %>

--- a/spec/system/planning_applications/assessing/cil_liability_spec.rb
+++ b/spec/system/planning_applications/assessing/cil_liability_spec.rb
@@ -75,6 +75,71 @@ RSpec.describe "Permitted development right" do
           expect(find_by_id("planning-application-cil-liable-field")).to be_selected
         end
       end
+
+      context "when there is no liability information from planx" do
+        it "explains that there is no liability information" do
+          visit planning_application_assessment_tasks_path(planning_application)
+          click_link "CIL Liability"
+
+          expect(page).to have_content("No information on potential CIL liability from PlanX.")
+        end
+
+        it "does not preselect any radio button" do
+          visit planning_application_assessment_tasks_path(planning_application)
+          click_link "CIL Liability"
+
+          expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+          expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+        end
+      end
+
+      context "when there is liability information from planx" do
+        before do
+          cil_liability_proposal_detail = instance_double(ProposalDetail)
+          allow(cil_liability_proposal_detail).to receive(:response_values).and_return([planx_response])
+          allow_any_instance_of(PlanningApplication).to receive(:cil_liability_proposal_detail).and_return(cil_liability_proposal_detail)
+        end
+
+        context "when the application might be liable" do
+          let(:planx_response) { "More than 100m²" }
+
+          it "shows relevant liability information" do
+            visit planning_application_assessment_tasks_path(planning_application)
+            click_link "CIL Liability"
+
+            expect(page).to have_content(planx_response)
+            expect(page).to have_content("This might mean that the application is liable for CIL.")
+          end
+
+          it "selects yes by default" do
+            visit planning_application_assessment_tasks_path(planning_application)
+            click_link "CIL Liability"
+
+            expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+            expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+          end
+        end
+
+        context "when the application might not be liable" do
+          let(:planx_response) { "Less than 100m²" }
+
+          it "shows relevant liability information" do
+            visit planning_application_assessment_tasks_path(planning_application)
+            click_link "CIL Liability"
+
+            expect(page).to have_content(planx_response)
+            expect(page).to have_content("This might mean that the application is not liable for CIL.")
+          end
+
+          it "selects no by default" do
+            visit planning_application_assessment_tasks_path(planning_application)
+            click_link "CIL Liability"
+
+            expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+            expect(find_by_id("planning-application-cil-liable-field")).to be_selected
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Description of change

For certain application types PlanX will send details which are relevant to determining whether the application is liable for CIL.

This is a draft both in terms of how to query that and how to display it.

### Story Link

https://trello.com/c/bJFCoQ00/1803-record-an-application-if-its-cil-liable

### Screenshots

<img width="655" alt="Screenshot 2023-09-06 at 16 43 58" src="https://github.com/unboxed/bops/assets/3986/1d8ff4fd-b8cc-407f-aa9f-1f789ca6a73a">
<img width="680" alt="Screenshot 2023-09-06 at 16 45 10" src="https://github.com/unboxed/bops/assets/3986/556da842-ad0d-4835-b5d5-713b198ba2cf">

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
