### PR TITLE
Remove planx_data from planning applications

### DIFF
--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -34,7 +34,6 @@ class PlanningApplicationCreationService
         boundary_geojson: (params[:boundary_geojson].to_json if params[:boundary_geojson].present?),
         proposal_details: (params[:proposal_details].to_json if params[:proposal_details].present?),
         old_constraints: constraints_array_from_param(params[:constraints]),
-        planx_data: (params[:planx_debug_data].to_json if params[:planx_debug_data].present?),
         api_user:,
         audit_log: params.to_json,
         user_role: params[:user_role].presence,

--- a/db/migrate/20230912095000_remove_planx_data_from_planning_applications.rb
+++ b/db/migrate/20230912095000_remove_planx_data_from_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePlanxDataFromPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :planning_applications, :planx_data, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -430,7 +430,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_143019) do
     t.string "latitude"
     t.string "longitude"
     t.datetime "closed_at", precision: nil
-    t.jsonb "planx_data"
     t.datetime "determination_date", precision: nil
     t.integer "user_role"
     t.boolean "updated_address_or_boundary_geojson", default: false

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
 
         planning_application = PlanningApplication.last
         expect(planning_application).to be_valid
-        expect(JSON.parse(planning_application.planx_data)).to be_a(Hash)
+        expect(JSON.parse(planning_application.planx_planning_data.entry)).to be_a(Hash)
       end
 
       it "saves the feedback as a hash" do

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
             id: planning_application.id + 1,
             local_authority_id: planning_application.local_authority.id,
             api_user_id: planning_application.api_user.id,
-            planx_data: planning_application.planx_data,
             audit_log: planning_application.audit_log,
             address_1: planning_application.address_1,
             address_2: planning_application.address_2,
@@ -75,6 +74,8 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
             from_production: false,
             lonlat: RGeo::Geographic.spherical_factory(srid: 4326).point(planning_application.longitude, planning_application.latitude)
           )
+
+          expect(planning_application.planx_planning_data.entry).to eq(cloned_planning_application.planx_planning_data.entry)
 
           # Proposal details have their own object id i.e. ProposalDetail:0x00007fe42a8476a8 so compare the json value instead
           proposal_details = planning_application.proposal_details.map(&:to_json)


### PR DESCRIPTION
### Description of change

Remove planx_data from planning applications

Needs to be merged/deployed after https://github.com/unboxed/bops/pull/1256