### PR TITLE
Produce doc tags based on application type

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -17,6 +17,10 @@ module DocumentHelper
     Document::SUPPORT_TAGS.include?(tag)
   end
 
+  def irrelevant_tags(planning_application, key)
+    Document.send("#{key}_tags") - planning_application.application_type.document_tags[key]
+  end
+
   def created_by(document)
     if document.user.present?
       "This document was manually uploaded by #{document.user.name}."

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -14,11 +14,7 @@ module DocumentHelper
   end
 
   def supporting_document_tag?(tag)
-    Document::SUPPORT_TAGS.include?(tag)
-  end
-
-  def irrelevant_tags(planning_application, key)
-    Document.send("#{key}_tags") - planning_application.application_type.document_tags[key]
+    Document::SUPPORTING_DOCUMENT_TAGS.include?(tag)
   end
 
   def created_by(document)
@@ -39,15 +35,5 @@ module DocumentHelper
 
   def reference_or_file_name(document)
     document.numbers.presence || document.name
-  end
-
-  def tags_first_half(tags)
-    count = (tags.count.round / 2.to_f).ceil
-    tags.in_groups_of(count).first
-  end
-
-  def tags_second_half(tags)
-    count = (tags.count.round / 2.to_f).ceil
-    tags.in_groups_of(count).second
   end
 end

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -13,6 +13,10 @@ module DocumentHelper
     Document::EVIDENCE_TAGS.include?(tag)
   end
 
+  def supporting_document_tag?(tag)
+    Document::SUPPORT_TAGS.include?(tag)
+  end
+
   def created_by(document)
     if document.user.present?
       "This document was manually uploaded by #{document.user.name}."
@@ -31,5 +35,15 @@ module DocumentHelper
 
   def reference_or_file_name(document)
     document.numbers.presence || document.name
+  end
+
+  def tags_first_half(tags)
+    count = (tags.count.round / 2.to_f).ceil
+    tags.in_groups_of(count).first
+  end
+
+  def tags_second_half(tags)
+    count = (tags.count.round / 2.to_f).ceil
+    tags.in_groups_of(count).second
   end
 end

--- a/app/javascript/controllers/show_hide_controller.js
+++ b/app/javascript/controllers/show_hide_controller.js
@@ -42,4 +42,18 @@ export default class extends Controller {
       "govuk-!-margin-top-2",
     )
   }
+
+  hideDisplayNone(event) {
+    event.preventDefault()
+
+    const target = event.currentTarget
+
+    target.parentElement.parentElement.classList.add("govuk-!-display-none")
+    target.parentElement.parentElement.parentElement
+      .querySelector(".show-document-tags")
+      .classList.remove("govuk-!-display-none")
+    target.parentElement.parentElement.parentElement
+      .querySelector(".govuk-grid-column-full")
+      .classList.add("govuk-!-margin-bottom-3", "govuk-!-margin-top-2")
+  }
 }

--- a/app/javascript/controllers/show_hide_controller.js
+++ b/app/javascript/controllers/show_hide_controller.js
@@ -27,4 +27,19 @@ export default class extends Controller {
       element.classList.add("govuk-!-display-none")
     })
   }
+
+  showDisplayNone(event) {
+    event.preventDefault()
+
+    const target = event.currentTarget
+
+    target.parentElement.parentElement
+      .querySelector(".document-tags")
+      .classList.remove("govuk-!-display-none")
+    target.classList.add("govuk-!-display-none")
+    target.parentElement.classList.remove(
+      "govuk-!-margin-bottom-3",
+      "govuk-!-margin-top-2",
+    )
+  }
 }

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -41,14 +41,6 @@ class ApplicationType < ApplicationRecord
     document_tags.values.flatten
   end
 
-  def document_evidence_tags
-    document_tags["evidence"]
-  end
-
-  def document_plan_tags
-    document_tags["plans"]
-  end
-
   class << self
     def menu(scope = all)
       scope.order(name: :asc).select(:name, :id).map do |application_type|

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -37,8 +37,17 @@ class ApplicationType < ApplicationRecord
     assessment_details.excluding("past_applications")
   end
 
