### PR TITLE
Resend letters to neighbours

### DIFF
--- a/app/controllers/planning_applications/consultations_controller.rb
+++ b/app/controllers/planning_applications/consultations_controller.rb
@@ -22,7 +22,7 @@ module PlanningApplications
     private
 
     def consultation_params
-      params.require(:consultation).permit(:neighbour_letter_text)
+      params.require(:consultation).permit(:neighbour_letter_text, :resend_existing, :resend_reason)
     end
   end
 end

--- a/app/views/planning_applications/neighbour_letters/_contacted_list.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_contacted_list.html.erb
@@ -1,8 +1,8 @@
-<% if @consultation.neighbours.with_letters.any?  %>
+<% if @consultation.neighbours.with_letters.any? %>
   <h3 class="govuk-heading-s govuk-!-margin-top-4">Contacted neighbours</h3>
   <% @consultation.neighbours.with_letters.each do |neighbour| %>
     <hr>
-    <div class="proposal-details-sub-heading">
+    <div class="proposal-details-sub-heading" id="contacted-neighbours-list">
       <p class="govuk-body govuk-!-margin-top-1">
         <%= neighbour.address %>
       </p>

--- a/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
@@ -23,6 +23,13 @@ method: 'post'
   <h2 class="govuk-heading-m govuk-!-margin-top-6">4) Send letter</h2>
   <p class="govuk-body">The letter will be sent to all selected neighbours.</p>
   <p class="govuk-body">A copy of the letter will be sent to the applicant by email.</p>
+
+  <%= form.govuk_check_boxes_fieldset :resend_existing, legend: -> { "" } do %>
+    <%= form.govuk_check_box :resend_existing, true, label: { text: "Resend letters to previously-contacted neighbours" }, link_errors: true, multiple: false do %>
+      <%= form.govuk_text_field :resend_reason, label: { text: "Specify a reason for resending" }, hint: { text: "This will be included in the letter" } %>
+    <% end %>
+  <% end %>
+
   <div class="govuk-button-group govuk-!-margin-top-5 align-buttons">
     <%= form.submit "Print and send letters", class: "govuk-button govuk-button--primary", style: "margin-inline-end: 2rem;" %>
   <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -769,6 +769,8 @@ en:
       create:
         failure: 'Error adding neighbour addresses with message: %{message}'
         success: Addresses have been successfully added.
+      send_letters:
+        require_resend_reason: Must provide a reason when resending letters to previously-contacted neighbours
     overdue:
       one: 1 day overdue
       other: "%{count} days overdue"

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require "faraday"
 
 RSpec.describe "Send letters to neighbours", js: true do
-  let!(:api_user) { create(:api_user, name: "PlanX") }
-  let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
-  let!(:application_type) { create(:application_type, :prior_approval) }
+  let(:api_user) { create(:api_user, name: "PlanX") }
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let(:application_type) { create(:application_type, :prior_approval) }
 
-  let!(:planning_application) do
+  let(:planning_application) do
     create(:planning_application,
            :from_planx_prior_approval,
            :with_boundary_geojson,
@@ -20,7 +21,7 @@ RSpec.describe "Send letters to neighbours", js: true do
            make_public: true)
   end
 
-  let!(:consultation) do
+  let(:consultation) do
     planning_application.consultation
   end
 
@@ -31,6 +32,7 @@ RSpec.describe "Send letters to neighbours", js: true do
     ENV["OS_VECTOR_TILES_API_KEY"] = "testtest"
     allow_any_instance_of(Faraday::Connection).to receive(:get).and_return(instance_double("response", status: 200, body: "some data")) # rubocop:disable RSpec/VerifiedDoubleReference
     allow_any_instance_of(Apis::OsPlaces::Query).to receive(:find_addresses).and_return(Faraday.new.get)
+    allow_any_instance_of(Apis::Mapit::Query).to receive(:fetch).and_return(Faraday.new.get)
 
     stub_any_os_places_api_request
 
@@ -198,7 +200,7 @@ RSpec.describe "Send letters to neighbours", js: true do
     end
 
     context "when planning application has not been made public on the BoPS Public Portal" do
-      let!(:planning_application) do
+      let(:planning_application) do
         create(:planning_application,
                :from_planx_prior_approval,
                application_type:,


### PR DESCRIPTION
### Description of change

Add an option to the "send letters to neighbours page" to resend letters to all existing neighbours rather than add new neighbours. Require a reason to be specified when doing so.

### Story Link

https://trello.com/c/csQTNIyO/1829-repeat-previous-publicity-tasks-at-any-point-of-the-planning-process

### Screenshots

<img width="992" alt="Screenshot_2023-10-04_at_14 55 57" src="https://github.com/unboxed/bops/assets/3986/eb405ec9-214c-4b28-9f0a-150e11bd52e6">

### Known issues

Currently this doesn't prevent the user from both adding new neighbours _and_ choosing to resend all. In this case it'll probably resend to existing neighbours _and_ send to the new neighbours, the latter of whom will be told it's a resend when it isn't (for them).

However it seems like this is an unlikely scenario. In the future we can either prevent the user from trying to do both, _or_ make both work (which would actually be quite easy in terms of the code but not preferable from a UX perspective I think).

