### PR TITLE
Re-consult Consultees when changes are made to application

### DIFF
--- a/app/components/reconsult_consultees_component.html.erb
+++ b/app/components/reconsult_consultees_component.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-form-group" id="resend-consultees">
+  <fieldset class="govuk-fieldset" aria-describedby="reconsult-hint">
+    <legend class="govuk-fieldset__legend">
+      <h2 class="govuk-heading-m"><%= t(".legend") %></h2>
+    </legend>
+    <div id="reconsult-hint" class="govuk-hint">
+      <%= t(".hint") %>
+    </div>
+    <div class="govuk-radios" data-module="govuk-radios">
+      <%= form.govuk_radio_button(:reconsult, "false", label: { text: t(".no") }) %>
+      <%= form.govuk_radio_button(:reconsult, "true", label: { text: t(".yes") }, data: { "aria-controls": "conditional-reconsult" }) %>
+      <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reconsult">
+        <%= form.govuk_text_area :reconsultation_message, label: { text: t(".message_label") }, rows: 5 %>
+        <p class="govuk-hint"><%= t(".formatting_hint_html") %></p>
+        <%= form.govuk_date_field :reconsultation_date, legend: { text: t(".date_label"), size: "s" } %>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/components/reconsult_consultees_component.rb
+++ b/app/components/reconsult_consultees_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ReconsultConsulteesComponent < ViewComponent::Base
+  def initialize(form:)
+    @form = form
+  end
+
+  private
+
+  attr_reader :form
+end

--- a/app/controllers/planning_applications/consultee/emails_controller.rb
+++ b/app/controllers/planning_applications/consultee/emails_controller.rb
@@ -36,7 +36,14 @@ module PlanningApplications
       end
 
       def consultation_params
-        [:consultee_email_subject, :consultee_email_body, {consultees_attributes: consultee_params}]
+        [
+          :consultee_email_subject,
+          :consultee_email_body,
+          :reconsult,
+          :reconsultation_message,
+          :reconsultation_date,
+          {consultees_attributes: consultee_params}
+        ]
       end
 
       def consultee_params

--- a/app/jobs/resend_consultee_emails_job.rb
+++ b/app/jobs/resend_consultee_emails_job.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class ResendConsulteeEmailsJob < NotifyEmailJob
+  queue_as :high_priority
+
+  def perform(consultation, consultees, message, date, subject, body)
+    planning_application = consultation.planning_application
+    local_authority = planning_application.local_authority
+
+    defaults = {
+      signatory_name: local_authority.signatory_name,
+      signatory_job_title: local_authority.signatory_job_title,
+      local_authority: local_authority.council_name,
+      reference: planning_application.reference,
+      description: planning_application.description,
+      address: planning_application.address,
+      link: consultation.application_link,
+      closing_date: date.to_fs
+    }
+
+    divider = "\n\n---\n\n"
+
+    consultees.each do |consultee|
+      next if consultee.email_address.blank?
+
+      variables = defaults.merge(name: consultee.name)
+
+      consultee_email = consultee.emails.create!(
+        subject: format(subject, variables),
+        body: format(message + divider + body, variables)
+      )
+
+      consultee.update!(
+        selected: false,
+        status: "sending",
+        email_sent_at: nil,
+        email_delivered_at: nil
+      )
+
+      SendConsulteeEmailJob.perform_later(consultation, consultee_email)
+    end
+  end
+end

--- a/app/jobs/send_consultee_emails_job.rb
+++ b/app/jobs/send_consultee_emails_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SendConsulteeEmailsJob < NotifyEmailJob
+class SendConsulteeEmailsJob < ApplicationJob
   queue_as :high_priority
 
   def perform(consultation, consultees, subject, body)

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -89,7 +89,8 @@ class Audit < ApplicationRecord
     press_notice: "press_notice",
     press_notice_mail: "press_notice_mail",
     site_notice_created: "site_notice_created",
