### PR TITLE
Add missing foreign keys

### DIFF
--- a/db/migrate/20231123141207_add_missing_planning_application_foreign_key_on_consultations.rb
+++ b/db/migrate/20231123141207_add_missing_planning_application_foreign_key_on_consultations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyOnConsultations < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :consultations, :planning_applications
+  end
+end

--- a/db/migrate/20231123141626_add_missing_local_authority_foreign_key_on_api_users.rb
+++ b/db/migrate/20231123141626_add_missing_local_authority_foreign_key_on_api_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingLocalAuthorityForeignKeyOnApiUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :api_users, :local_authorities
+  end
+end

--- a/db/migrate/20231123141933_add_missing_user_foreign_key_on_comments.rb
+++ b/db/migrate/20231123141933_add_missing_user_foreign_key_on_comments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingUserForeignKeyOnComments < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :comments, :users
+  end
+end

--- a/db/migrate/20231123142052_add_missing_planning_application_foreign_key_to_consistency_checklists.rb
+++ b/db/migrate/20231123142052_add_missing_planning_application_foreign_key_to_consistency_checklists.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToConsistencyChecklists < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :consistency_checklists, :planning_applications
+  end
+end

--- a/db/migrate/20231123142508_add_missing_planning_application_foreign_key_to_documents.rb
+++ b/db/migrate/20231123142508_add_missing_planning_application_foreign_key_to_documents.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToDocuments < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :documents, :planning_applications
+  end
+end

--- a/db/migrate/20231123142638_add_missing_identity_detail_foreign_key_on_evidence_groups.rb
+++ b/db/migrate/20231123142638_add_missing_identity_detail_foreign_key_on_evidence_groups.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingIdentityDetailForeignKeyOnEvidenceGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :evidence_groups, :immunity_details
+  end
+end

--- a/db/migrate/20231123142746_add_missing_planning_application_foreign_key_to_immunity_details.rb
+++ b/db/migrate/20231123142746_add_missing_planning_application_foreign_key_to_immunity_details.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToImmunityDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :immunity_details, :planning_applications
+  end
+end

--- a/db/migrate/20231123142848_add_missing_planning_application_foreign_key_to_local_policies.rb
+++ b/db/migrate/20231123142848_add_missing_planning_application_foreign_key_to_local_policies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToLocalPolicies < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :local_policies, :planning_applications
+  end
+end

--- a/db/migrate/20231123143021_add_missing_neighbour_foreign_key_to_neighbour_letters.rb
+++ b/db/migrate/20231123143021_add_missing_neighbour_foreign_key_to_neighbour_letters.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddMissingNeighbourForeignKeyToNeighbourLetters < ActiveRecord::Migration[7.0]
+  def change
+    up_only do
+      execute <<~SQL
+        DELETE FROM neighbour_letters
+        WHERE neighbour_id NOT IN (SELECT id FROM neighbours)
+      SQL
+    end
+
+    add_foreign_key :neighbour_letters, :neighbours
+  end
+end

--- a/db/migrate/20231123143433_add_missing_neighbour_foreign_key_to_neighbour_responses.rb
+++ b/db/migrate/20231123143433_add_missing_neighbour_foreign_key_to_neighbour_responses.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingNeighbourForeignKeyToNeighbourResponses < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :neighbour_responses, :neighbours
+  end
+end

--- a/db/migrate/20231123143537_add_missing_consultation_foreign_key_to_neighbours.rb
+++ b/db/migrate/20231123143537_add_missing_consultation_foreign_key_to_neighbours.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingConsultationForeignKeyToNeighbours < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :neighbours, :consultations
+  end
+end

--- a/db/migrate/20231123143700_add_missing_planning_application_foreign_key_to_permitted_development_rights.rb
+++ b/db/migrate/20231123143700_add_missing_planning_application_foreign_key_to_permitted_development_rights.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToPermittedDevelopmentRights < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :permitted_development_rights, :planning_applications
+  end
+end

