### PR TITLE
Remove broken grover 'fix'

### DIFF
--- a/config/initializers/grover.rb
+++ b/config/initializers/grover.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-Grover.configure do |config|
-  if Gem::Platform.local.os != "darwin"
-    config.options = {
-      executable_path: "/usr/bin/chromium"
-    }
-  end
-end


### PR DESCRIPTION
Hardcoding the path to chromium breaks production where we use chrome instead.