### PR TITLE
Update neighbour_letter model to permit resending

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,9 @@ Rails/SkipsModelValidations:
   Exclude:
     - db/migrate/*.rb
 
+  AllowedMethods:
+    - touch
+
 # Rspec
 RSpec/MultipleExpectations:
   Enabled: false

--- a/app/controllers/planning_application/consultations_controller.rb
+++ b/app/controllers/planning_application/consultations_controller.rb
@@ -71,6 +71,7 @@ class PlanningApplication
 
       @planning_application.send_neighbour_consultation_letter_copy_mail
 
+      # TODO: does this logic need to change when multiple letters can exist?
       @consultation.neighbours.reject(&:letter_created?).each do |neighbour|
         LetterSendingService.new(neighbour, consultation_params[:neighbour_letter_content]).deliver!
       end

--- a/app/models/neighbour.rb
+++ b/app/models/neighbour.rb
@@ -2,7 +2,7 @@
 
 class Neighbour < ApplicationRecord
   belongs_to :consultation
-  has_one :neighbour_letter, dependent: :destroy
+  has_many :neighbour_letters, dependent: :destroy
   has_many :neighbour_responses, dependent: :destroy
 
   validates :address, presence: true, unless: :not_selected?
@@ -15,22 +15,26 @@ class Neighbour < ApplicationRecord
   accepts_nested_attributes_for :neighbour_responses
 
   scope :without_letters, lambda {
-                            left_outer_joins(:neighbour_letter)
-                              .where(neighbour_letter: { neighbour_id: nil })
+                            left_outer_joins(:neighbour_letters)
+                              .where(neighbour_letters: { neighbour_id: nil })
                               .where(selected: true)
                           }
   scope :with_letters, lambda {
-                         includes([:neighbour_letter])
-                           .joins(:neighbour_letter)
-                           .where.not(neighbour_letter: { neighbour_id: nil })
+                         includes([:neighbour_letters])
+                           .joins(:neighbour_letters)
+                           .where.not(neighbour_letters: { neighbour_id: nil })
                        }
 
+  def last_letter
+    neighbour_letters.last
+  end
+
   def letter_created?
-    neighbour_letter.present?
+    neighbour_letters.present?
   end
 
   def letter_sent?
-    letter_created? && neighbour_letter.sent_at.present?
+    letter_created? && neighbour_letters.any? { |letter| letter.sent_at.present? }
   end
 
   private

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -3,6 +3,9 @@
 class NeighbourLetter < ApplicationRecord
   belongs_to :neighbour
 
+  validates :resend_reason, absence: true, unless: :resend?
+  validates :resend_reason, presence: true, if: :resend?
+
   STATUSES = {
     technical_failure: "technical failure",
     permanent_failure: "permanent failure",
@@ -36,5 +39,9 @@ class NeighbourLetter < ApplicationRecord
 
   def notify_api_key
     neighbour.consultation.planning_application.local_authority.notify_api_key || ENV.fetch("NOTIFY_API_KEY")
+  end
+
+  def resend?
+    neighbour.last_letter_sent_at.present?
   end
 end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -39,6 +39,7 @@ class LetterSendingService
     end
 
     update_letter!(letter_record, response)
+    neighbour.touch :last_letter_sent_at
   end
 
   private

--- a/app/views/planning_application/consultations/_contacted_list.html.erb
+++ b/app/views/planning_application/consultations/_contacted_list.html.erb
@@ -8,15 +8,15 @@
       </p>
       <div class="consultation-letter-status">
         <div>
-          <%= render(StatusTags::BaseComponent.new(status: NeighbourLetter::STATUSES[neighbour.neighbour_letter.status.to_sym])) %>
+          <%= render(StatusTags::BaseComponent.new(status: NeighbourLetter::STATUSES[neighbour.last_letter.status.to_sym])) %>
         </div>
-        <% if neighbour.neighbour_letter.status_updated_at.present? %>
+        <% if neighbour.last_letter.status_updated_at.present? %>
           <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-            on <%= neighbour.neighbour_letter.status_updated_at.to_date.to_formatted_s(:day_month_year_slashes) %>
+            on <%= neighbour.last_letter.status_updated_at.to_date.to_fs(:day_month_year_slashes) %>
           </p>
         <% else %>
           <p class="govuk-body-s govuk-!-margin-top-1 govuk-!-margin-bottom-0">
-            on <%= neighbour.neighbour_letter.created_at.to_formatted_s(:day_month_year_slashes) %>
+            on <%= neighbour.last_letter.created_at.to_fs(:day_month_year_slashes) %>
           </p>
         <% end %>
       </div>

--- a/db/migrate/20230928085439_neighbour_letters_add_resend_reason.rb
+++ b/db/migrate/20230928085439_neighbour_letters_add_resend_reason.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NeighbourLettersAddResendReason < ActiveRecord::Migration[7.0]
+  def change
+    add_column :neighbour_letters, :resend_reason, :string
+  end
+end

--- a/db/migrate/20230928094350_add_last_letter_sent_at_to_neighbour.rb
+++ b/db/migrate/20230928094350_add_last_letter_sent_at_to_neighbour.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastLetterSentAtToNeighbour < ActiveRecord::Migration[7.0]
+  def change
+    add_column :neighbours, :last_letter_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_28_085439) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -302,6 +302,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_085439) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "selected", default: true
+    t.datetime "last_letter_sent_at"
     t.index "lower((address)::text), consultation_id", name: "index_neighbours_on_lower_address_and_consultation_id", unique: true
     t.index ["consultation_id"], name: "ix_neighbours_on_consultation_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_21_094853) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_28_085439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -276,6 +276,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_21_094853) do
     t.string "status"
     t.string "status_updated_at"
     t.string "failure_reason"
+    t.string "resend_reason"
     t.index ["neighbour_id"], name: "ix_neighbour_letters_on_neighbour_id"
   end
 

--- a/spec/models/neighbour_letter_spec.rb
+++ b/spec/models/neighbour_letter_spec.rb
@@ -23,4 +23,40 @@ RSpec.describe NeighbourLetter do
       expect(neighbour_letter.status).to eq("received")
     end
   end
+
+  context "when setting a resend reason" do
+    let(:neighbour) { create(:neighbour) }
+    let(:neighbour_letter) { build(:neighbour_letter, neighbour:) }
+
+    context "when sending the first letter to a neighbour" do
+      it "must not have a reason" do
+        neighbour_letter.resend_reason = "blah blah"
+        expect do
+          neighbour_letter.save!
+        end.to raise_error(ActiveRecord::RecordInvalid)
+
+        neighbour_letter.resend_reason = nil
+        expect do
+          neighbour_letter.save!
+        end.not_to raise_error
+      end
+    end
+
+    context "when resending a letter to a neighbour" do
+      let(:previous_neighbour_letter) { create(:neighbour_letter, neighbour:) }
+
+      before { neighbour.touch(:last_letter_sent_at) }
+
+      it "must have a reason" do
+        expect do
+          neighbour_letter.save!
+        end.to raise_error(ActiveRecord::RecordInvalid)
+
+        neighbour_letter.resend_reason = "blah blah"
+        expect do
+          neighbour_letter.save!
+        end.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

- Make neighbour->neighbour_letter a one-to-many relationship
- Add resend reason to neighbour letter
- Add last_letter_sent_at to neighbour, and update it from LetterSendingService

### Story Link

https://trello.com/c/csQTNIyO/1829-repeat-previous-publicity-tasks-at-any-point-of-the-planning-process
