### PR TITLE
Limit most recent audits to 20 records

### DIFF
--- a/app/components/planning_applications/panels_component.rb
+++ b/app/components/planning_applications/panels_component.rb
@@ -27,7 +27,7 @@ module PlanningApplications
     end
 
     def local_authority_most_recent_audits_for_planning_applications
-      local_authority.audits.most_recent_for_planning_applications
+      local_authority.audits.most_recent_for_planning_applications.limit(20)
     end
   end
 end


### PR DESCRIPTION
- This is a stopgap until we look at improving the performance of this query and likely that we'll be using ajax to load the tab in when selected rather than query all records up front

