### PR TITLE
Fix db/schema.rb format

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -266,8 +266,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_04_160325) do
     t.string "council_code", null: false
     t.string "notify_api_key"
     t.string "notify_letter_template"
-    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
     t.string "press_notice_email"
+    t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 
   create_table "neighbour_letters", force: :cascade do |t|


### PR DESCRIPTION
Index definitions always come after column definitions so this must have been an error during a rebase/merge conflict.
