### PR TITLE
Fix site notice

### DIFF
--- a/app/components/task_list_items/confirm_site_notice_component.rb
+++ b/app/components/task_list_items/confirm_site_notice_component.rb
@@ -16,23 +16,17 @@ module TaskListItems
     end
 
     def link_path
-      if @site_notice.displayed_at.nil?
-        edit_planning_application_site_notice_path(planning_application, site_notice)
-      else
+      if @site_notice.document.present?
         planning_application_site_notice_path(planning_application, site_notice)
+      else
+        edit_planning_application_site_notice_path(planning_application, site_notice)
       end
     end
 
     def status_tag_component
-      if @site_notice.displayed_at.nil?
-        StatusTags::BaseComponent.new(
-          status: "not_started"
-        )
-      else
-        StatusTags::BaseComponent.new(
-          status: "complete"
-        )
-      end
+      StatusTags::BaseComponent.new(
+        status: @site_notice.document.present? ? "complete" : "not_started"
+      )
     end
   end
 end

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -2,8 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 import { jsPDF } from "jspdf"
 
 export default class extends Controller {
-  handleClick(event) {
-    event.preventDefault()
+  handleClick(_event) {
     const doc = new jsPDF("p", "px", "a4")
     const applicationReference = document.getElementById(
       "application-reference",
@@ -11,7 +10,7 @@ export default class extends Controller {
     const pdfjs = document.getElementById("site-notice-content")
     doc.html(pdfjs, {
       callback: function (doc) {
-        doc.setFont("Helvetica")
+        doc.setFont("Arial")
         doc.save(`site-notice-${applicationReference}.pdf`)
       },
     })

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -11,6 +11,7 @@ export default class extends Controller {
     const pdfjs = document.getElementById("site-notice-content")
     doc.html(pdfjs, {
       callback: function (doc) {
+        doc.setFont("Helvetica")
         doc.save(`site-notice-${applicationReference}.pdf`)
       },
     })

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -353,6 +353,10 @@ class PlanningApplication < ApplicationRecord
     audits.where(activity_type: "site_notice_created").order(:created_at).last
   end
 
+  def last_site_notice
+    site_notices.order(:created_at).last
+  end
+
   def invalid_documents_without_validation_request
     invalid_documents.reject { |x| replacement_document_validation_requests.where(old_document: x).any? }
   end

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -16,11 +16,15 @@ class SiteNotice < ApplicationRecord
            application_link: application_link(planning_application),
            council_address: I18n.t("council_addresses.#{planning_application.local_authority.subdomain}"),
            consultation_end_date: end_date_from_now.to_date.to_fs,
-           site_notice_display_date: Time.zone.today)
+           site_notice_display_date: displayed_at&.to_date&.to_fs || Time.zone.today.to_fs)
   end
 
   def end_date_from_now
-    Time.zone.today + 23.days
+    if displayed_at.present?
+      displayed_at + 21.days
+    else
+      Time.zone.today + 23.days
+    end
   end
 
   private

--- a/app/views/planning_application/site_notices/_status.html.erb
+++ b/app/views/planning_application/site_notices/_status.html.erb
@@ -1,7 +1,8 @@
 <hr>
-<div class="proposal-details-sub-heading govuk-!-margin-top-3 govuk-!-margin-bottom-3">
+<div class="proposal-details-sub-heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-controller="pdf">
   <p class="govuk-body govuk-!-margin-top-1">
-    <%= @planning_application.last_site_notice_audit&.audit_comment %>
+    <%= @planning_application.last_site_notice_audit&.audit_comment %><br>
+    <%= link_to "Download site notice PDF", "#", "data-action": "click->pdf#handleClick", class: "govuk-link" %>
   </p>
   <div class="consultation-letter-status">
     <div>
@@ -13,4 +14,11 @@
   </div>
 </div>
 <hr>
-
+<div class="display-none">
+  <span id="application-reference"><%= @planning_application.reference %></span>
+  <div id="site-notice-content">
+    <div style="width: 430px;">
+      <%= @planning_application.last_site_notice.preview_content(@planning_application.planning_application).html_safe %>
+    </div>
+  </div>
+</div>

--- a/app/views/planning_application/site_notices/new.html.erb
+++ b/app/views/planning_application/site_notices/new.html.erb
@@ -16,68 +16,54 @@
   <%= render "status", planning_application: @planning_application %>
 <% end %>
 
-<div data-controller="pdf">
-  <%= form_with(
-    model: [@planning_application, @site_notice],
-    builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-    class: "govuk-!-margin-top-5",
-    method: :post
-  ) do |form| %>
-    <div data-controller="show-hide-form">
-      <div class="display-none">
-        <span id="application-reference"><%= @planning_application.reference %></span>
-        <div id="site-notice-content">
-          <div style="width: 430px;">
-            <%= @site_notice.preview_content(@planning_application.planning_application).html_safe %>
-          </div>
-        </div>
-      </div>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+<%= form_with(
+  model: [@planning_application, @site_notice],
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  class: "govuk-!-margin-top-5 my-form",
+  method: :post
+) do |form| %>
+  <div data-controller="show-hide-form">
+    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
-      <%= form.govuk_radio_buttons_fieldset(
-        :required,
-        legend: { text: "Does this application require a site notice?", size: "m" }
-      ) do %>
-        <%= form.govuk_radio_button :required, :yes, label: { text: "Yes" }, data: { action: "change->show-hide-form#handleEvent" } %>
-        <%= form.govuk_radio_button :required, :no, label: { text: "No" }, data: { action: "change->show-hide-form#handleEvent" } %>
-      <% end %>
+    <%= form.govuk_radio_buttons_fieldset(
+      :required,
+      legend: { text: "Does this application require a site notice?", size: "m" }
+    ) do %>
+      <%= form.govuk_radio_button :required, :yes, label: { text: "Yes" }, data: { action: "change->show-hide-form#handleEvent" } %>
+      <%= form.govuk_radio_button :required, :no, label: { text: "No" }, data: { action: "change->show-hide-form#handleEvent" } %>
+    <% end %>
 
-      <div class="display-none" id="site-notice-options">
-        <div class="grey-box" id="email-site-notice">
-          <%= form.govuk_radio_buttons_fieldset(
-            :method,
-            legend: { text: "Email the site notice", size: "m" },
-            hint: { text: "If you are printing the site notice yourself, you can skip this step." }
-          ) do %>
-            <%= form.govuk_radio_button :method, :internal_team, label: { text: "Send it by email to internal team to post" } do %>
-              <%= form.govuk_text_field :internal_team_email, label: { text: "Internal team email" } %>
-            <% end %>
-            <%= form.govuk_radio_button :method, :applicant, label: { text: "Send it by email to applicant" } %>
+    <div class="display-none" id="site-notice-options">
+      <div class="grey-box" id="email-site-notice">
+        <%= form.govuk_radio_buttons_fieldset(
+          :method,
+          legend: { text: "Email the site notice", size: "m" },
+          hint: { text: "If you are printing the site notice yourself, you can skip this step." }
+        ) do %>
+          <%= form.govuk_radio_button :method, :internal_team, label: { text: "Send it by email to internal team to post" } do %>
+            <%= form.govuk_text_field :internal_team_email, label: { text: "Internal team email" } %>
           <% end %>
+          <%= form.govuk_radio_button :method, :applicant, label: { text: "Send it by email to applicant" } %>
+        <% end %>
 
-          <%= form.submit "Email site notice and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
-        </div>
-
-        <h3 class="govuk-heading-s">OR</h3>
-
-        <div class="grey-box" id="print-site-notice">
-          <%= form.govuk_date_field :displayed_at, legend: { text: "Print the site notice" }, hint: { text: "Automatically download a PDF which you can print. Enter the date the site notice will be displayed" } %>
-          <p class="govuk-body">
-            <%= link_to "Download site notice PDF", "#", "data-action": "click->pdf#handleClick", class: "govuk-link" %>
-          </p>
-          <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
-        </div>
-
-        <div class="govuk-button-group govuk-!-padding-top-7">
-          <%= back_link %>
-        </div>
+        <%= form.submit "Email site notice and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
       </div>
 
-      <div class="govuk-button-group govuk-!-padding-top-7 display-none" id="site-notice-form-actions">
-        <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary" %>
+      <h3 class="govuk-heading-s">OR</h3>
 
+      <div class="grey-box" id="print-site-notice">
+        <%= form.govuk_date_field :displayed_at, legend: { text: "Print the site notice" }, hint: { text: "Create and then download a PDF which you can print. Enter the date the site notice will be displayed" } %>
+        <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
+      </div>
+
+      <div class="govuk-button-group govuk-!-padding-top-7">
         <%= back_link %>
       </div>
     </div>
-  <% end %>
-</div>
+
+    <div class="govuk-button-group govuk-!-padding-top-7 display-none" id="site-notice-form-actions">
+      <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary" %>
+      <%= back_link %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/site_notices.yml
+++ b/config/locales/site_notices.yml
@@ -1,6 +1,6 @@
 en: 
   site_notice_template: |-
-    <div style="font-size: 10px; padding-left: 20px; padding-right: 20px;">
+    <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
     <div style="width: 420px; text-align: center">
       <h1 style="margin-bottom: 5px;">Planning notice</h1>
       <h2 style="margin-bottom: 5px;">%{council} Council</h2>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,6 +79,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "application_types_conditions", id: false, force: :cascade do |t|
+    t.bigint "condition_id", null: false
+    t.bigint "application_type_id", null: false
+    t.index ["application_type_id"], name: "ix_application_types_conditions_on_application_type_id"
+    t.index ["condition_id"], name: "ix_application_types_conditions_on_condition_id"
+  end
+
   create_table "assessment_details", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
@@ -119,6 +126,41 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "deleted_at", precision: nil
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "ix_comments_on_user_id"
+  end
+
+  create_table "condition_reasons", force: :cascade do |t|
+    t.text "text"
+    t.bigint "condition_id"
+    t.bigint "local_authority_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["condition_id"], name: "ix_condition_reasons_on_condition_id"
+    t.index ["local_authority_id"], name: "ix_condition_reasons_on_local_authority_id"
+  end
+
+  create_table "condition_reasons_planning_applications", id: false, force: :cascade do |t|
+    t.bigint "condition_reason_id", null: false
+    t.bigint "planning_application_id", null: false
+    t.index ["condition_reason_id"], name: "ix_condition_reasons_planning_applications_on_condition_reason_"
+    t.index ["planning_application_id"], name: "ix_condition_reasons_planning_applications_on_planning_applicat"
+  end
+
+  create_table "conditions", force: :cascade do |t|
+    t.string "title"
+    t.text "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "considerations", force: :cascade do |t|
+    t.string "area"
+    t.string "policies"
+    t.string "guidance"
+    t.text "assessment"
+    t.bigint "policy_area_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["policy_area_id"], name: "ix_considerations_on_policy_area_id"
   end
 
   create_table "consistency_checklists", force: :cascade do |t|
@@ -172,6 +214,21 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["planning_application_id"], name: "ix_consultees_on_planning_application_id"
   end
 
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at", precision: nil
+    t.datetime "locked_at", precision: nil
+    t.datetime "failed_at", precision: nil
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
+
   create_table "description_change_validation_requests", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
@@ -213,8 +270,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.bigint "replacement_document_validation_request_id"
     t.boolean "redacted", default: false, null: false
     t.bigint "evidence_group_id"
-    t.bigint "site_visit_id"
     t.bigint "neighbour_response_id"
+    t.bigint "site_visit_id"
     t.bigint "site_notice_id"
     t.bigint "press_notice_id"
     t.index ["additional_document_validation_request_id"], name: "ix_documents_on_additional_document_validation_request_id"
@@ -266,8 +323,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.string "council_code", null: false
     t.string "notify_api_key"
     t.string "notify_letter_template"
-    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
     t.string "press_notice_email"
+    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 
   create_table "neighbour_letters", force: :cascade do |t|
@@ -495,6 +552,20 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["policy_class_id"], name: "ix_policies_on_policy_class_id"
   end
 
+  create_table "policy_areas", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "review_status", default: "review_not_started", null: false
+    t.string "status", default: "not_started", null: false
+    t.bigint "assessor_id"
+    t.bigint "reviewer_id"
+    t.datetime "reviewed_at"
+    t.index ["assessor_id"], name: "ix_policy_areas_on_assessor_id"
+    t.index ["planning_application_id"], name: "ix_policy_areas_on_planning_application_id"
+    t.index ["reviewer_id"], name: "ix_policy_areas_on_reviewer_id"
+  end
+
   create_table "policy_classes", force: :cascade do |t|
     t.string "schedule", null: false
     t.integer "part", null: false
@@ -611,6 +682,23 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"
   end
 
+  create_table "review_policy_areas", force: :cascade do |t|
+    t.bigint "policy_area_id"
+    t.bigint "assessor_id"
+    t.bigint "reviewer_id"
+    t.boolean "accepted", default: false, null: false
+    t.string "status", default: "in_progress", null: false
+    t.string "review_status", default: "review_not_started", null: false
+    t.boolean "reviewer_edited", default: false, null: false
+    t.text "reviewer_comment"
+    t.datetime "reviewed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessor_id"], name: "ix_review_policy_areas_on_assessor_id"
+    t.index ["policy_area_id"], name: "ix_review_policy_areas_on_policy_area_id"
+    t.index ["reviewer_id"], name: "ix_review_policy_areas_on_reviewer_id"
+  end
+
   create_table "review_policy_classes", force: :cascade do |t|
     t.bigint "policy_class_id", null: false
     t.integer "mark", null: false
@@ -717,6 +805,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
   add_foreign_key "planx_planning_data", "planning_applications"
+  add_foreign_key "policy_areas", "users", column: "assessor_id"
+  add_foreign_key "policy_areas", "users", column: "reviewer_id"
   add_foreign_key "press_notices", "planning_applications"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"
@@ -727,6 +817,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "replacement_document_validation_requests", "users"
   add_foreign_key "review_immunity_details", "users", column: "assessor_id"
   add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
+  add_foreign_key "review_policy_areas", "users", column: "assessor_id"
+  add_foreign_key "review_policy_areas", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "site_visits", "consultations"
   add_foreign_key "site_visits", "users", column: "created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -79,13 +79,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "application_types_conditions", id: false, force: :cascade do |t|
-    t.bigint "condition_id", null: false
-    t.bigint "application_type_id", null: false
-    t.index ["application_type_id"], name: "ix_application_types_conditions_on_application_type_id"
-    t.index ["condition_id"], name: "ix_application_types_conditions_on_condition_id"
-  end
-
   create_table "assessment_details", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
@@ -126,41 +119,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "deleted_at", precision: nil
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["user_id"], name: "ix_comments_on_user_id"
-  end
-
-  create_table "condition_reasons", force: :cascade do |t|
-    t.text "text"
-    t.bigint "condition_id"
-    t.bigint "local_authority_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["condition_id"], name: "ix_condition_reasons_on_condition_id"
-    t.index ["local_authority_id"], name: "ix_condition_reasons_on_local_authority_id"
-  end
-
-  create_table "condition_reasons_planning_applications", id: false, force: :cascade do |t|
-    t.bigint "condition_reason_id", null: false
-    t.bigint "planning_application_id", null: false
-    t.index ["condition_reason_id"], name: "ix_condition_reasons_planning_applications_on_condition_reason_"
-    t.index ["planning_application_id"], name: "ix_condition_reasons_planning_applications_on_planning_applicat"
-  end
-
-  create_table "conditions", force: :cascade do |t|
-    t.string "title"
-    t.text "text"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "considerations", force: :cascade do |t|
-    t.string "area"
-    t.string "policies"
-    t.string "guidance"
-    t.text "assessment"
-    t.bigint "policy_area_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["policy_area_id"], name: "ix_considerations_on_policy_area_id"
   end
 
   create_table "consistency_checklists", force: :cascade do |t|
@@ -214,21 +172,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["planning_application_id"], name: "ix_consultees_on_planning_application_id"
   end
 
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
-    t.integer "attempts", default: 0, null: false
-    t.text "handler", null: false
-    t.text "last_error"
-    t.datetime "run_at", precision: nil
-    t.datetime "locked_at", precision: nil
-    t.datetime "failed_at", precision: nil
-    t.string "locked_by"
-    t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
-  end
-
   create_table "description_change_validation_requests", force: :cascade do |t|
     t.bigint "planning_application_id", null: false
     t.bigint "user_id", null: false
@@ -270,8 +213,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.bigint "replacement_document_validation_request_id"
     t.boolean "redacted", default: false, null: false
     t.bigint "evidence_group_id"
-    t.bigint "neighbour_response_id"
     t.bigint "site_visit_id"
+    t.bigint "neighbour_response_id"
     t.bigint "site_notice_id"
     t.bigint "press_notice_id"
     t.index ["additional_document_validation_request_id"], name: "ix_documents_on_additional_document_validation_request_id"
@@ -323,8 +266,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.string "council_code", null: false
     t.string "notify_api_key"
     t.string "notify_letter_template"
-    t.string "press_notice_email"
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
+    t.string "press_notice_email"
   end
 
   create_table "neighbour_letters", force: :cascade do |t|
@@ -552,20 +495,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["policy_class_id"], name: "ix_policies_on_policy_class_id"
   end
 
-  create_table "policy_areas", force: :cascade do |t|
-    t.bigint "planning_application_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "review_status", default: "review_not_started", null: false
-    t.string "status", default: "not_started", null: false
-    t.bigint "assessor_id"
-    t.bigint "reviewer_id"
-    t.datetime "reviewed_at"
-    t.index ["assessor_id"], name: "ix_policy_areas_on_assessor_id"
-    t.index ["planning_application_id"], name: "ix_policy_areas_on_planning_application_id"
-    t.index ["reviewer_id"], name: "ix_policy_areas_on_reviewer_id"
-  end
-
   create_table "policy_classes", force: :cascade do |t|
     t.string "schedule", null: false
     t.integer "part", null: false
@@ -682,23 +611,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.index ["reviewer_id"], name: "ix_review_immunity_details_on_reviewer_id"
   end
 
-  create_table "review_policy_areas", force: :cascade do |t|
-    t.bigint "policy_area_id"
-    t.bigint "assessor_id"
-    t.bigint "reviewer_id"
-    t.boolean "accepted", default: false, null: false
-    t.string "status", default: "in_progress", null: false
-    t.string "review_status", default: "review_not_started", null: false
-    t.boolean "reviewer_edited", default: false, null: false
-    t.text "reviewer_comment"
-    t.datetime "reviewed_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessor_id"], name: "ix_review_policy_areas_on_assessor_id"
-    t.index ["policy_area_id"], name: "ix_review_policy_areas_on_policy_area_id"
-    t.index ["reviewer_id"], name: "ix_review_policy_areas_on_reviewer_id"
-  end
-
   create_table "review_policy_classes", force: :cascade do |t|
     t.bigint "policy_class_id", null: false
     t.integer "mark", null: false
@@ -805,8 +717,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
   add_foreign_key "planx_planning_data", "planning_applications"
-  add_foreign_key "policy_areas", "users", column: "assessor_id"
-  add_foreign_key "policy_areas", "users", column: "reviewer_id"
   add_foreign_key "press_notices", "planning_applications"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"
@@ -817,8 +727,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "replacement_document_validation_requests", "users"
   add_foreign_key "review_immunity_details", "users", column: "assessor_id"
   add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
-  add_foreign_key "review_policy_areas", "users", column: "assessor_id"
-  add_foreign_key "review_policy_areas", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "site_visits", "consultations"
   add_foreign_key "site_visits", "users", column: "created_by_id"

--- a/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe "Confirm site notice", js: true do
     fill_in "Month", with: "02"
     fill_in "Year", with: "2023"
 
+    # Can't upload docs via Capybara yet
+    create(:document, site_notice:)
+
     click_button "Save and mark as complete"
 
     expect(page).to have_content("Site notice was successfully updated")

--- a/spec/system/planning_applications/consulting/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/create_site_notice_spec.rb
@@ -44,6 +44,10 @@ RSpec.describe "Create a site notice", js: true do
     click_button "Save and mark as complete", visible: true
 
     expect(page).to have_content "Site notice was successfully created"
+    expect(page).to have_link(
+      "Download site notice PDF",
+      href: "#"
+    )
   end
 
   it "allows officers to create a site notice and email it to the applicant" do
@@ -61,7 +65,7 @@ RSpec.describe "Create a site notice", js: true do
     perform_enqueued_jobs
     email_notification = ActionMailer::Base.deliveries.last
 
-    expect(email_notification.to).to contain_exactly(planning_application.applicant_email)
+    expect(email_notification.to).to contain_exactly(planning_application.agent_email)
 
     expect(email_notification.subject).to eq("Display site notice for your application 23-00100-PA")
 


### PR DESCRIPTION
### Description of change

- Make the PDF look a bit better
- Fix a bug so that the confirm page shows when there isn't a document showing the site notice in place attached
- Rework the flow for downloading a site notice. First input the date it will be displayed, create the site notice, then download it