-  def document_tag_list
-    document_tags.values.flatten
+  def irrelevant_tags(key)
+    case key
+    when "plans"
+      Document::PLAN_TAGS - document_tags[key]
+    when "evidence"
+      Document::EVIDENCE_TAGS - document_tags[key]
+    when "supporting_documents"
+      Document::SUPPORTING_DOCUMENT_TAGS - document_tags[key]
+    else
+      raise ArgumentError, "Unexpected document tag type: #{key}"
+    end
   end
 
   class << self

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -37,6 +37,18 @@ class ApplicationType < ApplicationRecord
     assessment_details.excluding("past_applications")
   end
 
+  def document_tag_list
+    document_tags.values.flatten
+  end
+
+  def document_evidence_tags
+    document_tags["evidence"]
+  end
+
+  def document_plan_tags
+    document_tags["plans"]
+  end
+
   class << self
     def menu(scope = all)
       scope.order(name: :asc).select(:name, :id).map do |application_type|

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -88,7 +88,8 @@ class Document < ApplicationRecord
     "Gypsy and Traveller Statement",
     "HMO statement",
     "Specialist Accommodation Statement",
-    "Student Accommodation Statement"
+    "Student Accommodation Statement",
+    "Other Supporting Document"
   ].freeze
 
   ## Needs to be better

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -60,7 +60,7 @@ class Document < ApplicationRecord
     "Other"
   ].freeze
 
-  SUPPORT_TAGS = [
+  SUPPORTING_DOCUMENT_TAGS = [
     "Site Visit",
     "Site Notice",
     "Press Notice",
@@ -128,7 +128,7 @@ class Document < ApplicationRecord
     other: ["What do these documents show?"]
   }.freeze
 
-  TAGS = PLAN_TAGS + EVIDENCE_TAGS + SUPPORT_TAGS
+  TAGS = PLAN_TAGS + EVIDENCE_TAGS + SUPPORTING_DOCUMENT_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze
   EXCLUDED_OWNERS = %w[PressNotice SiteNotice SiteVisit].freeze
@@ -173,20 +173,6 @@ class Document < ApplicationRecord
   before_create do
     self.api_user ||= Current.api_user
     self.user ||= Current.user
-  end
-
-  class << self
-    def evidence_tags
-      EVIDENCE_TAGS
-    end
-
-    def plans_tags
-      PLAN_TAGS
-    end
-
-    def supporting_documents_tags
-      SUPPORT_TAGS
-    end
   end
 
   def name

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -245,7 +245,7 @@ class Document < ApplicationRecord
   end
 
   def tag_values_permitted
-    errors.add(:tags, :unpermitted_tags) unless (tags - Document::TAGS).empty?
+    errors.add(:tags, :unpermitted_tags) unless (tags - planning_application.application_type.document_tag_list).empty?
   end
 
   def file_content_type_permitted

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -56,13 +56,39 @@ class Document < ApplicationRecord
     "Tenancy Invoice",
     "Bank Statement",
     "Statutory Declaration",
+    "Discounts",
     "Other"
   ].freeze
 
-  OTHER_TAGS = [
+  SUPPORT_TAGS = [
     "Site Visit",
     "Site Notice",
-    "Press Notice"
+    "Press Notice",
+    "Design and Access Statement",
+    "Planning Statement",
+    "Viability Appraisal",
+    "Heritage Statement",
+    "Agricultural, Forestry or Occupational Worker Dwelling Justification",
+    "Arboricultural Assessment",
+    "Structural Survey/report",
+    "Air Quality Assessment",
+    "Basement Impact Assessment",
+    "Biodiversity Net Gain (from April)",
+    "Contaminated Land Assessment",
+    "Daylight and Sunlight Assessment",
+    "Flood Risk Assessment/Drainage and SuDs Report",
+    "Landscape and Visual Impact Assessment",
+    "Noise Impact Assessment",
+    "Open Space Assessment",
+    "Sustainability and Energy Statement",
+    "Transport Statement",
+    "NDSS Compliance Statement",
+    "Ventilation/Extraction Statement",
+    "Community Infrastructure Levy (CIL) form",
+    "Gypsy and Traveller Statement",
+    "HMO statement",
+    "Specialist Accommodation Statement",
+    "Student Accommodation Statement"
   ].freeze
 
   ## Needs to be better
@@ -101,7 +127,7 @@ class Document < ApplicationRecord
     other: ["What do these documents show?"]
   }.freeze
 
