### PR TITLE
Change label of create site notice button

### DIFF
--- a/app/views/planning_application/site_notices/new.html.erb
+++ b/app/views/planning_application/site_notices/new.html.erb
@@ -53,7 +53,7 @@
 
       <div class="grey-box" id="print-site-notice">
         <%= form.govuk_date_field :displayed_at, legend: { text: "Print the site notice" }, hint: { text: "Create and then download a PDF which you can print. Enter the date the site notice will be displayed" } %>
-        <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
+        <%= form.submit "Create site notice", class: "govuk-button govuk-button--primary govuk-!-margin-bottom-0" %>
       </div>
 
       <div class="govuk-button-group govuk-!-padding-top-7">

--- a/spec/system/planning_applications/consulting/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/create_site_notice_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Create a site notice", js: true do
     fill_in "Month", with: "2"
     fill_in "Year", with: "2023"
 
-    click_button "Save and mark as complete", visible: true
+    click_button "Create site notice", visible: true
 
     expect(page).to have_content "Site notice was successfully created"
     expect(page).to have_link(


### PR DESCRIPTION
### Description of change

- Change label of site notice button to "Create site notice" to make it clearer what will happen
