### PR TITLE
Ensure address is valid when uploading neighbour response

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -138,9 +138,9 @@ module PlanningApplications
 
     def neighbours_to_contact
       if resend_existing?
-        @consultation.neighbours
+        @consultation.neighbours.with_letters
       else
-        @consultation.neighbours.reject(&:letter_created?)
+        @consultation.neighbours.without_letters
       end
     end
 

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -4,6 +4,8 @@ class NeighbourResponse < ApplicationRecord
   belongs_to :neighbour
   belongs_to :redacted_by, class_name: "User", optional: true
 
+  validates_associated :neighbour
+
   has_many :documents, dependent: :destroy
 
   attr_readonly :response

--- a/app/views/planning_applications/neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/neighbour_responses/edit.html.erb
@@ -20,20 +20,7 @@
   method: :patch
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <% if @neighbour_response.errors.any? %>
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% @neighbour_response.errors.full_messages.each do |error| %>
-            <li><%= error %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
+  
   <%= form.govuk_text_field :name %>
   <%= form.govuk_text_field :email %>
   <div class="govuk-form-group">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -992,6 +992,11 @@ en:
         success: Addresses have been successfully added.
       send_letters:
         require_resend_reason: Must provide a reason when resending letters to previously-contacted neighbours
+    neighbour_responses:
+      create:
+        success: Neighbour response successfully created.
+      update:
+        success: Neighbour response successfully updated.
     notes:
       create:
         success: Note was successfully created.

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
     json = {
       name: "Keira Walsh",
       response: "This is good",
-      address: "123 street",
+      address: "123 street, AAA111",
       summary_tag: "supportive",
       files: [""]
     }.to_json


### PR DESCRIPTION
### Description of change

- Ensure address is valid when uploading neighbour response
- Wrap related updates to neighbour, neighbour response in a transaction so we don't have unexpected updated results for one record without the other
- Since we need to send letters to these addresses, we need to validate the address here too

### Story Link

https://trello.com/c/Yu9iwQwv/2078-when-address-isnt-three-lines-we-should-probably-catch-it-earlier

### Screenshots

![Screenshot 2023-11-16 at 13 49 45](https://github.com/unboxed/bops/assets/34001723/eaef5da7-1773-40f6-87ce-ec8a8fd1dfdc)