-    consultee_emails_sent: "consultee_emails_sent"
+    consultee_emails_sent: "consultee_emails_sent",
+    consultee_emails_resent: "consultee_emails_resent"
   }
 
   validates :activity_type, presence: true

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -26,7 +26,6 @@ class Consultation < ApplicationRecord
 
   validate do
     next unless validation_context == :send_consultee_emails
-    next if consultees.none?
 
     errors.add(:consultees, :blank) if consultees.none_selected?
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -5,6 +5,10 @@ class Consultation < ApplicationRecord
 
   include GeojsonFormattable
 
+  attribute :reconsult, :boolean, default: false
+  attribute :reconsultation_message, :string
+  attribute :reconsultation_date, :date, default: -> { Date.current + 21.days }
+
   belongs_to :planning_application
   delegate :local_authority, to: :planning_application
 
@@ -28,6 +32,15 @@ class Consultation < ApplicationRecord
     next unless validation_context == :send_consultee_emails
 
     errors.add(:consultees, :blank) if consultees.none_selected?
+
+    if reconsult?
+      errors.add(:reconsultation_message, :blank) if reconsultation_message.blank?
+      errors.add(:reconsultation_date, :blank) if reconsultation_date.blank?
+
+      if reconsultation_date.present?
+        errors.add(:reconsultation_date, :in_the_past) unless reconsultation_date.future?
+      end
+    end
   end
 
   accepts_nested_attributes_for :consultees, :neighbours
@@ -43,23 +56,19 @@ class Consultation < ApplicationRecord
   format_geojson_epsg :polygon_geojson
 
   def send_consultee_emails(attributes)
-    self.attributes = attributes
+    begin
+      self.attributes = attributes
+    rescue ActiveRecord::MultiparameterAssignmentErrors
+      errors.add(:reconsultation_date, :invalid) and return false
+    end
+
     return false unless save(context: :send_consultee_emails)
 
-    SendConsulteeEmailsJob.perform_now(
-      self,
-      consultees.selected,
-      consultee_email_subject,
-      consultee_email_body
-    )
-
-    start_deadline
-
-    Audit.create!(
-      planning_application_id: planning_application_id,
-      user: Current.user,
-      activity_type: "consultee_emails_sent"
-    )
+    if reconsult?
+      perform_resend_consultee_emails_job
+    else
+      perform_send_consultee_emails_job
+    end
   end
 
   def start_deadline
@@ -237,6 +246,42 @@ class Consultation < ApplicationRecord
   end
 
   private
