### PR TITLE
Ask users to confirm email and set new password 

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,28 @@
+#frozen_string_literal: true
+
+class ConfirmationsController < Devise::ConfirmationsController
+  def show
+    @user = User.find_by(confirmation_token: params[:confirmation_token])
+
+    render :show
+  end
+
+  def confirm_and_set_password
+    @user = User.find(user_params[:user_id])
+
+    if @user.update({ password: user_params[:password],
+                      password_confirmation: user_params[:password_confirmation] })
+      @user.confirm
+
+    redirect_to new_user_session_path, notice: "Your email has been confirmed and your password reset. You may now log in"
+    else
+      render :show, alert: "We were unable to confirm your email. Click below to receive confirmation instructions"
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:user_id, :password, :password_confirmation, :_method, :authenticity_token, :user, :commit)
+  end
+end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,7 +4,11 @@ class ConfirmationsController < Devise::ConfirmationsController
   def show
     @user = User.find_by(confirmation_token: params[:confirmation_token])
 
-    render :show
+    if @user.confirmation_period_expired?
+      redirect_to new_user_confirmation_path, alert: t("devise.confirmations.confirmation_expired")
+    else
+      render :show
+    end
   end
 
   def confirm_and_set_password
@@ -14,9 +18,9 @@ class ConfirmationsController < Devise::ConfirmationsController
                       password_confirmation: user_params[:password_confirmation]})
       @user.confirm
 
-      redirect_to new_user_session_path, notice: "Your email has been confirmed and your password reset. You may now log in"
+      redirect_to new_user_session_path, notice: t("devise.confirmations.confirmed")
     else
-      render :show, alert: "We were unable to confirm your email. Click below to receive confirmation instructions"
+      render :show, alert: t("devise.confirmations.failed_confirmation")
     end
   end
 

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 class ConfirmationsController < Devise::ConfirmationsController
   def show
@@ -10,11 +10,11 @@ class ConfirmationsController < Devise::ConfirmationsController
   def confirm_and_set_password
     @user = User.find(user_params[:user_id])
 
-    if @user.update({ password: user_params[:password],
-                      password_confirmation: user_params[:password_confirmation] })
+    if @user.update({password: user_params[:password],
+                      password_confirmation: user_params[:password_confirmation]})
       @user.confirm
 
-    redirect_to new_user_session_path, notice: "Your email has been confirmed and your password reset. You may now log in"
+      redirect_to new_user_session_path, notice: "Your email has been confirmed and your password reset. You may now log in"
     else
       render :show, alert: "We were unable to confirm your email. Click below to receive confirmation instructions"
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,8 @@ class UsersController < AuthenticationController
     @user = current_local_authority.users.new(user_params)
 
     if @user.save
+
+      @user.send_confirmation_instructions
       flash[:notice] = I18n.t(
         "administrator_dashboard.show.user_successfully_created"
       )
@@ -45,7 +47,7 @@ class UsersController < AuthenticationController
   end
 
   def permitted_params
-    %i[name email otp_delivery_method password mobile_number role]
+    %i[name email otp_delivery_method password password_confirmation mobile_number role]
   end
 
   def set_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,14 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  def confirmation_timeout
+    6.hours
+  end
+
+  def confirmation_period_expired?
+    Time.now > confirmation_sent_at + confirmation_timeout if confirmation_sent_at.present?
+  end
+
   private
 
   def generate_otp_secret

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   enum otp_delivery_method: {sms: 0, email: 1}
 
   devise :recoverable, :two_factor_authenticatable, :recoverable, :timeoutable,
-    :validatable,
+    :validatable, :confirmable,
     otp_secret_encryption_key: Rails.configuration.otp_secret_encryption_key,
     request_keys: [:subdomains]
 
@@ -60,6 +60,10 @@ class User < ApplicationRecord
 
   def send_otp_by_sms?
     otp_delivery_method == "sms"
+  end
+
+  def confirmed?
+    confirmed_at.present?
   end
 
   private

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -2,19 +2,19 @@
   Resend confirmation instructions - <%= t('page_title') %>
 <% end %>
 
