### PR TITLE
Add neighbours to site visits

### DIFF
--- a/app/controllers/planning_application/site_visits_controller.rb
+++ b/app/controllers/planning_application/site_visits_controller.rb
@@ -63,7 +63,7 @@ class PlanningApplication
     end
 
     def site_visit_params
-      params.require(:site_visit).permit(:decision, :comment, :visited_at).merge(documents_attributes:)
+      params.require(:site_visit).permit(:decision, :comment, :visited_at, :neighbour_id).merge(documents_attributes:)
     end
 
     def documents_attributes

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -85,6 +85,10 @@ class Consultation < ApplicationRecord
     neighbours.select(&:persisted?).select(&:selected?).map(&:address)
   end
 
+  def selected_neighbours
+    neighbours.select(&:persisted?).select(&:selected?)
+  end
+
   def publicity_active?
     return false unless end_date
 

--- a/app/models/site_visit.rb
+++ b/app/models/site_visit.rb
@@ -4,6 +4,7 @@ class SiteVisit < ApplicationRecord
   belongs_to :created_by, class_name: "User"
   belongs_to :consultation
   has_many :documents, dependent: :destroy
+  belongs_to :neighbour, optional: true
 
   validates :status, :comment, presence: true
   validates :decision, inclusion: { in: [true, false] }

--- a/app/views/planning_application/site_visits/_form.html.erb
+++ b/app/views/planning_application/site_visits/_form.html.erb
@@ -19,6 +19,8 @@
         ) do %>
           <%= form.govuk_date_field(:visited_at, rows: 6, legend: { text: "Site visited at" }) %>
 
+          <%= form.govuk_collection_select :neighbour_id, @consultation.selected_neighbours, :id, :address, options: { include_blank: true }, label: { text: "Select site visit address" } %>
+
           <%= form.fields_for :documents, @site_visit.documents.new do |document_attributes| %>
             <%= document_attributes.govuk_file_field :files, 
               multiple: true, 

--- a/app/views/planning_application/site_visits/index.html.erb
+++ b/app/views/planning_application/site_visits/index.html.erb
@@ -29,6 +29,9 @@
         <p class="govuk-body">Site visit needed: <%= site_visit.decision? ? "Yes" : "No" %></p>
         <p class="govuk-body">Response created by: <%= site_visit.created_by.name %></p>
         <p class="govuk-body">Response created at: <%= site_visit.created_at.to_fs %></p>
+        <% if site_visit.neighbour.present? %>
+          <p class="govuk-body">Neighbour: <%= site_visit.neighbour.address %></p>
+        <% end %>
         <% if site_visit.decision? %>
           <p class="govuk-body">Visited at: <%= site_visit.visited_at&.to_fs %></p>
         <% end %>

--- a/app/views/planning_application/site_visits/show.html.erb
+++ b/app/views/planning_application/site_visits/show.html.erb
@@ -20,6 +20,9 @@
 <% if @site_visit.decision? %>
   <p class="govuk-body">Visited at: <%= @site_visit.visited_at&.to_date&.to_fs %></p>
 <% end %>
+<% if @site_visit.neighbour.present? %>
+  <p class="govuk-body">Neighbour: <%= @site_visit.neighbour.address %></p>
+<% end %>
 <p class="govuk-body">Comment: <%= @site_visit.comment %></p>
 
 <% if @site_visit.documents.any? %>

--- a/db/migrate/20231004160325_add_neighbour_to_site_visit.rb
+++ b/db/migrate/20231004160325_add_neighbour_to_site_visit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNeighbourToSiteVisit < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :site_visits, :neighbour, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_04_160325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -640,8 +640,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
     t.datetime "visited_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "neighbour_id"
     t.index ["consultation_id"], name: "ix_site_visits_on_consultation_id"
     t.index ["created_by_id"], name: "ix_site_visits_on_created_by_id"
+    t.index ["neighbour_id"], name: "ix_site_visits_on_neighbour_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -729,6 +731,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_28_094350) do
   add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "site_visits", "consultations"
+  add_foreign_key "site_visits", "neighbours"
   add_foreign_key "site_visits", "users", column: "created_by_id"
   add_foreign_key "validation_requests", "planning_applications"
 end

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Site visit" do
 
   let!(:consultation) { create(:consultation, end_date: "2023-07-08 16:17:35 +0100", planning_application:) }
   let!(:neighbour) { create(:neighbour, consultation:) }
+  let!(:neighbour2) { create(:neighbour, consultation:, address: "123 Another Address") }
 
   before do
     sign_in assessor
@@ -56,7 +57,7 @@ RSpec.describe "Site visit" do
   end
 
   describe "viewing site visits" do
-    let!(:site_visit1) { create(:site_visit, consultation:, comment: "Site visit 1") }
+    let!(:site_visit1) { create(:site_visit, consultation:, comment: "Site visit 1", neighbour:) }
     let!(:site_visit2) { create(:site_visit, decision: false, consultation:, comment: "Site visit 2") }
     let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:, received_at: Time.zone.now) }
 
@@ -91,6 +92,7 @@ RSpec.describe "Site visit" do
           expect(page).to have_content("Site visit needed: Yes")
           expect(page).to have_content("Response created by: #{site_visit1.created_by.name}")
           expect(page).to have_content("Response created at: #{site_visit1.created_at.to_fs}")
+          expect(page).to have_content("Neighbour: #{site_visit1.neighbour.address}")
           expect(page).to have_content("Comment: Site visit 1")
 
           expect(page).to have_content("Site visit needed: No")
@@ -156,6 +158,8 @@ RSpec.describe "Site visit" do
         fill_in "Month", with: "7"
         fill_in "Year", with: "2023"
 
+        select neighbour.address
+
         attach_file("Upload photo(s)", "spec/fixtures/images/proposed-floorplan.png")
 
         fill_in "Comment", with: "Site visit is needed"
@@ -190,6 +194,7 @@ RSpec.describe "Site visit" do
         expect(page).to have_content("Response created by: #{assessor.name}")
         expect(page).to have_content("Response created at: #{SiteVisit.last.created_at.to_fs}")
         expect(page).to have_content("Visited at: 20 July 2023")
+        expect(page).to have_content("Neighbour: #{neighbour.address}")
         expect(page).to have_content("Comment: Site visit is needed")
 
         within(".govuk-table") do


### PR DESCRIPTION
### Description of change

Allow officers to attach neighbours to site visits to give more context

### Story Link

https://trello.com/c/rw4Mk5rB/1896-add-context-to-site-visit-photos

### Screenshots
![Screenshot 2023-10-04 at 17 26 28](https://github.com/unboxed/bops/assets/35098639/bc0a75f7-2fc2-4253-9c64-0f5255946dc9)

