### PR TITLE
Create a consultation when the application is created

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,6 +51,11 @@ Rails/SkipsModelValidations:
   AllowedMethods:
     - touch
 
+# allow ActiveRecord::Base as a parent class in migrations
+Rails/ApplicationRecord:
+  Exclude:
+    - db/migrate/*.rb
+
 # Rspec
 RSpec/MultipleExpectations:
   Enabled: false

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationType < ApplicationRecord
-  APPLICATION_STEPS = %i[validation consultation assessment review].freeze
-
   NAME_ORDER = %w[prior_approval planning_permission lawfulness_certificate].freeze
 
   default_scope { in_order_of(:name, NAME_ORDER).order(:name) }
@@ -31,13 +29,8 @@ class ApplicationType < ApplicationRecord
     fetch_legislation_translation("description")
   end
 
-  def steps_for_type
-    case name
-    when "lawfulness_certificate"
-      APPLICATION_STEPS - %i[consultation]
-    else
-      APPLICATION_STEPS
-    end
+  def consultation?
+    steps.include?("consultation")
   end
 
   class << self

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -69,6 +69,7 @@ class PlanningApplication < ApplicationRecord
     has_one :consistency_checklist, dependent: :destroy
   end
 
+  delegate :consultation?, to: :application_type
   delegate :reviewer_group_email, to: :local_authority
   delegate :email, to: :user, prefix: true, allow_nil: true
   delegate :name, to: :user, prefix: true, allow_nil: true
@@ -93,6 +94,7 @@ class PlanningApplication < ApplicationRecord
   after_create :set_ward_and_parish_information
   after_create :create_audit!
   after_create :update_measurements, if: :prior_approval?
+  after_create :create_consultation!, if: :consultation?
   before_update :set_key_dates
   before_update lambda {
                   reset_validation_requests_update_counter!(red_line_boundary_change_validation_requests)

--- a/app/views/planning_applications/_application_steps.html.erb
+++ b/app/views/planning_applications/_application_steps.html.erb
@@ -1,3 +1,3 @@
-<% @planning_application.application_type.steps_for_type.each  do |step| %>
+<% @planning_application.application_type.steps.each do |step| %>
   <%= render "planning_applications/steps/#{step}" %>
 <% end %>

--- a/db/migrate/20231006175416_add_steps_to_application_type.rb
+++ b/db/migrate/20231006175416_add_steps_to_application_type.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AddStepsToApplicationType < ActiveRecord::Migration[7.0]
+  class PlanningApplication < ActiveRecord::Base
+    belongs_to :application_type
+    has_one :consultation, required: false
+  end
+
+  class ApplicationType < ActiveRecord::Base
+    has_many :planning_applications
+
+    def consultation?
+      steps.include?("consultation")
+    end
+  end
+
+  def change
+    add_column :application_types, :steps, :string, array: true, default: %w[validation consultation assessment review]
+    remove_index :consultations, :planning_application_id
+    add_index :consultations, :planning_application_id, unique: true
+
+    up_only do
+      ApplicationType.reset_column_information
+      ApplicationType.where(name: "lawfulness_certificate").update_all(steps: %w[validation assessment review])
+
+      PlanningApplication.find_each do |planning_application|
+        application_type = planning_application.application_type
+
+        if application_type.consultation? && planning_application.consultation.blank?
+          planning_application.create_consultation!
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_06_134128) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_06_175416) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_134128) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "assessment_details", array: true
+    t.string "steps", default: ["validation", "consultation", "assessment", "review"], array: true
   end
 
   create_table "assessment_details", force: :cascade do |t|
@@ -158,7 +159,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_134128) do
     t.jsonb "polygon_geojson"
     t.string "polygon_colour", default: "#d870fc", null: false
     t.geography "polygon_search", limit: {:srid=>4326, :type=>"geometry_collection", :geographic=>true}
-    t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id"
+    t.index ["planning_application_id"], name: "ix_consultations_on_planning_application_id", unique: true
   end
 
   create_table "consultees", force: :cascade do |t|

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -3,6 +3,8 @@
 FactoryBot.define do
   factory :application_type do
     name { "lawfulness_certificate" }
+    steps { %w[validation assessment review] }
+
     assessment_details do
       %w[
         summary_of_work
@@ -14,6 +16,8 @@ FactoryBot.define do
 
     trait :prior_approval do
       name { "prior_approval" }
+      steps { %w[validation consultation assessment review] }
+
       assessment_details do
         %w[
           summary_of_work
@@ -27,6 +31,8 @@ FactoryBot.define do
 
     trait :planning_permission do
       name { "planning_permission" }
+      steps { %w[validation consultation assessment review] }
+
       assessment_details do
         %w[
           summary_of_work

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -727,10 +727,6 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#neighbour_consultation_letter_copy_mail" do
-    let!(:consultation) do
-      travel_to("2022-01-01") { create(:consultation, planning_application:) }
-    end
-
     let(:application_type) { create(:application_type, :prior_approval) }
 
     let(:planning_application) do
@@ -751,6 +747,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
 
+    let(:consultation) do
+      planning_application.consultation
+    end
+
     let(:neighbour_consultation_letter_copy_mail) do
       described_class.neighbour_consultation_letter_copy_mail(planning_application, planning_application.agent_email)
     end
@@ -758,6 +758,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     let(:mail_body) { neighbour_consultation_letter_copy_mail.body.encoded }
 
     before do
+      travel_to("2022-01-01") do
+        consultation.update(start_date: 2.days.ago, end_date: (2.days.ago + 21.days))
+      end
+
       allow(ENV).to receive(:fetch).and_call_original
       allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("production")
 
@@ -812,15 +816,6 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#site_notice_mail" do
-    before do
-      allow(ENV).to receive(:[]).with("APPLICANTS_APP_HOST").and_return("example.com")
-      allow(ENV).to receive(:fetch).with("APPLICANTS_APP_HOST").and_return("example.com")
-    end
-
-    let!(:consultation) do
-      travel_to("2022-01-01") { create(:consultation, planning_application:) }
-    end
-
     let(:user) { create(:user) }
 
     let(:application_type) { create(:application_type, :prior_approval) }
@@ -844,6 +839,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
 
+    let(:consultation) do
+      planning_application.consultation
+    end
+
     let(:site_notice) { create(:site_notice, planning_application:) }
 
     let(:site_notice_mail) do
@@ -851,6 +850,15 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     let(:mail_body) { site_notice_mail.body.encoded }
+
+    before do
+      travel_to("2022-01-01") do
+        consultation.update(start_date: 2.days.ago, end_date: (2.days.ago + 21.days))
+      end
+
+      allow(ENV).to receive(:[]).with("APPLICANTS_APP_HOST").and_return("example.com")
+      allow(ENV).to receive(:fetch).with("APPLICANTS_APP_HOST").and_return("example.com")
+    end
 
     it "sets the subject" do
       expect(site_notice_mail.subject).to eq(
@@ -881,15 +889,6 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#internal_site_notice_mail" do
-    before do
-      allow(ENV).to receive(:[]).with("APPLICANTS_APP_HOST").and_return("example.com")
-      allow(ENV).to receive(:fetch).with("APPLICANTS_APP_HOST").and_return("example.com")
-    end
-
-    let!(:consultation) do
-      travel_to("2022-01-01") { create(:consultation, planning_application:) }
-    end
-
     let(:user) { create(:user) }
 
     let(:application_type) { create(:application_type, :prior_approval) }
@@ -913,6 +912,10 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
 
+    let(:consultation) do
+      planning_application.consultation
+    end
+
     let(:site_notice) { create(:site_notice, planning_application:) }
 
     let(:internal_team_site_notice_mail) do
@@ -920,6 +923,15 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
 
     let(:mail_body) { internal_team_site_notice_mail.body.encoded }
+
+    before do
+      travel_to("2022-01-01") do
+        consultation.update(start_date: 2.days.ago, end_date: (2.days.ago + 21.days))
+      end
+
+      allow(ENV).to receive(:[]).with("APPLICANTS_APP_HOST").and_return("example.com")
+      allow(ENV).to receive(:fetch).with("APPLICANTS_APP_HOST").and_return("example.com")
+    end
 
     it "sets the subject" do
       expect(internal_team_site_notice_mail.subject).to eq(

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -296,6 +296,24 @@ RSpec.describe PlanningApplication do
           expect(planning_application.ward_type).to be_nil
         end
       end
+
+      context "when a application type doesn't have a consultation" do
+        let(:application_type) { create(:application_type) }
+        let(:planning_application) { build(:planning_application, application_type:) }
+
+        it "doesn't create a consultation record after creating the planning application" do
+          expect { planning_application.save! }.not_to change(planning_application, :consultation).from(nil)
+        end
+      end
+
+      context "when a application type has a consultation" do
+        let(:application_type) { create(:application_type, :prior_approval) }
+        let(:planning_application) { build(:planning_application, application_type:) }
+
+        it "creates a consultation record after creating the planning application" do
+          expect { planning_application.save! }.to change(planning_application, :consultation).from(nil).to(an_instance_of(Consultation))
+        end
+      end
     end
 
     describe "::before_update #reset_validation_requests_update_counter" do

--- a/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Confirm site notice", js: true do
            make_public: true)
   end
 
-  let!(:consultation) { create(:consultation, planning_application:) }
+  let!(:consultation) { planning_application.consultation }
 
   let!(:site_notice) { create(:site_notice, planning_application:) }
   let!(:audit) { create(:audit, planning_application:, activity_type: "site_notice_created", audit_comment: "Site notice was emailed to the applicant") }

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -15,10 +15,12 @@ RSpec.describe "View neighbour responses", js: true do
            application_type:, local_authority: default_local_authority, api_user:)
   end
 
-  let!(:consultation) { create(:consultation, end_date: "2023-07-08 16:17:35 +0100", planning_application:) }
+  let!(:consultation) { planning_application.consultation }
   let!(:neighbour) { create(:neighbour, consultation:) }
 
   before do
+    consultation.update(end_date: "2023-07-08 16:17:35 +0100")
+
     sign_in assessor
     visit planning_application_path(planning_application)
     click_link "Consultees, neighbours and publicity"
@@ -211,8 +213,11 @@ RSpec.describe "View neighbour responses", js: true do
   end
 
   context "when there is no end date yet but there are responses" do
-    let!(:consultation) { create(:consultation, end_date: nil, planning_application:) }
     let!(:response) { create(:neighbour_response, neighbour:, consultation:) }
+
+    before do
+      consultation.update(end_date: nil)
+    end
 
     it "is marked as not started" do
       visit planning_application_path(planning_application)

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe "Send letters to neighbours", js: true do
            make_public: true)
   end
 
+  let!(:consultation) do
+    planning_application.consultation
+  end
+
   before do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("production")
@@ -104,7 +108,6 @@ RSpec.describe "Send letters to neighbours", js: true do
       sign_in assessor
       visit planning_application_path(planning_application)
 
-      consultation = create(:consultation, planning_application:)
       neighbour = create(:neighbour, consultation:)
       neighbour_letter = create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
 
@@ -225,7 +228,6 @@ RSpec.describe "Send letters to neighbours", js: true do
   end
 
   it "shows the status of letters that have been sent" do
-    consultation = create(:consultation, planning_application:)
     neighbour = create(:neighbour, consultation:)
     neighbour_letter = create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
 
@@ -246,8 +248,6 @@ RSpec.describe "Send letters to neighbours", js: true do
   end
 
   describe "showing the status on the dashboard" do
-    let(:consultation) { create(:consultation, planning_application:) }
-
     before do
       sign_in assessor
     end
@@ -377,7 +377,6 @@ RSpec.describe "Send letters to neighbours", js: true do
       end
 
       # Nothing is persisted to the database at this point
-      expect(Consultation.all.length).to eq(0)
       expect(Neighbour.all.length).to eq(0)
 
       click_button "Add neighbours"

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Site visit" do
            application_type:, local_authority:)
   end
 
-  let!(:consultation) { create(:consultation, end_date: "2023-07-08 16:17:35 +0100", planning_application:) }
+  let!(:consultation) { planning_application.consultation }
   let!(:neighbour) { create(:neighbour, consultation:) }
   let!(:neighbour2) { create(:neighbour, consultation:, address: "123 Another Address") }
 

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -774,6 +774,10 @@ RSpec.describe "Planning Application Assessment" do
       end
     end
 
+    let!(:consultation) do
+      planning_application.consultation
+    end
+
     before do
       sign_in assessor
       visit planning_applications_path
@@ -904,8 +908,8 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     context "when consultation is still ongoing" do
-      let!(:consultation) do
-        create(:consultation, end_date: 10.days.from_now, planning_application:)
+      before do
+        consultation.update(end_date: 10.days.from_now)
       end
 
       it "displays a warning message with the consultation end date" do
@@ -918,8 +922,8 @@ RSpec.describe "Planning Application Assessment" do
     end
 
     context "when consultation hasn't begun" do
-      let!(:consultation) do
-        create(:consultation, planning_application:)
+      before do
+        consultation.update(end_date: nil)
       end
 
       it "does not display a warning message" do

--- a/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/reviewing/reviewing_assessment_summaries_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe "Reviewing assessment summaries" do
     )
   end
 
+  let!(:consultation) do
+    planning_application.consultation
+  end
+
   before do
     create(
       :recommendation,
@@ -102,7 +106,6 @@ RSpec.describe "Reviewing assessment summaries" do
         )
       end
 
-      let!(:consultation) { create(:consultation, end_date: Time.zone.now, planning_application:) }
       let!(:neighbour1) { create(:neighbour, address: "1 Cookie Avenue", consultation:) }
       let!(:neighbour2) { create(:neighbour, address: "2 Cookie Avenue", consultation:) }
       let!(:neighbour3) { create(:neighbour, address: "3 Cookie Avenue", consultation:) }
@@ -842,7 +845,6 @@ RSpec.describe "Reviewing assessment summaries" do
         )
       end
 
-      let!(:consultation) { create(:consultation, end_date: Time.zone.now, planning_application:) }
       let!(:neighbour1) { create(:neighbour, address: "1 Cookie Avenue", consultation:) }
       let!(:neighbour2) { create(:neighbour, address: "2 Cookie Avenue", consultation:) }
       let!(:neighbour3) { create(:neighbour, address: "3 Cookie Avenue", consultation:) }

--- a/spec/system/planning_applications/reviewing/sign_off_spec.rb
+++ b/spec/system/planning_applications/reviewing/sign_off_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe "Reviewing sign-off" do
     end
   end
 
+  let!(:consultation) do
+    planning_application.consultation
+  end
+
   before do
     sign_in reviewer
   end
@@ -356,8 +360,8 @@ RSpec.describe "Reviewing sign-off" do
     end
 
     context "when consultation is still ongoing" do
-      let!(:consultation) do
-        create(:consultation, end_date: 10.days.from_now, planning_application:)
+      before do
+        consultation.update(end_date: 10.days.from_now)
       end
 
       it "displays a warning message with the consultation end date" do
@@ -370,8 +374,8 @@ RSpec.describe "Reviewing sign-off" do
     end
 
     context "when consultation hasn't begun" do
-      let!(:consultation) do
-        create(:consultation, planning_application:)
+      before do
+        consultation.update(end_date: nil)
       end
 
       it "does not display a warning message" do


### PR DESCRIPTION
This allows us to remove safeguarding elsewhere in the application and the steps are moved to the database for greater flexibility.