### PR TITLE
Return JSON from OS Places APIs

### DIFF
--- a/app/controllers/os_places_api_controller.rb
+++ b/app/controllers/os_places_api_controller.rb
@@ -5,7 +5,7 @@ class OsPlacesApiController < ApplicationController
     response = Apis::OsPlaces::Query.new.find_addresses(params[:query])
 
     respond_to do |format|
-      format.js { render json: response.body }
+      format.json { render json: response.body }
     end
   end
 
@@ -15,7 +15,7 @@ class OsPlacesApiController < ApplicationController
     response = Apis::OsPlaces::Query.new.find_addresses_by_polygon(geojson)
 
     respond_to do |format|
-      format.js { render json: response }
+      format.json { render json: response }
     end
   end
 end

--- a/app/javascript/controllers/address_fill_controller.js
+++ b/app/javascript/controllers/address_fill_controller.js
@@ -13,7 +13,7 @@ export default class extends Controller {
           type: "get",
           url: `${document.querySelector("#os_path").value}?query=${query}`,
           success: (data) => {
-            for (const i of JSON.parse(data).results) {
+            for (const i of data.results) {
               results.push(i.DPA.ADDRESS)
             }
             populateResults(results)

--- a/app/javascript/controllers/polygon_search_controller.js
+++ b/app/javascript/controllers/polygon_search_controller.js
@@ -73,12 +73,13 @@ export default class extends Controller {
   }
 
   onGeojsonChange({ detail: geoJSON }) {
-    const geoJsonFeatures = geoJSON["EPSG:27700"].features
+    const geoJsonFeatures = geoJSON["EPSG:27700"]
+
     if (geoJsonFeatures === undefined) {
       return
     }
 
-    this.handleGeojsonChange(geoJsonFeatures[0])
+    this.handleGeojsonChange(geoJsonFeatures.features[0])
   }
 
   clearAddresses = () => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,15 @@ Rails.application.routes.draw do
     get "resend_code", to: "users/sessions#resend_code", as: "resend_code"
   end
 
-  resources :os_places_api, only: %i[index]
-  post "search_addresses_by_polygon", to: "os_places_api#search_addresses_by_polygon"
+  defaults format: "json" do
+    get "/os_places_api",
+        to: "os_places_api#index",
+        as: "os_places_api_index"
+
+    post "/search_addresses_by_polygon",
+         to: "os_places_api#search_addresses_by_polygon",
+         as: "search_addresses_by_polygon"
+  end
 
   resources :users, only: %i[new create edit update]
 


### PR DESCRIPTION
By default Rails will return JS to non-HTML requests so we need to use the router's defaults feature to ensure that the response is application/json.
