### PR TITLE
Return empty array if ward_object is nil

### DIFF
--- a/app/services/apis/mapit/query.rb
+++ b/app/services/apis/mapit/query.rb
@@ -30,6 +30,8 @@ module Apis
         ward_id = body["shortcuts"]["ward"]
         ward_object = areas[ward_id.to_s]
 
+        return [] unless ward_object
+
         [ward_object["type_name"], ward_object["name"], parish_name(areas)]
       end
 


### PR DESCRIPTION
### Description of change

- Temporary fix for when ward_id returns an object with types of ward i.e. the postcode HP2 6PA returns {"district"=>17057, "county"=>150680} instead of just an id.
- Without this, certain postcode with district and county ward will cause the planning application to not be created. We need to add a way to handle the above properly when we understand what we want to do with that info.
- We still present the user with a link to mapit in the application details if they need to investigate this information

https://appsignal.com/southwark-bops/sites/63efadfcd2a5e42c27a8518c/exceptions/incidents/259/samples/timestamp/2023-09-12T14:58:07Z