### PR TITLE
Fix cil liability form

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -328,15 +328,27 @@ class PlanningApplication < ApplicationRecord
     proposal_details.select { |detail| detail.question == question }
   end
 
-  def cil_liability_proposal_detail
+  def cil_liability_questions
     [
       "How much new floor area is being added to the house?",
       "How much new floor area is being created?"
-    ].filter_map { |q| find_proposal_detail(q) }.flatten.first
+    ]
+  end
+
+  def cil_liability_planx_answers
+    cil_liability_questions.filter_map { |q| find_proposal_detail(q) }.flatten
+  end
+
+  def cil_liability_proposal_detail
+    cil_liability_planx_answers.first
+  end
+
+  def cil_liability_planx_answer?
+    cil_liability_planx_answers.present?
   end
 
   def likely_cil_liable?
-    cil_liability_proposal_detail&.response_values&.first != "Less than 100m²"
+    cil_liability_planx_answer? && cil_liability_proposal_detail&.response_values&.first != "Less than 100m²"
   end
 
   def secure_change_url

--- a/app/views/planning_applications/cil_liability/_form.html.erb
+++ b/app/views/planning_applications/cil_liability/_form.html.erb
@@ -9,13 +9,13 @@
         :cil_liability,
         legend: { text: "Is the application liable for CIL?", size: "s" }
       ) do %>
-    <%= form.govuk_radio_button(
-          :cil_liable, true, checked: @planning_application.cil_liable.nil? ? @planning_application.cil_liable : @planning_application.likely_cil_liable?, label: { text: "Yes" }
-        ) %>
-
-    <%= form.govuk_radio_button(
-          :cil_liable, false, checked: @planning_application.cil_liable.nil? ? !@planning_application.likely_cil_liable? : !@planning_application.cil_liable, label: { text: "No" }
-        ) %>
+    <% if @planning_application.cil_liable.nil? %>
+      <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.likely_cil_liable?, label: { text: "Yes" }) %>
+      <%= form.govuk_radio_button(:cil_liable, false, checked: !@planning_application.likely_cil_liable?, label: { text: "No" }) %>
+    <% else %>
+      <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.cil_liable, label: { text: "Yes" }) %>
+      <%= form.govuk_radio_button(:cil_liable, false, checked: !@planning_application.cil_liable, label: { text: "No" }) %>
+    <% end %>
   <% end %>
 
   <%= render(partial: "shared/submit_buttons", locals: { form: }) %>

--- a/app/views/planning_applications/cil_liability/_form.html.erb
+++ b/app/views/planning_applications/cil_liability/_form.html.erb
@@ -11,7 +11,7 @@
       ) do %>
     <% if @planning_application.cil_liable.nil? %>
       <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.likely_cil_liable?, label: { text: "Yes" }) %>
-      <%= form.govuk_radio_button(:cil_liable, false, checked: !@planning_application.likely_cil_liable?, label: { text: "No" }) %>
+      <%= form.govuk_radio_button(:cil_liable, false, checked: @planning_application.cil_liability_planx_answer? && !@planning_application.likely_cil_liable?, label: { text: "No" }) %>
     <% else %>
       <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.cil_liable, label: { text: "Yes" }) %>
       <%= form.govuk_radio_button(:cil_liable, false, checked: !@planning_application.cil_liable, label: { text: "No" }) %>

--- a/app/views/planning_applications/cil_liability/edit.html.erb
+++ b/app/views/planning_applications/cil_liability/edit.html.erb
@@ -15,7 +15,7 @@
     ) %>
 
 <p class="govuk-body">
-  <% if @planning_application.cil_liability_proposal_detail.present? %>
+  <% if @planning_application.cil_liability_planx_answer? %>
       According to PlanX the new floor area being added is:
       <strong><%= @planning_application.cil_liability_proposal_detail.response_values.to_sentence %></strong>.
       <br>

--- a/spec/system/planning_applications/assessing/cil_liability_spec.rb
+++ b/spec/system/planning_applications/assessing/cil_liability_spec.rb
@@ -11,134 +11,130 @@ RSpec.describe "Permitted development right" do
     create(:planning_application, :not_started, old_constraints: [], local_authority: default_local_authority)
   end
 