-  TAGS = PLAN_TAGS + EVIDENCE_TAGS + OTHER_TAGS
+  TAGS = PLAN_TAGS + EVIDENCE_TAGS + SUPPORT_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze
   EXCLUDED_OWNERS = %w[PressNotice SiteNotice SiteVisit].freeze
@@ -146,6 +172,20 @@ class Document < ApplicationRecord
   before_create do
     self.api_user ||= Current.api_user
     self.user ||= Current.user
+  end
+
+  class << self
+    def evidence_tags
+      EVIDENCE_TAGS
+    end
+
+    def plans_tags
+      PLAN_TAGS
+    end
+
+    def supporting_documents_tags
+      SUPPORT_TAGS
+    end
   end
 
   def name
@@ -245,7 +285,7 @@ class Document < ApplicationRecord
   end
 
   def tag_values_permitted
-    errors.add(:tags, :unpermitted_tags) unless (tags - planning_application.application_type.document_tag_list).empty?
+    errors.add(:tags, :unpermitted_tags) unless (tags - Document::TAGS).empty?
   end
 
   def file_content_type_permitted

--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -14,6 +14,13 @@
         </p>
       <% end %>
     <% end %>
+    <% document.tags.each do |tag| %>
+      <% if supporting_document_tag?(tag) %>
+        <p class="govuk-body">
+          <strong class="govuk-tag govuk-tag--turquoise"><%= tag %></strong><br>
+        </p>
+      <% end %>
+    <% end %>
   <% end %>
   <% if document.invalidated_document_reason %>
     <p class="govuk-body govuk-!-margin-bottom-1">

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -50,25 +50,25 @@
       <strong>File name:</strong> <%= @document.name %>
     </p>
 
-    <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
+    <p class="govuk-body govuk-!-margin-bottom-0">
       <strong>Date received:</strong> <%= @document.received_at_or_created %>
     </p>
 
     <% if @replacement_document_validation_request %>
-      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
+      <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>This document replaced:</strong>
         <%= link_to @replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, @replacement_document_validation_request.old_document), target: :_new, class: "govuk-link" %>
       </p>
 
-      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
+      <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>Reason this replacement document was requested:</strong> <%= render(FormattedContentComponent.new(text: @replacement_document_validation_request.invalidated_document_reason)) %>
       </p>
 
-      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
+      <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>Applicant accepted request and uploaded this document.</strong>
       </p>
     <% else %>
-      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
+      <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>Applicant reason for submitting document:</strong>
 
         <% if @document.applicant_description.present? %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -46,29 +46,29 @@
     <% end %>
   </div>
   <div class="govuk-grid-column-one-half">
-    <p class="govuk-body">
+    <p class="govuk-body govuk-!-margin-bottom-0">
       <strong>File name:</strong> <%= @document.name %>
     </p>
 
-    <p class="govuk-body">
+    <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
       <strong>Date received:</strong> <%= @document.received_at_or_created %>
     </p>
 
     <% if @replacement_document_validation_request %>
-      <p class="govuk-body">
+      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
         <strong>This document replaced:</strong>
         <%= link_to @replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, @replacement_document_validation_request.old_document), target: :_new, class: "govuk-link" %>
       </p>
 
-      <p class="govuk-body">
+      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
         <strong>Reason this replacement document was requested:</strong> <%= render(FormattedContentComponent.new(text: @replacement_document_validation_request.invalidated_document_reason)) %>
       </p>
 
-      <p class="govuk-body">
+      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
         <strong>Applicant accepted request and uploaded this document.</strong>
       </p>
     <% else %>
-      <p class="govuk-body">
+      <p class="govuk-body govuk-body govuk-!-margin-bottom-0">
         <strong>Applicant reason for submitting document:</strong>
 
         <% if @document.applicant_description.present? %>

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -1,5 +1,5 @@
 <hr>
-<div class="govuk-form-group <%= form.object.errors[:tags].any? ? 'govuk-form-group--error' : '' %>">
+<div class="govuk-form-group <%= form.object.errors[:tags].any? ? 'govuk-form-group--error' : '' %>" data-controller="show-hide">
   <fieldset class="govuk-fieldset govuk-!-margin-top-4">
     <legend class="govuk-fieldset__legend">
       <h3 class="govuk-heading-s">
@@ -31,8 +31,6 @@
                 <% end %>
               </div>
             </div>
