### PR TITLE
Mark press notice as required or not for planning application 

### DIFF
--- a/app/components/task_list_items/press_notice_component.rb
+++ b/app/components/task_list_items/press_notice_component.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class PressNoticeComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+      @press_notice = planning_application.press_notice
+    end
+
+    private
+
+    attr_reader :planning_application, :press_notice
+
+    def link_text
+      "Press notice"
+    end
+
+    def link_path
+      if press_notice.nil?
+        new_planning_application_press_notice_path(planning_application)
+      else
+        planning_application_press_notice_path(planning_application, press_notice)
+      end
+    end
+
+    def status_tag_component
+      StatusTags::BaseComponent.new(status:)
+    end
+
+    def status
+      return "not_started" if press_notice.nil?
+
+      "complete"
+    end
+  end
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -85,7 +85,8 @@ class Audit < ApplicationRecord
     neighbour_letter_copy_mail_sent: "neighbour_letter_copy_mail_sent",
     neighbour_response_uploaded: "neighbour_response_uploaded",
     neighbour_response_edited: "neighbour_response_edited",
-    legislation_checked: "legislation_checked"
+    legislation_checked: "legislation_checked",
+    press_notice: "press_notice"
   }
 
   validates :activity_type, presence: true

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -56,6 +56,7 @@ class PlanningApplication < ApplicationRecord
     has_one :consultation, required: false
     has_one :proposal_measurement, required: false
     has_one :planx_planning_data, required: false
