### PR TITLE
Confirm press notices

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -325,6 +325,10 @@ html * {
   display: flex;
 }
 
+.justify-content-space-between {
+  justify-content: space-between;
+}
+
 .align-items-center {
   align-items: center;
 }
@@ -404,4 +408,8 @@ body {
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding: 2rem;
+}
+
+.background-light-grey {
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
 }

--- a/app/components/task_list_items/confirm_press_notice_component.rb
+++ b/app/components/task_list_items/confirm_press_notice_component.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class ConfirmPressNoticeComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+      @press_notice = planning_application.press_notice
+    end
+
+    private
+
+    attr_reader :planning_application, :press_notice
+
+    def link_text
+      "Confirm press notice"
+    end
+
+    def link_active?
+      press_notice.try(:required)
+    end
+
+    def link_path
+      return unless link_active?
+
+      edit_planning_application_confirm_press_notice_path(planning_application, press_notice)
+    end
+
+    def status_tag_component
+      StatusTags::BaseComponent.new(status:)
+    end
+
+    def status
+      return "not_started" unless press_notice&.press_sent_at
+      return "in_progress" unless press_notice.published_at
+
+      "complete"
+    end
+  end
+end

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -22,7 +22,7 @@ class LocalAuthoritiesController < ApplicationController
   private
 
   def local_authority_params
-    params.require(:local_authority).permit(:reviewer_group_email)
+    params.require(:local_authority).permit(:reviewer_group_email, :press_notice_email)
   end
 
   def set_local_authority

--- a/app/controllers/planning_application/confirm_press_notices_controller.rb
+++ b/app/controllers/planning_application/confirm_press_notices_controller.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class PlanningApplication
+  class ConfirmPressNoticesController < AuthenticationController
+    before_action :set_planning_application
+    before_action :set_press_notice, only: %i[edit update]
+    before_action :ensure_press_notice_is_editable, only: %i[edit update]
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @press_notice.update(press_notice_params)
+          format.html do
+            redirect_to planning_application_consultations_path(@planning_application), notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    private
+
+    def press_notice_params
+      params.require(:press_notice).permit(
+        :press_sent_at,
+        :published_at,
+        :comment
+      ).merge(documents_attributes:)
+    end
+
+    def documents_attributes
+      files = params.dig(:press_notice, :documents_attributes, "0", :files).compact_blank
+      files.map.with_index do |file, i|
+        [i.to_s, { file:, planning_application_id: @planning_application.id, tags: ["Press Notice"] }]
+      end.to_h
+    end
+
+    def set_press_notice
+      @press_notice = @planning_application.press_notice
+    end
+
+    def ensure_press_notice_is_editable
+      return if @press_notice.required?
+
+      render plain: "forbidden", status: :forbidden
+    end
+  end
+end

--- a/app/controllers/planning_application/press_notices_controller.rb
+++ b/app/controllers/planning_application/press_notices_controller.rb
@@ -19,10 +19,10 @@ class PlanningApplication
 
     def create
       @press_notice = @planning_application.build_press_notice(assign_press_notice_params)
-      @press_notice.assign_attributes(requested_at: Time.current) if @press_notice.required?
 
       respond_to do |format|
         if @press_notice.save
+          @press_notice.send_press_notice_mail
           format.html do
             redirect_to planning_application_consultations_path(@planning_application), notice: t(".success")
           end
@@ -33,11 +33,9 @@ class PlanningApplication
     end
 
     def update
-      @press_notice.assign_attributes(assign_press_notice_params)
-      @press_notice.assign_attributes(requested_at: Time.current) if @press_notice.required?
-
       respond_to do |format|
-        if @press_notice.save
+        if @press_notice.update(assign_press_notice_params)
+          @press_notice.send_press_notice_mail
           format.html do
             redirect_to planning_application_consultations_path(@planning_application), notice: t(".success")
           end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -159,4 +159,16 @@ class PlanningApplicationMailer < ApplicationMailer
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
   end
+
+  def press_notice_mail(press_notice)
+    @press_notice = press_notice
+    @planning_application = press_notice.planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:press_notice_mail),
+      to: press_notice.press_notice_email,
+      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+    )
+  end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -87,6 +87,7 @@ class Audit < ApplicationRecord
     neighbour_response_edited: "neighbour_response_edited",
     legislation_checked: "legislation_checked",
     press_notice: "press_notice",
