### PR TITLE
Fix deprecation warning about TimeWithZone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   def prevent_caching
     response.headers["Cache-Control"] = "no-cache, no-store"
     response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = 100.years.ago
+    response.headers["Expires"] = 0
   end
 
   def set_current_user


### PR DESCRIPTION
### Description of change

Puma calls `to_s` on the value being sent. In older versions of rails, `to_s` on a `TimeWithZone` acted like `to_fs(:default)` but this is deprecated. If this was in our own code we'd want to switch to `to_fs`, but since we can't control that, we can convert it to a plain Ruby `Time` instead, and `Time#to_s` behaves normally.