+    has_one :press_notice, required: false
 
     has_many(
       :policy_classes,

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class PressNotice < ApplicationRecord
+  include Auditable
+
+  belongs_to :planning_application
+
+  with_options presence: true do
+    validates :reasons, if: :required?
+  end
+
+  validates :required, inclusion: { in: [true, false] }
+
+  after_save :audit_press_notice!
+
+  delegate :audits, to: :planning_application
+
+  class << self
+    def reasons_list
+      I18n.t("press_notice_reasons")
+    end
+
+    def reason_keys
+      reasons_list.keys.flatten
+    end
+  end
+
+  private
+
+  def audit_press_notice!
+    comment = if reasons.present?
+                "Press notice has been marked as required with the following reasons: #{joined_reasons}"
+              else
+                "Press notice has been marked as not required"
+              end
+
+    audit!(
+      activity_type: "press_notice",
+      audit_comment: comment
+    )
+  end
+
+  def joined_reasons
+    reasons.values.join(", ")
+  end
+end

--- a/app/views/planning_application/consultations/index.html.erb
+++ b/app/views/planning_application/consultations/index.html.erb
@@ -19,9 +19,9 @@
       <h2 class="govuk-heading-m">Neighbours</h2>
       <ul class="app-task-list__items" id="neighbour-section">
         <%= render(
-        TaskListItems::SendLettersToNeighboursComponent.new(
-          planning_application: @planning_application
-        )
+          TaskListItems::SendLettersToNeighboursComponent.new(
+            planning_application: @planning_application
+          )
         ) %>
         <%= render(
           TaskListItems::NeighbourResponsesComponent.new(
@@ -54,7 +54,7 @@
       </ul>
 
       <h2 class="govuk-heading-m">Publicity</h2>
-      <ul class="app-task-list__items" id="consultation-section">
+      <ul class="app-task-list__items" id="publicity-section">
         <li class="app-task-list__item" id="send-letters-to-neighbours">
           <span class="app-task-list__task-name">
             <a class="govuk-link" href="#">Send site notice</a>
@@ -65,12 +65,12 @@
             <a class="govuk-link" href="#">Confirm site notice</a>
           </span>
         </li>
-        <li class="app-task-list__item" id="send-letters-to-neighbours">
-          <span class="app-task-list__task-name">
-            <a class="govuk-link" href="#">Send press notice</a>
-          </span>
-        </li>
-        <li class="app-task-list__item" id="send-letters-to-neighbours">
+        <%= render(
+          TaskListItems::PressNoticeComponent.new(
+            planning_application: @planning_application
+          )
+        ) %>
+        <li class="app-task-list__item" id="confirm-press-notice">
           <span class="app-task-list__task-name">
             <a class="govuk-link" href="#">Confirm press notice</a>
           </span>

--- a/app/views/planning_application/press_notices/_form.html.erb
+++ b/app/views/planning_application/press_notices/_form.html.erb
@@ -1,0 +1,52 @@
+<%= form_with model: [@planning_application, @press_notice],
+              local: true,
+              builder: GOVUKDesignSystemFormBuilder::FormBuilder do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+    :required,
+    legend: nil
+  ) do %>
+    <%= form.govuk_radio_button(
+      :required, true, checked: @press_notice.required, label: { text: "Yes" }
+    ) do %>
+      <fieldset class="govuk-fieldset govuk-!-margin-top-3">
+        <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+          <% PressNotice.reasons_list.each do |key, values| %>
+            <div class="govuk-checkboxes__item">
+              <%= check_box_tag(
+                "press_notice[reasons][#{key}]",
+                values.first,
+                @press_notice.reasons&.key?(key.to_s),
+                class: "govuk-checkboxes__input",
+                id: "press_notice_reason_#{key}"
+              ) %>
+              <%= label_tag(
+                "press_notice_reason_#{key}",
+                values.first,
+                class: "govuk-label govuk-checkboxes__label",
+              ) %>
+            </div>
+          <% end %>
+
+          <p class="govuk-body-s">or</p>
+
+          <%= form.govuk_check_box :other_reason_selected, 1, 0, multiple: false, label: { text: "Other" }, checked: @press_notice.reasons&.key?("other") do %>
+            <%= form.govuk_text_area :"reasons[other]", value: @press_notice.reasons&.dig("other"), label: { text: "Provide an other reason why this application requires a press notice" } %>
+          <% end %>
+        </div>
+      </fieldset>
+    <% end %>
+
+    <%= form.govuk_radio_button(
+      :required, false, checked: @press_notice.required == false, label: { text: "No" }
+    ) %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <%= back_link %>
+  </div>
+<% end %>
+
+

--- a/app/views/planning_application/press_notices/_template.html.erb
+++ b/app/views/planning_application/press_notices/_template.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title do %>
+  Press notice - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultations_path(@planning_application) %>
+<% content_for :title, "Press notice" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Press notice" }
+) %>
+
+<%= yield %>

--- a/app/views/planning_application/press_notices/new.html.erb
+++ b/app/views/planning_application/press_notices/new.html.erb
@@ -1,0 +1,8 @@
+<%= render(
+  layout: "template",
+  locals: { planning_application: @planning_application }
+) do %>
+  <h2 class="govuk-heading-m">Does this application require a press notice?</h2>
+  
+  <%= render "form" %>
+<% end %>

--- a/app/views/planning_application/press_notices/show.html.erb
+++ b/app/views/planning_application/press_notices/show.html.erb
@@ -1,0 +1,8 @@
+<%= render(
+  layout: "template",
+  locals: { planning_application: @planning_application }
+) do %>
+  <h2 class="govuk-heading-m">Press notice details</h2>
+  
+  <%= render "form" %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,6 +179,12 @@ en:
           attributes:
             status:
               policies_to_be_determined: All policies must be assessed
+        press_notice:
+          attributes:
+            reasons:
+              blank: You must provide a reason for the press notice
+            required:
+              inclusion: You must choose 'Yes' or 'No'
         recommendation:
           attributes:
             challenged:
@@ -371,6 +377,7 @@ en:
       other_change_validation_request_cancelled: 'Cancelled: validation request (other change from applicant#%{args})'
       other_change_validation_request_received: 'Received: request for change (other validation#%{args})'
       other_change_validation_request_sent: 'Sent: validation request (other validation#%{args})'
+      press_notice: Press notice response added
       proposal_measurements_updated: Proposal measurements were updated
       red_line_boundary_change_validation_request_added: 'Added: validation request (red line boundary#%{args})'
       red_line_boundary_change_validation_request_auto_closed:
@@ -706,6 +713,11 @@ en:
     consultation_neighbour_addresses:
       create:
         success: Addresses have been successfully added.
+    press_notices:
+      create:
+        success: Press notice response has been successfully added
+      update:
+        success: Press notice response has been successfully updated
     review_documents:
       update:
         success: Documents were successfully updated.

--- a/config/locales/press_notice_reasons.yml
+++ b/config/locales/press_notice_reasons.yml
@@ -1,0 +1,18 @@
+en:
+  press_notice_reasons:
+    conservation_area:
+      - The site of the application is within/affecting the setting of a designated Conservation Area (Section 73) of the Planning (Listed Buildings and Conservation Areas) Act 1990
+    listed_building:
+      - The application relates to, or affects the setting of a Listed Building (Section 67) of the Planning (Listed Buildings and Conservation Areas) Act 1990
+    major_development:
+      - The application is for a Major Development
+    wildlife_and_countryside:
+      - The application would affect a right of way to which Part III of the Wildlife and Countryside Act 1981 (as amended) applies
+    development_plan:
+      - The application does not accord with the provisions of the development plan
+    environment:
+      - An environmental statement accompanies this application
+    ancient_monument:
+      - The site of the application is affecting the setting of an Ancient Monument
+    public_interest:
+      - Wider Public interest

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,8 @@ Rails.application.routes.draw do
       resources :assign_users, only: %i[index] do
         patch :update, on: :collection
       end
+
+      resources :press_notices, only: %i[index new create show edit update]
     end
   end
 

--- a/db/migrate/20230921094853_create_press_notices.rb
+++ b/db/migrate/20230921094853_create_press_notices.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreatePressNotices < ActiveRecord::Migration[7.0]
+  def change
+    create_table :press_notices do |t|
+      t.references :planning_application, null: false, foreign_key: true
+      t.boolean :required, null: false
+      t.jsonb :reasons
+      t.datetime :requested_at
+      t.datetime :press_sent_at
+      t.datetime :published_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_13_143019) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_21_094853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -498,6 +498,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_143019) do
     t.index ["planning_application_id"], name: "ix_policy_classes_on_planning_application_id"
   end
 