+    press_notice_mail: "press_notice_mail",
     site_notice_created: "site_notice_created"
   }
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -61,7 +61,8 @@ class Document < ApplicationRecord
 
   OTHER_TAGS = [
     "Site Visit",
-    "Site Notice"
+    "Site Notice",
+    "Press Notice"
   ].freeze
 
   ## Needs to be better
@@ -113,7 +114,7 @@ class Document < ApplicationRecord
   validate :numbered
   validate :created_date_is_in_the_past
 
-  default_scope -> { where(site_visit_id: nil, site_notice_id: nil) }
+  default_scope -> { where(site_visit_id: nil, site_notice_id: nil, press_notice_id: nil) }
 
   scope :by_created_at, -> { order(created_at: :asc) }
   scope :active, -> { where(archived_at: nil) }

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -11,7 +11,7 @@ class LocalAuthority < ApplicationRecord
             :feedback_email, presence: true
 
   validates(
-    :reviewer_group_email,
+    :reviewer_group_email, :press_notice_email,
     format: { with: URI::MailTo::EMAIL_REGEXP },
     allow_blank: true
   )

--- a/app/views/local_authorities/_table.html.erb
+++ b/app/views/local_authorities/_table.html.erb
@@ -2,13 +2,21 @@
   <caption class="govuk-table__caption govuk-table__caption--m">
     <%= t(".local_authority") %>
   </caption>
+
   <tbody class="govuk-table__body">
+    <% fields = [
+        { label: ".reviewer_group_email", method: :reviewer_group_email },
+        { label: ".press_notice_email", method: :press_notice_email }
+      ]
+    %>
+
+    <% fields.each do |field| %>
       <tr class="govuk-table__row">
         <th scope="row" class="govuk-table__header">
-          <%= t(".reviewer_group_email") %>
+          <%= t(field[:label]) %>
         </th>
         <td class="govuk-table__cell">
-          <%= local_authority.reviewer_group_email %>
+          <%= local_authority.public_send(field[:method]) %>
         </td>
         <td class="govuk-table__cell">
           <%= link_to(
@@ -18,5 +26,6 @@
           ) %>
         </td>
       </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/local_authorities/edit.html.erb
+++ b/app/views/local_authorities/edit.html.erb
@@ -13,6 +13,11 @@
          label: { text: t(".reviewer_group_email") },
          class: "govuk-input--width-30"
       ) %>
+      <%= form.govuk_text_field(
+         :press_notice_email,
+         label: { text: t(".press_notice_email") },
+         class: "govuk-input--width-30"
+      ) %>
     <% end %>
     <%= form.govuk_submit(t(".submit")) %>
   <% end %>

--- a/app/views/planning_application/confirm_press_notices/_documents.html.erb
+++ b/app/views/planning_application/confirm_press_notices/_documents.html.erb
@@ -1,0 +1,38 @@
+<% if documents.any? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Document</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Tags</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Date uploaded</th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% documents.with_file_attachment.each do |document| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= link_to image_tag(document.file.representation(resize: "300x212")),
+                          url_for_document(document), target: :_blank %>
+            </p>
+            <p class="govuk-body">
+              <%= truncate(document.name.to_s, length: 50) %><br>
+              <%= link_to "View in new window", url_for_document(document), target: :_new %>
+            </p>
+          </td>
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <% document.tags.each do |tag| %>
+              <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong>
+            <% end %>
+          </td>
+          <td class="govuk-table__cell govuk-!-width-one-third">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= document.created_at.to_fs %>
+            </p>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/planning_application/confirm_press_notices/_form.html.erb
+++ b/app/views/planning_application/confirm_press_notices/_form.html.erb
@@ -1,0 +1,36 @@
+<%= form_with(
+  model: [@planning_application, @press_notice],
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  class: "govuk-!-margin-top-5",
+  url: planning_application_confirm_press_notice_path(@planning_application, @press_notice),
+  method: :patch
+) do |form| %>
+
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <%= form.govuk_date_field(:press_sent_at, rows: 6, id: "press-sent-at-field", legend: { size: "s", text: "What date was the press notice sent?" }) %>
+      <%= form.govuk_date_field(:published_at, rows: 6, id: "published-at-field", legend: { size: "s", text: "What date was the press notice published?" }) %>
+
+      <%= render "documents", documents: @press_notice.documents %>
+
+      <%= form.fields_for :documents, @press_notice.documents.new do |document_attributes| %>
+        <%= document_attributes.govuk_file_field :files, 
+          multiple: true, 
+          label: { text: "Upload photo(s)", 
+          class: "govuk-label govuk-!-font-weight-bold" },
+          accept: acceptable_file_mime_types
+        %>
+      <% end %>
+
+      <%= form.govuk_text_area(:comment, rows: 3, label: { text: "Optional comment" }) %>
+    </fieldset>
+
+    <div class="govuk-button-group govuk-!-padding-top-7">
+      <%= form.submit "Save", class: "govuk-button govuk-button--primary" %>
+
+      <%= back_link %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/planning_application/confirm_press_notices/_template.html.erb
+++ b/app/views/planning_application/confirm_press_notices/_template.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title do %>
+  Press notice - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultations_path(@planning_application) %>
+<% content_for :title, "Confirm press notice" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Confirm press notice" }
+) %>
+
+<%= yield %>

