### PR TITLE
Move planx_data to its own table

### DIFF
--- a/db/migrate/20230911135911_create_planx_planning_data.rb
+++ b/db/migrate/20230911135911_create_planx_planning_data.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class CreatePlanxPlanningData < ActiveRecord::Migration[7.0]
+  def up
+    create_table :planx_planning_data do |t|
+      t.jsonb :entry, null: false
+      t.references :planning_application, index: true, foreign_key: true
+
+      t.timestamps
+    end
+
+    execute <<~SQL.squish
+      INSERT INTO planx_planning_data (entry, planning_application_id, created_at, updated_at)
+      SELECT planx_data, id, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM planning_applications
+      WHERE planx_data IS NOT NULL;
+    SQL
+  end
+
+  def down
+    drop_table :planx_planning_data if table_exists?(:planx_planning_data)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_08_124029) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_135911) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -465,6 +465,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_08_124029) do
     t.index ["user_id"], name: "ix_planning_applications_on_user_id"
   end
 
+  create_table "planx_planning_data", force: :cascade do |t|
+    t.jsonb "entry", null: false
+    t.bigint "planning_application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_planx_planning_data_on_planning_application_id"
+  end
+
   create_table "policies", force: :cascade do |t|
     t.string "section", null: false
     t.string "description", null: false
@@ -670,6 +678,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_08_124029) do
   add_foreign_key "planning_applications", "api_users"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
+  add_foreign_key "planx_planning_data", "planning_applications"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"
   add_foreign_key "recommendations", "users", column: "reviewer_id"


### PR DESCRIPTION
### Description of change

- The planx_debug_data field we receive from PlanX is usually a very large json so we don't need to load this in memory each time we query a planning application. It's not being used regularly either.
- This can be similarly applied to `audit_log` too as a future step and added as another field on the planx_planning_data table

We still need a PR to drop the planx_data table after the change is migrated successfully.

