### PR TITLE
Do not read from ENV directly post initialization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,11 +29,6 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always_true
 
-# TODO
-Rails/EnvironmentVariableAccess:
-  Exclude:
-    - app/**/*
-
 # past migrations are ignored; we don't expect to go back and edit them ever,
 # we'll fix them in future migrations if at all.
 Rails/BulkChangeTable:

--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -65,9 +65,7 @@ class NotifyEmailJob < ApplicationJob
   private
 
   def api_key
-    ENV.fetch("NOTIFY_API_KEY")
-  rescue KeyError
-    raise NotifyEmailJob::NotConfiguredError, "Notify API key not found"
+    Rails.configuration.default_notify_api_key.presence || (raise NotifyEmailJob::NotConfiguredError, "Notify API key not found")
   end
 
   def client

--- a/app/models/consultee/email.rb
+++ b/app/models/consultee/email.rb
@@ -48,7 +48,7 @@ class Consultee < ApplicationRecord
     end
 
     def api_key
-      consultee.consultation.planning_application.local_authority.notify_api_key || ENV.fetch("NOTIFY_API_KEY")
+      consultee.consultation.planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
     end
   end
 end

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -38,7 +38,7 @@ class NeighbourLetter < ApplicationRecord
   private
 
   def notify_api_key
-    neighbour.consultation.planning_application.local_authority.notify_api_key || ENV.fetch("NOTIFY_API_KEY")
+    neighbour.consultation.planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
   end
 
   def resend?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -533,7 +533,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def planning_history_enabled?
-    ENV.fetch("PLANNING_HISTORY_ENABLED", "false") == "true"
+    Rails.configuration.planning_history_enabled
   end
 
   def rejected_assessment_detail(category:)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
 
   devise :recoverable, :two_factor_authenticatable, :recoverable, :timeoutable,
     :validatable,
-    otp_secret_encryption_key: ENV.fetch("OTP_SECRET_ENCRYPTION_KEY", nil),
+    otp_secret_encryption_key: Rails.configuration.otp_secret_encryption_key,
     request_keys: [:subdomains]
 
   has_many :planning_applications, dependent: :nullify

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -5,7 +5,6 @@ require "faraday"
 module Apis
   module Bops
     class Client
-      HOST = ENV.fetch("STAGING_API_URL").freeze
       TIMEOUT = 5
 
       def call(local_authority, planning_application)
@@ -19,11 +18,11 @@ module Apis
       private
 
       def faraday(local_authority)
-        @faraday ||= Faraday.new(url: "https://#{local_authority}.#{HOST}") do |f|
+        @faraday ||= Faraday.new(url: "https://#{local_authority}.#{Rails.configuration.staging_api_url}") do |f|
           f.response :raise_error
           f.headers = {
             "Content-Type" => "application/json",
-            "Authorization" => "Bearer #{ENV.fetch("STAGING_API_BEARER")}"
+            "Authorization" => "Bearer #{Rails.configuration.staging_api_bearer}"
           }
         end
       end

--- a/app/services/apis/paapi/client.rb
+++ b/app/services/apis/paapi/client.rb
@@ -5,7 +5,6 @@ require "faraday"
 module Apis
   module Paapi
     class Client
-      HOST = ENV.fetch("PAAPI_URL", "https://staging.paapi.services/api/v1").freeze
       TIMEOUT = 5
 
       def call(uprn)
@@ -17,7 +16,7 @@ module Apis
       private
 
       def faraday
-        @faraday ||= Faraday.new(url: HOST) do |f|
+        @faraday ||= Faraday.new(url: Rails.configuration.paapi_url) do |f|
           f.response :raise_error
         end
       end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -55,7 +55,7 @@ class LetterSendingService
 
   def notify_api_key
     if Bops.env.production?
-      @notify_api_key ||= (@local_authority.notify_api_key || ENV.fetch("NOTIFY_API_KEY"))
+      @notify_api_key ||= (@local_authority.notify_api_key || Rails.configuration.default_notify_api_key)
     else
       @notify_api_key = ENV.fetch("NOTIFY_LETTER_API_KEY")
     end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -57,7 +57,7 @@ class LetterSendingService
     if Bops.env.production?
       @notify_api_key ||= (@local_authority.notify_api_key || Rails.configuration.default_notify_api_key)
     else
-      @notify_api_key = ENV.fetch("NOTIFY_LETTER_API_KEY")
+      @notify_api_key = Rails.configuration.notify_letter_api_key
     end
   end
 

--- a/app/services/two_factor/sms_notification.rb
+++ b/app/services/two_factor/sms_notification.rb
@@ -26,7 +26,7 @@ module TwoFactor
     private
 
     def client
-      @client ||= Notifications::Client.new(ENV.fetch("NOTIFY_API_KEY"))
+      @client ||= Notifications::Client.new(Rails.configuration.default_notify_api_key)
     end
   end
 end

--- a/app/services/upload_documents_service.rb
+++ b/app/services/upload_documents_service.rb
@@ -45,10 +45,10 @@ class UploadDocumentsService
 
   def planx_file_api_key
     if @planning_application.from_production?
-      ENV.fetch("PLANX_FILE_PRODUCTION_API_KEY",
-        nil)
+      Rails.configuration.planx_file_production_api_key
+
     else
-      ENV.fetch("PLANX_FILE_API_KEY", nil)
+      Rails.configuration.planx_file_api_key
     end
   end
 end

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -1,6 +1,6 @@
 <my-map
   style="width: 100%; height: 400px;"
-  osVectorTilesApiKey='<%= ENV['OS_VECTOR_TILES_API_KEY'] %>'
+  osVectorTilesApiKey='<%= Rails.configuration.os_vector_tiles_api_key %>'
   showScale
   useScaleBarStyle
   showNorthArrow

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,6 +59,8 @@ module Bops
     config.notify_letter_api_key = ENV["NOTIFY_LETTER_API_KEY"]
     config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
     config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