-          <% end %>
-          <% if @planning_application.application_type.document_tags[key].count > 1 %>
             <div class="govuk-grid-column-one-half">
               <div class="govuk-checkboxes govuk-checkboxes--small">
                 <%= form.collection_check_boxes :tags, tags_second_half(@planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
@@ -44,24 +42,38 @@
               </div>
             </div>
           <% end %>
-          <div class="govuk-grid-column-full">
-            <details class="govuk-details" data-module="govuk-details">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  See all (<%= (Document.send("#{key}_tags") - @planning_application.application_type.document_tags[key]).count %>)
-                </span>
-              </summary>
-              <div class="govuk-details__text">
-                <%= form.collection_check_boxes :tags, (Document.send("#{key}_tags") - @planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
+          <div>
+            <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
+              <a class="show-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#showDisplayNone">
+                Show all (<%= irrelevant_tags(@planning_application, key).count %>)
+              </a>
+            </div>
+            <div class="document-tags govuk-!-display-none">
+              <% if irrelevant_tags(@planning_application, key).count > 0 %>
+                <div class="govuk-grid-column-one-half">
                   <div class="govuk-checkboxes govuk-checkboxes--small">
-                    <div class="govuk-checkboxes__item">
-                      <%= b.check_box class: "govuk-checkboxes__input" %>
-                      <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                    <%= form.collection_check_boxes :tags, tags_first_half(irrelevant_tags(@planning_application, key)), :itself, :itself do |b| %>
+                      <div class="govuk-checkboxes__item">
+                        <%= b.check_box class: "govuk-checkboxes__input" %>
+                        <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+                <% unless tags_second_half(irrelevant_tags(@planning_application, key)).nil? %>
+                  <div class="govuk-grid-column-one-half">
+                    <div class="govuk-checkboxes govuk-checkboxes--small">
+                      <%= form.collection_check_boxes :tags, tags_second_half(irrelevant_tags(@planning_application, key)), :itself, :itself do |b| %>
+                        <div class="govuk-checkboxes__item">
+                          <%= b.check_box class: "govuk-checkboxes__input" %>
+                          <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                        </div>
+                      <% end %>
                     </div>
                   </div>
                 <% end %>
-              </div>
-            </details>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -20,20 +20,10 @@
           <h3 class="govuk-heading-s">
             <%= key.humanize %>
           </h3>
-          <% if @planning_application.application_type.document_tags[key].count > 1 %>
+          <% @planning_application.application_type.document_tags[key].in_groups(2, false) do |tags| %>
             <div class="govuk-grid-column-one-half">
               <div class="govuk-checkboxes govuk-checkboxes--small">
-                <%= form.collection_check_boxes :tags, tags_first_half(@planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
-                  <div class="govuk-checkboxes__item">
-                    <%= b.check_box class: "govuk-checkboxes__input" %>
-                    <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-            <div class="govuk-grid-column-one-half">
-              <div class="govuk-checkboxes govuk-checkboxes--small">
-                <%= form.collection_check_boxes :tags, tags_second_half(@planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
+                <%= form.collection_check_boxes :tags, tags, :itself, :itself do |b| %>
                   <div class="govuk-checkboxes__item">
                     <%= b.check_box class: "govuk-checkboxes__input" %>
                     <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
@@ -45,14 +35,14 @@
           <div>
             <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
               <a class="show-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#showDisplayNone">
-                Show all (<%= irrelevant_tags(@planning_application, key).count %>)
+                Show all (<%= @planning_application.application_type.irrelevant_tags(key).count %>)
               </a>
             </div>
             <div class="document-tags govuk-!-display-none">
-              <% if irrelevant_tags(@planning_application, key).count > 0 %>
+              <% @planning_application.application_type.irrelevant_tags(key).in_groups(2, false) do |tags| %>
                 <div class="govuk-grid-column-one-half">
                   <div class="govuk-checkboxes govuk-checkboxes--small">
-                    <%= form.collection_check_boxes :tags, tags_first_half(irrelevant_tags(@planning_application, key)), :itself, :itself do |b| %>
+                    <%= form.collection_check_boxes :tags, tags, :itself, :itself do |b| %>
                       <div class="govuk-checkboxes__item">
                         <%= b.check_box class: "govuk-checkboxes__input" %>
                         <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
@@ -60,18 +50,6 @@
                     <% end %>
                   </div>
                 </div>
-                <% unless tags_second_half(irrelevant_tags(@planning_application, key)).nil? %>
-                  <div class="govuk-grid-column-one-half">
-                    <div class="govuk-checkboxes govuk-checkboxes--small">
-                      <%= form.collection_check_boxes :tags, tags_second_half(irrelevant_tags(@planning_application, key)), :itself, :itself do |b| %>
-                        <div class="govuk-checkboxes__item">
-                          <%= b.check_box class: "govuk-checkboxes__input" %>
-                          <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
-                        </div>
-                      <% end %>
-                    </div>
-                  </div>
-                <% end %>
               <% end %>
               <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
                 <a class="remove-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#hideDisplayNone">

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -73,6 +73,11 @@
                   </div>
                 <% end %>
               <% end %>
+              <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
+                <a class="remove-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#hideDisplayNone">
+                  Show less
+                </a>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -1,9 +1,10 @@
+<hr>
 <div class="govuk-form-group <%= form.object.errors[:tags].any? ? 'govuk-form-group--error' : '' %>">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend">
-      <p class="govuk-fieldset__heading govuk-!-font-weight-bold">
+  <fieldset class="govuk-fieldset govuk-!-margin-top-4">
+    <legend class="govuk-fieldset__legend">
+      <h3 class="govuk-heading-s">
         What does the document contain?
-      </p>
+      </h3>
     </legend>
 
     <% if form.object.errors[:tags].any? %>
@@ -13,35 +14,58 @@
       <% end %>
     <% end %>
 
-
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s govuk-!-padding-top-4">
-          PLANS
-        </h3>
-        <div class="govuk-checkboxes govuk-checkboxes--small">
-          <%= form.collection_check_boxes :tags, @planning_application.application_type.document_plan_tags, :itself, :itself do |b| %>
-            <div class="govuk-checkboxes__item">
-              <%= b.check_box class: "govuk-checkboxes__input" %>
-              <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+    <% @planning_application.application_type.document_tags.keys.each do |key| %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          <h3 class="govuk-heading-s">
+            <%= key.humanize %>
+          </h3>
+          <% if @planning_application.application_type.document_tags[key].count > 1 %>
+            <div class="govuk-grid-column-one-half">
+              <div class="govuk-checkboxes govuk-checkboxes--small">
+                <%= form.collection_check_boxes :tags, tags_first_half(@planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
+                  <div class="govuk-checkboxes__item">
+                    <%= b.check_box class: "govuk-checkboxes__input" %>
+                    <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                  </div>
+                <% end %>
+              </div>
             </div>
           <% end %>
-        </div>
-      </div>
-
-      <div class="govuk-grid-column-one-half">
-        <h3 class="govuk-heading-s govuk-!-padding-top-5">
-          EVIDENCE
-        </h3>
-        <div class="govuk-checkboxes govuk-checkboxes--small">
-          <%= form.collection_check_boxes :tags, @planning_application.application_type.document_evidence_tags, :itself, :itself do |b| %>
-            <div class="govuk-checkboxes__item">
-              <%= b.check_box class: "govuk-checkboxes__input" %>
-              <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+          <% if @planning_application.application_type.document_tags[key].count > 1 %>
+            <div class="govuk-grid-column-one-half">
+              <div class="govuk-checkboxes govuk-checkboxes--small">
+                <%= form.collection_check_boxes :tags, tags_second_half(@planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
+                  <div class="govuk-checkboxes__item">
+                    <%= b.check_box class: "govuk-checkboxes__input" %>
+                    <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                  </div>
+                <% end %>
+              </div>
             </div>
           <% end %>
+          <div class="govuk-grid-column-full">
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  See all (<%= (Document.send("#{key}_tags") - @planning_application.application_type.document_tags[key]).count %>)
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <%= form.collection_check_boxes :tags, (Document.send("#{key}_tags") - @planning_application.application_type.document_tags[key]), :itself, :itself do |b| %>
+                  <div class="govuk-checkboxes govuk-checkboxes--small">
+                    <div class="govuk-checkboxes__item">
+                      <%= b.check_box class: "govuk-checkboxes__input" %>
+                      <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </details>
+          </div>
         </div>
       </div>
-    </div>
+      <hr>
+    <% end %>
   </fieldset>
 </div>

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -20,7 +20,7 @@
           PLANS
         </h3>
         <div class="govuk-checkboxes govuk-checkboxes--small">
-          <%= form.collection_check_boxes :tags, Document::PLAN_TAGS, :itself, :itself do |b| %>
+          <%= form.collection_check_boxes :tags, @planning_application.application_type.document_plan_tags, :itself, :itself do |b| %>
             <div class="govuk-checkboxes__item">
               <%= b.check_box class: "govuk-checkboxes__input" %>
               <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>
@@ -34,7 +34,7 @@
           EVIDENCE
         </h3>
         <div class="govuk-checkboxes govuk-checkboxes--small">
-          <%= form.collection_check_boxes :tags, Document::EVIDENCE_TAGS, :itself, :itself do |b| %>
+          <%= form.collection_check_boxes :tags, @planning_application.application_type.document_evidence_tags, :itself, :itself do |b| %>
             <div class="govuk-checkboxes__item">
               <%= b.check_box class: "govuk-checkboxes__input" %>
               <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" %>

--- a/db/migrate/20231117151209_add_document_tags_to_application_type.rb
+++ b/db/migrate/20231117151209_add_document_tags_to_application_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDocumentTagsToApplicationType < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_types, :document_tags, :jsonb
+  end
+end

--- a/db/migrate/20231117160537_add_data_to_document_tags.rb
+++ b/db/migrate/20231117160537_add_data_to_document_tags.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class AddDataToDocumentTags < ActiveRecord::Migration[7.0]
+  def up
+    ApplicationType.find_each do |type|
+      tags = {
+        evidence: [
+          "Photograph",
+          "Utility Bill",
+          "Building Control Certificate",
+          "Construction Invoice",
+          "Council Tax Document",
+          "Tenancy Agreement",
+          "Tenancy Invoice",
+          "Bank Statement",
+          "Statutory Declaration",
+          "Other"
+        ],
+        plans: %w[
+          Front
+          Rear
+          Side
+          Roof
+          Floor
+          Site
+          Plan
+          Elevation
+          Section
+          Proposed
+          Existing
+        ],
+        other: [
+          "Site Visit",
+          "Site Notice",
+          "Press Notice"
+        ]
+      }
+
+      type.update(document_tags: tags)
+    end
+  end
+
+  def down
+    ApplicationType.find_each do |type|
+      type.update(document_tags: [])
+    end
+  end
+end

--- a/db/migrate/20231211110231_update_document_tags.rb
+++ b/db/migrate/20231211110231_update_document_tags.rb
@@ -78,7 +78,8 @@ class UpdateDocumentTags < ActiveRecord::Migration[7.0]
             "Gypsy and Traveller Statement",
             "HMO statement",
             "Specialist Accommodation Statement",
-            "Student Accommodation Statement"
+            "Student Accommodation Statement",
+            "Other Supporting Document"
           ]
         }
       end

--- a/db/migrate/20231211110231_update_document_tags.rb
+++ b/db/migrate/20231211110231_update_document_tags.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+class UpdateDocumentTags < ActiveRecord::Migration[7.0]
+  def up
+    ApplicationType.find_each do |type|
+      tags = if type.name == "lawfulness_certificate"
+        {
+          evidence: [
+            "Photograph",
+            "Utility Bill",
+            "Building Control Certificate",
+            "Construction Invoice",
+            "Council Tax Document",
+            "Tenancy Agreement",
+            "Tenancy Invoice",
+            "Bank Statement",
+            "Statutory Declaration",
+            "Other"
+          ],
+          plans: %w[
+            Front
+            Rear
+            Side
+            Roof
+            Floor
+            Site
+            Plan
+            Elevation
+            Section
+            Proposed
+            Existing
+          ],
+          supporting_documents: []
+        }
+      else
+        {
+          evidence: [
+            "Discounts"
+          ],
+          plans: %w[
+            Front
+            Rear
+            Side
+            Roof
+            Floor
+            Site
+            Plan
+            Elevation
+            Section
+            Proposed
+            Existing
+          ],
+          supporting_documents: [
+            "Site Visit",
+            "Site Notice",
+            "Press Notice",
+            "Design and Access Statement",
+            "Planning Statement",
+            "Viability Appraisal",
+            "Heritage Statement",
+            "Agricultural, Forestry or Occupational Worker Dwelling Justification",
+            "Arboricultural Assessment",
+            "Structural Survey/report",
+            "Air Quality Assessment",
+            "Basement Impact Assessment",
+            "Biodiversity Net Gain (from April)",
+            "Contaminated Land Assessment",
+            "Daylight and Sunlight Assessment",
+            "Flood Risk Assessment/Drainage and SuDs Report",
+            "Landscape and Visual Impact Assessment",
+            "Noise Impact Assessment",
+            "Open Space Assessment",
+            "Sustainability and Energy Statement",
+            "Transport Statement",
+            "NDSS Compliance Statement",
+            "Ventilation/Extraction Statement",
+            "Community Infrastructure Levy (CIL) form",
+            "Gypsy and Traveller Statement",
+            "HMO statement",
+            "Specialist Accommodation Statement",
+            "Student Accommodation Statement"
+          ]
+        }
+      end
+
+      type.update(document_tags: tags)
+    end
+  end
+
+  def down
+    ApplicationType.find_each do |type|
+      tags = {
+        evidence: [
+          "Photograph",
+          "Utility Bill",
+          "Building Control Certificate",
+          "Construction Invoice",
+          "Council Tax Document",
+          "Tenancy Agreement",
+          "Tenancy Invoice",
+          "Bank Statement",
+          "Statutory Declaration",
+          "Other"
+        ],
+        plans: %w[
+          Front
+          Rear
+          Side
+          Roof
+          Floor
+          Site
+          Plan
+          Elevation
+          Section
+          Proposed
+          Existing
+        ],
+        other: [
+          "Site Visit",
+          "Site Notice",
+          "Press Notice"
+        ]
+      }
+
+      type.update(document_tags: tags)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_05_144826) do
     t.string "assessment_details", array: true
     t.string "steps", default: ["validation", "consultation", "assessment", "review"], array: true
     t.string "consistency_checklist", array: true
+    t.jsonb "document_tags"
   end
 
   create_table "assessment_details", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_05_144826) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_110231) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -24,6 +24,41 @@ FactoryBot.define do
       ]
     end
 
