### PR TITLE
Treat consultations with no end date as not started

### DIFF
--- a/app/components/task_list_items/neighbour_responses_component.rb
+++ b/app/components/task_list_items/neighbour_responses_component.rb
@@ -36,10 +36,10 @@ module TaskListItems
     end
 
     def status
-      if @planning_application.consultation.nil? || @planning_application.consultation.neighbour_responses.none?
+      if @planning_application.consultation.nil? ||
+         @planning_application.consultation.not_started?
         "not_started"
-      elsif @planning_application.consultation.neighbour_responses.any? &&
-            @planning_application.consultation.end_date < Time.zone.now
+      elsif @planning_application.consultation.complete?
         "complete"
       else
         "in_progress"

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -127,6 +127,18 @@ class Consultation < ApplicationRecord
     feature_collection_geojson
   end
 
+  def not_started?
+    !started?
+  end
+
+  def started?
+    neighbour_responses.present? && end_date.present?
+  end
+
+  def complete?
+    started? && end_date < Time.zone.now
+  end
+
   private
 
   def application_link

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -209,4 +209,15 @@ RSpec.describe "View neighbour responses", js: true do
     expect(page).to have_content("Summary tag can't be blank")
     expect(page).to have_content("Received at can't be blank")
   end
+
+  context "when there is no end date yet but there are responses" do
+    let!(:consultation) { create(:consultation, end_date: nil, planning_application:) }
+    let!(:response) { create(:neighbour_response, neighbour:, consultation:) }
+
+    it "is marked as not started" do
+      visit planning_application_path(planning_application)
+      click_link "Consultees, neighbours and publicity"
+      expect(page).to have_content("View neighbour responses Not started")
+    end
+  end
 end


### PR DESCRIPTION
A consultation doesn't immediately get an end_date set in every case, so we should treat nil values as not started.