-<h2>Resend confirmation instructions</h2>
+<h1 class="govuk-heading-l">
+  Resend confirmation instructions
+</h1>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), class: "govuk-input govuk-input--width-20", autofocus: true %>
   </div>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
-  </div>
+  <%= f.submit "Resend confirmation email", class: "govuk-button govuk-!-margin-top-7  govuk-!-margin-bottom-4", data: { module: "govuk-button" } %>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  Resend confirmation instructions - <%= t('page_title') %>
+<% end %>
+
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "devise/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -2,7 +2,7 @@
   Confirm - <%= t('page_title') %>
 <% end %>
 
-<h1>Confirm your account and set your email</h1>
+<h1>Create your password</h1>
 
 <%= form_for @user, url: {action: "confirm_and_set_password"} do |f| %>
   <div class="govuk-form-group govuk-!-margin-top-8">

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -2,13 +2,11 @@
   Confirm - <%= t('page_title') %>
 <% end %>
 
-<h2>Thank you for confirming your account</h2>
-
-<%= @user.email %>
+<h1>Confirm your account and set your email</h1>
 
 <%= form_for @user, url: {action: "confirm_and_set_password"} do |f| %>
   <div class="govuk-form-group govuk-!-margin-top-8">
-    <%= f.hidden_field :user_id, value: @user.id %>]
+    <%= f.hidden_field :user_id, value: @user.id %>
     <%= f.label :password, "New password", class: "govuk-heading-s govuk-!-margin-bottom-1" %>
     <span class="govuk-hint govuk-!-margin-bottom-1">Your password must have:</span>
     <ul class="govuk-!-margin-top-1">
@@ -24,7 +22,7 @@
     <%= f.label :password_confirmation, "Confirm new password", class: "govuk-heading-s govuk-!-margin-top-6" %>
     <%= f.password_field :password_confirmation, class: "govuk-input govuk-input--width-20", autocomplete: "new-password" %> <br>
 
-    <%= f.submit "Change password", class: "govuk-button govuk-!-margin-top-7  govuk-!-margin-bottom-4", data: { module: "govuk-button" } %>
+    <%= f.submit "Submit", class: "govuk-button govuk-!-margin-top-7  govuk-!-margin-bottom-4", data: { module: "govuk-button" } %>
   </div>
 <% end %>
 

--- a/app/views/devise/confirmations/show.html.erb
+++ b/app/views/devise/confirmations/show.html.erb
@@ -1,20 +1,33 @@
 <% content_for :page_title do %>
-  Resend confirmation instructions - <%= t('page_title') %>
+  Confirm - <%= t('page_title') %>
 <% end %>
 
-<h2>Resend confirmation instructions</h2>
+<h2>Thank you for confirming your account</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<%= @user.email %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
-  </div>
+<%= form_for @user, url: {action: "confirm_and_set_password"} do |f| %>
+  <div class="govuk-form-group govuk-!-margin-top-8">
+    <%= f.hidden_field :user_id, value: @user.id %>]
+    <%= f.label :password, "New password", class: "govuk-heading-s govuk-!-margin-bottom-1" %>
+    <span class="govuk-hint govuk-!-margin-bottom-1">Your password must have:</span>
+    <ul class="govuk-!-margin-top-1">
+      <% if @minimum_password_length %>
+        <li class="govuk-hint govuk-!-margin-bottom-1">at least <%= @minimum_password_length %> characters</li>
+      <% end %>
+      <li class="govuk-hint govuk-!-margin-bottom-1">at least one symbol (for example, ?!£%)</li>
+      <li class="govuk-hint govuk-!-margin-bottom-1">at least one capital letter</li>
+      <li class="govuk-hint govuk-!-margin-bottom-1">no dictionary words or other common passwords</li>
+    </ul>
+    <%= f.password_field :password, class: "govuk-input govuk-input--width-20", autofocus: true, autocomplete: "new-password" %>
 
