### PR TITLE
Use standardrb configuration for rubocop rather than the existing home-grown one

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,106 +1,36 @@
 ---
-inherit_mode:
-  merge:
-    - Exclude
-
 require:
+  - standard
+  - standard-custom
+  - standard-performance
+  - standard-rails
   - rubocop-performance
   - rubocop-rails
-  - rubocop-rspec
+
+inherit_gem:
+  standard: config/base.yml
+  standard-custom: config/base.yml
+  standard-performance: config/base.yml
+  standard-rails: config/base.yml
 
 AllCops:
   TargetRubyVersion: 3.2.2
   NewCops: enable
   Exclude:
+    - 'bin/*'
     - 'bops-applicants/**/*'
+    - 'db/schema.rb'
     - 'config/environments/**'
     - 'config/puma.rb'
+    - 'vendor/**/*'
 
-Style/HashSyntax:
-  EnforcedShorthandSyntax: either
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/Documentation:
-  Enabled: false
-
-# be a bit kinder with our metrics
-Metrics:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: true
-  Max: 100
+# TODO
+Rails/EnvironmentVariableAccess:
   Exclude:
-    - spec/**/*
-    - config/routes.rb
+    - app/**/*
 
-Layout/LineLength:
-  AllowedPatterns: ['^\s*#']
-  Exclude:
-    - spec/**/*
-
-Naming/VariableNumber:
-  Exclude:
-    - db/migrate/*
-    - spec/**/*
-
-# we tend to use update_all in migrations
-Rails/SkipsModelValidations:
-  Exclude:
-    - db/migrate/*.rb
-
-  AllowedMethods:
-    - touch
-
-# allow ActiveRecord::Base as a parent class in migrations
-Rails/ApplicationRecord:
-  Exclude:
-    - db/migrate/*.rb
-
-# Rspec
-RSpec/MultipleExpectations:
-  Enabled: false
-
-RSpec/ExampleLength:
-  Enabled: false
-
-RSpec/NestedGroups:
-  Max: 5
-
-RSpec/InstanceVariable:
-  Enabled: false
-
-RSpec/MultipleMemoizedHelpers:
-  Enabled: false
-
-RSpec/AnyInstance:
-  Enabled: false
-
-RSpec/ContextWording:
-  Prefixes:
-    - as
-    - before
-    - when
-    - with
-    - without
-
-RSpec/LetSetup:
-  Enabled: false
-
-RSpec/MessageSpies:
-  Enabled: false
-
-RSpec/StubbedMock:
-  Enabled: false
-
-Lint/MissingSuper:
-  Exclude:
-    - app/components/**/*.rb
-
-# these two are ignored because they're migrations from the past and we
-# don't expect to go back and edit them ever
+# past migrations are ignored; we don't expect to go back and edit them ever,
+# we'll fix them in future migrations if at all.
 Rails/BulkChangeTable:
   Exclude:
     - db/migrate/2020*
@@ -112,3 +42,16 @@ Rails/ReversibleMigration:
     - db/migrate/2020*
     - db/migrate/2021*
     - db/migrate/2022*
