### PR TITLE
Don't terminate the block early if update_status! fails

### DIFF
--- a/app/jobs/enqueue_update_consultee_email_status_job.rb
+++ b/app/jobs/enqueue_update_consultee_email_status_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class EnqueueUpdateConsulteeEmailStatusJob < ApplicationJob
+  queue_as :low_priority
+
+  def perform
+    Consultee::Email.overdue.find_each do |consultee_email|
+      UpdateConsulteeEmailStatusJob.perform_later(consultee_email)
+    end
+  end
+end

--- a/app/models/consultee/email.rb
+++ b/app/models/consultee/email.rb
@@ -17,6 +17,12 @@ class Consultee < ApplicationRecord
       technical_failure: "technical-failure"
     }, scopes: false
 
+    class << self
+      def overdue(time = 15.minutes.ago)
+        where(status: %w[created sending], status_updated_at: 7.days.ago..time)
+      end
+    end
+
     def failed?
       permanent_failure? | temporary_failure? | technical_failure?
     end

--- a/app/models/consultee/email.rb
+++ b/app/models/consultee/email.rb
@@ -29,11 +29,7 @@ class Consultee < ApplicationRecord
       return if notify_id.blank?
       return if finalized?
 
-      begin
-        response = client.get_notification(notify_id)
-      rescue Notifications::Client::RequestError
-        return false
-      end
+      response = client.get_notification(notify_id)
 
       update!(
         status: response.status,

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -18,3 +18,7 @@ production:
       cron: '0 9 * * *'   # Runs at 9am every morning
       class: CloseDescriptionChangeJob
       queue: low_priority
+    enqueue_update_consultee_email_status:
+      cron: '9 * * * *'   # Runs every hour at 9 minutes past
+      class: EnqueueUpdateConsulteeEmailStatusJob
+      queue: low_priority

--- a/spec/factories/consultee.rb
+++ b/spec/factories/consultee.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :consultee do
     name { Faker::Name.name }
+    email_address { Faker::Internet.email }
     status { "not_consulted" }
     origin { :internal }
 

--- a/spec/factories/consultee.rb
+++ b/spec/factories/consultee.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :consultee do
     name { Faker::Name.name }
+    status { "not_consulted" }
     origin { :internal }
 
     trait :internal do
@@ -13,7 +14,40 @@ FactoryBot.define do
       origin { :external }
     end
 
+    trait :created do
+      status { "sending" }
+      email_sent_at { nil }
+      email_delivered_at { nil }
+      last_email_sent_at { nil }
+      last_email_delivered_at { nil }
+    end
+
+    trait :sending do
+      status { "sending" }
+      email_sent_at { 5.minutes.ago }
+      email_delivered_at { nil }
+      last_email_sent_at { 5.minutes.ago }
+      last_email_delivered_at { nil }
+    end
+
+    trait :resending do
+      status { "sending" }
+      email_sent_at { 7.days.ago }
+      email_delivered_at { 7.days.ago }
+      last_email_sent_at { 5.minutes.ago }
+      last_email_delivered_at { 7.days.ago }
+    end
+
+    trait :resend_failed do
+      status { "failed" }
+      email_sent_at { 7.days.ago }
+      email_delivered_at { 7.days.ago }
+      last_email_sent_at { 5.minutes.ago }
+      last_email_delivered_at { 7.days.ago }
+    end
+
     trait :consulted do
+      status { "awaiting_response" }
       email_sent_at { 7.days.ago }
       email_delivered_at { 7.days.ago }
       last_email_sent_at { 7.days.ago }

--- a/spec/factories/consultee_email.rb
+++ b/spec/factories/consultee_email.rb
@@ -5,5 +5,54 @@ FactoryBot.define do
     subject { Faker::Lorem.sentence }
     body { Faker::Lorem.paragraph }
     status { "pending" }
+
+    trait :pending do
+      sent_at { nil }
+      notify_id { nil }
+      status { "pending" }
+      status_updated_at { nil }
+    end
+
+    trait :created do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "created" }
+      status_updated_at { 5.minutes.ago }
+    end
+
+    trait :sending do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "sending" }
+      status_updated_at { 5.minutes.ago }
+    end
+
+    trait :delivered do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "delivered" }
+      status_updated_at { 5.minutes.ago }
+    end
+
+    trait :technical_failure do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "technical-failure" }
+      status_updated_at { 5.minutes.ago }
+    end
+
+    trait :temporary_failure do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "temporary-failure" }
+      status_updated_at { 5.minutes.ago }
+    end
+
+    trait :permanent_failure do
+      sent_at { 5.minutes.ago }
+      notify_id { SecureRandom.uuid }
+      status { "permanent-failure" }
+      status_updated_at { 5.minutes.ago }
+    end
   end
 end