--- a/db/migrate/20231123143840_add_missing_local_authorities_foreign_key_to_planning_applications.rb
+++ b/db/migrate/20231123143840_add_missing_local_authorities_foreign_key_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingLocalAuthoritiesForeignKeyToPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :planning_applications, :local_authorities
+  end
+end

--- a/db/migrate/20231123143957_add_missing_local_policy_class_foreign_key_to_policies.rb
+++ b/db/migrate/20231123143957_add_missing_local_policy_class_foreign_key_to_policies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingLocalPolicyClassForeignKeyToPolicies < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :policies, :policy_classes
+  end
+end

--- a/db/migrate/20231123144057_add_missing_planning_application_foreign_key_to_policy_classes.rb
+++ b/db/migrate/20231123144057_add_missing_planning_application_foreign_key_to_policy_classes.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToPolicyClasses < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :policy_classes, :planning_applications
+  end
+end

--- a/db/migrate/20231123144207_add_missing_planning_application_foreign_key_to_proposal_measurements.rb
+++ b/db/migrate/20231123144207_add_missing_planning_application_foreign_key_to_proposal_measurements.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToProposalMeasurements < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :proposal_measurements, :planning_applications
+  end
+end

--- a/db/migrate/20231123144411_add_missing_local_authorities_foreign_key_to_users.rb
+++ b/db/migrate/20231123144411_add_missing_local_authorities_foreign_key_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingLocalAuthoritiesForeignKeyToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :users, :local_authorities
+  end
+end

--- a/db/migrate/20231123144515_add_missing_planning_application_foreign_key_to_site_notices.rb
+++ b/db/migrate/20231123144515_add_missing_planning_application_foreign_key_to_site_notices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingPlanningApplicationForeignKeyToSiteNotices < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :site_notices, :planning_applications
+  end
+end

--- a/db/migrate/20231123144650_add_missing_immunity_detail_foreign_key_to_review_immunity_details.rb
+++ b/db/migrate/20231123144650_add_missing_immunity_detail_foreign_key_to_review_immunity_details.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddMissingImmunityDetailForeignKeyToReviewImmunityDetails < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :review_immunity_details, :immunity_details
+  end
+end

--- a/db/migrate/20231123144842_add_missing_foreign_keys_to_red_line_boundary_change_validation_request.rb
+++ b/db/migrate/20231123144842_add_missing_foreign_keys_to_red_line_boundary_change_validation_request.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddMissingForeignKeysToRedLineBoundaryChangeValidationRequest < ActiveRecord::Migration[7.0]
+  def change
+    change_column :red_line_boundary_change_validation_requests, :planning_application_id, :bigint, null: false
+    change_column :red_line_boundary_change_validation_requests, :user_id, :bigint, null: false
+
+    add_foreign_key :red_line_boundary_change_validation_requests, :planning_applications
+    add_foreign_key :red_line_boundary_change_validation_requests, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_23_144842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -672,8 +672,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
   end
 
   create_table "red_line_boundary_change_validation_requests", force: :cascade do |t|
-    t.integer "planning_application_id", null: false
-    t.integer "user_id", null: false
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
     t.string "state", null: false
     t.jsonb "new_geojson", null: false
     t.string "reason", null: false
@@ -843,14 +843,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "additional_document_validation_requests", "planning_applications"
   add_foreign_key "additional_document_validation_requests", "users"
+  add_foreign_key "api_users", "local_authorities"
   add_foreign_key "assessment_details", "planning_applications"
   add_foreign_key "assessment_details", "users"
   add_foreign_key "audits", "api_users"
   add_foreign_key "audits", "planning_applications"
   add_foreign_key "audits", "users"
+  add_foreign_key "comments", "users"
   add_foreign_key "condition_sets", "planning_applications"
   add_foreign_key "conditions", "condition_sets"
+  add_foreign_key "consistency_checklists", "planning_applications"
   add_foreign_key "constraints", "local_authorities"
+  add_foreign_key "consultations", "planning_applications"
   add_foreign_key "consultee_emails", "consultees"
   add_foreign_key "consultee_responses", "consultees"
   add_foreign_key "consultee_responses", "users", column: "redacted_by_id"
