### PR TITLE
Expose determined planning applications publicly

### DIFF
--- a/app/controllers/public/planning_applications_controller.rb
+++ b/app/controllers/public/planning_applications_controller.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Public
+  class PlanningApplicationsController < ApplicationController
+    skip_before_action :set_current_user
+
+    before_action :set_planning_application, only: :decision_notice
+    before_action :ensure_decision_is_present, only: :decision_notice
+
+    def decision_notice
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    private
+
+    def ensure_decision_is_present
+      render plain: "Not Found", status: :not_found if @planning_application.determined_at.blank?
+    end
+  end
+end

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -68,5 +68,8 @@ if planning_application.consultation.present?
     json.received_at response.received_at
     json.summary_tag response.summary_tag
   end
+  json.consultation do
+    json.end_date planning_application.consultation.end_date
+  end
 end
 json.make_public planning_application.make_public

--- a/app/views/public/planning_applications/decision_notice.html.erb
+++ b/app/views/public/planning_applications/decision_notice.html.erb
@@ -1,0 +1,10 @@
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Decision notice" }
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "planning_applications/decision_notice", planning_application: @planning_application %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,14 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :public do
+    resources :planning_applications, only: [] do
+      member do
+        get "decision_notice"
+      end
+    end
+  end
+
   namespace :api do
     namespace :v1 do
       resources :planning_applications, only: %i[index create show] do

--- a/spec/system/public/planning_applications/decision_notice_spec.rb
+++ b/spec/system/public/planning_applications/decision_notice_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Decision notice" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:planning_application) do
+    create(:planning_application, :determined, local_authority: default_local_authority, decision: "granted")
+  end
+
+  context "when not logged in" do
+    before do
+      visit decision_notice_public_planning_application_path(planning_application)
+    end
+
+    context "when planning application has been determined" do
+      it "shows a publicly available decision notice" do
+        expect(page).to have_content("Decision notice")
+
+        within(".govuk-tag.govuk-tag--green") do
+          expect(page).to have_content("Granted")
+        end
+
+        expect(page).to have_css(".decision-notice")
+      end
+    end
+
+    context "when planning application has not been determined" do
+      let!(:planning_application) do
+        create(:planning_application, :awaiting_determination, local_authority: default_local_authority)
+      end
+
+      it "shows a not found page" do
+        expect(page).not_to have_content("Decision notice")
+        expect(page).to have_content("Not Found")
+      end
+    end
+  end
+
+  context "when logged in" do
+    let(:user) { create(:user, local_authority: default_local_authority) }
+
+    before do
+      sign_in(user)
+
+      visit decision_notice_public_planning_application_path(planning_application)
+    end
+
+    it "is accessible" do
+      expect(page).to have_content("Decision notice")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

-Expose determined planning applications publicly
- This is needed as a publicly available url for Bops Applicants to use when a planning application is determined. In this case neighbours won't be able to make a decision
- Related to https://github.com/unboxed/bops-applicants/pull/177

### Story Link

https://trello.com/c/7hCXyuiQ/2054-update-the-bops-applicant-page-when-a-decision-has-been-made-on-the-case

