### PR TITLE
Show expiry minutes on 2FA login email

### DIFF
--- a/app/views/user_mailer/otp_mail.text.erb
+++ b/app/views/user_mailer/otp_mail.text.erb
@@ -1,3 +1,3 @@
 <%= t(".otp_is_your", otp: @otp) %>
 
-<%= t(".otp_expires", expires: @expires_minutes) %>
+<%= t(".otp_expires", expires: @expiry_minutes) %>

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe UserMailer, type: :mailer do
         "#{user.current_otp} is your Back Office Planning System verification code."
       )
     end
+
+    it "includes the otp expiry" do
+      expect(mail.body.encoded).to include(
+        "It will expire in 5 minutes."
+      )
+    end
   end
 
   describe "#assigned_notification_mail" do


### PR DESCRIPTION
### Description of change

Show expiry minutes on 2FA login email
- Looks as if there was a typo for the instance variable used

### Story Link

https://trello.com/c/tehRkYUy/2073-update-bops-login-2fa-email-to-include-minutes-till-expiry

