### PR TITLE
Switch away from native interpolation and validate fields

### DIFF
--- a/app/components/consultee_accordian_component.html.erb
+++ b/app/components/consultee_accordian_component.html.erb
@@ -1,3 +1,4 @@
+<a name="consultation-consultees-field-error"></a>
 <%= accordian_tag do %>
   <%= render ConsulteeAccordianSectionComponent.new(consultees: consultees.external, origin: "external") %>
   <%= render ConsulteeAccordianSectionComponent.new(consultees: consultees.internal, origin: "internal") %>

--- a/app/components/consultee_email_component.html.erb
+++ b/app/components/consultee_email_component.html.erb
@@ -9,13 +9,11 @@
 
   <%= wrapper_tag do %>
     <%= form_group_tag do %>
-      <%= label_tag :consultee_email_subject, t(".message_subject_label") %>
-      <%= text_field_tag :consultee_email_subject %>
+      <%= text_field_tag :consultee_email_subject, label: { text: t(".message_subject_label"), size: "s" } %>
     <% end %>
 
     <%= form_group_tag do %>
-      <%= label_tag :consultee_email_body, t(".message_body_label") %>
-      <%= text_area_tag :consultee_email_body, rows: 25 %>
+      <%= text_area_tag :consultee_email_body, rows: 25, label: { text: t(".message_body_label"), size: "s" } %>
     <% end %>
 
     <%= hint_tag do %>

--- a/app/components/consultee_email_component.rb
+++ b/app/components/consultee_email_component.rb
@@ -9,9 +9,22 @@ class ConsulteeEmailComponent < ViewComponent::Base
 
   attr_reader :form
 
+  def subject_invalid?
+    form.object.errors.key?(:consultee_email_subject)
+  end
+
+  def body_invalid?
+    form.object.errors.key?(:consultee_email_body)
+  end
+
+  def message_invalid?
+    subject_invalid? || body_invalid?
+  end
+
   def details_tag(&)
     options = {
       class: "govuk-details",
+      open: message_invalid?,
       data: {
         module: "govuk-details"
       }
@@ -34,16 +47,12 @@ class ConsulteeEmailComponent < ViewComponent::Base
     content_tag(:div, class: "govuk-form-group", &)
   end
 
-  def label_tag(name, content)
-    form.label(name, content, class: "govuk-label govuk-label--s")
+  def text_field_tag(name, **)
+    form.govuk_text_field(name, **)
   end
 
-  def text_field_tag(name)
-    form.text_field(name, class: "govuk-input")
-  end
-
-  def text_area_tag(name, **extra)
-    form.text_area(name, **{class: "govuk-textarea"}.merge(extra))
+  def text_area_tag(name, **)
+    form.govuk_text_area(name, **)
   end
 
   def hint_tag(&)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,12 @@ en:
               open_red_line_boundary_change_requests: Red line boundary change requests must be closed or cancelled
         consultation:
           attributes:
+            consultee_email_body:
+              blank: Please enter a message body
+              invalid: The message body contains an invalid placeholder '{{%{placeholder}}}'
+            consultee_email_subject:
+              blank: Please enter a message subject
+              invalid: The message subject contains an invalid placeholder '{{%{placeholder}}}'
             consultees:
               blank: Please select at least one consultee
             reconsult_date:
@@ -156,6 +162,9 @@ en:
               invalid: Please enter a valid date
             reconsult_message:
               blank: Please enter the reasons for the reconsultation
+              invalid: The reasons for reconsultation contains an invalid placeholder '{{%{placeholder}}}'
+            resend_message:
+              invalid: The additional message contains an invalid placeholder '{{%{placeholder}}}'
         document:
           attributes:
             file:
@@ -407,40 +416,41 @@ en:
     status: Status
     toggle_selection: Toggle selection
   consultee_email_component:
-    formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <code>%{name}</code> will be substituted when the email is sent.
+    formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <code>{{name}}</code> will be substituted when the email is sent.
     header: 2) Send email to selected consultees
     message_body_label: Message body
     message_subject_label: Message subject
     view_or_edit_email_template: View/edit email template
   consultee_emails:
     body: |
-      Dear %{name}
+      Dear {{name}}
 
-      Application number %{reference}
+      Application number {{reference}}
 
       We have received an application for the development described below.
 
       ## Proposal
 
-      %{description}
+      {{description}}
 
       ## Site address
 
-      %{address}
+      {{address}}
 
-      To view the application documents, visit %{link}.
+      To view the application documents, visit:
+      {{link}}.
 
       ## Comment on this application
 
