### PR TITLE
Use glob routing for the planning guides

### DIFF
--- a/app/controllers/public/planning_guides_controller.rb
+++ b/app/controllers/public/planning_guides_controller.rb
@@ -4,7 +4,8 @@ module Public
   class PlanningGuidesController < ApplicationController
     skip_before_action :set_current_user
 
-    BASE_URL = "public/planning_guides/"
+    before_action :set_planning_guide, only: :show
+    before_action :raise_routing_error, only: :show, unless: :planning_guide_exists?
 
     def index
       respond_to do |format|
@@ -14,14 +15,22 @@ module Public
 
     def show
       respond_to do |format|
-        format.html do
-          if params[:type]
-            render "#{BASE_URL}#{params[:type]}/#{params[:page]}"
-          else
-            render "#{BASE_URL}#{params[:page]}"
-          end
-        end
+        format.html
       end
+    end
+
+    private
+
+    def set_planning_guide
+      @planning_guide = "public/planning_guides/#{params[:path]}"
+    end
+
+    def planning_guide_exists?
+      template_exists?(@planning_guide)
+    end
+
+    def raise_routing_error
+      raise ActionController::RoutingError, "Couldn't find planning guide #{params[:path]}"
     end
   end
 end

--- a/app/views/public/planning_guides/show.html.erb
+++ b/app/views/public/planning_guides/show.html.erb
@@ -1,0 +1,1 @@
+<%= render template: @planning_guide %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -207,10 +207,9 @@ Rails.application.routes.draw do
   end
 
   namespace :public, path: "/" do
-    resources :planning_guides, only: :index
-    resource :planning_guides, only: :show do
-      get "/:page", action: "show"
-      get "/:type/:page", action: "show"
+    scope "/planning_guides" do
+      get "/", to: "planning_guides#index", as: :planning_guides
+      get "/*path", to: "planning_guides#show", as: nil
     end
   end
 

--- a/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
@@ -171,7 +171,10 @@ RSpec.describe "Review documents for recommendation" do
 
     it "I can edit whether documents are on the decision notice / made public and save and come back later" do
       click_link "Check and assess"
+      expect(page).to have_selector("h1", text: "Assess the application")
+
       click_link "Review documents for recommendation"
+      expect(page).to have_selector("h1", text: "Review documents for recommendation")
 
       within(".govuk-table__body") do
         document_with_reference_and_tags__decision_notice_checkbox.click
@@ -193,7 +196,10 @@ RSpec.describe "Review documents for recommendation" do
 
     it "I see a link to add a document reference when a reference hasn't been set" do
       click_link "Check and assess"
+      expect(page).to have_selector("h1", text: "Assess the application")
+
       click_link "Review documents for recommendation"
+      expect(page).to have_selector("h1", text: "Review documents for recommendation")
 
       within("#document_#{document_without_reference.id}") do
         expect(page).to have_link(
@@ -211,7 +217,10 @@ RSpec.describe "Review documents for recommendation" do
 
       it "there is an error message and no update is persisted" do
         click_link "Check and assess"
+        expect(page).to have_selector("h1", text: "Assess the application")
+
         click_link "Review documents for recommendation"
+        expect(page).to have_selector("h1", text: "Review documents for recommendation")
 
         document_with_reference__decision_notice_checkbox.click
         document_with_reference_and_tags__decision_notice_checkbox.click

--- a/spec/system/public/planning_guides_spec.rb
+++ b/spec/system/public/planning_guides_spec.rb
@@ -159,6 +159,13 @@ RSpec.describe "Planning guides" do
       expect(page).to have_image_displayed("use_plans/proposed")
       expect(page).to have_link("Back", href: public_planning_guides_path)
     end
+
+    it "returns 404 for guides that don't exist" do
+      expect do
+        visit "/planning_guides/does/not/exist"
+        expect(page).to have_selector("h1", text: "Does not exist")
+      end.to raise_error(ActionController::RoutingError, "Couldn't find planning guide does/not/exist")
+    end
   end
 
   context "when logged in" do


### PR DESCRIPTION
The template_exists? method is restricted to the configured view paths so there is no risk of escaping to render files outside of the application.