### PR TITLE
BUG FIX Consultation summary review

### DIFF
--- a/app/form_models/review_assessment_details_form.rb
+++ b/app/form_models/review_assessment_details_form.rb
@@ -5,29 +5,6 @@ class ReviewAssessmentDetailsForm
   include ActiveModel::Model
   extend ActiveModel::Callbacks
 
-  LDC_ASSESSMENT_DETAILS = %i[
-    summary_of_work
-    site_description
-    consultation_summary
-    additional_evidence
-  ].freeze
-
-  PRIOR_APPROVAL_ASSESSMENT_DETAILS = %i[
-    summary_of_work
-    site_description
-    additional_evidence
-    publicity_summary
-    amenity
-  ].freeze
-
-  PLANNING_PERMISSION_ASSESSMENT_DETAILS = %i[
-    summary_of_work
-    site_description
-    additional_evidence
-    consultation_summary
-    publicity_summary
-  ].freeze
-
   ASSESSMENT_DETAILS = %i[
     summary_of_work
     site_description
@@ -125,17 +102,6 @@ class ReviewAssessmentDetailsForm
     true
   end
 
-  def assessment_detail_types
-    case planning_application.application_type.name.to_sym
-    when :lawfulness_certificate
-      LDC_ASSESSMENT_DETAILS
-    when :prior_approval
-      PRIOR_APPROVAL_ASSESSMENT_DETAILS
-    else
-      PLANNING_PERMISSION_ASSESSMENT_DETAILS
-    end
-  end
-
   private
 
   def recommendation_not_accepted
@@ -162,14 +128,7 @@ class ReviewAssessmentDetailsForm
     define_method("#{assessment_detail}_for_application?") do
       next if status == :in_progress
 
-      case planning_application.type
-      when "Lawful Development Certificate"
-        LDC_ASSESSMENT_DETAILS.include? assessment_detail
-      when "Prior approval"
-        PRIOR_APPROVAL_ASSESSMENT_DETAILS.include? assessment_detail
-      when "Householder Application for Planning Permission"
-        PLANNING_PERMISSION_ASSESSMENT_DETAILS.include? assessment_detail
-      end
+      planning_application.application_type.assessment_details.include? assessment_detail.to_s
     end
   end
 end

--- a/app/form_models/review_assessment_details_form.rb
+++ b/app/form_models/review_assessment_details_form.rb
@@ -20,6 +20,14 @@ class ReviewAssessmentDetailsForm
     amenity
   ].freeze
 
+  PLANNING_PERMISSION_ASSESSMENT_DETAILS = %i[
+    summary_of_work
+    site_description
+    additional_evidence
+    consultation_summary
+    publicity_summary
+  ].freeze
+
   ASSESSMENT_DETAILS = %i[
     summary_of_work
     site_description
@@ -121,8 +129,10 @@ class ReviewAssessmentDetailsForm
     case planning_application.application_type.name.to_sym
     when :lawfulness_certificate
       LDC_ASSESSMENT_DETAILS
-    else
+    when :prior_approval
       PRIOR_APPROVAL_ASSESSMENT_DETAILS
+    else
+      PLANNING_PERMISSION_ASSESSMENT_DETAILS
     end
   end
 
@@ -152,10 +162,13 @@ class ReviewAssessmentDetailsForm
     define_method("#{assessment_detail}_for_application?") do
       next if status == :in_progress
 
-      if planning_application.type == "Prior approval"
-        PRIOR_APPROVAL_ASSESSMENT_DETAILS.include? assessment_detail
-      else
+      case planning_application.type
+      when "Lawful Development Certificate"
         LDC_ASSESSMENT_DETAILS.include? assessment_detail
+      when "Prior approval"
+        PRIOR_APPROVAL_ASSESSMENT_DETAILS.include? assessment_detail
+      when "Householder Application for Planning Permission"
+        PLANNING_PERMISSION_ASSESSMENT_DETAILS.include? assessment_detail
       end
     end
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -78,7 +78,7 @@ class Consultation < ApplicationRecord
   end
 
   def neighbour_responses_by_summary_tag
-    neighbour_responses.group(:summary_tag).count
+    neighbour_responses.group(:summary_tag).order(:summary_tag).count
   end
 
   def selected_neighbour_addresses

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -17,7 +17,7 @@
           "Applicant" => planning_application.applicant_name,
           "Application number" => planning_application.reference,
           "Application received" => planning_application.received_at.to_fs,
-          "Decision date" => planning_application.determination_date.to_fs || "TBD",
+          "Decision date" => planning_application.determination_date&.to_fs || "TBD",
           "Site address" => planning_application.full_address,
           "Use/development" => planning_application.description,
         }.each do |key, value|

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -16,8 +16,8 @@
         {
           "Applicant" => planning_application.applicant_name,
           "Application number" => planning_application.reference,
-          "Application received" => planning_application.received_at,
-          "Decision date" => planning_application.determination_date || "TBD",
+          "Application received" => planning_application.received_at.to_fs,
+          "Decision date" => planning_application.determination_date.to_fs || "TBD",
           "Site address" => planning_application.full_address,
           "Use/development" => planning_application.description,
         }.each do |key, value|