--- a/app/views/planning_application/confirm_press_notices/edit.html.erb
+++ b/app/views/planning_application/confirm_press_notices/edit.html.erb
@@ -1,0 +1,33 @@
+<%= render(
+  layout: "template",
+  locals: { planning_application: @planning_application }
+) do %>
+  <% if @press_notice.requested_at %>
+    <hr>
+      <div class="display-flex justify-content-space-between">
+        <p class="govuk-body">
+          Press notice requested 
+        </p>
+        <div>
+          <div>
+            <%= render(StatusTags::BaseComponent.new(status: :emailed)) %>
+          </div>
+          <p class="govuk-body-s">
+            on <%=  @press_notice.requested_at.to_fs(:day_month_year_slashes) %>
+          </p>
+        </div>
+      </div>
+      <hr>
+  <% end %>
+
+  <div class="background-light-grey govuk-!-padding-3">
+    <p class="govuk-body-s"><strong>Reasons selected:</strong></p>
+    <ul>
+      <% @press_notice.reasons.try(:values).each do |reason| %>
+        <li><%= reason %></li>
+      <% end %>
+    </ul>
+  </div>
+  
+  <%= render "form" %>
+<% end %>

--- a/app/views/planning_application/consultations/index.html.erb
+++ b/app/views/planning_application/consultations/index.html.erb
@@ -72,11 +72,13 @@
             planning_application: @planning_application
           )
         ) %>
-        <li class="app-task-list__item" id="confirm-press-notice">
-          <span class="app-task-list__task-name">
-            <a class="govuk-link" href="#">Confirm press notice</a>
-          </span>
-        </li>
+        <% if @planning_application.press_notice.try(:required) %>
+          <%= render(
+            TaskListItems::ConfirmPressNoticeComponent.new(
+              planning_application: @planning_application
+            )
+          ) %>
+        <% end %>
       </ul>
     <ol>
     <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/planning_application/press_notices/_form.html.erb
+++ b/app/views/planning_application/press_notices/_form.html.erb
@@ -8,7 +8,7 @@
     legend: nil
   ) do %>
     <%= form.govuk_radio_button(
-      :required, true, checked: @press_notice.required, label: { text: "Yes" }
+      :required, true, checked: @press_notice.required, disabled: @press_notice.published_at, label: { text: "Yes" }
     ) do %>
       <fieldset class="govuk-fieldset govuk-!-margin-top-3">
         <div class="govuk-checkboxes" data-module="govuk-checkboxes">
@@ -19,7 +19,8 @@
                 values.first,
                 @press_notice.reasons&.key?(key.to_s),
                 class: "govuk-checkboxes__input",
