### PR TITLE
Add a migration to rename constraint's name to type

### DIFF
--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -18,7 +18,7 @@ class ConstraintsController < AuthenticationController
     ActiveRecord::Base.transaction do
       if local_constraint.present?
         @planning_application.constraints.find_or_create_by!(
-          name: local_constraint.titleize,
+          type: local_constraint.titleize,
           category: "local",
           local_authority_id: @planning_application.local_authority_id
         )
@@ -63,7 +63,7 @@ class ConstraintsController < AuthenticationController
   end
 
   def local_constraint
-    params.dig(:planning_application, :name)
+    params.dig(:planning_application, :constraint_type)
   end
 
   def constraint_ids

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class Constraint < ApplicationRecord
-  validates :category, :name, presence: true
-  validates :name, uniqueness: { scope: :local_authority }
+  self.inheritance_column = "inheritance_type"
+
+  validates :category, :type, presence: true
+  validates :type, uniqueness: { scope: :local_authority }
 
   belongs_to :local_authority, optional: true
 

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -10,7 +10,7 @@ class PlanningApplicationConstraint < ApplicationRecord
   after_create :audit_constraint_added!
   before_destroy :audit_constraint_removed!
 
-  delegate :name, to: :constraint
+  delegate :type, to: :constraint
   delegate :audits, to: :planning_application
 
   scope :active, -> { where({ removed_at: nil }) }
@@ -19,10 +19,10 @@ class PlanningApplicationConstraint < ApplicationRecord
   private
 
   def audit_constraint_added!
-    audit!(activity_type: "constraint_added", audit_comment: name)
+    audit!(activity_type: "constraint_added", audit_comment: type)
   end
 
   def audit_constraint_removed!
-    audit!(activity_type: "constraint_removed", audit_comment: name)
+    audit!(activity_type: "constraint_removed", audit_comment: type)
   end
 end

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -10,7 +10,7 @@ class ConstraintsCreationService
   def call
     constraints.each do |constraint|
       existing_constraint = Constraint.options_for_local_authority(planning_application.local_authority_id)
-                                      .find_by("LOWER(name)= ?", constraint.downcase)
+                                      .find_by("LOWER(type)= ?", constraint.downcase)
 
       if existing_constraint
         planning_application.planning_application_constraints.find_or_create_by!(
@@ -19,7 +19,7 @@ class ConstraintsCreationService
         ).save!
       else
         planning_application.constraints.find_or_create_by!(
-          name: constraint.titleize, category: "local", local_authority_id: planning_application.local_authority_id
+          type: constraint.titleize, category: "local", local_authority_id: planning_application.local_authority_id
         )
       end
     end
@@ -27,7 +27,7 @@ class ConstraintsCreationService
     previous_constraints =
       planning_application.planning_application_constraints.active
     previous_constraints.each do |constraint|
-      constraint.update!(removed_at: Time.current) unless constraints.include?(constraint.constraint.name.humanize)
+      constraint.update!(removed_at: Time.current) unless constraints.include?(constraint.constraint.type.humanize)
     end
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
     Appsignal.send_error(e)

--- a/app/views/constraints/_info.html.erb
+++ b/app/views/constraints/_info.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <ul class="govuk-list govuk-list--bullet">
     <% constraints.each do |constraint| %>
-      <li><%= constraint.name %></li>
+      <li><%= constraint.type %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/constraints/edit.html.erb
+++ b/app/views/constraints/edit.html.erb
@@ -42,7 +42,7 @@
                       ) %>
                     <%= label_tag(
                       "constraint_id_#{constraint.id}",
-                      constraint.name,
+                      constraint.type,
                       class: "govuk-label govuk-checkboxes__label",
                     ) %>
                   </div>
@@ -54,8 +54,8 @@
       <% end %>
 
       <div class="form-group">
-        <%= form.label :name, "Add a local constraint", class: 'govuk-heading-s govuk-!-margin-top-6' %>
-        <%= form.text_area :name, class: "govuk-textarea", rows: "3", "aria-describedby": "constraints-hint" %>
+        <%= form.label :constraint_type, "Add a local constraint", class: 'govuk-heading-s govuk-!-margin-top-6' %>
+        <%= form.text_area :constraint_type, class: "govuk-textarea", rows: "3", "aria-describedby": "constraints-hint" %>
       </div>
 
       <div class="govuk-button-group">

