### PR TITLE
Add redaction guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ db-prompt:
 lint:
 	$(DOCKER-RUN) web rubocop
 
+lint-auto-correct:
+	$(DOCKER-RUN) web rubocop --auto-correct-all
+
 # this regenerates the Rubocop TODO and ensures that cops aren't
 # turned off over a max number of file offenses. Note: we don't want
 # to run this within Docker so we can avoid a write-projected file (by

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -270,6 +270,7 @@ html * {
 
   &:hover {
     color: #003078;
+    cursor: pointer;
   }
 
   &:focus {

--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -4,7 +4,7 @@ module PlanningApplications
   class NeighbourResponsesController < AuthenticationController
     before_action :set_planning_application
     before_action :set_consultation
-    before_action :set_neighbour_responses, except: %i[edit update]
+    before_action :set_neighbour_responses, only: :index
     before_action :set_neighbour_response, only: %i[edit update]
 
     def index; end
@@ -22,6 +22,7 @@ module PlanningApplications
       @neighbour_response.neighbour = find_neighbour
 
       create_files(@neighbour_response) if neighbour_response_params[:files].compact_blank.any?
+      @neighbour_response.redacted_by = current_user if @neighbour_response.redacted_response.present?
 
       if @neighbour_response.save
         respond_to do |format|
@@ -72,7 +73,9 @@ module PlanningApplications
     end
 
     def set_neighbour_responses
-      @neighbour_responses = @consultation.neighbour_responses.includes([:neighbour]).select(&:persisted?)
+      @neighbour_responses = @consultation.neighbour_responses.includes(
+        %i[neighbour redacted_by documents]
+      ).select(&:persisted?)
     end
 
     def set_neighbour_response

--- a/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  class RedactNeighbourResponsesController < AuthenticationController
+    before_action :set_planning_application
+    before_action :set_consultation
+    before_action :set_neighbour_response
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      @neighbour_response.redacted_by = current_user
+
+      respond_to do |format|
+        if @neighbour_response.update(redact_neighbour_response_params)
+          format.html do
+            redirect_to neighbour_responses_path, notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    private
+
+    def redact_neighbour_response_params
+      params.require(:neighbour_response).permit(
+        :response, :redacted_response
+      )
+    end
+
+    def set_neighbour_response
+      @neighbour_response = @consultation.neighbour_responses.find(Integer(params[:id]))
+    end
+
+    def neighbour_responses_path
+      planning_application_consultation_neighbour_responses_path(@planning_application, @consultation)
+    end
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -32,3 +32,6 @@ application.register("submit-form", SubmitFormController)
 
 import UnsavedChangesController from "./unsaved_changes_controller.js"
 application.register("unsaved-changes", UnsavedChangesController)
+
+import ResetTextController from "./reset_text_controller.js"
+application.register("reset-text", ResetTextController)

--- a/app/javascript/controllers/reset_text_controller.js
+++ b/app/javascript/controllers/reset_text_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["source", "destination"]
+
+  reset() {
+    this.destinationTarget.value = this.sourceTarget.value
+  }
+}

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -3,8 +3,11 @@
 class NeighbourResponse < ApplicationRecord
   belongs_to :neighbour
   belongs_to :consultation
+  belongs_to :redacted_by, class_name: "User", optional: true
 
   has_many :documents, dependent: :destroy
+
+  attr_readonly :response
 
   validates :name, :response, :summary_tag, :received_at, presence: true
 
@@ -23,7 +26,6 @@ class NeighbourResponse < ApplicationRecord
   end
 
   def truncated_comment
-    comment = (redacted_response.presence || response)
     comment.truncate(100, separator: " ")
   end
 

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -80,12 +80,13 @@
                     <% end %>
                   </tbody>
                 <% end %>
-                <div class="display-flex">
-                  <%= link_to "Edit", edit_planning_application_consultation_neighbour_response_path(@planning_application, @consultation, response) %>
-                  <% if response.redacted_response.present? %>
-                    <span class="govuk-hint govuk-!-margin-left-1">(redacted)</span>
+                <p class="govuk-body">
+                  <%= link_to "Redact and publish", edit_planning_application_consultation_redact_neighbour_response_path(@planning_application, @consultation, response), class: "govuk-link" %>
+                  <% if response.redacted_by.try(:name) %>
+                    (Redacted by: <%= response.redacted_by.name %>)
                   <% end %>
-                </div>
+                </p>
+                <%= link_to "Edit", edit_planning_application_consultation_neighbour_response_path(@planning_application, @consultation, response) %>
               </div>
             </div>
           <% end %>

--- a/app/views/planning_applications/neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/neighbour_responses/edit.html.erb
@@ -59,5 +59,5 @@
     "Update response",
     class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
   ) %>