-                id: "press_notice_reason_#{key}"
+                id: "press_notice_reason_#{key}",
+                disabled: @press_notice.published_at
               ) %>
               <%= label_tag(
                 "press_notice_reason_#{key}",
@@ -31,20 +32,42 @@
 
           <p class="govuk-body-s">or</p>
 
-          <%= form.govuk_check_box :other_reason_selected, 1, 0, multiple: false, label: { text: "Other" }, checked: @press_notice.reasons&.key?("other") do %>
-            <%= form.govuk_text_area :"reasons[other]", value: @press_notice.reasons&.dig("other"), label: { text: "Provide an other reason why this application requires a press notice" } %>
+          <%= form.govuk_check_box :other_reason_selected, 1, 0, multiple: false, disabled: @press_notice.published_at, label: { text: "Other" }, checked: @press_notice.reasons&.key?("other") do %>
+            <%= form.govuk_text_area :"reasons[other]", value: @press_notice.reasons&.dig("other"), disabled: @press_notice.published_at, label: { text: "Provide an other reason why this application requires a press notice" } %>
           <% end %>
         </div>
       </fieldset>
+
+      <% unless @press_notice.published_at %>
+        <div class="govuk-inset-text">
+          <p class="govuk-body">
+            <% if @press_notice.press_notice_email.present? %>
+              An email notification will be sent to <strong><%= @planning_application.local_authority.press_notice_email %></strong> if a press notice is required.
+            <% else %>
+              No press notice email has been set. This can be done by an administrator in the admin dashboard.
+            <% end %>
+          </p>
+        </div>
+      <% end %>
     <% end %>
 
     <%= form.govuk_radio_button(
-      :required, false, checked: @press_notice.required == false, label: { text: "No" }
+      :required, false, checked: @press_notice.required == false, disabled: @press_notice.published_at, label: { text: "No" }
     ) %>
   <% end %>
 
+  <% if @press_notice.published_at %>
+    <div class="govuk-inset-text">
+      <p class="govuk-body">
+        Press notice was published on <%= @press_notice.published_at.to_date.to_fs %>
+      </p>
+    </div>
+  <% end %>
+
   <div class="govuk-button-group">
-    <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <% unless @press_notice.published_at %>
+      <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <% end %>
     <%= back_link %>
   </div>
 <% end %>

--- a/app/views/planning_application_mailer/press_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/press_notice_mail.text.erb
@@ -1,0 +1,11 @@
+Application reference number: <%= @planning_application.reference_in_full %>
+
+Address: <%= @planning_application.full_address %>
+
+This application requires a press notice with the following reasons:
+
+<% @press_notice.reasons.values.each do |reason| %>
+- <%= reason %>
+<% end %>
+
+View the application at <%= edit_planning_application_confirm_press_notice_url(@planning_application, @press_notice) %>.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,6 +378,7 @@ en:
       other_change_validation_request_received: 'Received: request for change (other validation#%{args})'
       other_change_validation_request_sent: 'Sent: validation request (other validation#%{args})'
       press_notice: Press notice response added
+      press_notice_mail: Request made for press notice
       proposal_measurements_updated: Proposal measurements were updated
       red_line_boundary_change_validation_request_added: 'Added: validation request (red line boundary#%{args})'
       red_line_boundary_change_validation_request_auto_closed:
@@ -548,6 +549,7 @@ en:
       neighbour_consultation_letter_copy_mail: Neighbour consultation letter copy
       otp_mail: Back Office Planning System verification code
       post_validation_request_mail: "%{application_type_name} application - changes needed"
+      press_notice_mail: Request for press notice
       receipt_notice_mail: "%{application_type_name} application received"
       site_notice_mail: Display site notice for your application %{reference}
       update_notification_mail: BoPS case %{reference} has a new update
@@ -640,6 +642,7 @@ en:
     table:
       edit: Edit
       local_authority: Council information
+      press_notice_email: Press notice email
       reviewer_group_email: Manager group email
   neighbour_letter_header:
     planning_permission: Submit your comments by %{closing_date}
@@ -713,6 +716,9 @@ en:
     cil_liability:
       update:
         success: CIL liability updated
+    confirm_press_notices:
+      update:
+        success: Press notice response has been successfully updated
     consultation_neighbour_addresses:
       create:
         success: Addresses have been successfully added.
@@ -1053,6 +1059,7 @@ en:
   shared:
     administrator_layout:
       add_user: Add user
+      press_notice_email: Press notice email
       reviewer_group_email: Manager group email
       submit: Submit
     alert_banner:
@@ -1100,6 +1107,7 @@ en:
     checked: Checked
     cil_liable: Liable
     complete: Completed
+    emailed: Emailed
     failed: Failed
     granted: To grant
     granted_not_required: Prior approval not required

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,7 +171,8 @@ Rails.application.routes.draw do
         patch :update, on: :collection
       end
 
-      resources :press_notices, only: %i[index new create show edit update]
+      resources :press_notices, only: %i[new create show update]
+      resources :confirm_press_notices, only: %i[edit update]
     end
   end
 

--- a/db/migrate/20230926145640_add_documents_and_comment_to_press_notices.rb
+++ b/db/migrate/20230926145640_add_documents_and_comment_to_press_notices.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDocumentsAndCommentToPressNotices < ActiveRecord::Migration[7.0]
+  def change
+    add_column :press_notices, :comment, :text
+    add_reference :documents, :press_notice, null: true, foreign_key: true
+  end
+end

--- a/db/migrate/20230926145751_add_press_notice_email_to_local_authorities.rb
+++ b/db/migrate/20230926145751_add_press_notice_email_to_local_authorities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPressNoticeEmailToLocalAuthorities < ActiveRecord::Migration[7.0]
+  def change
+    add_column :local_authorities, :press_notice_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -216,11 +216,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.bigint "site_visit_id"
     t.bigint "neighbour_response_id"
     t.bigint "site_notice_id"
+    t.bigint "press_notice_id"
     t.index ["additional_document_validation_request_id"], name: "ix_documents_on_additional_document_validation_request_id"
     t.index ["api_user_id"], name: "ix_documents_on_api_user_id"
     t.index ["evidence_group_id"], name: "ix_documents_on_evidence_group_id"
     t.index ["neighbour_response_id"], name: "ix_documents_on_neighbour_response_id"
     t.index ["planning_application_id"], name: "index_documents_on_planning_application_id"
+    t.index ["press_notice_id"], name: "ix_documents_on_press_notice_id"
     t.index ["replacement_document_validation_request_id"], name: "ix_documents_on_replacement_document_validation_request_id"
     t.index ["site_notice_id"], name: "ix_documents_on_site_notice_id"
     t.index ["site_visit_id"], name: "ix_documents_on_site_visit_id"
@@ -265,6 +267,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.string "notify_api_key"
     t.string "notify_letter_template"
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
+    t.string "press_notice_email"
   end
 
   create_table "neighbour_letters", force: :cascade do |t|
@@ -510,6 +513,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "comment"
     t.index ["planning_application_id"], name: "ix_press_notices_on_planning_application_id"
   end
 
@@ -689,6 +693,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "evidence_groups"
   add_foreign_key "documents", "neighbour_responses"
+  add_foreign_key "documents", "press_notices"
   add_foreign_key "documents", "replacement_document_validation_requests"
   add_foreign_key "documents", "site_notices"
   add_foreign_key "documents", "site_visits"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,8 @@ lambeth = LocalAuthority.find_or_create_by!(
   signatory_job_title: "Director of Finance & Property",
   enquiries_paragraph: "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG",
   email_address: "planning@lambeth.gov.uk",
-  feedback_email: "digitalplanning@lambeth.gov.uk"
+  feedback_email: "digitalplanning@lambeth.gov.uk",
+  press_notice_email: "digitalplanning@lambeth.gov.uk"
 )
 southwark = LocalAuthority.find_or_create_by!(
   council_code: "SWK",
@@ -18,7 +19,8 @@ southwark = LocalAuthority.find_or_create_by!(
   signatory_job_title: "Director of Planning and Growth",
   enquiries_paragraph: "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG",
   email_address: "planning@southwark.gov.uk",
-  feedback_email: "digital.projects@southwark.gov.uk"
+  feedback_email: "digital.projects@southwark.gov.uk",
+  press_notice_email: "digital.projects@southwark.gov.uk"
 )
 
 buckinghamshire = LocalAuthority.find_or_create_by!(
@@ -28,7 +30,8 @@ buckinghamshire = LocalAuthority.find_or_create_by!(
   signatory_job_title: "Director of Planning",
   enquiries_paragraph: "Planning, Buckinghamshire Council, Gatehouse Rd, Aylesbury HP19 8FF",
   email_address: "planning@buckinghamshire.gov.uk",
-  feedback_email: "planning.digital@buckinghamshire.gov.uk"
+  feedback_email: "planning.digital@buckinghamshire.gov.uk",
+  press_notice_email: "planning.digital@buckinghamshire.gov.uk"
 )
 
 ApiUser.find_or_create_by!(name: "api_user", token: (ENV["API_TOKEN"] || "123"))

--- a/spec/factories/press_notice.rb
+++ b/spec/factories/press_notice.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
           development_plan: "The application does not accord with the provisions of the development plan"
         }
       end
+      requested_at { Time.zone.now }
     end
 
     trait :with_other_reason do

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -61,6 +61,10 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
     PlanningApplicationMailer.validation_request_closure_mail(planning_application)
   end
 
+  def press_notice_mail
+    PlanningApplicationMailer.press_notice_mail(PressNotice.required.last)
+  end
+
   private
 
   def planning_application

--- a/spec/system/managing_council_information_spec.rb
+++ b/spec/system/managing_council_information_spec.rb
@@ -26,4 +26,25 @@ RSpec.describe "managing council information" do
       with: "list@example.com"
     )
   end
+
+  it "allows the administrator to manage the press notice email" do
+    sign_in(user)
+    visit(administrator_dashboard_path)
+    row = row_with_content("Press notice email")
+    within(row) { click_link("Edit") }
+    fill_in("Press notice email", with: "ssssss")
+    click_button("Submit")
+
+    expect(page).to have_content("Press notice email is invalid")
+
+    fill_in("Press notice email", with: "press_notice@example.com")
+    click_button("Submit")
+
+    expect(page).to have_content("Council information successfully updated")
+
+    expect(page).to have_row_for(
+      "Press notice email",
+      with: "press_notice@example.com"
+    )
+  end
 end

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Press notice" do
-  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:local_authority) { create(:local_authority, :default, press_notice_email: "pressnotice@example.com") }
   let!(:assessor) { create(:user, :assessor, local_authority:) }
 
   let!(:planning_application) do
