### PR TITLE
Validate that neighbour address is at least 3 lines

### DIFF
--- a/app/assets/stylesheets/components/_flashes.scss
+++ b/app/assets/stylesheets/components/_flashes.scss
@@ -3,7 +3,6 @@
 }
 
 .flash {
-  padding: govuk-spacing(5) 0;
   &.notice {
     @include flash;
     color: govuk-colour("green");

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -30,7 +30,7 @@ class LetterSendingService
     end
 
     personalisation = {message: letter_content, heading: @consultation.neighbour_letter_header}
-    personalisation.merge! address
+    personalisation.merge! neighbour.format_address_lines
 
     begin
       response = client.send_letter(
@@ -66,15 +66,6 @@ class LetterSendingService
       @notify_template_id ||= @local_authority.notify_letter_template || DEFAULT_NOTIFY_TEMPLATE_ID
     else
       @notify_template_id = DEFAULT_NOTIFY_TEMPLATE_ID
-    end
-  end
-
-  def address
-    # split on commas unless preceded by digits (i.e. house numbers)
-    address_lines = neighbour.address.split(/(?<!\d), */).compact
-    address_lines.insert(0, "The Occupier")
-    address_lines.each_with_index.to_h do |line, i|
-      ["address_line_#{i + 1}", line]
     end
   end
 

--- a/app/views/application/_flash_content.html.erb
+++ b/app/views/application/_flash_content.html.erb
@@ -21,14 +21,16 @@
     </div>
   </div>
 <% elsif flash.key?(:error) %>
-  <div class="flash govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
-    </h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <%= flash[:error] %>
-      </ul>
+  <div class="flash govuk-error-summary" aria-labelledby="error-summary-title" tabindex="-1" data-module="govuk-error-summary">
+    <div role="alert">
+      <h2 class="govuk-error-summary__title" id="error-summary-title">
+        There is a problem
+      </h2>
+      <div class="govuk-error-summary__body">
+        <ul class="govuk-list govuk-error-summary__list">
+          <a href="#error_message"><%= simple_format(flash[:error]) %></a>
+        </ul>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/planning_applications/neighbour_letters/_form.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_form.html.erb
@@ -6,13 +6,21 @@
   id: "consultation-form",
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <div>
+  <div class="govuk-!-padding-bottom-5">
     <label for="neighbour-address" class="govuk-heading-s">Search for neighbours by address</label>
       <span id="neighbour-address-hint" class="govuk-hint">
         Start typing address or postcode
       </span>
     <div id="neighbour-address-container"></div>
   </div>
+
+  <% if flash["error"].present? %>
+    <div class="govuk-error-message" id="error_message">
+      <span class="govuk-visually-hidden">Error: </span>
+      <%= simple_format(flash["error"], {}, wrapper_tag: "span") %>
+    </div>
+  <% end %>
+
   <%= form.submit(
     "Add neighbour",
     class: "govuk-button govuk-button--secondary govuk-!-margin-top-5"

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -15,18 +15,18 @@ RSpec.describe Consultation do
     describe "address" do
       let!(:consultation) { create(:consultation) }
       let!(:other_consultation) { create(:consultation) }
-      let!(:neighbour) { create(:neighbour, address: "1 Test lane", consultation:) }
+      let!(:neighbour) { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }
 
       it "validates uniqueness within the scope of consultation_id" do
-        expect { create(:neighbour, address: "1 Test lane", consultation:) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Address 1 Test lane has already been added.")
+        expect { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Address 1, Test Lane, AAA111 has already been added.")
       end
 
       it "is case insensitive when validating uniqueness within the scope of consultation_id" do
-        expect { create(:neighbour, address: "1 TEST LAnE", consultation:) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Address 1 TEST LAnE has already been added.")
+        expect { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Address 1, Test Lane, AAA111 has already been added.")
       end
 
       it "allows the same address for different consultations" do
-        neighbour_for_other_consultation = create(:neighbour, address: "1 Test lane", consultation: other_consultation)
+        neighbour_for_other_consultation = create(:neighbour, address: "1, Test Lane, AAA111", consultation: other_consultation)
 
         expect(neighbour_for_other_consultation).to be_valid
       end
@@ -148,9 +148,9 @@ RSpec.describe Consultation do
 
   describe "#neighbour_responses_by_summary_tag" do
     let!(:consultation) { create(:consultation) }
-    let!(:neighbour1) { create(:neighbour, address: "1 Random Lane", consultation:) }
-    let!(:neighbour2) { create(:neighbour, address: "2 Random Lane", consultation:) }
-    let!(:neighbour3) { create(:neighbour, address: "3 Random Lane", consultation:) }
+    let!(:neighbour1) { create(:neighbour, address: "1, Random Lane, AAA111", consultation:) }
+    let!(:neighbour2) { create(:neighbour, address: "2, Random Lane, AAA111", consultation:) }
+    let!(:neighbour3) { create(:neighbour, address: "3, Random Lane, AAA111", consultation:) }
     let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
     let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
     let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "neighbour responses" do
 
   context "when planning application is in assessment" do
     let!(:consultation) { planning_application.consultation }
-    let!(:neighbour1) { create(:neighbour, address: "1 Test Lane", consultation:) }
-    let!(:neighbour2) { create(:neighbour, address: "2 Test Lane", consultation:) }
-    let!(:neighbour3) { create(:neighbour, address: "3 Test Lane", consultation:) }
+    let!(:neighbour1) { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }
+    let!(:neighbour2) { create(:neighbour, address: "2, Test Lane, AAA111", consultation:) }
+    let!(:neighbour3) { create(:neighbour, address: "3, Test Lane, AAA111", consultation:) }
     let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
     let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
     let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe "View neighbour responses", js: true do
 
     fill_in "Name", with: "Sara Neighbour"
     fill_in "Email", with: "sara@email.com"
-    fill_in "Address", with: "124 Made up Street"
+    fill_in "Address", with: "124, Made up, Street"
     fill_in "Day", with: "21"
     fill_in "Month", with: "2"
     fill_in "Year", with: "2023"
@@ -187,7 +187,7 @@ RSpec.describe "View neighbour responses", js: true do
     expect(page).to have_content("Received on 21/02/2023")
     expect(page).to have_content("Sara Neighbour")
     expect(page).to have_content("sara@email.com")
-    expect(page).to have_content("124 Made up Street")
+    expect(page).to have_content("124, Made up, Street")
     expect(page).to have_content("I think this proposal looks ****")
 
     expect(page).to have_link("Back", href: planning_application_consultation_path(planning_application))

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -58,17 +58,17 @@ RSpec.describe "Send letters to neighbours", js: true do
     click_link "Consultees, neighbours and publicity"
     click_link "Send letters to neighbours"
 
-    fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+    fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
     # # Something weird is happening with the javascript, so having to double click for it to register
     # # This doesn't happen in "real life"
     page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-    expect(page).to have_content("60-62 Commercial Street")
+    expect(page).to have_content("60-62, Commercial Street, E16LT")
 
-    fill_in "Search for neighbours by address", with: "60-61 Commercial Road"
+    fill_in "Search for neighbours by address", with: "60-61, Commercial Road, E16LT"
     page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-    expect(page).to have_content("60-61 Commercial Road")
+    expect(page).to have_content("60-61, Commercial Road, E16LT")
 
     expect(page).not_to have_content("Contacted neighbours")
   end
@@ -77,31 +77,31 @@ RSpec.describe "Send letters to neighbours", js: true do
     click_link "Consultees, neighbours and publicity"
     click_link "Send letters to neighbours"
 
-    fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+    fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
     page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-    expect(page).to have_content("60-62 Commercial Street")
+    expect(page).to have_content("60-62, Commercial Street, E16LT")
 
     click_link "Edit"
 
-    fill_in "Address", with: "60-62 Commercial Road"
+    fill_in "Address", with: "60-62, Commercial Road, E18PT"
     click_button "Save"
 
-    expect(page).to have_content("60-62 Commercial Road")
+    expect(page).to have_content("60-62, Commercial Road, E18PT")
   end
 
   it "allows me to delete addresses" do
     click_link "Consultees, neighbours and publicity"
     click_link "Send letters to neighbours"
 
-    fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+    fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
     page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-    expect(page).to have_content("60-62 Commercial Street")
+    expect(page).to have_content("60-62, Commercial Street, E16LT")
 
     click_link "Remove"
 
-    expect(page).not_to have_content("60-62 Commercial Street")
+    expect(page).not_to have_content("60-62, Commercial Street, E16LT")
   end
 
   context "when sending letters" do
@@ -127,17 +127,17 @@ RSpec.describe "Send letters to neighbours", js: true do
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
-      fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+      fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
       # # Something weird is happening with the javascript, so having to double click for it to register
       # # This doesn't happen in "real life"
       page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-      expect(page).to have_content("60-62 Commercial Street")
+      expect(page).to have_content("60-62, Commercial Street, E16LT")
 
       expect(page).to have_content("# Submit your comments by")
       expect(page).to have_content("Application number: #{planning_application.reference}")
 
-      fill_in "Search for neighbours by address", with: "60-61 Commercial Road"
+      fill_in "Search for neighbours by address", with: "60-61, Commercial Road, E16LT"
       page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
       expect(page).to have_content("A copy of the letter will be sent to the applicant by email.")
@@ -173,12 +173,12 @@ RSpec.describe "Send letters to neighbours", js: true do
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
-      fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+      fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
       # # Something weird is happening with the javascript, so having to double click for it to register
       # # This doesn't happen in "real life"
       page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-      expect(page).to have_content("60-62 Commercial Street")
+      expect(page).to have_content("60-62, Commercial Street, E16LT")
 
       expect(page).to have_content("3) Check letter")
       expect(page).to have_content("Check the letter. You can edit the letter before you send it to selected neighbours.")
@@ -216,7 +216,7 @@ RSpec.describe "Send letters to neighbours", js: true do
         click_link "Consultees, neighbours and publicity"
         click_link "Send letters to neighbours"
 
-        fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+        fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
         page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
         click_button "Print and send letters"
@@ -226,6 +226,67 @@ RSpec.describe "Send letters to neighbours", js: true do
           expect(page).to have_link("made public on the BoPS Public Portal", href: make_public_planning_application_path(planning_application))
         end
       end
+    end
+  end
+
+  context "when there is a validation error on a provided address" do
+    let(:neighbour) { Neighbour.new(address: "Cheese cottage", consultation:) }
+
+    before do
+      sign_in assessor
+      visit planning_application_path(planning_application)
+      click_link "Consultees, neighbours and publicity"
+      click_link "Send letters to neighbours"
+    end
+
+    it "I can not add an invalid address" do
+      fill_in "Search for neighbours by address", with: "Biscuit town"
+      page.find(:xpath, "//input[@value='Add neighbour']").click.click
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("'Biscuit town' is invalid")
+        expect(page).to have_content("Enter the property name or number, followed by a comma")
+        expect(page).to have_content("Enter the street name, followed by a comma")
+        expect(page).to have_content("Enter a postcode, like AA11AA")
+      end
+
+      within(".govuk-error-message") do
+        expect(page).to have_content("'Biscuit town' is invalid")
+        expect(page).to have_content("Enter the property name or number, followed by a comma")
+        expect(page).to have_content("Enter the street name, followed by a comma")
+        expect(page).to have_content("Enter a postcode, like AA11AA")
+      end
+
+      expect(Neighbour.count).to eq(0)
+    end
+
+    it "I can not send letters with an invalid address" do
+      neighbour.save(validate: false)
+
+      click_button "Print and send letters"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("'Cheese cottage' is invalid")
+        expect(page).to have_content("Enter the property name or number, followed by a comma")
+        expect(page).to have_content("Enter the street name, followed by a comma")
+        expect(page).to have_content("Enter a postcode, like AA11AA")
+      end
+
+      within(".govuk-error-message") do
+        expect(page).to have_content("'Cheese cottage' is invalid")
+        expect(page).to have_content("Enter the property name or number, followed by a comma")
+        expect(page).to have_content("Enter the street name, followed by a comma")
+        expect(page).to have_content("Enter a postcode, like AA11AA")
+      end
+
+      expect(NeighbourLetter.count).to eq(0)
+      expect(ActionMailer::Base.deliveries.count).to eq(0)
+      expect(consultation.status).to eq("not_started")
+      expect(Audit.where(
+        activity_type: "neighbour_letters_sent"
+      )).not_to exist
     end
   end
 
@@ -243,10 +304,10 @@ RSpec.describe "Send letters to neighbours", js: true do
     expect(page).to have_content(neighbour.address)
     expect(page).to have_content("Posted")
 
-    fill_in "Search for neighbours by address", with: "60-62 Commercial Street"
+    fill_in "Search for neighbours by address", with: "60-62, Commercial Street, E16LT"
     page.find(:xpath, "//input[@value='Add neighbour']").click.click
 
-    expect(page).to have_content("60-62 Commercial Street")
+    expect(page).to have_content("60-62, Commercial Street, E16LT")
   end
 
   describe "showing the status on the dashboard" do
@@ -277,8 +338,8 @@ RSpec.describe "Send letters to neighbours", js: true do
 
     context "when there are failed letters" do
       before do
-        neighbour1 = create(:neighbour, address: "1 Test Lane", consultation:)
-        neighbour2 = create(:neighbour, address: "2 Test Lane", consultation:)
+        neighbour1 = create(:neighbour, address: "1, Test Lane, AAA111", consultation:)
+        neighbour2 = create(:neighbour, address: "2, Test Lane, AAA111", consultation:)
         create(:neighbour_letter, neighbour: neighbour1, status: "submitted", notify_id: "123")
         create(:neighbour_letter, neighbour: neighbour2, status: "rejected", notify_id: "123")
       end
@@ -501,7 +562,7 @@ RSpec.describe "Send letters to neighbours", js: true do
 
       within(".govuk-error-summary") do
         expect(page).to have_content(
-          "Error adding neighbour addresses with message: Validation failed: Neighbours address 5, COXSON WAY, LONDON, SE1 2XB has already been added."
+          "Neighbours address 5, COXSON WAY, LONDON, SE1 2XB has already been added."
         )
       end
     end
@@ -612,7 +673,7 @@ RSpec.describe "Send letters to neighbours", js: true do
   end
 
   context "when letters have already been sent" do
-    let(:neighbour) { create(:neighbour, address: "1 Test Lane", consultation:) }
+    let(:neighbour) { create(:neighbour, address: "1, Test Lane, E1 5AT", consultation:) }
 
     before do
       travel_to(2.weeks.ago) do

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Site visit" do
 
   let!(:consultation) { planning_application.consultation }
   let!(:neighbour) { create(:neighbour, consultation:) }
-  let!(:neighbour2) { create(:neighbour, consultation:, address: "123 Another Address") }
+  let!(:neighbour2) { create(:neighbour, consultation:, address: "123, Another, Address") }
 
   before do
     sign_in assessor

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -115,9 +115,9 @@ RSpec.describe "Reviewing assessment summaries" do
         )
       end
 
-      let!(:neighbour1) { create(:neighbour, address: "1 Cookie Avenue", consultation:) }
-      let!(:neighbour2) { create(:neighbour, address: "2 Cookie Avenue", consultation:) }
-      let!(:neighbour3) { create(:neighbour, address: "3 Cookie Avenue", consultation:) }
+      let!(:neighbour1) { create(:neighbour, address: "1, Cookie Avenue, AAA111", consultation:) }
+      let!(:neighbour2) { create(:neighbour, address: "2, Cookie Avenue, AAA111", consultation:) }
+      let!(:neighbour3) { create(:neighbour, address: "3, Cookie Avenue, AAA111", consultation:) }
       let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
       let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
       let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
@@ -904,9 +904,9 @@ RSpec.describe "Reviewing assessment summaries" do
         )
       end
 
-      let!(:neighbour1) { create(:neighbour, address: "1 Cookie Avenue", consultation:) }
-      let!(:neighbour2) { create(:neighbour, address: "2 Cookie Avenue", consultation:) }
-      let!(:neighbour3) { create(:neighbour, address: "3 Cookie Avenue", consultation:) }
+      let!(:neighbour1) { create(:neighbour, address: "1, Cookie Avenue, AAA111", consultation:) }
+      let!(:neighbour2) { create(:neighbour, address: "2, Cookie Avenue, AAA111", consultation:) }
+      let!(:neighbour3) { create(:neighbour, address: "3, Cookie Avenue, AAA111", consultation:) }
       let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
       let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
       let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }


### PR DESCRIPTION
### Description of change

- Validate that neighbour address is at least 3 lines
- Do not send letter if an address is invalid, GOV.UK Notify will reject this anyway
- Improve send_letters controller action and wrap related updates in a transaction

### Story Link

https://trello.com/c/Yu9iwQwv/2078-when-address-isnt-three-lines-we-should-probably-catch-it-earlier

