### PR TITLE
List consultee responses if any exist

### DIFF
--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -7,4 +7,6 @@ class Consultee < ApplicationRecord
   validates :name, :origin, presence: true
 
   enum origin: { internal: 0, external: 1 }
+
+  scope :with_response, -> { where.not(response: nil) }
 end

--- a/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_consultee_table.html.erb
@@ -6,6 +6,9 @@
         <td class="govuk-table__cell">
           <%= consultee.external? ? t(".external") : t(".internal")  %>
         </td>
+        <td class="govuk-table__cell">
+          <% if consultee.response.blank? %>No response<% end %>
+        </td>
         <% unless read_only %>
           <td class="govuk-table__cell">
             <%= link_to "Edit response", edit_planning_application_consultee_path(planning_application, consultee), class: "govuk-link" %>

--- a/app/views/planning_application/assessment_details/consultation_summary/_information.html.erb
+++ b/app/views/planning_application/assessment_details/consultation_summary/_information.html.erb
@@ -6,3 +6,24 @@
     read_only: read_only
   }
 ) %>
+
+<% if @planning_application.consultees.with_response.present? %>
+  <h3>Consultation responses</h3>
+  <div class="govuk-accordion" data-module="govuk-accordion">
+    <% @planning_application.consultees.with_response.each do |consultee| %>
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h3 class="govuk-accordion__section-heading">
+            <button type="button"
+                    class="govuk-accordion__section-button"
+                    id="accordion-default-heading-<%= consultee.id %>"><%= consultee.name %></button>
+            <span class="govuk-accordion__icon"></span>
+          </h3>
+        </div>
+        <div class="govuk-accordion__section-content">
+          <p><%= consultee.response %></p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
@@ -98,20 +98,34 @@ RSpec.describe "adding consultation summary" do
         expect(page).to have_content("Edit response")
       end
 
+      expect(page).not_to have_content("Consultation responses")
+
       click_link("Edit response")
       fill_in("Response", with: "test 123")
       click_button("Update response")
 
       expect(page).not_to have_content("No response")
-
       click_button("Save and come back later")
       expect(page).to have_content("Consultation summary successfully added.")
 
       click_link("Summary of consultation")
+      expect(page).to have_content("Consultation responses")
+      within(".govuk-accordion") do
+        expect(page).to have_content("Alice Smith")
+        click_button("Alice Smith")
+        expect(page).to have_content("test 123")
+      end
 
       fill_in("Enter a new consultee", with: "Bob Smith")
       choose("External consultee")
       click_button("Add consultee")
+
+      click_button("Save and come back later")
+      click_link("Summary of consultation")
+
+      within(".govuk-accordion") do
+        expect(page).not_to have_content("Bob Smith")
+      end
 
       within(".govuk-table__row:nth-child(2)") do
         expect(page).to have_content("No response")
@@ -122,6 +136,13 @@ RSpec.describe "adding consultation summary" do
       click_button("Update response")
       click_button("Save and come back later")
       expect(page).to have_content("Consultation summary successfully updated.")
+
+      click_link("Summary of consultation")
+      within(".govuk-accordion") do
+        expect(page).to have_content("Bob Smith")
+        click_button("Bob Smith")
+        expect(page).to have_content("test 234")
+      end
 
       expect(planning_application.consultees.length).to eq(2)
       expect(planning_application.consultees.first.name).to eq("Alice Smith")

--- a/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
@@ -93,22 +93,29 @@ RSpec.describe "adding consultation summary" do
       choose("Internal consultee")
       click_button("Add consultee")
 
-      expect(page).to have_content("Edit response")
+      within(".govuk-table__row:first-child") do
+        expect(page).to have_content("No response")
+        expect(page).to have_content("Edit response")
+      end
 
       click_link("Edit response")
       fill_in("Response", with: "test 123")
       click_button("Update response")
+
+      expect(page).not_to have_content("No response")
+
       click_button("Save and come back later")
       expect(page).to have_content("Consultation summary successfully added.")
 
       click_link("Summary of consultation")
+
       fill_in("Enter a new consultee", with: "Bob Smith")
       choose("External consultee")
       click_button("Add consultee")
 
-      expect(page).to have_content("Edit response")
-
       within(".govuk-table__row:nth-child(2)") do
+        expect(page).to have_content("No response")
+        expect(page).to have_content("Edit response")
         click_link("Edit response")
       end
       fill_in("Response", with: "test 234")


### PR DESCRIPTION
### Description of change

If any consultee responses exist with a response text attached, list them for ease of writing a summary.

### Story Link

https://trello.com/c/KYztoXq0/1888-view-all-comments-received-from-consultees

### Screenshots

![Screenshot 2023-09-11 at 15 21 41](https://github.com/unboxed/bops/assets/3986/843d77a8-1160-4329-9bd5-0c62cbd32022)
