### PR TITLE
Add session_id and params fields to planx_planning_data

### DIFF
--- a/app/models/planx_planning_data.rb
+++ b/app/models/planx_planning_data.rb
@@ -4,4 +4,9 @@ class PlanxPlanningData < ApplicationRecord
   belongs_to :planning_application
 
   validates :entry, presence: true
+  validates :session_id, uniqueness: true, allow_nil: true
+
+  def session_id
+    super || JSON.parse(entry)["session_id"]
+  end
 end

--- a/db/migrate/20231117132948_add_session_id_to_planx_planning_data.rb
+++ b/db/migrate/20231117132948_add_session_id_to_planx_planning_data.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddSessionIdToPlanxPlanningData < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planx_planning_data, :session_id, :string, null: true
+    add_index :planx_planning_data, :session_id, unique: true
+  end
+end

--- a/db/migrate/20231117134418_add_param_fields_to_planx_planning_data.rb
+++ b/db/migrate/20231117134418_add_param_fields_to_planx_planning_data.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddParamFieldsToPlanxPlanningData < ActiveRecord::Migration[7.0]
+  def up
+    add_column :planx_planning_data, :params_v1, :jsonb
+    add_column :planx_planning_data, :params_v2, :jsonb
+
+    execute <<-SQL
+      UPDATE planx_planning_data
+      SET params_v1 = planning_applications.audit_log
+      FROM planning_applications
+      WHERE planx_planning_data.planning_application_id = planning_applications.id
+        AND planning_applications.audit_log IS NOT NULL;
+    SQL
+  end
+
+  def down
+    remove_column :planx_planning_data, :params_v1, :jsonb
+    remove_column :planx_planning_data, :params_v2, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -605,7 +605,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_20_040052) do
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "session_id"
+    t.jsonb "params_v1"
+    t.jsonb "params_v2"
     t.index ["planning_application_id"], name: "ix_planx_planning_data_on_planning_application_id"
+    t.index ["session_id"], name: "ix_planx_planning_data_on_session_id", unique: true
   end
 
   create_table "policies", force: :cascade do |t|

--- a/spec/factories/planx_planning_data.rb
+++ b/spec/factories/planx_planning_data.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :planx_planning_data do
+    planning_application
+    entry { "{\"session_id\":\"21161b70-0e29-40e6-9a38-c42f61f25ab9\"}" }
+    params_v1 { "{\"application_type\":\"planning_permission\",\"site\":{\"uprn\":\"100081043511\",\"address_1\":\"11 Abbey Gardens\",\"address_2\":\"Southwark\",\"town\":\"London\",\"postcode\":\"SE16 3RQ\",\"latitude\":\"51.4842536\",\"longitude\":\"-0.0764165\"}" }
+    session_id { "21161b70-0e29-40e6-9a38-c42f61f25ab9" }
+  end
+end

--- a/spec/models/planx_planning_data_spec.rb
+++ b/spec/models/planx_planning_data_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe PlanxPlanningData do
   describe "validations" do
-    subject(:planx_planning_data) { described_class.new }
+    subject(:planx_planning_data) { described_class.new(session_id: "12345678") }
 
     describe "#entry" do
       it "validates presence" do
@@ -15,6 +15,16 @@ RSpec.describe PlanxPlanningData do
     describe "#planning_application" do
       it "validates presence" do
         expect { planx_planning_data.valid? }.to change { planx_planning_data.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+
+    describe "#session_id" do
+      it "validates uniqueness" do
+        create(:planx_planning_data, session_id: "12345678")
+
+        expect { create(:planx_planning_data, session_id: "12345678") }.to raise_error(
+          ActiveRecord::RecordInvalid, "Validation failed: Session has already been taken"
+        )
       end
     end
   end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
           )
 
           expect(planning_application.planx_planning_data.entry).to eq(cloned_planning_application.planx_planning_data.entry)
+          expect(cloned_planning_application.planx_planning_data.read_attribute(:session_id)).to eq(nil)
 
           # Proposal details have their own object id i.e. ProposalDetail:0x00007fe42a8476a8 so compare the json value instead
           proposal_details = planning_application.proposal_details.map(&:to_json)
@@ -160,7 +161,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
         end
       end
 
-      [Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError, NoMethodError].each do |error|
+      [Api::V1::Errors::WrongFileTypeError, Api::V1::Errors::GetFileError, ActiveRecord::RecordInvalid, ArgumentError, NoMethodError, ActiveRecord::RecordNotUnique].each do |error|
         context "when there is an error of type: #{error} saving the new planning application" do
           before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(error) }
 
@@ -194,6 +195,12 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
 
         it "creates a new planx planning data record" do
           expect { create_planning_application }.to change(PlanxPlanningData, :count).by(1)
+        end
+
+        it "sets the session_id on the planx planning data record" do
+          create_planning_application
+
+          expect(PlanxPlanningData.last.session_id).to eq("21161b70-0e29-40e6-9a38-c42f61f25ab9")
         end
       end
     end


### PR DESCRIPTION
### Description of change

Adding session_id and param fields to planx_planning_data in preparation for the new ODP schema submission.
We want a relation between the old and new using the unique session_id. 
As part of this, we also want to drop the bulky `audit_log` field on planning applications and have it live in `params_v1` instead and this is the first necessary step towards that

### Story Link

https://trello.com/c/FM5ycejN/2159-receive-planning-applications-using-new-odp-submission-schema