+
+  def perform_send_consultee_emails_job
+    SendConsulteeEmailsJob.perform_now(
+      self,
+      consultees.selected,
+      consultee_email_subject,
+      consultee_email_body
+    )
+
+    start_deadline
+
+    Audit.create!(
+      planning_application_id: planning_application_id,
+      user: Current.user,
+      activity_type: "consultee_emails_sent"
+    )
+  end
+
+  def perform_resend_consultee_emails_job
+    ResendConsulteeEmailsJob.perform_now(
+      self,
+      consultees.selected,
+      reconsultation_message,
+      reconsultation_date,
+      consultee_email_subject,
+      consultee_email_body
+    )
+
+    update!(end_date: reconsultation_date.end_of_day)
+
+    Audit.create!(
+      planning_application_id: planning_application_id,
+      user: Current.user,
+      activity_type: "consultee_emails_resent"
+    )
+  end
 
   def audit_letter_copy_sent!
     Audit.create!(

--- a/app/models/consultation/consultees_extension.rb
+++ b/app/models/consultation/consultees_extension.rb
@@ -22,6 +22,10 @@ class Consultation < ApplicationRecord
       reject(&:not_consulted?)
     end
 
+    def consulted?
+      consulted.present?
+    end
+
     def failed?
       consulted.any?(&:failed?)
     end

--- a/app/views/planning_applications/consultee/emails/index.html.erb
+++ b/app/views/planning_applications/consultee/emails/index.html.erb
@@ -31,6 +31,7 @@
 
       <%= render ConsulteesComponent.new(consultees: @consultees, form: form) %>
       <%= render ConsulteeEmailComponent.new(form: form) %>
+      <%= render ReconsultConsulteesComponent.new(form: form) if @consultees.consulted? %>
 
       <div class="govuk-button-group">
         <%= form.submit "Send emails to consultees", id: "send-emails-button", class: "govuk-button", data: { consultees_target: "submit" } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -150,6 +150,12 @@ en:
           attributes:
             consultees:
               blank: Please select at least one consultee
+            reconsultation_date:
+              blank: Please enter the date by which consultees need to respond by
+              in_the_past: Please enter a date in the future
+              invalid: Please enter a valid date
+            reconsultation_message:
+              blank: Please enter the reasons for the reconsultation
         document:
           attributes:
             file:
@@ -370,6 +376,7 @@ en:
       constraint_added: Constraint added
       constraint_removed: Constraint removed
       constraints_checked: Constraints Checked
+      consultee_emails_resent: Consultee emails resent
       consultee_emails_sent: Consultee emails sent
       created: Application created by %{args}
       description_change_request_cancelled: 'Cancelled: description change request (description#%{args})'
@@ -1164,6 +1171,15 @@ en:
       update_assessment: Update assessment
     update:
       success: Recommendation was successfully reviewed.
+  reconsult_consultees_component:
+    date_label: Consultee reponse required by
+    formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <nobr><code>%{closing_date}</code></nobr> will be substituted when the email is sent.
+    hint: Choosing 'Yes' will allow you to add the reasons why this application is being reconsulted.
+    legend: 3) Is this a reconsultation?
+    message_hint: This text will go at the top of the new email
+    message_label: Reasons for reconsultation
+    'no': No, I’m sending to new consultees
+    'yes': Yes, I’m resending to existing consultees
   red_line_boundary_change_validation_requests:
     create:
       validation_request_for: Validation request for red line boundary successfully created.

