### PR TITLE
Allow consultee email content to be reset

### DIFF
--- a/app/components/consultee_email_component.html.erb
+++ b/app/components/consultee_email_component.html.erb
@@ -19,5 +19,9 @@
     <%= hint_tag do %>
       <%= t(".formatting_hint_html") %>
     <% end %>
+
+    <%= button_tag do %>
+      <%= t(".reset_message_to_default") %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/consultee_email_component.rb
+++ b/app/components/consultee_email_component.rb
@@ -21,12 +21,23 @@ class ConsulteeEmailComponent < ViewComponent::Base
     subject_invalid? || body_invalid?
   end
 
+  def default_subject
+    form.object.default_consultee_email_subject
+  end
+
+  def default_body
+    form.object.default_consultee_email_body
+  end
+
   def details_tag(&)
     options = {
       class: "govuk-details",
       open: message_invalid?,
       data: {
-        module: "govuk-details"
+        module: "govuk-details",
+        controller: "consultee-email",
+        consultee_email_default_subject: default_subject,
+        consultee_email_default_body: default_body
       }
     }
 
@@ -48,11 +59,22 @@ class ConsulteeEmailComponent < ViewComponent::Base
   end
 
   def text_field_tag(name, **)
-    form.govuk_text_field(name, **)
+    form.govuk_text_field(name, data: {consultee_email_target: "subject"}, **)
   end
 
   def text_area_tag(name, **)
-    form.govuk_text_area(name, **)
+    form.govuk_text_area(name, data: {consultee_email_target: "body"}, **)
+  end
+
+  def button_tag(&)
+    options = {
+      type: "button",
+      class: "govuk-button govuk-button--secondary",
+      data: {
+        action: "click->consultee-email#reset"
+      }
+    }
+    content_tag(:button, **options, &)
   end
 
   def hint_tag(&)

--- a/app/javascript/controllers/consultee_email_controller.js
+++ b/app/javascript/controllers/consultee_email_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["subject", "body"]
+
+  reset() {
+    console.log("Reset consultee email")
+    this.subjectTarget.value = this.defaultSubject
+    this.bodyTarget.value = this.defaultBody
+  }
+
+  get defaultSubject() {
+    return this.data.get("default-subject")
+  }
+
+  get defaultBody() {
+    return this.data.get("default-body")
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,6 +9,9 @@ application.register("address-fill", AddressFillController)
 import ConsulteesController from "./consultees_controller.js"
 application.register("consultees", ConsulteesController)
 
+import ConsulteeEmailController from "./consultee_email_controller.js"
+application.register("consultee-email", ConsulteeEmailController)
+
 import ClearFormController from "./clear_form_controller.js"
 application.register("clear-form", ClearFormController)
 

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -12,8 +12,8 @@ class Consultation < ApplicationRecord
     signatory_name signatory_job_title local_authority
   ].freeze
 
-  attribute :consultee_email_subject, :string, default: -> { I18n.t("subject", scope: "consultee_emails") }
-  attribute :consultee_email_body, :string, default: -> { I18n.t("body", scope: "consultee_emails") }
+  attribute :consultee_email_subject, :string, default: -> { default_consultee_email_subject }
+  attribute :consultee_email_body, :string, default: -> { default_consultee_email_body }
 
   attribute :email_reason, :string, default: "send"
   attribute :resend_message, :string
@@ -92,6 +92,19 @@ class Consultation < ApplicationRecord
   before_update :audit_letter_copy_sent!, if: :letter_copy_sent_at_changed?
 
   format_geojson_epsg :polygon_geojson
+
+  class << self
+    def default_consultee_email_subject
+      I18n.t("subject", scope: "consultee_emails")
+    end
+
+    def default_consultee_email_body
+      I18n.t("body", scope: "consultee_emails")
+    end
+  end
+
+  delegate :default_consultee_email_subject, to: :class
+  delegate :default_consultee_email_body, to: :class
 
   def resend?
     email_reason == "resend"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -424,6 +424,7 @@ en:
     header: 2) Send email to selected consultees
     message_body_label: Message body
     message_subject_label: Message subject
+    reset_message_to_default: Reset message to default content
     view_or_edit_email_template: View/edit email template
   consultee_emails:
     body: |

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -153,7 +153,17 @@ RSpec.describe "Consultation", js: true do
 
     expect(page).to have_selector("[role=alert] li", text: "The message subject contains an invalid placeholder '{{uuid}}'")
 
-    fill_in "Message subject", with: "Consultation for planning application {{reference}}"
+    fill_in "Message subject", with: ""
+    fill_in "Message body", with: ""
+
+    accept_confirm(text: "Send emails to consultees?") do
+      click_button "Send emails to consultees"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "Please enter a message subject")
+    expect(page).to have_selector("[role=alert] li", text: "Please enter a message body")
+
+    click_button "Reset message to default content"
 
     expect do
       accept_confirm(text: "Send emails to consultees?") do
@@ -182,7 +192,7 @@ RSpec.describe "Consultation", js: true do
             email_address: "chris.wood@planx.gov.uk",
             email_reply_to_id: "4485df6f-a728-41ed-bc46-cdb2fc6789aa",
             personalisation: hash_including(
-              "subject" => "Consultation for planning application #{planning_application.reference}"
+              "subject" => "Application for planning permission #{planning_application.reference}"
             )
           }
         ))
@@ -203,7 +213,7 @@ RSpec.describe "Consultation", js: true do
             email_address: "planning@london.gov.uk",
             email_reply_to_id: "4485df6f-a728-41ed-bc46-cdb2fc6789aa",
             personalisation: hash_including(
-              "subject" => "Consultation for planning application #{planning_application.reference}"
+              "subject" => "Application for planning permission #{planning_application.reference}"
             )
           }
         ))


### PR DESCRIPTION
Now that the message content is only set to the default on record creation add an explicit mechanism to reset the message as blanking out the content no longer works and wasn't particularly user-friendly.

### Story Link

https://trello.com/c/YXWqoPzz

### Screenshots

<img width="1004" alt="image" src="https://github.com/unboxed/bops/assets/6321/fd90a60c-9dcb-4d88-9a7a-2452c5887a52">
