### PR TITLE
Use link for downloading site notice

### DIFF
--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -2,12 +2,16 @@ import { Controller } from "@hotwired/stimulus"
 import { jsPDF } from "jspdf"
 
 export default class extends Controller {
-  handleClick(_event) {
+  handleClick(event) {
+    event.preventDefault()
     const doc = new jsPDF("p", "px", "a4")
+    const applicationReference = document.getElementById(
+      "application-reference",
+    ).innerText
     const pdfjs = document.getElementById("site-notice-content")
     doc.html(pdfjs, {
       callback: function (doc) {
-        doc.save("site-notice.pdf")
+        doc.save(`site-notice-${applicationReference}.pdf`)
       },
     })
   }

--- a/app/views/planning_application/site_notices/new.html.erb
+++ b/app/views/planning_application/site_notices/new.html.erb
@@ -25,6 +25,7 @@
   ) do |form| %>
     <div data-controller="show-hide-form">
       <div class="display-none">
+        <span id="application-reference"><%= @planning_application.reference %></span>
         <div id="site-notice-content">
           <div style="width: 430px;">
             <%= @site_notice.preview_content(@planning_application.planning_application).html_safe %>
@@ -42,7 +43,7 @@
       <% end %>
 
       <div class="display-none" id="site-notice-options">
-        <div class="grey-box">
+        <div class="grey-box" id="email-site-notice">
           <%= form.govuk_radio_buttons_fieldset(
             :method,
             legend: { text: "Email the site notice", size: "m" },
@@ -59,10 +60,12 @@
 
         <h3 class="govuk-heading-s">OR</h3>
 
-        <div class="grey-box">
+        <div class="grey-box" id="print-site-notice">
           <%= form.govuk_date_field :displayed_at, legend: { text: "Print the site notice" }, hint: { text: "Automatically download a PDF which you can print. Enter the date the site notice will be displayed" } %>
-
-          <%= form.submit "Create PDF and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0", "data-action": "click->pdf#handleClick" %>
+          <p class="govuk-body">
+            <%= link_to "Download site notice PDF", "#", "data-action": "click->pdf#handleClick", class: "govuk-link" %>
+          </p>
+          <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
         </div>
 
         <div class="govuk-button-group govuk-!-padding-top-7">

--- a/app/views/planning_application_mailer/internal_team_site_notice_mail.erb
+++ b/app/views/planning_application_mailer/internal_team_site_notice_mail.erb
@@ -2,6 +2,7 @@ Application number <%= @planning_application.reference_in_full %>
 
 The site notice for this application is ready for display.
 
-<%= link_to "Print site notice", @planning_application.site_notice_link %>.
+To print the site notice, go to:
+<%= @planning_application.site_notice_link %>
 
 Case officer: <%= @planning_application.user.name %>

--- a/spec/system/planning_applications/consulting/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/create_site_notice_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Create a site notice", js: true do
     fill_in "Month", with: "2"
     fill_in "Year", with: "2023"
 
-    click_button "Create PDF and mark as complete"
+    click_button "Save and mark as complete", visible: true
 
     expect(page).to have_content "Site notice was successfully created"
   end
@@ -97,7 +97,7 @@ RSpec.describe "Create a site notice", js: true do
 
     choose "No"
 
-    click_button "Save and mark as complete"
+    click_button "Save and mark as complete", visible: true
 
     expect(page).not_to have_content "Confirm site notice is in place"
   end


### PR DESCRIPTION
### Description of change

Sometimes the redirect would happen before the site notice had had time to be produced, so it would fail. Instead, just put it in a link

And some other minor fix ups