--- a/app/views/review_assessment_details/_form.html.erb
+++ b/app/views/review_assessment_details/_form.html.erb
@@ -29,10 +29,9 @@
         ) %>
         <h3><%= t(".summary_of_consultee") %><h3>
       <% end %>
-      <% if assessment_detail == :amenity %>
+      <% if assessment_detail == :amenity || assessment_detail == :publicity_summary %>
         <% if consultation = @planning_application.consultation %>
           <p>View neighbour responses: <%= neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %></p>
-            
           <p><%= link_to "View neighbour responses", new_planning_application_consultation_neighbour_response_path(@planning_application, consultation) %></p>
         <% else %>
           <p>There is no existing consultation for this planning application.</p>

--- a/app/views/review_assessment_details/_form.html.erb
+++ b/app/views/review_assessment_details/_form.html.erb
@@ -5,7 +5,7 @@
   builder: GOVUKDesignSystemFormBuilder::FormBuilder
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <% @form.assessment_detail_types.each_with_index do |assessment_detail, index| %>
+  <% planning_application.application_type.assessment_details.each_with_index do |assessment_detail, index| %>
     <% unless index == 0 %>
       <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <% end %>
@@ -19,17 +19,17 @@
           assessment_detail: form.object.send(assessment_detail)
         )
       ) %>
-      <% if assessment_detail == :site_description %>
+      <% if assessment_detail == "site_description" %>
         <p><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></p>
       <% end %>
-      <% if assessment_detail == :consultation_summary %>
+      <% if assessment_detail == "consultation_summary" %>
         <%= render(
           partial: "consultees",
           locals: { consultees: planning_application.consultees }
         ) %>
         <h3><%= t(".summary_of_consultee") %><h3>
       <% end %>
-      <% if assessment_detail == :amenity || assessment_detail == :publicity_summary %>
+      <% if assessment_detail == "amenity" || assessment_detail == "publicity_summary" %>
         <% if consultation = @planning_application.consultation %>
           <p>View neighbour responses: <%= neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %></p>
           <p><%= link_to "View neighbour responses", new_planning_application_consultation_neighbour_response_path(@planning_application, consultation) %></p>

--- a/db/migrate/20231006134128_add_assessment_details_to_application_type.rb
+++ b/db/migrate/20231006134128_add_assessment_details_to_application_type.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AddAssessmentDetailsToApplicationType < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_types, :assessment_details, :string, array: true
+
+    ApplicationType.all.find_each do |type|
+      details = case type.name.to_sym
+                when :lawfulness_certificate
+                  %w[
+                    summary_of_work
+                    site_description
+                    consultation_summary
+                    additional_evidence
+                  ]
+                when :prior_approval
+                  %w[
+                    summary_of_work
+                    site_description
+                    additional_evidence
+                    publicity_summary
+                    amenity
+                  ]
+                else
+                  %w[
+                    summary_of_work
+                    site_description
+                    additional_evidence
+                    consultation_summary
+                    publicity_summary
+                  ]
+                end
+      type.update(assessment_details: details)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_04_160325) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_06_134128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -77,6 +77,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_04_160325) do
     t.string "section"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "assessment_details", array: true
   end
 
   create_table "assessment_details", force: :cascade do |t|

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -3,13 +3,39 @@
 FactoryBot.define do
   factory :application_type do
     name { "lawfulness_certificate" }