+    document_tags do
+      {
+        evidence: [
+          "Photograph",
+          "Utility Bill",
+          "Building Control Certificate",
+          "Construction Invoice",
+          "Council Tax Document",
+          "Tenancy Agreement",
+          "Tenancy Invoice",
+          "Bank Statement",
+          "Statutory Declaration",
+          "Other"
+        ],
+        plans: %w[
+          Front
+          Rear
+          Side
+          Roof
+          Floor
+          Site
+          Plan
+          Elevation
+          Section
+          Proposed
+          Existing
+        ],
+        other: [
+          "Site Visit",
+          "Site Notice",
+          "Press Notice"
+        ]
+      }
+    end
+
     trait :prior_approval do
       name { "prior_approval" }
       steps { %w[validation consultation assessment review] }

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
           "Tenancy Invoice",
           "Bank Statement",
           "Statutory Declaration",
+          "Discounts",
           "Other"
         ],
         plans: %w[
@@ -51,11 +52,7 @@ FactoryBot.define do
           Proposed
           Existing
         ],
-        other: [
-          "Site Visit",
-          "Site Notice",
-          "Press Notice"
-        ]
+        supporting_documents: []
       }
     end
 
@@ -83,6 +80,57 @@ FactoryBot.define do
           site_map_correct
         ]
       end