--- a/spec/system/planning_applications/consulting/resend_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resend_emails_to_consultees_spec.rb
@@ -1,0 +1,293 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Consultation", js: true do
+  let(:api_user) { create(:api_user, name: "PlanX") }
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority:) }
+  let(:application_type) { create(:application_type, :planning_permission) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :from_planx_prior_approval,
+      :with_boundary_geojson,
+      application_type:,
+      local_authority:,
+      api_user:,
+      agent_email: "agent@example.com",
+      applicant_email: "applicant@example.com",
+      make_public: true
+    )
+  end
+
+  let(:consultation) do
+    planning_application.consultation
+  end
+
+  let(:notify_url) do
+    "https://api.notifications.service.gov.uk/v2/notifications"
+  end
+
+  let(:today) do
+    Date.current
+  end
+
+  let(:future) do
+    Date.current + 14.days
+  end
+
+  let(:future_date) do
+    future.to_fs
+  end
+
+  let(:current_date) do
+    today.to_fs(:day_month_year_slashes)
+  end
+
+  let(:start_date) do
+    consultation.start_date.to_fs(:day_month_year_slashes)
+  end
+
+  before do
+    create(
+      :consultee, :external,
+      consultation: consultation,
+      name: "Consultations",
+      role: "Planning Department",
+      organisation: "GLA",
+      email_address: "planning@london.gov.uk",
+      status: "awaiting_response",
+      email_sent_at: 14.days.ago,
+      email_delivered_at: 14.days.ago + 5.minutes
+    )
+
+    create(
+      :consultee, :internal,
+      consultation: consultation,
+      name: "Chris Wood",
+      role: "Tree Officer",
+      organisation: local_authority.council_name,
+      email_address: "chris.wood@#{local_authority.subdomain}.gov.uk",
+      status: "awaiting_response",
+      email_sent_at: 14.days.ago,
+      email_delivered_at: 14.days.ago + 5.minutes
+    )
+
+    consultation.update(
+      status: "in_progress",
+      start_date: 14.days.ago,
+      end_date: 7.days.from_now
+    )
+  end
+
+  it "resends emails to consultees" do
+    sign_in assessor
+
+    visit "/planning_applications/#{planning_application.id}"
+    expect(page).to have_selector("h1", text: "Application")
+
+    within "#consultation-section" do
+      expect(page).to have_selector("li:first-child a", text: "Consultees, neighbours and publicity")
+      expect(page).to have_selector("li:first-child .govuk-tag", text: "In progress")
+    end
+
+    click_link "Consultees, neighbours and publicity"
+    expect(page).to have_selector("h1", text: "Consultation")
+
+    within "#consultee-tasks" do
+      expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
+      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+    end
+
+    click_link "Send emails to consultees"
+    expect(page).to have_selector("h1", text: "Send emails to consultees")
+    expect(page).to have_selector("h2", text: "1) Select the consultees to consult")
+    expect(page).to have_selector("h2", text: "2) Send email to selected consultees")
+    expect(page).to have_selector("h2", text: "3) Is this a reconsultation?")
+
+    within "#external-consultees" do
+      within "table tbody tr:first-child" do
+        expect(page).to have_unchecked_field("Select consultee")
+        expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(3)", text: "7 days")
+        expect(page).to have_selector("td:nth-child(4)", text: start_date)
+        expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
+      end
+    end
+
+    within "#internal-consultees" do
+      within "table tbody tr:first-child" do
+        expect(page).to have_unchecked_field("Select consultee")
+        expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(3)", text: "7 days")
+        expect(page).to have_selector("td:nth-child(4)", text: start_date)
+        expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
+      end
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please select at least one consultee")
+
+    within "#external-consultees" do
+      within "table tbody tr:first-child" do
+        check "Select consultee"
+      end
+    end
+
+    within "#resend-consultees" do
+      choose "Yes, I’m resending to existing consultees"
+
+      fill_in "Day", with: ""
+      fill_in "Month", with: ""
+      fill_in "Year", with: ""
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please enter the reasons for the reconsultation")
+    expect(page).to have_selector("[role=alert] li", text: "Please enter the date by which consultees need to respond by")
+
+    within "#resend-consultees" do
+      fill_in "Day", with: today.day
+      fill_in "Month", with: today.month
+      fill_in "Year", with: today.year
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please enter a date in the future")
+
+    within "#resend-consultees" do
+      fill_in "Day", with: "50"
+      fill_in "Month", with: today.month
+      fill_in "Year", with: today.year
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please enter a valid date")
+
+    within "#resend-consultees" do
+      fill_in "Reasons for reconsultation", with: "Application has changes - please respond by %<closing_date>s"
+      fill_in "Day", with: future.day
+      fill_in "Month", with: future.month
+      fill_in "Year", with: future.year
+    end
+
+    expect do
+      accept_confirm(text: "Send emails to consultees?") do
+        click_button "Send emails to consultees"
+      end
+
+      expect(page).to have_selector("h1", text: "Consultation")
+      expect(page).to have_selector("[role=alert] h3", text: "Emails have been sent to the selected consultees.")
+
+      expect(Audit.where(
+        planning_application_id: planning_application.id,
+        user_id: assessor.id,
+        activity_type: "consultee_emails_resent"
+      )).to exist
+
+      within "#consultee-tasks" do
+        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+      end
+    end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
+
+    external = \
+      stub_request(:post, "#{notify_url}/email")
+        .with(body: hash_including(
+          {
+            email_address: "planning@london.gov.uk",
+            email_reply_to_id: "4485df6f-a728-41ed-bc46-cdb2fc6789aa",
+            personalisation: hash_including(
+              "body" => a_string_starting_with("Application has changes - please respond by #{future_date}")
+            )
+          }
+        ))
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "48025d96-abc9-4b1d-a519-3cbc1c7f700b"
+          }.to_json
+        )
+
+    perform_enqueued_jobs(at: Time.current)
+    expect(external).to have_been_requested
+    expect(consultation.reload.end_date).to eq(future.end_of_day.floor(6))
+    expect(UpdateConsulteeEmailStatusJob).to have_been_enqueued.exactly(:once)
+
+    click_link "Send emails to consultees"
+    expect(page).to have_selector("h1", text: "Send emails to consultees")
+
+    within "#external-consultees" do
+      within "table tbody tr:first-child" do
+        expect(page).to have_unchecked_field("Select consultee")
+        expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(3)", text: "–")
+        expect(page).to have_selector("td:nth-child(4)", text: "–")
+        expect(page).to have_selector("td:nth-child(5)", text: "Sending")
+      end
+    end
+
+    external_status = \
+      stub_request(:get, "#{notify_url}/48025d96-abc9-4b1d-a519-3cbc1c7f700b")
+        .to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            status: "delivered"
+          }.to_json
+        )
+
+    perform_enqueued_jobs
+    expect(external_status).to have_been_requested
+
+    click_link "Back"
+    expect(page).to have_selector("h1", text: "Consultation")
+    expect(page).to have_text("Consultation end date: #{future_date}")
+
+    within "#consultee-tasks" do
+      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+    end
+
+    click_link "Send emails to consultees"
+    expect(page).to have_selector("h1", text: "Send emails to consultees")
+
+    within "#external-consultees" do
+      within "table tbody tr:first-child" do
+        expect(page).to have_unchecked_field("Select consultee")
+        expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(3)", text: "21 days")
+        expect(page).to have_selector("td:nth-child(4)", text: current_date)
+        expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
+      end
+    end
+
+    within "#internal-consultees" do
+      within "table tbody tr:first-child" do
+        expect(page).to have_unchecked_field("Select consultee")
+        expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(3)", text: "7 days")
+        expect(page).to have_selector("td:nth-child(4)", text: start_date)
+        expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -74,6 +74,9 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Send emails to consultees"
     expect(page).to have_selector("h1", text: "Send emails to consultees")
