### PR TITLE
Speed up rubocop by ignoring storage and tmp directories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ AllCops:
     - 'db/schema.rb'
     - 'config/environments/**'
     - 'config/puma.rb'
+    - 'storage/**/*'
+    - 'tmp/**/*'
     - 'vendor/**/*'
 
 Style/FrozenStringLiteralComment:


### PR DESCRIPTION
Before:
  real  0m24.669s
  user 0m31.788s
  sys   0m4.565s

After:
  real  0m5.298s
  user  0m4.233s
  sys   0m1.082s
