### PR TITLE
Remove use of `raw` with i18n lookups

### DIFF
--- a/app/views/planning_applications/consultee/responses/edit.html.erb
+++ b/app/views/planning_applications/consultee/responses/edit.html.erb
@@ -19,7 +19,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <%= raw I18n.t("redaction_guidelines") %>
+    <%= t("redaction_guidelines_html") %>
   </div>
 </details>
 

--- a/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
@@ -32,7 +32,7 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    <%= raw I18n.t("redaction_guidelines") %>
+    <%= t("redaction_guidelines_html") %>
   </div>
 </details>
 

--- a/config/locales/redaction_guidelines.yml
+++ b/config/locales/redaction_guidelines.yml
@@ -1,5 +1,5 @@
-en: 
-  redaction_guidelines: |
+en:
+  redaction_guidelines_html: |
     <div class="govuk-body">
       <p>You need to redact any:</p>
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
Keys suffixed with `_html` will be marked as HTML-safe.