+  create_table "press_notices", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.boolean "required", null: false
+    t.jsonb "reasons"
+    t.datetime "requested_at"
+    t.datetime "press_sent_at"
+    t.datetime "published_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_press_notices_on_planning_application_id"
+  end
+
   create_table "proposal_measurements", force: :cascade do |t|
     t.bigint "planning_application_id"
     t.float "eaves_height"
@@ -682,6 +694,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_13_143019) do
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
   add_foreign_key "planx_planning_data", "planning_applications"
+  add_foreign_key "press_notices", "planning_applications"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"
   add_foreign_key "recommendations", "users", column: "reviewer_id"

--- a/spec/factories/press_notice.rb
+++ b/spec/factories/press_notice.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :press_notice do
+    planning_application
+
+    required { false }
+
+    trait :required do
+      required { true }
+      reasons do
+        {
+          environment: "An environmental statement accompanies this application",
+          development_plan: "The application does not accord with the provisions of the development plan"
+        }
+      end
+    end
+
+    trait :with_other_reason do
+      required { true }
+      reasons do
+        {
+          environment: "An environmental statement accompanies this application",
+          other: "An other reason"
+        }
+      end
+    end
+  end
+end

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PressNotice do
+  describe "validations" do
+    subject(:press_notice) { described_class.new }
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { press_notice.valid? }.to change { press_notice.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+
+    describe "#required" do
+      it "validates inclusion in [true, false]" do
+        expect { press_notice.valid? }.to change { press_notice.errors[:required] }.to ["You must choose 'Yes' or 'No'"]
+      end
+    end
+
+    describe "#reasons" do
+      context "when required is 'true'" do
+        subject(:press_notice) { described_class.new(required: true) }
+
+        it "validates presence" do
+          expect { press_notice.valid? }.to change { press_notice.errors[:reasons] }.to ["You must provide a reason for the press notice"]
+        end
+      end
+
+      context "when required is 'false'" do
+        subject(:press_notice) { described_class.new(required: false) }
+
+        it "does not validate presence" do
+          expect { press_notice.valid? }.not_to(change { press_notice.errors[:reasons] })
+        end
+      end
+    end
+
+    describe "class methods" do
+      describe "#reasons_list" do
+        it "returns the reasons for press notice" do
+          expect(described_class.reasons_list).to eq(
+            { conservation_area: ["The site of the application is within/affecting the setting of a designated Conservation Area (Section 73) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
+              listed_building: ["The application relates to, or affects the setting of a Listed Building (Section 67) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
+              major_development: ["The application is for a Major Development"],
+              wildlife_and_countryside: ["The application would affect a right of way to which Part III of the Wildlife and Countryside Act 1981 (as amended) applies"],
+              development_plan: ["The application does not accord with the provisions of the development plan"],
+              environment: ["An environmental statement accompanies this application"],
+              ancient_monument: ["The site of the application is affecting the setting of an Ancient Monument"],
+              public_interest: ["Wider Public interest"] }
+          )
+        end
+      end
+
+      describe "#reason_keys" do
+        it "returns the reason types for press notice" do
+          expect(described_class.reason_keys).to eq(
+            %i[conservation_area
+               listed_building
+               major_development
+               wildlife_and_countryside
+               development_plan
+               environment
+               ancient_monument
+               public_interest]
+          )
+        end
+      end
+    end
+
+    describe "callbacks" do
+      describe "::after_save #audit_press_notice!" do
+        let(:default_local_authority) { create(:local_authority, :default) }
+        let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+        let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+
+        before do
+          Current.user = assessor
+        end
+
+        context "when reasons is present" do
+          let(:press_notice) { create(:press_notice, :required, planning_application:) }
+
+          it "adds an audit entry with the reasons when creating the press notice response" do
+            expect do
+              press_notice
+            end.to change(Audit, :count).by(1)
+
+            expect(Audit.last).to have_attributes(
+              planning_application_id: planning_application.id,
+              activity_type: "press_notice",
+              audit_comment: "Press notice has been marked as required with the following reasons: An environmental statement accompanies this application, The application does not accord with the provisions of the development plan",
+              user: assessor
+            )
+          end
+
+          it "adds an audit entry with the reasons when updating the press notice response" do
+            press_notice
+
+            expect do
+              press_notice.update!(reasons: { ancient_monument: "The site of the application is affecting the setting of an Ancient Monument" })
+            end.to change(Audit, :count).by(1)
+
+            expect(Audit.last).to have_attributes(
+              planning_application_id: press_notice.planning_application.id,
+              activity_type: "press_notice",
+              audit_comment: "Press notice has been marked as required with the following reasons: The site of the application is affecting the setting of an Ancient Monument",
+              user: assessor
+            )
+          end
+        end
+
+        context "when reasons is not present" do
+          let(:press_notice) { create(:press_notice, planning_application:) }
+
+          it "adds an audit entry when creating the press notice response" do
+            expect do
+              press_notice
+            end.to change(Audit, :count).by(1)
+
+            expect(Audit.last).to have_attributes(
+              planning_application_id: planning_application.id,
+              activity_type: "press_notice",
+              audit_comment: "Press notice has been marked as not required",
+              user: assessor
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -1,0 +1,311 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Press notice" do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority:) }
+
+  let!(:planning_application) do
+    create(:planning_application, :prior_approval, local_authority:)
+  end
+
+  before do
+    sign_in assessor
+
+    visit planning_application_path(planning_application)
+  end
+
+  describe "responding to whether a press notice is required" do
+    before { travel_to(Time.zone.local(2023, 3, 15, 12)) }
+
+    it "shows the press notice item in the tasklist" do
+      click_link "Consultees, neighbours and publicity"
+
+      within("#publicity-section") do
+        expect(page).to have_css("#press-notice")
+        expect(page).to have_link("Press notice")
+        expect(page).to have_content("Not started")
+      end
+    end
+
+    it "I can see the relevant information on the press notice page" do
+      click_link "Consultees, neighbours and publicity"
+      click_link "Press notice"
+
+      within("#planning-application-details") do
+        expect(page).to have_content("Press notice")
+        expect(page).to have_content(planning_application.reference)
+        expect(page).to have_content(planning_application.full_address)
+        expect(page).to have_content(planning_application.description)
+      end
+
+      expect(page).to have_content("Does this application require a press notice?")
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Press notice")
+      end
+    end
+
+    context "when a press notice is required" do
+      it "I get an error when not providing a reason" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+
+        choose("Yes")
+        click_button("Save and mark as complete")
+
+        within(".govuk-error-summary") do
+          expect(page).to have_content("There is a problem")
+          expect(page).to have_content("You must provide a reason for the press notice")
+        end
+      end
+
+      it "I provide reasons why a press notice is required" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+
+        choose("Yes")
+        check("The application is for a Major Development")
+        check("An environmental statement accompanies this application")
+
+        click_button("Save and mark as complete")
+        expect(page).to have_content("Press notice response has been successfully added")
+
+        within("#publicity-section") do
+          expect(page).to have_content("Completed")
+          click_link("Press notice")
+        end
+
+        expect(find_by_id("press-notice-required-true-field")).to be_checked
+        expect(find_by_id("press_notice_reason_major_development")).to be_checked
+        expect(find_by_id("press_notice_reason_environment")).to be_checked
+
+        expect(PressNotice.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          required: true,
+          reasons: {
+            "environment" => "An environmental statement accompanies this application",
+            "major_development" => "The application is for a Major Development"
+          },
+          requested_at: Time.zone.local(2023, 3, 15, 12)
+        )
+
+        expect(Audit.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice",
+          audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application",
+          user: assessor
+        )
+
+        visit planning_application_audits_path(planning_application)
+        within("#audit_#{Audit.last.id}") do
+          expect(page).to have_content("Press notice response added")
+          expect(page).to have_content(assessor.name)
+          expect(page).to have_content("Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application")
+          expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+        end
+      end
+
+      it "I provide a standard reason and an other reason why a press notice is required" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+
+        choose("Yes")
+        check("The application is for a Major Development")
+        check("Other")
+        fill_in(
+          "Provide an other reason why this application requires a press notice",
+          with: "An other reason not included in the list"
+        )
+
+        click_button("Save and mark as complete")
+        click_link("Press notice")
+
+        expect(find_by_id("press-notice-required-true-field")).to be_checked
+        expect(find_by_id("press_notice_reason_major_development")).to be_checked
+        expect(find_by_id("press-notice-other-reason-selected-1-field")).to be_checked
+
+        expect(PressNotice.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          required: true,
+          reasons: {
+            "other" => "An other reason not included in the list",
+            "major_development" => "The application is for a Major Development"
+          },
+          requested_at: Time.zone.local(2023, 3, 15, 12)
+        )
+
+        expect(Audit.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice",
+          audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An other reason not included in the list",
+          user: assessor
+        )
+      end
+
+      it "I provide an other reason why a press notice is required" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+
+        choose("Yes")
+        check("Other")
+        fill_in(
+          "Provide an other reason why this application requires a press notice",
+          with: "An other reason not included in the list"
+        )
+
+        click_button("Save and mark as complete")
+        click_link("Press notice")
+
+        expect(find_by_id("press-notice-required-true-field")).to be_checked
+        expect(find_by_id("press-notice-other-reason-selected-1-field")).to be_checked
+
+        expect(PressNotice.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          required: true,
+          reasons: {
+            "other" => "An other reason not included in the list"
+          },
+          requested_at: Time.zone.local(2023, 3, 15, 12)
+        )
+
+        expect(Audit.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice",
+          audit_comment: "Press notice has been marked as required with the following reasons: An other reason not included in the list",
+          user: assessor
+        )
+      end
+    end
+
+    context "when a press notice is not required" do
+      it "I can mark it as not required" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+
+        choose("No")
+
+        click_button("Save and mark as complete")
+        expect(page).to have_content("Press notice response has been successfully added")
+        within("#publicity-section") do
+          expect(page).to have_content("Completed")
+          click_link("Press notice")
+        end
+
+        expect(find_by_id("press-notice-required-field")).to be_checked
+
+        expect(PressNotice.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          required: false,
+          reasons: {},
+          requested_at: nil
+        )
+
+        expect(Audit.last).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice",
+          audit_comment: "Press notice has been marked as not required",
+          user: assessor
+        )
+      end
+    end
+
+    context "when editing a press notice" do
+      context "when press notice has been marked as required" do
+        let!(:press_notice) { create(:press_notice, :with_other_reason, planning_application:, requested_at: Time.zone.local(2023, 3, 14, 12)) }
+
+        it "I can mark a press notice as not required after it was marked as required" do
+          click_link "Consultees, neighbours and publicity"
+          click_link "Press notice"
+
+          choose("No")
+
+          click_button("Save and mark as complete")
+          click_link("Press notice")
+
+          expect(find_by_id("press-notice-required-field")).to be_checked
+
+          expect(PressNotice.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            required: false,
+            reasons: {},
+            requested_at: Time.zone.local(2023, 3, 14, 12)
+          )
+
+          expect(Audit.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            activity_type: "press_notice",
+            audit_comment: "Press notice has been marked as not required",
+            user: assessor
+          )
+        end
+
+        it "I can modify the reasons to why the press notice is required" do
+          click_link "Consultees, neighbours and publicity"
+          click_link "Press notice"
+          expect(find_by_id("press-notice-other-reason-selected-1-field")).to be_checked
+
+          check("The application is for a Major Development")
+          check("Wider Public interest")
+          uncheck("Other")
+
+          click_button("Save and mark as complete")
+          click_link("Press notice")
+
+          expect(find_by_id("press-notice-required-true-field")).to be_checked
+          expect(find_by_id("press_notice_reason_major_development")).to be_checked
+          expect(find_by_id("press_notice_reason_public_interest")).to be_checked
+          expect(find_by_id("press-notice-other-reason-selected-1-field")).not_to be_checked
+
+          expect(PressNotice.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            required: true,
+            reasons: { "environment" => "An environmental statement accompanies this application", "major_development" => "The application is for a Major Development", "public_interest" => "Wider Public interest" },
+            requested_at: Time.zone.local(2023, 3, 15, 12)
+          )
+
+          expect(Audit.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            activity_type: "press_notice",
+            audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application, Wider Public interest",
+            user: assessor
+          )
+        end
+      end
+
+      context "when press notice has not been marked as required" do
+        let!(:press_notice) { create(:press_notice, planning_application:) }
+
+        it "I can mark the press notice as not required when it" do
+          click_link "Consultees, neighbours and publicity"
+          click_link "Press notice"
+
+          choose("Yes")
+          check("The application is for a Major Development")
+
+          click_button("Save and mark as complete")
+          click_link("Press notice")
+
+          expect(find_by_id("press-notice-required-true-field")).to be_checked
+          expect(find_by_id("press_notice_reason_major_development")).to be_checked
+
+          expect(PressNotice.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            required: true,
+            reasons: {
+              "major_development" => "The application is for a Major Development"
+            },
+            requested_at: Time.zone.local(2023, 3, 15, 12)
+          )
+
+          expect(Audit.last).to have_attributes(
+            planning_application_id: planning_application.id,
+            activity_type: "press_notice",
+            audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development",
+            user: assessor
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Mark press notice as required or not for planning application

- Choosing yes enables the officer to add from a predetermined set of reasons or add an other reason
- Choosing no requires no reason

### Story Link

https://trello.com/c/v3wZXr3E/2015-mark-press-notice-as-required-or-not-and-provide-reasons

### Screenshots

![Screenshot 2023-09-25 at 15 50 54](https://github.com/unboxed/bops/assets/34001723/41efdfd8-8479-4261-b1a9-c66660f2feac)
![Screenshot 2023-09-25 at 15 51 03](https://github.com/unboxed/bops/assets/34001723/70b00879-d58e-4e40-9044-cc3386036d72)

### **AUDIT LOG**
![Screenshot 2023-09-22 at 11 35 27](https://github.com/unboxed/bops/assets/34001723/3e6ad0bd-4e96-474d-8860-7e2eddf2be0d)
![Screenshot 2023-09-22 at 11 35 39](https://github.com/unboxed/bops/assets/34001723/598b71b9-7e0e-4184-aa65-b32bbf7e4210)