+    assessment_details do
+      %w[
+        summary_of_work
+        site_description
+        consultation_summary
+        additional_evidence
+      ]
+    end
 
     trait :prior_approval do
       name { "prior_approval" }
+      assessment_details do
+        %w[
+          summary_of_work
+          site_description
+          additional_evidence
+          publicity_summary
+          amenity
+        ]
+      end
     end
 
     trait :planning_permission do
       name { "planning_permission" }
+      assessment_details do
+        %w[
+          summary_of_work
+          site_description
+          additional_evidence
+          consultation_summary
+          publicity_summary
+        ]
+      end
     end
 
     initialize_with { ApplicationType.find_or_create_by(name:) }

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -94,11 +94,11 @@ RSpec.describe "Reviewing assessment summaries" do
 
         create(
           :assessment_detail,
-          :additional_evidence,
+          :publicity_summary,
           assessment_status: :complete,
           planning_application:,
           user: assessor,
-          entry: "public summary"
+          entry: "publicity summary"
         )
       end
 
@@ -202,11 +202,11 @@ RSpec.describe "Reviewing assessment summaries" do
           choose("Accept")
         end
 
-        within(find("fieldset", text: "Summary of neighbour responses")) do
+        within(find("fieldset", text: "Amenity assessment")) do
           choose("Accept")
         end
 
