### PR TITLE
Add warning if site notice or press notice not complete

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -11,6 +11,10 @@ class PlanningApplicationsController < AuthenticationController
 
   before_action :ensure_draft_recommendation_complete, only: :update
 
+  before_action :ensure_site_notice_displayed_at, only: %i[determine]
+
+  before_action :ensure_press_notice_published_at, only: %i[determine]
+
   rescue_from PlanningApplication::WithdrawRecommendationError do |_exception|
     redirect_failed_withdraw_recommendation
   end
@@ -354,5 +358,29 @@ class PlanningApplicationsController < AuthenticationController
         before updating application fields."
 
     render :edit and return
+  end
+
+  def ensure_site_notice_displayed_at
+    return unless @planning_application.site_notice_needs_displayed_at?
+
+    flash.now[:alert] = sanitize "You must
+        #{view_context.link_to 'confirm the site notice displayed at date',
+                               edit_planning_application_site_notice_path(@planning_application,
+                                                                          @planning_application.site_notice)}
+        before determining the application."
+
+    render :publish and return
+  end
+
+  def ensure_press_notice_published_at
+    return unless @planning_application.press_notice_needs_published_at?
+
+    flash.now[:alert] = sanitize "You must
+        #{view_context.link_to 'confirm the press notice published at date',
+                               edit_planning_application_confirm_press_notice_path(@planning_application,
+                                                                                   @planning_application.press_notice)}
+        before determining the application."
+
+    render :publish and return
   end
 end

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -44,4 +44,15 @@ module PlanningApplicationHelper
     filters = (%i[application_type status] - [filter])
     params[filter]&.include?(value) && filters.all? { |param| params[param].blank? }
   end
+
+  def display_or_publish_required?(planning_application, type)
+    case type
+    when :site
+      planning_application.site_notice_needs_displayed_at?
+    when :press
+      planning_application.press_notice_needs_published_at?
+    else
+      raise ArgumentError, "Unexpected value for 'type': #{type.inspect}"
+    end
+  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -72,8 +72,12 @@ class PlanningApplication < ApplicationRecord
 
   delegate :consultation?, to: :application_type
   delegate :reviewer_group_email, to: :local_authority
-  delegate :email, to: :user, prefix: true, allow_nil: true
-  delegate :name, to: :user, prefix: true, allow_nil: true
+  with_options prefix: true, allow_nil: true do
+    delegate :email, to: :user
+    delegate :name, to: :user
+    delegate :required?, to: :press_notice
+    delegate :required?, to: :site_notice
+  end
 
   belongs_to :user, optional: true
   belongs_to :api_user, optional: true
@@ -648,6 +652,18 @@ class PlanningApplication < ApplicationRecord
 
   def longitude
     super || lonlat.try(:x)
+  end
+
+  def site_notice
+    site_notices.by_created_at_desc.first
+  end
+
+  def site_notice_needs_displayed_at?
+    site_notice_required? && site_notice.displayed_at.nil?
+  end
+
+  def press_notice_needs_published_at?
+    press_notice_required? && press_notice.published_at.nil?
   end
 
   delegate :name, to: :application_type, prefix: true

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -12,9 +12,11 @@ class PressNotice < ApplicationRecord
 
   validates :required, inclusion: { in: [true, false] }
 
+  after_update :update_consultation_end_date!
   after_save :audit_press_notice!
 
   delegate :audits, to: :planning_application
+  delegate :consultation, to: :planning_application
   delegate :press_notice_email, to: "planning_application.local_authority", allow_nil: true
 
   scope :required, -> { where(required: true) }
@@ -65,5 +67,12 @@ class PressNotice < ApplicationRecord
 
   def joined_reasons
     reasons.values.join(", ")
+  end
+
+  def update_consultation_end_date!
+    return unless consultation
+    return unless saved_changes.include? "published_at"
+
+    consultation.update!(end_date: published_at + 21.days)
   end
 end

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -73,6 +73,10 @@ class PressNotice < ApplicationRecord
     return unless consultation
     return unless saved_changes.include? "published_at"
 