--- a/spec/jobs/enqueue_update_consultee_email_status_job_spec.rb
+++ b/spec/jobs/enqueue_update_consultee_email_status_job_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe EnqueueUpdateConsulteeEmailStatusJob do
+  let(:planning_application) { create(:planning_application, :planning_permission) }
+  let(:consultation) { planning_application.consultation }
+
+  let(:consultee_1) { create(:consultee, :sending, consultation:) }
+  let(:consultee_2) { create(:consultee, :sending, consultation:) }
+  let(:consultee_3) { create(:consultee, :awaiting_response, consultation:) }
+  let(:consultee_4) { create(:consultee, :sending, consultation:) }
+
+  let!(:consultee_email_1) { create(:consultee_email, :created, consultee: consultee_1, status_updated_at: 1.hour.ago) }
+  let!(:consultee_email_2) { create(:consultee_email, :created, consultee: consultee_2, status_updated_at: 30.minutes.ago) }
+  let!(:consultee_email_3) { create(:consultee_email, :delivered, consultee: consultee_3, status_updated_at: 30.minutes.ago) }
+  let!(:consultee_email_4) { create(:consultee_email, :created, consultee: consultee_4, status_updated_at: 5.minutes.ago) }
+
+  let(:job_class) { UpdateConsulteeEmailStatusJob }
+
+  it "Enqueues update status jobs for emails that appear to have been dropped" do
+    described_class.perform_now
+
+    expect(job_class).to have_been_enqueued.with(consultee_email_1)
+    expect(job_class).to have_been_enqueued.with(consultee_email_2)
+    expect(job_class).not_to have_been_enqueued.with(consultee_email_3)
+    expect(job_class).not_to have_been_enqueued.with(consultee_email_4)
+  end
+end

