### PR TITLE
Update decision notice for householder applications

### DIFF
--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -3,7 +3,7 @@
     <span class="govuk-caption-xl">
       <%= planning_application.local_authority.council_name %>
     </span>
-    <br/>
+    <br>
     <h3 class="govuk-heading-s">
       <%= t("recommendation.#{planning_application.application_type.name}.legislation_html") %>
     </h3>
@@ -12,16 +12,14 @@
     </h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <dl class="govuk-summary-list govuk-summary-list--no-border">
-      <%
-        {
-          "Applicant" => planning_application.applicant_name,
-          "Application number" => planning_application.reference,
-          "Application received" => planning_application.received_at.to_fs,
-          "Decision date" => planning_application.determination_date&.to_fs || "TBD",
-          "Site address" => planning_application.full_address,
-          "Use/development" => planning_application.description,
-        }.each do |key, value|
-      %>
+ <% {
+      "Applicant" => planning_application.applicant_name,
+      "Application number" => planning_application.reference,
+      "Application received" => planning_application.received_at.to_fs,
+      "Decision date" => planning_application.determination_date&.to_fs || "TBD",
+      "Site address" => planning_application.full_address,
+      "Use/development" => planning_application.description
+    }.each do |key, value| %>
         <div class="govuk-summary-list__column">
           <dt class="govuk-summary-list__key">
             <%= key %>
@@ -34,14 +32,18 @@
         </div>
       <% end %>
     </dl>
-    <% if @planning_application.application_type.name == "lawfulness_certificate"  %>
+    <% if @planning_application.application_type.name == "lawfulness_certificate" %>
       <p class="govuk-body">
-        We certify that on the date of the application, the <%= @planning_application.work_status %> use or operations described in the application and supporting plans were <%= @planning_application.granted? ? "lawful" : "not lawful" %> for the purposes of <%= @planning_application.work_status == "proposed" ? "S.192" : "S.191" %> of the Town and Country Planning Act 1990.
+        We certify that on the date of the application, the <%= @planning_application.work_status %> use or operations described in the application and supporting plans were <%= @planning_application.granted? ? "lawful" : "not lawful" %> for the purposes of <%= (@planning_application.work_status == "proposed") ? "S.192" : "S.191" %> of the Town and Country Planning Act 1990.
       </p>
-    <% end  %>
+    <% end %>
     <p class="govuk-body">
       <strong>
-        The proposal <%= @planning_application.granted? ? "complies" : "does not comply" %> due to the following reason(s):
+        <% if @planning_application.application_type.name == "planning_permission" %>
+          Permission is <%= @planning_application.granted? ? "granted" : "refused" %> due to the following reason(s):
+        <% else %>
+          The proposal <%= @planning_application.granted? ? "complies" : "does not comply" %> due to the following reason(s):
+        <% end %>
       </strong>
     </p>
     <p class="govuk-body">
@@ -54,7 +56,7 @@
         </strong>
       </p>
       <p class="govuk-body">
-        <%= @planning_application.assessment_details.select { |ad| ad.category == "amenity" }.first.entry %>
+        <%= @planning_application.assessment_details.find { |ad| ad.category == "amenity" }.entry %>
       </p>
     <% end %>
     <h3 class="govuk-heading-s">
@@ -110,7 +112,7 @@
     </h3>
 
     <% if @planning_application.boundary_geojson.present? %>
-      <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson } %>
+      <%= render "shared/location_map", locals: {geojson: @planning_application.boundary_geojson} %>
     <% else %>
       <p class="govuk-body">No digital sitemap provided</p>
     <% end %>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -39,11 +39,7 @@
     <% end %>
     <p class="govuk-body">
       <strong>
-        <% if @planning_application.application_type.name == "planning_permission" %>
-          Permission is <%= @planning_application.granted? ? "granted" : "refused" %> due to the following reason(s):
-        <% else %>
-          The proposal <%= @planning_application.granted? ? "complies" : "does not comply" %> due to the following reason(s):
-        <% end %>
+        <%= t("recommendation.decisions.#{@planning_application.application_type.name}.#{@planning_application.decision}") %>:
       </strong>
     </p>
     <p class="govuk-body">

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -59,17 +59,19 @@
         <%= @planning_application.assessment_details.find { |ad| ad.category == "amenity" }.entry %>
       </p>
     <% end %>