-    consultation.update!(end_date: published_at + 21.days)
+    new_end_date = published_at + 21.days
+
+    return unless consultation.end_date.nil? || new_end_date > consultation.end_date
+
+    consultation.update!(end_date: new_end_date)
   end
 end

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -4,6 +4,8 @@ class SiteNotice < ApplicationRecord
   belongs_to :planning_application
   has_one :document, dependent: :destroy
 
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+
   attr_reader :method
 
   def preview_content(planning_application)

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -1,39 +1,58 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="dates-and-assignment-details">
-      <p class="govuk-body">
-        <strong>Validation date:</strong>
-        <% if @planning_application.valid_from.present? %>
-          <%= time_tag @planning_application.valid_from %>
-        <% else %>
-          Not yet valid
-        <% end %>
-      </p>
-      <% if @planning_application.consultation.present? %>
-      <p class="govuk-body">
+    <p class="govuk-body">
+      <strong>Validation date:</strong>
+      <% if @planning_application.valid_from.present? %>
+        <%= time_tag @planning_application.valid_from %>
+      <% else %>
+        Not yet valid
+      <% end %>
+    </p>
+    <% if @planning_application.consultation.present? %>
+      <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>Consultation start date:</strong>
         <% if @planning_application.consultation.start_date.present? %>
           <%= time_tag @planning_application.consultation.start_date %>
         <% else %>
           <%= t(".consultation_end_date_not_set") %>
         <% end %>
-        <br>
+      </p>
+
+      <p class="govuk-body">
         <strong>Consultation end date:</strong>
         <% if @planning_application.consultation.end_date.present? %>
-          <%= time_tag @planning_application.consultation.end_date %>
-          <span class="govuk-!-margin-left-1">
-            <span class="govuk-tag govuk-tag--#{status_consultation_date_tag_colour}">
-            <% if @planning_application.consultation.days_left >0 %>
-              <%= t("planning_applications.days_left", count: @planning_application.consultation.days_left) %>
-            <% else %>
-              <%= t("planning_applications.overdue", count: @planning_application.consultation.days_left.abs) %>
-            <% end %>
+          <% unless display_or_publish_required?(@planning_application, :site) || display_or_publish_required?(@planning_application, :press) %>
+            <%= time_tag @planning_application.consultation.end_date %>
+            <span class="govuk-!-margin-left-1">
+              <span class="govuk-tag govuk-tag--#{status_consultation_date_tag_colour}">
+                <% days_left = @planning_application.consultation.days_left %>
+                <%= days_left > 0 ? t("planning_applications.days_left", count: days_left) : t("planning_applications.overdue", count: days_left.abs) %>
+              </span>
             </span>
-          </span>
+          <% end %>
+
+          <% if display_or_publish_required?(@planning_application, :site) %>
+            <div id="confirm-site-notice-warning">
+              <%= render(
+                partial: "shared/warning_text",
+                locals: { message: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice)) }
+              ) %>
+            </div>
+          <% end %>
+
+          <% if display_or_publish_required?(@planning_application, :press) %>
+            <div id="confirm-press-notice-warning">
+              <%= render(
+                partial: "shared/warning_text",
+                locals: { message: link_to("Confirm press notice publication date", edit_planning_application_confirm_press_notice_path(@planning_application, @planning_application.press_notice)) }
+              ) %>
+            </div>
+          <% end %>
         <% else %>
           <%= t(".consultation_end_date_not_set") %>
         <% end %>
       </p>
-      <% end %>
+    <% end %>
 
     <p class="govuk-body">
       <%= @planning_application.next_relevant_date_tag %>

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -148,6 +148,25 @@ RSpec.describe PressNotice do
             expect { press_notice.update(press_sent_at: Time.zone.local(2023, 3, 15, 12)) }.not_to change(consultation, :end_date)
           end
         end
+
+        context "when consultation end date is later than the published at date + 21 days" do
+          let!(:consultation) { create(:consultation, planning_application:, end_date: Time.zone.local(2023, 3, 15, 12) + 22.days) }
+
+          it "there is no update to the consultation end date" do
+            expect { press_notice.update(published_at: Time.zone.local(2023, 3, 15, 12)) }.not_to change(consultation, :end_date)
+          end
+        end
+
+        context "when consultation end date is less than the published at date + 21 days" do
+          let!(:consultation) { create(:consultation, planning_application:, end_date: Time.zone.local(2023, 3, 15, 12) + 20.days) }
+
+          it "there is an update to the consultation end date" do
+            expect do
+              press_notice.update(published_at: Time.zone.local(2023, 3, 15, 12))
+            end.to change(consultation, :end_date)
+              .from(Time.zone.local(2023, 3, 15, 12) + 20.days).to(Time.zone.local(2023, 3, 15, 12) + 21.days)
+          end
+        end
       end
     end
 

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -127,6 +127,28 @@ RSpec.describe PressNotice do
           end
         end
       end