@@ -44,6 +44,8 @@ RSpec.describe "Press notice" do
       within(".govuk-breadcrumbs__list") do
         expect(page).to have_content("Press notice")
       end
+
+      expect(page).to have_content("An email notification will be sent to pressnotice@example.com if a press notice is required.")
     end
 
     context "when a press notice is required" do
@@ -90,19 +92,32 @@ RSpec.describe "Press notice" do
           requested_at: Time.zone.local(2023, 3, 15, 12)
         )
 
-        expect(Audit.last).to have_attributes(
+        audits = Audit.last(2)
+        expect(audits.first).to have_attributes(
           planning_application_id: planning_application.id,
           activity_type: "press_notice",
           audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application",
           user: assessor
         )
+        expect(audits.second).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice_mail",
+          audit_comment: "Press notice request was sent to pressnotice@example.com",
+          user: assessor
+        )
 
         visit planning_application_audits_path(planning_application)
-        within("#audit_#{Audit.last.id}") do
+        within("#audit_#{audits.first.id}") do
           expect(page).to have_content("Press notice response added")
           expect(page).to have_content(assessor.name)
           expect(page).to have_content("Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application")
-          expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+          expect(page).to have_content(audits.first.created_at.strftime("%d-%m-%Y %H:%M"))
+        end
+        within("#audit_#{audits.second.id}") do
+          expect(page).to have_content("Request made for press notice")
+          expect(page).to have_content(assessor.name)
+          expect(page).to have_content("Press notice request was sent to pressnotice@example.com")
+          expect(page).to have_content(audits.second.created_at.strftime("%d-%m-%Y %H:%M"))
         end
       end
 