+
+      document_tags do
+        {
+          evidence: [
+            "Discounts"
+          ],
+          plans: %w[
+            Front
+            Rear
+            Side
+            Roof
+            Floor
+            Site
+            Plan
+            Elevation
+            Section
+            Proposed
+            Existing
+          ],
+          supporting_documents: [
+            "Site Visit",
+            "Site Notice",
+            "Press Notice",
+            "Design and Access Statement",
+            "Planning Statement",
+            "Viability Appraisal",
+            "Heritage Statement",
+            "Agricultural, Forestry or Occupational Worker Dwelling Justification",
+            "Arboricultural Assessment",
+            "Structural Survey/report",
+            "Air Quality Assessment",
+            "Basement Impact Assessment",
+            "Biodiversity Net Gain (from April)",
+            "Contaminated Land Assessment",
+            "Daylight and Sunlight Assessment",
+            "Flood Risk Assessment/Drainage and SuDs Report",
+            "Landscape and Visual Impact Assessment",
+            "Noise Impact Assessment",
+            "Open Space Assessment",
+            "Sustainability and Energy Statement",
+            "Transport Statement",
+            "NDSS Compliance Statement",
+            "Ventilation/Extraction Statement",
+            "Community Infrastructure Levy (CIL) form",
+            "Gypsy and Traveller Statement",
+            "HMO statement",
+            "Specialist Accommodation Statement",
+            "Student Accommodation Statement"
+          ]
+        }
+      end
     end
 
     trait :planning_permission do
