### PR TITLE
Set the path to chromium so that puppeteer can find it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       PIDFILE: /tmp/pids/server.pid
       OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
       REDIS_URL: redis://redis:6379/1
+      PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:


### PR DESCRIPTION
We don't want puppeteer to download chrome so set the environment variable PUPPETEER_EXECUTABLE_PATH to the path to the pre-installed chromium version.