-  <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+  <%= link_to "Back", planning_application_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
 <% end %>

--- a/app/views/planning_applications/neighbour_responses/new.html.erb
+++ b/app/views/planning_applications/neighbour_responses/new.html.erb
@@ -58,6 +58,6 @@
       "Save response",
       class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
     ) %>
-    <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+    <%= link_to "Back", planning_application_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
   </div>
 <% end %>

--- a/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
@@ -1,0 +1,66 @@
+<% content_for :page_title do %>
+  Redact comment - <%= t('page_title') %>
+<% end %>
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultations_path(@planning_application) %>
+<% content_for :title, "Redact comment" %>
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Redact comment" }
+) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-5">Comment submitted by</h2>
+<hr>
+
+<ul class="govuk-list">
+  <li>
+    <strong><%= @neighbour_response.name %></strong> <span class="govuk-hint" style="display: inline;"><%= @neighbour_response.email %></span>
+  </li>
+  <li class="govuk-hint">
+    <%= @neighbour_response.neighbour.address %>
+  </li>
+  <li class="govuk-hint">
+    Received on <%= @neighbour_response.received_at.to_formatted_s(:day_month_year_slashes) %>
+  </li>
+</ul>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      What you need to redact
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= raw I18n.t("redaction_guidelines") %>
+  </div>
+</details>
+
+<%= form_with(
+  model: [@planning_application, @consultation, @neighbour_response],
+  builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+  class: "govuk-!-margin-top-5",
+  url: planning_application_consultation_redact_neighbour_response_path(@planning_application, @consultation, @neighbour_response),
+  method: :patch,
+  data: { controller: "reset-text" }
+) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_text_area :response, 
+    rows: 8, 
+    label: { size: "l", text: "Full comment" }, 
+    data: { reset_text_target: "source" },
+    readonly: true
+  %>
+  <%= form.label :redacted_response, "Redacted comment", class: "govuk-label govuk-label--l" %>
+  <%= content_tag :span, "Replace text you want to redact with [redacted] then save to publish the comment.", class: "govuk-hint" %>
+  <%= button_tag "Reset comment", type: "button", class: "button-as-link govuk-!-margin-bottom-3", data: { action: "click->reset-text#reset"  } %>
+  <%= form.text_area :redacted_response, class: "govuk-textarea", rows: 8, data: { reset_text_target: "destination" } %>
+
+  <div class="govuk-button-group">
+    <%= form.submit(
+      "Save and publish",
+      class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
+    ) %>
+    <%= link_to "Back", planning_application_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-button govuk-button--secondary govuk-!-margin-top-5" %>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -579,6 +579,8 @@ en:
     save_and_mark_as_complete: Save and mark as complete
   helpers:
     hint:
+      neighbour_response:
+        response: This is the full text of the comment before redaction.
       other_change_validation_request:
         suggestion: Add all information that they will need to complete this action.
     label:
@@ -798,6 +800,9 @@ en:
         success: Press notice response has been successfully updated
     publish:
       review_and_publish_determination: Review and publish determination
+    redact_neighbour_responses:
+      update:
+        success: Neighbour response was successully updated.
     review_documents:
       update:
         success: Documents were successfully updated.

--- a/config/locales/redaction_guidelines.yml
+++ b/config/locales/redaction_guidelines.yml
@@ -1,0 +1,36 @@
+en: 
+  redaction_guidelines: |
+    <div class="govuk-body">
+      <p>You need to redact any:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>personal data</li>
+        <li>special category data</li>
+      </ul>
+      <strong>Personal data</strong>
+      <p>This includes any words or phrases that could identify a particular person, such as names, addresses or descriptions.</p>
+      <strong>Names</strong>
+      <p>Redact the name of the person or people making the comment.</p>
+      <p>The applicant’s name does not usually need to be redacted. However, you may need to redact it if the nature of the application could mean that the applicant’s name is linked to ‘special category data’. For example, when a flat is obviously being adapted for a disabled person.</p>
+      <p>Redact any other names or references to neighbours.</p>
+      <strong>Third party address</strong>
+      <p>Do not redact the address of the person making the comment. This may be made public by the Planning Inspectorate in the event of an appeal in order to give the comment weight.</p>
+      <p>Redact any other third party addresses.</p>
+      <strong>Contact information</strong>
+      <p>Redact all contact information such as telephone, email or websites.</p>
+      <strong>Personal details</strong>
+      <p>Redact any words or phrases that could help someone to identify a person. This includes descriptions of:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>how a person looks or speaks</li>
+        <li>a person’s occupation</li>
+        <li>a place in relation to the site, for example, ‘the garden two doors down on the right’</li>
+      </ul>
+      <strong>Special category data</strong>
+      <p>Redact any information about a person’s:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>race or ethnic origin</li>
+        <li>politics, religion or philosophical beliefs</li>
+        <li>trade union membership</li>
+        <li>health</li>
+        <li>sex life or sexual orientation</li>
+      </ul>
+    </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,7 @@ Rails.application.routes.draw do
       resources :consultations do
         post :send_neighbour_letters
         resources :neighbour_responses, only: %i[new index create edit update]