+    config.staging_api_bearer = ENV["STAGING_API_BEARER"]
+    config.staging_api_url = ENV["STAGING_API_URL"]
   end
 
   def self.env

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module Bops
     config.google_tag_manager_id = ENV["GOOGLE_TAG_MANAGER_ID"]
 
     config.default_notify_api_key = ENV["NOTIFY_API_KEY"]
+    config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
   end
 
   def self.env

--- a/config/application.rb
+++ b/config/application.rb
@@ -58,6 +58,7 @@ module Bops
     config.default_notify_api_key = ENV["NOTIFY_API_KEY"]
     config.notify_letter_api_key = ENV["NOTIFY_LETTER_API_KEY"]
     config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
+    config.paapi_url = ENV.fetch("PAAPI_URL", "https://staging.paapi.services/api/v1")
     config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
     config.staging_api_bearer = ENV["STAGING_API_BEARER"]
     config.staging_api_url = ENV["STAGING_API_URL"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,6 +54,8 @@ module Bops
     config.os_vector_tiles_api_key = ENV["OS_VECTOR_TILES_API_KEY"]
     config.feedback_fish_id = ENV["FEEDBACK_FISH_ID"]
     config.google_tag_manager_id = ENV["GOOGLE_TAG_MANAGER_ID"]
+
+    config.default_notify_api_key = ENV["NOTIFY_API_KEY"]
   end
 
   def self.env

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,8 @@ module Bops
     config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
     config.paapi_url = ENV.fetch("PAAPI_URL", "https://staging.paapi.services/api/v1")
     config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
+    config.planx_file_api_key = ENV["PLANX_FILE_API_KEY"]
+    config.planx_file_production_api_key = ENV["PLANX_FILE_PRODUCTION_API_KEY"]
     config.staging_api_bearer = ENV["STAGING_API_BEARER"]
     config.staging_api_url = ENV["STAGING_API_URL"]
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module Bops
     config.google_tag_manager_id = ENV["GOOGLE_TAG_MANAGER_ID"]
 
     config.default_notify_api_key = ENV["NOTIFY_API_KEY"]
+    config.notify_letter_api_key = ENV["NOTIFY_LETTER_API_KEY"]
     config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
     config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,7 @@ module Bops
     config.google_tag_manager_id = ENV["GOOGLE_TAG_MANAGER_ID"]
 
     config.default_notify_api_key = ENV["NOTIFY_API_KEY"]
+    config.otp_secret_encryption_key = ENV["OTP_SECRET_ENCRYPTION_KEY"]
     config.planning_history_enabled = ENV["PLANNING_HISTORY_ENABLED"] == true
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,9 +51,9 @@ module Bops
     # Don't log certain requests that spam the log files
     config.middleware.insert_before Rails::Rack::Logger, QuietLogger, paths: ["/healthcheck"]
 
-    config.os_vector_tiles_api_key = ENV.fetch("OS_VECTOR_TILES_API_KEY", nil)
-    config.feedback_fish_id = ENV.fetch("FEEDBACK_FISH_ID", nil)
-    config.google_tag_manager_id = ENV.fetch("GOOGLE_TAG_MANAGER_ID", " ").presence
+    config.os_vector_tiles_api_key = ENV["OS_VECTOR_TILES_API_KEY"]
+    config.feedback_fish_id = ENV["FEEDBACK_FISH_ID"]
+    config.google_tag_manager_id = ENV["GOOGLE_TAG_MANAGER_ID"]
   end
 
   def self.env

--- a/spec/services/apis/bops/client_spec.rb
+++ b/spec/services/apis/bops/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Apis::Bops::Client do
 
   describe "#call" do
     it "is successful" do
-      allow(ENV).to receive(:fetch).with("STAGING_API_BEARER").and_return("testtesttest")
+      Rails.configuration.staging_api_bearer = "testtesttest"
 
       expect(client.call(planning_application.local_authority.subdomain, planning_application).status).to eq(200)
     end

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Assessment tasks" do
 
   before do
     sign_in assessor
-    allow(ENV).to receive(:fetch).and_call_original
-    allow(ENV).to receive(:fetch).with("PLANNING_HISTORY_ENABLED", "false").and_return("true")
+    Rails.configuration.planning_history_enabled = true
     visit(planning_application_assessment_tasks_path(planning_application))
   end
 

--- a/spec/system/planning_applications/assessing/planning_history_show_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_history_show_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Planning History" do
   before do
     sign_in assessor
 
-    ENV["PLANNING_HISTORY_ENABLED"] = "true"
+    Rails.configuration.planning_history_enabled = true
   end
 
   context "when planning application's property uprn has planning history" do


### PR DESCRIPTION
### Description of change

Apply a rubocop rule left over from #1337

This was the only actual code change required for that (as opposed to purely formatting changes), and it seems like good practice anyway, which we already use in some cases but inconsistently.

I've also rewritten some uses of `ENV.fetch(…, nil)` to use `ENV[…]` instead, because `nil` is what `[]` returns for a missing key anyway. I think we should only use fetch if we're setting an actual default value.

### Known issues

This will mean environment variables are accessed at startup, not just when they're used, which means that if they're unset, `fetch` will always throw an error. I think this primarily applies to `STAGING_API_URL` and `STAGING_API_BEARER`, which didn't have a default value and aren't in `.env.example`. I've chosen to default them to `nil`. In practice I don't think this will cause any harmful effects because of how the value is used (it will error at runtime, which is the same as the previous failure mode; see `app/services/apis/bops/client.rb`) but it might be better wrapped in a conditional.