--- a/db/migrate/20230912154603_rename_constraints_name_to_type.rb
+++ b/db/migrate/20230912154603_rename_constraints_name_to_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameConstraintsNameToType < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :constraints, :name, :type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_11_135911) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_154603) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -136,12 +136,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_11_135911) do
   end
 
   create_table "constraints", force: :cascade do |t|
-    t.string "name", null: false
+    t.string "type", null: false
     t.string "category", null: false
     t.bigint "local_authority_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["local_authority_id", "name"], name: "ix_constraints_on_local_authority_id__name", unique: true
+    t.index ["local_authority_id", "type"], name: "ix_constraints_on_local_authority_id__type", unique: true
     t.index ["local_authority_id"], name: "ix_constraints_on_local_authority_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -107,9 +107,9 @@ constraints_list = {
   ]
 }
 
-constraints_list.each do |category, names|
-  names.each do |name|
-    Constraint.create!(name:, category: category.to_s)
+constraints_list.each do |category, types|
+  types.each do |type|
+    Constraint.create!(type:, category: category.to_s)
   rescue ActiveRecord::RecordInvalid, ArgumentError => e
     raise "Could not create constraint with category: '#{category}' and name: '#{name}' with error: #{e.message}"
   end

--- a/spec/factories/constraint.rb
+++ b/spec/factories/constraint.rb
@@ -2,10 +2,10 @@
 
 FactoryBot.define do
   factory :constraint do
-    name { "Flood zone" }
+    type { "flood_zone" }
     category { "flooding" }
     local_authority { nil }
 
-    initialize_with { Constraint.find_or_create_by(name:, category:, local_authority:) }
+    initialize_with { Constraint.find_or_create_by(type:, category:, local_authority:) }
   end
 end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -309,8 +309,8 @@ FactoryBot.define do
 
     trait :with_constraints do
       after(:create) do |planning_application|
-        constraint1 = create(:constraint, name: "Conservation area", category: "heritage_and_conservation")
-        constraint2 = create(:constraint, name: "Listed building", category: "heritage_and_conservation")
+        constraint1 = create(:constraint, type: "Conservation area", category: "heritage_and_conservation")
+        constraint2 = create(:constraint, type: "Listed building", category: "heritage_and_conservation")
 
         planning_application.planning_application_constraints.find_or_create_by(constraint: constraint1).save!
         planning_application.planning_application_constraints.find_or_create_by(constraint: constraint2).save!

--- a/spec/models/constraint_spec.rb
+++ b/spec/models/constraint_spec.rb
@@ -6,16 +6,16 @@ RSpec.describe Constraint do
   describe "validations" do
     subject(:constraint) { described_class.new }
 
-    describe "#name" do
+    describe "#type" do
       it "validates presence" do
-        expect { constraint.valid? }.to change { constraint.errors[:name] }.to ["can't be blank"]
+        expect { constraint.valid? }.to change { constraint.errors[:type] }.to ["can't be blank"]
       end
 
       it "validates uniqueness" do
-        create(:constraint, name: "Flood zone")
+        create(:constraint, type: "flood_zone")
 