+        resources :redact_neighbour_responses, only: %i[edit update]
         resources :site_visits, only: %i[index new create edit show update]
       end
 

--- a/db/migrate/20231009093157_add_redacted_by_to_neighbour_responses.rb
+++ b/db/migrate/20231009093157_add_redacted_by_to_neighbour_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddRedactedByToNeighbourResponses < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :neighbour_responses, :redacted_by, references: :users, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_06_175416) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_09_093157) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -324,8 +324,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_175416) do
     t.text "redacted_response"
     t.jsonb "tags", default: [], null: false
     t.bigint "consultation_id"
+    t.bigint "redacted_by_id"
     t.index ["consultation_id"], name: "ix_neighbour_responses_on_consultation_id"
     t.index ["neighbour_id"], name: "ix_neighbour_responses_on_neighbour_id"
+    t.index ["redacted_by_id"], name: "ix_neighbour_responses_on_redacted_by_id"
   end
 
   create_table "neighbours", force: :cascade do |t|
@@ -752,6 +754,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_06_175416) do
   add_foreign_key "local_policies", "users", column: "reviewer_id"
   add_foreign_key "local_policy_areas", "local_policies"
   add_foreign_key "neighbour_responses", "consultations"
+  add_foreign_key "neighbour_responses", "users", column: "redacted_by_id"
   add_foreign_key "notes", "planning_applications"
   add_foreign_key "notes", "users"
   add_foreign_key "other_change_validation_requests", "planning_applications"

--- a/spec/factories/neighbour_response.rb
+++ b/spec/factories/neighbour_response.rb
@@ -11,4 +11,14 @@ FactoryBot.define do
     neighbour
     consultation { neighbour.consultation }
   end
+
+  trait :objection do
+    summary_tag { "objection" }
+    response { "I hate it rude word" }
+    redacted_response { "I hate it [redacted]" }
+  end
+
+  trait :without_redaction do
+    redacted_response { nil }
+  end
 end

--- a/spec/models/neighbour_response_spec.rb
+++ b/spec/models/neighbour_response_spec.rb
@@ -58,4 +58,14 @@ RSpec.describe NeighbourResponse do
       end
     end
   end
+
+  describe "#response" do
+    let!(:neighbour_response) { create(:neighbour_response, response: "A response") }
+
+    it "response is a readonly attribute" do
+      neighbour_response.update(response: "A new response")
+
+      expect(neighbour_response.reload.response).to eq("A response")
+    end
+  end
 end

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -113,6 +113,37 @@ RSpec.describe "View neighbour responses", js: true do
     expect(page).not_to have_content("123 Street")
   end
 
+  it "allows planning officer to upload neighbour response with redaction" do
+    click_link "View neighbour responses"
+    click_link "Add a new neighbour response"
+
+    fill_in "Name", with: "Matt Neighbour"
+    fill_in "Email", with: "matt@email.com"
+    select(neighbour.address.to_s, from: "Select an existing neighbour address")
+    fill_in "Day", with: "21"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "2023"
+    fill_in "Response", with: "This proposal will block my sunlight and I hate my neighbour."
+    fill_in "Redacted response", with: "This proposal will block my sunlight [redacted]."
+    choose "An objection"
+
+    click_button "Save response"
+    click_button "Objection responses (1)"
+
+    within(".neighbour-response-content") do
+      expect(page).to have_content("Received on 21/01/2023")
+      expect(page).to have_content("Matt Neighbour")
+      expect(page).to have_content("matt@email.com")
+      expect(page).to have_content(neighbour.address.to_s)
+      expect(page).to have_content("This proposal will block my sunlight [redacted].")
+      expect(page).to have_content("Objection")
+      expect(page).to have_content("Adjoining neighbour")
+    end
+
+    expect(page).to have_link("Redact and publish")
+    expect(page).to have_content("Redacted by: #{assessor.name}")
+  end
+
   it "allows planning officer to edit neighbour responses" do
     click_link "View neighbour responses"
 