@@ -135,10 +150,17 @@ RSpec.describe "Press notice" do
           requested_at: Time.zone.local(2023, 3, 15, 12)
         )
 
-        expect(Audit.last).to have_attributes(
+        audits = Audit.last(2)
+        expect(audits.first).to have_attributes(
           planning_application_id: planning_application.id,
           activity_type: "press_notice",
           audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An other reason not included in the list",
+          user: assessor
+        )
+        expect(audits.second).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice_mail",
+          audit_comment: "Press notice request was sent to pressnotice@example.com",
           user: assessor
         )
       end
@@ -169,12 +191,64 @@ RSpec.describe "Press notice" do
           requested_at: Time.zone.local(2023, 3, 15, 12)
         )
 
-        expect(Audit.last).to have_attributes(
+        audits = Audit.last(2)
+        expect(audits.first).to have_attributes(
           planning_application_id: planning_application.id,
           activity_type: "press_notice",
           audit_comment: "Press notice has been marked as required with the following reasons: An other reason not included in the list",
           user: assessor
         )
+        expect(audits.second).to have_attributes(
+          planning_application_id: planning_application.id,
+          activity_type: "press_notice_mail",
+          audit_comment: "Press notice request was sent to pressnotice@example.com",
+          user: assessor
+        )
+      end
+
+      it "sends an email to the press notice team" do
+        delivered_emails = ActionMailer::Base.deliveries.count
+
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+        choose("Yes")
+        check("The application is for a Major Development")
+        click_button("Save and mark as complete")
+
+        expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
+      end
+
+      context "when no press notice email exists" do
+        let!(:local_authority) { create(:local_authority, :default, press_notice_email: nil) }
+
+        it "does not send an email to the press notice team" do
+          delivered_emails = ActionMailer::Base.deliveries.count
+
+          click_link "Consultees, neighbours and publicity"
+          click_link "Press notice"
+          choose("Yes")
+          check("The application is for a Major Development")
+          expect(page).to have_content("No press notice email has been set. This can be done by an administrator in the admin dashboard.")
+          click_button("Save and mark as complete")
+
+          expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails)
+        end
+      end
+
+      context "when press notice published at date has been set" do
+        let!(:press_notice) { create(:press_notice, :required, planning_application:, published_at: Time.zone.now) }
+
+        it "I cannot edit or submit the press notice response" do
+          click_link "Consultees, neighbours and publicity"
+          click_link "Press notice"
+
+          expect(find_by_id("press-notice-required-true-field")).to be_disabled
+          expect(find_by_id("press-notice-required-field")).to be_disabled
+          expect(find_by_id("press-notice-other-reason-selected-1-field")).to be_disabled
+
+          expect(page).not_to have_button("Save and mark as complete")
+          expect(page).to have_content("Press notice was published on #{press_notice.published_at.to_date.to_fs}")
+        end
       end
     end
 
