### PR TITLE
Use planx planning data

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -55,6 +55,7 @@ class PlanningApplication < ApplicationRecord
     has_one :immunity_detail, required: false
     has_one :consultation, required: false
     has_one :proposal_measurement, required: false
+    has_one :planx_planning_data, required: false
 
     has_many(
       :policy_classes,

--- a/app/models/planx_planning_data.rb
+++ b/app/models/planx_planning_data.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PlanxPlanningData < ApplicationRecord
+  belongs_to :planning_application
+
+  validates :entry, presence: true
+end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -56,6 +56,11 @@ class PlanningApplicationCreationService
         if planning_application.from_production?
           PlanningApplicationAnonymisationService.new(planning_application:).call!
         end
+        if params[:planx_debug_data].present?
+          PlanxPlanningData.create!(
+            planning_application:, entry: params[:planx_debug_data].to_json
+          )
+        end
         ConstraintsCreationService.new(planning_application:,
                                        constraints_params: params[:constraints]&.to_unsafe_hash).call
         UploadDocumentsJob.perform_now(planning_application:, files: params[:files])

--- a/spec/fixtures/files/planx_params.json
+++ b/spec/fixtures/files/planx_params.json
@@ -761,5 +761,11 @@
     },
     "make_public": false 
   },
+  "planx_debug_data": {
+    "session_id": "21161b70-0e29-40e6-9a38-c42f61f25ab9",
+    "passport": {
+      "data": {}
+    }
+  },
   "format": "json"
 }

--- a/spec/models/planx_planning_data_spec.rb
+++ b/spec/models/planx_planning_data_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanxPlanningData do
+  describe "validations" do
+    subject(:planx_planning_data) { described_class.new }
+
+    describe "#entry" do
+      it "validates presence" do
+        expect { planx_planning_data.valid? }.to change { planx_planning_data.errors[:entry] }.to ["can't be blank"]
+      end
+    end
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { planx_planning_data.valid? }.to change { planx_planning_data.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+  end
+end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -188,6 +188,10 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         it "calls the constraints creation service" do
           expect { create_planning_application }.to change(Constraint, :count).by(2).and change(PlanningApplicationConstraint, :count).by(2)
         end
+
+        it "creates a new planx planning data record" do
+          expect { create_planning_application }.to change(PlanxPlanningData, :count).by(1)
+        end
       end
     end
 


### PR DESCRIPTION
### Description of change

Update to use new planx_planning_data table to store the json we receive from planx_debug_data

Related to https://github.com/unboxed/bops/pull/1254
The above will need to be deployed to production before merging this change