--- a/spec/jobs/update_consultee_email_status_job_spec.rb
+++ b/spec/jobs/update_consultee_email_status_job_spec.rb
@@ -1,0 +1,1030 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateConsulteeEmailStatusJob do
+  let(:planning_application) { create(:planning_application, :planning_permission) }
+  let(:consultation) { planning_application.consultation }
+
+  let(:notify_url) do
+    "https://api.notifications.service.gov.uk/v2/notifications/ddc217c4-7f45-47ad-9dab-cb245ec31e55"
+  end
+
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  context "when the email has not been sent yet" do
+    let(:consultee) { create(:consultee, :created, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :pending, consultee:) }
+
+    it "doesn't touch the status_updated_at timestamp" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee_email.status_updated_at
+      }.from(nil)
+    end
+
+    it "enqueues another job" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+    end
+
+    it "doesn't change the consultee status from 'sending'" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee.reload.status
+      }.from("sending")
+    end
+  end
+
+  context "when the email has been created" do
+    let(:consultee) { create(:consultee, :sending, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :created, notify_id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55", consultee:) }
+
+    context "and the Notify API returns an error" do
+      before do
+        stub_request(:get, notify_url).to_timeout
+      end
+
+      it "doesn't change the status" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status
+        }.from("created")
+      end
+
+      it "doesn't touch the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "doesn't change the consultee status from 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("sending")
+      end
+
+      it "doesn't change the consultee status from 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("sending")
+      end
+    end
+
+    context "and the Notify API returns a 'sending' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "sending"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("created").to("sending")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "doesn't change the consultee status from 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("sending")
+      end
+    end
+
+    context "and the Notify API returns a 'temporary-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "temporary-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'temporary-failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("created").to("temporary_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+
+    context "and the Notify API returns a 'delivered' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "delivered"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'delivered'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("created").to("delivered")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'awaiting_response'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("awaiting_response")
+      end
+
+      it "touches the consultee email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      it "touches the consultee last_email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.last_email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      context "and the message is a resend or reconsultation" do
+        let(:consultee) { create(:consultee, :resending, consultation:, email_address: "planning@london.gov.uk") }
+
+        it "changes the consultee status to 'awaiting_response'" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.status
+          }.from("sending").to("awaiting_response")
+        end
+
+        it "doesn't touch the consultee email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.not_to change {
+            consultee.reload.email_delivered_at
+          }.from(7.days.ago)
+        end
+
+        it "touches the consultee last_email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.last_email_delivered_at
+          }.from(7.days.ago).to(Time.current)
+        end
+      end
+    end
+
+    context "and the Notify API returns a 'permanent-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "permanent-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'permanent_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("created").to("permanent_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+
+    context "and the Notify API returns a 'technical-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "technical-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'technical_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("created").to("technical_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+  end
+
+  context "when the email is sending" do
+    let(:consultee) { create(:consultee, :sending, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :sending, notify_id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55", consultee:) }
+
+    context "and the Notify API returns an error" do
+      before do
+        stub_request(:get, notify_url).to_timeout
+      end
+
+      it "doesn't change the status" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status
+        }.from("sending")
+      end
+
+      it "doesn't touch the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "doesn't change the consultee status from 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("sending")
+      end
+    end
+
+    context "and the Notify API returns a 'sending' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "sending"
+          }.to_json
+        )
+      end
+
+      it "doesn't change the status" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status
+        }.from("sending")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "doesn't change the consultee status from 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("sending")
+      end
+    end
+
+    context "and the Notify API returns a 'temporary-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "temporary-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'temporary-failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("sending").to("temporary_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+
+    context "and the Notify API returns a 'delivered' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "delivered"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'delivered'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("sending").to("delivered")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'awaiting_response'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("awaiting_response")
+      end
+
+      it "touches the consultee email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      it "touches the consultee last_email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.last_email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      context "and the message is a resend or reconsultation" do
+        let(:consultee) { create(:consultee, :resending, consultation:, email_address: "planning@london.gov.uk") }
+
+        it "changes the consultee status to 'awaiting_response'" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.status
+          }.from("sending").to("awaiting_response")
+        end
+
+        it "doesn't touch the consultee email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.not_to change {
+            consultee.reload.email_delivered_at
+          }.from(7.days.ago)
+        end
+
+        it "touches the consultee last_email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.last_email_delivered_at
+          }.from(7.days.ago).to(Time.current)
+        end
+      end
+    end
+
+    context "and the Notify API returns a 'permanent-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "permanent-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'permanent_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("sending").to("permanent_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+
+    context "and the Notify API returns a 'technical-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "technical-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'technical_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("sending").to("technical_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("sending").to("failed")
+      end
+    end
+  end
+
+  context "when the email has a temporary failure" do
+    let(:consultee) { create(:consultee, :failed, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :temporary_failure, notify_id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55", consultee:) }
+
+    context "and the Notify API returns an error" do
+      before do
+        stub_request(:get, notify_url).to_timeout
+      end
+
+      it "doesn't change the status" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status
+        }.from("temporary_failure")
+      end
+
+      it "doesn't touch the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+    end
+
+    context "and the Notify API returns a 'sending' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "sending"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'sending'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("temporary_failure").to("sending")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+    end
+
+    context "and the Notify API returns a 'temporary-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "temporary-failure"
+          }.to_json
+        )
+      end
+
+      it "doesn't change the status from 'temporary-failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee_email.status
+        }.from("temporary_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "enqueues another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to have_enqueued_job(described_class).with(consultee_email).at(5.minutes.from_now)
+      end
+    end
+
+    context "and the Notify API returns a 'delivered' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "delivered"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'delivered'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("temporary_failure").to("delivered")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "changes the consultee status to 'awaiting_response'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.status
+        }.from("failed").to("awaiting_response")
+      end
+
+      it "touches the consultee email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      it "touches the consultee last_email_delivered_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee.reload.last_email_delivered_at
+        }.from(nil).to(Time.current)
+      end
+
+      context "and the message is a resend or reconsultation" do
+        let(:consultee) { create(:consultee, :resend_failed, consultation:, email_address: "planning@london.gov.uk") }
+
+        it "changes the consultee status to 'awaiting_response'" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.status
+          }.from("failed").to("awaiting_response")
+        end
+
+        it "doesn't touch the consultee email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.not_to change {
+            consultee.reload.email_delivered_at
+          }.from(7.days.ago)
+        end
+
+        it "touches the consultee last_email_delivered_at timestamp" do
+          expect do
+            described_class.perform_now(consultee_email)
+          end.to change {
+            consultee.reload.last_email_delivered_at
+          }.from(7.days.ago).to(Time.current)
+        end
+      end
+    end
+
+    context "and the Notify API returns a 'permanent-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "permanent-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'permanent_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("temporary_failure").to("permanent_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "doesn't change the consultee status from 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("failed")
+      end
+    end
+
+    context "and the Notify API returns a 'technical-failure' status" do
+      before do
+        stub_request(:get, notify_url).to_return(
+          status: 200,
+          headers: {
+            "Content-Type" => "application/json"
+          },
+          body: {
+            id: "ddc217c4-7f45-47ad-9dab-cb245ec31e55",
+            status: "technical-failure"
+          }.to_json
+        )
+      end
+
+      it "changes the status to 'technical_failure'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status
+        }.from("temporary_failure").to("technical_failure")
+      end
+
+      it "touches the status_updated_at timestamp" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.to change {
+          consultee_email.status_updated_at
+        }.from(5.minutes.ago).to(Time.current)
+      end
+
+      it "doesn't enqueue another job" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to have_enqueued_job(described_class).with(consultee_email)
+      end
+
+      it "doesn't change the consultee status from 'failed'" do
+        expect do
+          described_class.perform_now(consultee_email)
+        end.not_to change {
+          consultee.reload.status
+        }.from("failed")
+      end
+    end
+  end
+
+  context "when the email has been delivered" do
+    let(:consultee) { create(:consultee, :consulted, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :delivered, consultee:) }
+
+    it "doesn't touch the status_updated_at timestamp" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee_email.status_updated_at
+      }.from(5.minutes.ago)
+    end
+
+    it "doesn't enqueue another job" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to have_enqueued_job(described_class).with(consultee_email)
+    end
+  end
+
+  context "when the email has had a technical failure" do
+    let(:consultee) { create(:consultee, :failed, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :technical_failure, consultee:) }
+
+    it "doesn't touch the status_updated_at timestamp" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee_email.status_updated_at
+      }.from(5.minutes.ago)
+    end
+
+    it "doesn't enqueue another job" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to have_enqueued_job(described_class).with(consultee_email)
+    end
+
+    it "doesn't change the consultee status from 'failed'" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee.reload.status
+      }.from("failed")
+    end
+  end
+
+  context "when the email has permanently failed" do
+    let(:consultee) { create(:consultee, :failed, consultation:, email_address: "planning@london.gov.uk") }
+    let(:consultee_email) { create(:consultee_email, :permanent_failure, consultee:) }
+
+    it "doesn't touch the status_updated_at timestamp" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee_email.status_updated_at
+      }.from(5.minutes.ago)
+    end
+
+    it "doesn't enqueue another job" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to have_enqueued_job(described_class).with(consultee_email)
+    end
+
+    it "doesn't change the consultee status from 'failed'" do
+      expect do
+        described_class.perform_now(consultee_email)
+      end.not_to change {
+        consultee.reload.status
+      }.from("failed")
+    end
+  end
+end


### PR DESCRIPTION
We need to retry the job if Notify returns an error.
