### PR TITLE
Use JSONB column type instead of JSON

### DIFF
--- a/db/migrate/20230906161817_use_jsonb_column_type.rb
+++ b/db/migrate/20230906161817_use_jsonb_column_type.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class UseJsonbColumnType < ActiveRecord::Migration[7.0]
+  def up
+    change_table :consultations do |t|
+      t.change :polygon_geojson, :jsonb
+    end
+
+    change_table :neighbour_letters do |t|
+      t.change :notify_response, :jsonb
+    end
+
+    change_table :planning_application_constraints_queries do |t|
+      t.change :geojson, :jsonb
+    end
+
+    change_table :planning_applications do |t|
+      t.change :boundary_geojson, :jsonb
+    end
+
+    change_table :red_line_boundary_change_validation_requests, bulk: true do |t|
+      t.change :new_geojson, :jsonb
+      t.change :original_geojson, :jsonb
+    end
+  end
+
+  def down
+    change_table :consultations do |t|
+      t.change :polygon_geojson, :json
+    end
+
+    change_table :neighbour_letters do |t|
+      t.change :notify_response, :json
+    end
+
+    change_table :planning_application_constraints_queries do |t|
+      t.change :geojson, :json
+    end
+
+    change_table :planning_applications do |t|
+      t.change :boundary_geojson, :json
+    end
+
+    change_table :red_line_boundary_change_validation_requests, bulk: true do |t|
+      t.change :new_geojson, :json
+      t.change :original_geojson, :json
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_06_161817) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -153,7 +153,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
     t.string "neighbour_letter_text"
     t.datetime "end_date"
     t.datetime "letter_copy_sent_at"
-    t.json "polygon_geojson"
+    t.jsonb "polygon_geojson"
     t.string "polygon_colour", default: "#d870fc", null: false
     t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id"
   end
@@ -265,7 +265,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
     t.bigint "neighbour_id", null: false
     t.string "text"
     t.string "sent_at"
-    t.json "notify_response"
+    t.jsonb "notify_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "notify_id"
@@ -359,7 +359,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
   end
 
   create_table "planning_application_constraints_queries", force: :cascade do |t|
-    t.json "geojson", null: false
+    t.jsonb "geojson", null: false
     t.text "wkt", null: false
     t.string "planx_query", null: false
     t.string "planning_data_query", null: false
@@ -406,7 +406,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
     t.string "county"
     t.string "postcode"
     t.string "uprn"
-    t.json "boundary_geojson"
+    t.jsonb "boundary_geojson"
     t.text "old_constraints", default: [], null: false, array: true
     t.string "change_access_id"
     t.date "expiry_date"
@@ -512,7 +512,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
     t.integer "planning_application_id", null: false
     t.integer "user_id", null: false
     t.string "state", null: false
-    t.json "new_geojson", null: false
+    t.jsonb "new_geojson", null: false
     t.string "reason", null: false
     t.string "rejection_reason"
     t.boolean "approved"
@@ -522,7 +522,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_150942) do
     t.date "notified_at"
     t.text "cancel_reason"
     t.datetime "cancelled_at", precision: nil
-    t.json "original_geojson"
+    t.jsonb "original_geojson"
     t.boolean "post_validation", default: false, null: false
     t.boolean "auto_closed", default: false, null: false
     t.datetime "auto_closed_at", precision: nil


### PR DESCRIPTION
### Description of change

The JSON column type, as I understand, stores JSON in a string-based format, and parses it into a data structure on read. JSONB on the other hand parses it on write, and stores it as a data structure. This makes writes very slightly slower but reads faster; as we do more reads than writes this seems like a worthwhile tradeoff.

There don't seem to be any specific requirements for converting the row types in current versions of Rails (in older versions it was harder). The migration might take a little time but likely under a minute given the number of records we currently have.