-  <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.label :password_confirmation, "Confirm new password", class: "govuk-heading-s govuk-!-margin-top-6" %>
+    <%= f.password_field :password_confirmation, class: "govuk-input govuk-input--width-20", autocomplete: "new-password" %> <br>
+
+    <%= f.submit "Change password", class: "govuk-button govuk-!-margin-top-7  govuk-!-margin-bottom-4", data: { module: "govuk-button" } %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<p class="govuk-body govuk-!-margin-top-8">
+  <%= render "devise/shared/links" %>
+</p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,7 @@
-<p>Welcome <%= @email %>.</p>
+<p>Dear <%= @user.name %>,</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>Welcome to the Back-office Planning System for <%= @user.local_authority %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p>You can confirm your account and set a password through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_path(@resource, subdomain: @resource.local_authority.subdomain, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -4,4 +4,6 @@
 
 <p>You can confirm your account and set a password through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_path(@resource, subdomain: @resource.local_authority.subdomain, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, subdomain: @resource.local_authority.subdomain, confirmation_token: @token) %></p>
+
+<p>The link will expire in 3 days.</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -25,7 +25,7 @@ Devise.setup do |config|
 
   config.stretches = Rails.env.test? ? 1 : 11
 
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   config.expire_all_remember_me_on_sign_out = true
 
@@ -33,7 +33,7 @@ Devise.setup do |config|
 
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 3.days
 
   config.sign_out_via = :delete
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -33,7 +33,7 @@ Devise.setup do |config|
 
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
-  config.reset_password_within = 3.days
+  config.reset_password_within = 6.hours
 
   config.sign_out_via = :delete
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -2,7 +2,9 @@
 en:
   devise:
     confirmations:
-      confirmed: Your email address has been successfully confirmed. You may now log in.
+      confirmed: Your email address has been successfully confirmed and your password has been set. You may now log in.
+      failed_confirmation: We were unable to confirm your email. Click below to receive confirmation instructions
+      confirmation_expired: The confirmtion link has expired. Request a new confirmation link on this page
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -2,7 +2,7 @@
 en:
   devise:
     confirmations:
-      confirmed: Your email address has been successfully confirmed.
+      confirmed: Your email address has been successfully confirmed. You may now log in.
       send_instructions: You will receive an email with instructions for how to confirm your email address in a few minutes.
       send_paranoid_instructions: If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes.
     failure:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,13 +15,15 @@ Rails.application.routes.draw do
   end
 
   devise_for :users, controllers: {
-    sessions: "users/sessions"
+    sessions: "users/sessions",
+    confirmations: "confirmations",
   }
 
   devise_scope :user do
     get "setup", to: "users/sessions#setup", as: "setup"
     get "two_factor", to: "users/sessions#two_factor", as: "two_factor"
     get "resend_code", to: "users/sessions#resend_code", as: "resend_code"
+    patch "/confirmations/confirm_and_set_password", to: "confirmations#confirm_and_set_password"
   end
 
   defaults format: "json" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: {
     sessions: "users/sessions",
-    confirmations: "confirmations",
+    confirmations: "confirmations"
   }
 
   devise_scope :user do

--- a/db/migrate/20231118113927_add_confirmed_at_to_devise.rb
+++ b/db/migrate/20231118113927_add_confirmed_at_to_devise.rb
@@ -1,0 +1,13 @@
+class AddConfirmedAtToDevise < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+
+    User.all.find_each do |user|
+      user.update(
+        confirmed_at: Time.zone.now
+      )
+    end
+  end
+end

--- a/db/migrate/20231118113927_add_confirmed_at_to_devise.rb
+++ b/db/migrate/20231118113927_add_confirmed_at_to_devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddConfirmedAtToDevise < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :confirmation_token, :string

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -823,6 +823,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_074256) do
     t.string "mobile_number"
     t.integer "otp_delivery_method", default: 0
     t.string "otp_secret"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
     t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true
     t.index ["encrypted_otp_secret"], name: "ix_users_on_encrypted_otp_secret", unique: true
     t.index ["local_authority_id"], name: "index_users_on_local_authority_id"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password { "Id!l]GT1-{ncnZ!oSvrF.*jx\\w1>V@]_}e>B,A\\yI&'4z6P$2iIQDZ-*rsiFoBP~0=uL/%2wHFg_RrF%nx[`oeY4" }
     mobile_number { "07656546552" }
