### PR TITLE
Add planning_permission full householder application type

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -3,7 +3,7 @@
 class ApplicationType < ApplicationRecord
   APPLICATION_STEPS = %i[validation publicity assessment review].freeze
 
-  NAME_ORDER = %w[prior_approval lawfulness_certificate].freeze
+  NAME_ORDER = %w[prior_approval planning_permission lawfulness_certificate].freeze
 
   default_scope { in_order_of(:name, NAME_ORDER).order(:name) }
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -87,7 +87,7 @@ class PlanningApplication < ApplicationRecord
   before_create :set_change_access_id
   after_create :set_ward_and_parish_information
   after_create :create_audit!
-  after_create :update_measurements, if: :prior_approval_case?
+  after_create :update_measurements, if: :prior_approval?
   before_update :set_key_dates
   before_update lambda {
                   reset_validation_requests_update_counter!(red_line_boundary_change_validation_requests)
@@ -806,7 +806,9 @@ class PlanningApplication < ApplicationRecord
     end
   end
 
-  def prior_approval_case?
-    type == "Prior approval"
+  ApplicationType::NAME_ORDER.each do |name|
+    define_method "#{name}?" do
+      name == application_type_name
+    end
   end
 end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -73,6 +73,7 @@ class PlanningApplicationCreationService
 
   def planning_application_params
     check_for_prior_approval
+    check_for_planning_permission
 
     permitted_keys = [:application_type,
                       :description,
@@ -140,6 +141,10 @@ class PlanningApplicationCreationService
     raise CreateError, "BoPS does not accept this Prior Approval type" unless permitted_prior_approval_type?
 
     params[:application_type] = "prior_approval"
+  end
+
+  def check_for_planning_permission
+    params[:application_type] = "planning_permission" if params[:application_type] == "Apply for planning permission"
   end
 
   def permitted_prior_approval_type?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,8 @@ en:
     lawfulness_certificate:
       existing: LDCE
       proposed: LDCP
+    planning_permission:
+      proposed: HAPP
     prior_approval:
       existing: PA
       proposed: PA
@@ -237,6 +239,7 @@ en:
           description: Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A.
           link: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made
           link_text: The Town and Country Planning (General Permitted Development) (England) Order 2015
+    planning_permission: Full householder planning permission
     prior_approval: Prior approval
     prior_approval_abbr: PA
   archive_reasons:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -58,8 +58,15 @@ local_authorities.each do |authority|
   end
 end
 
-ApplicationType.create(name: "lawfulness_certificate")
-ApplicationType.create(name: "prior_approval", part: 1, section: "A")
+application_types = [
+  { name: "lawfulness_certificate" },
+  { name: "prior_approval", part: 1, section: "A" },
+  { name: "planning_permission" }
+]
+
+application_types.each do |attrs|
+  ApplicationType.find_or_create_by!(attrs)
+end
 
 constraints_list = {
   flooding: [

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -8,6 +8,10 @@ FactoryBot.define do
       name { "prior_approval" }
     end
 
+    trait :planning_permission do
+      name { "planning_permission" }
+    end
+
     initialize_with { ApplicationType.find_or_create_by(name:) }
   end
 end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -282,6 +282,10 @@ FactoryBot.define do
       end
     end
 
+    trait :planning_permission do
+      application_type { association :application_type, :planning_permission }
+    end
+
     trait :with_consultees do
       after(:create) do |planning_application|
         create_list(:consultee, 3, planning_application:)

--- a/spec/fixtures/files/planx_params_planning_permission_full_householder.json
+++ b/spec/fixtures/files/planx_params_planning_permission_full_householder.json
@@ -1,0 +1,899 @@
+{
+  "action": "create",
+  "application_type": "Apply for planning permission",
+  "applicant_first_name": "Albert",
+  "applicant_last_name": "Manteras",
+  "applicant_phone": "23432325435",
+  "applicant_email": "applicant@example.com",
+  "agent_first_name": "Jennifer",
+  "agent_last_name": "Harper",
+  "agent_phone": "237878889",
+  "agent_email": "agent@example.com",
+  "boundary_geojson": {
+    "geometry": {
+      "coordinates": [
+        [
+          [
+            -0.08776590228080519,
+            51.44966858819353
+          ],
+          [
+            -0.08766129612922446,
+            51.44968196065312
+          ],
+          [
+            -0.08747622370719702,
+            51.44934764798825
+          ],
+          [
+            -0.08756607770919585,
+            51.44930836608941
+          ],
+          [
+            -0.08776590228080519,
+            51.44966858819353
+          ]
+        ]
+      ],
+      "type": "Polygon"
+    },
+    "properties": null,
+    "type": "Feature"
+  },
+  "constraints": {
+    "article4": false,
+    "article4.southwark.caz": false,
+    "designated": true,
+    "designated.AONB": false,
+    "designated.SPA": false,
+    "designated.WHS": false,
+    "designated.conservationArea": true,
+    "designated.nationalPark": false,
+    "designated.nationalPark.broads": false,
+    "listed": false,
+    "locallyListed": false,
+    "monument": false,
+    "nature.ASNW": false,
+    "nature.SAC": false,
+    "nature.SSSI": false,
+    "registeredPark": false,
+    "road.classified": true,
+    "tpo": false
+  },
+  "constraints_proposed": [
+    {
+      "constraints": {
+        "article4": {
+          "category": "General policy",
+          "fn": "article4",
+          "text": "is not subject to local permitted development restrictions (known as Article 4 directions)",
+          "value": false
+        },
+        "article4.southwark.caz": {
+          "category": "General policy",
+          "fn": "article4.caz",
+          "text": "is not in the Central Activities Zone",
+          "value": false
+        },
+        "designated": {
+          "value": true
+        },
+        "designated.AONB": {
+          "category": "Heritage and conservation",
+          "fn": "designated.AONB",
+          "text": "is not in an Area of Outstanding Natural Beauty",
+          "value": false
+        },
+        "designated.SPA": {
+          "category": "Heritage and conservation",
+          "fn": "designated.SPA",
+          "text": "is not in a Special Protection Area (SPA)",
+          "value": false
+        },
+        "designated.WHS": {
+          "category": "Heritage and conservation",
+          "fn": "designated.WHS",
+          "text": "is not an UNESCO World Heritage Site",
+          "value": false
+        },
+        "designated.conservationArea": {
+          "category": "Heritage and conservation",
+          "data": [
+            {
+              "dataset": "conservation-area",
+              "documentation-url": "https://www.southwark.gov.uk/planning-and-building-control/design-and-conservation/conservation-areas?chapter=11",
+              "end-date": "",
+              "entity": 44007440,
+              "entry-date": "2023-08-16",
+              "name": "Dulwich Village",
+              "organisation-entity": "329",
+              "prefix": "conservation-area",
+              "reference": "7",
+              "start-date": "1968-09-27",
+              "typology": "geography"
+            }
+          ],
+          "fn": "designated.conservationArea",
+          "text": "is in a Conservation Area",
+          "value": true
+        },
+        "designated.nationalPark": {
+          "category": "Heritage and conservation",
+          "fn": "designated.nationalPark",
+          "text": "is not in a National Park",
+          "value": false
+        },
+        "designated.nationalPark.broads": {
+          "fn": "designated.nationalPark.broads",
+          "value": false
+        },
+        "listed": {
+          "category": "Heritage and conservation",
+          "fn": "listed",
+          "text": "is not, or is not within, a Listed Building",
+          "value": false
+        },
+        "locallyListed": {
+          "category": "Heritage and conservation",
+          "fn": "locallyListed",
+          "text": "is not, or is not within, a Locally Listed Building",
+          "value": false
+        },
+        "monument": {
+          "category": "Heritage and conservation",
+          "fn": "monument",
+          "text": "is not the site of a Scheduled Monument",
+          "value": false
+        },
+        "nature.ASNW": {
+          "category": "Ecology",
+          "fn": "nature.ASNW",
+          "text": "is not in an Ancient Semi-Natural Woodland (ASNW)",
+          "value": false
+        },
+        "nature.SAC": {
+          "category": "Ecology",
+          "fn": "nature.SAC",
+          "text": "is not in a Special Area of Conservation (SAC)",
+          "value": false
+        },
+        "nature.SSSI": {
+          "category": "Ecology",
+          "fn": "nature.SSSI",
+          "text": "is not a Site of Special Scientific Interest (SSSI)",
+          "value": false
+        },
+        "registeredPark": {
+          "category": "Heritage and conservation",
+          "fn": "registeredPark",
+          "text": "is not in a Historic Park or Garden",
+          "value": false
+        },
+        "tpo": {
+          "category": "Trees",
+          "fn": "tpo",
+          "text": "is not in a Tree Preservation Order (TPO) Zone",
+          "value": false
+        }
+      },
+      "metadata": {
+        "article4": {
+          "attribution": "crown-copyright",
+          "attribution-text": "© Crown copyright and database right 2023",
+          "collection": "article-4-direction",
+          "dataset": "article-4-direction-area",
+          "description": "Orders made by the local planning authority to remove all or some of the permitted development rights on a site in order to protect it",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 1369,
+            "dataset": "article-4-direction-area"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Article 4 direction area",
+          "paint-options": "",
+          "plural": "Article 4 direction areas",
+          "prefix": "",
+          "start-date": "",
+          "text": "A local planning authority may create an [article 4 direction](https://www.gov.uk/guidance/when-is-permission-required#article-4-direction) to alter or remove [permitted development rights](https://www.gov.uk/government/publications/permitted-development-rights-for-householders-technical-guidance) from a building or area.\n\nEach [article 4 direction](/dataset/article-4-direction) may apply to one or more article 4 direction areas, each with one or more [article 4 direction rules](/dataset/article-4-direction-rule).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for article 4 directions](https://www.digital-land.info/guidance/specifications/article-4-direction).",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "",
+          "wikipedia": ""
+        },
+        "article4.caz": {
+          "attribution": "crown-copyright",
+          "attribution-text": "© Crown copyright and database right 2023",
+          "collection": "central-activities-zone",
+          "dataset": "central-activities-zone",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 10,
+            "dataset": "central-activities-zone"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Central activities zone",
+          "paint-options": "",
+          "plural": "Central activities zones",
+          "prefix": "",
+          "start-date": "",
+          "text": "The [Greater London Authority](https://www.london.gov.uk/) (GLA) designates a central area of London with [implications for planning](https://www.london.gov.uk/what-we-do/planning/implementing-london-plan/london-plan-guidance-and-spgs/central-activities-zone)\nThis dataset combines data provided by the GLA with the boundary from the individual London boroughs.",
+          "themes": [
+            "development"
+          ],
+          "typology": "geography",
+          "wikidata": "",
+          "wikipedia": ""
+        },
+        "designated.AONB": {
+          "attribution": "natural-england",
+          "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2023.",
+          "collection": "area-of-outstanding-natural-beauty",
+          "dataset": "area-of-outstanding-natural-beauty",
+          "description": "Land protected by law to conserve and enhance its natural beauty",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 34,
+            "dataset": "area-of-outstanding-natural-beauty"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Area of outstanding natural beauty",
+          "paint-options": {
+            "colour": "#d53880"
+          },
+          "plural": "Areas of outstanding natural beauty",
+          "prefix": "",
+          "start-date": "",
+          "text": "An area of outstanding natural beauty (AONB) as designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\n\nNatural England provides [guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications) to help local authorities decide on planning applications in protected sites and areas.",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "Q174945",
+          "wikipedia": "Area_of_Outstanding_Natural_Beauty"
+        },
+        "designated.SPA": {
+          "attribution": "natural-england",
+          "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2023.",
+          "collection": "special-protection-area",
+          "dataset": "special-protection-area",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 88,
+            "dataset": "special-protection-area"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Special protection area",
+          "paint-options": "",
+          "plural": "Special protection areas",
+          "prefix": "",
+          "start-date": "",
+          "text": "[Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated \nfor the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "",
+          "wikipedia": ""
+        },
+        "designated.WHS": {
+          "attribution": "historic-england",
+          "attribution-text": "© Historic England 2023. Contains Ordnance Survey data © Crown copyright and database right 2023.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+          "collection": "historic-england",
+          "dataset": "world-heritage-site-buffer-zone",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 8,
+            "dataset": "world-heritage-site-buffer-zone"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "World heritage site buffer zone",
+          "paint-options": {
+            "colour": "#EB1EE5"
+          },
+          "plural": "World heritage site buffer zones",
+          "prefix": "",
+          "start-date": "",
+          "text": "A [World Heritage Site](/dataset/world-heritage-site) may have a [buffer zone](https://whc.unesco.org/en/series/25/) with implications for planning.",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q9259",
+          "wikipedia": "World_Heritage_Site"
+        },
+        "designated.conservationArea": {
+          "attribution": "historic-england",
+          "attribution-text": "© Historic England 2023. Contains Ordnance Survey data © Crown copyright and database right 2023.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+          "collection": "conservation-area",
+          "dataset": "conservation-area",
+          "description": "Special architectural or historic interest, the character or appearance of which it is desirable to preserve or enhance",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 8600,
+            "dataset": "conservation-area"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Conservation area",
+          "paint-options": {
+            "colour": "#78AA00"
+          },
+          "plural": "Conservation areas",
+          "prefix": "",
+          "start-date": "",
+          "text": "Local planning authorities are responsible for designating conservation areas, though [Historic England](https://historicengland.org.uk/) and the Secretary of State also have powers to create them.\n\nThis dataset also contains the boundaries of conservation areas from Historic England, as well as other data found on [data.gov.uk](https://www.data.gov.uk/search?q=conservation+area) and currently contains a number of duplicate areas we are working to remove.\n\nWe are also [working with a group of local planning authorities](/about/) to help them publish their conservation areas, and to develop a [data specification for conservation areas](https://www.digital-land.info/guidance/specifications/conservation-area).\n\nHistoric England provide [guidance](https://historicengland.org.uk/advice/your-home/owning-historic-property/conservation-area/) to help householders understand the implications of living in a conservation area for planning applications.",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q5162904",
+          "wikipedia": "Conservation_area_(United_Kingdom)"
+        },
+        "designated.nationalPark": {
+          "attribution": "ons-boundary",
+          "attribution-text": "Source: Office for National Statistics licensed under the Open Government Licence v.3.0\nContains OS data © Crown copyright and database right 2023",
+          "collection": "national-park",
+          "dataset": "national-park",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 10,
+            "dataset": "national-park"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "National park",
+          "paint-options": {
+            "colour": "#3DA52C"
+          },
+          "plural": "National parks",
+          "prefix": "statistical-geography",
+          "start-date": "",
+          "text": "The administrative boundaries of [national park authorities](/dataset/national-park-authority) in England as provided by the ONS for the purposes of producing statistics.",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q60256727",
+          "wikipedia": "National_park"
+        },
+        "listed": {
+          "attribution": "crown-copyright",
+          "attribution-text": "© Crown copyright and database right 2023",
+          "collection": "listed-building",
+          "dataset": "listed-building-outline",
+          "description": "boundary of a listed building",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 12237,
+            "dataset": "listed-building-outline"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Listed building outline",
+          "paint-options": {
+            "colour": "#F9C744"
+          },
+          "plural": "Listed building outlines",
+          "prefix": "",
+          "start-date": "",
+          "text": "The geospatial boundary for [listed buildings](https://historicengland.org.uk/listing/what-is-designation/listed-buildings) as designated by [Historic England](https://historicengland.org.uk/) as collected from local planning authorities.\n\nWe are [working with a group of local planning authorities](/about/) to help them publish their data to inform planning decisions, and to develop a [data specification for listed building outlines](https://www.digital-land.info/guidance/specifications/listed-building).\n\nWe expect to eventually merge this dataset with the [listed building](/dataset/listed-building) dataset.",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q570600",
+          "wikipedia": "Listed_building"
+        },
+        "locallyListed": {
+          "attribution": "crown-copyright",
+          "attribution-text": "© Crown copyright and database right 2023",
+          "collection": "listed-building",
+          "dataset": "locally-listed-building",
+          "description": "locally listed heritage assets, including buildings",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 448,
+            "dataset": "locally-listed-building"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Locally listed building",
+          "paint-options": {
+            "colour": "#F9C744"
+          },
+          "plural": "Locally listed buildings",
+          "prefix": "",
+          "start-date": "",
+          "text": "A building or site in a local planning authority’s area that make a positive contribution to its local character and sense of place because of their heritage value. Although such heritage assets may not be nationally designated or even located within the boundaries of a conservation area, they may be offered some level of protection by the local planning authority identifying them on a formally adopted list of local heritage assets.\n\nThis is an experimental dataset of locally listed buildings found on [data.gov.uk](https://www.data.gov.uk/search?q=locally+listed+buildings).\nWe are [working with a group of local planning authorities](/about/) to help them publish their locally listed buildings, and to develop a data specification for locally listed buildings.",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q570600",
+          "wikipedia": "Listed_building#Locally_listed_buildings"
+        },
+        "monument": {
+          "attribution": "historic-england",
+          "attribution-text": "© Historic England 2023. Contains Ordnance Survey data © Crown copyright and database right 2023.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+          "collection": "historic-england",
+          "dataset": "scheduled-monument",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 19935,
+            "dataset": "scheduled-monument"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Scheduled monument",
+          "paint-options": {
+            "colour": "#0F9CDA"
+          },
+          "plural": "Scheduled monuments",
+          "prefix": "",
+          "start-date": "",
+          "text": "Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). \n\nThis list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).",
+          "themes": [
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q219538",
+          "wikipedia": "Scheduled_monument"
+        },
+        "nature.ASNW": {
+          "attribution": "natural-england",
+          "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2023.",
+          "collection": "ancient-woodland",
+          "dataset": "ancient-woodland",
+          "description": "An area that’s been wooded continuously since at least 1600 AD",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 44355,
+            "dataset": "ancient-woodland"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Ancient woodland",
+          "paint-options": {
+            "colour": "#00703c",
+            "opacity": 0.2
+          },
+          "plural": "Ancient woodlands",
+          "prefix": "",
+          "start-date": "",
+          "text": "An area designated as ancient woodland by Natural England.\n\nNatural England and Forestry Commission [Guidance](https://www.gov.uk/guidance/ancient-woodland-and-veteran-trees-protection-surveys-licences)  is used in planning decisions.",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "Q3078732",
+          "wikipedia": "Ancient_woodland"
+        },
+        "nature.SAC": {
+          "attribution": "natural-england",
+          "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2023.",
+          "collection": "special-area-of-conservation",
+          "dataset": "special-area-of-conservation",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 256,
+            "dataset": "special-area-of-conservation"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Special area of conservation",
+          "paint-options": {
+            "colour": "#7A8705"
+          },
+          "plural": "Special areas of conservation",
+          "prefix": "",
+          "start-date": "",
+          "text": "Special areas of conservation (SACs) are area of land which have been designated by\n[DEFRA](https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs),\nwith advice from the [Joint Nature Conservation Committee](https://jncc.gov.uk/),\nto protect specific habitats and species.\n\nDEFRA and [Natural England](https://www.gov.uk/government/organisations/natural-england) publish\n[guidance](https://www.gov.uk/guidance/protected-sites-and-areas-how-to-review-planning-applications)\non how to review planning applications in protected sites and areas.",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "Q1191622",
+          "wikipedia": "Special_Area_of_Conservation"
+        },
+        "nature.SSSI": {
+          "attribution": "natural-england",
+          "attribution-text": "© Natural England copyright. Contains Ordnance Survey data © Crown copyright and database right 2023.",
+          "collection": "site-of-special-scientific-interest",
+          "dataset": "site-of-special-scientific-interest",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 4128,
+            "dataset": "site-of-special-scientific-interest"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Site of special scientific interest",
+          "paint-options": {
+            "colour": "#308fac"
+          },
+          "plural": "Sites of special scientific interest",
+          "prefix": "",
+          "start-date": "",
+          "text": "Sites of special scientific interest (SSSI) are nationally protected sites that have features such as wildlife or geology. \n\nSSSIs are designated by [Natural England](https://www.gov.uk/government/organisations/natural-england).\nThere is [guidance](https://www.gov.uk/guidance/protected-areas-sites-of-special-scientific-interest) to help local authorities decide on planning applications in protected SSSIs.",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "Q422211",
+          "wikipedia": "Site_of_Special_Scientific_Interest"
+        },
+        "registeredPark": {
+          "attribution": "historic-england",
+          "attribution-text": "© Historic England 2023. Contains Ordnance Survey data © Crown copyright and database right 2023.\nThe Historic England GIS Data contained in this material was obtained on [date].\nThe most publicly available up to date Historic England GIS Data can be obtained from [HistoricEngland.org.uk](https://historicengland.org.uk).",
+          "collection": "historic-england",
+          "dataset": "park-and-garden",
+          "description": "",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 1699,
+            "dataset": "park-and-garden"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Historic parks and gardens",
+          "paint-options": {
+            "colour": "#0EB951"
+          },
+          "plural": "Parks and gardens",
+          "prefix": "",
+          "start-date": "",
+          "text": "Historic parks and gardens as listed by [Historic England](https://historicengland.org.uk/) in the [Register of Parks and Gardens of Special Historic Interest](https://historicengland.org.uk/listing/what-is-designation/registered-parks-and-gardens/).",
+          "themes": [
+            "environment",
+            "heritage"
+          ],
+          "typology": "geography",
+          "wikidata": "Q6975250",
+          "wikipedia": "Register_of_Historic_Parks_and_Gardens_of_Special_Historic_Interest_in_England"
+        },
+        "tpo": {
+          "attribution": "crown-copyright",
+          "attribution-text": "© Crown copyright and database right 2023",
+          "collection": "tree-preservation-order",
+          "dataset": "tree-preservation-zone",
+          "description": "An area covered by a tree preservation order",
+          "end-date": "",
+          "entities": "",
+          "entity-count": {
+            "count": 13161,
+            "dataset": "tree-preservation-zone"
+          },
+          "entry-date": "",
+          "licence": "ogl3",
+          "licence-text": "Licensed under the [Open Government Licence v.3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).",
+          "name": "Tree preservation zone",
+          "paint-options": "",
+          "plural": "Trees preservation zones",
+          "prefix": "",
+          "start-date": "",
+          "text": "A Tree Preservation Order (TPO) can be placed on single trees, groups of trees and even whole woodlands. Tree Preservation Orders are made by local planning authorities following [guidance](https://www.gov.uk/guidance/tree-preservation-orders-and-trees-in-conservation-areas) provided by the [Department for Levelling Up, Housing and Communities](https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities).\n\nEach [tree preservation order](/dataset/tree-preservation-order) may apply to a number of tree preservation order zones, and a number of individual [trees](/dataset/tree).\n\nThis dataset contains data from [a small group of local planning authorities](/about/) who we are working with to develop a [data specification for tree preservation orders](https://www.digital-land.info/guidance/specifications/tree-preservation-order).",
+          "themes": [
+            "environment"
+          ],
+          "typology": "geography",
+          "wikidata": "Q10884",
+          "wikipedia": "Tree"
+        }
+      },
+      "planxRequest": "https://api.editor.planx.dev/gis/southwark?geom=POLYGON+%28%28-0.08776590228080519+51.44966858819353%2C+-0.08766129612922446+51.44968196065312%2C+-0.08747622370719702+51.44934764798825%2C+-0.08756607770919585+51.44930836608941%2C+-0.08776590228080519+51.44966858819353%29%29&analytics=false&sessionId=59848044-2967-482f-95fa-51b8edc32dd1",
+      "sourceRequest": "https://www.planning.data.gov.uk/entity.json?entries=current&geometry=POLYGON+%28%28-0.08776590228080519+51.44966858819353%2C+-0.08766129612922446+51.44968196065312%2C+-0.08747622370719702+51.44934764798825%2C+-0.08756607770919585+51.44930836608941%2C+-0.08776590228080519+51.44966858819353%29%29&geometry_relation=intersects&limit=100&dataset=article-4-direction-area&dataset=central-activities-zone&dataset=listed-building&dataset=listed-building-outline&dataset=locally-listed-building&dataset=park-and-garden&dataset=conservation-area&dataset=area-of-outstanding-natural-beauty&dataset=national-park&dataset=world-heritage-site&dataset=world-heritage-site-buffer-zone&dataset=special-protection-area&dataset=scheduled-monument&dataset=tree&dataset=tree-preservation-order&dataset=tree-preservation-zone&dataset=site-of-special-scientific-interest&dataset=special-area-of-conservation&dataset=ancient-woodland"
+    },
+    {
+      "constraints": {
+        "road.classified": {
+          "category": "General policy",
+          "data": [
+            {
+              "name": "Turney Road - Classified Unnumbered",
+              "properties": {
+                "AlternateIdentifier": "5840_5328260173956",
+                "AlternateIdentifierScheme": "NSG Elementary Street Unit ID (ESU ID)",
+                "AlternateName1": "null",
+                "AlternateName1Lang": "null",
+                "AlternateName2": "null",
+                "AlternateName2Lang": "null",
+                "BeginLifespanVersion": "4/15/2017",
+                "CycleFacility": "null",
+                "Directionality": "bothDirections",
+                "ElevationGainInDir": "0.1",
+                "ElevationGainInOppDir": "0",
+                "EndGradeSeparation": 0,
+                "EndNode": "osgb4000000029961836",
+                "Fictitious": "false",
+                "FormOfWay": "Single Carriageway",
+                "FormsPartOf": "Road#osgb4000000030569610,Street#usrn22502561,Street#usrn22503450",
+                "GmlID": "Highways_RoadLink.147192",
+                "ID": "osgb5000005126474361",
+                "Identifier": "http://data.os.uk/id/5000005126474361",
+                "InspireIDLocalID": "5000005126474361",
+                "InspireIDNamespace": "http://data.os.uk/",
+                "Length": "39.56",
+                "LengthUOM": "m",
+                "MatchStatus": "Matched",
+                "NumberOfLanes1": null,
+                "NumberOfLanes1Direction": "null",
+                "NumberOfLanes1MinMax": "null",
+                "NumberOfLanes2": null,
+                "NumberOfLanes2Direction": "null",
+                "NumberOfLanes2MinMax": "null",
+                "NumberOfLanes3": null,
+                "NumberOfLanes3Direction": "null",
+                "NumberOfLanes3MinMax": "null",
+                "NumberOfLanes4": null,
+                "NumberOfLanes4Direction": "null",
+                "NumberOfLanes4MinMax": "null",
+                "OBJECTID": 147192,
+                "OperationalState": "Open",
+                "PrimaryRoute": "false",
+                "Provenance": "OS Urban And OS Height",
+                "ReasonForChange": "Modified Geometry And Attributes",
+                "RelatedRoadArea": "osgb1000001767336185,osgb1000001767336220,osgb1000001769528749,osgb1000001769528755",
+                "RoadClassification": "Classified Unnumbered",
+                "RoadClassificationNumber": "null",
+                "RoadName1": "Turney Road",
+                "RoadName1Lang": "null",
+                "RoadName2": "null",
+                "RoadName2Lang": "null",
+                "RoadStructure": "null",
+                "RoadWidth": "null",
+                "RoadWidthAverage": "9.3",
+                "RoadWidthConfidenceLevel": "OS Urban And Full Extent",
+                "RoadWidthMinimum": "8.9",
+                "RouteHierarchy": "Minor Road",
+                "SHAPE_Length": 39.56018336,
+                "StartGradeSeparation": 0,
+                "StartNode": "osgb5000005126472415",
+                "TrunkRoad": "false",
+                "ValidForm": "null"
+              }
+            }
+          ],
+          "fn": "road.classified",
+          "text": "is on a Classified Road",
+          "value": true
+        }
+      },
+      "metadata": {
+        "road.classified": {
+          "name": "Classified road",
+          "plural": "Classified roads",
+          "text": "This will effect your project if you are looking to add a dropped kerb. It may also impact some agricultural or forestry projects within 25 metres of a classified road."
+        }
+      },
+      "planxRequest": "https://api.editor.planx.dev/roads?usrn=22502561",
+      "sourceRequest": "https://api.os.uk/features/v1/wfs?service=WFS&request=GetFeature&version=2.0.0&typeNames=Highways_RoadLink&outputFormat=GEOJSON&srsName=urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326&count=1&filter=%0A++++%3Cogc%3AFilter%3E%0A++++++%3Cogc%3APropertyIsLike+wildCard%3D%22%25%22+singleChar%3D%22%23%22+escapeChar%3D%22%21%22%3E%0A++++++++%3Cogc%3APropertyName%3EFormsPartOf%3C%2Fogc%3APropertyName%3E%0A++++++++%3Cogc%3ALiteral%3E%25Street%23usrn22502561%25%3C%2Fogc%3ALiteral%3E%0A++++++%3C%2Fogc%3APropertyIsLike%3E%0A++++%3C%2Fogc%3AFilter%3E%0A++&"
+    }
+  ],
+  "controller": "api/v1/planning_applications",
+  "description": "Alterations to roof to create a loft conversion using an 'L' shaped dormer, to provide additional residential accommodation.",
+  "files": [
+    {
+      "filename": "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf",
+      "applicant_description": "This is the side plan",
+      "tags": [
+        "Side"
+      ]
+    }
+	],
+  "format": "json",
+  "payment_amount": 20600,
+  "payment_reference": "fb4v6c47coecjk40seh3ima37k",
+  "planning_application": {
+    "boundary_geojson": {
+      "geometry": {
+        "coordinates": [
+          [
+            [
+              -0.08776590228080519,
+              51.44966858819353
+            ],
+            [
+              -0.08766129612922446,
+              51.44968196065312
+            ],
+            [
+              -0.08747622370719702,
+              51.44934764798825
+            ],
+            [
+              -0.08756607770919585,
+              51.44930836608941
+            ],
+            [
+              -0.08776590228080519,
+              51.44966858819353
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "properties": null,
+      "type": "Feature"
+    },
+    "description": "Alterations to roof to create a loft conversion using an 'L' shaped dormer, to provide additional residential accommodation.",
+    "payment_amount": 20600,
+    "payment_reference": "fb4v6c47coecjk40seh3ima37k",
+    "proposal_details": [
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "The property"
+        },
+        "question": "Is the property in Southwark?",
+        "responses": [
+          {
+            "value": "Yes"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "The property"
+        },
+        "question": "Is the property in a flood zone?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "About the project"
+        },
+        "question": "What type of property is it?",
+        "responses": [
+          {
+            "metadata": {
+              "flags": [
+                "Listed building consent / Not required"
+              ]
+            },
+            "value": "House"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "section_name": "About the project"
+        },
+        "question": "List the changes involved in the project",
+        "responses": [
+          {
+            "metadata": {
+              "flags": [
+                "Listed building consent / Not required"
+              ]
+            },
+            "value": "Add roof dormers"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "section_name": "About the project"
+        },
+        "question": "Have works already started?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "About the project"
+        },
+        "question": "Is the property in a flood zone?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "About the project"
+        },
+        "question": "What type of changes does the project involve?",
+        "responses": [
+          {
+            "value": "Extension"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "auto_answered": true,
+          "section_name": "About the project"
+        },
+        "question": "Is the project to add an outbuilding?",
+        "responses": [
+          {
+            "value": "No"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "section_name": "About the project"
+        },
+        "question": "How much new floor area is being added to the house?",
+        "responses": [
+          {
+            "value": "Less than 100m²"
+          }
+        ]
+      },
+      {
+        "metadata": {
+          "policy_refs": [
+            {
+              "text": "The Town and Country Planning (Development Management Procedure) (England) 2015 (as amended)"
+            }
+          ],
+          "section_name": "About the project"
+        },
+        "question": "How much exactly is the internal floor area of the property increasing by?",
+        "responses": [
+          {
+            "value": "35"
+          }
+        ]
+      },
+      "[This array has been truncated from '73' values to '10' values]"
+    ],
+    "user_role": "agent"
+  }
+}

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -259,6 +259,17 @@ RSpec.describe PlanningApplication do
               .to("22-00100-PA")
           end
         end
+
+        it "is set for the planning permission full householder application type" do
+          planning_application = build(:planning_application, :planning_permission)
+
+          travel_to(DateTime.new(2022, 1, 1)) do
+            expect { planning_application.save }
+              .to change(planning_application, :reference)
+              .from(nil)
+              .to("22-00100-HAPP")
+          end
+        end
       end
     end
 

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -189,5 +189,26 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         end
       end
     end
+
+    context "when application type is planning permission full householder" do
+      let(:local_authority) { create(:local_authority) }
+      let(:params) { ActionController::Parameters.new(JSON.parse(file_fixture("planx_params_planning_permission_full_householder.json").read)) }
+      let!(:application_type) { create(:application_type, name: "planning_permission") }
+
+      let(:create_planning_application) do
+        described_class.new(
+          local_authority:, params:, api_user:
+        ).call
+      end
+
+      context "when successful" do
+        it "creates a new planning application from the params" do
+          expect { create_planning_application }.to change(PlanningApplication, :count).by(1)
+
+          planning_application = PlanningApplication.last
+          expect(planning_application.reference).to eq("#{planning_application.created_at.year % 100}-00100-HAPP")
+        end
+      end
+    end
   end
 end

--- a/spec/services/planning_application_search_spec.rb
+++ b/spec/services/planning_application_search_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe PlanningApplicationSearch do
     )
   end
 
+  let!(:planning_permission_full_householder_in_assessment) do
+    create(
+      :planning_application,
+      :in_assessment,
+      :planning_permission,
+      local_authority:,
+      received_at: nil
+    )
+  end
+
   before do
     Current.user = assessor
   end
@@ -84,6 +94,7 @@ RSpec.describe PlanningApplicationSearch do
                                     prior_approval_not_started,
                                     ldc_not_started,
                                     prior_approval_in_assessment,
+                                    planning_permission_full_householder_in_assessment,
                                     ldc_in_assessment_2,
                                     ldc_in_assessment_1
                                   ])
@@ -119,7 +130,8 @@ RSpec.describe PlanningApplicationSearch do
           ldc_not_started,
           prior_approval_in_assessment,
           ldc_in_assessment_2,
-          ldc_in_assessment_1
+          ldc_in_assessment_1,
+          planning_permission_full_householder_in_assessment
         )
       end
 
@@ -257,7 +269,8 @@ RSpec.describe PlanningApplicationSearch do
             ldc_not_started,
             prior_approval_in_assessment,
             ldc_in_assessment_2,
-            ldc_in_assessment_1
+            ldc_in_assessment_1,
+            planning_permission_full_householder_in_assessment
           )
         end
 

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe "Planning Application index page" do
         end
 
         expect(current_url).to include(
-          "query=&application_type%5B%5D=&application_type%5B%5D=prior_approval&status%5B%5D=&status%5B%5D=in_assessment#all"
+          "query=&application_type%5B%5D=&application_type%5B%5D=prior_approval&application_type%5B%5D=planning_permission&status%5B%5D=&status%5B%5D=in_assessment#all"
         )
       end
 
@@ -230,7 +230,7 @@ RSpec.describe "Planning Application index page" do
         end
 
         expect(current_url).to include(
-          "query=&application_type%5B%5D=&application_type%5B%5D=prior_approval&status%5B%5D=&status%5B%5D=not_started&status%5B%5D=invalidated&status%5B%5D=in_assessment&status%5B%5D=awaiting_determination&status%5B%5D=to_be_reviewed#all"
+          "query=&application_type%5B%5D=&application_type%5B%5D=prior_approval&application_type%5B%5D=planning_permission&status%5B%5D=&status%5B%5D=not_started&status%5B%5D=invalidated&status%5B%5D=in_assessment&status%5B%5D=awaiting_determination&status%5B%5D=to_be_reviewed#all"
         )
       end
 

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -95,6 +95,15 @@ RSpec.describe "Planning Application show page" do
     it "Assessment tasks are visible" do
       expect(page).to have_text("Check and assess")
     end
+
+    context "when application type is planning permission" do
+      let(:application_type) { create(:application_type, :planning_permission) }
+
+      it "I can view the correct application type name and the planning application code" do
+        expect(page).to have_content("#{planning_application.created_at.year % 100}-00100-HAPP")
+        expect(page).to have_content("Full householder planning permission")
+      end
+    end
   end
 
   context "as an assessor when target date is within a week" do


### PR DESCRIPTION
### Description of change

Add support for planning permission full householder applications.
Currently we receive `"application_type": "Apply for planning permission"` from PlanX so this is a temporary solution until they can send us the proper format 

### Story Link

https://trello.com/c/q26RKA7c/1986-add-householder-application-type-so-we-can-receive-this-from-planx