@@ -207,6 +281,17 @@ RSpec.describe "Press notice" do
           audit_comment: "Press notice has been marked as not required",
           user: assessor
         )
+      end
+
+      it "does not send an email to the press notice team" do
+        delivered_emails = ActionMailer::Base.deliveries.count
+
+        click_link "Consultees, neighbours and publicity"
+        click_link "Press notice"
+        choose("No")
+        click_button("Save and mark as complete")
+
+        expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails)
       end
     end
 
@@ -264,10 +349,17 @@ RSpec.describe "Press notice" do
             requested_at: Time.zone.local(2023, 3, 15, 12)
           )
 
-          expect(Audit.last).to have_attributes(
+          audits = Audit.last(2)
+          expect(audits.first).to have_attributes(
             planning_application_id: planning_application.id,
             activity_type: "press_notice",
             audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development, An environmental statement accompanies this application, Wider Public interest",
+            user: assessor
+          )
+          expect(audits.second).to have_attributes(
+            planning_application_id: planning_application.id,
+            activity_type: "press_notice_mail",
+            audit_comment: "Press notice request was sent to pressnotice@example.com",
             user: assessor
           )
         end
@@ -298,13 +390,126 @@ RSpec.describe "Press notice" do
             requested_at: Time.zone.local(2023, 3, 15, 12)
           )
 