+    confirmed_at { Time.zone.now }
   end
 
   trait :assessor do
@@ -21,5 +22,9 @@ FactoryBot.define do
 
   trait :administrator do
     role { :administrator }
+  end
+
+  trait :unconfirmed do
+    confirmed_at { nil }
   end
 end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -108,4 +108,24 @@ RSpec.describe UserMailer, type: :mailer do
       )
     end
   end
+
+  describe "#confirmation mail" do
+    let(:user) { create(:user, :unconfirmed, email: "heidi@example.com") }
+
+    it "sets subject" do
+      user.send_confirmation_instructions
+      mail = Devise.mailer.deliveries.last
+
+      expect(mail.subject).to eq(
+        "Confirmation instructions"
+      )
+      expect(mail.to).to contain_exactly("heidi@example.com")
+      expect(mail.body.encoded).to include(
+        user.confirmation_token
+      )
+      expect(mail.body.encoded).to include(
+        "The link will expire in 3 days."
+      )
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -167,6 +167,34 @@ RSpec.describe User do
     end
   end
 
+  describe "#confirmed?" do
+    context "when user is unconfirmed" do
+      let(:user) { build(:user, :unconfirmed) }
+
+      it "returns true" do
+        expect(user.confirmed?).to be(false)
+      end
+    end
+
+    context "when user is unconfirmed" do
+      let(:user) { build(:user) }
+
+      it "returns true" do
+        expect(user.confirmed?).to be(true)
+      end
+    end
+  end
+
+  describe "#confirmation_period_expired?" do
+    context "when confirmation period has expired" do
+      let(:user) { build(:user, confirmed_at: 4.days.ago) }
+
+      it "returns true" do
+        expect(user.confirmation_period_expired?).to be(true)
+      end
+    end
+  end
+
   describe "#send_otp" do
     let(:session_mobile_number) { "07717123123" }
 

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -536,4 +536,31 @@ RSpec.describe "Sign in" do
       expect(page).to have_content("Password is too weak")
     end
   end
+
+  context "when I am a new user who has not confirmed my email" do
+    let!(:user) { create(:user, :unconfirmed, local_authority: default_local_authority) }
+
+    it "does not allow me to log in without confirmation" do
+      visit("/")
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+      click_button("Log in")
+      fill_in("Security code", with: user.current_otp)
+      click_button("Enter code")
+
+      expect(page).to have_content("Email is not confirmed")
+    end
+
+    it "allows me to log in after confirmation" do
+      user.confirm
+
+      visit("/")
+      fill_in("Email", with: user.email)
+      fill_in("Password", with: user.password)
+      fill_in("Security code", with: user.current_otp)
+      click_button("Enter code")
+
+      expect(page).to have_text("Signed in successfully.")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

The previous workflow required the admin to set a password, which would have enabled the admin to log in with the user's credentials. This change overrides the Devise `confirmable` flow to add a password reset screen that confirms the user and asks them to create a password in a single action.

The confirmation token expires after 3 days and the user is prompted to request a new link. 

### Story Link

https://trello.com/c/qSaxCTE6/1496-when-a-new-user-is-created-on-the-system-send-them-an-email-to-create-their-password
https://trello.com/c/SPBjc9AQ/1514-add-expiry-time-to-email-for-users-to-create-their-password

### Screenshots

<img width="1095" alt="confirm2" src="https://github.com/unboxed/bops/assets/1880450/14420259-d9c3-43a2-9882-11ec2973e58a">
<img width="900" alt="confirm_account" src="https://github.com/unboxed/bops/assets/1880450/3f4203b1-06d3-4551-b8c4-9606371afa72">

### Further testing or sign off required 

I need to get Laura to review email content and user messaging for alerts etc.
