### PR TITLE
Allow web-console to connect to the docker container

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUNDLE_WITHOUT: development
+      RAILS_ENV: test
 
     steps:
       - name: Check out code

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,4 +77,7 @@ Rails.application.configure do
   config.hosts << ".bops-care.link"
   config.hosts << "southwark.bops.web"
   config.hosts << "southwark.bops.localhost"
+
+  # Allow web-console connections into docker
+  config.web_console.permissions = %w( 127.0.0.1 ::1 172.23.9.254 )
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,14 @@ services:
       - type: tmpfs
         target: /tmp/pids
 
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: 172.23.0.0/16
+          ip_range: 172.23.9.0/24
+          gateway: 172.23.9.254
+
 volumes:
   redis:
   db:


### PR DESCRIPTION
The default permissions for the web-console gem only allow localhost connections so we specify a fixed range for the docker compose network and then allow that.