+
+      describe "::after_update #update_consultation_end_date!" do
+        let(:default_local_authority) { create(:local_authority, :default) }
+        let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+        let!(:consultation) { create(:consultation, planning_application:) }
+        let(:press_notice) { create(:press_notice, planning_application:) }
+
+        context "when there is an update to the published_at date" do
+          it "there is an update of 21 days added to the consultation end date" do
+            expect do
+              press_notice.update(published_at: Time.zone.local(2023, 3, 15, 12))
+            end.to change(consultation, :end_date)
+              .from(nil).to(Time.zone.local(2023, 3, 15, 12) + 21.days)
+          end
+        end
+
+        context "when there is an update to another field" do
+          it "there is no update to the consultation end date" do
+            expect { press_notice.update(press_sent_at: Time.zone.local(2023, 3, 15, 12)) }.not_to change(consultation, :end_date)
+          end
+        end
+      end
     end
 
     describe "instance methods" do

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -189,6 +189,42 @@ RSpec.describe "Planning Application Assessment" do
           expect(page).not_to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39")
         end
       end
+
+      context "when there is a required site notice without a displayed at date" do
+        let!(:site_notice) do
+          create(:site_notice, planning_application:, displayed_at: nil)
+        end
+
+        it "displays a warning when trying to determine an application" do
+          click_link("Publish determination")
+          click_button("Publish determination")
+
+          within(".govuk-error-summary") do
+            expect(page).to have_content("You must confirm the site notice displayed at date before determining the application")
+            expect(page).to have_link(
+              "confirm the site notice displayed at date", href: edit_planning_application_site_notice_path(planning_application, site_notice)
+            )
+          end
+        end
+      end
+
+      context "when there is a required press notice without a published at date" do
+        let!(:press_notice) do
+          create(:press_notice, :required, planning_application:, published_at: nil)
+        end
+
+        it "displays a warning when trying to determine an application" do
+          click_link("Publish determination")
+          click_button("Publish determination")
+
+          within(".govuk-error-summary") do
+            expect(page).to have_content("You must confirm the press notice published at date before determining the application")
+            expect(page).to have_link(
+              "confirm the press notice published at date", href: edit_planning_application_confirm_press_notice_path(planning_application, press_notice)
+            )
+          end
+        end
+      end
     end
 
     context "when I'm signed in as an assessor" do

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Press notice" do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority:) }
+  let!(:planning_application) do
+    create(:planning_application, :prior_approval, local_authority:)
+  end
+
+  before do
+    sign_in assessor
+
+    planning_application.consultation.update(end_date: Time.zone.local(2023, 9, 15, 12))
+    visit planning_application_path(planning_application)
+  end
+
+  context "when there is a consultation end date" do
+    it "displays the consultation end date" do
+      click_link "Consultees, neighbours and publicity"
+
+      expect(page).to have_content("Consultation end date: 15 September 2023")
+    end
+  end
+
+  context "when there is an oustanding action to take that has an effect on the consultation end date" do
+    let!(:press_notice) do
+      create(:press_notice, :required, planning_application:, published_at: nil)
+    end
+    let!(:site_notice) do
+      create(:site_notice, planning_application:, displayed_at: nil)
+    end
+
+    before do
+      travel_to(Time.zone.local(2023, 3, 15, 12))
+      click_link "Consultees, neighbours and publicity"
+    end
+
+    it "displays a warning if there is a required site notice without a displayed at date" do
+      within("#confirm-site-notice-warning .govuk-warning-text") do
+        expect(page).to have_link(
+          "Confirm site notice display date",
+          href: edit_planning_application_site_notice_path(planning_application, site_notice)
+        )
+      end
+    end
+
+    it "displays a warning if there is a required press notice without a published at date" do
+      within("#confirm-press-notice-warning .govuk-warning-text") do
+        expect(page).to have_link(
+          "Confirm press notice publication date",
+          href: edit_planning_application_confirm_press_notice_path(planning_application, press_notice)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- If no site notice displayed at or press notice published at dates have been set, display a warning as this has an implication on the consultation end date
- Display warning to reviewer when determining the application if these dates have not been set

### Story Link

https://trello.com/c/VcpHL603/2026-make-sure-a-press-notice-and-site-notice-has-been-displayed-for-three-weeks-before-making-a-decision-and-update-the-consultation