### PR TITLE
Do not duplicate list of assessment details per application type

### DIFF
--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -58,25 +58,6 @@ class AssessmentDetail < ApplicationRecord
     scope :"#{category}", -> { where(category:) }
   end
 
-  class << self
-    def category_keys
-      categories = AssessmentDetail.categories.keys.excluding("past_applications")
-
-      categories.partition { |category| category != "additional_evidence" }.sum([])
-    end
-
-    def categories_for(application_type)
-      case application_type
-      when :lawfulness_certificate
-        category_keys - %w[publicity_summary amenity]
-      when :prior_approval
-        category_keys - %w[consultation_summary]
-      else
-        category_keys
-      end
-    end
-  end
-
   def existing_or_new_comment
     comment || build_comment
   end

--- a/app/views/planning_applications/assessment_tasks/_assessment_information.html.erb
+++ b/app/views/planning_applications/assessment_tasks/_assessment_information.html.erb
@@ -4,13 +4,13 @@
   </h2>
 
   <ul class="app-task-list__items">
-    <% AssessmentDetail.categories_for(@planning_application.application_type.name.to_sym).each do |category| %>
+    <% @planning_application.application_type.assessment_details.each do |category| %>
       <%= render(
-        TaskListItems::AssessmentDetailComponent.new(
-          planning_application: @planning_application,
-          category: category
-        )
-      ) %>
+            TaskListItems::AssessmentDetailComponent.new(
+              planning_application: @planning_application,
+              category:
+            )
+          ) %>
     <% end %>
   </ul>
 </li>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,9 +71,32 @@ local_authorities.each do |authority|
 end
 
 application_types = [
-  {name: "lawfulness_certificate"},
-  {name: "prior_approval", part: 1, section: "A"},
-  {name: "planning_permission"}
+  {name: "lawfulness_certificate",
+   steps: %w[validation assessment review],
+   assessment_details: %w[
+     summary_of_work
+     site_description
+     consultation_summary
+     additional_evidence
+   ]},
+  {name: "prior_approval", part: 1, section: "A",
+   steps: %w[validation consultation assessment review],
+   assessment_details: %w[
+     summary_of_work
+     site_description
+     additional_evidence
+     publicity_summary
+     amenity
+   ]},
+  {name: "planning_permission",
+   steps: %w[validation consultation assessment review],
+   assessment_details: %w[
+     summary_of_work
+     site_description
+     additional_evidence
+     consultation_summary
+     publicity_summary
+   ]}
 ]
 
 application_types.each do |attrs|

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -955,7 +955,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   context "when the application is a prior approval" do
-    let(:application_type) { create(:application_type, name: "prior_approval") }
+    let(:application_type) { create(:application_type, :prior_approval) }
 
     let(:planning_application) do
       create(

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe ApplicationType do
 
   describe "class methods" do
     describe "#menu" do
-      let!(:lawfulness_certificate) { create(:application_type, name: "lawfulness_certificate") }
-      let!(:prior_approval) { create(:application_type, name: "prior_approval") }
+      let!(:lawfulness_certificate) { create(:application_type) }
+      let!(:prior_approval) { create(:application_type, :prior_approval) }
 
       it "returns an array of application type names (humanized) and ids" do
         expect(described_class.menu).to eq(
@@ -28,7 +28,7 @@ RSpec.describe ApplicationType do
 
   describe "legislation details" do
     context "when planning application type has legislation details defined in en.yml translation" do
-      let!(:application_type) { create(:application_type, name: "prior_approval", part: 1, section: "A") }
+      let!(:application_type) { create(:application_type, :prior_approval, part: 1, section: "A") }
 
       describe "legislation_link" do
         it "returns the legislation link" do

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -123,16 +123,6 @@ RSpec.describe AssessmentDetail do
     end
   end
 
-  describe "class methods" do
-    describe "#category_keys" do
-      it "returns an array of categories with additional_evidence as the last item" do
-        expect(described_class.category_keys).to eq(
-          %w[summary_of_work site_description consultation_summary publicity_summary amenity additional_evidence]
-        )
-      end
-    end
-  end
-
   describe "#valid?" do
     let(:planning_application) { create(:planning_application) }
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe PlanningApplication do
         end
 
         it "works for other planning application types" do
-          prior_approval_type = create(:application_type, name: "prior_approval")
+          prior_approval_type = create(:application_type, :prior_approval)
           planning_application = build(:planning_application, work_status: "proposed", application_type: prior_approval_type)
 
           travel_to(DateTime.new(2022, 1, 1)) do

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -5,8 +5,8 @@ require "rails_helper"
 RSpec.describe PlanningApplicationCreationService, type: :service do
   describe "#call" do
     let(:api_user) { create(:api_user) }
-    let!(:application_type) { create(:application_type, name: "prior_approval") }
-    let!(:application_type1) { create(:application_type, name: "lawfulness_certificate") }
+    let!(:application_type_pa) { create(:application_type, :prior_approval) }
+    let!(:application_type_ldc) { create(:application_type) }
 
     before do
       stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
@@ -201,7 +201,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
     context "when application type is Householder Application for Planning Permission" do
       let(:local_authority) { create(:local_authority) }
       let(:params) { ActionController::Parameters.new(JSON.parse(file_fixture("planx_params_householder_application_for_planning_permission.json").read)) }
-      let!(:application_type) { create(:application_type, name: "planning_permission") }
+      let!(:application_type) { create(:application_type, :planning_permission) }
 
       let(:create_planning_application) do
         described_class.new(

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "neighbour responses" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
-  let!(:application_type) { create(:application_type, name: :prior_approval) }
+  let!(:application_type) { create(:application_type, :prior_approval) }
   let!(:planning_application) do
     create(:planning_application, :in_assessment, :from_planx_immunity, application_type:,
       local_authority: default_local_authority)
@@ -18,7 +18,7 @@ RSpec.describe "neighbour responses" do
   end
 
   context "when planning application is in assessment" do
-    let!(:consultation) { create(:consultation, end_date: Time.zone.now, planning_application:) }
+    let!(:consultation) { planning_application.consultation }
     let!(:neighbour1) { create(:neighbour, address: "1 Test Lane", consultation:) }
     let!(:neighbour2) { create(:neighbour, address: "2 Test Lane", consultation:) }
     let!(:neighbour3) { create(:neighbour, address: "3 Test Lane", consultation:) }
@@ -143,7 +143,7 @@ RSpec.describe "neighbour responses" do
   end
 
   context "when it's an LDC application" do
-    let!(:application_type) { create(:application_type, name: :lawfulness_certificate) }
+    let!(:application_type) { create(:application_type) }
     let!(:planning_application) do
       create(:planning_application, :in_assessment, application_type:, local_authority: default_local_authority)
     end

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe "Planning Application Assessment" do
       end
 
       context "when the application is for a prior approval" do
-        let(:application_type) { create(:application_type, name: "prior_approval") }
+        let(:application_type) { create(:application_type, :prior_approval) }
         let!(:planning_application) do
           create(:planning_application, :awaiting_determination,
             :from_planx_prior_approval,

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "editing planning application" do
   before do
     travel_to(DateTime.new(2023, 1, 1))
     sign_in(assessor)
-    create(:application_type, name: "prior_approval")
+    create(:application_type, :prior_approval)
     visit(planning_application_path(planning_application))
   end
 

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Planning Application index page" do
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
-  let(:application_type_prior_approval) { create(:application_type, name: :prior_approval) }
+  let(:application_type_prior_approval) { create(:application_type, :prior_approval) }
 
   context "as an assessor" do
     before do


### PR DESCRIPTION
### Description of change

This has now (5599c39) been moved to a database field, but some code still uses the static lists. This then prevents changes to the assessment detail task list being applied correctly.

### Story Link

https://trello.com/c/wZIjZwLe/2045-remove-amenity-in-task-list-for-householder-assessment
