### PR TITLE
Display role and organisation when adding consultees

### DIFF
--- a/app/javascript/controllers/consultees_controller.js
+++ b/app/javascript/controllers/consultees_controller.js
@@ -219,7 +219,25 @@ export default class extends Controller {
     checkboxInput.name = fieldName
     checkboxInput.id = domId
     inputLabel.htmlFor = domId
-    nameCell.textContent = data.name
+
+    const consulteeWrapper = document.createElement("div")
+
+    if (data.role || data.organisation) {
+      const suffix = [data.role, data.organisation].filter((v) => v).join(", ")
+      const suffixWrapper = document.createElement("span")
+      suffixWrapper.classList.add("govuk-!-font-size-16")
+      suffixWrapper.textContent = suffix
+
+      consulteeWrapper.append(
+        data.name,
+        document.createElement("br"),
+        suffixWrapper,
+      )
+    } else {
+      consulteeWrapper.textContent = data.name
+    }
+
+    nameCell.appendChild(consulteeWrapper)
 
     return consultee
   }

--- a/app/views/planning_applications/consultees/create.json.jbuilder
+++ b/app/views/planning_applications/consultees/create.json.jbuilder
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-json.extract! @consultee, :id, :name, :origin
+json.extract! @consultee, :id, :name, :role, :organisation, :origin

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -151,6 +151,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -161,6 +162,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -278,6 +280,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "14 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Sending")
@@ -325,6 +328,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "14 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -335,6 +339,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -147,6 +147,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -157,6 +158,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -233,6 +235,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Sending")
@@ -280,6 +283,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -290,6 +294,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "7 days")
         expect(page).to have_selector("td:nth-child(4)", text: start_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_checked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Not consulted")
@@ -135,6 +136,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_checked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Not consulted")
@@ -219,6 +221,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Sending")
@@ -229,6 +232,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Sending")
@@ -277,6 +281,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Failed")
@@ -287,6 +292,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
+        expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
         expect(page).to have_selector("td:nth-child(3)", text: "#{period} days")
         expect(page).to have_selector("td:nth-child(4)", text: current_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
@@ -349,6 +355,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "–")
         expect(page).to have_selector("td:nth-child(4)", text: "–")
         expect(page).to have_selector("td:nth-child(5)", text: "Sending")
@@ -390,6 +397,7 @@ RSpec.describe "Consultation", js: true do
       within "table tbody tr:first-child" do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
+        expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
         expect(page).to have_selector("td:nth-child(3)", text: "#{period} days")
         expect(page).to have_selector("td:nth-child(4)", text: current_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")


### PR DESCRIPTION
### Description of change

The StimulusJS controller was just using the name when adding a consultee

### Screenshots

![image](https://github.com/unboxed/bops/assets/6321/aba79f2b-3649-4215-a00c-424b4cc0c358)