-    <h3 class="govuk-heading-s">
-      Conditions:
-    </h3>
-    <ul class="govuk-list">
-      <% @planning_application.conditions.each do |condition| %>
-        <li>
-          <%= condition.text %><br>
-          <%= condition.reason %>
-        </li>
-      <% end %>
-    </p>
+    <% if @planning_application.conditions.present? %>
+      <h3 class="govuk-heading-s">
+        Conditions:
+      </h3>
+      <ul class="govuk-list">
+        <% @planning_application.conditions.each do |condition| %>
+          <li>
+            <%= condition.text %><br>
+            <%= condition.reason %>
+          </li>
+        <% end %>
+      </p>
+    <% end %>
     <h3 class="govuk-heading-s">
       This decision is based on the following approved plans:
     </h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1070,6 +1070,17 @@ en:
     summary_component:
       auto_answered: Auto-answered by PlanX
   recommendation:
+    decisions:
+      lawfulness_certificate:
+        granted: The proposal complies due to the following reason(s)
+        refused: The proposal does not comply due to the following reason(s)
+      planning_permission:
+        granted: Permission is granted due to the following reason(s)
+        refused: Permission is refused due to the following reason(s)
+      prior_approval:
+        granted: The proposal complies due to the following reason(s)
+        granted_not_required: The proposal complies due to the following reason(s)
+        refused: The proposal does not comply due to the following reason(s)
     lawfulness_certificate:
       granted_html: Certificate of Lawful Use or Development <br> <strong>Granted</strong>
       legislation_html: 'Town and Country Planning Act 1990 (as amended): sections 191 and 192<br>Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1077,11 +1077,9 @@ en:
     planning_permission:
       granted: Planning permission approved
       granted_html: "<strong>Planning permission approved</strong>"
-      granted_not_required: Prior approval not required
-      granted_not_required_html: "<strong>Prior approval not required</strong>"
-      legislation_html: Town and Country Planning Act 1990 (as amended)
-      refused: Prior approval required and refused
-      refused_html: "<strong>Prior approval required and refused</strong>"
+      legislation_html: Town and Country Planning Act 1990 (as amended)<br><br>Town and Country Planning (Development Management Procedure) (England) Order 2015
+      refused: Planning permission refused
+      refused_html: "<strong>Planning permission refused</strong>"
     prior_approval:
       granted: Prior approval required and approved
       granted_html: "<strong>Prior approval required and approved</strong>"

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -225,6 +225,38 @@ RSpec.describe "Planning Application Assessment" do
           end
         end
       end
+
+      context "when the decision is for a householder application" do
+        let(:application_type) { create(:application_type, :planning_permission) }
+        let!(:planning_application) do
+          create(:planning_application, :awaiting_determination,
+            :from_planx_prior_approval,
+            application_type:,
+            local_authority: default_local_authority,
+            decision: "granted")
+        end
+
+        before do
+          click_link("Publish determination")
+
+          within("#determination-date") do
+            # Enter date today
+            fill_in "Day", with: "2"
+            fill_in "Month", with: "1"
+            fill_in "Year", with: "2024"
+          end
+
+          click_button("Publish determination")
+        end
+
+        it "lists different legislation in the decision notice" do
+          click_link("View decision notice")
+          expect(page).to have_content("Town and Country Planning Act 1990 (as amended)")
+          expect(page).to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015")
+          expect(page).not_to have_content("sections 191 and 192")
+          expect(page).not_to have_content("Article 39")
+        end
+      end
     end
 
     context "when I'm signed in as an assessor" do


### PR DESCRIPTION
### Description of change

Updating the decision notice to reflect the right details for householder applications

### Story Link

https://trello.com/c/GuGd7HoE/2046-show-correct-information-on-householder-decision-notices

### Screenshots

![failures_r_spec_example_groups_planning_application_assessment_when_the_planning_application_is_awaiting_determination_when_im_signed_in_as_a_reviewer_when_the_decision_is_for_a_householder_application_lists_d_943](https://github.com/unboxed/bops/assets/3986/b1779a57-ff8b-4f3f-be0a-c83b74a2813a)

### Known issues

This view could probably do with further refactoring to support different chunks of information on the basis of application type. Or, perhaps, a separate top-level template per-type, which pulls in shared partials as appropriate.