@@ -107,6 +155,57 @@ FactoryBot.define do
           proposal_details_match_documents
           site_map_correct
         ]
+      end
+
+      document_tags do
+        {
+          evidence: [
+            "Discounts"
+          ],
+          plans: %w[
+            Front
+            Rear
+            Side
+            Roof
+            Floor
+            Site
+            Plan
+            Elevation
+            Section
+            Proposed
+            Existing
+          ],
+          supporting_documents: [
+            "Site Visit",
+            "Site Notice",
+            "Press Notice",
+            "Design and Access Statement",
+            "Planning Statement",
+            "Viability Appraisal",
+            "Heritage Statement",
+            "Agricultural, Forestry or Occupational Worker Dwelling Justification",
+            "Arboricultural Assessment",
+            "Structural Survey/report",
+            "Air Quality Assessment",
+            "Basement Impact Assessment",
+            "Biodiversity Net Gain (from April)",
+            "Contaminated Land Assessment",
+            "Daylight and Sunlight Assessment",
+            "Flood Risk Assessment/Drainage and SuDs Report",
+            "Landscape and Visual Impact Assessment",
+            "Noise Impact Assessment",
+            "Open Space Assessment",
+            "Sustainability and Energy Statement",
+            "Transport Statement",
+            "NDSS Compliance Statement",
+            "Ventilation/Extraction Statement",
+            "Community Infrastructure Levy (CIL) form",
+            "Gypsy and Traveller Statement",
+            "HMO statement",
+            "Specialist Accommodation Statement",
+            "Student Accommodation Statement"
+          ]
+        }
       end
     end
 

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "Edit document numbers page" do
         expect(page).to have_text("Elevation")
         expect(page).to have_text("Proposed")
         expect(page).to have_text("Photograph")
