### PR TITLE
Split migration up and down to be easy for rollback

### DIFF
--- a/db/migrate/20231027102432_migrate_conditions_to_condition_set.rb
+++ b/db/migrate/20231027102432_migrate_conditions_to_condition_set.rb
@@ -16,15 +16,23 @@ class MigrateConditionsToConditionSet < ActiveRecord::Migration[7.0]
     belongs_to :condition_set
   end
 
-  def change
+  def up
     change_column_null :conditions, :planning_application_id, true
 
-    up_only do
-      PlanningApplication.joins(:conditions).find_each do |pa|
-        condition_set = pa.condition_set || pa.create_condition_set!
+    PlanningApplication.joins(:conditions).find_each do |pa|
+      condition_set = pa.condition_set || pa.create_condition_set!
 
-        pa.conditions.update_all(condition_set_id: condition_set.id)
+      pa.conditions.update_all(condition_set_id: condition_set.id)
+    end
+  end
+
+  def down
+    ConditionSet.find_each do |cs|
+      cs.conditions.each do |condition|
+        condition.update(planning_application_id: cs.planning_application_id)
       end
     end
+
+    change_column_null :conditions, :planning_application_id, false
   end
 end


### PR DESCRIPTION
### Description of change

Split migration up and down to be easy for rollback