### PR TITLE
Renamed planx_url to planxRequest

### DIFF
--- a/app/services/apis/plan_x/query.rb
+++ b/app/services/apis/plan_x/query.rb
@@ -40,7 +40,7 @@ module Apis
           request.options[:timeout] = TIMEOUT
         end
 
-        { response:, wkt:, geojson:, planx_url: "#{HOST}#{request_url}" }
+        { response:, wkt:, geojson:, planxRequest: "#{HOST}#{request_url}" }
       end
 
       def self.geojson_to_wkt(geojson)

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -12,7 +12,7 @@ class ConstraintsCreationService
         planning_application:,
         geojson: planning_application.boundary_geojson,
         wkt: constraint["wkt"],
-        planx_query: constraint["planxRequest"] || constraint["planx_url"],
+        planx_query: constraint["planxRequest"],
         planning_data_query: constraint["sourceRequest"]
       )
 


### PR DESCRIPTION
### Description of change

Renamed planx_url to planxRequest

Making it consistent with PlanX new `constraints_proposed` field which includes the `planxRequest`