### PR TITLE
Save screenshots of spec failures to artifacts store

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -109,6 +109,15 @@ jobs:
         run: |
           bundle exec rake spec
 
+      - name: Save screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: selenium-screenshots
+          path: ${{ github.workspace }}/tmp/capybara/*.png
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Run cucumber specs
         if: ${{ inputs.test-runner == 'cucumber' }}
         env:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -118,6 +118,15 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Save rails logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: rails-logs
+          path: ${{ github.workspace }}/log/test.log
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Run cucumber specs
         if: ${{ inputs.test-runner == 'cucumber' }}
         env:

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -303,6 +303,7 @@ RSpec.describe "Requesting a new document for a planning application" do
           click_link("Delete request")
         end
 
+        expect(page).to have_current_path(planning_application_validation_tasks_path(planning_application))
         expect(page).to have_content("Validation request was successfully deleted.")
 
         within("#additional-documents-validation-task") do


### PR DESCRIPTION
Despite our best efforts we're still seeing some intermittent spec failures which seem impossible to recreate locally so save the screenshots from these failures to the GHA artifacts store