-      Please submit your comments by %{closing_date} by replying to this email. You can include attachments. We may not be able to consider comments received after this date.
+      Please submit your comments by {{closing_date}} by replying to this email. You can include attachments. We may not be able to consider comments received after this date.
 
       Yours
 
 
-      %{signatory_name}
-      %{signatory_job_title}
-      %{local_authority}
-    subject: Application for planning permission %{reference}
+      {{signatory_name}}
+      {{signatory_job_title}}
+      {{local_authority}}
+    subject: Application for planning permission {{reference}}
   consultee_overview_component:
     chase_outstanding_consultees: Chase outstanding consultees
     consulted: Date last consulted
@@ -1242,7 +1252,7 @@ en:
       refused: Prior approval required and refused
       refused_html: "<strong>Prior approval required and refused</strong>"
   reconsult_consultees_component:
-    formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <nobr><code>%{closing_date}</code></nobr> will be substituted when the email is sent.
+    formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <nobr><code>{{closing_date}}</code></nobr> will be substituted when the email is sent.
     hint: Choosing 'Yes' will allow you to add the reasons why this application is being reconsulted.
     legend: 3) Is this a reconsultation?
     reconsult: Yes, I’m reconsulting existing consultees

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -221,7 +221,17 @@ RSpec.describe "Consultation", js: true do
     expect(page).to have_selector("[role=alert] li", text: "Please enter a valid date")
 
     within "#resend-consultees" do
-      fill_in "Reasons for reconsultation", with: "Application has changes - please respond by %<closing_date>s"
+      fill_in "Reasons for reconsultation", with: "Application has changes - please respond by {{close_date}}"
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "The reasons for reconsultation contains an invalid placeholder '{{close_date}}'")
+
+    within "#resend-consultees" do
+      fill_in "Reasons for reconsultation", with: "Application has changes - please respond by {{closing_date}}"
       fill_in "Day", with: future.day
       fill_in "Month", with: future.month
       fill_in "Year", with: future.year

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -180,7 +180,17 @@ RSpec.describe "Consultation", js: true do
     within "#resend-consultees" do
       choose "No, I’m chasing existing consultees"
 
-      fill_in "Additional message to include in the email", with: "Please respond to the message below"
+      fill_in "Additional message to include in the email", with: "Please respond to the message below by {{close_date}}"
+    end
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "The additional message contains an invalid placeholder '{{close_date}}'")
+
+    within "#resend-consultees" do
+      fill_in "Additional message to include in the email", with: "Please respond to the message below by {{closing_date}}"
     end
 
     expect do
@@ -210,7 +220,7 @@ RSpec.describe "Consultation", js: true do
             email_address: "planning@london.gov.uk",
             email_reply_to_id: "4485df6f-a728-41ed-bc46-cdb2fc6789aa",
             personalisation: hash_including(
-              "body" => a_string_starting_with("Please respond to the message below")
+              "body" => a_string_starting_with("Please respond to the message below by #{existing_date}")
             )
           }
         ))

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -145,7 +145,15 @@ RSpec.describe "Consultation", js: true do
 
     toggle "View/edit email template"
 
-    fill_in "Message subject", with: "Consultation for planning application %<reference>s"
+    fill_in "Message subject", with: "Consultation for planning application {{uuid}}"
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "The message subject contains an invalid placeholder '{{uuid}}'")
+
+    fill_in "Message subject", with: "Consultation for planning application {{reference}}"
 
     expect do
       accept_confirm(text: "Send emails to consultees?") do
@@ -307,7 +315,7 @@ RSpec.describe "Consultation", js: true do
 
     toggle "View/edit email template"
 
-    fill_in "Message subject", with: "Resend: Consultation for planning application %<reference>s"
+    fill_in "Message subject", with: "Resend: Consultation for planning application {{reference}}"
 
     expect do
       accept_confirm(text: "Send emails to consultees?") do


### PR DESCRIPTION
### Description of change

The built-in Ruby `format` method is inappropriate for use on user-supplied data as it can use a variety of formats and generate exceptions when substitutions are improperly formed. Use `gsub` instead which will ignore anything that doesn't match the pattern and validate the message fields on submission for any placeholders that don't match expected values.


A brief description of the change, with enough context for the reviewer to be able to understand why we're making this change.

### Story Link

https://trello.com/c/hIn32jDk

### Screenshots

![image](https://github.com/unboxed/bops/assets/6321/da93f32a-9b7f-4dca-b97f-7cd7a4283de9)
![image](https://github.com/unboxed/bops/assets/6321/65d45b96-1a5c-4463-8d6a-68920f79e802)