+    expect(page).to have_selector("h2", text: "1) Select the consultees to consult")
+    expect(page).to have_selector("h2", text: "2) Send email to selected consultees")
+    expect(page).not_to have_selector("h2", text: "3) Is this a reconsultation?")
 
     accept_confirm(text: "Send emails to consultees?") do
       click_button "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe "Consultation", js: true do
     click_link "Send emails to consultees"
     expect(page).to have_selector("h1", text: "Send emails to consultees")
 
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please select at least one consultee")
+
     fill_in "Search for consultees", with: "GLA"
     expect(page).to have_selector("#add-consultee__listbox li:first-child", text: "Consultations (Planning Department, GLA)")
 

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -129,6 +129,12 @@ RSpec.describe "Consultation", js: true do
       expect(page).to have_selector("h1", text: "Consultation")
       expect(page).to have_selector("[role=alert] h3", text: "Emails have been sent to the selected consultees.")
 
+      expect(Audit.where(
+        planning_application_id: planning_application.id,
+        user_id: assessor.id,
+        activity_type: "consultee_emails_sent"
+      )).to exist
+
       within "#consultee-tasks" do
         expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
         expect(page).to have_selector("li:first-child .govuk-tag", text: "In progress")


### PR DESCRIPTION
### Description of change

Add the ability to reconsult existing consultees with a reasons message added to the top of the new email.

### Story Link

https://trello.com/c/GUacbpjT

### Screenshots

![image](https://github.com/unboxed/bops/assets/6321/fe847bf6-5157-47aa-a5a0-943327bebbbb)