+
+Rails/ThreeStateBooleanColumn:
+  Exclude:
+    - db/migrate/2020*
+    - db/migrate/2021*
+    - db/migrate/2022*
+    - db/migrate/20230*
+    - db/migrate/202310*
+
+# False positive: if being used in migrations, behaviour is different and intentional
+Rails/ApplicationRecord:
+  Exclude:
+    - db/migrate/*

--- a/Gemfile
+++ b/Gemfile
@@ -51,10 +51,10 @@ group :development, :test do
   gem "pry-byebug"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 4.0.0"
-  gem "rubocop", require: false
-  gem "rubocop-performance", require: false
-  gem "rubocop-rails", require: false
-  gem "rubocop-rspec", require: false
+  gem "standard", "~> 1.31", require: false
+  gem "standard-custom", require: false
+  gem "standard-performance", require: false
+  gem "standard-rails", require: false
   gem "selenium-webdriver"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.4)
       aws-eventstream (~> 1, >= 1.0.2)
+    base64 (0.1.1)
     bcrypt (3.1.18)
     better_html (2.0.1)
       actionview (>= 6.0)
@@ -285,6 +286,8 @@ GEM
       railties (>= 6.0.0)
     json (2.6.3)
     jwt (2.7.0)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -444,27 +447,27 @@ GEM
     rswag-ui (2.8.0)
       actionpack (>= 3.1, < 7.1)
       railties (>= 3.1, < 7.1)
-    rubocop (1.52.1)
+    rubocop (1.56.4)
+      base64 (~> 0.1.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.15.1)
+    rubocop-performance (1.19.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
-    rubocop-rails (2.17.4)
+    rubocop-rails (2.20.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.17.1)
-      rubocop (~> 1.33)
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby-vips (2.1.4)
@@ -495,6 +498,21 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    standard (1.31.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.56.4)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.2)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.2.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.19.1)
+    standard-rails (0.2.0)
+      lint_roller (~> 1.0)
+      rubocop-rails (~> 2.20.2)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
     strong_password (0.0.10)
@@ -586,14 +604,14 @@ DEPENDENCIES
   rgeo-geojson
   rspec-rails (~> 4.0.0)
   rswag-ui
-  rubocop
-  rubocop-performance
-  rubocop-rails
-  rubocop-rspec
   selenium-webdriver
   sidekiq
   sidekiq-scheduler
   sprockets-rails
+  standard (~> 1.31)
+  standard-custom
+  standard-performance
+  standard-rails
   stimulus-rails
   strong_password (~> 0.0.9)
   view_component

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
-    brakeman (5.4.0)
+    brakeman (6.0.1)
     builder (3.2.4)
     bullet (7.0.7)
       activesupport (>= 3.0.0)

--- a/Guardfile
+++ b/Guardfile
@@ -56,13 +56,13 @@ guard :rspec, cmd: "bin/rspec --order defined --fail-fast", failed_mode: :focus 
   end
 
   # Rails config changes
-  watch(rails.spec_helper)     { rspec.spec_dir }
-  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
-  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+  watch(rails.spec_helper) { rspec.spec_dir }
+  watch(rails.routes) { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller) { "#{rspec.spec_dir}/controllers" }
 
   # Capybara features specs
-  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.view_dirs) { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts) { |m| rspec.spec.call("features/#{m[1]}") }
 
   # Turnip features and steps
   watch(%r{^spec/acceptance/(.+)\.feature$})

--- a/app/components/accordion_sections/application_information_component.rb
+++ b/app/components/accordion_sections/application_information_component.rb
@@ -51,8 +51,8 @@ module AccordionSections
 
     def description_change_request
       @description_change_request ||= planning_application
-                                      .open_description_change_requests
-                                      .last
+        .open_description_change_requests
+        .last
     end
 
     def payment_reference
@@ -60,7 +60,7 @@ module AccordionSections
     end
 
     def work_already_started
-      planning_application.work_status == "proposed" ? t(".no") : t(".yes")
+      (planning_application.work_status == "proposed") ? t(".no") : t(".yes")
     end
 
     def map_link

--- a/app/components/accordion_sections/site_map_component.rb
+++ b/app/components/accordion_sections/site_map_component.rb
@@ -35,9 +35,9 @@ module AccordionSections
 
     def change_request
       @change_request ||= planning_application
-                          .red_line_boundary_change_validation_requests
-                          .post_validation
-                          .last
+        .red_line_boundary_change_validation_requests
+        .post_validation
+        .last
     end
   end
 end

--- a/app/components/assessment_details/previous_summary_component.rb
+++ b/app/components/assessment_details/previous_summary_component.rb
@@ -14,7 +14,7 @@ module AssessmentDetails
     attr_reader :assessment_details, :assessment_detail
 
     def description
-      action = assessment_detail == assessment_details.last ? :created : :updated
+      action = (assessment_detail == assessment_details.last) ? :created : :updated
       key = ".user_#{action}_#{assessment_detail.category}"
       t(key, user: assessment_detail.user.name)
     end

--- a/app/components/audits/activity_component.rb
+++ b/app/components/audits/activity_component.rb
@@ -13,8 +13,8 @@ module Audits
       if activity_type.match?("/*_validation_request_cancelled")
         "validation_request_cancelled"
       elsif activity_type.include?("request") ||
-            activity_type.include?("document_received_at_changed") ||
-            activity_type.include?("submitted")
+          activity_type.include?("document_received_at_changed") ||
+          activity_type.include?("submitted")
         activity_type
       else
         "generic_audit_entry"

--- a/app/components/consultee_email_component.rb
+++ b/app/components/consultee_email_component.rb
@@ -43,7 +43,7 @@ class ConsulteeEmailComponent < ViewComponent::Base
   end
 
   def text_area_tag(name, **extra)
-    form.text_area(name, **{ class: "govuk-textarea" }.merge(extra))
+    form.text_area(name, **{class: "govuk-textarea"}.merge(extra))
   end
 
   def hint_tag(&)

--- a/app/components/formatted_content_component.rb
+++ b/app/components/formatted_content_component.rb
@@ -21,10 +21,10 @@ class FormattedContentComponent < ViewComponent::Base
   end
 
   def simple_format_content
-    simple_format(auto_link_content, { class: classname }, sanitize: false)
+    simple_format(auto_link_content, {class: classname}, sanitize: false)
   end
 
   def auto_link_content
-    auto_link(text.to_s, html: { target: "_blank" }, sanitize: false)
+    auto_link(text.to_s, html: {target: "_blank"}, sanitize: false)
   end
 end

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -14,7 +14,7 @@ module PlanningApplications
     attr_reader :planning_applications, :type, :search
 
     def title
-      type == :all ? all_applications_title : t(".#{type}")
+      (type == :all) ? all_applications_title : t(".#{type}")
     end
 
     def attributes

--- a/app/components/status_tags/review/immunity_detail_component.rb
+++ b/app/components/status_tags/review/immunity_detail_component.rb
@@ -14,10 +14,10 @@ module StatusTags
 
       def status
         if review_immunity_detail.reviewed_at.present? &&
-           review_immunity_detail.immunity_detail.review_status == "review_complete"
+            review_immunity_detail.immunity_detail.review_status == "review_complete"
           :complete
         elsif review_immunity_detail.reviewed_at.present? &&
-              review_immunity_detail.immunity_detail.review_status == "review_in_progress"
+            review_immunity_detail.immunity_detail.review_status == "review_in_progress"
           :in_progress
         else
           :not_started

--- a/app/components/task_list_items/check_red_line_boundary_component.rb
+++ b/app/components/task_list_items/check_red_line_boundary_component.rb
@@ -36,14 +36,14 @@ module TaskListItems
 
     def status
       @status = if valid?
-                  :valid
-                elsif red_line_boundary_change_validation_requests.open_or_pending.any?
-                  :invalid
-                elsif change_request&.approved == false
-                  :updated
-                else
-                  :not_started
-                end
+        :valid
+      elsif red_line_boundary_change_validation_requests.open_or_pending.any?
+        :invalid
+      elsif change_request&.approved == false
+        :updated
+      else
+        :not_started
+      end
     end
 
     def render_sitemap_path?
@@ -57,9 +57,9 @@ module TaskListItems
 
     def change_request
       @change_request ||= red_line_boundary_change_validation_requests
-                          .not_cancelled
-                          .order(:created_at)
-                          .last
+        .not_cancelled
+        .order(:created_at)
+        .last
     end
   end
 end

--- a/app/components/task_list_items/document_component.rb
+++ b/app/components/task_list_items/document_component.rb
@@ -45,14 +45,14 @@ module TaskListItems
 
     def status
       @status ||= if document.validated?
-                    :valid
-                  elsif replacement_document_validation_request&.open_or_pending?
-                    :invalid
-                  elsif ReplacementDocumentValidationRequest.find_by(new_document: document).present?
-                    :updated
-                  else
-                    :not_started
-                  end
+        :valid
+      elsif replacement_document_validation_request&.open_or_pending?
+        :invalid
+      elsif ReplacementDocumentValidationRequest.find_by(new_document: document).present?
+        :updated
+      else
+        :not_started
+      end
     end
   end
 end

--- a/app/components/task_list_items/fee_component.rb
+++ b/app/components/task_list_items/fee_component.rb
@@ -33,14 +33,14 @@ module TaskListItems
 
     def status
       @status ||= if planning_application.valid_fee?
-                    :valid
-                  elsif fee_item_validation_requests.open_or_pending.any?
-                    :invalid
-                  elsif fee_item_validation_requests.closed.any?
-                    :updated
-                  else
-                    :not_started
-                  end
+        :valid
+      elsif fee_item_validation_requests.open_or_pending.any?
+        :invalid
+      elsif fee_item_validation_requests.closed.any?
+        :updated
+      else
+        :not_started
+      end
     end
   end
 end

--- a/app/components/task_list_items/review/immunity_details_component.rb
+++ b/app/components/task_list_items/review/immunity_details_component.rb
@@ -23,7 +23,7 @@ module TaskListItems
 
       def link_path
         if immunity_detail.current_evidence_review_immunity_detail&.reviewed_at.present? &&
-           immunity_detail.review_status == "review_complete"
+            immunity_detail.review_status == "review_complete"
           planning_application_review_immunity_detail_path(
             planning_application,
             review_immunity_detail

--- a/app/components/task_list_items/review/local_policy_component.rb
+++ b/app/components/task_list_items/review/local_policy_component.rb
@@ -23,7 +23,7 @@ module TaskListItems
 
       def link_path
         if review_local_policy&.reviewed_at.present? &&
-           local_policy.review_status == "review_complete"
+            local_policy.review_status == "review_complete"
           planning_application_review_local_policy_path(
             planning_application,
             review_local_policy

--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -7,9 +7,9 @@ module Api
 
       before_action :check_token_and_set_application
       before_action :check_files_params_are_present,
-                    :check_files_size,
-                    :check_files_type,
-                    :current_api_user, only: :update
+        :check_files_size,
+        :check_files_type,
+        :current_api_user, only: :update
 
       rescue_from AdditionalDocumentValidationRequest::UploadFilesError do |_exception|
         render_failed_request
@@ -30,8 +30,8 @@ module Api
             format.json
           else
             format.json do
-              render json: { message: "Unable to find additional document validation request with id: #{params[:id]}" },
-                     status: :not_found
+              render json: {message: "Unable to find additional document validation request with id: #{params[:id]}"},
+                status: :not_found
             end
           end
         end
@@ -44,7 +44,7 @@ module Api
         if @additional_document_validation_request.can_upload?
           @additional_document_validation_request.upload_files!(params[:files])
           @planning_application.send_update_notification_to_assessor
-          render json: { message: "Validation request updated" }, status: :ok
+          render json: {message: "Validation request updated"}, status: :ok
         else
           render_failed_request
         end
@@ -55,23 +55,23 @@ module Api
       def check_files_params_are_present
         return unless params[:files].empty?
 
-        render json: { message: "At least one file must be selected to proceed." }, status: :bad_request
+        render json: {message: "At least one file must be selected to proceed."}, status: :bad_request
       end
 
       def check_files_size
         params[:files].each do |file|
           next unless file_size_over_30mb?(file)
 
-          render json: { message: "The file: '#{file.original_filename}' exceeds the limit of 30mb. " \
-                                  "Each file must be 30MB or less" },
-                 status: :payload_too_large
+          render json: {message: "The file: '#{file.original_filename}' exceeds the limit of 30mb. " \
+                                  "Each file must be 30MB or less"},
+            status: :payload_too_large
         end
       end
 
       def check_files_type
         return unless params[:files].any? { |file| Document::PERMITTED_CONTENT_TYPES.exclude? file.content_type }
 
-        render json: { message: "The file type must be JPEG, PNG or PDF" }, status: :bad_request
+        render json: {message: "The file type must be JPEG, PNG or PDF"}, status: :bad_request
       end
     end
   end

--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -10,7 +10,7 @@ module Api
       protect_from_forgery with: :null_session
 
       rescue_from ActionController::ParameterMissing do |e|
-        render json: { error: e.message }, status: :bad_request
+        render json: {error: e.message}, status: :bad_request
       end
 
       def set_default_format
@@ -39,11 +39,11 @@ module Api
           if params[:change_access_id] == @planning_application.change_access_id
             @planning_application
           else
-            render json: { message: "Change access id is invalid" }, status: :unauthorized
+            render json: {message: "Change access id is invalid"}, status: :unauthorized
           end
         else
-          render json: { message: "Unable to find planning application with id: #{params[:planning_application_id]}" },
-                 status: :not_found
+          render json: {message: "Unable to find planning application with id: #{params[:planning_application_id]}"},
+            status: :not_found
         end
       end
 
@@ -65,7 +65,7 @@ module Api
 
       def request_http_token_authentication(realm = "Application", _message = nil)
         headers["WWW-Authenticate"] = %(Token realm="#{realm.delete('"')}")
-        render json: { error: "HTTP Token: Access denied." }, status: :unauthorized
+        render json: {error: "HTTP Token: Access denied."}, status: :unauthorized
       end
     end
   end

--- a/app/controllers/api/v1/description_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_validation_requests_controller.rb
@@ -21,8 +21,8 @@ module Api
             format.json
           else
             format.json do
-              render json: { message: "Unable to find description change validation request with id: #{params[:id]}" },
-                     status: :not_found
+              render json: {message: "Unable to find description change validation request with id: #{params[:id]}"},
+                status: :not_found
             end
           end
         end
@@ -39,19 +39,19 @@ module Api
           end
           @description_change_validation_request.create_api_audit!
           @planning_application.send_update_notification_to_assessor
-          render json: { message: "Description change request updated" }, status: :ok
+          render json: {message: "Description change request updated"}, status: :ok
         else
-          render json: { message: "Unable to update request. " \
-                                  "Please ensure rejection_reason is present if approved is false." },
-                 status: :bad_request
+          render json: {message: "Unable to update request. " \
+                                  "Please ensure rejection_reason is present if approved is false."},
+            status: :bad_request
         end
       end
 
       private
 
       def description_change_params
-        { approved: params[:data][:approved],
-          rejection_reason: params[:data][:rejection_reason] }
+        {approved: params[:data][:approved],
+         rejection_reason: params[:data][:rejection_reason]}
       end
     end
   end

--- a/app/controllers/api/v1/local_authorities_controller.rb
+++ b/app/controllers/api/v1/local_authorities_controller.rb
@@ -18,8 +18,8 @@ module Api
       end
 
       def send_not_found_response
-        render json: { message: "Unable to find record" },
-               status: :not_found
+        render json: {message: "Unable to find record"},
+          status: :not_found
       end
     end
   end

--- a/app/controllers/api/v1/neighbour_responses_controller.rb
+++ b/app/controllers/api/v1/neighbour_responses_controller.rb
@@ -19,15 +19,15 @@ module Api
       end
 
       def send_success_response
-        render json: { id: @planning_application.reference.to_s,
-                       message: "Response submitted" }, status: :ok
+        render json: {id: @planning_application.reference.to_s,
+                      message: "Response submitted"}, status: :ok
       end
 
       def send_failed_response(error)
         Appsignal.send_error(error)
 
-        render json: { message: error.message.to_s || "Unable to create response" },
-               status: :bad_request
+        render json: {message: error.message.to_s || "Unable to create response"},
+          status: :bad_request
       end
 
       private
@@ -42,7 +42,7 @@ module Api
                  message:
                   "Unable to find planning application with id: #{params[:planning_application_id]}"
                },
-               status: :not_found
+          status: :not_found
       end
     end
   end

--- a/app/controllers/api/v1/other_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/other_change_validation_requests_controller.rb
@@ -21,8 +21,8 @@ module Api
             format.json
           else
             format.json do
-              render json: { message: "Unable to find other change validation request with id: #{params[:id]}" },
-                     status: :not_found
+              render json: {message: "Unable to find other change validation request with id: #{params[:id]}"},
+                status: :not_found
             end
           end
         end
@@ -33,13 +33,13 @@ module Api
           @planning_application.other_change_validation_requests.where(id: params[:id]).first
 
         if params[:data][:response].present? &&
-           @other_change_validation_request.update(response: params[:data][:response])
+            @other_change_validation_request.update(response: params[:data][:response])
           @other_change_validation_request.close!
           @other_change_validation_request.create_api_audit!
           @planning_application.send_update_notification_to_assessor
-          render json: { message: "Change request updated" }, status: :ok
+          render json: {message: "Change request updated"}, status: :ok
         else
-          render json: { message: "Unable to update request. Please ensure response is present" }, status: :bad_request
+          render json: {message: "Unable to update request. Please ensure response is present"}, status: :bad_request
         end
       end
     end

--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -43,22 +43,22 @@ module Api
       private
 
       def send_success_response
-        render json: { id: @planning_application.reference.to_s,
-                       message: "Application created" }, status: :ok
+        render json: {id: @planning_application.reference.to_s,
+                      message: "Application created"}, status: :ok
       end
 
       def send_failed_response(error, params)
         Appsignal.send_error(error) do |transaction|
-          transaction.params = { params: params.to_unsafe_hash }
+          transaction.params = {params: params.to_unsafe_hash}
         end
 
-        render json: { message: error.message.to_s || "Unable to create application" },
-               status: :bad_request
+        render json: {message: error.message.to_s || "Unable to create application"},
+          status: :bad_request
       end
 
       def send_not_found_response
-        render json: { message: "Unable to find record" },
-               status: :not_found
+        render json: {message: "Unable to find record"},
+          status: :not_found
       end
 
       def post_application_to_staging

--- a/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
@@ -25,7 +25,7 @@ module Api
               render json: {
                        message: "Unable to find red line boundary change validation request with id: #{params[:id]}"
                      },
-                     status: :not_found
+                status: :not_found
             end
           end
         end
@@ -43,20 +43,20 @@ module Api
 
           @red_line_boundary_change_validation_request.create_api_audit!
           @planning_application.send_update_notification_to_assessor
-          render json: { message: "Validation request updated" }, status: :ok
+          render json: {message: "Validation request updated"}, status: :ok
         else
           render json: {
                    message: "Unable to update request. Please ensure rejection_reason is present if approved is false."
                  },
-                 status: :bad_request
+            status: :bad_request
         end
       end
 
       private
 
       def red_line_boundary_change_params
-        { approved: params[:data][:approved],
-          rejection_reason: params[:data][:rejection_reason] }
+        {approved: params[:data][:approved],
+         rejection_reason: params[:data][:rejection_reason]}
       end
     end
   end

--- a/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/replacement_document_validation_requests_controller.rb
@@ -7,8 +7,8 @@ module Api
 
       before_action :check_token_and_set_application
       before_action :check_file_params_are_present,
-                    :check_file_size,
-                    :check_file_type, only: :update
+        :check_file_size,
+        :check_file_type, only: :update
 
       def index
         respond_to do |format|
@@ -28,7 +28,7 @@ module Api
               render json: {
                        message: "Unable to find replacement document validation request with id: #{params[:id]}"
                      },
-                     status: :not_found
+                status: :not_found
             end
           end
         end
@@ -45,9 +45,9 @@ module Api
 
         @replacement_document_validation_request.create_api_audit!
         @planning_application.send_update_notification_to_assessor
-        render(json: { message: t(".success") }, status: :ok)
-      rescue StandardError
-        render(json: { message: t(".error") }, status: :bad_request)
+        render(json: {message: t(".success")}, status: :ok)
+      rescue
+        render(json: {message: t(".error")}, status: :bad_request)
       end
 
       private
@@ -55,19 +55,19 @@ module Api
       def check_file_type
         return if Document::PERMITTED_CONTENT_TYPES.include? params[:new_file].content_type
 
-        render json: { message: "The file type must be JPEG, PNG or PDF" }, status: :bad_request
+        render json: {message: "The file type must be JPEG, PNG or PDF"}, status: :bad_request
       end
 
       def check_file_size
         return unless file_size_over_30mb?(params[:new_file])
 
-        render json: { message: "The file must be smaller than 30MB" }, status: :payload_too_large
+        render json: {message: "The file must be smaller than 30MB"}, status: :payload_too_large
       end
 
       def check_file_params_are_present
         return if params[:new_file].present?
 
-        render json: { message: "A file must be selected to proceed." }, status: :bad_request
+        render json: {message: "A file must be selected to proceed."}, status: :bad_request
       end
     end
   end

--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -5,7 +5,8 @@ module Api
     class ValidationRequestsController < Api::V1::ApplicationController
       before_action :check_token_and_set_application, only: %i[index], if: :json_request?
 
-      def index; end
+      def index
+      end
 
       private
 
@@ -14,8 +15,8 @@ module Api
       end
 
       def render_failed_request
-        render json: { message: "Validation request could not be updated - please contact support" },
-               status: :bad_request
+        render json: {message: "Validation request could not be updated - please contact support"},
+          status: :bad_request
       end
 
       def file_size_over_30mb?(file)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,13 +6,13 @@ class CommentsController < AuthenticationController
   def create
     new_comment = @comment_type.comments.new(comment_params)
     new_comment = @comment_type.comments.new if new_comment.save
-    render(json: { partial: create_comment_partial(new_comment) })
+    render(json: {partial: create_comment_partial(new_comment)})
   end
 
   def update
     comment = @comment_type.comments.find(params[:id])
     comment.update(deleted_at: DateTime.current)
-    render(json: { partial: update_comment_partial })
+    render(json: {partial: update_comment_partial})
   end
 
   private
@@ -85,9 +85,9 @@ class CommentsController < AuthenticationController
 
   def set_comment_type
     @comment_type = if params[:evidence_group_id].present?
-                      EvidenceGroup.find(params[:evidence_group_id])
-                    else
-                      policy_class.policies.find(params[:policy_id])
-                    end
+      EvidenceGroup.find(params[:evidence_group_id])
+    else
+      policy_class.policies.find(params[:policy_id])
+    end
   end
 end

--- a/app/controllers/concerns/active_storage/set_disk_blob.rb
+++ b/app/controllers/concerns/active_storage/set_disk_blob.rb
@@ -14,7 +14,7 @@ module ActiveStorage
     def set_disk_blob
       @blob ||= begin # rubocop:disable Naming/MemoizedInstanceVariableName
         ActiveStorage::Blob.find_by(key: decrypted_hash[:key])
-      rescue StandardError
+      rescue
         head :not_found
       end
     end

--- a/app/controllers/concerns/validation_requests.rb
+++ b/app/controllers/concerns/validation_requests.rb
@@ -18,12 +18,12 @@ module ValidationRequests
         if request_type_instance.destroyed?
           format.html do
             redirect_to planning_application_validation_tasks_path(@planning_application),
-                        notice: t("concerns.validation_requests.destroy.success")
+              notice: t("concerns.validation_requests.destroy.success")
           end
         else
           format.html do
             redirect_to planning_application_validation_tasks_path(@planning_application),
-                        alert: t("concerns.validation_requests.destroy.failure")
+              alert: t("concerns.validation_requests.destroy.failure")
           end
         end
       end
@@ -49,7 +49,7 @@ module ValidationRequests
 
           format.html do
             redirect_to cancel_redirect_url,
-                        notice: t("concerns.validation_requests.cancel.success")
+              notice: t("concerns.validation_requests.cancel.success")
           end
         else
           format.html { redirect_failed_cancel_request }
@@ -61,8 +61,8 @@ module ValidationRequests
 
     def redirect_failed_cancel_request
       redirect_to send("cancel_confirmation_planning_application_#{request_type}_path",
-                       @planning_application, request_type_instance),
-                  alert: t("concerns.validation_requests.cancel.failure")
+        @planning_application, request_type_instance),
+        alert: t("concerns.validation_requests.cancel.failure")
     end
 
     def cancel_validation_request_params
@@ -94,7 +94,7 @@ module ValidationRequests
     def send_cancelled_validation_request_mail
       unless request_type_instance.cancelled?
         raise ValidationRequestable::CancelledEmailError,
-              "Validation request: #{request_klass_name}, ID: #{request_type_instance.id} must have a cancelled state."
+          "Validation request: #{request_klass_name}, ID: #{request_type_instance.id} must have a cancelled state."
       end
 
       PlanningApplicationMailer

--- a/app/controllers/consistency_checklists_controller.rb
+++ b/app/controllers/consistency_checklists_controller.rb
@@ -6,13 +6,15 @@ class ConsistencyChecklistsController < AuthenticationController
   before_action :set_planning_application
   before_action :set_consistency_checklist, except: %i[new create]
 
-  def show; end
+  def show
+  end
 
   def new
     @consistency_checklist = @planning_application.build_consistency_checklist
   end
 
-  def edit; end
+  def edit
+  end
 
   def create
     @consistency_checklist = @planning_application.build_consistency_checklist(
@@ -65,7 +67,7 @@ class ConsistencyChecklistsController < AuthenticationController
       :proposal_details_match_documents_comment,
       :site_map_correct,
       :proposal_measurements_match_documents,
-      { proposal_measurement: %i[eaves_height max_height depth] }
+      {proposal_measurement: %i[eaves_height max_height depth]}
     ]
   end
 

--- a/app/controllers/constraints_controller.rb
+++ b/app/controllers/constraints_controller.rb
@@ -5,7 +5,8 @@ class ConstraintsController < AuthenticationController
   before_action :ensure_constraint_edits_unlocked, only: %i[show update]
   before_action :set_planning_application_constraints, only: %i[update]
 
-  def show; end
+  def show
+  end
 
   def update
     ActiveRecord::Base.transaction do
@@ -37,18 +38,18 @@ class ConstraintsController < AuthenticationController
       if @planning_application.constraints_checked?
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      alert: t(".failure")
+            alert: t(".failure")
         end
       end
     end
   rescue ActiveRecord::ActiveRecordError => e
     redirect_to planning_application_constraints_path(@planning_application),
-                alert: "Couldn't update constraints with error: #{e.message}. Please contact support."
+      alert: "Couldn't update constraints with error: #{e.message}. Please contact support."
   end
 
   private

--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -16,6 +16,6 @@ class ContactsController < AuthenticationController
   end
 
   def search_options
-    { local_authority: current_local_authority, category: params[:category] }
+    {local_authority: current_local_authority, category: params[:category]}
   end
 end

--- a/app/controllers/description_change_validation_requests_controller.rb
+++ b/app/controllers/description_change_validation_requests_controller.rb
@@ -4,7 +4,8 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
   before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
   before_action :set_description_change_request, only: %i[show cancel]
 
-  def show; end
+  def show
+  end
 
   def new
     @description_change_request = @planning_application.description_change_validation_requests.new

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -13,9 +13,9 @@ class DocumentsController < AuthenticationController
   def index
     @documents = @planning_application.documents.with_file_attachment
     @additional_document_validation_requests = @planning_application
-                                               .additional_document_validation_requests
-                                               .post_validation
-                                               .open_or_pending
+      .additional_document_validation_requests
+      .post_validation
+      .open_or_pending
 
     respond_to do |format|
       format.html
@@ -100,9 +100,9 @@ class DocumentsController < AuthenticationController
 
   def document_params
     document_params = params.fetch(:document, {}).permit(:archive_reason, :name, :archived_at,
-                                                         :numbers, :publishable, :referenced_in_decision_notice,
-                                                         :validated, :invalidated_document_reason, :file,
-                                                         :received_at, :created_by, tags: [])
+      :numbers, :publishable, :referenced_in_decision_notice,
+      :validated, :invalidated_document_reason, :file,
+      :received_at, :created_by, tags: [])
     document_params[:tags]&.reject!(&:blank?)
     document_params
   end

--- a/app/controllers/fee_items_controller.rb
+++ b/app/controllers/fee_items_controller.rb
@@ -17,13 +17,13 @@ class FeeItemsController < ValidationRequestsController
       format.html do
         if @planning_application.valid_fee?
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         elsif @planning_application.valid_fee.nil?
           flash.now[:alert] = "You must first select Yes or No to continue."
           render :show
         else
           redirect_to new_planning_application_other_change_validation_request_path(@planning_application,
-                                                                                    validate_fee: "yes")
+            validate_fee: "yes")
         end
       end
     end

--- a/app/controllers/legislations_controller.rb
+++ b/app/controllers/legislations_controller.rb
@@ -19,7 +19,7 @@ class LegislationsController < AuthenticationController
       if @planning_application.legislation_checked?
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         format.html do

--- a/app/controllers/local_authorities_controller.rb
+++ b/app/controllers/local_authorities_controller.rb
@@ -5,7 +5,8 @@ class LocalAuthoritiesController < ApplicationController
 
   before_action :set_local_authority, only: %i[edit update]
 
-  def edit; end
+  def edit
+  end
 
   def update
     if @local_authority.update(local_authority_params)

--- a/app/controllers/other_change_validation_requests_controller.rb
+++ b/app/controllers/other_change_validation_requests_controller.rb
@@ -42,7 +42,7 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
       if @other_change_validation_request.save
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         format.html { render :new, validate_fee: params[:validate_fee] }
@@ -55,7 +55,7 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
       if @other_change_validation_request.update(other_change_validation_request_params)
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         format.html { render :edit }

--- a/app/controllers/planning_applications/assess_immunity_detail_permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/assess_immunity_detail_permitted_development_rights_controller.rb
@@ -54,7 +54,7 @@ module PlanningApplications
 
       if @form.save
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: I18n.t("assess_immunity_detail_permitted_development_rights.successfully_created")
+          notice: I18n.t("assess_immunity_detail_permitted_development_rights.successfully_created")
       else
         set_permitted_development_rights
         set_review_immunity_details
@@ -72,7 +72,7 @@ module PlanningApplications
 
       if @form.update
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: I18n.t("assess_immunity_detail_permitted_development_rights.successfully_updated")
+          notice: I18n.t("assess_immunity_detail_permitted_development_rights.successfully_updated")
       else
         set_permitted_development_rights
         set_review_immunity_details
@@ -85,7 +85,7 @@ module PlanningApplications
     def assess_immunity_detail_permitted_development_right_form_params
       params.require(:assess_immunity_detail_permitted_development_right_form).permit(
         review_immunity_detail: %i[decision decision_reason yes_decision_reason no_decision_reason decision_type
-                                   summary],
+          summary],
         permitted_development_right: %i[removed removed_reason]
       ).merge(review_immunity_detail_status:, permitted_development_right_status:)
     end

--- a/app/controllers/planning_applications/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment_details_controller.rb
@@ -54,7 +54,7 @@ module PlanningApplications
         if @assessment_detail.update(assessment_details_params)
           format.html do
             redirect_to planning_application_assessment_tasks_path(@planning_application),
-                        notice: I18n.t("assessment_details.#{@assessment_detail.category}_successfully_updated")
+              notice: I18n.t("assessment_details.#{@assessment_detail.category}_successfully_updated")
           end
         else
           format.html { render :edit }

--- a/app/controllers/planning_applications/assign_users_controller.rb
+++ b/app/controllers/planning_applications/assign_users_controller.rb
@@ -21,7 +21,7 @@ module PlanningApplications
       end
     rescue ActiveRecord::ActiveRecordError => e
       redirect_to planning_application_assign_users_path(@planning_application),
-                  alert: "Couldn't assign user with error: #{e.message}. Please contact support."
+        alert: "Couldn't assign user with error: #{e.message}. Please contact support."
     end
 
     def set_users

--- a/app/controllers/planning_applications/conditions_controller.rb
+++ b/app/controllers/planning_applications/conditions_controller.rb
@@ -8,18 +8,21 @@ module PlanningApplications
     before_action :set_new_conditions, only: :new
     before_action :set_conditions, only: :edit
 
-    def show; end
+    def show
+    end
 
-    def new; end
+    def new
+    end
 
-    def edit; end
+    def edit
+    end
 
     def create
       if @planning_application.update(assign_params)
         respond_to do |format|
           format.html do
             redirect_to(planning_application_assessment_tasks_path(@planning_application),
-                        notice: I18n.t("conditions.create.success"))
+              notice: I18n.t("conditions.create.success"))
           end
         end
       else
@@ -33,7 +36,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             redirect_to(planning_application_assessment_tasks_path(@planning_application),
-                        notice: I18n.t("conditions.update.success"))
+              notice: I18n.t("conditions.update.success"))
           end
         end
       else
@@ -52,9 +55,9 @@ module PlanningApplications
 
     def condition_params
       params.require(:planning_application)
-            .permit(
-              conditions_attributes: [:title, :text, :reason, :id, :standard, :new_condition, { conditions: [] }]
-            )
+        .permit(
+          conditions_attributes: [:title, :text, :reason, :id, :standard, :new_condition, {conditions: []}]
+        )
     end
 
     def assign_params

--- a/app/controllers/planning_applications/confirm_press_notices_controller.rb
+++ b/app/controllers/planning_applications/confirm_press_notices_controller.rb
@@ -37,7 +37,7 @@ module PlanningApplications
     def documents_attributes
       files = params.dig(:press_notice, :documents_attributes, "0", :files).compact_blank
       files.map.with_index do |file, i|
-        [i.to_s, { file:, planning_application_id: @planning_application.id, tags: ["Press Notice"] }]
+        [i.to_s, {file:, planning_application_id: @planning_application.id, tags: ["Press Notice"]}]
       end.to_h
     end
 

--- a/app/controllers/planning_applications/consultee/emails_controller.rb
+++ b/app/controllers/planning_applications/consultee/emails_controller.rb
@@ -17,7 +17,7 @@ module PlanningApplications
         respond_to do |format|
           if @consultation.send_consultee_emails(permitted_params)
             format.html do
-              redirect_to consultation_url, flash: { sent_consultee_emails: true }
+              redirect_to consultation_url, flash: {sent_consultee_emails: true}
             end
           else
             format.html { render :index }
@@ -36,7 +36,7 @@ module PlanningApplications
       end
 
       def consultation_params
-        [:consultee_email_subject, :consultee_email_body, { consultees_attributes: consultee_params }]
+        [:consultee_email_subject, :consultee_email_body, {consultees_attributes: consultee_params}]
       end
 
       def consultee_params

--- a/app/controllers/planning_applications/immunity_details_controller.rb
+++ b/app/controllers/planning_applications/immunity_details_controller.rb
@@ -32,7 +32,7 @@ module PlanningApplications
         if @immunity_detail.update(immunity_details_params)
           format.html do
             redirect_to planning_application_assessment_tasks_path(@planning_application),
-                        notice: I18n.t("assessment_details.immunity_detail_successfully_updated")
+              notice: I18n.t("assessment_details.immunity_detail_successfully_updated")
           end
         else
           format.html { render :edit }
@@ -48,18 +48,18 @@ module PlanningApplications
 
     def immunity_details_params
       params.require(:immunity_detail)
-            .permit(
-              evidence_groups_attributes:
-                [
-                  :id,
-                  :start_date,
-                  :end_date,
-                  :missing_evidence,
-                  :missing_evidence_entry,
-                  { comments_attributes: [:text] }
-                ]
-            )
-            .merge(status:)
+        .permit(
+          evidence_groups_attributes:
+            [
+              :id,
+              :start_date,
+              :end_date,
+              :missing_evidence,
+              :missing_evidence_entry,
+              {comments_attributes: [:text]}
+            ]
+        )
+        .merge(status:)
     end
 
     def status

--- a/app/controllers/planning_applications/local_policies_controller.rb
+++ b/app/controllers/planning_applications/local_policies_controller.rb
@@ -9,20 +9,22 @@ module PlanningApplications
     before_action :set_local_policy_areas, only: %i[new edit]
     before_action :set_reviewer_comment, only: %i[edit new show]
 
-    def show; end
+    def show
+    end
 
     def new
       @local_policy = @planning_application.build_local_policy
     end
 
-    def edit; end
+    def edit
+    end
 
     def create
       @local_policy = @planning_application.build_local_policy(assign_params.except(:areas))
 
       if @local_policy.save
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: I18n.t("local_policies.successfully_created")
+          notice: I18n.t("local_policies.successfully_created")
       else
         set_local_policy_areas
         render :new
@@ -32,7 +34,7 @@ module PlanningApplications
     def update
       if @local_policy.update(assign_params.except(:areas))
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: I18n.t("local_policies.successfully_updated")
+          notice: I18n.t("local_policies.successfully_updated")
       else
         set_local_policy_areas
         render :edit
@@ -51,11 +53,11 @@ module PlanningApplications
 
     def local_policy_params
       params.require(:local_policy)
-            .permit(
-              areas: [],
-              local_policy_areas_attributes: %i[area policies guidance assessment id]
-            )
-            .to_h.merge(status:)
+        .permit(
+          areas: [],
+          local_policy_areas_attributes: %i[area policies guidance assessment id]
+        )
+        .to_h.merge(status:)
     end
 
     def assign_params

--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -59,7 +59,7 @@ module PlanningApplications
       if consultation_params[:resend_existing] == "true"
         @consultation.neighbours.each do |neighbour|
           LetterSendingService.new(neighbour, @consultation.neighbour_letter_text,
-                                   resend_reason: consultation_params[:resend_reason]).deliver!
+            resend_reason: consultation_params[:resend_reason]).deliver!
         end
       else
         @consultation.neighbours.reject(&:letter_created?).each do |neighbour|
@@ -76,7 +76,7 @@ module PlanningApplications
       respond_to do |format|
         format.html do
           redirect_to planning_application_consultation_neighbour_letters_path(@planning_application),
-                      flash: { sent_neighbour_letters: true }
+            flash: {sent_neighbour_letters: true}
         end
       end
     end
@@ -119,7 +119,7 @@ module PlanningApplications
       return if @planning_application.make_public?
 
       flash.now[:alert] = sanitize "The planning application must be
-      #{view_context.link_to 'made public on the BoPS Public Portal', make_public_planning_application_path(@planning_application)}
+      #{view_context.link_to "made public on the BoPS Public Portal", make_public_planning_application_path(@planning_application)}
       before you can send letters to neighbours."
 
       render :index and return

--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -7,17 +7,19 @@ module PlanningApplications
     before_action :set_neighbour_responses, only: :index
     before_action :set_neighbour_response, only: %i[edit update]
 
-    def index; end
+    def index
+    end
 
     def new
       @neighbour_response = @consultation.neighbour_responses.new
     end
 
-    def edit; end
+    def edit
+    end
 
     def create
       @neighbour_response = @consultation.neighbour_responses
-                                         .build(neighbour_response_params.except(:address, :new_address, :files))
+        .build(neighbour_response_params.except(:address, :new_address, :files))
 
       @neighbour_response.neighbour = find_neighbour
 
@@ -47,7 +49,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             redirect_to planning_application_consultation_neighbour_responses_path(@planning_application,
-                                                                                   @consultation)
+              @consultation)
           end
           create_audit_log(@neighbour_response, "edited")
         end

--- a/app/controllers/planning_applications/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/permitted_development_rights_controller.rb
@@ -44,7 +44,7 @@ module PlanningApplications
 
       if @permitted_development_right.save
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: I18n.t("permitted_development_rights.successfully_created")
+          notice: I18n.t("permitted_development_rights.successfully_created")
       else
         set_permitted_development_rights
         render :new
@@ -58,7 +58,7 @@ module PlanningApplications
         if @permitted_development_right.update(permitted_development_right_params)
           format.html do
             redirect_to planning_application_assessment_tasks_path(@planning_application),
-                        notice: I18n.t("permitted_development_rights.successfully_updated")
+              notice: I18n.t("permitted_development_rights.successfully_updated")
           end
         else
           set_permitted_development_rights

--- a/app/controllers/planning_applications/review/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/review/assessment_details_controller.rb
@@ -9,9 +9,11 @@ module PlanningApplications
       before_action :set_consultation
       before_action :set_assessment_detail_review
 
-      def show; end
+      def show
+      end
 
-      def edit; end
+      def edit
+      end
 
       def update
         @form.attributes = review_assessment_details_params

--- a/app/controllers/planning_applications/review/documents_controller.rb
+++ b/app/controllers/planning_applications/review/documents_controller.rb
@@ -29,10 +29,10 @@ module PlanningApplications
         end
 
         redirect_to planning_application_assessment_tasks_path(@planning_application),
-                    notice: t(".success")
+          notice: t(".success")
       rescue ActiveRecord::ActiveRecordError => e
         redirect_to planning_application_review_documents_path(@planning_application),
-                    alert: "Couldn't update documents with error: #{e.message}. Please contact support."
+          alert: "Couldn't update documents with error: #{e.message}. Please contact support."
       end
 
       private

--- a/app/controllers/planning_applications/review/immunity_details_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_details_controller.rb
@@ -31,7 +31,7 @@ module PlanningApplications
           if update_immunity_details
             format.html do
               redirect_to planning_application_review_tasks_path(@planning_application),
-                          notice: I18n.t("immunity_details.successfully_updated")
+                notice: I18n.t("immunity_details.successfully_updated")
             end
           else
             set_immunity_detail
@@ -52,9 +52,9 @@ module PlanningApplications
 
       def review_immunity_detail_params
         params.require(:review_immunity_detail)
-              .permit(:reviewer_comment, :accepted)
-              .to_h
-              .deep_merge(reviewed_at: Time.current, reviewer: current_user)
+          .permit(:reviewer_comment, :accepted)
+          .to_h
+          .deep_merge(reviewed_at: Time.current, reviewer: current_user)
       end
 
       def review_status

--- a/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
@@ -32,7 +32,7 @@ module PlanningApplications
           if @review_immunity_detail.update(review_immunity_detail_params)
             format.html do
               redirect_to planning_application_review_tasks_path(@planning_application),
-                          notice: I18n.t("review_immunity_enforcements.successfully_updated")
+                notice: I18n.t("review_immunity_enforcements.successfully_updated")
             end
           else
             set_review_immunity_detail

--- a/app/controllers/planning_applications/review/local_policies_controller.rb
+++ b/app/controllers/planning_applications/review/local_policies_controller.rb
@@ -29,7 +29,7 @@ module PlanningApplications
           if update_local_policies
             format.html do
               redirect_to planning_application_review_tasks_path(@planning_application),
-                          notice: I18n.t("local_policies.successfully_updated")
+                notice: I18n.t("local_policies.successfully_updated")
             end
           else
             set_local_policy
@@ -45,20 +45,20 @@ module PlanningApplications
         ActiveRecord::Base.transaction do
           @review_local_policy.update(review_local_policy_params) &&
             @local_policy.update(local_policy_areas_params[:local_policy].merge(status: local_policy_status,
-                                                                                review_status:))
+              review_status:))
         end
       end
 
       def review_local_policy_params
         params.require(:review_local_policy)
-              .permit(:reviewer_comment, :accepted)
-              .to_h
-              .deep_merge(
-                reviewed_at: Time.current,
-                reviewer: current_user,
-                review_status:,
-                status: local_policy_status
-              )
+          .permit(:reviewer_comment, :accepted)
+          .to_h
+          .deep_merge(
+            reviewed_at: Time.current,
+            reviewer: current_user,
+            review_status:,
+            status: local_policy_status
+          )
       end
 
       def review_status
@@ -67,7 +67,7 @@ module PlanningApplications
 
       def local_policy_areas_params
         params.require(:review_local_policy)
-              .permit(local_policy:
+          .permit(local_policy:
                 [local_policy_areas_attributes: %i[area policies guidance assessment id]])
       end
 

--- a/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
@@ -33,7 +33,7 @@ module PlanningApplications
           if @permitted_development_right.update(permitted_development_right_params)
             format.html do
               redirect_to planning_application_review_tasks_path(@planning_application),
-                          notice: I18n.t("permitted_development_rights.successfully_updated")
+                notice: I18n.t("permitted_development_rights.successfully_updated")
             end
           else
             set_permitted_development_rights

--- a/app/controllers/planning_applications/review/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_classes_controller.rb
@@ -8,7 +8,8 @@ module PlanningApplications
       before_action :ensure_user_is_reviewer
       before_action :set_policy_class, only: %i[edit update show]
 
-      def show; end
+      def show
+      end
 
       def edit
         @policy_class.build_review_policy_class if @policy_class.review_policy_class.nil?
@@ -17,7 +18,7 @@ module PlanningApplications
       def update
         if @policy_class.update(policy_class_params)
           redirect_to(planning_application_review_tasks_path(@planning_application),
-                      notice: t(".successfully_updated_policy_class"))
+            notice: t(".successfully_updated_policy_class"))
         else
           render :edit
         end
@@ -35,10 +36,10 @@ module PlanningApplications
         params
           .require(:policy_class)
           .permit(policies_attributes: %i[id status],
-                  review_policy_class_attributes: %i[id mark comment])
+            review_policy_class_attributes: %i[id mark comment])
           .to_h
           .deep_merge(status: policy_class_status,
-                      review_policy_class_attributes: { status: review_status })
+            review_policy_class_attributes: {status: review_status})
       end
 
       def review_status

--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -36,11 +36,11 @@ module PlanningApplications
         send_mail if params[:commit] == "Email site notice and mark as complete"
 
         respond_to do |format|
-          action = params[:commit] == "Email site notice and mark as complete" ? "emailed" : "created"
+          action = (params[:commit] == "Email site notice and mark as complete") ? "emailed" : "created"
           format.html do
             if @site_notice.displayed_at.present?
               redirect_to new_planning_application_site_notice_path(@planning_application),
-                          notice: t(".success", action:)
+                notice: t(".success", action:)
             else
               redirect_to planning_application_consultation_path(@planning_application), notice: t(".success", action:)
             end
@@ -57,7 +57,7 @@ module PlanningApplications
       if @site_notice.update(site_notice_params.except(:file))
         if site_notice_params[:file]
           @planning_application.documents.create!(file: site_notice_params[:file], site_notice: @site_notice,
-                                                  tags: ["Site Notice"])
+            tags: ["Site Notice"])
         end
 
         calculate_consultation_end_date
@@ -102,7 +102,7 @@ module PlanningApplications
       return if @planning_application.make_public? || site_notice_params[:required] == "No"
 
       flash.now[:alert] = sanitize "The planning application must be
-      #{view_context.link_to 'made public on the BoPS Public Portal', make_public_planning_application_path(@planning_application)}
+      #{view_context.link_to "made public on the BoPS Public Portal", make_public_planning_application_path(@planning_application)}
       before you can create a site notice."
 
       @site_notice = SiteNotice.new
@@ -113,7 +113,7 @@ module PlanningApplications
       return if @planning_application.user.present?
 
       flash.now[:alert] = sanitize "The planning application must be
-      #{view_context.link_to 'assigned to an officer', planning_application_assign_users_path(@planning_application)}
+      #{view_context.link_to "assigned to an officer", planning_application_assign_users_path(@planning_application)}
       before you can create a site notice."
 
       @site_notice = SiteNotice.new
@@ -122,12 +122,12 @@ module PlanningApplications
 
     def create_audit_log
       comment = if site_notice_params[:internal_team_email].present?
-                  "Site notice was emailed to internal team to print"
-                elsif params[:commit] == "Email site notice and mark as complete"
-                  "Site notice was emailed to the applicant"
-                else
-                  "Site notice PDF was created"
-                end
+        "Site notice was emailed to internal team to print"
+      elsif params[:commit] == "Email site notice and mark as complete"
+        "Site notice was emailed to the applicant"
+      else
+        "Site notice PDF was created"
+      end
 
       Audit.create!(
         planning_application_id:,

--- a/app/controllers/planning_applications/site_visits_controller.rb
+++ b/app/controllers/planning_applications/site_visits_controller.rb
@@ -55,7 +55,7 @@ module PlanningApplications
     def documents_attributes
       files = params.dig(:site_visit, :documents_attributes, "0", :files).compact_blank
       files.map.with_index do |file, i|
-        [i.to_s, { file:, planning_application_id: @planning_application.id, tags: ["Site Visit"] }]
+        [i.to_s, {file:, planning_application_id: @planning_application.id, tags: ["Site Visit"]}]
       end.to_h
     end
 

--- a/app/controllers/planning_applications/validation_tasks_controller.rb
+++ b/app/controllers/planning_applications/validation_tasks_controller.rb
@@ -5,7 +5,8 @@ module PlanningApplications
     before_action :set_planning_application
     before_action :set_items_counter, only: :index
 
-    def index; end
+    def index
+    end
 
     private
 

--- a/app/controllers/planning_applications/withdraw_or_cancels_controller.rb
+++ b/app/controllers/planning_applications/withdraw_or_cancels_controller.rb
@@ -53,7 +53,7 @@ module PlanningApplications
 
     def redirect_failed_withdraw_or_cancel(error)
       redirect_to planning_application_withdraw_or_cancel_path(@planning_application),
-                  alert: "Error withdrawing or cancelling the application with message: #{error.message}."
+        alert: "Error withdrawing or cancelling the application with message: #{error.message}."
     end
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -31,13 +31,15 @@ class PlanningApplicationsController < AuthenticationController
     @planning_applications = search.call
   end
 
-  def show; end
+  def show
+  end
 
   def new
     @planning_application = PlanningApplication.new
   end
 
-  def edit; end
+  def edit
+  end
 
   def create
     @planning_application = PlanningApplication.new(planning_application_params)
@@ -82,7 +84,7 @@ class PlanningApplicationsController < AuthenticationController
       @planning_application.errors.add(:planning_application, "Please enter a valid date")
     elsif @planning_application.open_validation_requests?
       @planning_application.errors.add(:planning_application,
-                                       "Planning application cannot be validated if open validation requests exist.")
+        "Planning application cannot be validated if open validation requests exist.")
     elsif @planning_application.invalid_documents.present?
       @planning_application.errors.add(
         :planning_application,
@@ -152,7 +154,7 @@ class PlanningApplicationsController < AuthenticationController
 
         format.html do
           redirect_to submit_recommendation_planning_application_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         format.html { redirect_failed_withdraw_recommendation }
@@ -174,9 +176,11 @@ class PlanningApplicationsController < AuthenticationController
     end
   end
 
-  def publish; end
+  def publish
+  end
 
-  def make_public; end
+  def make_public
+  end
 
   def determine
     respond_to do |format|
@@ -205,9 +209,9 @@ class PlanningApplicationsController < AuthenticationController
   def validation_documents
     @documents = @planning_application.documents.active
     @additional_document_validation_requests = @planning_application
-                                               .additional_document_validation_requests
-                                               .pre_validation
-                                               .open_or_pending
+      .additional_document_validation_requests
+      .pre_validation
+      .open_or_pending
 
     respond_to do |format|
       format.html
@@ -219,7 +223,7 @@ class PlanningApplicationsController < AuthenticationController
       if @planning_application.update(validate_documents_params)
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: validate_documents_notice(@planning_application)
+            notice: validate_documents_notice(@planning_application)
         end
       else
         format.html { render :validation_documents }
@@ -249,30 +253,30 @@ class PlanningApplicationsController < AuthenticationController
   def planning_application_params
     # rubocop:disable Naming/VariableNumber
     permitted_keys = %i[address_1
-                        address_2
-                        application_type
-                        application_type_id
-                        applicant_first_name
-                        applicant_last_name
-                        applicant_phone
-                        applicant_email
-                        agent_first_name
-                        agent_last_name
-                        agent_phone
-                        agent_email
-                        county
-                        constraints_proposed
-                        description
-                        proposal_details
-                        payment_reference
-                        payment_amount
-                        postcode
-                        public_comment
-                        received_at
-                        town
-                        uprn
-                        work_status
-                        make_public]
+      address_2
+      application_type
+      application_type_id
+      applicant_first_name
+      applicant_last_name
+      applicant_phone
+      applicant_email
+      agent_first_name
+      agent_last_name
+      agent_phone
+      agent_email
+      county
+      constraints_proposed
+      description
+      proposal_details
+      payment_reference
+      payment_amount
+      postcode
+      public_comment
+      received_at
+      town
+      uprn
+      work_status
+      make_public]
     # rubocop:enable Naming/VariableNumber
     params.require(:planning_application).permit permitted_keys
   end
@@ -287,8 +291,8 @@ class PlanningApplicationsController < AuthenticationController
 
   def validation_date_fields
     [params[:planning_application]["validated_at(3i)"],
-     params[:planning_application]["validated_at(2i)"],
-     params[:planning_application]["validated_at(1i)"]]
+      params[:planning_application]["validated_at(2i)"],
+      params[:planning_application]["validated_at(1i)"]]
   end
 
   def date_from_params
@@ -299,27 +303,27 @@ class PlanningApplicationsController < AuthenticationController
 
   def redirect_failed_withdraw_recommendation
     redirect_to view_recommendation_planning_application_path(@planning_application),
-                alert: t("planning_applications.withdraw_recommendation.failure")
+      alert: t("planning_applications.withdraw_recommendation.failure")
   end
 
   def redirect_failed_submit_recommendation
     redirect_to submit_recommendation_planning_application_path(@planning_application),
-                alert: t("planning_applications.submit_recommendation.failure")
+      alert: t("planning_applications.submit_recommendation.failure")
   end
 
   def redirect_failed_clone_planning_application(error)
     redirect_to @planning_application,
-                alert: t("planning_applications.clone.failure", message: error.message)
+      alert: t("planning_applications.clone.failure", message: error.message)
   end
 
   def redirect_update_url
     case params[:edit_action]&.to_sym
     when :edit_payment_amount
       redirect_to planning_application_fee_items_path(@planning_application, validate_fee: "yes"),
-                  notice: t(".edit_payment_amount")
+        notice: t(".edit_payment_amount")
     when :edit_public_comment
       redirect_to edit_planning_application_recommendations_path(@planning_application),
-                  notice: t(".edit_public_comment")
+        notice: t(".edit_public_comment")
     else
       redirect_to(after_update_url, notice: t(".success"))
     end
@@ -353,8 +357,8 @@ class PlanningApplicationsController < AuthenticationController
     return unless @planning_application.try(:assessment_in_progress?)
 
     flash.now[:alert] = sanitize "Please save and mark as complete the
-        #{view_context.link_to 'draft recommendation',
-                               new_planning_application_recommendation_path(@planning_application)}
+        #{view_context.link_to "draft recommendation",
+          new_planning_application_recommendation_path(@planning_application)}
         before updating application fields."
 
     render :edit and return
@@ -364,9 +368,9 @@ class PlanningApplicationsController < AuthenticationController
     return unless @planning_application.site_notice_needs_displayed_at?
 
     flash.now[:alert] = sanitize "You must
-        #{view_context.link_to 'confirm the site notice displayed at date',
-                               edit_planning_application_site_notice_path(@planning_application,
-                                                                          @planning_application.site_notice)}
+        #{view_context.link_to "confirm the site notice displayed at date",
+          edit_planning_application_site_notice_path(@planning_application,
+            @planning_application.site_notice)}
         before determining the application."
 
     render :publish and return
@@ -376,9 +380,9 @@ class PlanningApplicationsController < AuthenticationController
     return unless @planning_application.press_notice_needs_published_at?
 
     flash.now[:alert] = sanitize "You must
-        #{view_context.link_to 'confirm the press notice published at date',
-                               edit_planning_application_confirm_press_notice_path(@planning_application,
-                                                                                   @planning_application.press_notice)}
+        #{view_context.link_to "confirm the press notice published at date",
+          edit_planning_application_confirm_press_notice_path(@planning_application,
+            @planning_application.press_notice)}
         before determining the application."
 
     render :publish and return

--- a/app/controllers/policy_classes_controller.rb
+++ b/app/controllers/policy_classes_controller.rb
@@ -11,7 +11,8 @@ class PolicyClassesController < PlanningApplicationsController
     @part_number = params[:part]&.to_i
   end
 
-  def show; end
+  def show
+  end
 
   def new
     @part = params[:part]
@@ -19,10 +20,11 @@ class PolicyClassesController < PlanningApplicationsController
     return if @part.present?
 
     redirect_to part_new_planning_application_policy_class_path(@planning_application),
-                alert: t(".failure")
+      alert: t(".failure")
   end
 
-  def edit; end
+  def edit
+  end
 
   def create
     class_ids = planning_application_params[:policy_classes].compact_blank
@@ -33,8 +35,8 @@ class PolicyClassesController < PlanningApplicationsController
     end
 
     classes = PolicyClass
-              .classes_for_part(params[:part])
-              .select { |c| class_ids.include?(c.section) }
+      .classes_for_part(params[:part])
+      .select { |c| class_ids.include?(c.section) }
 
     @planning_application.policy_classes += classes
 
@@ -42,7 +44,7 @@ class PolicyClassesController < PlanningApplicationsController
       success_redirect_url
     else
       redirect_to new_planning_application_policy_class_path(@planning_application, part: params[:part]),
-                  alert: @planning_application.errors.full_messages
+        alert: @planning_application.errors.full_messages
     end
   end
 
@@ -80,7 +82,7 @@ class PolicyClassesController < PlanningApplicationsController
   def policy_class_params
     params
       .require(:policy_class)
-      .permit(policies_attributes: [:id, :status, { comments_attributes: [:text] }])
+      .permit(policies_attributes: [:id, :status, {comments_attributes: [:text]}])
       .merge(status:)
   end
 
@@ -100,6 +102,6 @@ class PolicyClassesController < PlanningApplicationsController
 
   def success_redirect_url
     redirect_to planning_application_assessment_tasks_path(@planning_application),
-                notice: t(".success")
+      notice: t(".success")
   end
 end

--- a/app/controllers/recommendations_controller.rb
+++ b/app/controllers/recommendations_controller.rb
@@ -52,7 +52,7 @@ class RecommendationsController < AuthenticationController
 
       format.html do
         redirect_to planning_application_review_tasks_path(@planning_application),
-                    notice: t(".success")
+          notice: t(".success")
       end
     end
   end

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -19,7 +19,7 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
   def create
     @red_line_boundary_change_validation_request =
       RedLineBoundaryChangeValidationRequest.new(
-        red_line_boundary_change_validation_request_params.merge!({ planning_application_id: @planning_application.id })
+        red_line_boundary_change_validation_request_params.merge!({planning_application_id: @planning_application.id})
       )
     @red_line_boundary_change_validation_request.user = current_user
 

--- a/app/controllers/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/replacement_document_validation_requests_controller.rb
@@ -27,7 +27,7 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
     ActiveRecord::Base.transaction do
       @replacement_document_validation_request =
         @planning_application
-        .replacement_document_validation_requests.new(replacement_document_validation_request_params).tap do |record|
+          .replacement_document_validation_requests.new(replacement_document_validation_request_params).tap do |record|
           record.old_document = @document
           record.post_validation = @planning_application.validated? unless @planning_application.validated?.nil?
           record.user = current_user
@@ -49,7 +49,7 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
     respond_to do |format|
       format.html do
         redirect_to planning_application_validation_tasks_path(@planning_application),
-                    alert: "Could not find document with id: #{document_id}"
+          alert: "Could not find document with id: #{document_id}"
       end
     end
   end
@@ -70,10 +70,10 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
 
   def set_document
     @document = if @replacement_document_validation_request
-                  @replacement_document_validation_request.old_document
-                else
-                  @planning_application.documents.find(params[:document])
-                end
+      @replacement_document_validation_request.old_document
+    else
+      @planning_application.documents.find(params[:document])
+    end
   end
 
   def set_replacement_document_validation_request

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -16,7 +16,7 @@ class SitemapsController < AuthenticationController
       format.html do
         if @planning_application.valid_red_line_boundary?
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         elsif @planning_application.valid_red_line_boundary.nil?
           flash.now[:alert] = t(".failure")
           render :show
@@ -32,24 +32,24 @@ class SitemapsController < AuthenticationController
 
     respond_to do |format|
       if @planning_application.update(boundary_geojson: boundary_geojson_params[:boundary_geojson],
-                                      boundary_created_by: current_user)
+        boundary_created_by: current_user)
 
         @planning_application.audit_boundary_geojson!(audit_action)
 
         format.html do
           redirect_to planning_application_validation_tasks_path(@planning_application),
-                      notice: t(".success")
+            notice: t(".success")
         end
       else
         flash.now[:alert] = t(".failure")
-        flash.now[:alert] << (": #{@planning_application.errors.join('; ')}") if @planning_application.errors.present?
+        flash.now[:alert] << (": #{@planning_application.errors.join("; ")}") if @planning_application.errors.present?
         render :show
       end
     end
   rescue ConstraintQueryUpdateService::SaveError => e
     Appsignal.send_error(e)
     redirect_to planning_application_sitemap_path(@planning_application),
-                alert: t(".error")
+      alert: t(".error")
   end
 
   private

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -70,7 +70,7 @@ module Users
       respond_to do |format|
         format.html do
           redirect_to two_factor_path,
-                      alert: "Notify was unable to send sms with error: #{exception.message}."
+            alert: "Notify was unable to send sms with error: #{exception.message}."
         end
       end
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,8 @@ class UsersController < AuthenticationController
     @user = current_local_authority.users.new
   end
 
-  def edit; end
+  def edit
+  end
 
   def create
     @user = current_local_authority.users.new(user_params)

--- a/app/form_models/assess_immunity_detail_permitted_development_right_form.rb
+++ b/app/form_models/assess_immunity_detail_permitted_development_right_form.rb
@@ -12,7 +12,7 @@ class AssessImmunityDetailPermittedDevelopmentRightForm
     validates :removed_reason, if: :removed
   end
 
-  validates :removed, inclusion: { in: [true, false], if: :decision_is_no? }
+  validates :removed, inclusion: {in: [true, false], if: :decision_is_no?}
 
   delegate(
     :decision,
@@ -78,7 +78,7 @@ class AssessImmunityDetailPermittedDevelopmentRightForm
   private
 
   attr_reader :review_immunity_detail_params, :permitted_development_right_params,
-              :review_immunity_detail, :permitted_development_right
+    :review_immunity_detail, :permitted_development_right
 
   def decision_is_yes?
     review_immunity_detail_params["decision"] == "Yes"
@@ -94,12 +94,12 @@ class AssessImmunityDetailPermittedDevelopmentRightForm
     review_immunity_detail_params = params[:review_immunity_detail]
 
     review_immunity_detail_params["decision_reason"] = if review_immunity_detail_params["decision_type"] == "other"
-                                                         review_immunity_detail_params["yes_decision_reason"]
-                                                       elsif review_immunity_detail_params["decision"] == "Yes"
-                                                         review_immunity_detail_params["decision_type"]
-                                                       else
-                                                         review_immunity_detail_params["no_decision_reason"]
-                                                       end
+      review_immunity_detail_params["yes_decision_reason"]
+    elsif review_immunity_detail_params["decision"] == "Yes"
+      review_immunity_detail_params["decision_type"]
+    else
+      review_immunity_detail_params["no_decision_reason"]
+    end
 
     review_immunity_detail_params.except("yes_decision_reason", "no_decision_reason")
   end

--- a/app/helpers/assessment_detail_helper.rb
+++ b/app/helpers/assessment_detail_helper.rb
@@ -8,6 +8,6 @@ module AssessmentDetailHelper
       "#{count} #{tag}"
     end
 
-    "There is #{summary_text.join(', ')}."
+    "There is #{summary_text.join(", ")}."
   end
 end

--- a/app/helpers/audit_helper.rb
+++ b/app/helpers/audit_helper.rb
@@ -47,8 +47,8 @@ module AuditHelper
     if audit.activity_type.match?("/*_validation_request_cancelled")
       "validation_request_cancelled"
     elsif audit.activity_type.include?("request") ||
-          audit.activity_type.include?("document_received_at_changed") ||
-          audit.activity_type.include?("submitted")
+        audit.activity_type.include?("document_received_at_changed") ||
+        audit.activity_type.include?("submitted")
       audit.activity_type
     else
       "generic_audit_entry"

--- a/app/helpers/breadcrumb_navigation_helper.rb
+++ b/app/helpers/breadcrumb_navigation_helper.rb
@@ -2,11 +2,11 @@
 
 module BreadcrumbNavigationHelper
   def add_parent_breadcrumb_link(title, path)
-    navigation << { title:, path: }
+    navigation << {title:, path:}
   end
 
   def render_navigation
-    render partial: "breadcrumb_navigation", locals: { nav: navigation }
+    render partial: "breadcrumb_navigation", locals: {nav: navigation}
   end
 
   private

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -22,7 +22,7 @@ module DocumentHelper
   end
 
   def document_name_and_reference(document)
-    "#{document.name}#{document.numbers? ? " - #{document.numbers}" : ''}"
+    "#{document.name}#{document.numbers? ? " - #{document.numbers}" : ""}"
   end
 
   def titled_reference_or_file_name(document)

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -12,21 +12,21 @@ module PlanningApplicationHelper
   def validation_request_summary(validation_requests, planning_application)
     if planning_application.invalidated?
       "This application has #{pluralize(validation_requests.count(&:open?),
-                                        'unresolved validation request')} and #{pluralize(
-                                          validation_requests.count(&:closed?), 'resolved validation request'
-                                        )}"
+        "unresolved validation request")} and #{pluralize(
+          validation_requests.count(&:closed?), "resolved validation request"
+        )}"
     elsif planning_application.validation_requests.none? &&
-          (planning_application.recommendable? || planning_application.closed_or_cancelled?)
+        (planning_application.recommendable? || planning_application.closed_or_cancelled?)
       "This application had no validation requests"
     elsif planning_application.recommendable? ||
-          (planning_application.closed_or_cancelled? && planning_application.validation_requests.present?)
-      "This application has #{pluralize(validation_requests.count(&:closed?), 'resolved validation request')}"
+        (planning_application.closed_or_cancelled? && planning_application.validation_requests.present?)
+      "This application has #{pluralize(validation_requests.count(&:closed?), "resolved validation request")}"
     else # rubocop:disable Lint/DuplicateBranch
       # FIXME: same body as first branch
       "This application has #{pluralize(validation_requests.count(&:open?),
-                                        'unresolved validation request')} and #{pluralize(
-                                          validation_requests.count(&:closed?), 'resolved validation request'
-                                        )}"
+        "unresolved validation request")} and #{pluralize(
+          validation_requests.count(&:closed?), "resolved validation request"
+        )}"
     end
   end
 

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -10,12 +10,12 @@ module ValidationRequestHelper
       end
     elsif validation_request.class.name.include?("Other") && validation_request.closed?
       link_to("View response",
-              planning_application_other_change_validation_request_path(validation_request.planning_application,
-                                                                        validation_request))
+        planning_application_other_change_validation_request_path(validation_request.planning_application,
+          validation_request))
     elsif validation_request.closed?
       link_to(validation_request.new_document.name.to_s,
-              edit_planning_application_document_path(validation_request.planning_application,
-                                                      validation_request.new_document.id.to_s))
+        edit_planning_application_document_path(validation_request.planning_application,
+          validation_request.new_document.id.to_s))
     end
   end
 
@@ -31,26 +31,26 @@ module ValidationRequestHelper
 
   def edit_request_url(planning_application, validation_request, classname: nil)
     link_to "Edit request",
-            send("edit_planning_application_#{request_type(validation_request)}_path", planning_application,
-                 validation_request), class: classname
+      send("edit_planning_application_#{request_type(validation_request)}_path", planning_application,
+        validation_request), class: classname
   end
 
   def cancel_confirmation_request_url(planning_application, validation_request, classname: nil)
     link_to "Cancel request",
-            send("cancel_confirmation_planning_application_#{request_type(validation_request)}_path",
-                 planning_application, validation_request), class: classname
+      send("cancel_confirmation_planning_application_#{request_type(validation_request)}_path",
+        planning_application, validation_request), class: classname
   end
 
   def delete_confirmation_request_url(planning_application, validation_request, classname: nil)
     link_to "Delete request",
-            send("planning_application_#{request_type(validation_request)}_path",
-                 planning_application, validation_request),
-            method: :delete, data: { confirm: "Are you sure?" }, class: classname
+      send("planning_application_#{request_type(validation_request)}_path",
+        planning_application, validation_request),
+      method: :delete, data: {confirm: "Are you sure?"}, class: classname
   end
 
   def cancel_request_url(planning_application, validation_request)
     send("cancel_planning_application_#{request_type(validation_request)}_path", planning_application,
-         validation_request)
+      validation_request)
   end
 
   def edit_validation_request_url(planning_application, validation_request)
@@ -63,7 +63,7 @@ module ValidationRequestHelper
 
   def document_url(document)
     link_to(document.name.to_s,
-            edit_planning_application_document_path(document.planning_application, document.id))
+      edit_planning_application_document_path(document.planning_application, document.id))
   end
 
   def show_validation_request_link(application, request)

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -20,7 +20,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:validation_notice_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: email,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -32,7 +32,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:invalidation_notice_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -55,7 +55,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:validation_request_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -68,7 +68,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:post_validation_request_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -80,7 +80,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:cancelled_validation_request_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -93,7 +93,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:description_change_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -106,7 +106,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:description_closure_notification_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )
@@ -118,7 +118,7 @@ class PlanningApplicationMailer < ApplicationMailer
     view_mail(
       NOTIFY_TEMPLATE_ID,
       subject: subject(:validation_request_closure_mail,
-                       application_type_name: @planning_application.application_type.human_name),
+        application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
       reply_to_id: @planning_application.local_authority.reply_to_notify_id
     )

--- a/app/models/additional_document_validation_request.rb
+++ b/app/models/additional_document_validation_request.rb
@@ -67,7 +67,7 @@ class AdditionalDocumentValidationRequest < ApplicationRecord
   end
 
   def audit_comment
-    { document: document_request_type,
-      reason: document_request_reason }.to_json
+    {document: document_request_type,
+     reason: document_request_reason}.to_json
   end
 end

--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -52,7 +52,7 @@ module PlanningApplicationStatus
 
       event :assess do
         transitions from: %i[in_assessment assessment_in_progress to_be_reviewed], to: :in_assessment,
-                    guard: :decision_present?
+          guard: :decision_present?
       end
 
       event :invalidate do
@@ -80,35 +80,35 @@ module PlanningApplicationStatus
 
       event :request_correction do
         transitions from: :awaiting_determination, to: :to_be_reviewed,
-                    after: proc { |comment| audit!(activity_type: "challenged", audit_comment: comment) }
+          after: proc { |comment| audit!(activity_type: "challenged", audit_comment: comment) }
 
         after { send_update_notification_to_assessor }
       end
 
       event :return do
         transitions from: IN_PROGRESS_STATUSES, to: :returned,
-                    after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
+          after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
 
         after { audit!(activity_type: "returned", audit_comment: closed_or_cancellation_comment) }
       end
 
       event :withdraw do
         transitions from: IN_PROGRESS_STATUSES, to: :withdrawn,
-                    after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
+          after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
 
         after { audit!(activity_type: "withdrawn", audit_comment: closed_or_cancellation_comment) }
       end
 
       event :close do
         transitions from: IN_PROGRESS_STATUSES, to: :closed,
-                    after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
+          after: proc { |comment| update!(closed_or_cancellation_comment: comment) }
 
         after { audit!(activity_type: "closed", audit_comment: closed_or_cancellation_comment) }
       end
 
       event :submit do
         transitions from: :in_assessment, to: :awaiting_determination,
-                    guards: %i[decision_present? no_open_post_validation_requests?] do
+          guards: %i[decision_present? no_open_post_validation_requests?] do
           after { recommendation.update!(submitted: true) }
         end
       end

--- a/app/models/concerns/validation_requestable.rb
+++ b/app/models/concerns/validation_requestable.rb
@@ -119,7 +119,7 @@ module ValidationRequestable
       cancel!
       reset_columns
       audit!(activity_type: "#{self.class.name.underscore}_#{cancel_audit_event}", activity_information: sequence,
-             audit_comment: { cancel_reason: }.to_json)
+        audit_comment: {cancel_reason:}.to_json)
     end
   rescue ActiveRecord::ActiveRecordError, AASM::InvalidTransition => e
     raise RecordCancelError, e.message
@@ -141,12 +141,12 @@ module ValidationRequestable
 
   def create_audit!
     event = if planning_application.not_started?
-              "added"
-            elsif post_validation?
-              "sent_post_validation"
-            else
-              "sent"
-            end
+      "added"
+    elsif post_validation?
+      "sent_post_validation"
+    else
+      "sent"
+    end
 
     create_audit_for!(event)
   end
@@ -155,19 +155,19 @@ module ValidationRequestable
     return unless planning_application_validated?
 
     raise ValidationRequestNotCreatableError,
-          "Cannot create #{self.class.name.titleize} when planning application has been validated"
+      "Cannot create #{self.class.name.titleize} when planning application has been validated"
   end
 
   def ensure_planning_application_not_closed_or_cancelled!
     return unless planning_application_closed_or_cancelled?
 
     raise ValidationRequestNotCreatableError,
-          "Cannot create #{self.class.name.titleize} when planning application has been closed or cancelled"
+      "Cannot create #{self.class.name.titleize} when planning application has been closed or cancelled"
   end
 
   def create_validation_request!
     ValidationRequest.create!(requestable_id: id, requestable_type: self.class,
-                              planning_application:)
+      planning_application:)
   end
 
   def open_or_pending?
@@ -205,8 +205,8 @@ module ValidationRequestable
 
   def update_counter!
     unless is_a?(ReplacementDocumentValidationRequest) ||
-           is_a?(RedLineBoundaryChangeValidationRequest) ||
-           is_a?(OtherChangeValidationRequest)
+        is_a?(RedLineBoundaryChangeValidationRequest) ||
+        is_a?(OtherChangeValidationRequest)
       return
     end
 

--- a/app/models/consistency_checklist.rb
+++ b/app/models/consistency_checklist.rb
@@ -30,10 +30,10 @@ class ConsistencyChecklist < ApplicationRecord
     end
   end
 
-  enum status: { in_assessment: 0, complete: 1 }, _default: :in_assessment
+  enum status: {in_assessment: 0, complete: 1}, _default: :in_assessment
 
   CHECKS.each do |check|
-    enum(check => { to_be_determined: 0, yes: 1, no: 2 }, _prefix: check)
+    enum(check => {to_be_determined: 0, yes: 1, no: 2}, :_prefix => check)
   end
 
   REQUEST_TYPES.each do |check, request_type|

--- a/app/models/constraint.rb
+++ b/app/models/constraint.rb
@@ -4,7 +4,7 @@ class Constraint < ApplicationRecord
   self.inheritance_column = "inheritance_type"
 
   validates :category, :type, presence: true
-  validates :type, uniqueness: { scope: :local_authority }
+  validates :type, uniqueness: {scope: :local_authority}
 
   belongs_to :local_authority, optional: true
 
@@ -12,7 +12,7 @@ class Constraint < ApplicationRecord
 
   scope :options_for_local_authority, ->(local_authority_id) { where(local_authority_id: [local_authority_id, nil]) }
 
-  alias constraint_id id
+  alias_method :constraint_id, :id
 
   def type_code
     if I18n.t("constraint_type_codes.#{type}").include?("translation missing")

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -138,24 +138,24 @@ class Consultation < ApplicationRecord
 
   def neighbour_letter_header
     I18n.t("neighbour_letter_header.#{planning_application.application_type.name}",
-           closing_date: end_date_from_now.to_date.to_fs)
+      closing_date: end_date_from_now.to_date.to_fs)
   end
 
   def neighbour_letter_body
     I18n.t("neighbour_letter_template.#{planning_application.application_type.name}",
-           expiry_date: planning_application.expiry_date.to_date.to_fs,
-           address: planning_application.full_address,
-           council: local_authority.short_name,
-           applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
-           description: planning_application.description,
-           reference: planning_application.reference,
-           closing_date: end_date_from_now.to_date.to_fs,
-           rear_wall: planning_application&.proposal_measurement&.depth,
-           max_height: planning_application&.proposal_measurement&.max_height,
-           eaves_height: planning_application&.proposal_measurement&.eaves_height,
-           current_user: Current.user.name,
-           council_address: I18n.t("council_addresses.#{local_authority.subdomain}"),
-           application_link:)
+      expiry_date: planning_application.expiry_date.to_date.to_fs,
+      address: planning_application.full_address,
+      council: local_authority.short_name,
+      applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
+      description: planning_application.description,
+      reference: planning_application.reference,
+      closing_date: end_date_from_now.to_date.to_fs,
+      rear_wall: planning_application&.proposal_measurement&.depth,
+      max_height: planning_application&.proposal_measurement&.max_height,
+      eaves_height: planning_application&.proposal_measurement&.eaves_height,
+      current_user: Current.user.name,
+      council_address: I18n.t("council_addresses.#{local_authority.subdomain}"),
+      application_link:)
   end
 
   def neighbour_letter_content
@@ -211,7 +211,7 @@ class Consultation < ApplicationRecord
       feature_collection_geojson["features"].concat(boundary_geojson["features"])
     else
       raise ArgumentError,
-            "Invalid GeoJSON type. Expected 'Feature' or 'FeatureCollection', got #{boundary_geojson['type']}."
+        "Invalid GeoJSON type. Expected 'Feature' or 'FeatureCollection', got #{boundary_geojson["type"]}."
     end
 
     feature_collection_geojson
@@ -241,7 +241,7 @@ class Consultation < ApplicationRecord
       user: Current.user,
       activity_type: "neighbour_letter_copy_mail_sent",
       audit_comment:
-        "Neighbour letter copy sent by email to #{planning_application.applicant_and_agent_email.join(', ')}"
+        "Neighbour letter copy sent by email to #{planning_application.applicant_and_agent_email.join(", ")}"
     )
   end
 
@@ -262,7 +262,7 @@ class Consultation < ApplicationRecord
       {
         "type" => "Feature",
         "geometry" => RGeo::GeoJSON.encode(geometry),
-        "properties" => { color: polygon_colour }
+        "properties" => {color: polygon_colour}
       }
     end
 

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -32,16 +32,16 @@ class Contact < ApplicationRecord
     delegate :quote_column_name, to: :connection
 
     def search_query
-      "#{quoted_table_name}.#{quote_column_name('search')} @@ to_tsquery('simple', ?)"
+      "#{quoted_table_name}.#{quote_column_name("search")} @@ to_tsquery('simple', ?)"
     end
 
     def search_param(query)
       query.to_s
-           .scan(/[-\w]{3,}/)
-           .map { |word| word.gsub(/^-/, "!") }
-           .map { |word| word.gsub(/-$/, "") }
-           .map { |word| word.gsub(/.+/, "\\0:*") }
-           .join(" & ")
+        .scan(/[-\w]{3,}/)
+        .map { |word| word.gsub(/^-/, "!") }
+        .map { |word| word.gsub(/-$/, "") }
+        .map { |word| word.gsub(/.+/, "\\0:*") }
+        .join(" & ")
     end
   end
 end

--- a/app/models/description_change_validation_request.rb
+++ b/app/models/description_change_validation_request.rb
@@ -21,8 +21,8 @@ class DescriptionChangeValidationRequest < ApplicationRecord
     return unless approved == false && rejection_reason.blank?
 
     errors.add(:base,
-               "Please include a comment for the case officer to " \
-               "indicate why the description change has been rejected.")
+      "Please include a comment for the case officer to " \
+      "indicate why the description change has been rejected.")
   end
 
   def set_previous_application_description
@@ -79,14 +79,14 @@ class DescriptionChangeValidationRequest < ApplicationRecord
 
   def audit_api_comment
     if approved?
-      { response: "approved" }.to_json
+      {response: "approved"}.to_json
     else
-      { response: "rejected", reason: rejection_reason }.to_json
+      {response: "rejected", reason: rejection_reason}.to_json
     end
   end
 
   def audit_comment
-    { previous: planning_application.description,
-      proposed: proposed_description }.to_json
+    {previous: planning_application.description,
+     proposed: proposed_description}.to_json
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -21,11 +21,11 @@ class Document < ApplicationRecord
   end
 
   has_one :replacement_document_validation_request,
-          lambda { |document|
-            unscope(:where).where(old_document_id: document.id, cancelled_at: nil)
-          },
-          dependent: :destroy,
-          inverse_of: false
+    lambda { |document|
+      unscope(:where).where(old_document_id: document.id, cancelled_at: nil)
+    },
+    dependent: :destroy,
+    inverse_of: false
 
   has_one_attached :file, dependent: :destroy
   after_create :create_audit!
@@ -156,7 +156,7 @@ class Document < ApplicationRecord
   def archive(archive_reason)
     if replacement_document_validation_request.try(:open_or_pending?)
       raise NotArchiveableError,
-            "Cannot archive document with an open or pending validation request"
+        "Cannot archive document with an open or pending validation request"
     end
 
     return if archived?
@@ -187,13 +187,13 @@ class Document < ApplicationRecord
 
     if saved_change_to_attribute?("received_at")
       audit!(activity_type: "document_received_at_changed", activity_information: file.filename,
-             audit_comment: audit_date_comment)
+        audit_comment: audit_date_comment)
     end
     if saved_change_to_attribute?(:validated, from: false, to: true)
       audit!(activity_type: "document_changed_to_validated", activity_information: file.filename)
     elsif saved_change_to_attribute?(:validated, to: false)
       audit!(activity_type: "document_invalidated", activity_information: file.filename,
-             audit_comment: invalidated_document_reason)
+        audit_comment: invalidated_document_reason)
     end
   end
 
@@ -262,8 +262,8 @@ class Document < ApplicationRecord
   end
 
   def audit_date_comment
-    { previous_received_date: saved_change_to_received_at.first,
-      updated_received_date: saved_change_to_received_at.second }.to_json
+    {previous_received_date: saved_change_to_received_at.first,
+     updated_received_date: saved_change_to_received_at.second}.to_json
   end
 
   def reset_replacement_document_validation_request_update_counter!

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -15,13 +15,13 @@ class LocalAuthority < ApplicationRecord
     validates :enquiries_paragraph, :feedback_email
   end
 
-  with_options format: { with: URI::HTTP::ABS_URI } do
+  with_options format: {with: URI::HTTP::ABS_URI} do
     with_options allow_blank: true do
       validates :applicants_url
     end
   end
 
-  with_options format: { with: URI::MailTo::EMAIL_REGEXP } do
+  with_options format: {with: URI::MailTo::EMAIL_REGEXP} do
     with_options allow_blank: true do
       validates :email_address
       validates :reviewer_group_email

--- a/app/models/local_policy.rb
+++ b/app/models/local_policy.rb
@@ -13,7 +13,7 @@ class LocalPolicy < ApplicationRecord
 
   accepts_nested_attributes_for :local_policy_areas
   validates_associated :local_policy_areas
-  validates :local_policy_areas, presence: { if: :completed? }
+  validates :local_policy_areas, presence: {if: :completed?}
 
   enum(
     status: {

--- a/app/models/local_policy_area.rb
+++ b/app/models/local_policy_area.rb
@@ -3,7 +3,7 @@
 class LocalPolicyArea < ApplicationRecord
   belongs_to :local_policy
 
-  validates :assessment, :policies, :area, presence: { if: :completed? }
+  validates :assessment, :policies, :area, presence: {if: :completed?}
 
   attr_reader :policy
 

--- a/app/models/neighbour.rb
+++ b/app/models/neighbour.rb
@@ -16,13 +16,13 @@ class Neighbour < ApplicationRecord
 
   scope :without_letters, lambda {
                             left_outer_joins(:neighbour_letters)
-                              .where(neighbour_letters: { neighbour_id: nil })
+                              .where(neighbour_letters: {neighbour_id: nil})
                               .where(selected: true)
                           }
   scope :with_letters, lambda {
                          includes([:neighbour_letters])
                            .joins(:neighbour_letters)
-                           .where.not(neighbour_letters: { neighbour_id: nil })
+                           .where.not(neighbour_letters: {neighbour_id: nil})
                        }
 
   def last_letter

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -10,7 +10,7 @@ class NeighbourResponse < ApplicationRecord
 
   validates :name, :response, :summary_tag, :received_at, presence: true
 
-  enum(summary_tag: { supportive: "supportive", neutral: "neutral", objection: "objection" })
+  enum(summary_tag: {supportive: "supportive", neutral: "neutral", objection: "objection"})
 
   scope :redacted, -> { where.not(redacted_response: "") }
 

--- a/app/models/other_change_validation_request.rb
+++ b/app/models/other_change_validation_request.rb
@@ -48,12 +48,12 @@ class OtherChangeValidationRequest < ApplicationRecord
   private
 
   def audit_api_comment
-    { response: }.to_json
+    {response:}.to_json
   end
 
   def audit_comment
-    { summary:,
-      suggestion: }.to_json
+    {summary:,
+     suggestion:}.to_json
   end
 
   def ensure_no_open_or_pending_fee_item_validation_request

--- a/app/models/permitted_development_right.rb
+++ b/app/models/permitted_development_right.rb
@@ -86,6 +86,6 @@ class PermittedDevelopmentRight < ApplicationRecord
     return if last_permitted_development_right.to_be_reviewed?
 
     raise NotCreatableError,
-          "Cannot create a permitted development right response when there is already an open response"
+      "Cannot create a permitted development right response when there is already an open response"
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -21,9 +21,9 @@ class PlanningApplication < ApplicationRecord
 
   DAYS_TO_EXPIRE = 56
 
-  enum user_role: { applicant: 0, agent: 1, proxy: 2 }
+  enum user_role: {applicant: 0, agent: 1, proxy: 2}
 
-  enum decision: { granted: "granted", refused: "refused", granted_not_required: "granted_not_required" }
+  enum decision: {granted: "granted", refused: "refused", granted_not_required: "granted_not_required"}
 
   with_options dependent: :destroy do
     has_many :audits, -> { by_created_at }, inverse_of: :planning_application
@@ -39,9 +39,9 @@ class PlanningApplication < ApplicationRecord
     has_many :replacement_document_validation_requests
     has_many :other_change_validation_requests
     has_many :fee_item_validation_requests,
-             -> { fee_item },
-             class_name: "OtherChangeValidationRequest",
-             inverse_of: :planning_application
+      -> { fee_item },
+      class_name: "OtherChangeValidationRequest",
+      inverse_of: :planning_application
     has_many :additional_document_validation_requests
     has_many :red_line_boundary_change_validation_requests
     has_many :notes, -> { by_created_at_desc }, inverse_of: :planning_application
@@ -90,7 +90,7 @@ class PlanningApplication < ApplicationRecord
   scope :by_status_order, -> { in_order_of(:status, PlanningApplication.aasm.states.map(&:name)) }
   scope :with_user, -> { preload(:user) }
   scope :for_user_and_null_users, ->(user_id) { where(user_id: [user_id, nil]) }
-  scope :prior_approvals, -> { joins(:application_type).where(application_type: { name: :prior_approval }) }
+  scope :prior_approvals, -> { joins(:application_type).where(application_type: {name: :prior_approval}) }
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create
@@ -120,51 +120,51 @@ class PlanningApplication < ApplicationRecord
   WORK_STATUSES = %w[proposed existing].freeze
 
   PLANNING_APPLICATION_PERMITTED_KEYS = %w[address_1
-                                           address_2
-                                           applicant_first_name
-                                           applicant_last_name
-                                           applicant_phone
-                                           applicant_email
-                                           agent_first_name
-                                           agent_last_name
-                                           agent_phone
-                                           agent_email
-                                           county
-                                           old_constraints
-                                           created_at(3i)
-                                           created_at(2i)
-                                           created_at(1i)
-                                           description
-                                           proposal_details
-                                           payment_reference
-                                           payment_amount
-                                           postcode
-                                           public_comment
-                                           town
-                                           uprn
-                                           work_status].freeze
+    address_2
+    applicant_first_name
+    applicant_last_name
+    applicant_phone
+    applicant_email
+    agent_first_name
+    agent_last_name
+    agent_phone
+    agent_email
+    county
+    old_constraints
+    created_at(3i)
+    created_at(2i)
+    created_at(1i)
+    description
+    proposal_details
+    payment_reference
+    payment_amount
+    postcode
+    public_comment
+    town
+    uprn
+    work_status].freeze
 
   ADDRESS_AND_BOUNDARY_GEOJSON_FIELDS = %w[address_1
-                                           address_2
-                                           county
-                                           postcode
-                                           town
-                                           uprn
-                                           boundary_geojson].freeze
+    address_2
+    county
+    postcode
+    town
+    uprn
+    boundary_geojson].freeze
 
   PROGRESS_STATUSES = %w[not_started in_progress complete].freeze
 
   private_constant :PLANNING_APPLICATION_PERMITTED_KEYS
 
   validates :work_status,
-            inclusion: { in: WORK_STATUSES }
+    inclusion: {in: WORK_STATUSES}
   validates :review_documents_for_recommendation_status,
-            inclusion: { in: PROGRESS_STATUSES }
+    inclusion: {in: PROGRESS_STATUSES}
   validates :application_number, :reference, presence: true
   validates :payment_amount,
-            :invalid_payment_amount,
-            numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1_000_000 },
-            allow_nil: true
+    :invalid_payment_amount,
+    numericality: {greater_than_or_equal_to: 0, less_than_or_equal_to: 1_000_000},
+    allow_nil: true
 
   validate :applicant_or_agent_email
   validate :validated_at_date
@@ -353,7 +353,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def secure_change_url
-    params = { planning_application_id: id, change_access_id: }
+    params = {planning_application_id: id, change_access_id:}
     "#{local_authority.applicants_url}/validation_requests?#{params.to_query}"
   end
 
@@ -465,7 +465,7 @@ class PlanningApplication < ApplicationRecord
         planning_application_id: id,
         user: Current.user,
         activity_type: "submitted",
-        audit_comment: { assessor_comment: recommendation.assessor_comment }.to_json
+        audit_comment: {assessor_comment: recommendation.assessor_comment}.to_json
       )
     end
 
@@ -781,8 +781,8 @@ class PlanningApplication < ApplicationRecord
       audit_old_constraints!(saved_changes)
     else
       audit!(activity_type: "updated",
-             activity_information: attribute_name.humanize,
-             audit_comment: audit_comment(attribute_name))
+        activity_information: attribute_name.humanize,
+        audit_comment: audit_comment(attribute_name))
     end
   end
 
@@ -791,8 +791,8 @@ class PlanningApplication < ApplicationRecord
     new_attribute = saved_change_to_attribute(attribute_name).second
 
     if attribute_name == "payment_amount"
-      "Changed from: £#{format('%.2f',
-                               original_attribute.to_f)} \r\n Changed to: £#{format('%.2f', new_attribute.to_f)}"
+      "Changed from: £#{format("%.2f",
+        original_attribute.to_f)} \r\n Changed to: £#{format("%.2f", new_attribute.to_f)}"
     else
       "Changed from: #{original_attribute} \r\n Changed to: #{new_attribute}"
     end
@@ -840,10 +840,10 @@ class PlanningApplication < ApplicationRecord
     local_authority_planning_applications = local_authority.planning_applications
 
     self.application_number = if local_authority_planning_applications.any?
-                                local_authority_planning_applications.maximum(:application_number) + 1
-                              else
-                                100
-                              end
+      local_authority_planning_applications.maximum(:application_number) + 1
+    else
+      100
+    end
   end
 
   def application_type_code

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -14,10 +14,10 @@ class PlanningApplicationConstraint < ApplicationRecord
   delegate :type, :category, :type_code, to: :constraint
   delegate :audits, to: :planning_application
 
-  scope :active, -> { where({ removed_at: nil }) }
-  scope :identified_by_planx, -> { where({ identified_by: "PlanX" }) }
-  scope :identified_by_others, -> { where({ removed_at: nil, identified: true }).where.not({ identified_by: "plax" }) }
-  scope :removed, -> { where.not({ removed_at: nil }) }
+  scope :active, -> { where({removed_at: nil}) }
+  scope :identified_by_planx, -> { where({identified_by: "PlanX"}) }
+  scope :identified_by_others, -> { where({removed_at: nil, identified: true}).where.not({identified_by: "plax"}) }
+  scope :removed, -> { where.not({removed_at: nil}) }
 
   def start_date
     data.first["start-date"] if data

--- a/app/models/policy.rb
+++ b/app/models/policy.rb
@@ -21,7 +21,7 @@ class Policy < ApplicationRecord
   validates :description, :status, presence: true
 
   enum(
-    status: { complies: 0, does_not_comply: 1, to_be_determined: 2 },
+    status: {complies: 0, does_not_comply: 1, to_be_determined: 2},
     _default: :to_be_determined
   )
 

--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -11,7 +11,7 @@ class PolicyClass < ApplicationRecord
 
   validate :all_policies_are_determined, if: :complete?
 
-  enum status: { in_assessment: 0, complete: 1, to_be_reviewed: 2 }, _default: :in_assessment
+  enum status: {in_assessment: 0, complete: 1, to_be_reviewed: 2}, _default: :in_assessment
 
   def update_required?
     to_be_reviewed? && review_policy_class&.status_complete?

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -10,7 +10,7 @@ class PressNotice < ApplicationRecord
     validates :reasons, if: :required?
   end
 
-  validates :required, inclusion: { in: [true, false] }
+  validates :required, inclusion: {in: [true, false]}
 
   after_update :update_consultation_end_date!
   after_save :audit_press_notice!
@@ -54,10 +54,10 @@ class PressNotice < ApplicationRecord
     return unless saved_change_to_required? || saved_change_to_reasons?
 
     comment = if reasons.present?
-                "Press notice has been marked as required with the following reasons: #{joined_reasons}"
-              else
-                "Press notice has been marked as not required"
-              end
+      "Press notice has been marked as required with the following reasons: #{joined_reasons}"
+    else
+      "Press notice has been marked as not required"
+    end
 
     audit!(
       activity_type: "press_notice",

--- a/app/models/proposal_measurement.rb
+++ b/app/models/proposal_measurement.rb
@@ -3,5 +3,5 @@
 class ProposalMeasurement < ApplicationRecord
   belongs_to :planning_application
 
-  validates :depth, :max_height, :eaves_height, numericality: { only_float: true }
+  validates :depth, :max_height, :eaves_height, numericality: {only_float: true}
 end

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -83,6 +83,6 @@ class Recommendation < ApplicationRecord
     return unless challenged? && !reviewer_comment?
 
     errors.add(:base,
-               "Please include a comment for the case officer to indicate why the recommendation has been challenged.")
+      "Please include a comment for the case officer to indicate why the recommendation has been challenged.")
   end
 end

--- a/app/models/red_line_boundary_change_validation_request.rb
+++ b/app/models/red_line_boundary_change_validation_request.rb
@@ -29,8 +29,8 @@ class RedLineBoundaryChangeValidationRequest < ApplicationRecord
     return unless approved == false && rejection_reason.blank?
 
     errors.add(:base,
-               "Please include a comment for the case officer to " \
-               "indicate why the red line boundary change has been rejected.")
+      "Please include a comment for the case officer to " \
+      "indicate why the red line boundary change has been rejected.")
   end
 
   def geojson
@@ -58,9 +58,9 @@ class RedLineBoundaryChangeValidationRequest < ApplicationRecord
 
   def audit_api_comment
     if approved?
-      { response: "approved" }.to_json
+      {response: "approved"}.to_json
     else
-      { response: "rejected", reason: rejection_reason }.to_json
+      {response: "rejected", reason: rejection_reason}.to_json
     end
   end
 

--- a/app/models/replacement_document_validation_request.rb
+++ b/app/models/replacement_document_validation_request.rb
@@ -12,7 +12,7 @@ class ReplacementDocumentValidationRequest < ApplicationRecord
 
   validates :reason, presence: true
 
-  scope :with_active_document, -> { joins(:old_document).where(documents: { archived_at: nil }) }
+  scope :with_active_document, -> { joins(:old_document).where(documents: {archived_at: nil}) }
 
   delegate :invalidated_document_reason, to: :old_document
   delegate :validated?, :archived?, to: :new_document, prefix: :new_document
@@ -49,8 +49,8 @@ class ReplacementDocumentValidationRequest < ApplicationRecord
   end
 
   def audit_comment
-    { old_document: old_document.name,
-      reason: invalidated_document_reason }.to_json
+    {old_document: old_document.name,
+     reason: invalidated_document_reason}.to_json
   end
 
   def reset_replacement_document_validation_request_update_counter!

--- a/app/models/review_immunity_detail.rb
+++ b/app/models/review_immunity_detail.rb
@@ -34,7 +34,7 @@ class ReviewImmunityDetail < ApplicationRecord
     evidence: "evidence"
   }
 
-  validates :decision, inclusion: { in: DECISIONS }, allow_blank: true
+  validates :decision, inclusion: {in: DECISIONS}, allow_blank: true
 
   before_create :ensure_no_open_evidence_review_immunity_detail_response!
   before_create :ensure_no_open_enforcement_review_immunity_detail_response!
@@ -95,7 +95,7 @@ class ReviewImmunityDetail < ApplicationRecord
     return if last_evidence_review_immunity_detail.reviewed_at?
 
     raise NotCreatableError,
-          "Cannot create an evidence review immunity detail response when there is already an open response"
+      "Cannot create an evidence review immunity detail response when there is already an open response"
   end
 
   def ensure_no_open_enforcement_review_immunity_detail_response!
@@ -106,6 +106,6 @@ class ReviewImmunityDetail < ApplicationRecord
     return if last_enforcement_review_immunity_detail.reviewed_at?
 
     raise NotCreatableError,
-          "Cannot create an enforcement review immunity detail response when there is already an open response"
+      "Cannot create an enforcement review immunity detail response when there is already an open response"
   end
 end

--- a/app/models/review_policy_class.rb
+++ b/app/models/review_policy_class.rb
@@ -3,10 +3,10 @@
 class ReviewPolicyClass < ApplicationRecord
   belongs_to :policy_class, optional: true
 
-  enum mark: { not_marked: 0, accept: 1, return_to_officer_with_comment: 2 }
+  enum mark: {not_marked: 0, accept: 1, return_to_officer_with_comment: 2}
 
   enum(
-    status: { not_started: 0, complete: 1, updated: 2 },
+    status: {not_started: 0, complete: 1, updated: 2},
     _default: :not_started,
     _prefix: true
   )

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -10,15 +10,15 @@ class SiteNotice < ApplicationRecord
 
   def preview_content(planning_application)
     I18n.t("site_notice_template",
-           council: planning_application.local_authority.subdomain.capitalize,
-           reference: planning_application.reference,
-           application_description: planning_application.description,
-           site_address: planning_application.full_address,
-           applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
-           application_link: application_link(planning_application),
-           council_address: I18n.t("council_addresses.#{planning_application.local_authority.subdomain}"),
-           consultation_end_date: end_date_from_now.to_date.to_fs,
-           site_notice_display_date: displayed_at&.to_date&.to_fs || Time.zone.today.to_fs)
+      council: planning_application.local_authority.subdomain.capitalize,
+      reference: planning_application.reference,
+      application_description: planning_application.description,
+      site_address: planning_application.full_address,
+      applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
+      application_link: application_link(planning_application),
+      council_address: I18n.t("council_addresses.#{planning_application.local_authority.subdomain}"),
+      consultation_end_date: end_date_from_now.to_date.to_fs,
+      site_notice_display_date: displayed_at&.to_date&.to_fs || Time.zone.today.to_fs)
   end
 
   def end_date_from_now

--- a/app/models/site_visit.rb
+++ b/app/models/site_visit.rb
@@ -7,7 +7,7 @@ class SiteVisit < ApplicationRecord
   belongs_to :neighbour, optional: true
 
   validates :status, :comment, presence: true
-  validates :decision, inclusion: { in: [true, false] }
+  validates :decision, inclusion: {in: [true, false]}
   validates :visited_at, presence: true, if: :decision?
 
   enum status: {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  enum role: { assessor: 0, reviewer: 1, administrator: 2 }
+  enum role: {assessor: 0, reviewer: 1, administrator: 2}
 
-  enum otp_delivery_method: { sms: 0, email: 1 }
+  enum otp_delivery_method: {sms: 0, email: 1}
 
   devise :recoverable, :two_factor_authenticatable, :recoverable, :timeoutable,
-         :validatable,
-         otp_secret_encryption_key: ENV.fetch("OTP_SECRET_ENCRYPTION_KEY", nil),
-         request_keys: [:subdomains]
+    :validatable,
+    otp_secret_encryption_key: ENV.fetch("OTP_SECRET_ENCRYPTION_KEY", nil),
+    request_keys: [:subdomains]
 
   has_many :planning_applications, dependent: :nullify
   has_many :audits, dependent: :nullify
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   before_create :generate_otp_secret
 
   validates :mobile_number, phone_number: true
-  validates :password, password_strength: { use_dictionary: true }, unless: ->(user) { user.password.blank? }
+  validates :password, password_strength: {use_dictionary: true}, unless: ->(user) { user.password.blank? }
   validate :password_complexity
 
   scope :non_administrator, -> { where.not(role: "administrator") }
@@ -93,7 +93,7 @@ class User < ApplicationRecord
     # The last 16 bytes of the ciphertext are the authentication tag - we use
     # Galois Counter Mode which is an authenticated encryption mode
     cipher_text = raw_cipher_text[0..-17]
-    auth_tag =  raw_cipher_text[-16..]
+    auth_tag = raw_cipher_text[-16..]
 
     # this alrorithm lifted from
     # https://github.com/attr-encrypted/encryptor/blob/master/lib/encryptor.rb#L54

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -13,7 +13,7 @@ class ValidationRequest < ApplicationRecord
   belongs_to :planning_application
 
   validates :requestable_id, presence: true # rubocop:disable Rails/RedundantPresenceValidationOnBelongsTo
-  validates :requestable_type, presence: true, inclusion: { in: VALIDATION_REQUEST_TYPES }
+  validates :requestable_type, presence: true, inclusion: {in: VALIDATION_REQUEST_TYPES}
 
   scope :closed, -> { where.not(closed_at: nil) }
 

--- a/app/presenters/concerns/presentable.rb
+++ b/app/presenters/concerns/presentable.rb
@@ -19,9 +19,9 @@ module Presentable
 
   private
 
-  def method_missing(method_name, *args, **kwargs, &)
+  def method_missing(method_name, *, **kwargs, &)
     if presented.respond_to?(method_name)
-      kwargs.any? ? presented.send(method_name, **kwargs, &) : presented.send(method_name, *args, &)
+      kwargs.any? ? presented.send(method_name, **kwargs, &) : presented.send(method_name, *, &)
     else
       super
     end

--- a/app/presenters/consultation_summary_error_presenter.rb
+++ b/app/presenters/consultation_summary_error_presenter.rb
@@ -4,6 +4,6 @@ class ConsultationSummaryErrorPresenter < ErrorPresenter
   private
 
   def attributes_map
-    { entry: :summary_of_consultation_responses }
+    {entry: :summary_of_consultation_responses}
   end
 end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -21,7 +21,7 @@ class ErrorPresenter
     if message.match?(/\A[A-Z].+\Z/)
       message
     else
-      "#{attribute.to_s.humanize.tr('.', ' ')} #{message}"
+      "#{attribute.to_s.humanize.tr(".", " ")} #{message}"
     end
   end
 

--- a/app/presenters/policy_class_error_presenter.rb
+++ b/app/presenters/policy_class_error_presenter.rb
@@ -4,6 +4,6 @@ class PolicyClassErrorPresenter < ErrorPresenter
   private
 
   def attributes_map
-    { "policies.comments.text": :existing_comment }
+    {"policies.comments.text": :existing_comment}
   end
 end

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -12,7 +12,7 @@ module Apis
         faraday(local_authority).post("planning_applications") do |request|
           request.options[:timeout] = TIMEOUT
           request.body = JSON.parse(planning_application.audit_log).merge("send_email" => "false",
-                                                                          "from_production" => "true").to_json
+            "from_production" => "true").to_json
         end
       end
 
@@ -23,7 +23,7 @@ module Apis
           f.response :raise_error
           f.headers = {
             "Content-Type" => "application/json",
-            "Authorization" => "Bearer #{ENV.fetch('STAGING_API_BEARER')}"
+            "Authorization" => "Bearer #{ENV.fetch("STAGING_API_BEARER")}"
           }
         end
       end

--- a/app/services/apis/os_places/client.rb
+++ b/app/services/apis/os_places/client.rb
@@ -28,7 +28,7 @@ module Apis
       private
 
       def key
-        { key: Rails.configuration.os_vector_tiles_api_key }
+        {key: Rails.configuration.os_vector_tiles_api_key}
       end
 
       def faraday

--- a/app/services/apis/plan_x/query.rb
+++ b/app/services/apis/plan_x/query.rb
@@ -10,8 +10,8 @@ module Apis
       HOST = "https://api.editor.planx.uk"
       TIMEOUT = 5
 
-      def self.query(**args)
-        request(**args) => {response:, **query_details}
+      def self.query(**)
+        request(**) => {response:, **query_details}
 
         if response&.success?
           JSON.parse(response.body, symbolize_names: true).merge(query_details)
@@ -32,7 +32,7 @@ module Apis
           wkt = geojson_to_wkt(geojson)
         end
 
-        return { response: nil } if wkt.blank?
+        return {response: nil} if wkt.blank?
 
         faraday = Faraday.new(url: HOST) { |f| f.response :raise_error }
         request_url = "/gis/opensystemslab?geom=#{URI.encode_uri_component wkt}&analytics=false"
@@ -40,7 +40,7 @@ module Apis
           request.options[:timeout] = TIMEOUT
         end
 
-        { response:, wkt:, geojson:, planxRequest: "#{HOST}#{request_url}" }
+        {response:, wkt:, geojson:, planxRequest: "#{HOST}#{request_url}"}
       end
 
       def self.geojson_to_wkt(geojson)
@@ -52,7 +52,7 @@ module Apis
           # we need to handle this, but we're not likely to get more than one
           # element for our usecase.
           entries = geom.entries.filter_map(&:geometry).map(&:as_text)
-          "GEOMETRYCOLLECTION (#{entries.join(', ')})"
+          "GEOMETRYCOLLECTION (#{entries.join(", ")})"
         elsif geom.respond_to? :geometry
           geom.geometry.as_text
         elsif geom.respond_to? :as_text

--- a/app/services/apis/planning_data/query.rb
+++ b/app/services/apis/planning_data/query.rb
@@ -24,7 +24,7 @@ module Apis
 
       def council_code(reference)
         body = fetch(reference, ["local-authority"])
-        body[:count] == 1 && body[:"end-date"].blank? ? body[:entities].first[:reference] : nil
+        (body[:count] == 1 && body[:"end-date"].blank?) ? body[:entities].first[:reference] : nil
       end
 
       private

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -33,7 +33,7 @@ class ConstraintsCreationService
             metadata:
           )
         else
-          Appsignal.send_error("Unexpected constraint type: #{k}, category #{v['category']}")
+          Appsignal.send_error("Unexpected constraint type: #{k}, category #{v["category"]}")
         end
       end
     end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -29,7 +29,7 @@ class LetterSendingService
       letter_content.prepend "# Application updated\nThis application has been updated. Reason: #{resend_reason}\n\n"
     end
 
-    personalisation = { message: letter_content, heading: @consultation.neighbour_letter_header }
+    personalisation = {message: letter_content, heading: @consultation.neighbour_letter_header}
     personalisation.merge! address
 
     begin

--- a/app/services/local_authority_creation_service.rb
+++ b/app/services/local_authority_creation_service.rb
@@ -22,8 +22,8 @@ class LocalAuthorityCreationService
   private
 
   attr_reader :subdomain, :council_code, :short_name, :council_name, :applicants_url,
-              :signatory_name, :signatory_job_title, :enquiries_paragraph,
-              :email_address, :feedback_email, :admin_email
+    :signatory_name, :signatory_job_title, :enquiries_paragraph,
+    :email_address, :feedback_email, :admin_email
 
   def setup
     local_authority

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -61,7 +61,7 @@ class PlanningApplicationCreationService
           )
         end
         ConstraintsCreationService.new(planning_application:,
-                                       constraints_params: params[:constraints_proposed]&.map(&:to_unsafe_hash)).call
+          constraints_params: params[:constraints_proposed]&.map(&:to_unsafe_hash)).call
         UploadDocumentsJob.perform_now(planning_application:, files: params[:files])
         CreateImmunityDetailsJob.perform_now(planning_application:) if possibly_immune?(planning_application)
       end
@@ -71,7 +71,7 @@ class PlanningApplicationCreationService
 
     planning_application
   rescue Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid,
-         ArgumentError, NoMethodError => e
+    ArgumentError, NoMethodError => e
     raise CreateError, e.message
   end
 
@@ -80,23 +80,23 @@ class PlanningApplicationCreationService
     check_for_planning_permission
 
     permitted_keys = [:application_type,
-                      :description,
-                      :applicant_first_name,
-                      :applicant_last_name,
-                      :applicant_phone,
-                      :applicant_email,
-                      :agent_first_name,
-                      :agent_last_name,
-                      :agent_phone,
-                      :agent_email,
-                      :user_role,
-                      :proposal_details,
-                      :files,
-                      :payment_reference,
-                      :work_status,
-                      :planx_debug_data,
-                      :from_production,
-                      { feedback: %i[result find_property planning_constraints] }]
+      :description,
+      :applicant_first_name,
+      :applicant_last_name,
+      :applicant_phone,
+      :applicant_email,
+      :agent_first_name,
+      :agent_last_name,
+      :agent_phone,
+      :agent_email,
+      :user_role,
+      :proposal_details,
+      :files,
+      :payment_reference,
+      :work_status,
+      :planx_debug_data,
+      :from_production,
+      {feedback: %i[result find_property planning_constraints]}]
 
     params.permit permitted_keys
   end
@@ -116,21 +116,21 @@ class PlanningApplicationCreationService
   def site_params
     return unless params[:site]
 
-    { uprn: params[:site][:uprn],
-      address_1: params[:site][:address_1], # rubocop:disable Naming/VariableNumber
-      address_2: params[:site][:address_2], # rubocop:disable Naming/VariableNumber
-      town: params[:site][:town],
-      postcode: params[:site][:postcode],
-      lonlat: lonlat(params[:site][:longitude], params[:site][:latitude]) }
+    {uprn: params[:site][:uprn],
+     address_1: params[:site][:address_1], # rubocop:disable Naming/VariableNumber
+     address_2: params[:site][:address_2], # rubocop:disable Naming/VariableNumber
+     town: params[:site][:town],
+     postcode: params[:site][:postcode],
+     lonlat: lonlat(params[:site][:longitude], params[:site][:latitude])}
   end
 
   def result_params
     return unless params[:result]
 
-    { result_flag: params[:result][:flag],
-      result_heading: params[:result][:heading],
-      result_description: params[:result][:description],
-      result_override: params[:result][:override] }
+    {result_flag: params[:result][:flag],
+     result_heading: params[:result][:heading],
+     result_description: params[:result][:description],
+     result_override: params[:result][:override]}
   end
 
   def payment_amount_in_pounds(amount)

--- a/app/services/upload_documents_service.rb
+++ b/app/services/upload_documents_service.rb
@@ -34,7 +34,7 @@ class UploadDocumentsService
 
   def attach_files(planning_application, file, file_params)
     planning_application.documents.create!(tags: Array(file_params[:tags]),
-                                           applicant_description: file_params[:applicant_description]) do |document|
+      applicant_description: file_params[:applicant_description]) do |document|
       document.file.attach(io: file, filename: new_filename(file_params[:filename]).to_s)
     end
   end
@@ -46,7 +46,7 @@ class UploadDocumentsService
   def planx_file_api_key
     if @planning_application.from_production?
       ENV.fetch("PLANX_FILE_PRODUCTION_API_KEY",
-                nil)
+        nil)
     else
       ENV.fetch("PLANX_FILE_API_KEY", nil)
     end

--- a/app/views/api/v1/description_change_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/description_change_validation_requests/_show.json.jbuilder
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 json.extract! description_change_validation_request,
-              :id,
-              :state,
-              :response_due,
-              :proposed_description,
-              :previous_description,
-              :rejection_reason,
-              :approved,
-              :days_until_response_due,
-              :cancel_reason,
-              :cancelled_at
+  :id,
+  :state,
+  :response_due,
+  :proposed_description,
+  :previous_description,
+  :rejection_reason,
+  :approved,
+  :days_until_response_due,
+  :cancel_reason,
+  :cancelled_at

--- a/app/views/api/v1/other_change_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/other_change_validation_requests/_show.json.jbuilder
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 json.extract! other_change_validation_request,
-              :id,
-              :state,
-              :response_due,
-              :response,
-              :summary,
-              :suggestion,
-              :days_until_response_due,
-              :cancel_reason,
-              :cancelled_at
+  :id,
+  :state,
+  :response_due,
+  :response,
+  :summary,
+  :suggestion,
+  :days_until_response_due,
+  :cancel_reason,
+  :cancelled_at

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -1,35 +1,35 @@
 # frozen_string_literal: true
 
 json.extract! planning_application,
-              :agent_first_name,
-              :agent_last_name,
-              :agent_phone,
-              :agent_email,
-              :applicant_first_name,
-              :applicant_last_name,
-              :user_role,
-              :awaiting_determination_at,
-              :to_be_reviewed_at,
-              :created_at,
-              :description,
-              :determined_at,
-              :determination_date,
-              :id,
-              :invalidated_at,
-              :in_assessment_at,
-              :payment_reference,
-              :payment_amount,
-              :result_flag,
-              :result_heading,
-              :result_description,
-              :result_override,
-              :returned_at,
-              :started_at,
-              :status,
-              :target_date,
-              :withdrawn_at,
-              :work_status,
-              :boundary_geojson
+  :agent_first_name,
+  :agent_last_name,
+  :agent_phone,
+  :agent_email,
+  :applicant_first_name,
+  :applicant_last_name,
+  :user_role,
+  :awaiting_determination_at,
+  :to_be_reviewed_at,
+  :created_at,
+  :description,
+  :determined_at,
+  :determination_date,
+  :id,
+  :invalidated_at,
+  :in_assessment_at,
+  :payment_reference,
+  :payment_amount,
+  :result_flag,
+  :result_heading,
+  :result_description,
+  :result_override,
+  :returned_at,
+  :started_at,
+  :status,
+  :target_date,
+  :withdrawn_at,
+  :work_status,
+  :boundary_geojson
 if planning_application.site_notices.any?
   json.site_notice_content planning_application.site_notices.order(:created_at).last.content
 end
@@ -57,10 +57,10 @@ json.documents planning_application.documents.for_publication do |document|
   json.url api_v1_planning_application_document_url(planning_application, document)
   json.blob_url url_for(document.blob_url).to_s
   json.extract! document,
-                :created_at,
-                :tags,
-                :numbers,
-                :applicant_description
+    :created_at,
+    :tags,
+    :numbers,
+    :applicant_description
 end
 if planning_application.consultation.present?
   json.published_comments planning_application.consultation.neighbour_responses.redacted do |response|

--- a/app/views/api/v1/red_line_boundary_change_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/red_line_boundary_change_validation_requests/_show.json.jbuilder
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 json.extract! red_line_boundary_change_validation_request,
-              :id,
-              :state,
-              :response_due,
-              :original_geojson,
-              :new_geojson,
-              :reason,
-              :rejection_reason,
-              :approved,
-              :days_until_response_due,
-              :cancel_reason,
-              :cancelled_at
+  :id,
+  :state,
+  :response_due,
+  :original_geojson,
+  :new_geojson,
+  :reason,
+  :rejection_reason,
+  :approved,
+  :days_until_response_due,
+  :cancel_reason,
+  :cancelled_at

--- a/app/views/api/v1/replacement_document_validation_requests/_show.json.jbuilder
+++ b/app/views/api/v1/replacement_document_validation_requests/_show.json.jbuilder
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 json.extract! replacement_document_validation_request,
-              :id,
-              :state,
-              :response_due,
-              :days_until_response_due,
-              :cancel_reason,
-              :cancelled_at
+  :id,
+  :state,
+  :response_due,
+  :days_until_response_due,
+  :cancel_reason,
+  :cancelled_at
 
 json.old_document do
   json.name replacement_document_validation_request.old_document.file.filename

--- a/app/views/api/v1/validation_requests/index.json.jbuilder
+++ b/app/views/api/v1/validation_requests/index.json.jbuilder
@@ -4,44 +4,44 @@ json.data do
   json.description_change_validation_requests @planning_application
     .description_change_validation_requests do |description_change_validation_request|
     json.extract! description_change_validation_request,
-                  :id,
-                  :state,
-                  :response_due,
-                  :proposed_description,
-                  :previous_description,
-                  :rejection_reason,
-                  :approved,
-                  :days_until_response_due,
-                  :cancel_reason,
-                  :cancelled_at
+      :id,
+      :state,
+      :response_due,
+      :proposed_description,
+      :previous_description,
+      :rejection_reason,
+      :approved,
+      :days_until_response_due,
+      :cancel_reason,
+      :cancelled_at
     json.type "description_change_validation_request"
   end
 
   json.red_line_boundary_change_validation_requests @planning_application
     .red_line_boundary_change_validation_requests do |red_line_boundary_change_validation_request|
     json.extract! red_line_boundary_change_validation_request,
-                  :id,
-                  :state,
-                  :response_due,
-                  :new_geojson,
-                  :reason,
-                  :rejection_reason,
-                  :approved,
-                  :days_until_response_due,
-                  :cancel_reason,
-                  :cancelled_at
+      :id,
+      :state,
+      :response_due,
+      :new_geojson,
+      :reason,
+      :rejection_reason,
+      :approved,
+      :days_until_response_due,
+      :cancel_reason,
+      :cancelled_at
     json.type "red_line_boundary_change_validation_request"
   end
 
   json.replacement_document_validation_requests @planning_application
     .replacement_document_validation_requests do |replacement_document_validation_request|
     json.extract! replacement_document_validation_request,
-                  :id,
-                  :state,
-                  :response_due,
-                  :days_until_response_due,
-                  :cancel_reason,
-                  :cancelled_at
+      :id,
+      :state,
+      :response_due,
+      :days_until_response_due,
+      :cancel_reason,
+      :cancelled_at
     json.old_document do
       json.name replacement_document_validation_request.old_document.file.filename
       json.invalid_document_reason replacement_document_validation_request.invalidated_document_reason
@@ -60,14 +60,14 @@ json.data do
   json.additional_document_validation_requests @planning_application
     .additional_document_validation_requests do |additional_document_validation_request|
     json.extract! additional_document_validation_request,
-                  :id,
-                  :state,
-                  :response_due,
-                  :days_until_response_due,
-                  :document_request_type,
-                  :document_request_reason,
-                  :cancel_reason,
-                  :cancelled_at
+      :id,
+      :state,
+      :response_due,
+      :days_until_response_due,
+      :document_request_type,
+      :document_request_reason,
+      :cancel_reason,
+      :cancelled_at
 
     json.documents additional_document_validation_request.documents do |document|
       json.name document.file.filename
@@ -81,15 +81,15 @@ json.data do
   json.other_change_validation_requests @planning_application
     .other_change_validation_requests do |other_change_validation_request|
     json.extract! other_change_validation_request,
-                  :id,
-                  :state,
-                  :response_due,
-                  :response,
-                  :summary,
-                  :suggestion,
-                  :days_until_response_due,
-                  :cancel_reason,
-                  :cancelled_at
+      :id,
+      :state,
+      :response_due,
+      :response,
+      :summary,
+      :suggestion,
+      :days_until_response_due,
+      :cancel_reason,
+      :cancelled_at
     json.type "other_change_validation_request"
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -15,7 +15,7 @@
           "type": "controller",
           "class": "PlanningApplicationsController",
           "method": "confirm_validation",
-          "line": 74,
+          "line": 80,
           "file": "app/controllers/planning_applications_controller.rb",
           "rendered": {
             "name": "planning_applications/confirm_validation",
@@ -41,7 +41,7 @@
       "check_name": "VerbConfusion",
       "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
       "file": "app/controllers/application_controller.rb",
-      "line": 46,
+      "line": 67,
       "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
       "code": "session[:back_path] = request.referer if request.get?",
       "render_path": null,
@@ -72,7 +72,7 @@
           "type": "controller",
           "class": "PlanningApplicationsController",
           "method": "make_public",
-          "line": 176,
+          "line": 183,
           "file": "app/controllers/planning_applications_controller.rb",
           "rendered": {
             "name": "planning_applications/make_public",
@@ -92,6 +92,6 @@
       "note": ""
     }
   ],
-  "updated": "2023-10-06 16:04:25 +0000",
-  "brakeman_version": "5.4.0"
+  "updated": "2023-10-24 14:24:08 +0100",
+  "brakeman_version": "6.0.1"
 }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,11 +16,11 @@ GOOGLE_ANALYTICS_HOSTNAMES = %w[
 
 Rails.application.config.content_security_policy do |policy|
   policy.default_src :self, :https
-  policy.font_src    :self, :https, :data
-  policy.img_src     :self, :https, :data, GOOGLE_TAG_MANAGER_HOSTNAME, *GOOGLE_ANALYTICS_HOSTNAMES
-  policy.object_src  :none
-  policy.script_src  :self, :https, GOOGLE_TAG_MANAGER_HOSTNAME, *GOOGLE_ANALYTICS_HOSTNAMES
-  policy.style_src   :self, :https, :unsafe_inline, GOOGLE_TAG_MANAGER_HOSTNAME
+  policy.font_src :self, :https, :data
+  policy.img_src :self, :https, :data, GOOGLE_TAG_MANAGER_HOSTNAME, *GOOGLE_ANALYTICS_HOSTNAMES
+  policy.object_src :none
+  policy.script_src :self, :https, GOOGLE_TAG_MANAGER_HOSTNAME, *GOOGLE_ANALYTICS_HOSTNAMES
+  policy.style_src :self, :https, :unsafe_inline, GOOGLE_TAG_MANAGER_HOSTNAME
   policy.connect_src :self, :https, GOOGLE_TAG_MANAGER_HOSTNAME, *GOOGLE_ANALYTICS_HOSTNAMES
 end
 

--- a/config/initializers/generated_index_name.rb
+++ b/config/initializers/generated_index_name.rb
@@ -8,7 +8,7 @@ module ActiveRecord
       def index_name(table_name, options) # :nodoc:
         if options.is_a?(Hash)
           if options[:column]
-            "ix_#{table_name}_on_#{Array(options[:column]) * '__'}".slice(0, 63)
+            "ix_#{table_name}_on_#{Array(options[:column]) * "__"}".slice(0, 63)
           elsif options[:name]
             options[:name]
           else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,15 +25,15 @@ Rails.application.routes.draw do
 
   defaults format: "json" do
     get "/os_places_api",
-        to: "os_places_api#index",
-        as: "os_places_api_index"
+      to: "os_places_api#index",
+      as: "os_places_api_index"
 
     post "/search_addresses_by_polygon",
-         to: "os_places_api#search_addresses_by_polygon",
-         as: "search_addresses_by_polygon"
+      to: "os_places_api#search_addresses_by_polygon",
+      as: "search_addresses_by_polygon"
 
     scope "/contacts" do
-      get "/consultees", to: "contacts#index", defaults: { category: "consultee" }
+      get "/consultees", to: "contacts#index", defaults: {category: "consultee"}
     end
   end
 

--- a/db/migrate/20200414172738_devise_create_users.rb
+++ b/db/migrate/20200414172738_devise_create_users.rb
@@ -4,11 +4,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
   def change
     create_table :users do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
+      t.string :email, null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
-      t.string   :reset_password_token
+      t.string :reset_password_token
       t.datetime :reset_password_sent_at
 
       ## Rememberable
@@ -35,7 +35,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
+    add_index :users, :email, unique: true
     add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true

--- a/db/migrate/20200610000000_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200610000000_create_active_storage_tables.active_storage.rb
@@ -4,26 +4,26 @@
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
     create_table :active_storage_blobs do |t|
-      t.string   :key,        null: false
-      t.string   :filename,   null: false
-      t.string   :content_type
-      t.text     :metadata
-      t.bigint   :byte_size,  null: false
-      t.string   :checksum,   null: false
+      t.string :key, null: false
+      t.string :filename, null: false
+      t.string :content_type
+      t.text :metadata
+      t.bigint :byte_size, null: false
+      t.string :checksum, null: false
       t.datetime :created_at, null: false
 
       t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
-      t.string     :name,     null: false
-      t.references :record,   null: false, polymorphic: true, index: false
-      t.references :blob,     null: false
+      t.string :name, null: false
+      t.references :record, null: false, polymorphic: true, index: false
+      t.references :blob, null: false
 
       t.datetime :created_at, null: false
 
       t.index %i[record_type record_id name blob_id], name: "index_active_storage_attachments_uniqueness",
-                                                      unique: true
+        unique: true
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
   end

--- a/db/migrate/20210128155246_create_recommendations.rb
+++ b/db/migrate/20210128155246_create_recommendations.rb
@@ -4,8 +4,8 @@ class CreateRecommendations < ActiveRecord::Migration[6.0]
   def change
     create_table :recommendations do |t|
       t.references :planning_application, null: false, foreign_key: true
-      t.references :assessor, null: false, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, null: false, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.text :assessor_comment
       t.text :reviewer_comment
       t.datetime :reviewed_at

--- a/db/migrate/20210522255806_create_document_change_requests.rb
+++ b/db/migrate/20210522255806_create_document_change_requests.rb
@@ -5,8 +5,8 @@ class CreateDocumentChangeRequests < ActiveRecord::Migration[6.1]
     create_table :document_change_requests do |t|
       t.references :planning_application, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
-      t.references :old_document, null: false, foreign_key: { to_table: :documents }
-      t.references :new_document, foreign_key: { to_table: :documents }
+      t.references :old_document, null: false, foreign_key: {to_table: :documents}
+      t.references :new_document, foreign_key: {to_table: :documents}
       t.string :state, default: "open", null: false
 
       t.timestamps

--- a/db/migrate/20210524165604_create_document_create_requests.rb
+++ b/db/migrate/20210524165604_create_document_create_requests.rb
@@ -5,7 +5,7 @@ class CreateDocumentCreateRequests < ActiveRecord::Migration[6.1]
     create_table :document_create_requests do |t|
       t.references :planning_application, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
-      t.references :new_document, foreign_key: { to_table: :documents }
+      t.references :new_document, foreign_key: {to_table: :documents}
       t.string :state, default: "open", null: false
       t.string :document_request_type
       t.string :document_request_reason

--- a/db/migrate/20210727123609_add_boundary_created_by_to_planning_applications.rb
+++ b/db/migrate/20210727123609_add_boundary_created_by_to_planning_applications.rb
@@ -2,6 +2,6 @@
 
 class AddBoundaryCreatedByToPlanningApplications < ActiveRecord::Migration[6.1]
   def change
-    add_reference :planning_applications, :boundary_created_by, references: :users, foreign_key: { to_table: :users }
+    add_reference :planning_applications, :boundary_created_by, references: :users, foreign_key: {to_table: :users}
   end
 end

--- a/db/migrate/20211020153256_create_delayed_jobs.rb
+++ b/db/migrate/20211020153256_create_delayed_jobs.rb
@@ -5,7 +5,7 @@ class CreateDelayedJobs < ActiveRecord::Migration[6.1]
     create_table :delayed_jobs do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
       table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
-      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :handler, null: false # YAML-encoded string of the object that will do work
       table.text :last_error                           # reason for last failure (See Note below)
 
       # When to run. Could be Time.zone.now for immediately, or sometime in the future.

--- a/db/migrate/20220211153225_add_user_role_to_planning_applications.rb
+++ b/db/migrate/20220211153225_add_user_role_to_planning_applications.rb
@@ -2,7 +2,7 @@
 
 class AddUserRoleToPlanningApplications < ActiveRecord::Migration[6.1]
   class PlanningApplication < ApplicationRecord
-    enum user_role: { applicant: 0, agent: 1, proxy: 2 }
+    enum user_role: {applicant: 0, agent: 1, proxy: 2}
   end
 
   def up

--- a/db/migrate/20220722101202_add_reference_to_planning_applications.rb
+++ b/db/migrate/20220722101202_add_reference_to_planning_applications.rb
@@ -12,7 +12,7 @@ class AddReferenceToPlanningApplications < ActiveRecord::Migration[6.1]
 
     private
 
-    enum application_type: { lawfulness_certificate: 0, full: 1 }
+    enum application_type: {lawfulness_certificate: 0, full: 1}
 
     def application_number
       self[:application_number].to_s.rjust(5, "0")

--- a/db/migrate/20220804122218_create_validation_requests.rb
+++ b/db/migrate/20220804122218_create_validation_requests.rb
@@ -15,8 +15,8 @@ class CreateValidationRequests < ActiveRecord::Migration[6.1]
 
   def up
     create_table :validation_requests do |t|
-      t.bigint  :requestable_id, null: false
-      t.string  :requestable_type, null: false
+      t.bigint :requestable_id, null: false
+      t.string :requestable_type, null: false
 
       t.timestamps
     end

--- a/db/migrate/20220808200219_add_planning_application_to_validation_requests.rb
+++ b/db/migrate/20220808200219_add_planning_application_to_validation_requests.rb
@@ -27,6 +27,6 @@ class AddPlanningApplicationToValidationRequests < ActiveRecord::Migration[6.1]
 
   def down
     remove_reference :validation_requests, :planning_application if column_exists?(:validation_requests,
-                                                                                   :planning_application_id)
+      :planning_application_id)
   end
 end

--- a/db/migrate/20220808200234_add_update_counter_to_validation_requests.rb
+++ b/db/migrate/20220808200234_add_update_counter_to_validation_requests.rb
@@ -29,7 +29,7 @@ class AddUpdateCounterToValidationRequests < ActiveRecord::Migration[6.1]
 
   def down
     remove_column :validation_requests, :update_counter, :boolean if column_exists?(:validation_requests,
-                                                                                    :update_counter)
+      :update_counter)
   end
 
   private
@@ -62,8 +62,8 @@ class AddUpdateCounterToValidationRequests < ActiveRecord::Migration[6.1]
     new_documents_id = requests.pluck(:new_document_id)
 
     requests.where.not(old_document_id: new_documents_id)
-            .reject(&:new_document_archived?)
-            .reject(&:new_document_validated?)
+      .reject(&:new_document_archived?)
+      .reject(&:new_document_validated?)
   end
 
   def by_closed_at(requests)

--- a/db/migrate/20220815130202_update_audits_generated_by_api_user.rb
+++ b/db/migrate/20220815130202_update_audits_generated_by_api_user.rb
@@ -29,5 +29,6 @@ class UpdateAuditsGeneratedByApiUser < ActiveRecord::Migration[6.1]
     )
   end
 
-  def down; end
+  def down
+  end
 end

--- a/db/migrate/20221107110702_add_review_documents_for_recommendation_status_to_planning_applications.rb
+++ b/db/migrate/20221107110702_add_review_documents_for_recommendation_status_to_planning_applications.rb
@@ -3,6 +3,6 @@
 class AddReviewDocumentsForRecommendationStatusToPlanningApplications < ActiveRecord::Migration[6.1]
   def change
     add_column :planning_applications, :review_documents_for_recommendation_status, :string, default: "not_started",
-                                                                                             null: false
+      null: false
   end
 end

--- a/db/migrate/20221114100849_add_review_columns_to_permitted_development_rights.rb
+++ b/db/migrate/20221114100849_add_review_columns_to_permitted_development_rights.rb
@@ -8,8 +8,8 @@ class AddReviewColumnsToPermittedDevelopmentRights < ActiveRecord::Migration[6.1
       t.boolean :reviewer_edited, default: false, null: false
       t.boolean :accepted, default: false, null: false
       t.datetime :reviewed_at
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
     end
 
     up_only do

--- a/db/migrate/20221123161814_create_review_policy_classes.rb
+++ b/db/migrate/20221123161814_create_review_policy_classes.rb
@@ -5,7 +5,7 @@ class CreateReviewPolicyClasses < ActiveRecord::Migration[6.1]
     create_table :review_policy_classes do |t|
       t.belongs_to :policy_class, null: false, foreign_key: true
       t.integer :mark, null: false
-      t.string  :comment
+      t.string :comment
       t.integer :status, null: false
       t.timestamps
     end

--- a/db/migrate/20221125171818_remove_updated_from_assessment_detail_reviewer_verdict.rb
+++ b/db/migrate/20221125171818_remove_updated_from_assessment_detail_reviewer_verdict.rb
@@ -9,5 +9,6 @@ class RemoveUpdatedFromAssessmentDetailReviewerVerdict < ActiveRecord::Migration
     )
   end
 
-  def down; end
+  def down
+  end
 end

--- a/db/migrate/20230412133459_drop_delayed_job_table.rb
+++ b/db/migrate/20230412133459_drop_delayed_job_table.rb
@@ -9,7 +9,7 @@ class DropDelayedJobTable < ActiveRecord::Migration[7.0]
     create_table :delayed_jobs do |table|
       table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
       table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
-      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :handler, null: false # YAML-encoded string of the object that will do work
       table.text :last_error                           # reason for last failure (See Note below)
       table.datetime :run_at                           # When to run. Could be Time.zone.now
       table.datetime :locked_at                        # Set when a client is working on this object

--- a/db/migrate/20230413104701_add_review_status_to_immunity_detail.rb
+++ b/db/migrate/20230413104701_add_review_status_to_immunity_detail.rb
@@ -4,8 +4,8 @@ class AddReviewStatusToImmunityDetail < ActiveRecord::Migration[7.0]
   def change
     change_table :immunity_details, bulk: true do |t|
       t.string :review_status, default: "review_not_started", null: false
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.datetime :reviewed_at
     end
   end

--- a/db/migrate/20230417092412_create_evidence_groups.rb
+++ b/db/migrate/20230417092412_create_evidence_groups.rb
@@ -16,6 +16,6 @@ class CreateEvidenceGroups < ActiveRecord::Migration[7.0]
     end
 
     add_reference :documents, :evidence_group, references: :evidence_groups,
-                                               foreign_key: { to_table: :evidence_groups }, null: true
+      foreign_key: {to_table: :evidence_groups}, null: true
   end
 end

--- a/db/migrate/20230418103900_add_review_immunity_details.rb
+++ b/db/migrate/20230418103900_add_review_immunity_details.rb
@@ -4,8 +4,8 @@ class AddReviewImmunityDetails < ActiveRecord::Migration[7.0]
   def up
     create_table :review_immunity_details do |t|
       t.references :immunity_detail
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.string :decision
       t.text :decision_reason
       t.text :summary
@@ -25,8 +25,8 @@ class AddReviewImmunityDetails < ActiveRecord::Migration[7.0]
     drop_table :review_immunity_details if table_exists?(:review_immunity_details)
 
     change_table :immunity_details, bulk: true do |t|
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.datetime :reviewed_at
     end
   end

--- a/db/migrate/20230609140723_create_application_type.rb
+++ b/db/migrate/20230609140723_create_application_type.rb
@@ -25,7 +25,7 @@ class CreateApplicationType < ActiveRecord::Migration[7.0]
     )
 
     PlanningApplication.find_each do |application|
-      type = (application.application_type == "lawfulness_certificate" ? lawful : prior)
+      type = ((application.application_type == "lawfulness_certificate") ? lawful : prior)
       application.update(application_type_id: type.id)
     end
 

--- a/db/migrate/20230718134342_create_site_visits.rb
+++ b/db/migrate/20230718134342_create_site_visits.rb
@@ -4,7 +4,7 @@ class CreateSiteVisits < ActiveRecord::Migration[7.0]
   def change
     create_table :site_visits do |t|
       t.references :consultation, foreign_key: true
-      t.references :created_by, null: false, foreign_key: { to_table: :users }
+      t.references :created_by, null: false, foreign_key: {to_table: :users}
       t.string :status, default: "not_started", null: false
       t.text :comment, null: false
       t.boolean :decision, null: false

--- a/db/migrate/20230823103441_add_unique_index_on_address_and_consultation_for_neighbours.rb
+++ b/db/migrate/20230823103441_add_unique_index_on_address_and_consultation_for_neighbours.rb
@@ -3,7 +3,7 @@
 class AddUniqueIndexOnAddressAndConsultationForNeighbours < ActiveRecord::Migration[7.0]
   def change
     add_index :neighbours, "LOWER(address), consultation_id",
-              unique: true,
-              name: "index_neighbours_on_lower_address_and_consultation_id"
+      unique: true,
+      name: "index_neighbours_on_lower_address_and_consultation_id"
   end
 end

--- a/db/migrate/20230926083930_create_review_policy_area.rb
+++ b/db/migrate/20230926083930_create_review_policy_area.rb
@@ -4,8 +4,8 @@ class CreateReviewPolicyArea < ActiveRecord::Migration[7.0]
   def change
     create_table :review_policy_areas do |t|
       t.references :policy_area
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.boolean :accepted, default: false, null: false
       t.string :status, default: "in_progress", null: false
       t.string :review_status, default: "review_not_started", null: false
@@ -18,8 +18,8 @@ class CreateReviewPolicyArea < ActiveRecord::Migration[7.0]
     change_table :policy_areas, bulk: true do |t|
       t.string :review_status, default: "review_not_started", null: false
       t.string :status, default: "not_started", null: false
-      t.references :assessor, foreign_key: { to_table: :users }
-      t.references :reviewer, foreign_key: { to_table: :users }
+      t.references :assessor, foreign_key: {to_table: :users}
+      t.references :reviewer, foreign_key: {to_table: :users}
       t.datetime :reviewed_at
     end
   end

--- a/db/migrate/20231006134128_add_assessment_details_to_application_type.rb
+++ b/db/migrate/20231006134128_add_assessment_details_to_application_type.rb
@@ -6,30 +6,30 @@ class AddAssessmentDetailsToApplicationType < ActiveRecord::Migration[7.0]
 
     ApplicationType.all.find_each do |type|
       details = case type.name.to_sym
-                when :lawfulness_certificate
-                  %w[
-                    summary_of_work
-                    site_description
-                    consultation_summary
-                    additional_evidence
-                  ]
-                when :prior_approval
-                  %w[
-                    summary_of_work
-                    site_description
-                    additional_evidence
-                    publicity_summary
-                    amenity
-                  ]
-                else
-                  %w[
-                    summary_of_work
-                    site_description
-                    additional_evidence
-                    consultation_summary
-                    publicity_summary
-                  ]
-                end
+      when :lawfulness_certificate
+        %w[
+          summary_of_work
+          site_description
+          consultation_summary
+          additional_evidence
+        ]
+      when :prior_approval
+        %w[
+          summary_of_work
+          site_description
+          additional_evidence
+          publicity_summary
+          amenity
+        ]
+      else
+        %w[
+          summary_of_work
+          site_description
+          additional_evidence
+          consultation_summary
+          publicity_summary
+        ]
+      end
       type.update(assessment_details: details)
     end
   end

--- a/db/migrate/20231009093157_add_redacted_by_to_neighbour_responses.rb
+++ b/db/migrate/20231009093157_add_redacted_by_to_neighbour_responses.rb
@@ -2,6 +2,6 @@
 
 class AddRedactedByToNeighbourResponses < ActiveRecord::Migration[7.0]
   def change
-    add_reference :neighbour_responses, :redacted_by, references: :users, foreign_key: { to_table: :users }
+    add_reference :neighbour_responses, :redacted_by, references: :users, foreign_key: {to_table: :users}
   end
 end

--- a/db/migrate/20231015233022_add_consultee_tables.rb
+++ b/db/migrate/20231015233022_add_consultee_tables.rb
@@ -2,7 +2,9 @@
 
 class AddConsulteeTables < ActiveRecord::Migration[7.0]
   class Consultation < ActiveRecord::Base; end
+
   class Consultee < ActiveRecord::Base; end
+
   class ConsulteeResponse < ActiveRecord::Base; end
 
   def up
@@ -47,7 +49,7 @@ class AddConsulteeTables < ActiveRecord::Migration[7.0]
       t.text :response
       t.datetime :received_at
       t.text :redacted_response
-      t.references :redacted_by, index: true, foreign_key: { to_table: :users }
+      t.references :redacted_by, index: true, foreign_key: {to_table: :users}
       t.datetime :redacted_at
       t.timestamps
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,9 +71,9 @@ local_authorities.each do |authority|
 end
 
 application_types = [
-  { name: "lawfulness_certificate" },
-  { name: "prior_approval", part: 1, section: "A" },
-  { name: "planning_permission" }
+  {name: "lawfulness_certificate"},
+  {name: "prior_approval", part: 1, section: "A"},
+  {name: "planning_permission"}
 ]
 
 application_types.each do |attrs|

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -59,8 +59,8 @@ end
 
 Given("a new application of type prior approval") do
   @planning_application = FactoryBot.create(:planning_application,
-                                            :prior_approval,
-                                            local_authority: @officer.local_authority)
+    :prior_approval,
+    local_authority: @officer.local_authority)
 end
 
 Given("the planning application is invalidated") do

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Capybara.server = :puma, { Silent: true }
+Capybara.server = :puma, {Silent: true}
 
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium

--- a/spec/components/accordion_sections/constraints_component_spec.rb
+++ b/spec/components/accordion_sections/constraints_component_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe AccordionSections::ConstraintsComponent, type: :component do
 
   context "when feedback is present" do
     let(:feedback) do
-      { planning_constraints: "feedback" }
+      {planning_constraints: "feedback"}
     end
 
     before { render_inline(component) }

--- a/spec/components/accordion_sections/pre_assessment_outcome_component_spec.rb
+++ b/spec/components/accordion_sections/pre_assessment_outcome_component_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe AccordionSections::PreAssessmentOutcomeComponent, type: :componen
 
     context "when 'result' feedback is present" do
       let(:feedback) do
-        { result: "feedback" }
+        {result: "feedback"}
       end
 
       it "renders feedback" do
@@ -102,7 +102,7 @@ RSpec.describe AccordionSections::PreAssessmentOutcomeComponent, type: :componen
             responses: [
               {
                 value: "test response",
-                metadata: { flags: ["test flag"] }
+                metadata: {flags: ["test flag"]}
               }
             ]
           }

--- a/spec/components/accordion_sections/proposal_details_component_spec.rb
+++ b/spec/components/accordion_sections/proposal_details_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AccordionSections::ProposalDetailsComponent, type: :component do
 
   context "when 'find_property' feedback is present" do
     let(:planning_application) do
-      create(:planning_application, feedback: { find_property: "feedback" })
+      create(:planning_application, feedback: {find_property: "feedback"})
     end
 
     it "renders warning message" do

--- a/spec/components/policy_classes/comment_field_component_spec.rb
+++ b/spec/components/policy_classes/comment_field_component_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PolicyClasses::CommentFieldComponent, type: :component do
     let(:comment) { nil }
 
     before do
-      policy.update(status: nil, comments_attributes: [{ text: "test" }])
+      policy.update(status: nil, comments_attributes: [{text: "test"}])
       render_inline(component)
     end
 
@@ -66,7 +66,7 @@ RSpec.describe PolicyClasses::CommentFieldComponent, type: :component do
     end
 
     before do
-      policy.update(comments_attributes: [{ text: "" }])
+      policy.update(comments_attributes: [{text: ""}])
       render_inline(component)
     end
 

--- a/spec/components/proposal_details/group_component_spec.rb
+++ b/spec/components/proposal_details/group_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ProposalDetails::GroupComponent, type: :component do
   let(:proposal_detail_attributes) do
     {
       question: "Test question 1",
-      responses: [{ value: "Test response 1" }],
-      metadata: { section_name: "group_x" }
+      responses: [{value: "Test response 1"}],
+      metadata: {section_name: "group_x"}
     }.deep_stringify_keys
   end
 

--- a/spec/components/proposal_details/link_component_spec.rb
+++ b/spec/components/proposal_details/link_component_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe ProposalDetails::LinkComponent, type: :component do
   let(:proposal_detail_attributes) do
     {
       question: "Test question 1",
-      responses: [{ value: "Test response 1" }],
-      metadata: { section_name: }
+      responses: [{value: "Test response 1"}],
+      metadata: {section_name:}
     }.deep_stringify_keys
   end
 

--- a/spec/components/proposal_details/list_component_spec.rb
+++ b/spec/components/proposal_details/list_component_spec.rb
@@ -7,18 +7,18 @@ RSpec.describe ProposalDetails::ListComponent, type: :component do
     [
       {
         question: "Test question 1",
-        responses: [{ value: "Test response 1" }],
-        metadata: { auto_answered: true, section_name: "group_a" }
+        responses: [{value: "Test response 1"}],
+        metadata: {auto_answered: true, section_name: "group_a"}
       },
       {
         question: "Test question 2",
-        responses: [{ value: "Test response 2" }],
-        metadata: { auto_answered: true, section_name: "group_b" }
+        responses: [{value: "Test response 2"}],
+        metadata: {auto_answered: true, section_name: "group_b"}
       },
       {
         question: "Test question 3",
-        responses: [{ value: "Test response 3" }],
-        metadata: { auto_answered: true, section_name: "group_a" }
+        responses: [{value: "Test response 3"}],
+        metadata: {auto_answered: true, section_name: "group_a"}
       }
     ].to_json
   end

--- a/spec/components/proposal_details/policy_refs_component_spec.rb
+++ b/spec/components/proposal_details/policy_refs_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ProposalDetails::PolicyRefsComponent, type: :component do
   let(:policy_refs) do
-    [{ "url" => "www.example.com" }, { "text" => "Test ref" }]
+    [{"url" => "www.example.com"}, {"text" => "Test ref"}]
   end
 
   let(:component) { described_class.new(policy_refs:) }

--- a/spec/components/proposal_details/summary_component_spec.rb
+++ b/spec/components/proposal_details/summary_component_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe ProposalDetails::SummaryComponent, type: :component do
   let(:proposal_detail_attributes) do
     {
       question: "Test question 1",
-      responses: [{ value: "Test response 1" }, { value: "Test response 2" }],
+      responses: [{value: "Test response 1"}, {value: "Test response 2"}],
       metadata: {
         section_name: "group_x",
         notes: "Test note",
         auto_answered: true,
-        policy_refs: [{ url: "www.example.com" }, { text: "Test ref" }]
+        policy_refs: [{url: "www.example.com"}, {text: "Test ref"}]
       }
     }.deep_stringify_keys
   end

--- a/spec/components/review/policy_class/link_component_spec.rb
+++ b/spec/components/review/policy_class/link_component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Review::PolicyClass::LinkComponent, type: :component do
     render_inline(described_class.new(policy_class:))
 
     expect(page).to have_link("Review assessment of Part 1, Class D",
-                              href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+      href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
   end
 
   it "displays edit link when status not checked yet" do
@@ -21,7 +21,7 @@ RSpec.describe Review::PolicyClass::LinkComponent, type: :component do
     render_inline(described_class.new(policy_class: review_policy_class.policy_class))
 
     expect(page).to have_link("Review assessment of Part 1, Class D",
-                              href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+      href: edit_planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
   end
 
   it "displays show link when status complete" do
@@ -30,6 +30,6 @@ RSpec.describe Review::PolicyClass::LinkComponent, type: :component do
     render_inline(described_class.new(policy_class: review_policy_class.policy_class))
 
     expect(page).to have_link("Review assessment of Part 1, Class D",
-                              href: planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
+      href: planning_application_review_policy_class_path(policy_class.planning_application, policy_class))
   end
 end

--- a/spec/components/review/policy_class/navigation_component_spec.rb
+++ b/spec/components/review/policy_class/navigation_component_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Review::PolicyClass::NavigationComponent, type: :component do
     render_inline(described_class.new(policy_class:))
 
     expect(page).to have_link "View previous class",
-                              href: edit_planning_application_review_policy_class_path(planning_application, prv)
+      href: edit_planning_application_review_policy_class_path(planning_application, prv)
     expect(page).not_to have_text "View next class"
   end
 
@@ -33,7 +33,7 @@ RSpec.describe Review::PolicyClass::NavigationComponent, type: :component do
 
     expect(page).not_to have_text "View previous class"
     expect(page).to have_link "View next class",
-                              href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+      href: edit_planning_application_review_policy_class_path(planning_application, nxt)
   end
 
   it "displays both links with higher and lower sort policy_class" do
@@ -44,8 +44,8 @@ RSpec.describe Review::PolicyClass::NavigationComponent, type: :component do
     render_inline(described_class.new(policy_class:))
 
     expect(page).to have_link "View previous class",
-                              href: edit_planning_application_review_policy_class_path(planning_application, prv)
+      href: edit_planning_application_review_policy_class_path(planning_application, prv)
     expect(page).to have_link "View next class",
-                              href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+      href: edit_planning_application_review_policy_class_path(planning_application, nxt)
   end
 end

--- a/spec/components/review/tasks/after_sign_off_component_spec.rb
+++ b/spec/components/review/tasks/after_sign_off_component_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Review::Tasks::AfterSignOffComponent, type: :component do
 
   it "renders nothing when not submitted" do
     rec = create(:recommendation,
-                 :with_planning_application,
-                 submitted: false,
-                 challenged: false)
+      :with_planning_application,
+      submitted: false,
+      challenged: false)
 
     render_inline(described_class.new(planning_application: rec.planning_application))
 
@@ -31,12 +31,12 @@ RSpec.describe Review::Tasks::AfterSignOffComponent, type: :component do
   %i[true nil].each do |challenged|
     it "renders assessment name when submitted and challenged" do
       rec = create(:recommendation,
-                   :with_planning_application,
-                   status: :review_complete,
-                   reviewer_comment: "reviewer comment",
-                   submitted: true,
-                   challenged:,
-                   assessor:)
+        :with_planning_application,
+        status: :review_complete,
+        reviewer_comment: "reviewer comment",
+        submitted: true,
+        challenged:,
+        assessor:)
 
       render_inline(described_class.new(planning_application: rec.planning_application))
 

--- a/spec/components/review/tasks/button_group_component_spec.rb
+++ b/spec/components/review/tasks/button_group_component_spec.rb
@@ -12,39 +12,39 @@ RSpec.describe Review::Tasks::ButtonGroupComponent, type: :component do
     render_inline(described_class.new(planning_application: pa))
 
     expect(page).not_to have_link("Review and publish decision",
-                                  href: publish_planning_application_path(pa))
+      href: publish_planning_application_path(pa))
     expect(page).to have_link("Back",
-                              href: planning_application_path(pa))
+      href: planning_application_path(pa))
   end
 
   it "renders only back button when not publishing" do
     rec = create(:recommendation,
-                 :with_planning_application,
-                 status: :review_complete,
-                 reviewer_comment: "reviewer comment",
-                 submitted: true,
-                 challenged: nil)
+      :with_planning_application,
+      status: :review_complete,
+      reviewer_comment: "reviewer comment",
+      submitted: true,
+      challenged: nil)
     render_inline(described_class.new(planning_application: rec.planning_application))
 
     expect(page).not_to have_link("Review and publish decision",
-                                  href: publish_planning_application_path(rec.planning_application))
+      href: publish_planning_application_path(rec.planning_application))
     expect(page).to have_link("Back",
-                              href: planning_application_path(rec.planning_application))
+      href: planning_application_path(rec.planning_application))
   end
 
   it "renders back and publish button when publishing" do
     rec = create(:recommendation,
-                 :with_planning_application,
-                 status: :review_complete,
-                 reviewer_comment: "reviewer comment",
-                 submitted: true,
-                 challenged: false)
+      :with_planning_application,
+      status: :review_complete,
+      reviewer_comment: "reviewer comment",
+      submitted: true,
+      challenged: false)
 
     render_inline(described_class.new(planning_application: rec.planning_application))
 
     expect(page).to have_link("Review and publish decision",
-                              href: publish_planning_application_path(rec.planning_application))
+      href: publish_planning_application_path(rec.planning_application))
     expect(page).to have_link("Back",
-                              href: planning_application_path(rec.planning_application))
+      href: planning_application_path(rec.planning_application))
   end
 end

--- a/spec/controllers/additional_document_validation_requests_controller_spec.rb
+++ b/spec/controllers/additional_document_validation_requests_controller_spec.rb
@@ -4,5 +4,5 @@ require "rails_helper"
 
 RSpec.describe AdditionalDocumentValidationRequestsController do
   it_behaves_like "ValidationRequests", described_class,
-                  "additional_document_validation_request"
+    "additional_document_validation_request"
 end

--- a/spec/controllers/recommendations_controller_spec.rb
+++ b/spec/controllers/recommendations_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RecommendationsController do
     end
 
     let(:recommendation_params) do
-      { challenged: false, reviewer_comment: "Comment" }
+      {challenged: false, reviewer_comment: "Comment"}
     end
 
     let(:params) do

--- a/spec/controllers/red_line_boundary_change_validation_requests_controller_spec.rb
+++ b/spec/controllers/red_line_boundary_change_validation_requests_controller_spec.rb
@@ -4,5 +4,5 @@ require "rails_helper"
 
 RSpec.describe RedLineBoundaryChangeValidationRequestsController do
   it_behaves_like "ValidationRequests", described_class,
-                  "red_line_boundary_change_validation_request"
+    "red_line_boundary_change_validation_request"
 end

--- a/spec/controllers/replacement_document_validation_requests_controller_spec.rb
+++ b/spec/controllers/replacement_document_validation_requests_controller_spec.rb
@@ -4,5 +4,5 @@ require "rails_helper"
 
 RSpec.describe ReplacementDocumentValidationRequestsController do
   it_behaves_like "ValidationRequests", described_class,
-                  "replacement_document_validation_request"
+    "replacement_document_validation_request"
 end

--- a/spec/factories/consultation.rb
+++ b/spec/factories/consultation.rb
@@ -14,12 +14,12 @@ FactoryBot.define do
         factory = RGeo::Geographic.spherical_factory(srid: 4326)
         polygon = factory.polygon(
           factory.linear_ring([
-                                factory.point(-0.07739927369747812, 51.501345554406896),
-                                factory.point(-0.0778893839394212, 51.501002280754676),
-                                factory.point(-0.07690508968054104, 51.50102474569704),
-                                factory.point(-0.07676672973966252, 51.50128963605792),
-                                factory.point(-0.07739927369747812, 51.501345554406896)
-                              ])
+            factory.point(-0.07739927369747812, 51.501345554406896),
+            factory.point(-0.0778893839394212, 51.501002280754676),
+            factory.point(-0.07690508968054104, 51.50102474569704),
+            factory.point(-0.07676672973966252, 51.50128963605792),
+            factory.point(-0.07739927369747812, 51.501345554406896)
+          ])
         )
         geometry_collection = factory.collection([polygon])
         geometry_collection

--- a/spec/factories/document.rb
+++ b/spec/factories/document.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
   trait :with_other_file do
     file do
       fixture_file_upload(Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf"),
-                          "proposed-first-floor-plan/pdf")
+        "proposed-first-floor-plan/pdf")
     end
   end
 

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -87,7 +87,7 @@ FactoryBot.define do
     end
 
     trait :awaiting_determination do
-      status                    { :awaiting_determination }
+      status { :awaiting_determination }
       awaiting_determination_at { Time.zone.now }
       decision { "granted" }
 
@@ -128,7 +128,7 @@ FactoryBot.define do
     end
 
     trait :determined do
-      status        { :determined }
+      status { :determined }
       determined_at { Time.zone.now }
       determination_date { Time.zone.now }
       decision { "granted" }
@@ -150,7 +150,7 @@ FactoryBot.define do
     end
 
     trait :closed do
-      status    { :closed }
+      status { :closed }
       closed_at { Time.zone.now }
     end
 

--- a/spec/helpers/assessment_detail_helper_spec.rb
+++ b/spec/helpers/assessment_detail_helper_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe AssessmentDetailHelper do
   describe ".neighbour_responses_summary_text" do
     it "generates the correct text from a given hash" do
-      summary_hash = { "objection" => 1, "supportive" => 2, "neutral" => 1 }
+      summary_hash = {"objection" => 1, "supportive" => 2, "neutral" => 1}
 
       result = neighbour_responses_summary_text(summary_hash)
       expect(result).to eq("There is 1 objection, 2 supportive, 1 neutral.")

--- a/spec/helpers/audit_helper_spec.rb
+++ b/spec/helpers/audit_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AuditHelper do
 
     it "returns the correct wording for an assigned audit" do
       expect(activity(assigned_audit.activity_type,
-                      assigned_audit.activity_information)).to eq("Application assigned to Maria")
+        assigned_audit.activity_information)).to eq("Application assigned to Maria")
     end
 
     it "returns the correct wording for an challenged audit" do
@@ -26,7 +26,7 @@ RSpec.describe AuditHelper do
 
     it "returns the correct wording for a created audit" do
       expect(activity(created_audit.activity_type,
-                      created_audit.activity_information)).to eq("Application created by Polly")
+        created_audit.activity_information)).to eq("Application created by Polly")
     end
 
     it "returns the correct wording for an archive audit" do

--- a/spec/helpers/planning_application_helper_spec.rb
+++ b/spec/helpers/planning_application_helper_spec.rb
@@ -6,12 +6,12 @@ require "rails_helper"
 RSpec.describe PlanningApplicationHelper do
   describe "#filter_enabled_uniquely?" do
     it "returns true if this is the only filter enabled" do
-      allow(helper).to receive(:params).and_return(ActionController::Parameters.new({ status: "not_started" }))
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new({status: "not_started"}))
       expect(helper.filter_enabled_uniquely?(status: "not_started")).to be_truthy
     end
 
     it "returns false if this is not the only filter enabled" do
-      allow(helper).to receive(:params).and_return(ActionController::Parameters.new({ status: "not_started", application_type: "prior_approval" }))
+      allow(helper).to receive(:params).and_return(ActionController::Parameters.new({status: "not_started", application_type: "prior_approval"}))
       expect(helper.filter_enabled_uniquely?(status: "not_started")).to be_falsy
     end
 

--- a/spec/helpers/validation_request_helper_spec.rb
+++ b/spec/helpers/validation_request_helper_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe ValidationRequestHelper do
   describe "#cancel_confirmation_request_url" do
     it "returns the link text and url to the cancel confirmation page for a validation request" do
       url = link_to "Cancel request",
-                    cancel_confirmation_planning_application_other_change_validation_request_path(planning_application,
-                                                                                                  request)
+        cancel_confirmation_planning_application_other_change_validation_request_path(planning_application,
+          request)
       expect(cancel_confirmation_request_url(planning_application, request)).to eq(url)
     end
   end

--- a/spec/jobs/close_description_change_job_spec.rb
+++ b/spec/jobs/close_description_change_job_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe CloseDescriptionChangeJob do
 
   let!(:description_change_request) do
     create(:description_change_validation_request,
-           planning_application:,
-           created_at: 6.business_days.ago)
+      planning_application:,
+      created_at: 6.business_days.ago)
   end
 
   it "changes the application's description" do

--- a/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
+++ b/spec/jobs/close_red_line_boundary_change_validation_request_job_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe CloseRedLineBoundaryChangeValidationRequestJob do
 
     let!(:red_line_boundary_change_validation_request) do
       create(:red_line_boundary_change_validation_request, :open,
-             planning_application:,
-             created_at: 6.business_days.ago)
+        planning_application:,
+        created_at: 6.business_days.ago)
     end
 
     it "changes the planning application's boundary geojson" do
@@ -43,8 +43,8 @@ RSpec.describe CloseRedLineBoundaryChangeValidationRequestJob do
   context "when less than 5 business days have passed" do
     let!(:red_line_boundary_change_validation_request) do
       create(:red_line_boundary_change_validation_request, :open,
-             planning_application:,
-             created_at: 4.business_days.ago)
+        planning_application:,
+        created_at: 4.business_days.ago)
     end
 
     it "does not change the planning application's boundary geojson" do

--- a/spec/jobs/notify_email_job_spec.rb
+++ b/spec/jobs/notify_email_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "Exception", message: "Internal server error" }
+                {error: "Exception", message: "Internal server error"}
               ]
             }.to_json
           )
@@ -95,7 +95,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "BadRequestError", message: "Can't send to this recipient using a team-only API key" }
+                {error: "BadRequestError", message: "Can't send to this recipient using a team-only API key"}
               ]
             }.to_json
           )
@@ -124,7 +124,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "AuthError", message: "Invalid token: API key not found" }
+                {error: "AuthError", message: "Invalid token: API key not found"}
               ]
             }.to_json
           )
@@ -153,7 +153,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "NotFoundError", message: "Not Found" }
+                {error: "NotFoundError", message: "Not Found"}
               ]
             }.to_json
           )
@@ -182,7 +182,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "RequestTimeoutError", message: "Request Timeout" }
+                {error: "RequestTimeoutError", message: "Request Timeout"}
               ]
             }.to_json
           )
@@ -211,7 +211,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "RateLimitError", message: "Exceeded rate limit for key type LIVE of 3000 requests per 60 seconds" }
+                {error: "RateLimitError", message: "Exceeded rate limit for key type LIVE of 3000 requests per 60 seconds"}
               ]
             }.to_json
           )
@@ -240,7 +240,7 @@ RSpec.describe NotifyEmailJob do
             },
             body: {
               errors: [
-                { error: "TooManyRequestsError", message: "Exceeded send limits (250,000) for today" }
+                {error: "TooManyRequestsError", message: "Exceeded send limits (250,000) for today"}
               ]
             }.to_json
           )

--- a/spec/jobs/upload_documents_job_spec.rb
+++ b/spec/jobs/upload_documents_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe UploadDocumentsJob do
   let!(:planning_application) { create(:planning_application) }
   let(:document) do
     create(:document, :with_file, :with_tags,
-           planning_application:)
+      planning_application:)
   end
 
   describe "#perform" do

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -48,15 +48,15 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
   let(:document_with_tags) do
     create(:document, :with_tags,
-           planning_application:,
-           numbers: "proposed_number_1, proposed_number_2",
-           referenced_in_decision_notice: true)
+      planning_application:,
+      numbers: "proposed_number_1, proposed_number_2",
+      referenced_in_decision_notice: true)
   end
 
   let(:archived_document_with_tags) do
     create(:document, :archived, :with_tags,
-           planning_application:,
-           numbers: "archived_number")
+      planning_application:,
+      numbers: "archived_number")
   end
 
   before do
@@ -142,7 +142,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       it "includes the name of the applicant in the body if no agent is present" do
         planning_application.update!(agent_first_name: "")
         mail = described_class.decision_notice_mail(planning_application.reload, host,
-                                                    [planning_application.agent_email, planning_application.applicant_email])
+          [planning_application.agent_email, planning_application.applicant_email])
 
         expect(mail.body.encoded).to include(planning_application.applicant_first_name)
         expect(mail.body.encoded).to include(planning_application.applicant_last_name)
@@ -321,7 +321,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   describe "#post_validation_request_mail" do
     let!(:validation_request) do
       create(:red_line_boundary_change_validation_request, planning_application: invalid_planning_application,
-                                                           user: assessor)
+        user: assessor)
     end
     let(:post_validation_request_mail) do
       described_class.post_validation_request_mail(planning_application, validation_request)
@@ -1098,7 +1098,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     describe "#post_validation_request_mail" do
       let!(:validation_request) do
         create(:red_line_boundary_change_validation_request, planning_application: invalid_planning_application,
-                                                             user: assessor)
+          user: assessor)
       end
       let(:post_validation_request_mail) do
         described_class.post_validation_request_mail(planning_application, validation_request)

--- a/spec/models/additional_document_validation_request_spec.rb
+++ b/spec/models/additional_document_validation_request_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe AdditionalDocumentValidationRequest do
 
           expect { additional_document_validation_request.upload_files!(files) }
             .to raise_error(AdditionalDocumentValidationRequest::UploadFilesError,
-                            "Event 'close' cannot transition from 'closed'.")
+              "Event 'close' cannot transition from 'closed'.")
             .and not_change(Audit, :count)
 
           additional_document_validation_request.reload

--- a/spec/models/concerns/planning_application_status_spec.rb
+++ b/spec/models/concerns/planning_application_status_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe PlanningApplicationStatus do
   describe "states" do
     let(:proposed_document1) do
       create(:document, :with_tags,
-             planning_application:,
-             numbers: "number")
+        planning_application:,
+        numbers: "number")
     end
 
     let(:description_change_validation_request) do
       create(:description_change_validation_request, planning_application:, state: "open",
-                                                     created_at: 12.days.ago)
+        created_at: 12.days.ago)
     end
 
     context "when not started" do
@@ -27,17 +27,17 @@ RSpec.describe PlanningApplicationStatus do
 
     context "when in assessment" do
       it_behaves_like "PlanningApplicationStateMachineEvents", "in_assessment",
-                      %i[start save_assessment return close withdraw]
+        %i[start save_assessment return close withdraw]
     end
 
     context "when assessment in progress" do
       it_behaves_like "PlanningApplicationStateMachineEvents", "assessment_in_progress",
-                      %i[save_assessment]
+        %i[save_assessment]
     end
 
     context "when awaiting determination" do
       it_behaves_like "PlanningApplicationStateMachineEvents", "awaiting_determination",
-                      %i[determine request_correction return close withdraw withdraw_recommendation]
+        %i[determine request_correction return close withdraw withdraw_recommendation]
     end
 
     context "when determined" do
@@ -85,8 +85,8 @@ RSpec.describe PlanningApplicationStatus do
 
       let(:proposed_drawing1) do
         create(:document, :with_tags,
-               planning_application:,
-               numbers: "number")
+          planning_application:,
+          numbers: "number")
       end
 
       it "sets work_status to proposed" do

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Consultation do
     let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
 
     it "returns correct count of summary tags" do
-      expect(consultation.neighbour_responses_by_summary_tag).to eq({ "objection" => 1, "supportive" => 2, "neutral" => 1 })
+      expect(consultation.neighbour_responses_by_summary_tag).to eq({"objection" => 1, "supportive" => 2, "neutral" => 1})
     end
   end
 
@@ -375,7 +375,7 @@ RSpec.describe Consultation do
       let(:planning_application) { create(:planning_application) }
 
       it "raises an error" do
-        allow(planning_application).to receive(:boundary_geojson).and_return({ "type" => "InvalidType" }.to_json)
+        allow(planning_application).to receive(:boundary_geojson).and_return({"type" => "InvalidType"}.to_json)
 
         expect { consultation.polygon_search_and_boundary_geojson }.to raise_error(/Invalid GeoJSON type/)
       end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Contact do
 
     context "when no local authority is specified" do
       let(:options) do
-        { category: "consultee" }
+        {category: "consultee"}
       end
 
       it "returns only external consultees" do
@@ -90,7 +90,7 @@ RSpec.describe Contact do
 
     context "when the local authority is specified" do
       let(:options) do
-        { category: "consultee", local_authority: lambeth }
+        {category: "consultee", local_authority: lambeth}
       end
 
       it "returns internal and external contacts" do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -300,7 +300,7 @@ RSpec.describe Document do
 
     context "when there is no 'file' attribute" do
       let(:attributes) do
-        { numbers: "DOC345" }
+        {numbers: "DOC345"}
       end
 
       it "updates existing document" do
@@ -311,7 +311,7 @@ RSpec.describe Document do
 
       context "when the attributes are invalid" do
         let(:attributes) do
-          { referenced_in_decision_notice: true, numbers: "" }
+          {referenced_in_decision_notice: true, numbers: ""}
         end
 
         it "returns false" do
@@ -330,7 +330,7 @@ RSpec.describe Document do
 
     context "when there is a 'file' attribute" do
       let(:attributes) do
-        { file: file2 }
+        {file: file2}
       end
 
       it "archives existing document" do

--- a/spec/models/other_change_validation_request_spec.rb
+++ b/spec/models/other_change_validation_request_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe OtherChangeValidationRequest do
         context "when it is not a closed fee item validation request" do
           let!(:other_change_validation_request) do
             create(:other_change_validation_request, :pending, fee_item: true,
-                                                               planning_application:)
+              planning_application:)
           end
 
           before { other_change_validation_request.update(summary: "bla") }
@@ -141,7 +141,7 @@ RSpec.describe OtherChangeValidationRequest do
         context "when it is a fee item validation request" do
           let(:other_change_validation_request) do
             create(:other_change_validation_request, :pending, fee_item: true,
-                                                               planning_application:)
+              planning_application:)
           end
 
           it "updates and resets the valid_fee to nil on the planning application" do
@@ -152,7 +152,7 @@ RSpec.describe OtherChangeValidationRequest do
         context "when it is not a fee item validation request" do
           let(:other_change_validation_request) do
             create(:other_change_validation_request, :pending, fee_item: false,
-                                                               planning_application:)
+              planning_application:)
           end
 
           it "does not update the valid_fee on the planning application" do
@@ -169,7 +169,7 @@ RSpec.describe OtherChangeValidationRequest do
         context "when it is a fee item validation request" do
           let(:other_change_validation_request) do
             create(:other_change_validation_request, :pending, fee_item: true,
-                                                               planning_application:)
+              planning_application:)
           end
 
           it "updates the invalid payment amount on the planning application" do
@@ -182,7 +182,7 @@ RSpec.describe OtherChangeValidationRequest do
         context "when it is not a fee item validation request" do
           let(:other_change_validation_request) do
             create(:other_change_validation_request, :pending, fee_item: false,
-                                                               planning_application:)
+              planning_application:)
           end
 
           it "does not update the invalid payment amount on the planning application" do
@@ -204,7 +204,7 @@ RSpec.describe OtherChangeValidationRequest do
             expect do
               other_change_validation_request
             end.to raise_error(ValidationRequestable::ValidationRequestNotCreatableError,
-                               "Cannot create Other Change Validation Request when planning application has been validated")
+              "Cannot create Other Change Validation Request when planning application has been validated")
           end
         end
       end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -394,7 +394,7 @@ RSpec.describe PlanningApplication do
           expect do
             ldc_planning_application.update!(application_type_id: ApplicationType.find_by(name: "prior_approval").id)
           end.to change(Audit, :count)
-             .by(1)
+            .by(1)
             .and change(ldc_planning_application, :application_number)
             .from("00101").to("00102")
             .and change(ldc_planning_application, :reference)
@@ -512,14 +512,14 @@ RSpec.describe PlanningApplication do
 
     it "returns true if name and email are given" do
       planning_application.update!(agent_first_name: "first", agent_last_name: "last",
-                                   agent_phone: "", agent_email: "agent@example.com")
+        agent_phone: "", agent_email: "agent@example.com")
 
       expect(planning_application.agent?).to be true
     end
 
     it "returns true if name and phone are given" do
       planning_application.update!(agent_first_name: "first", agent_last_name: "last",
-                                   agent_phone: "34433454", agent_email: "")
+        agent_phone: "34433454", agent_email: "")
 
       expect(planning_application.agent?).to be true
     end
@@ -528,28 +528,28 @@ RSpec.describe PlanningApplication do
   describe "#applicant?" do
     it "returns false if no values are given" do
       planning_application.update!(applicant_first_name: "", applicant_last_name: "",
-                                   applicant_phone: "", applicant_email: "")
+        applicant_phone: "", applicant_email: "")
 
       expect(planning_application.applicant?).to be false
     end
 
     it "returns true if only name is given" do
       planning_application.update!(applicant_first_name: "first", applicant_last_name: "last",
-                                   applicant_phone: "", applicant_email: "")
+        applicant_phone: "", applicant_email: "")
 
       expect(planning_application.applicant?).to be true
     end
 
     it "returns true if name and email are given" do
       planning_application.update!(applicant_first_name: "first", applicant_last_name: "last",
-                                   applicant_phone: "", applicant_email: "applicant@example.com")
+        applicant_phone: "", applicant_email: "applicant@example.com")
 
       expect(planning_application.applicant?).to be true
     end
 
     it "returns true if name and phone are given" do
       planning_application.update!(applicant_first_name: "first", applicant_last_name: "last",
-                                   applicant_phone: "34433454", applicant_email: "")
+        applicant_phone: "34433454", applicant_email: "")
 
       expect(planning_application.applicant?).to be true
     end
@@ -741,7 +741,7 @@ RSpec.describe PlanningApplication do
         [
           {
             question: "Test question?",
-            responses: [{ value: "Test response" }],
+            responses: [{value: "Test response"}],
             metadata: {
               auto_answered: true,
               portal_name: "Test portal",
@@ -850,7 +850,7 @@ RSpec.describe PlanningApplication do
       [
         {
           question: "Test question?",
-          responses: [{ value: "Test response" }],
+          responses: [{value: "Test response"}],
           metadata: {
             auto_answered: true,
             portal_name: "immunity-check"
@@ -858,7 +858,7 @@ RSpec.describe PlanningApplication do
         },
         {
           question: "Test question 2?",
-          responses: [{ value: "Test response" }],
+          responses: [{value: "Test response"}],
           metadata: {
             auto_answered: true,
             portal_name: "immunity-check"
@@ -929,7 +929,7 @@ RSpec.describe PlanningApplication do
       it "submits the recommendation and creates an audit record" do
         expect { planning_application.submit_recommendation! }
           .to change(planning_application, :status).from("in_assessment").to("awaiting_determination")
-                                                   .and change(planning_application.recommendation.reload, :submitted).from(false).to(true)
+          .and change(planning_application.recommendation.reload, :submitted).from(false).to(true)
 
         expect(planning_application.awaiting_determination_at).to eq(Time.current)
 
@@ -997,7 +997,7 @@ RSpec.describe PlanningApplication do
       it "withdraws the recommendation and creates an audit record" do
         expect { planning_application.withdraw_last_recommendation! }
           .to change(planning_application, :status).from("awaiting_determination").to("in_assessment")
-                                                   .and change(planning_application.recommendation.reload, :submitted).from(true).to(false)
+          .and change(planning_application.recommendation.reload, :submitted).from(true).to(false)
 
         expect(planning_application.in_assessment_at).to eq(Time.current)
 
@@ -1452,10 +1452,10 @@ RSpec.describe PlanningApplication do
         statuses.each do |status|
           it "returns false when #{status} and the last recommendation when challenge is #{challenge}" do
             create(:recommendation,
-                   status:,
-                   challenged: challenge,
-                   reviewer_comment: "Nope",
-                   planning_application:)
+              status:,
+              challenged: challenge,
+              reviewer_comment: "Nope",
+              planning_application:)
 
             expect(planning_application.last_recommendation_accepted?).to be false
           end
@@ -1467,9 +1467,9 @@ RSpec.describe PlanningApplication do
       %i[assessment_in_progress assessment_complete review_in_progress].each do |status|
         it "returns false when #{status} and the last recommendation is challenged" do
           create(:recommendation,
-                 status:,
-                 challenged: false,
-                 planning_application:)
+            status:,
+            challenged: false,
+            planning_application:)
 
           expect(planning_application.last_recommendation_accepted?).to be false
         end
@@ -1477,9 +1477,9 @@ RSpec.describe PlanningApplication do
 
       it "returns true when the last recommendation is accepted" do
         create(:recommendation,
-               status: :review_complete,
-               challenged: false,
-               planning_application:)
+          status: :review_complete,
+          challenged: false,
+          planning_application:)
 
         expect(planning_application.last_recommendation_accepted?).to be true
       end

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe Policy do
   describe ".with_a_comment" do
     it "returns policies with a comment" do
       policy = create(:policy,
-                      :complies,
-                      section: "1A")
+        :complies,
+        section: "1A")
 
       create(:comment, commentable: policy)
 
@@ -63,8 +63,8 @@ RSpec.describe Policy do
 
     it "excludes policies without a comment" do
       create(:policy,
-             :complies,
-             section: "1A")
+        :complies,
+        section: "1A")
 
       expect(described_class.with_a_comment).to eq []
     end
@@ -73,8 +73,8 @@ RSpec.describe Policy do
   describe ".existing_or_new_comment" do
     it "returns policies that do not comply" do
       policy = create(:policy,
-                      :does_not_comply,
-                      section: "1A")
+        :does_not_comply,
+        section: "1A")
 
       expect(described_class.commented_or_does_not_comply).to eq [policy]
     end
@@ -82,8 +82,8 @@ RSpec.describe Policy do
     %i[complies to_be_determined].each do |status|
       it "excludes policies that" do
         create(:policy,
-               status,
-               section: "1A")
+          status,
+          section: "1A")
 
         expect(described_class.commented_or_does_not_comply).to eq []
       end
@@ -92,8 +92,8 @@ RSpec.describe Policy do
     %i[complies does_not_comply to_be_determined].each do |status|
       it "includes any commented legal clause" do
         policy = create(:policy,
-                        status,
-                        section: "1A")
+          status,
+          section: "1A")
 
         create(:comment, commentable: policy)
 
@@ -103,11 +103,11 @@ RSpec.describe Policy do
 
     it "orders by section" do
       last_section = create(:policy,
-                            :does_not_comply,
-                            section: "2B")
+        :does_not_comply,
+        section: "2B")
       first_section = create(:policy,
-                             :complies,
-                             section: "1A")
+        :complies,
+        section: "1A")
 
       create(:comment, commentable: first_section)
 

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe PressNotice do
       describe "#reasons_list" do
         it "returns the reasons for press notice" do
           expect(described_class.reasons_list).to eq(
-            { conservation_area: ["The site of the application is within/affecting the setting of a designated Conservation Area (Section 73) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
-              listed_building: ["The application relates to, or affects the setting of a Listed Building (Section 67) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
-              major_development: ["The application is for a Major Development"],
-              wildlife_and_countryside: ["The application would affect a right of way to which Part III of the Wildlife and Countryside Act 1981 (as amended) applies"],
-              development_plan: ["The application does not accord with the provisions of the development plan"],
-              environment: ["An environmental statement accompanies this application"],
-              ancient_monument: ["The site of the application is affecting the setting of an Ancient Monument"],
-              public_interest: ["Wider Public interest"] }
+            {conservation_area: ["The site of the application is within/affecting the setting of a designated Conservation Area (Section 73) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
+             listed_building: ["The application relates to, or affects the setting of a Listed Building (Section 67) of the Planning (Listed Buildings and Conservation Areas) Act 1990"],
+             major_development: ["The application is for a Major Development"],
+             wildlife_and_countryside: ["The application would affect a right of way to which Part III of the Wildlife and Countryside Act 1981 (as amended) applies"],
+             development_plan: ["The application does not accord with the provisions of the development plan"],
+             environment: ["An environmental statement accompanies this application"],
+             ancient_monument: ["The site of the application is affecting the setting of an Ancient Monument"],
+             public_interest: ["Wider Public interest"]}
           )
         end
       end
@@ -56,13 +56,13 @@ RSpec.describe PressNotice do
         it "returns the reason types for press notice" do
           expect(described_class.reason_keys).to eq(
             %i[conservation_area
-               listed_building
-               major_development
-               wildlife_and_countryside
-               development_plan
-               environment
-               ancient_monument
-               public_interest]
+              listed_building
+              major_development
+              wildlife_and_countryside
+              development_plan
+              environment
+              ancient_monument
+              public_interest]
           )
         end
       end
@@ -98,7 +98,7 @@ RSpec.describe PressNotice do
             press_notice
 
             expect do
-              press_notice.update!(reasons: { ancient_monument: "The site of the application is affecting the setting of an Ancient Monument" })
+              press_notice.update!(reasons: {ancient_monument: "The site of the application is affecting the setting of an Ancient Monument"})
             end.to change(Audit, :count).by(1)
 
             expect(Audit.last).to have_attributes(

--- a/spec/models/proposal_detail_spec.rb
+++ b/spec/models/proposal_detail_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe ProposalDetail do
       responses: [
         {
           value: "Test response",
-          metadata: { flags: ["Test flag"] }
+          metadata: {flags: ["Test flag"]}
         }
       ],
       metadata: {
         auto_answered: auto_asnwered,
         section_name: "Test portal",
         policy_refs: [
-          { text: "Test ref text", url: "https://www.exampleref.com" }
+          {text: "Test ref text", url: "https://www.exampleref.com"}
         ],
         notes: "Test notes"
       }
@@ -77,7 +77,7 @@ RSpec.describe ProposalDetail do
   describe "#policy refs" do
     it "returns array of policy refs" do
       expect(proposal_detail.policy_refs).to contain_exactly(
-        { "text" => "Test ref text", "url" => "https://www.exampleref.com" }
+        {"text" => "Test ref text", "url" => "https://www.exampleref.com"}
       )
     end
   end

--- a/spec/models/recommendation_spec.rb
+++ b/spec/models/recommendation_spec.rb
@@ -161,7 +161,7 @@ RSpec.describe Recommendation do
         it "reviews the recommendation and the planning application state updates to to_be_reviewed" do
           expect { recommendation.review! }
             .to change(recommendation, :reviewed_at).from(nil).to(Time.current)
-                                                    .and change(recommendation, :reviewer_id).from(nil).to(reviewer.id)
+            .and change(recommendation, :reviewer_id).from(nil).to(reviewer.id)
 
           expect(planning_application.status).to eq("to_be_reviewed")
 
@@ -180,7 +180,7 @@ RSpec.describe Recommendation do
         it "reviews the recommendation and the planning application state updates to to_be_reviewed" do
           expect { recommendation.review! }
             .to change(recommendation, :reviewed_at).from(nil).to(Time.current)
-                                                    .and change(recommendation, :reviewer_id).from(nil).to(reviewer.id)
+            .and change(recommendation, :reviewer_id).from(nil).to(reviewer.id)
 
           expect(planning_application.status).to eq("awaiting_determination")
 

--- a/spec/models/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/models/red_line_boundary_change_validation_request_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe RedLineBoundaryChangeValidationRequest do
       it "sets the original geojson field using the planning application boundary geojson" do
         planning_application = create(:planning_application, :invalidated, :with_boundary_geojson)
         red_line_boundary_change_validation_request = create(:red_line_boundary_change_validation_request,
-                                                             planning_application:)
+          planning_application:)
 
         expect(red_line_boundary_change_validation_request.original_geojson).to eq(planning_application.boundary_geojson)
       end

--- a/spec/models/replacement_document_validation_request_spec.rb
+++ b/spec/models/replacement_document_validation_request_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe ReplacementDocumentValidationRequest do
           expect do
             replacement_document_validation_request
           end.not_to raise_error(ValidationRequestable::ValidationRequestNotCreatableError,
-                                 "Cannot create Replacement Document Validation Request when planning application has been validated")
+            "Cannot create Replacement Document Validation Request when planning application has been validated")
         end
       end
     end

--- a/spec/models/validation_requestable_spec.rb
+++ b/spec/models/validation_requestable_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ValidationRequestable do
     end
 
     %w[additional_document other_change red_line_boundary_change
-       replacement_document].each do |request_type|
+      replacement_document].each do |request_type|
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "pending", %i[open cancelled]
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "open", %i[cancelled closed]
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "cancelled", %i[]
@@ -43,7 +43,7 @@ RSpec.describe ValidationRequestable do
 
           expect { request.cancel! }
             .to change(request, :state).from("pending").to("cancelled")
-                                       .and change(request, :cancelled_at).from(nil).to(Time.current)
+            .and change(request, :cancelled_at).from(nil).to(Time.current)
         end
       end
     end
@@ -68,7 +68,7 @@ RSpec.describe ValidationRequestable do
       it "returns non cancelled replacement document requests" do
         expect(ReplacementDocumentValidationRequest.not_cancelled).to match_array(
           [replacement_document_validation_request1, replacement_document_validation_request2,
-           replacement_document_validation_request3]
+            replacement_document_validation_request3]
         )
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe ValidationRequestable do
 
           expect { request.cancel_request! }
             .to change(request, :cancelled_at).from(nil).to(Time.current)
-                                              .and change(request, :state).from("pending").to("cancelled")
+            .and change(request, :state).from("pending").to("cancelled")
 
           expect(Audit.last).to have_attributes(
             planning_application_id: request.planning_application.id,

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -152,28 +152,28 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       [
         {
           question: "Question 1",
-          responses: [{ value: "Answer 1" }],
-          metadata: { section_name: "Fee Related Group" }
+          responses: [{value: "Answer 1"}],
+          metadata: {section_name: "Fee Related Group"}
         },
         {
           question: "Question 2",
-          responses: [{ value: "Answer 2" }],
-          metadata: { section_name: "group-about-fee" }
+          responses: [{value: "Answer 2"}],
+          metadata: {section_name: "group-about-fee"}
         },
         {
           question: "Question 3",
-          responses: [{ value: "Answer 3" }],
-          metadata: { section_name: "a_fee_group" }
+          responses: [{value: "Answer 3"}],
+          metadata: {section_name: "a_fee_group"}
         },
         {
           question: "Question 4",
-          responses: [{ value: "Answer 4" }],
-          metadata: { section_name: "Other Group" }
+          responses: [{value: "Answer 4"}],
+          metadata: {section_name: "Other Group"}
         },
         {
           question: "Question 5",
-          responses: [{ value: "Answer 5" }],
-          metadata: { section_name: "Birdfeed Related" }
+          responses: [{value: "Answer 5"}],
+          metadata: {section_name: "Birdfeed Related"}
         }
       ].to_json
     end

--- a/spec/requests/api/additional_document_validation_request_patch_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_patch_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
 
   let!(:additional_document_validation_request) do
     create(:additional_document_validation_request,
-           planning_application:)
+      planning_application:)
   end
 
   let(:path) do
@@ -39,7 +39,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
   end
 
   let(:headers) do
-    { Authorization: "Bearer #{api_user.token}" }
+    {Authorization: "Bearer #{api_user.token}"}
   end
 
   it "successfully accepts a new document" do
@@ -79,21 +79,21 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
 
   it "rejects wrong document types" do
     patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: { files: [fixture_file_upload("../images/proposed-floorplan.png", "application/octet-stream")] },
-          headers: { Authorization: "Bearer #{api_user.token}" }
+      params: {files: [fixture_file_upload("../images/proposed-floorplan.png", "application/octet-stream")]},
+      headers: {Authorization: "Bearer #{api_user.token}"}
 
     expect(response).not_to be_successful
-    expect(json).to eq({ "message" => "The file type must be JPEG, PNG or PDF" })
+    expect(json).to eq({"message" => "The file type must be JPEG, PNG or PDF"})
 
     expect(additional_document_validation_request).to be_open
   end
 
   it "returns a 400 if the new document is missing" do
     patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: { files: "" },
-          headers: { Authorization: "Bearer #{api_user.token}" }
+      params: {files: ""},
+      headers: {Authorization: "Bearer #{api_user.token}"}
 
-    expect(json).to eq({ "message" => "At least one file must be selected to proceed." })
+    expect(json).to eq({"message" => "At least one file must be selected to proceed."})
     expect(response).to have_http_status(:bad_request)
   end
 
@@ -102,10 +102,10 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
     allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
 
     patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: { files: [file] },
-          headers: { Authorization: "Bearer #{api_user.token}" }
+      params: {files: [file]},
+      headers: {Authorization: "Bearer #{api_user.token}"}
 
-    expect(json).to eq({ "message" => "The file: 'proposed-floorplan.png' exceeds the limit of 30mb. Each file must be 30MB or less" })
+    expect(json).to eq({"message" => "The file: 'proposed-floorplan.png' exceeds the limit of 30mb. Each file must be 30MB or less"})
     expect(response).to have_http_status(:payload_too_large)
   end
 end

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
     context "when the request is successful" do
       it "retrieves all additional document validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(sort_by_id(json["data"])).to eq(
@@ -95,7 +95,7 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
     context "when the request is successful" do
       it "retrieves a additional document validation request for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(json).to eq(

--- a/spec/requests/api/description_change_validation_request_put_spec.rb
+++ b/spec/requests/api/description_change_validation_request_put_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   let(:params) do
     {
       change_access_id: planning_application.change_access_id,
-      data: { approved: true }
+      data: {approved: true}
     }
   end
 
   let(:headers) do
-    { Authorization: "Bearer #{api_user.token}" }
+    {Authorization: "Bearer #{api_user.token}"}
   end
 
   let!(:default_local_authority) { create(:local_authority, :default) }
@@ -33,8 +33,8 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
 
   let!(:description_change_validation_request) do
     create(:description_change_validation_request,
-           planning_application:,
-           proposed_description: "new roof")
+      planning_application:,
+      proposed_description: "new roof")
   end
 
   approved_json = '{
@@ -87,7 +87,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
 
     expect(planning_application.audits.reload.last).to have_attributes(
       activity_type: "description_change_validation_request_received",
-      audit_comment: { response: "approved" }.to_json,
+      audit_comment: {response: "approved"}.to_json,
       activity_information: "1",
       api_user:
     )
@@ -95,8 +95,8 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
 
   it "successfully accepts a rejection" do
     patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: rejected_json,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: rejected_json,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to be_successful
 
@@ -105,30 +105,30 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
     expect(description_change_validation_request.approved).to be(false)
     expect(description_change_validation_request.rejection_reason).to eq("The description is unclear")
     expect(Audit.all.last.activity_type).to eq("description_change_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq({ response: "rejected", reason: "The description is unclear" }.to_json)
+    expect(Audit.all.last.audit_comment).to eq({response: "rejected", reason: "The description is unclear"}.to_json)
     expect(Audit.all.last.activity_information).to eq("1")
   end
 
   it "returns a 400 if the rejection is missing a rejection reason" do
     patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: rejected_json_missing_reason,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: rejected_json_missing_reason,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:bad_request)
   end
 
   it "returns a 401 if API key is wrong" do
     patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: approved_json,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER" }
+      params: approved_json,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
     expect(response).to have_http_status(:unauthorized)
   end
 
   it "returns a 401 if change_access_id is wrong" do
     patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=CHANGEISGOOD",
-          params: approved_json,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: approved_json,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/api/description_change_validation_request_spec.rb
+++ b/spec/requests/api/description_change_validation_request_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe "Description change validation requests API", show_exceptions: tr
       it "succeeds" do
         get(
           path,
-          params: { change_access_id: planning_application.change_access_id },
-          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          params: {change_access_id: planning_application.change_access_id},
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
         )
 
         expect(response).to be_successful
@@ -47,8 +47,8 @@ RSpec.describe "Description change validation requests API", show_exceptions: tr
         travel_to(DateTime.new(2022, 6, 20)) do
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
 
           expect(json["data"]).to contain_exactly(
@@ -94,8 +94,8 @@ RSpec.describe "Description change validation requests API", show_exceptions: tr
       it "is successful" do
         get(
           path,
-          params: { change_access_id: planning_application.change_access_id },
-          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          params: {change_access_id: planning_application.change_access_id},
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
         )
 
         expect(response).to be_successful
@@ -105,8 +105,8 @@ RSpec.describe "Description change validation requests API", show_exceptions: tr
         travel_to(DateTime.new(2022, 6, 20)) do
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
 
           expect(json).to eq(

--- a/spec/requests/api/document_tags_spec.rb
+++ b/spec/requests/api/document_tags_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "API request to show document tags", show_exceptions: true do
       expect(response).to be_successful
 
       expect(json).to eq({
-                           "tags" => Document::TAGS,
-                           "evidence_tags" => Document::EVIDENCE_TAGS,
-                           "plan_tags" => Document::PLAN_TAGS
-                         })
+        "tags" => Document::TAGS,
+        "evidence_tags" => Document::EVIDENCE_TAGS,
+        "plan_tags" => Document::PLAN_TAGS
+      })
     end
   end
 end

--- a/spec/requests/api/local_authority_show_spec.rb
+++ b/spec/requests/api/local_authority_show_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "API request to show a local authority", show_exceptions: true do
     it "returns a 404 if local authority not there" do
       get "/api/v1/local_authorities/xxx"
       expect(response.code).to eq("404")
-      expect(local_authority_json).to eq({ "message" => "Unable to find record" })
+      expect(local_authority_json).to eq({"message" => "Unable to find record"})
     end
 
     it "returns the accurate data" do

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
   end
 
   let(:headers) do
-    { "CONTENT-TYPE": "application/json",
-      Authorization: "Bearer #{api_user.token}" }
+    {"CONTENT-TYPE": "application/json",
+     Authorization: "Bearer #{api_user.token}"}
   end
 
   it "successfully creates a new neighbour response" do

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
     document.paths[path][http_method].responses[response_code.to_s].content["application/json"].examples[example_name].value.to_h.to_json
   end
 
-  def example_response_hash_for(*attrs)
-    JSON.parse(example_response_json_for(*attrs))
+  def example_response_hash_for(*)
+    JSON.parse(example_response_json_for(*))
   end
 
   it "is a valid oas3 document" do
@@ -36,12 +36,12 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
       .to_return(
         status: 200,
         body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
-        headers: { "Content-Type" => "application/pdf" }
+        headers: {"Content-Type" => "application/pdf"}
       )
     expect do
       post "/api/v1/planning_applications",
-           params: example_request_json_for("/api/v1/planning_applications", "post", "ldc_proposed"),
-           headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+        params: example_request_json_for("/api/v1/planning_applications", "post", "ldc_proposed"),
+        headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     end.to change(PlanningApplication, :count).by(1)
     expect(response.code).to eq("200")
     expect(PlanningApplication.last.application_type.name).to eq("lawfulness_certificate")
@@ -77,21 +77,21 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
   it "successfully returns the listing of applications as specified" do
     travel_to(DateTime.new(2020, 5, 14))
     planning_application_hash = example_response_hash_for("/api/v1/planning_applications", "get", 200,
-                                                          "ldc_proposed")["data"].first
+      "ldc_proposed")["data"].first
 
     planning_application = PlanningApplication.create! planning_application_hash.except("reference", "reference_in_full",
-                                                                                        "received_date", "documents", "site", "constraints",
-                                                                                        "application_type").merge(
-                                                                                          local_authority:
-                                                                                          default_local_authority,
-                                                                                          old_constraints: planning_application_hash["constraints"],
-                                                                                          application_type_id: ApplicationType.first.id
-                                                                                        )
+      "received_date", "documents", "site", "constraints",
+      "application_type").merge(
+        local_authority:
+        default_local_authority,
+        old_constraints: planning_application_hash["constraints"],
+        application_type_id: ApplicationType.first.id
+      )
 
     planning_application.update!(planning_application_hash["site"])
     planning_application_document = planning_application.documents.create!(planning_application_hash.fetch("documents").first.except("url", "blob_url")) do |document|
       document.file.attach(io: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").open,
-                           filename: "roofplan")
+        filename: "roofplan")
       document.publishable = true
     end
 
@@ -112,22 +112,22 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
     travel_to(DateTime.new(2020, 5, 14))
     planning_application_hash = example_response_hash_for("/api/v1/planning_applications/{id}", "get", 200, "ldc_proposed")
     planning_application = PlanningApplication.create! planning_application_hash.except("reference", "reference_in_full", "status",
-                                                                                        "received_date", "documents", "site", "constraints",
-                                                                                        "application_type").merge(
-                                                                                          local_authority: default_local_authority,
-                                                                                          old_constraints: planning_application_hash["constraints"],
-                                                                                          application_type_id: ApplicationType.first.id,
-                                                                                          status: "in_assessment",
-                                                                                          validated_at: Time.zone.now
-                                                                                        )
+      "received_date", "documents", "site", "constraints",
+      "application_type").merge(
+        local_authority: default_local_authority,
+        old_constraints: planning_application_hash["constraints"],
+        application_type_id: ApplicationType.first.id,
+        status: "in_assessment",
+        validated_at: Time.zone.now
+      )
     planning_application.update!(planning_application_hash["site"])
     planning_application_document = planning_application.documents.create!(planning_application_hash.fetch("documents").first.except("url", "blob_url")) do |document|
       document.file.attach(io: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").open,
-                           filename: "roofplan")
+        filename: "roofplan")
       document.publishable = true
     end
 
-    get "/api/v1/planning_applications/#{planning_application_hash['id']}"
+    get "/api/v1/planning_applications/#{planning_application_hash["id"]}"
 
     expected_response = example_response_hash_for("/api/v1/planning_applications/{id}", "get", 200, "ldc_proposed")
     expected_response["status"] = "in_assessment"

--- a/spec/requests/api/other_change_validation_request_put_spec.rb
+++ b/spec/requests/api/other_change_validation_request_put_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   let(:params) do
     {
       change_access_id: planning_application.change_access_id,
-      data: { response: "I will send an extra payment" }
+      data: {response: "I will send an extra payment"}
     }
   end
 
   let(:headers) do
-    { Authorization: "Bearer #{api_user.token}" }
+    {Authorization: "Bearer #{api_user.token}"}
   end
 
   let!(:default_local_authority) { create(:local_authority, :default) }
@@ -34,7 +34,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
 
   let!(:other_change_validation_request) do
     create(:other_change_validation_request,
-           planning_application:)
+      planning_application:)
   end
 
   valid_response = '{
@@ -65,7 +65,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
 
     expect(planning_application.audits.reload.last).to have_attributes(
       activity_type: "other_change_validation_request_received",
-      audit_comment: { response: "I will send an extra payment" }.to_json,
+      audit_comment: {response: "I will send an extra payment"}.to_json,
       activity_information: "1",
       api_user:
     )
@@ -85,24 +85,24 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
 
   it "returns a 400 if the update is missing a response" do
     patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: missing_response,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: missing_response,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:bad_request)
   end
 
   it "returns a 401 if API key is wrong" do
     patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: valid_response,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER" }
+      params: valid_response,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
     expect(response).to have_http_status(:unauthorized)
   end
 
   it "returns a 401 if change_access_id is wrong" do
     patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=CHANGEISGOOD",
-          params: valid_response,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: valid_response,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
     context "when the request is successful" do
       it "retrieves all other change validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(sort_by_id(json["data"])).to eq(
@@ -87,7 +87,7 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
     context "when the request is successful" do
       it "retrieves an other change validation request for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(json).to eq(

--- a/spec/requests/api/planning_application_list_spec.rb
+++ b/spec/requests/api/planning_application_list_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
           expect(planning_application_json["documents"].size).to eq(1)
           expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(
-                                                                              planning_application, document_with_number
-                                                                            ))
+            planning_application, document_with_number
+          ))
           expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document_with_number.created_at))
           expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document_with_number.archived_at))
           expect(planning_application_json["documents"].first["archive_reason"]).to eq(document_with_number.archive_reason)

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -38,13 +38,13 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
     it "returns a 404 if no planning application" do
       get "/api/v1/planning_applications/xxx"
       expect(response.code).to eq("404")
-      expect(planning_application_json).to eq({ "message" => "Unable to find record" })
+      expect(planning_application_json).to eq({"message" => "Unable to find record"})
     end
 
     it "returns 404 if planning application is from another authority" do
       get "/api/v1/planning_applications/#{planning_application_lambeth.id}"
       expect(response.code).to eq("404")
-      expect(planning_application_json).to eq({ "message" => "Unable to find record" })
+      expect(planning_application_json).to eq({"message" => "Unable to find record"})
     end
 
     context "with a new planning application" do
@@ -137,8 +137,8 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["constraints"]).to eq(planning_application.old_constraints)
           expect(planning_application_json["documents"].size).to eq(1)
           expect(planning_application_json["documents"].first["url"]).to eq(api_v1_planning_application_document_url(
-                                                                              planning_application, document_with_number
-                                                                            ))
+            planning_application, document_with_number
+          ))
           expect(planning_application_json["documents"].first["created_at"]).to eq(json_time_format(document_with_number.created_at))
           expect(planning_application_json["documents"].first["archived_at"]).to eq(json_time_format(document_with_number.archived_at))
           expect(planning_application_json["documents"].first["archive_reason"]).to eq(document_with_number.archive_reason)

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
         .to_return(
           status: 200,
           body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
-          headers: { "Content-Type" => "application/pdf" }
+          headers: {"Content-Type" => "application/pdf"}
         )
     end
 
@@ -44,14 +44,14 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
       end
 
       it "returns 401 if user is not authenticated" do
-        post_with(params: json, headers: { Authorization: "Bearer dasfdsafdsaf" })
+        post_with(params: json, headers: {Authorization: "Bearer dasfdsafdsaf"})
 
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "renders failure message" do
         post "/api/v1/planning_applications", params: json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
         expect(response.body).to eq("{\"message\":\"Validation failed: Application type must exist, An applicant or agent email is required.\"}")
       end
     end
@@ -147,26 +147,26 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
 
       it "downloads and saves the plan against the planning application" do
         post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
         expect(PlanningApplication.last.documents.first.file).to be_present
       end
 
       it "returns a 200 response" do
         post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
         expect(response).to have_http_status(:ok)
       end
 
       it "renders success message" do
         post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
-        expect(response.body).to eq({ id: PlanningApplication.all[0].reference.to_s,
-                                      message: "Application created" }.to_json)
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
+        expect(response.body).to eq({id: PlanningApplication.all[0].reference.to_s,
+                                     message: "Application created"}.to_json)
       end
 
       it "returns 401 if user is not authenticated" do
         post "/api/v1/planning_applications", params: permitted_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer dasfdsafdsaf" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer dasfdsafdsaf"}
         expect(response).to have_http_status(:unauthorized)
       end
     end
@@ -177,32 +177,32 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
 
       it "saves a valid planning application" do
         post "/api/v1/planning_applications", params: minimal_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
         expect(PlanningApplication.all[0]).to be_valid
       end
 
       it "returns a 200 response" do
         post "/api/v1/planning_applications", params: minimal_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
         expect(response).to have_http_status(:ok)
       end
 
       it "renders success message" do
         post "/api/v1/planning_applications", params: minimal_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
-        expect(response.body).to eq({ id: PlanningApplication.all[0].reference.to_s,
-                                      message: "Application created" }.to_json)
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
+        expect(response.body).to eq({id: PlanningApplication.all[0].reference.to_s,
+                                     message: "Application created"}.to_json)
       end
 
       it "returns 401 if user is not authenticated" do
         post "/api/v1/planning_applications", params: minimal_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer dasfdsafdsaf" }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer dasfdsafdsaf"}
         expect(response).to have_http_status(:unauthorized)
       end
 
       it "returns 401 if no authorization is supplied" do
         post "/api/v1/planning_applications", params: minimal_development_json,
-                                              headers: { "CONTENT-TYPE": "application/json" }
+          headers: {"CONTENT-TYPE": "application/json"}
         expect(response).to have_http_status(:unauthorized)
         expect(response.body).to eq('{"error":"HTTP Token: Access denied."}')
       end
@@ -233,7 +233,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
   context "with the wrong type of document" do
     before do
       stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
-        .to_return(status: 200, body: "some document", headers: { "Content-Type" => "application/octet-stream" })
+        .to_return(status: 200, body: "some document", headers: {"Content-Type" => "application/octet-stream"})
     end
 
     context "when passed a request with the minimal parameters" do

--- a/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   let(:params) do
     {
       change_access_id: planning_application.change_access_id,
-      data: { approved: true }
+      data: {approved: true}
     }
   end
 
   let(:headers) do
-    { Authorization: "Bearer #{api_user.token}" }
+    {Authorization: "Bearer #{api_user.token}"}
   end
 
   let!(:api_user) { create(:api_user) }
@@ -35,7 +35,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
   let!(:red_line_boundary_change_validation_request) do
     create(:red_line_boundary_change_validation_request,
-           planning_application:)
+      planning_application:)
   end
 
   rejected_json = '{
@@ -70,7 +70,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
     expect(planning_application.audits.reload.last).to have_attributes(
       activity_type: "red_line_boundary_change_validation_request_received",
-      audit_comment: { response: "approved" }.to_json,
+      audit_comment: {response: "approved"}.to_json,
       activity_information: "1",
       api_user:
     )
@@ -90,8 +90,8 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
   it "successfully accepts a rejection" do
     patch "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: rejected_json,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: rejected_json,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to be_successful
 
@@ -100,14 +100,14 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     expect(red_line_boundary_change_validation_request.approved).to be(false)
     expect(red_line_boundary_change_validation_request.rejection_reason).to eq("The boundary is incorrect")
     expect(Audit.all.last.activity_type).to eq("red_line_boundary_change_validation_request_received")
-    expect(Audit.all.last.audit_comment).to eq({ response: "rejected", reason: "The boundary is incorrect" }.to_json)
+    expect(Audit.all.last.audit_comment).to eq({response: "rejected", reason: "The boundary is incorrect"}.to_json)
     expect(Audit.all.last.activity_information).to eq("1")
   end
 
   it "returns a 400 if params are missing" do
     patch "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: rejected_json_missing_reason,
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: rejected_json_missing_reason,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:bad_request)
   end

--- a/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
     context "when the request is successful" do
       it "retrieves all red line boundary change validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(sort_by_id(json["data"])).to eq(
@@ -77,7 +77,7 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
     context "when the request is successful" do
       it "retrieves a red line boundary change validation request for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
 
         expect(response).to be_successful
         expect(json).to eq(

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
   let!(:replacement_document_validation_request) do
     create(:replacement_document_validation_request,
-           planning_application:,
-           old_document: document)
+      planning_application:,
+      old_document: document)
   end
 
   let(:path) do
@@ -53,7 +53,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   let(:headers) do
-    { Authorization: "Bearer #{api_user.token}" }
+    {Authorization: "Bearer #{api_user.token}"}
   end
 
   it "successfully accepts a new document and archives the old document" do
@@ -86,9 +86,9 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     patch(path, params:, headers:)
 
     audit = planning_application
-            .audits
-            .where(activity_type: "replacement_document_validation_request_received")
-            .last
+      .audits
+      .where(activity_type: "replacement_document_validation_request_received")
+      .last
 
     expect(audit).to have_attributes(
       audit_comment: "proposed-floorplan.png",
@@ -101,9 +101,9 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     patch(path, params:, headers:)
 
     audit = planning_application
-            .audits
-            .where(activity_type: "uploaded")
-            .last
+      .audits
+      .where(activity_type: "uploaded")
+      .last
 
     expect(audit).to have_attributes(
       activity_information: "proposed-floorplan.png",
@@ -125,8 +125,8 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
   it "rejects wrong document types" do
     patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: { new_file: fixture_file_upload("../images/proposed-floorplan.png", "image/gif") },
-          headers: { Authorization: "Bearer #{api_user.token}" }
+      params: {new_file: fixture_file_upload("../images/proposed-floorplan.png", "image/gif")},
+      headers: {Authorization: "Bearer #{api_user.token}"}
 
     expect(response).not_to be_successful
 
@@ -135,8 +135,8 @@ RSpec.describe "API request to patch document validation requests", show_excepti
 
   it "returns a 400 if the new document is missing" do
     patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: "{}",
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: "{}",
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:bad_request)
   end
@@ -146,10 +146,10 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
 
     patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
-          params: { new_file: file },
-          headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      params: {new_file: file},
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
-    expect(json).to eq({ "message" => "The file must be smaller than 30MB" })
+    expect(json).to eq({"message" => "The file must be smaller than 30MB"})
     expect(response).to have_http_status(:payload_too_large)
   end
 end

--- a/spec/requests/api/replacement_document_validation_request_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
       it "is successful" do
         get(
           path,
-          params: { change_access_id: planning_application.change_access_id },
-          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          params: {change_access_id: planning_application.change_access_id},
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
         )
 
         expect(response).to be_successful
@@ -74,8 +74,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
         travel_to(DateTime.new(2022, 1, 2)) do
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
         end
 
@@ -158,8 +158,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
       it "is successful" do
         get(
           path,
-          params: { change_access_id: planning_application.change_access_id },
-          headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+          params: {change_access_id: planning_application.change_access_id},
+          headers: {"CONTENT-TYPE": "application/json", Authorization: token}
         )
 
         expect(response).to be_successful
@@ -169,8 +169,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
         travel_to(DateTime.new(2022, 1, 2)) do
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
         end
 
@@ -201,8 +201,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
         it "is successful" do
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
 
           expect(response).to be_successful
@@ -212,8 +212,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
           travel_to(DateTime.new(2022, 1, 2)) do
             get(
               path,
-              params: { change_access_id: planning_application.change_access_id },
-              headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+              params: {change_access_id: planning_application.change_access_id},
+              headers: {"CONTENT-TYPE": "application/json", Authorization: token}
             )
           end
 
@@ -241,8 +241,8 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
 
           get(
             path,
-            params: { change_access_id: planning_application.change_access_id },
-            headers: { "CONTENT-TYPE": "application/json", Authorization: token }
+            params: {change_access_id: planning_application.change_access_id},
+            headers: {"CONTENT-TYPE": "application/json", Authorization: token}
           )
         end
       end

--- a/spec/requests/api/validation_request_list_spec.rb
+++ b/spec/requests/api/validation_request_list_spec.rb
@@ -18,55 +18,55 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
 
   it "lists the all description validation requests that exist on the planning application" do
     get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["description_change_validation_requests"]).to eq([{
-                                                                           "id" => description_change_validation_request.id,
-                                                                           "type" => "description_change_validation_request",
-                                                                           "state" => "open",
-                                                                           "response_due" => description_change_validation_request.response_due.to_fs(:db),
-                                                                           "proposed_description" => description_change_validation_request.proposed_description,
-                                                                           "previous_description" => description_change_validation_request.previous_description,
-                                                                           "approved" => nil,
-                                                                           "rejection_reason" => nil,
-                                                                           "days_until_response_due" => description_change_validation_request.days_until_response_due,
-                                                                           "cancel_reason" => nil,
-                                                                           "cancelled_at" => nil
-                                                                         }])
+      "id" => description_change_validation_request.id,
+      "type" => "description_change_validation_request",
+      "state" => "open",
+      "response_due" => description_change_validation_request.response_due.to_fs(:db),
+      "proposed_description" => description_change_validation_request.proposed_description,
+      "previous_description" => description_change_validation_request.previous_description,
+      "approved" => nil,
+      "rejection_reason" => nil,
+      "days_until_response_due" => description_change_validation_request.days_until_response_due,
+      "cancel_reason" => nil,
+      "cancelled_at" => nil
+    }])
   end
 
   it "lists the all document validation requests that exist on the planning application" do
     get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["replacement_document_validation_requests"].first).to include({
-                                                                                        "id" => replacement_document_validation_request.id,
-                                                                                        "state" => "closed",
-                                                                                        "response_due" => replacement_document_validation_request.response_due.strftime("%Y-%m-%d"),
-                                                                                        "days_until_response_due" => replacement_document_validation_request.days_until_response_due,
-                                                                                        "old_document" => {
-                                                                                          "name" => replacement_document_validation_request.old_document.name.to_s,
-                                                                                          "invalid_document_reason" => "Document is invalid"
-                                                                                        },
-                                                                                        "type" => "replacement_document_validation_request"
-                                                                                      })
+      "id" => replacement_document_validation_request.id,
+      "state" => "closed",
+      "response_due" => replacement_document_validation_request.response_due.strftime("%Y-%m-%d"),
+      "days_until_response_due" => replacement_document_validation_request.days_until_response_due,
+      "old_document" => {
+        "name" => replacement_document_validation_request.old_document.name.to_s,
+        "invalid_document_reason" => "Document is invalid"
+      },
+      "type" => "replacement_document_validation_request"
+    })
     expect(json["data"]["replacement_document_validation_requests"].first["new_document"]["name"]).to eq("proposed-floorplan.png")
     expect(json["data"]["replacement_document_validation_requests"].first["new_document"]["url"]).to be_a(String)
   end
 
   it "lists the all document create requests that exist on the planning application" do
     get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["additional_document_validation_requests"].first).to include({
-                                                                                       "id" => additional_document_validation_request.id,
-                                                                                       "state" => "open",
-                                                                                       "response_due" => additional_document_validation_request.response_due.strftime("%Y-%m-%d"),
-                                                                                       "days_until_response_due" => additional_document_validation_request.days_until_response_due,
-                                                                                       "document_request_type" => additional_document_validation_request.document_request_type,
-                                                                                       "document_request_reason" => additional_document_validation_request.document_request_reason,
-                                                                                       "type" => "additional_document_validation_request"
-                                                                                     })
+      "id" => additional_document_validation_request.id,
+      "state" => "open",
+      "response_due" => additional_document_validation_request.response_due.strftime("%Y-%m-%d"),
+      "days_until_response_due" => additional_document_validation_request.days_until_response_due,
+      "document_request_type" => additional_document_validation_request.document_request_type,
+      "document_request_reason" => additional_document_validation_request.document_request_reason,
+      "type" => "additional_document_validation_request"
+    })
 
     expect(json["data"]["additional_document_validation_requests"].first["documents"][0]["name"]).to eq("proposed-floorplan.png")
     expect(json["data"]["additional_document_validation_requests"].first["documents"][0]["url"]).to be_a(String)
@@ -74,13 +74,13 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
 
   it "returns a 401 if API key is wrong" do
     get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer bipbopboop" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer bipbopboop"}
     expect(response).to have_http_status(:unauthorized)
   end
 
   it "returns a 401 if change_access_id is wrong" do
     get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=fffffff",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to have_http_status(:unauthorized)
   end
 end

--- a/spec/services/apis/plan_x/query_spec.rb
+++ b/spec/services/apis/plan_x/query_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe Apis::PlanX::Query do
   before do
     stub_request(:get,
-                 "https://api.editor.planx.uk/gis/opensystemslab").with(
-                   query: hash_including({ geom: /POLYGON/ })
-                 ).to_return(body: {}.to_json)
+      "https://api.editor.planx.uk/gis/opensystemslab").with(
+        query: hash_including({geom: /POLYGON/})
+      ).to_return(body: {}.to_json)
   end
 
   describe "#request" do

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         .to_return(
           status: 200,
           body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
-          headers: { "Content-Type" => "application/pdf" }
+          headers: {"Content-Type" => "application/pdf"}
         )
     end
 

--- a/spec/services/planning_application_search_spec.rb
+++ b/spec/services/planning_application_search_spec.rb
@@ -91,20 +91,20 @@ RSpec.describe PlanningApplicationSearch do
 
       it "returns correct planning applications" do
         expect(search.call).to eq([
-                                    prior_approval_not_started,
-                                    ldc_not_started,
-                                    prior_approval_in_assessment,
-                                    householder_application_for_planning_permission_in_assessment,
-                                    ldc_in_assessment_2,
-                                    ldc_in_assessment_1
-                                  ])
+          prior_approval_not_started,
+          ldc_not_started,
+          prior_approval_in_assessment,
+          householder_application_for_planning_permission_in_assessment,
+          ldc_in_assessment_2,
+          ldc_in_assessment_1
+        ])
       end
     end
 
     context "when is search with exclude_others" do
       let(:params) do
         ActionController::Parameters.new(
-          { view: "mine" }
+          {view: "mine"}
         )
       end
 

--- a/spec/services/upload_documents_service_spec.rb
+++ b/spec/services/upload_documents_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe UploadDocumentsService, type: :service do
       {
         status: 200,
         body: File.open(file_path),
-        headers: { "Content-Type": "image/png" }
+        headers: {"Content-Type": "image/png"}
       }
     end
 

--- a/spec/support/api/bops_helpers.rb
+++ b/spec/support/api/bops_helpers.rb
@@ -16,7 +16,7 @@ module BopsHelper
 
     body = Rails.root.join("spec/fixtures/files/planx_params.json").read
 
-    { status:, body: }
+    {status:, body:}
   end
 end
 

--- a/spec/support/api/mapit_helpers.rb
+++ b/spec/support/api/mapit_helpers.rb
@@ -15,14 +15,14 @@ module MapitHelper
     status = Rack::Utils.status_code(status)
 
     body = if block
-             yield
-           elsif body == "no_result"
-             []
-           else
-             Rails.root.join("spec", "fixtures", "mapit", "#{body}.json").read
-           end
+      yield
+    elsif body == "no_result"
+      []
+    else
+      Rails.root.join("spec", "fixtures", "mapit", "#{body}.json").read
+    end
 
-    { status:, body: }
+    {status:, body:}
   end
 end
 

--- a/spec/support/api/os_places_helper.rb
+++ b/spec/support/api/os_places_helper.rb
@@ -22,7 +22,7 @@ module OsPlacesHelper
 
     body = "{'results': [{'address': '123 place'}]}"
 
-    { status:, body: }
+    {status:, body:}
   end
 
   def mock_csrf_token(token = "mock")

--- a/spec/support/api/paapi_helpers.rb
+++ b/spec/support/api/paapi_helpers.rb
@@ -11,12 +11,12 @@ module PaapiHelper
     status = Rack::Utils.status_code(status)
 
     body = if body == "no_result"
-             []
-           else
-             Rails.root.join("spec", "fixtures", "paapi", "#{body}.json").read
-           end
+      []
+    else
+      Rails.root.join("spec", "fixtures", "paapi", "#{body}.json").read
+    end
 
-    { status:, body: }
+    {status:, body:}
   end
 end
 

--- a/spec/support/api/planning_data_helpers.rb
+++ b/spec/support/api/planning_data_helpers.rb
@@ -12,7 +12,7 @@ module PlanningDataHelper
 
     body = Rails.root.join("spec", "fixtures", "planning_data", "#{body}.json").read
 
-    { status:, body: }
+    {status:, body:}
   end
 end
 

--- a/spec/support/api/request_shared_examples.rb
+++ b/spec/support/api/request_shared_examples.rb
@@ -5,27 +5,27 @@ require "rails_helper"
 RSpec.shared_examples "ApiRequest::Forbidden" do
   it "returns a 401 if API key is invalid" do
     get "#{path}?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "invalidtoken" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "invalidtoken"}
 
     expect(response).to have_http_status(:unauthorized)
-    expect(json).to eq({ "error" => "HTTP Token: Access denied." })
+    expect(json).to eq({"error" => "HTTP Token: Access denied."})
   end
 
   it "returns a 401 if change_access_id is invalid" do
     get "#{path}?change_access_id=invalidchangeaccessid",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:unauthorized)
-    expect(json).to eq({ "message" => "Change access id is invalid" })
+    expect(json).to eq({"message" => "Change access id is invalid"})
   end
 end
 
 RSpec.shared_examples "ApiRequest::NotFound" do |entity|
   it "returns a 404" do
     get "#{path}?change_access_id=#{planning_application.change_access_id}",
-        headers: { "CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}" }
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
     expect(response).to have_http_status(:not_found)
-    expect(json).to eq({ "message" => "Unable to find #{entity.humanize.downcase} with id: #{send(entity).id + 1}" })
+    expect(json).to eq({"message" => "Unable to find #{entity.humanize.downcase} with id: #{send(entity).id + 1}"})
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
     Capybara.automatic_label_click = true
     Capybara.enable_aria_label = true
     Capybara.ignore_hidden_elements = false
-    Capybara.server = :puma, { Silent: true }
+    Capybara.server = :puma, {Silent: true}
   end
 
   config.before type: :system do

--- a/spec/support/notify_helpers.rb
+++ b/spec/support/notify_helpers.rb
@@ -12,7 +12,7 @@ module NotifyHelper
   def sms_notification_api_response(status, body = "{}")
     status = Rack::Utils.status_code(status)
 
-    { status:, body: }
+    {status:, body:}
   end
 
   def stub_post_sms_notification(phone_number:, otp:, status:)
@@ -33,8 +33,8 @@ module NotifyHelper
   end
 
   def stub_send_letter(status:)
-    body = { status_code: status }
-    body[:errors] = [{ error: "Exception", message: "Internal server error" }] if status >= 400
+    body = {status_code: status}
+    body[:errors] = [{error: "Exception", message: "Internal server error"}] if status >= 400
 
     stub_request(:post, LETTER_URL)
       .with do |request|

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -26,7 +26,7 @@ module SystemSpecHelpers
   end
 
   def pick(value, from:)
-    listbox = "ul[@id='#{from.delete_prefix('#')}__listbox']"
+    listbox = "ul[@id='#{from.delete_prefix("#")}__listbox']"
     option = "li[@role='option' and normalize-space(.)='#{value}']"
 
     find(:xpath, "//#{listbox}/#{option}").click

--- a/spec/support/validation_request_shared_examples.rb
+++ b/spec/support/validation_request_shared_examples.rb
@@ -102,7 +102,7 @@ RSpec.shared_examples "ValidationRequest" do |klass, request_type|
           expect do
             request.destroy!
           end.to raise_error(ValidationRequestable::NotDestroyableError,
-                             "Only requests that are pending can be destroyed")
+            "Only requests that are pending can be destroyed")
         end
       end
     end

--- a/spec/support/validation_requests_shared_examples.rb
+++ b/spec/support/validation_requests_shared_examples.rb
@@ -51,7 +51,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
         params = {
           id: request.id,
           planning_application_id: request.planning_application.id,
-          "#{request_type}": { cancel_reason: "my mistake" }
+          "#{request_type}": {cancel_reason: "my mistake"}
         }
 
         patch(:cancel, params:)
@@ -65,13 +65,13 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
         params = {
           id: request.id,
           planning_application_id: request.planning_application.id,
-          "#{request_type}": { cancel_reason: "" }
+          "#{request_type}": {cancel_reason: ""}
         }
 
         patch(:cancel, params:)
 
         expect(response).to redirect_to send("cancel_confirmation_planning_application_#{request_type}_path",
-                                             planning_application, request)
+          planning_application, request)
       end
 
       it "when state is not pending/open it redirects back to the cancel_confirmation page" do
@@ -80,13 +80,13 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
         params = {
           id: request.id,
           planning_application_id: request.planning_application.id,
-          "#{request_type}": { cancel_reason: request.cancel_reason }
+          "#{request_type}": {cancel_reason: request.cancel_reason}
         }
 
         patch(:cancel, params:)
 
         expect(response).to redirect_to send("cancel_confirmation_planning_application_#{request_type}_path",
-                                             planning_application, request)
+          planning_application, request)
       end
     end
   end

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Documents index page" do
 
   let!(:planning_application) do
     create(:planning_application,
-           local_authority: default_local_authority,
-           address_1: "Elm Grove")
+      local_authority: default_local_authority,
+      address_1: "Elm Grove")
   end
 
   let(:document_tags) do
@@ -19,32 +19,32 @@ RSpec.describe "Documents index page" do
 
   let!(:document) do
     create(:document, :with_file,
-           planning_application:,
-           tags: document_tags)
+      planning_application:,
+      tags: document_tags)
   end
 
   let!(:not_started_planning_application) do
     create(:planning_application, :not_started,
-           local_authority: default_local_authority,
-           address_1: "Elm Grove")
+      local_authority: default_local_authority,
+      address_1: "Elm Grove")
   end
 
   let!(:not_started_document) do
     create(:document, :with_file,
-           planning_application: not_started_planning_application,
-           tags: document_tags)
+      planning_application: not_started_planning_application,
+      tags: document_tags)
   end
 
   let!(:awaiting_determination_planning_application) do
     create(:planning_application, :awaiting_determination,
-           local_authority: default_local_authority,
-           address_1: "Elm Grove")
+      local_authority: default_local_authority,
+      address_1: "Elm Grove")
   end
 
   let!(:awaiting_document) do
     create(:document, :with_file,
-           planning_application: awaiting_determination_planning_application,
-           tags: document_tags)
+      planning_application: awaiting_determination_planning_application,
+      tags: document_tags)
   end
 
   context "as a user who is not logged in" do
@@ -221,7 +221,7 @@ RSpec.describe "Documents index page" do
   context "with an associated replacement document validation request" do
     let!(:replacement_document_validation_request) do
       create(:replacement_document_validation_request, planning_application: not_started_planning_application,
-                                                       old_document: not_started_document)
+        old_document: not_started_document)
     end
 
     before do

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Edit document numbers page" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) do
     create(:planning_application,
-           local_authority: default_local_authority)
+      local_authority: default_local_authority)
   end
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -20,17 +20,17 @@ RSpec.describe "Edit document numbers page" do
 
       let!(:proposed_document_1) do
         create(:document, :with_file, :with_tags,
-               planning_application:)
+          planning_application:)
       end
 
       let!(:proposed_document_2) do
         create(:document, :with_file,
-               planning_application:)
+          planning_application:)
       end
 
       let!(:archived_document) do
         create(:document, :with_file, :archived,
-               planning_application:)
+          planning_application:)
       end
 
       before do

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Edit document" do
 
   let!(:document) do
     create(:document, :with_file, planning_application:,
-                                  applicant_description: "This file shows the drawing")
+      applicant_description: "This file shows the drawing")
   end
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Documents index page" do
 
   let!(:planning_application) do
     create(:planning_application,
-           local_authority: default_local_authority,
-           address_1: "7 Elm Grove")
+      local_authority: default_local_authority,
+      address_1: "7 Elm Grove")
   end
 
   let!(:document) do
@@ -121,11 +121,11 @@ RSpec.describe "Documents index page" do
     end
     let!(:invalid_document) do
       create(:document, :with_file, planning_application:,
-                                    validated: false, invalidated_document_reason: "Document is invalid")
+        validated: false, invalidated_document_reason: "Document is invalid")
     end
     let!(:replacement_document_validation_request) do
       create(:replacement_document_validation_request, planning_application:,
-                                                       old_document: invalid_document)
+        old_document: invalid_document)
     end
 
     before do

--- a/spec/system/documents/upload_spec.rb
+++ b/spec/system/documents/upload_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Document uploads" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) do
     create(:planning_application,
-           local_authority: default_local_authority,
-           decision: "granted")
+      local_authority: default_local_authority,
+      decision: "granted")
   end
 
   let!(:document) { create(:document, planning_application:) }

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Requesting a new document for a planning application" do
 
   it "displays the details of the received request in the audit log" do
     create(:audit, planning_application_id: planning_application.id,
-                   activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf", api_user:)
+      activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf", api_user:)
 
     sign_in assessor
     visit planning_application_path(planning_application)

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "neighbour responses" do
   let!(:application_type) { create(:application_type, name: :prior_approval) }
   let!(:planning_application) do
     create(:planning_application, :in_assessment, :from_planx_immunity, application_type:,
-                                                                        local_authority: default_local_authority)
+      local_authority: default_local_authority)
   end
 
   before do
@@ -123,7 +123,7 @@ RSpec.describe "neighbour responses" do
       expect(page).to have_link(
         "Edit summary of neighbour responses",
         href: edit_planning_application_assessment_detail_path(planning_application,
-                                                               AssessmentDetail.publicity_summary.last, category: "publicity_summary")
+          AssessmentDetail.publicity_summary.last, category: "publicity_summary")
       )
     end
   end

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "assessment against legislation" do
           expect(page).to have_content("Listed building outline")
 
           expect(page).to have_link("Edit constraints",
-                                    href: planning_application_constraints_path(planning_application))
+            href: planning_application_constraints_path(planning_application))
         end
       end
 
@@ -439,7 +439,7 @@ RSpec.describe "assessment against legislation" do
           expect(page).to have_content("Listed building outline")
 
           expect(page).not_to have_link("Edit constraints",
-                                        href: planning_application_constraints_path(planning_application))
+            href: planning_application_constraints_path(planning_application))
         end
       end
     end

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -137,22 +137,22 @@ RSpec.describe "Assessment tasks" do
       [
         {
           question: "Question 1",
-          responses: [{ value: "Answer 1" }],
-          metadata: { section_name: "About the property", auto_answered: true }
+          responses: [{value: "Answer 1"}],
+          metadata: {section_name: "About the property", auto_answered: true}
         },
         {
           question: "Question 2",
-          responses: [{ value: "Answer 2" }],
-          metadata: { section_name: "About the property" }
+          responses: [{value: "Answer 2"}],
+          metadata: {section_name: "About the property"}
         },
         {
           question: "Question 3",
-          responses: [{ value: "Answer 3" }],
-          metadata: { section_name: "group_1", auto_answered: true }
+          responses: [{value: "Answer 3"}],
+          metadata: {section_name: "group_1", auto_answered: true}
         },
         {
           question: "Question 4",
-          responses: [{ value: "Answer 4" }]
+          responses: [{value: "Answer 4"}]
         }
       ].to_json
     end

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -340,9 +340,9 @@ RSpec.describe "checking consistency" do
     )
 
     request = planning_application
-              .description_change_validation_requests
-              .open
-              .last
+      .description_change_validation_requests
+      .open
+      .last
 
     request.close!
     request.update!(approved: true)

--- a/spec/system/planning_applications/assessing/constraints_spec.rb
+++ b/spec/system/planning_applications/assessing/constraints_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe "Constraints" do
 
       click_button "Other constraints"
 
-      find_checkbox_by_id("constraint_id_#{Constraint.find_by(type: 'monument').id}").click
-      find_checkbox_by_id("constraint_id_#{Constraint.find_by(type: 'nature_asnw').id}").click
+      find_checkbox_by_id("constraint_id_#{Constraint.find_by(type: "monument").id}").click
+      find_checkbox_by_id("constraint_id_#{Constraint.find_by(type: "nature_asnw").id}").click
 
       click_button "Save and mark as checked"
 

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Planning Application Assessment" do
 
   let!(:planning_application) do
     create(:planning_application, :awaiting_determination,
-           local_authority: default_local_authority,
-           decision: "granted")
+      local_authority: default_local_authority,
+      decision: "granted")
   end
 
   context "when the planning application is awaiting determination" do
@@ -166,10 +166,10 @@ RSpec.describe "Planning Application Assessment" do
         let(:application_type) { create(:application_type, name: "prior_approval") }
         let!(:planning_application) do
           create(:planning_application, :awaiting_determination,
-                 :from_planx_prior_approval,
-                 application_type:,
-                 local_authority: default_local_authority,
-                 decision: "granted")
+            :from_planx_prior_approval,
+            application_type:,
+            local_authority: default_local_authority,
+            decision: "granted")
         end
 
         it "lists different legislation in the decision notice" do

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "Auditing changes to a planning application" do
 
   before do
     create(:audit, planning_application_id: planning_application.id,
-                   activity_type: "red_line_boundary_change_validation_request_received", activity_information: 1, audit_comment: { response: "rejected", reason: "The boundary was too small" }.to_json, api_user:)
+      activity_type: "red_line_boundary_change_validation_request_received", activity_information: 1, audit_comment: {response: "rejected", reason: "The boundary was too small"}.to_json, api_user:)
     create(:audit, planning_application_id: planning_application.id,
-                   activity_type: "other_change_validation_request_received", activity_information: 1, audit_comment: { response: "I have sent the fee" }.to_json, api_user:)
+      activity_type: "other_change_validation_request_received", activity_information: 1, audit_comment: {response: "I have sent the fee"}.to_json, api_user:)
     create(:audit, planning_application_id: planning_application.id,
-                   activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf", api_user:)
+      activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf", api_user:)
 
     sign_in assessor
     visit planning_application_path(planning_application)

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "cloning a planning application" do
       .to_return(
         status: 200,
         body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
-        headers: { "Content-Type" => "application/pdf" }
+        headers: {"Content-Type" => "application/pdf"}
       )
 
     sign_in(assessor)

--- a/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/confirm_site_notice_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Confirm site notice", js: true do
 
   let!(:planning_application) do
     create(:planning_application,
-           :from_planx_prior_approval,
-           :with_boundary_geojson,
-           application_type:,
-           local_authority: default_local_authority,
-           api_user:,
-           agent_email: "agent@example.com",
-           applicant_email: "applicant@example.com",
-           make_public: true)
+      :from_planx_prior_approval,
+      :with_boundary_geojson,
+      application_type:,
+      local_authority: default_local_authority,
+      api_user:,
+      agent_email: "agent@example.com",
+      applicant_email: "applicant@example.com",
+      make_public: true)
   end
 
   let!(:consultation) { planning_application.consultation }

--- a/spec/system/planning_applications/consulting/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/consulting/create_site_notice_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe "Create a site notice", js: true do
 
   let!(:planning_application) do
     create(:planning_application,
-           :from_planx_prior_approval,
-           :with_boundary_geojson,
-           application_type:,
-           local_authority: default_local_authority,
-           api_user:,
-           agent_email: "agent@example.com",
-           applicant_email: "applicant@example.com",
-           user: assessor,
-           make_public: true)
+      :from_planx_prior_approval,
+      :with_boundary_geojson,
+      application_type:,
+      local_authority: default_local_authority,
+      api_user:,
+      agent_email: "agent@example.com",
+      applicant_email: "applicant@example.com",
+      user: assessor,
+      make_public: true)
   end
 
   before do

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "View neighbour responses", js: true do
 
   let!(:planning_application) do
     create(:planning_application, :from_planx_prior_approval,
-           application_type:, local_authority: default_local_authority, api_user:)
+      application_type:, local_authority: default_local_authority, api_user:)
   end
 
   let!(:consultation) { planning_application.consultation }

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -131,43 +131,43 @@ RSpec.describe "Consultation", js: true do
 
     internal = \
       stub_request(:post, "#{notify_url}/email")
-      .with(body: hash_including(
-        {
-          email_address: "chris.wood@planx.gov.uk",
-          personalisation: hash_including(
-            "subject" => "Consultation for planning application #{planning_application.reference}"
-          )
-        }
-      ))
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          id: "ee35ce55-f32e-4269-a217-18517745fe8b"
-        }.to_json
-      )
+        .with(body: hash_including(
+          {
+            email_address: "chris.wood@planx.gov.uk",
+            personalisation: hash_including(
+              "subject" => "Consultation for planning application #{planning_application.reference}"
+            )
+          }
+        ))
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ee35ce55-f32e-4269-a217-18517745fe8b"
+          }.to_json
+        )
 
     external = \
       stub_request(:post, "#{notify_url}/email")
-      .with(body: hash_including(
-        {
-          email_address: "planning@london.gov.uk",
-          personalisation: hash_including(
-            "subject" => "Consultation for planning application #{planning_application.reference}"
-          )
-        }
-      ))
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          id: "48025d96-abc9-4b1d-a519-3cbc1c7f700b"
-        }.to_json
-      )
+        .with(body: hash_including(
+          {
+            email_address: "planning@london.gov.uk",
+            personalisation: hash_including(
+              "subject" => "Consultation for planning application #{planning_application.reference}"
+            )
+          }
+        ))
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "48025d96-abc9-4b1d-a519-3cbc1c7f700b"
+          }.to_json
+        )
 
     perform_enqueued_jobs(at: Time.current)
     expect(internal).to have_been_requested
@@ -199,27 +199,27 @@ RSpec.describe "Consultation", js: true do
 
     internal_status = \
       stub_request(:get, "#{notify_url}/ee35ce55-f32e-4269-a217-18517745fe8b")
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          status: "delivered"
-        }.to_json
-      )
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            status: "delivered"
+          }.to_json
+        )
 
     external_status = \
       stub_request(:get, "#{notify_url}/48025d96-abc9-4b1d-a519-3cbc1c7f700b")
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          status: "permanent-failure"
-        }.to_json
-      )
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            status: "permanent-failure"
+          }.to_json
+        )
 
     perform_enqueued_jobs
     expect(internal_status).to have_been_requested
@@ -281,23 +281,23 @@ RSpec.describe "Consultation", js: true do
 
     resend = \
       stub_request(:post, "#{notify_url}/email")
-      .with(body: hash_including(
-        {
-          email_address: "planning@london.gov.uk",
-          personalisation: hash_including(
-            "subject" => "Resend: Consultation for planning application #{planning_application.reference}"
-          )
-        }
-      ))
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          id: "17d69fb7-5d4c-400b-af11-2952266d2e2b"
-        }.to_json
-      )
+        .with(body: hash_including(
+          {
+            email_address: "planning@london.gov.uk",
+            personalisation: hash_including(
+              "subject" => "Resend: Consultation for planning application #{planning_application.reference}"
+            )
+          }
+        ))
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "17d69fb7-5d4c-400b-af11-2952266d2e2b"
+          }.to_json
+        )
 
     perform_enqueued_jobs(at: Time.current)
     expect(resend).to have_been_requested
@@ -318,15 +318,15 @@ RSpec.describe "Consultation", js: true do
 
     resend_status = \
       stub_request(:get, "#{notify_url}/17d69fb7-5d4c-400b-af11-2952266d2e2b")
-      .to_return(
-        status: 200,
-        headers: {
-          "Content-Type" => "application/json"
-        },
-        body: {
-          status: "delivered"
-        }.to_json
-      )
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            status: "delivered"
+          }.to_json
+        )
 
     perform_enqueued_jobs
     expect(resend_status).to have_been_requested

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe "Send letters to neighbours", js: true do
 
   let(:planning_application) do
     create(:planning_application,
-           :from_planx_prior_approval,
-           :with_boundary_geojson,
-           application_type:,
-           local_authority: default_local_authority,
-           api_user:,
-           agent_email: "agent@example.com",
-           applicant_email: "applicant@example.com",
-           make_public: true)
+      :from_planx_prior_approval,
+      :with_boundary_geojson,
+      application_type:,
+      local_authority: default_local_authority,
+      api_user:,
+      agent_email: "agent@example.com",
+      applicant_email: "applicant@example.com",
+      make_public: true)
   end
 
   let(:consultation) do
@@ -202,10 +202,10 @@ RSpec.describe "Send letters to neighbours", js: true do
     context "when planning application has not been made public on the BoPS Public Portal" do
       let(:planning_application) do
         create(:planning_application,
-               :from_planx_prior_approval,
-               application_type:,
-               local_authority: default_local_authority,
-               make_public: false)
+          :from_planx_prior_approval,
+          application_type:,
+          local_authority: default_local_authority,
+          make_public: false)
       end
 
       it "prevents me sending letters and displays an alert" do
@@ -646,7 +646,7 @@ RSpec.describe "Send letters to neighbours", js: true do
 
       check "Resend letters to previously-contacted neighbours"
       fill_in("Specify a reason for resending",
-              with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
+        with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
       orig_deadline = consultation.end_date
 
@@ -684,10 +684,10 @@ RSpec.describe "Send letters to neighbours", js: true do
 
       check "Resend letters to previously-contacted neighbours"
       fill_in("Specify a reason for resending",
-              with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
+        with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
       expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-                                                                                  personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date}\r\n\r\nDear Resident/))).and_call_original
+        personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date}\r\n\r\nDear Resident/))).and_call_original
       click_button "Print and send letters"
     end
   end

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Site visit" do
 
   let!(:planning_application) do
     create(:planning_application, :from_planx_prior_approval,
-           application_type:, local_authority:)
+      application_type:, local_authority:)
   end
 
   let!(:consultation) { planning_application.consultation }
@@ -79,7 +79,7 @@ RSpec.describe "Site visit" do
     it "I can view the objected neighbour responses" do
       expect(page).to have_content("Objected neighbour responses")
       expect(page).to have_content("Objection")
-      expect(page).to have_content("Received on #{Time.zone.now.strftime('%d/%m/%Y')}")
+      expect(page).to have_content("Received on #{Time.zone.now.strftime("%d/%m/%Y")}")
       expect(page).to have_content("neighbour@example.com")
       expect(page).to have_content(neighbour.address.to_s)
       expect(page).to have_content("I like it *****")
@@ -145,7 +145,7 @@ RSpec.describe "Site visit" do
     it "I can view the objected neighbour responses" do
       expect(page).to have_content("Objected neighbour responses")
       expect(page).to have_content("Objection")
-      expect(page).to have_content("Received on #{Time.zone.now.strftime('%d/%m/%Y')}")
+      expect(page).to have_content("Received on #{Time.zone.now.strftime("%d/%m/%Y")}")
       expect(page).to have_content("neighbour@example.com")
       expect(page).to have_content(neighbour.address.to_s)
       expect(page).to have_content("I like it *****")

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "editing planning application" do
 
     # Check audit
     visit planning_application_audits_path(planning_application)
-    within("#audit_#{Audit.find_by(activity_information: 'Application type').id}") do
+    within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(
         "Application type changed from: Lawfulness certificate / Changed to: Prior approval, Reference changed from 23-00100-LDCP to 23-00101-PA"

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Requesting other changes to a planning application" do
 
     fill_in "Tell the applicant another reason why the application is invalid", with: "The wrong fee has been paid"
     fill_in "Explain to the applicant how the application can be made valid",
-            with: "You need to pay £100, which is the correct fee"
+      with: "You need to pay £100, which is the correct fee"
 
     within(".govuk-button-group") do
       click_button "Send request"
@@ -102,9 +102,9 @@ RSpec.describe "Requesting other changes to a planning application" do
 
   it "lists the current change requests and their statuses" do
     create(:other_change_validation_request, planning_application:, state: "open",
-                                             created_at: 12.days.ago, notified_at: 12.days.ago, summary: "Missing information", suggestion: "Please provide more details about ownership")
+      created_at: 12.days.ago, notified_at: 12.days.ago, summary: "Missing information", suggestion: "Please provide more details about ownership")
     create(:other_change_validation_request, planning_application:, state: "closed",
-                                             created_at: 12.days.ago, notified_at: 12.days.ago, summary: "Fees outstanding", suggestion: "Please pay the balance", response: "paid")
+      created_at: 12.days.ago, notified_at: 12.days.ago, summary: "Fees outstanding", suggestion: "Please pay the balance", response: "paid")
 
     click_link "Check and validate"
     click_link "Send validation decision"
@@ -139,7 +139,7 @@ RSpec.describe "Requesting other changes to a planning application" do
     it "updates the notified_at date of an open request when application is invalidated" do
       new_planning_application = create(:planning_application, :not_started, local_authority: default_local_authority)
       request = create(:other_change_validation_request, planning_application: new_planning_application, state: "pending",
-                                                         created_at: 12.days.ago)
+        created_at: 12.days.ago)
 
       visit planning_application_path(new_planning_application)
       click_link "Check and validate"
@@ -183,7 +183,7 @@ RSpec.describe "Requesting other changes to a planning application" do
 
       fill_in "Tell the applicant another reason why the application is invalid", with: "View info on https://www.bops.co.uk/info"
       fill_in "Explain to the applicant how the application can be made valid",
-              with: "You need to pay the right amount, view <a href='https://www.bops.co.uk/payment'>Payment info</a>"
+        with: "You need to pay the right amount, view <a href='https://www.bops.co.uk/payment'>Payment info</a>"
 
       within(".govuk-button-group") do
         click_button "Send request"

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe "Press notice" do
           expect(PressNotice.last).to have_attributes(
             planning_application_id: planning_application.id,
             required: true,
-            reasons: { "environment" => "An environmental statement accompanies this application", "major_development" => "The application is for a Major Development", "public_interest" => "Wider Public interest" },
+            reasons: {"environment" => "An environmental statement accompanies this application", "major_development" => "The application is for a Major Development", "public_interest" => "Wider Public interest"},
             requested_at: Time.zone.local(2023, 3, 15, 12)
           )
 

--- a/spec/system/planning_applications/recommending/legislation_spec.rb
+++ b/spec/system/planning_applications/recommending/legislation_spec.rb
@@ -82,18 +82,18 @@ RSpec.describe "Planning Application Assessment Legislation" do
   context "when uncommented" do
     it "excludes 'more details' when complying or to_be_determined" do
       policy_class = create(:policy_class,
-                            part: 1,
-                            section: "T",
-                            planning_application:)
+        part: 1,
+        section: "T",
+        planning_application:)
       create(:policy,
-             :complies,
-             section: "1A",
-             policy_class:)
+        :complies,
+        section: "1A",
+        policy_class:)
 
       create(:policy,
-             :to_be_determined,
-             section: "1A",
-             policy_class:)
+        :to_be_determined,
+        section: "1A",
+        policy_class:)
 
       visit(new_planning_application_recommendation_path(planning_application))
 
@@ -103,13 +103,13 @@ RSpec.describe "Planning Application Assessment Legislation" do
 
     it "includes 'more details' when clause does not comply" do
       policy_class = create(:policy_class,
-                            part: 1,
-                            section: "T",
-                            planning_application:)
+        part: 1,
+        section: "T",
+        planning_application:)
       create(:policy,
-             :does_not_comply,
-             section: "1A",
-             policy_class:)
+        :does_not_comply,
+        section: "1A",
+        policy_class:)
 
       visit(new_planning_application_recommendation_path(planning_application))
 
@@ -121,13 +121,13 @@ RSpec.describe "Planning Application Assessment Legislation" do
   context "when commented" do
     it "shows legislation paragraphs that comply" do
       policy_class = create(:policy_class,
-                            part: 1,
-                            section: "T",
-                            planning_application:)
+        part: 1,
+        section: "T",
+        planning_application:)
       policy = create(:policy,
-                      :complies,
-                      section: "1M",
-                      policy_class:)
+        :complies,
+        section: "1M",
+        policy_class:)
 
       create(:comment, commentable: policy)
 

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe "Planning Application Assessment" do
           click_link("Make draft recommendation")
           expect(page).to have_checked_field("Yes")
           expect(page).to have_field("Provide supporting information for your manager.",
-                                     with: "This is a private assessor comment")
+            with: "This is a private assessor comment")
           choose "No"
           fill_in "State the reasons why this application is, or is not lawful.", with: "This is a new public comment"
           fill_in "Provide supporting information for your manager.", with: "Edited private assessor comment"
@@ -273,7 +273,7 @@ RSpec.describe "Planning Application Assessment" do
 
       let!(:recommendation) do
         create(:recommendation, :reviewed, planning_application:,
-                                           reviewer_comment: "I disagree", assessor_comment: "This looks good")
+          reviewer_comment: "I disagree", assessor_comment: "This looks good")
       end
 
       it "displays the previous recommendations" do
@@ -291,7 +291,7 @@ RSpec.describe "Planning Application Assessment" do
 
         choose "Yes"
         fill_in "State the reasons why this application is, or is not lawful.",
-                with: "This is so granted and GDPO everything"
+          with: "This is so granted and GDPO everything"
         fill_in "Provide supporting information for your manager.", with: "This is a private assessor comment"
         click_button "Update assessment"
 
@@ -311,7 +311,7 @@ RSpec.describe "Planning Application Assessment" do
 
         expect(page).to have_checked_field("Yes")
         expect(page).to have_field("Provide supporting information for your manager.",
-                                   with: "This is a private assessor comment")
+          with: "This is a private assessor comment")
       end
     end
 
@@ -504,7 +504,7 @@ RSpec.describe "Planning Application Assessment" do
           expect(page).to have_checked_field("Yes")
           expect(page).to have_content("This is a public comment")
           expect(page).to have_field("Provide supporting information for your manager.",
-                                     with: "This is a private assessor comment")
+            with: "This is a private assessor comment")
         end
       end
 
@@ -818,7 +818,7 @@ RSpec.describe "Planning Application Assessment" do
           expect(page).not_to have_checked_field("Prior approval required and refused")
 
           expect(page).to have_field("Provide supporting information for your manager.",
-                                     with: "This is a private assessor comment")
+            with: "This is a private assessor comment")
           choose "Prior approval not required"
           fill_in "State the reasons for your recommendation.", with: "This is a new public comment"
           fill_in "Provide supporting information for your manager.", with: "Edited private assessor comment"
@@ -843,7 +843,7 @@ RSpec.describe "Planning Application Assessment" do
           expect(page).not_to have_checked_field("Prior approval required and refused")
 
           expect(page).to have_field("Provide supporting information for your manager.",
-                                     with: "Edited private assessor comment")
+            with: "Edited private assessor comment")
           choose "Prior approval required and refused"
           fill_in "State the reasons for your recommendation.", with: "This is a new public comment"
           fill_in "Provide supporting information for your manager.", with: "Edited private assessor comment"

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe "Requesting document changes to a planning application" do
 
       let!(:replacement_document_validation_request) do
         create(:replacement_document_validation_request, :with_response,
-               planning_application:, old_document: document1, new_document: document_response)
+          planning_application:, old_document: document1, new_document: document_response)
       end
 
       before do
@@ -626,7 +626,7 @@ RSpec.describe "Requesting document changes to a planning application" do
     end
     let!(:replacement_document_validation_request) do
       create(:replacement_document_validation_request, planning_application:,
-                                                       state: "pending", created_at: 12.days.ago)
+        state: "pending", created_at: 12.days.ago)
     end
 
     it "updates the notified_at date of an open request when application is invalidated" do

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -187,14 +187,14 @@ RSpec.describe "Reviewing evidence of immunity" do
           click_button "Edit comment"
 
           fill_in "Comment added on #{comment.created_at.to_date.to_fs} by",
-                  with: ""
+            with: ""
 
           click_button "Update"
 
           expect(page).to have_content "Text can't be blank"
 
           fill_in "Comment added on #{comment.created_at.to_date.to_fs} by",
-                  with: "This is a new comment now"
+            with: "This is a new comment now"
 
           click_button "Update"
 

--- a/spec/system/planning_applications/review/permitted_development_rights_spec.rb
+++ b/spec/system/planning_applications/review/permitted_development_rights_spec.rb
@@ -204,9 +204,9 @@ RSpec.describe "Permitted development right" do
       context "when reviewer has signed off and agreed with the recommendation" do
         let!(:recommendation) do
           create(:recommendation,
-                 planning_application:,
-                 assessor_comment: "New assessor comment",
-                 submitted: true)
+            planning_application:,
+            assessor_comment: "New assessor comment",
+            submitted: true)
         end
 
         before { planning_application.recommendations << recommendation }

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -63,10 +63,10 @@ RSpec.describe "Reviewing Policy Class" do
 
     it "can return legislation to officer and be updated when corrected" do
       create(:policy_class,
-             :complies,
-             section: "A",
-             status: :complete,
-             planning_application:)
+        :complies,
+        section: "A",
+        status: :complete,
+        planning_application:)
       visit(planning_application_review_tasks_path(planning_application))
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
@@ -237,9 +237,9 @@ RSpec.describe "Reviewing Policy Class" do
       click_on "Review assessment of Part 1, Class B"
 
       expect(page).to have_link "View previous class",
-                                href: edit_planning_application_review_policy_class_path(planning_application, prv)
+        href: edit_planning_application_review_policy_class_path(planning_application, prv)
       expect(page).to have_link "View next class",
-                                href: edit_planning_application_review_policy_class_path(planning_application, nxt)
+        href: edit_planning_application_review_policy_class_path(planning_application, nxt)
     end
 
     it "can display errors" do

--- a/spec/system/planning_applications/review/sign_off_spec.rb
+++ b/spec/system/planning_applications/review/sign_off_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe "Reviewing sign-off" do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:reviewer) do
     create(:user,
-           :reviewer,
-           local_authority: default_local_authority)
+      :reviewer,
+      local_authority: default_local_authority)
   end
   let!(:assessor) do
     create(:user,
-           :assessor,
-           name: "The name of assessor",
-           local_authority: default_local_authority)
+      :assessor,
+      name: "The name of assessor",
+      local_authority: default_local_authority)
   end
   let(:user) { create(:user) }
 
@@ -39,14 +39,14 @@ RSpec.describe "Reviewing sign-off" do
 
   it "can be accepted" do
     create(:recommendation, :reviewed,
-           planning_application:,
-           assessor_comment: "First assessor comment",
-           reviewer_comment: "First reviewer comment")
+      planning_application:,
+      assessor_comment: "First assessor comment",
+      reviewer_comment: "First reviewer comment")
 
     create(:recommendation,
-           planning_application:,
-           assessor_comment: "New assessor comment",
-           submitted: true)
+      planning_application:,
+      assessor_comment: "New assessor comment",
+      submitted: true)
 
     visit(planning_application_path(planning_application))
 
@@ -70,7 +70,7 @@ RSpec.describe "Reviewing sign-off" do
     expect(page).to have_selector("h1", text: "Review and sign-off")
     expect(page).to have_content("Recommendation was successfully reviewed.")
     expect(page).to have_link("Sign-off recommendation",
-                              href: edit_planning_application_recommendations_path(planning_application))
+      href: edit_planning_application_recommendations_path(planning_application))
 
     expect(list_item("Sign-off recommendation")).to have_content("Completed")
 
@@ -96,10 +96,10 @@ RSpec.describe "Reviewing sign-off" do
 
   it "can be rejected" do
     create(:recommendation,
-           assessor:,
-           planning_application:,
-           assessor_comment: "New assessor comment",
-           submitted: true)
+      assessor:,
+      planning_application:,
+      assessor_comment: "New assessor comment",
+      submitted: true)
 
     visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
@@ -121,7 +121,7 @@ RSpec.describe "Reviewing sign-off" do
     expect(list_item("Sign-off recommendation")).to have_content("Completed")
     expect(page).to have_text("Sign-off recommendation")
     expect(page).not_to have_link("Sign-off recommendation",
-                                  href: edit_planning_application_recommendations_path(planning_application))
+      href: edit_planning_application_recommendations_path(planning_application))
 
     expect(page).to have_text "Application is now in assessment and assigned to The name of assessor"
 
@@ -155,9 +155,9 @@ RSpec.describe "Reviewing sign-off" do
 
   it "cannot be rejected without a review comment" do
     create(:recommendation,
-           planning_application:,
-           assessor_comment: "New assessor comment",
-           submitted: true)
+      planning_application:,
+      assessor_comment: "New assessor comment",
+      submitted: true)
 
     visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
@@ -175,9 +175,9 @@ RSpec.describe "Reviewing sign-off" do
 
   it "can be accepted without a review comment" do
     create(:recommendation,
-           planning_application:,
-           assessor_comment: "New assessor comment",
-           submitted: true)
+      planning_application:,
+      assessor_comment: "New assessor comment",
+      submitted: true)
 
     visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
@@ -200,7 +200,7 @@ RSpec.describe "Reviewing sign-off" do
 
   it "can edit an existing review of an assessment" do
     recommendation = create(:recommendation, :reviewed, planning_application:,
-                                                        reviewer_comment: "Reviewer private comment")
+      reviewer_comment: "Reviewer private comment")
 
     visit(planning_application_path(planning_application))
     click_link "Review and sign-off"
@@ -234,9 +234,9 @@ RSpec.describe "Reviewing sign-off" do
   context "when editing the public comment that appears on the decision notice" do
     it "as a reviewer I am able to edit", skip: "flaky" do
       create(:recommendation,
-             planning_application:,
-             assessor_comment: "New assessor comment",
-             submitted: true)
+        planning_application:,
+        assessor_comment: "New assessor comment",
+        submitted: true)
 
       visit(planning_application_path(planning_application))
       click_link "Review and sign-off"

--- a/spec/system/planning_applications/review/tasks_index_spec.rb
+++ b/spec/system/planning_applications/review/tasks_index_spec.rb
@@ -34,20 +34,20 @@ RSpec.describe "Reviewing Tasks Index" do
 
     it "without awaiting determination there is no navigation" do
       visit planning_application_path(create(:planning_application,
-                                             :not_started,
-                                             local_authority: default_local_authority))
+        :not_started,
+        local_authority: default_local_authority))
 
       expect(page).to have_content("Review and sign-off")
     end
 
     it "displays chosen policy class in a list" do
-      policy_classes =  create_list(:policy_class, 3, planning_application:)
+      policy_classes = create_list(:policy_class, 3, planning_application:)
       visit(planning_application_review_tasks_path(planning_application))
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       policy_classes.each do |policy_class|
         expect(page).to have_link("Review assessment of Part 1, Class #{policy_class.section}",
-                                  href: edit_planning_application_review_policy_class_path(planning_application, policy_class))
+          href: edit_planning_application_review_policy_class_path(planning_application, policy_class))
 
         expect(page).to have_list_item_for(
           "Review assessment of Part 1, Class #{policy_class.section}",

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -11,22 +11,22 @@ RSpec.describe "Planning Application show page" do
     [
       {
         question: "What do you want to do?",
-        responses: [{ value: "Modify or extend" }],
-        metadata: { section_name: "_root", auto_answered: true }
+        responses: [{value: "Modify or extend"}],
+        metadata: {section_name: "_root", auto_answered: true}
       },
       {
         question: "Is the property a house?",
-        responses: [{ value: "Yes" }],
-        metadata: { section_name: "_root" }
+        responses: [{value: "Yes"}],
+        metadata: {section_name: "_root"}
       },
       {
         question: "What will the height of the new structure be?",
-        responses: [{ value: "2.5m" }],
-        metadata: { section_name: "Dimensions", auto_answered: true }
+        responses: [{value: "2.5m"}],
+        metadata: {section_name: "Dimensions", auto_answered: true}
       },
       {
         question: "Is the property in a world heritage site?",
-        responses: [{ value: "No" }]
+        responses: [{value: "No"}]
       }
     ].to_json
   end

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "Drawing a sitemap on a planning application" do
       expect(map["showMarker"]).to eq("true")
 
       find(".govuk-visually-hidden",
-           visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'
+        visible: false).set '{"type":"Feature","properties":{},"geometry":{"type":"Polygon","coordinates":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}'
       fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Coordinates look wrong"
       click_button "Send request"
 
@@ -251,7 +251,7 @@ RSpec.describe "Drawing a sitemap on a planning application" do
       end
 
       let(:new_geojson) do
-        { type: "FeatureCollection", features: [new_geojson_feature] }.to_json
+        {type: "FeatureCollection", features: [new_geojson_feature]}.to_json
       end
 
       before do

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is awaiting determination" do
       planning_application = create(:planning_application, :awaiting_determination,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
       create(:recommendation, planning_application:)
       visit planning_application_path(planning_application)
       within "#validation-section" do
@@ -96,7 +96,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
       visit planning_application_path(planning_application)
 
@@ -112,7 +112,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is to be reviewed and no re-proposal has been made" do
       planning_application = create(:planning_application, :to_be_reviewed,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
 
       create(
         :recommendation,
@@ -140,7 +140,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is to be reviewed and a re-proposal has been made" do
       planning_application = create(:planning_application, :to_be_reviewed,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
       create(:recommendation, planning_application:, submitted: true)
       visit planning_application_path(planning_application)
@@ -177,7 +177,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is awaiting determination" do
       planning_application = create(:planning_application, :awaiting_determination,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
       create(:recommendation, planning_application:)
       visit planning_application_path(planning_application)
       within "#validation-section" do
@@ -208,7 +208,7 @@ RSpec.describe "Planning Application show page" do
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
       planning_application = create(:planning_application, :awaiting_determination,
-                                    local_authority: default_local_authority)
+        local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
       visit planning_application_path(planning_application)
 

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe "FeeItemsValidation" do
       [
         {
           question: "What type of planning application are you making?",
-          responses: [{ value: "Existing changes" }],
-          metadata: { section_name: "fee-related" }
+          responses: [{value: "Existing changes"}],
+          metadata: {section_name: "fee-related"}
         },
         {
           question: "What type of changes does the project involve?",
-          responses: [{ value: "Alteration" }],
+          responses: [{value: "Alteration"}],
           metadata: {
             section_name: "fee-related",
             policy_refs: [
-              { text: "The Town and Country Planning Order 2015" },
-              { url: "https://www.example.com/planning/policy/1" }
+              {text: "The Town and Country Planning Order 2015"},
+              {url: "https://www.example.com/planning/policy/1"}
             ]
           }
         }

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -52,7 +52,7 @@ RSpec.shared_examples "validate and invalidate" do
 
   it "allows document edit, archive and upload after invalidation" do
     create(:additional_document_validation_request, planning_application:, state: "open",
-                                                    created_at: 12.days.ago)
+      created_at: 12.days.ago)
 
     within(govuk_tab_all) do
       click_link(planning_application.reference)
@@ -70,14 +70,14 @@ RSpec.shared_examples "validate and invalidate" do
 
   it "displays a validation date of the last closed validation request if any closed validation requests exist" do
     create(:additional_document_validation_request,
-           planning_application:,
-           state: "closed",
-           updated_at: Time.zone.today - 2.days)
+      planning_application:,
+      state: "closed",
+      updated_at: Time.zone.today - 2.days)
 
     create(:replacement_document_validation_request,
-           planning_application:,
-           state: "closed",
-           updated_at: Time.zone.today - 3.days)
+      planning_application:,
+      state: "closed",
+      updated_at: Time.zone.today - 3.days)
 
     within(govuk_tab_all) do
       click_link(planning_application.reference)
@@ -204,7 +204,7 @@ RSpec.describe "Planning Application Assessment" do
   context "when checking documents from Not Started status" do
     it "can be invalidated and email is sent when there is an open validation request" do
       create(:additional_document_validation_request, planning_application:, state: "pending",
-                                                      created_at: 12.days.ago)
+        created_at: 12.days.ago)
 
       delivered_emails = ActionMailer::Base.deliveries.count
 
@@ -253,8 +253,8 @@ RSpec.describe "Planning Application Assessment" do
   context "when planning application does not transition when expected inputs are not sent" do
     it "shows an error when invalid documents are present" do
       create(:document, :with_file,
-             planning_application:,
-             validated: false, invalidated_document_reason: "Missing a lazy Suzan")
+        planning_application:,
+        validated: false, invalidated_document_reason: "Missing a lazy Suzan")
 
       within(govuk_tab_all) do
         click_link(planning_application.reference)
@@ -410,7 +410,7 @@ RSpec.describe "Planning Application Assessment" do
   context "when application invalidated" do
     it "does not show the invalidate button when application is invalid" do
       invalid_planning_application = create(:planning_application, :invalidated,
-                                            local_authority: default_local_authority)
+        local_authority: default_local_authority)
 
       visit planning_application_path(invalid_planning_application)
       click_link "Check and validate"

--- a/spec/system/planning_applications/validating/validation_banner_display_spec.rb
+++ b/spec/system/planning_applications/validating/validation_banner_display_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Validation banners" do
 
     it "shows the correct count for 2 overdue request validations" do
       create(:replacement_document_validation_request,
-             planning_application:,
-             state: "open")
+        planning_application:,
+        state: "open")
 
       travel 2.months
       visit planning_application_path(planning_application)

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Validation tasks" do
   context "when application has been validated" do
     let!(:planning_application) do
       create(:planning_application, :in_assessment, :with_boundary_geojson, local_authority: default_local_authority,
-                                                                            constraints_checked: true)
+        constraints_checked: true)
     end
 
     it "displays the validation tasks list but no actions to create new requests can be taken" do


### PR DESCRIPTION
### Description of change

Switch our Rubocop rules to be based on [standardrb](https://github.com/standardrb/standard) rather than the default batch plus miscellaneous customisations

Configuring through Rubocop rather than using Standard's CLI tool so that we can keep all our existing tooling.

I've also removed `rubocop-rspec`. We've been ignoring most of its rules anyway, and changing the code to pass the checks would be a lot more work. (There also isn't a standard-rspec set of rules like there is for rails, it's just the upstream rubocop rules. That's fine but I don't know if the defaults are actually any good and what they should be changed to if not.)