@@ -138,7 +169,7 @@ RSpec.describe "View neighbour responses", js: true do
     expect(page).to have_content("Received on 21/01/2023")
     expect(page).to have_content("Sarah Neighbour")
     expect(page).to have_content("sarah@email.com")
-    expect(page).to have_content(" #{neighbour.address}")
+    expect(page).to have_content(neighbour.address.to_s)
     expect(page).to have_content("I think this proposal looks great")
 
     click_link "Edit"
@@ -223,6 +254,75 @@ RSpec.describe "View neighbour responses", js: true do
       visit planning_application_path(planning_application)
       click_link "Consultees, neighbours and publicity"
       expect(page).to have_content("View neighbour responses Not started")
+    end
+  end
+
+  context "when redacting a response" do
+    let!(:response) { create(:neighbour_response, :objection, :without_redaction, neighbour:, consultation:, response: "It will be too noisy, I hate my neighbour!") }
+
+    it "shows the relevant content for redacting a comment" do
+      click_link "View neighbour responses"
+      click_button "Objection responses (1)"
+      click_link "Redact and publish"
+
+      within("#planning-application-details") do
+        expect(page).to have_content("Redact comment")
+        expect(page).to have_content(planning_application.reference)
+        expect(page).to have_content(planning_application.full_address)
+        expect(page).to have_content(planning_application.description)
+      end
+      within(".govuk-breadcrumbs__list") do
+        expect(page).to have_content("Redact comment")
+      end
+
+      expect(page).to have_content("Comment submitted by")
+      expect(page).to have_content(response.name.to_s)
+      expect(page).to have_content(response.email.to_s)
+      expect(page).to have_content(neighbour.address.to_s)
+      expect(page).to have_content("It will be too noisy, I hate my neighbour!")
+
+      within(".govuk-details") do
+        within(".govuk-details__summary") do
+          expect(page).to have_content("What you need to redact")
+        end
+
+        within(".govuk-details__text") do
+          expect(page).to have_content("You need to redact any:")
+          expect(page).to have_content("Personal data")
+          expect(page).to have_content("Names")
+          expect(page).to have_content("Third party address")
+          expect(page).to have_content("Contact information")
+          expect(page).to have_content("Personal details")
+          expect(page).to have_content("Special category data")
+        end
+      end
+
+      expect(page).to have_link "Back", href: planning_application_consultation_neighbour_responses_path(planning_application, consultation)
+    end
+
+    it "allows officer to review redaction guidelines and redact a neighbour response" do
+      click_link "View neighbour responses"
+      click_button "Objection responses (1)"
+      expect(page).not_to have_content("Redacted by")
+
+      click_link "Redact and publish"
+      expect(page).to have_content("This is the full text of the comment before redaction.")
+      expect(page).to have_selector("#neighbour-response-response-field[readonly]")
+
+      expect(page).to have_content("Replace text you want to redact with [redacted] then save to publish the comment.")
+      fill_in "Redacted comment", with: "It will be too noisy, [redaction]"
+
+      click_button "Save and publish"
+      expect(page).to have_content("Neighbour response was successully updated.")
+
+      click_button "Objection responses (1)"
+      expect(page).to have_content("Redacted by: #{assessor.name}")
+
+      click_link "Redact and publish"
+      # Check I can reset redacted comment to the original comment
+      expect(find_by_id("neighbour_response_redacted_response").value).to eq("It will be too noisy, [redaction]")
+      click_button "Reset comment"
+      expect(find_by_id("neighbour_response_redacted_response").value).to eq("It will be too noisy, I hate my neighbour!")
     end
   end
 end


### PR DESCRIPTION
### Description of change

- Add redaction guidelines
- Add redacted_by association to neighbour responses
- Allow officer to reset redacted comment  

### Story Link

https://trello.com/c/nZ4tm1he/1827-guidance-on-redacting-comments-and-showing-they-have-been-received

### Screenshots

![Screenshot 2023-10-09 at 15 50 57](https://github.com/unboxed/bops/assets/34001723/f7a24429-7c2f-419e-bd3a-b32cc765059c)
![Screenshot 2023-10-09 at 15 51 14](https://github.com/unboxed/bops/assets/34001723/39d2fb21-87a6-4fdb-9b18-7c47db835976)
