### PR TITLE
Use default GOV.UK Notify account for all emails

### DIFF
--- a/app/models/consultee/email.rb
+++ b/app/models/consultee/email.rb
@@ -50,7 +50,7 @@ class Consultee < ApplicationRecord
     end
 
     def api_key
-      consultee.consultation.planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
+      Rails.configuration.default_notify_api_key.presence || (raise NotifyEmailJob::NotConfiguredError, "Notify API key not found")
     end
   end
 end


### PR DESCRIPTION
Need to get individual accounts working properly and obtain access to configure all the reply-to addresses, branding, etc.
