### PR TITLE
Update to new way of installing Nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN gem install bundler -v 2.3.26
 
 # Update the system
 RUN apt-get update -y
+RUN apt-get install -y ca-certificates curl gnupg
 
 # Install Chromium for the feature tests
 RUN apt-get install -y --no-install-recommends chromium chromium-driver
@@ -18,8 +19,9 @@ COPY Gemfile Gemfile.lock ./
 RUN bundle
 
 ## Node
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
 ARG NODE_MAJOR=18
-RUN curl -fsSL https://deb.nodesource.com/setup_$NODE_MAJOR.x | bash -
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 RUN apt-get install -y nodejs
 
 ## Yarn


### PR DESCRIPTION
This has been printing a deprecation warning during docker build, and actually the new way is more straightforward anyway (why run a script just to write one line to one file?).