-        within(find("fieldset", text: "Amenity assessment")) do
+        within(find("fieldset", text: "Summary of neighbour responses")) do
           expect(page).to have_link(
             "View neighbour responses",
             href: new_planning_application_consultation_neighbour_response_path(planning_application, consultation)
@@ -431,10 +431,6 @@ RSpec.describe "Reviewing assessment summaries" do
 
         expect(page).to have_content(
           "Site description reviewer verdict can't be blank"
-        )
-
-        expect(page).to have_content(
-          "Consultation summary reviewer verdict can't be blank"
         )
 
         expect(page).to have_content(
@@ -771,6 +767,310 @@ RSpec.describe "Reviewing assessment summaries" do
         click_link("Review assessment summaries")
 
         within(find("fieldset", text: "Summary of additional evidence")) do
+          choose("Accept")
+        end
+
+        click_button("Save and mark as complete")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Checked"
+        )
+      end
+    end
+  end
+
+  context "when planning application is planning permission" do
+    before do
+      planning_permission = create(:application_type, :planning_permission)
+      planning_application.update(application_type: planning_permission)
+    end
+
+    context "when assessor filled out summaries" do
+      before do
+        create(
+          :assessment_detail,
+          :summary_of_work,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "summary of works"
+        )
+
+        create(
+          :assessment_detail,
+          :site_description,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "site description"
+        )
+
+        create(
+          :assessment_detail,
+          :additional_evidence,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "additional evidence"
+        )
+
+        create(
+          :assessment_detail,
+          :additional_evidence,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "public summary"
+        )
+
+        create(
+          :assessment_detail,
+          :consultation_summary,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "consultation summary"
+        )
+
+        create(
+          :assessment_detail,
+          :publicity_summary,
+          assessment_status: :complete,
+          planning_application:,
+          user: assessor,
+          entry: "publicity summary"
+        )
+      end
+
+      let!(:consultation) { create(:consultation, end_date: Time.zone.now, planning_application:) }
+      let!(:neighbour1) { create(:neighbour, address: "1 Cookie Avenue", consultation:) }
+      let!(:neighbour2) { create(:neighbour, address: "2 Cookie Avenue", consultation:) }
+      let!(:neighbour3) { create(:neighbour, address: "3 Cookie Avenue", consultation:) }
+      let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
+      let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+      let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+      let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
+
+      it "allows reviewer to submit correctly filled out form" do
+        travel_to(Time.zone.local(2022, 11, 28, 12, 30))
+        visit(planning_application_review_tasks_path(planning_application))
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Not started"
+        )
+
+        click_link("Review assessment summaries")
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Not started"
+        )
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Summary of works")) do
+          expect(find(".govuk-tag")).to have_content("Completed")
+
+          choose("Accept")
+        end
+
+        click_button("Save and mark as complete")
+
+        expect(page).to have_content(
+          "Additional evidence reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Site description reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Publicity summary reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Consultation summary reviewer verdict can't be blank"
+        )
+
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "In progress"
+        )
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Site description")) do
+          expect(page).to have_link(
+            "View site on Google Maps",
+            href: "https://google.co.uk/maps/place/#{CGI.escape(planning_application.full_address)}"
+          )
+          choose("Edit to accept")
+        end
+
+        click_button("Save and come back later")
+
+        expect(page).to have_content("Site description entry must be edited")
+
+        within(find("fieldset", text: "Site description")) do
+          fill_in("Update site description", with: "")
+        end
+
+        click_button("Save and come back later")
+
+        expect(page).to have_content("Site description entry can't be blank")
+
+        within(find("fieldset", text: "Site description")) do
+          fill_in("Update site description", with: "edited site description")
+        end
+
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "In progress"
+        )
+
+        within("ul#review-assessment-section") do
+          expect(page).to have_list_item_for(
+            "Review assessment summaries", with: "In progress"
+          )
+        end
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Summary of additional evidence")) do
+          choose("Accept")
+        end
+
+        within(find("fieldset", text: "Summary of neighbour responses")) do
+          choose("Accept")
+        end
+
+        within(find("fieldset", text: "Consultation")) do
+          choose("Accept")
+        end
+
+        click_button("Save and mark as complete")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Checked"
+        )
+
+        click_link("Sign-off recommendation")
+        choose("No (return the case for assessment)")
+
+        fill_in(
+          "Explain to the officer why the case is being returned",
+          with: "recommendation challenged"
+        )
+
+        click_button("Save and mark as complete")
+        click_link("Review assessment summaries")
+
+        click_link("Log out")
+        sign_in(assessor)
+        visit(planning_application_path(planning_application))
+
+        expect(page).to have_list_item_for(
+          "Check and assess", with: "To be reviewed"
+        )
+
+        click_link("Check and assess")
+        click_link("Make draft recommendation")
+
+        click_button("Update assessment")
+        click_link("Review and submit recommendation")
+        click_button("Submit recommendation")
+        click_link("Log out")
+        sign_in(reviewer)
+        visit(planning_application_path(planning_application))
+
+        click_link("Review and sign-off")
+        click_link("Sign-off recommendation")
+        choose("Yes")
+        click_button("Save and mark as complete")
+        click_link("Review assessment summaries")
+      end
+    end
+
+    context "when assessor didn't fill out summaries" do
+      it "allows reviewer to submit correctly filled out form" do
+        visit(planning_application_review_tasks_path(planning_application))
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Not started"
+        )
+
+        click_link("Review assessment summaries")
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "Not started"
+        )
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Summary of works")) do
+          expect(find(".govuk-tag")).to have_content("Not started")
+
+          choose("Accept")
+        end
+
+        click_button("Save and mark as complete")
+
+        expect(page).to have_content(
+          "Additional evidence reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Site description reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Publicity summary reviewer verdict can't be blank"
+        )
+
+        expect(page).to have_content(
+          "Consultation summary reviewer verdict can't be blank"
+        )
+
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "In progress"
+        )
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Site description")) do
+          choose("Edit to accept")
+        end
+
+        click_button("Save and come back later")
+
+        expect(page).to have_content("Site description entry can't be blank")
+
+        within(find("fieldset", text: "Site description")) do
+          fill_in("Update site description", with: "edited site description")
+        end
+
+        click_button("Save and come back later")
+
+        expect(page).to have_list_item_for(
+          "Review assessment summaries", with: "In progress"
+        )
+
+        click_link("Review assessment summaries")
+
+        within(find("fieldset", text: "Summary of additional evidence")) do
+          choose("Accept")
+        end
+
+        within(find("fieldset", text: "Summary of neighbour responses")) do
+          choose("Accept")
+        end
+
+        within(find("fieldset", text: "Consultation")) do
           choose("Accept")
         end
 


### PR DESCRIPTION
### Description of change

Make sure the reviewer sees the right assessment details per application type when they're reviewing the assessor's work

### Story Link

https://trello.com/c/rASG8D9t/2017-consultation-review-summary-cant-be-blank-but-theres-no-option-to-complete-it