-  context "when signed in as an assessor" do
-    before do
-      sign_in assessor
-      visit planning_application_path(planning_application)
+  before do
+    sign_in assessor
+    visit planning_application_path(planning_application)
+  end
+
+  it "is listed as incomplete by default" do
+    visit planning_application_validation_tasks_path(planning_application)
+
+    within "#cil-liability-validation-tasks" do
+      expect(page).to have_content "CIL liability Not started"
+    end
+  end
+
+  it "can be marked as liable" do
+    visit planning_application_validation_tasks_path(planning_application)
+    click_link "CIL liability"
+    choose "Yes"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_content "CIL liability updated"
+    within "#cil-liability-validation-tasks" do
+      expect(page).to have_content "CIL liability Liable"
+    end
+  end
+
+  it "can be marked as not liable" do
+    visit planning_application_validation_tasks_path(planning_application)
+    click_link "CIL liability"
+    choose "No"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_content "CIL liability updated"
+    within "#cil-liability-validation-tasks" do
+      expect(page).to have_content "CIL liability Not liable"
+    end
+  end
+
+  context "when revisiting the edit page" do
+    it "is marked as true when liable" do
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "CIL liability"
+      choose "Yes"
+      click_button "Save and mark as complete"
+
+      click_link "CIL liability"
+
+      expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
+      expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
     end
 
-    context "when planning application is in assessment" do
-      it "is listed as incomplete by default" do
-        visit planning_application_validation_tasks_path(planning_application)
+    it "is marked as false when not liable" do
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "CIL liability"
+      choose "No"
+      click_button "Save and mark as complete"
 
-        within "#cil-liability-validation-tasks" do
-          expect(page).to have_content "CIL liability Not started"
-        end
-      end
+      click_link "CIL liability"
 
-      it "can be marked as liable" do
+      expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+      expect(find_by_id("planning-application-cil-liable-field")).to be_selected
+    end
+  end
+
+  context "when there is no liability information from planx" do
+    it "explains that there is no liability information" do
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "CIL liability"
+
+      expect(page).to have_content("No information on potential CIL liability from PlanX.")
+    end
+
+    it "does not preselect any radio button" do
+      visit planning_application_validation_tasks_path(planning_application)
+      click_link "CIL liability"
+
+      expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+      expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+    end
+  end
+
+  context "when there is liability information from planx" do
+    before do
+      cil_liability_proposal_detail = instance_double(ProposalDetail)
+      allow(cil_liability_proposal_detail).to receive(:response_values).and_return([planx_response])
+      allow_any_instance_of(PlanningApplication).to receive(:cil_liability_proposal_detail).and_return(cil_liability_proposal_detail)
+    end
+
+    context "when the application might be liable" do
+      let(:planx_response) { "More than 100m²" }
+
+      it "shows relevant liability information" do
         visit planning_application_validation_tasks_path(planning_application)
         click_link "CIL liability"
-        choose "Yes"
-        click_button "Save and mark as complete"
 
-        expect(page).to have_content "CIL liability updated"
-        within "#cil-liability-validation-tasks" do
-          expect(page).to have_content "CIL liability Liable"
-        end
+        expect(page).to have_content(planx_response)
+        expect(page).to have_content("This might mean that the application is liable for CIL.")
       end
 
-      it "can be marked as not liable" do
+      it "selects yes by default" do
         visit planning_application_validation_tasks_path(planning_application)
         click_link "CIL liability"
-        choose "No"
-        click_button "Save and mark as complete"
 
-        expect(page).to have_content "CIL liability updated"
-        within "#cil-liability-validation-tasks" do
-          expect(page).to have_content "CIL liability Not liable"
-        end
+        expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+        expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+      end
+    end
+
+    context "when the application might not be liable" do
+      let(:planx_response) { "Less than 100m²" }
+
+      it "shows relevant liability information" do
+        visit planning_application_validation_tasks_path(planning_application)
+        click_link "CIL liability"
+
+        expect(page).to have_content(planx_response)
+        expect(page).to have_content("This might mean that the application is not liable for CIL.")
       end
 
