### PR TITLE
Show assessor recommendation on review tasks page

### DIFF
--- a/app/views/planning_applications/review_tasks/index.html.erb
+++ b/app/views/planning_applications/review_tasks/index.html.erb
@@ -24,6 +24,14 @@
     <h2 class="app-task-list__section govuk-!-margin-top-8">
       Review assessment
     </h2>
+    <span class="govuk-body govuk-!-font-weight-bold">
+      Assessor recommendation
+      <%= render(
+      StatusTags::DecisionComponent.new(
+        planning_application: @planning_application
+      )
+    ) %>
+    </span>
     <ul class="app-task-list__items" id="review-assessment-section">
       <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.review_immunity_details.evidence.any? %>
           <%= render(

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -89,6 +89,7 @@ FactoryBot.define do
     trait :awaiting_determination do
       status                    { :awaiting_determination }
       awaiting_determination_at { Time.zone.now }
+      decision { "granted" }
 
       after(:create) do |pa|
         pa.target_date = 35.business_days.from_now

--- a/spec/system/planning_applications/reviewing/tasks_index_spec.rb
+++ b/spec/system/planning_applications/reviewing/tasks_index_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Reviewing Tasks Index" do
       click_on "Review and sign-off"
 
       expect(page).to have_title("Review and sign-off")
+      expect(page).to have_content("Assessor recommendation To grant")
 
       click_on "Back"
 


### PR DESCRIPTION
### Description of change

Show the assessor's recommendation on the review tasks page

### Story Link

https://trello.com/c/OaaEew1k/1595-reviewer-can-see-the-recommendation-from-the-review-tasklist

### Screenshots
![Screenshot 2023-10-09 at 11 05 53](https://github.com/unboxed/bops/assets/35098639/7d9870c3-b12c-4885-998c-be3ee7c0e703)