-          expect(Audit.last).to have_attributes(
+          audits = Audit.last(2)
+          expect(audits.first).to have_attributes(
             planning_application_id: planning_application.id,
             activity_type: "press_notice",
             audit_comment: "Press notice has been marked as required with the following reasons: The application is for a Major Development",
             user: assessor
           )
+          expect(audits.second).to have_attributes(
+            planning_application_id: planning_application.id,
+            activity_type: "press_notice_mail",
+            audit_comment: "Press notice request was sent to pressnotice@example.com",
+            user: assessor
+          )
         end
+      end
+    end
+  end
+
+  describe "confirming a press notice" do
+    context "when a press notice is required" do
+      let!(:press_notice) { create(:press_notice, :required, planning_application:) }
+
+      it "I can view the relevant information" do
+        click_link "Consultees, neighbours and publicity"
+
+        within("#confirm-press-notice") do
+          expect(page).to have_content("Not started")
+          click_link("Confirm press notice")
+        end
+
+        within("#planning-application-details") do
+          expect(page).to have_content("Confirm press notice")
+          expect(page).to have_content(planning_application.reference)
+          expect(page).to have_content(planning_application.full_address)
+          expect(page).to have_content(planning_application.description)
+        end
+
+        expect(page).to have_content("Press notice requested")
+        expect(page).to have_content("Emailed on #{press_notice.requested_at.to_fs(:day_month_year_slashes)}")
+
+        within(".govuk-breadcrumbs__list") do
+          expect(page).to have_content("Confirm press notice")
+        end
+
+        expect(page).to have_content("Reasons selected:")
+        expect(page).to have_content("An environmental statement accompanies this application")
+        expect(page).to have_content("The application does not accord with the provisions of the development plan")
+      end
+
+      it "there is a validation error when saving unsupported file type" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Confirm press notice"
+
+        attach_file("Upload photo(s)", "spec/fixtures/images/image.gif")
+        click_button("Save")
+
+        expect(page).to have_content("The selected file must be a PDF, JPG or PNG")
+      end
+
+      it "I can confirm the press notice details" do
+        click_link "Consultees, neighbours and publicity"
+        click_link "Confirm press notice"
+
+        within("#press-sent-at-field") do
+          expect(page).to have_content("What date was the press notice sent?")
+          fill_in "Day", with: "25"
+          fill_in "Month", with: "9"
+          fill_in "Year", with: "2023"
+        end
+
+        attach_file("Upload photo(s)", "spec/fixtures/images/proposed-floorplan.png")
+
+        fill_in "Optional comment", with: "Press notice comment"
+        click_button "Save"
+
+        expect(page).to have_content("Press notice response has been successfully updated")
+
+        within("#confirm-press-notice") do
+          expect(page).to have_content("In progress")
+          click_link("Confirm press notice")
+        end
+
+        within(".govuk-table") do
+          document = PressNotice.last.documents.first
+          expect(page).to have_content(document.name.to_s)
+          expect(page).to have_link("View in new window")
+          expect(page).to have_content("Press Notice")
+          expect(page).to have_content(document.created_at.to_fs)
+        end
+
+        within("#published-at-field") do
+          expect(page).to have_content("What date was the press notice published?")
+          fill_in "Day", with: "29"
+          fill_in "Month", with: "9"
+          fill_in "Year", with: "2023"
+        end
+
+        click_button "Save"
+
+        within("#confirm-press-notice") do
+          expect(page).to have_content("Complete")
+        end
+
+        expect(PressNotice.last).to have_attributes(
+          press_sent_at: Time.zone.local(2023, 9, 25),
+          published_at: Time.zone.local(2023, 9, 29),
+          comment: "Press notice comment"
+        )
+      end
+    end
+
+    context "when a press notice is not required" do
+      let!(:press_notice) { create(:press_notice, required: false, planning_application:) }
+
+      it "I cannot confirm the press notice" do
+        click_link "Consultees, neighbours and publicity"
+        expect(page).not_to have_content("Confirm press notice")
+
+        visit edit_planning_application_confirm_press_notice_path(planning_application, press_notice)
+        expect(page).to have_content("forbidden")
       end
     end
   end


### PR DESCRIPTION
### Description of change

### **Confirm press notices**

- Add press_notice_email to local authorities which can be edited in the admin area
- Add press sent at and published at dates
- Ability to upload documents in support of the press notice
- Add updates to audit log

### Story Link

https://trello.com/c/VBzgVc6o/2016-send-press-notice-response

### Screenshots

![Screenshot 2023-09-29 at 13 34 16](https://github.com/unboxed/bops/assets/34001723/64731e53-7138-4d39-b172-64d3ad04ad63)

![Screenshot 2023-09-29 at 13 41 46](https://github.com/unboxed/bops/assets/34001723/c9150cca-ee4e-4704-a858-455a03466320)


![Screenshot 2023-09-29 at 13 36 11](https://github.com/unboxed/bops/assets/34001723/72781bca-600b-4d80-a485-29bdbb77d9ce)

![Screenshot 2023-09-29 at 13 50 52](https://github.com/unboxed/bops/assets/34001723/b5751738-9159-429b-bbc8-34ec2240ac27)