-      context "when revisiting the edit page" do
-        it "is marked as true when liable" do
-          visit planning_application_validation_tasks_path(planning_application)
-          click_link "CIL liability"
-          choose "Yes"
-          click_button "Save and mark as complete"
+      it "selects no by default" do
+        visit planning_application_validation_tasks_path(planning_application)
+        click_link "CIL liability"
 
-          click_link "CIL liability"
-
-          expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
-          expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
-        end
-
-        it "is marked as false when not liable" do
-          visit planning_application_validation_tasks_path(planning_application)
-          click_link "CIL liability"
-          choose "No"
-          click_button "Save and mark as complete"
-
-          click_link "CIL liability"
-
-          expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-          expect(find_by_id("planning-application-cil-liable-field")).to be_selected
-        end
-      end
-
-      context "when there is no liability information from planx" do
-        it "explains that there is no liability information" do
-          visit planning_application_validation_tasks_path(planning_application)
-          click_link "CIL liability"
-
-          expect(page).to have_content("No information on potential CIL liability from PlanX.")
-        end
-
-        it "does not preselect any radio button" do
-          visit planning_application_validation_tasks_path(planning_application)
-          click_link "CIL liability"
-
-          expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-          expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
-        end
-      end
-
-      context "when there is liability information from planx" do
-        before do
-          cil_liability_proposal_detail = instance_double(ProposalDetail)
-          allow(cil_liability_proposal_detail).to receive(:response_values).and_return([planx_response])
-          allow_any_instance_of(PlanningApplication).to receive(:cil_liability_proposal_detail).and_return(cil_liability_proposal_detail)
-        end
-
-        context "when the application might be liable" do
-          let(:planx_response) { "More than 100m²" }
-
-          it "shows relevant liability information" do
-            visit planning_application_validation_tasks_path(planning_application)
-            click_link "CIL liability"
-
-            expect(page).to have_content(planx_response)
-            expect(page).to have_content("This might mean that the application is liable for CIL.")
-          end
-
-          it "selects yes by default" do
-            visit planning_application_validation_tasks_path(planning_application)
-            click_link "CIL liability"
-
-            expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-            expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
-          end
-        end
-
-        context "when the application might not be liable" do
-          let(:planx_response) { "Less than 100m²" }
-
-          it "shows relevant liability information" do
-            visit planning_application_validation_tasks_path(planning_application)
-            click_link "CIL liability"
-
-            expect(page).to have_content(planx_response)
-            expect(page).to have_content("This might mean that the application is not liable for CIL.")
-          end
-
-          it "selects no by default" do
-            visit planning_application_validation_tasks_path(planning_application)
-            click_link "CIL liability"
-
-            expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-            expect(find_by_id("planning-application-cil-liable-field")).to be_selected
-          end
-        end
+        expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+        expect(find_by_id("planning-application-cil-liable-field")).to be_selected
       end
     end
   end

--- a/spec/system/planning_applications/assessing/cil_liability_spec.rb
+++ b/spec/system/planning_applications/assessing/cil_liability_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Permitted development right" do
-  let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
-  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
-  let!(:planning_application) do
+  let(:planning_application) do
     create(:planning_application, :not_started, old_constraints: [], local_authority: default_local_authority)
   end
 
@@ -95,7 +95,7 @@ RSpec.describe "Permitted development right" do
     before do
       cil_liability_proposal_detail = instance_double(ProposalDetail)
       allow(cil_liability_proposal_detail).to receive(:response_values).and_return([planx_response])
-      allow_any_instance_of(PlanningApplication).to receive(:cil_liability_proposal_detail).and_return(cil_liability_proposal_detail)
+      allow_any_instance_of(PlanningApplication).to receive(:cil_liability_planx_answers).and_return([cil_liability_proposal_detail])
     end
 
     context "when the application might be liable" do
@@ -113,7 +113,7 @@ RSpec.describe "Permitted development right" do
         visit planning_application_validation_tasks_path(planning_application)
         click_link "CIL liability"
 
-        expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
+        expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
         expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
       end
     end


### PR DESCRIPTION
### Description of change

Restructuring the logic to ensure correctness, as this was not correctly displaying the result from the database if one existed.

### Story Link

https://trello.com/c/ojat5cyr/2050-cil-liability-state-doesnt-select-yes-when-returning-to-edit-view