-        expect { described_class.create!(name: "Flood zone") }.to raise_error(
-          ActiveRecord::RecordInvalid, "Validation failed: Category can't be blank, Name has already been taken"
+        expect { described_class.create!(type: "flood_zone") }.to raise_error(
+          ActiveRecord::RecordInvalid, "Validation failed: Category can't be blank, Type has already been taken"
         )
       end
     end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -113,8 +113,8 @@ RSpec.describe PlanningApplication do
     describe "constraints" do
       let!(:planning_application) { create(:planning_application) }
 
-      let!(:constraint1) { create(:constraint, name: "Constraint 1", category: "other") }
-      let!(:constraint2) { create(:constraint, name: "Constraint 2", category: "other") }
+      let!(:constraint1) { create(:constraint, type: "Constraint 1", category: "other") }
+      let!(:constraint2) { create(:constraint, type: "Constraint 2", category: "other") }
 
       let!(:planning_application_constraints_query) { create(:planning_application_constraints_query, planning_application:) }
       let!(:planning_application_constraint1) { create(:planning_application_constraint, planning_application_constraints_query:, planning_application:, constraint: constraint1) }

--- a/spec/services/constraints_creation_service_spec.rb
+++ b/spec/services/constraints_creation_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ConstraintsCreationService, type: :service do
           create_constraints
         end.to change(Constraint, :count).by(4).and change(PlanningApplicationConstraint, :count).by(4)
 
-        expect(Constraint.pluck(:name, :category, :local_authority_id)).to eq(
+        expect(Constraint.pluck(:type, :category, :local_authority_id)).to eq(
           [
             ["Conservation Area", "local", local_authority1.id],
             ["Protected Trees", "local", local_authority1.id],
@@ -47,11 +47,11 @@ RSpec.describe ConstraintsCreationService, type: :service do
     end
 
     context "when existing constraints are added" do
-      let!(:constraint1) { create(:constraint, name: "conservation area", local_authority: local_authority1) }
-      let!(:constraint2) { create(:constraint, name: "Protected trees") }
-      let!(:constraint3) { create(:constraint, name: "National Park") }
+      let!(:constraint1) { create(:constraint, type: "conservation area", local_authority: local_authority1) }
+      let!(:constraint2) { create(:constraint, type: "Protected trees") }
+      let!(:constraint3) { create(:constraint, type: "National Park") }
       # Constraint for another local authority
-      let!(:constraint4) { create(:constraint, name: "Listed building", local_authority: local_authority2) }
+      let!(:constraint4) { create(:constraint, type: "Listed building", local_authority: local_authority2) }
 
       it "creates planning application constraints using the existing constraint for the local authority" do
         expect do
@@ -64,8 +64,8 @@ RSpec.describe ConstraintsCreationService, type: :service do
     end
 
     context "when existing and new constraints are added" do
-      let!(:constraint1) { create(:constraint, name: "conservation area") }
-      let!(:constraint2) { create(:constraint, name: "Protected trees") }
+      let!(:constraint1) { create(:constraint, type: "conservation area") }
+      let!(:constraint2) { create(:constraint, type: "Protected trees") }
 
       it "creates the non existing constraints and planning application constraints" do
         expect do
@@ -78,8 +78,8 @@ RSpec.describe ConstraintsCreationService, type: :service do
     end
 
     context "when constraints are removed" do
-      let!(:constraint1) { create(:constraint, name: "conservation area") }
-      let!(:constraint2) { create(:constraint, name: "Listed Building") }
+      let!(:constraint1) { create(:constraint, type: "conservation area") }
+      let!(:constraint2) { create(:constraint, type: "Listed Building") }
 
       before do
         create_constraints
@@ -99,10 +99,10 @@ RSpec.describe ConstraintsCreationService, type: :service do
         app_constraints = planning_application.planning_application_constraints
 
         expect(app_constraints.active.count).to eq(2)
-        expect(app_constraints.active.map(&:name)).to eq(["conservation area",
+        expect(app_constraints.active.map(&:type)).to eq(["conservation area",
                                                           "Listed Building"])
         expect(app_constraints.removed.count).to eq(2)
-        expect(app_constraints.removed.map(&:name)).to eq(["Protected Trees",
+        expect(app_constraints.removed.map(&:type)).to eq(["Protected Trees",
                                                            "National Park"])
       end
     end

--- a/spec/system/planning_applications/assessing/constraints_spec.rb
+++ b/spec/system/planning_applications/assessing/constraints_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Constraints" do
       check "Site of Special Scientific Interest (SSSI)"
       check "National Park"
 
-      fill_in "planning_application[name]", with: "local constraint"
+      fill_in "planning_application[constraint_type]", with: "local constraint"
 
       click_button "Save"
 
@@ -114,7 +114,7 @@ RSpec.describe "Constraints" do
 
       it "presents an error message to the user and does not persist any updates" do
         check "Flood zone"
-        fill_in "planning_application[name]", with: "local constraint"
+        fill_in "planning_application[constraint_type]", with: "local constraint"
 
         click_button "Save"
 

--- a/spec/system/planning_applications/updating_constraints_spec.rb
+++ b/spec/system/planning_applications/updating_constraints_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "updating constraints" do
   let!(:constraint) do
     create(
       :constraint,
-      name: "Conservation Area"
+      type: "Conservation Area"
     )
   end
 


### PR DESCRIPTION
### Description of change

What we're actually storing from PlanX is constraint's prefix type and not a name. An additional PR will follow which will include more fields to story more data

### Story Link

https://trello.com/c/yL8eKT6l