### PR TITLE
Move CIL liability from assessment to validation

### DIFF
--- a/app/components/status_tags/cil_liability_component.rb
+++ b/app/components/status_tags/cil_liability_component.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module TaskListItems
-  class CilLiabilityComponent < TaskListItems::BaseComponent
+module StatusTags
+  class CilLiabilityComponent < StatusTags::BaseComponent
     def initialize(planning_application:)
       @planning_application = planning_application
     end
@@ -11,16 +11,6 @@ module TaskListItems
     attr_reader :planning_application
 
     delegate(:cil_liable, to: :planning_application)
-
-    def link_text
-      t(".link_text")
-    end
-
-    def link_path
-      edit_planning_application_cil_liability_path(
-        planning_application
-      )
-    end
 
     def status
       case cil_liable

--- a/app/controllers/planning_applications/cil_liability_controller.rb
+++ b/app/controllers/planning_applications/cil_liability_controller.rb
@@ -4,7 +4,6 @@ module PlanningApplications
   class CilLiabilityController < ApplicationController
     include PlanningApplicationAssessable
     before_action :set_planning_application
-    before_action :ensure_planning_application_is_validated
 
     def edit
       respond_to do |format|
@@ -14,7 +13,7 @@ module PlanningApplications
 
     def update
       if @planning_application.update(cil_liability_params)
-        redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+        redirect_to planning_application_validation_tasks_path(@planning_application), notice: t(".success")
       else
         render :edit
       end

--- a/app/views/planning_applications/assessment_tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment_tasks/_check_consistency.html.erb
@@ -54,10 +54,5 @@
         )
       ) %>
     <% end %>
-    <%= render(
-      TaskListItems::CilLiabilityComponent.new(
-        planning_application: @planning_application
-      )
-    ) %>
   </ul>
 </li>

--- a/app/views/planning_applications/cil_liability/edit.html.erb
+++ b/app/views/planning_applications/cil_liability/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%= render(
-      partial: "shared/assessment_task_breadcrumbs",
+      partial: "validation_requests/validation_requests_breadcrumbs",
       locals: { planning_application: @planning_application }
     ) %>
 

--- a/app/views/planning_applications/validation_tasks/_cil_liability.html.erb
+++ b/app/views/planning_applications/validation_tasks/_cil_liability.html.erb
@@ -1,0 +1,17 @@
+<li id="cil-liability-validation-tasks">
+  <h2 class="app-task-list__section">
+    CIL liability
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        <%= link_to "CIL liability", edit_planning_application_cil_liability_path(@planning_application), class: "govuk-link" %>
+      </span>
+      <%= render(
+            StatusTags::CilLiabilityComponent.new(
+              planning_application: @planning_application
+            )
+          ) %>
+    </li>
+  </ul>
+</li>

--- a/app/views/planning_applications/validation_tasks/index.html.erb
+++ b/app/views/planning_applications/validation_tasks/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  Validation tasks - <%= t('page_title') %>
+  Validation tasks - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
@@ -7,9 +7,9 @@
 <% content_for :title, "Validation tasks" %>
 
 <%= render(
-  partial: "shared/proposal_header",
-  locals: { heading: "Check the application"  }
-) %>
+      partial: "shared/proposal_header",
+      locals: { heading: "Check the application" }
+    ) %>
 
 <%= render "shared/dates_and_assignment_header" %>
 
@@ -20,15 +20,17 @@
       <%= t(".application_details") %>
     </h2>
     <%= render(
-      AccordionComponent.new(
-        planning_application: @planning_application,
-        sections: %i[application_information proposal_details documents]
-      )
-    ) %>
+          AccordionComponent.new(
+            planning_application: @planning_application,
+            sections: %i[application_information proposal_details documents]
+          )
+        ) %>
     <ol class="app-task-list govuk-!-margin-top-8">
       <%= render "red_line_boundary" %>
 
       <%= render "fee_validation" %>
+
+      <%= render "cil_liability" %>
 
       <%= render "constraints" %>
 

--- a/spec/system/planning_applications/assessing/cil_liability_spec.rb
+++ b/spec/system/planning_applications/assessing/cil_liability_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Permitted development right" do
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
   let!(:planning_application) do
-    create(:planning_application, :in_assessment, old_constraints: [], local_authority: default_local_authority)
+    create(:planning_application, :not_started, old_constraints: [], local_authority: default_local_authority)
   end
 
   context "when signed in as an assessor" do
@@ -19,57 +19,57 @@ RSpec.describe "Permitted development right" do
 
     context "when planning application is in assessment" do
       it "is listed as incomplete by default" do
-        visit planning_application_assessment_tasks_path(planning_application)
+        visit planning_application_validation_tasks_path(planning_application)
 
-        within "#check-consistency-assessment-tasks" do
-          expect(page).to have_content "CIL Liability Not started"
+        within "#cil-liability-validation-tasks" do
+          expect(page).to have_content "CIL liability Not started"
         end
       end
 
       it "can be marked as liable" do
