### PR TITLE
Remove database column 'selected' from consultees

### DIFF
--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Consultee < ApplicationRecord
+  attribute :selected, :boolean, default: false
+
   belongs_to :consultation
   has_many :emails, dependent: :destroy
   has_many :responses, dependent: :destroy

--- a/db/migrate/20231025153041_drop_selected_column_from_consultees.rb
+++ b/db/migrate/20231025153041_drop_selected_column_from_consultees.rb
@@ -1,0 +1,5 @@
+class DropSelectedColumnFromConsultees < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :consultees, :selected, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_25_103432) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_25_153041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -217,7 +217,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_25_103432) do
     t.string "organisation"
     t.string "email_address"
     t.string "status", default: "not_consulted"
-    t.boolean "selected", default: true
     t.datetime "email_sent_at"
     t.datetime "email_delivered_at"
     t.index ["consultation_id"], name: "ix_consultees_on_consultation_id"


### PR DESCRIPTION
We can use a virtual attribute to handle this and we don't accidentally include others when sending by defaulting to false. When the rows are added by the StimulusJS controller they're selected by default.

NOTE: This should really be two PRs - one for the virtual attribute and then one for removing the column but as long as no-one uses the consultee feature after the migration has been applied before the ECS tasks have been replaced we'll be fine.