### PR TITLE
Improve the reliability when running the app in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 	docker compose build
 
 up:
-	docker compose up
+	docker compose up || true
 
 down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     image: bops/ruby
     build: docker/ruby
     working_dir: /home/rails/bops
-    command: ["bin/dev"]
+    command: ["foreman", "start", "-f", "Procfile.dev"]
     stdin_open: true
     tty: true
     environment:
@@ -67,7 +67,7 @@ services:
     image: bops/applicants
     build: bops-applicants/docker/ruby
     working_dir: /home/rails/bops-applicants
-    command: ["bin/dev"]
+    command: ["foreman", "start", "-f", "Procfile.dev"]
     stdin_open: true
     tty: true
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
         target: /home/rails/bops/node_modules
       - type: tmpfs
         target: /tmp/pids
+        tmpfs:
+          mode: 0777
 
   applicants:
     image: bops/applicants
@@ -94,6 +96,8 @@ services:
         target: /home/rails/bops-applicants/node_modules
       - type: tmpfs
         target: /tmp/pids
+        tmpfs:
+          mode: 0777
 
 networks:
   default:

--- a/docker/ruby/docker-entrypoint.sh
+++ b/docker/ruby/docker-entrypoint.sh
@@ -8,5 +8,5 @@ else
   yarn install
   bundle check || bundle install
 
-  bundle exec "$@"
+  exec bundle exec "$@"
 fi


### PR DESCRIPTION
* Fixing file permissions on `/tmp/pids` ensures that the container restarts correctly
* Using `exec bundle exec` ensures that foreman gets the interrupt signal