### PR TITLE
Ensure email is present for site notice email

### DIFF
--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -93,7 +93,7 @@ module PlanningApplications
         @planning_application.send_internal_team_site_notice_mail(site_notice_params[:internal_team_email])
       else
         @planning_application.send_site_notice_mail(
-          @planning_application.agent_email || @planning_application.applicant_email
+          @planning_application.agent_email.presence || @planning_application.applicant_email
         )
       end
     end

--- a/spec/system/planning_applications/consulting/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/create_site_notice_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Create a site notice", js: true do
     )
   end
 
-  it "allows officers to create a site notice and email it to the applicant" do
+  it "allows officers to create a site notice and email it to the agent" do
     click_link "Send site notice"
     expect(page).to have_content("Send site notice")
 
@@ -66,6 +66,27 @@ RSpec.describe "Create a site notice", js: true do
     email_notification = ActionMailer::Base.deliveries.last
 
     expect(email_notification.to).to contain_exactly(planning_application.agent_email)
+
+    expect(email_notification.subject).to eq("Display site notice for your application 23-00100-PA")
+
+    expect(page).to have_content "Site notice was successfully emailed"
+  end
+
+  it "sends it to the applicant if agent email is not present" do
+    planning_application.update(agent_email: "")
+
+    click_link "Send site notice"
+
+    choose "Yes"
+
+    choose "Send it by email to applicant"
+
+    click_button "Email site notice and mark as complete"
+
+    perform_enqueued_jobs
+    email_notification = ActionMailer::Base.deliveries.last
+
+    expect(email_notification.to).to contain_exactly(planning_application.applicant_email)
 
     expect(email_notification.subject).to eq("Display site notice for your application 23-00100-PA")
 


### PR DESCRIPTION
### Description of change

The code wasn't actually defaulting to applicant_email if agent_email was blank when sending site notices. I think because agent_email was `""` rather than `nil`. This fixes that and has a test as well