-        expect(page).to have_text("EVIDENCE")
+        expect(page).to have_text("Evidence")
+        expect(page).to have_text("Supporting documents")
         expect(page).to have_text("proposed-floorplan.png")
       end
 

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Requesting document changes to a planning application" do
         click_link("Check document - proposed-roofplan.png")
       end
 
-      find("span", text: "See all (28)").click
+      find("span", text: "Show all (29)").click
 
       check "Sustainability and Energy Statement"
 

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Requesting document changes to a planning application" do
         click_link("Check document - proposed-roofplan.png")
       end
 
-      find("span", text: "Show all (29)").click
+      click_link "Show all (29)"
 
       check "Sustainability and Energy Statement"
 

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -191,9 +191,15 @@ RSpec.describe "Requesting document changes to a planning application" do
         click_link("Check document - proposed-roofplan.png")
       end
 
+      find("span", text: "See all (28)").click
+
+      check "Sustainability and Energy Statement"
+
       # Mark document as valid
       within("#validate-document") { choose "Yes" }
       click_button "Save"
+
+      expect(page).to have_content "Sustainability and Energy Statement"
 
       within("#document-validation-tasks") do
         expect(page).to have_list_item_for(


### PR DESCRIPTION
### Description of change

Produce document tags dynamically based on application type

### Story Link

https://trello.com/c/bu6RZstR/2153-show-relevant-tags-for-full-planning-applications

![screencapture-southwark-bops-localhost-3000-planning-applications-2204-documents-7594-edit-2023-12-11-15_27_19](https://github.com/unboxed/bops/assets/35098639/2c07fd8f-5c18-4b93-a820-f02979dbf8dd)
![screencapture-southwark-bops-localhost-3000-planning-applications-2204-documents-7594-edit-2023-12-11-15_27_32](https://github.com/unboxed/bops/assets/35098639/15537a75-c08d-47a1-a1ed-cc27bed68e26)