@@ -862,20 +866,28 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
   add_foreign_key "documents", "api_users"
   add_foreign_key "documents", "evidence_groups"
   add_foreign_key "documents", "neighbour_responses"
+  add_foreign_key "documents", "planning_applications"
   add_foreign_key "documents", "press_notices"
   add_foreign_key "documents", "replacement_document_validation_requests"
   add_foreign_key "documents", "site_notices"
   add_foreign_key "documents", "site_visits"
   add_foreign_key "documents", "users"
+  add_foreign_key "evidence_groups", "immunity_details"
+  add_foreign_key "immunity_details", "planning_applications"
+  add_foreign_key "local_policies", "planning_applications"
   add_foreign_key "local_policies", "users", column: "assessor_id"
   add_foreign_key "local_policies", "users", column: "reviewer_id"
   add_foreign_key "local_policy_areas", "local_policies"
+  add_foreign_key "neighbour_letters", "neighbours"
   add_foreign_key "neighbour_responses", "consultations"
+  add_foreign_key "neighbour_responses", "neighbours"
   add_foreign_key "neighbour_responses", "users", column: "redacted_by_id"
+  add_foreign_key "neighbours", "consultations"
   add_foreign_key "notes", "planning_applications"
   add_foreign_key "notes", "users"
   add_foreign_key "other_change_validation_requests", "planning_applications"
   add_foreign_key "other_change_validation_requests", "users"
+  add_foreign_key "permitted_development_rights", "planning_applications"
   add_foreign_key "permitted_development_rights", "users", column: "assessor_id"
   add_foreign_key "permitted_development_rights", "users", column: "reviewer_id"
   add_foreign_key "planning_application_constraints", "constraints"
@@ -883,17 +895,24 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
   add_foreign_key "planning_application_constraints", "planning_applications"
   add_foreign_key "planning_application_constraints_queries", "planning_applications"
   add_foreign_key "planning_applications", "api_users"
+  add_foreign_key "planning_applications", "local_authorities"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
   add_foreign_key "planx_planning_data", "planning_applications"
+  add_foreign_key "policies", "policy_classes"
+  add_foreign_key "policy_classes", "planning_applications"
   add_foreign_key "press_notices", "planning_applications"
+  add_foreign_key "proposal_measurements", "planning_applications"
   add_foreign_key "recommendations", "planning_applications"
   add_foreign_key "recommendations", "users", column: "assessor_id"
   add_foreign_key "recommendations", "users", column: "reviewer_id"
+  add_foreign_key "red_line_boundary_change_validation_requests", "planning_applications"
+  add_foreign_key "red_line_boundary_change_validation_requests", "users"
   add_foreign_key "replacement_document_validation_requests", "documents", column: "new_document_id"
   add_foreign_key "replacement_document_validation_requests", "documents", column: "old_document_id"
   add_foreign_key "replacement_document_validation_requests", "planning_applications"
   add_foreign_key "replacement_document_validation_requests", "users"
+  add_foreign_key "review_immunity_details", "immunity_details"
   add_foreign_key "review_immunity_details", "users", column: "assessor_id"
   add_foreign_key "review_immunity_details", "users", column: "reviewer_id"
   add_foreign_key "review_local_policies", "local_policies"
@@ -902,8 +921,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_23_140158) do
   add_foreign_key "review_policy_classes", "policy_classes"
   add_foreign_key "reviews", "users", column: "assessor_id"
   add_foreign_key "reviews", "users", column: "reviewer_id"
+  add_foreign_key "site_notices", "planning_applications"
   add_foreign_key "site_visits", "consultations"
   add_foreign_key "site_visits", "neighbours"
   add_foreign_key "site_visits", "users", column: "created_by_id"
+  add_foreign_key "users", "local_authorities"
   add_foreign_key "validation_requests", "planning_applications"
 end


### PR DESCRIPTION
Although it'd be possible to do all these in a single migration it's better to do it individually since it'll keep the already applied foreign keys. The potential for this happening is quite high - there could be orphan records that need removing.