-        visit planning_application_assessment_tasks_path(planning_application)
-        click_link "CIL Liability"
+        visit planning_application_validation_tasks_path(planning_application)
+        click_link "CIL liability"
         choose "Yes"
         click_button "Save and mark as complete"
 
         expect(page).to have_content "CIL liability updated"
-        within "#check-consistency-assessment-tasks" do
-          expect(page).to have_content "CIL Liability Liable"
+        within "#cil-liability-validation-tasks" do
+          expect(page).to have_content "CIL liability Liable"
         end
       end
 
       it "can be marked as not liable" do
-        visit planning_application_assessment_tasks_path(planning_application)
-        click_link "CIL Liability"
+        visit planning_application_validation_tasks_path(planning_application)
+        click_link "CIL liability"
         choose "No"
         click_button "Save and mark as complete"
 
         expect(page).to have_content "CIL liability updated"
-        within "#check-consistency-assessment-tasks" do
-          expect(page).to have_content "CIL Liability Not liable"
+        within "#cil-liability-validation-tasks" do
+          expect(page).to have_content "CIL liability Not liable"
         end
       end
 
       context "when revisiting the edit page" do
         it "is marked as true when liable" do
-          visit planning_application_assessment_tasks_path(planning_application)
-          click_link "CIL Liability"
+          visit planning_application_validation_tasks_path(planning_application)
+          click_link "CIL liability"
           choose "Yes"
           click_button "Save and mark as complete"
 
-          click_link "CIL Liability"
+          click_link "CIL liability"
 
           expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
           expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
         end
 
         it "is marked as false when not liable" do
-          visit planning_application_assessment_tasks_path(planning_application)
-          click_link "CIL Liability"
+          visit planning_application_validation_tasks_path(planning_application)
+          click_link "CIL liability"
           choose "No"
           click_button "Save and mark as complete"
 
-          click_link "CIL Liability"
+          click_link "CIL liability"
 
           expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
           expect(find_by_id("planning-application-cil-liable-field")).to be_selected
@@ -78,15 +78,15 @@ RSpec.describe "Permitted development right" do
 
       context "when there is no liability information from planx" do
         it "explains that there is no liability information" do
-          visit planning_application_assessment_tasks_path(planning_application)
-          click_link "CIL Liability"
+          visit planning_application_validation_tasks_path(planning_application)
+          click_link "CIL liability"
 
           expect(page).to have_content("No information on potential CIL liability from PlanX.")
         end
 
         it "does not preselect any radio button" do
-          visit planning_application_assessment_tasks_path(planning_application)
-          click_link "CIL Liability"
+          visit planning_application_validation_tasks_path(planning_application)
+          click_link "CIL liability"
 
           expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
           expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
@@ -104,16 +104,16 @@ RSpec.describe "Permitted development right" do
           let(:planx_response) { "More than 100m²" }
 
           it "shows relevant liability information" do
-            visit planning_application_assessment_tasks_path(planning_application)
-            click_link "CIL Liability"
+            visit planning_application_validation_tasks_path(planning_application)
+            click_link "CIL liability"
 
             expect(page).to have_content(planx_response)
             expect(page).to have_content("This might mean that the application is liable for CIL.")
           end
 
           it "selects yes by default" do
-            visit planning_application_assessment_tasks_path(planning_application)
-            click_link "CIL Liability"
+            visit planning_application_validation_tasks_path(planning_application)
+            click_link "CIL liability"
 
             expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
             expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
@@ -124,39 +124,22 @@ RSpec.describe "Permitted development right" do
           let(:planx_response) { "Less than 100m²" }
 
           it "shows relevant liability information" do
-            visit planning_application_assessment_tasks_path(planning_application)
-            click_link "CIL Liability"
+            visit planning_application_validation_tasks_path(planning_application)
+            click_link "CIL liability"
 
             expect(page).to have_content(planx_response)
             expect(page).to have_content("This might mean that the application is not liable for CIL.")
           end
 
           it "selects no by default" do
-            visit planning_application_assessment_tasks_path(planning_application)
-            click_link "CIL Liability"
+            visit planning_application_validation_tasks_path(planning_application)
+            click_link "CIL liability"
 
             expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
             expect(find_by_id("planning-application-cil-liable-field")).to be_selected
           end
         end
       end
-    end
-  end
-
-  context "when planning application has not been validated yet" do
-    let!(:planning_application) do
-      create(:planning_application, :not_started, local_authority: default_local_authority)
-    end
-
-    it "does not allow me to visit the page" do
-      sign_in assessor
-      visit planning_application_path(planning_application)
-
-      expect(page).not_to have_link("CIL Liability")
-
-      visit edit_planning_application_cil_liability_path(planning_application)
-
-      expect(page).to have_content("forbidden")
     end
   end
 end


### PR DESCRIPTION
### Description of change

Moving this to the correct section

### Story Link

<https://trello.com/c/7LL6Ip7U/2032-cil-liability-should-be-in-validation-not-assessment>

### Screenshots

If you have made changes to the frontend please add screenshots
