### PR TITLE
Override AR::Base#update to allow passing of validation context

### DIFF
--- a/app/controllers/planning_applications/consultee/responses_controller.rb
+++ b/app/controllers/planning_applications/consultee/responses_controller.rb
@@ -40,10 +40,8 @@ module PlanningApplications
       end
 
       def update
-        @consultee_response.attributes = redaction_params
-
         respond_to do |format|
-          if @consultee_response.save(context: :redaction)
+          if @consultee_response.update(redaction_params, :redaction)
             format.html do
               redirect_to planning_application_consultee_path(@planning_application, @consultee), notice: t(".success")
             end

--- a/app/controllers/planning_applications/press_notices/confirmations_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmations_controller.rb
@@ -13,10 +13,8 @@ module PlanningApplications
       end
 
       def update
-        @press_notice.assign_attributes(press_notice_params)
-
         respond_to do |format|
-          if @press_notice.save(context: :confirmation)
+          if @press_notice.update(press_notice_params, :confirmation)
             format.html do
               redirect_to planning_application_consultation_path(@planning_application), notice: t(".success")
             end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,4 +2,18 @@
 
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def update(attributes, context = nil)
+    with_transaction_returning_status do
+      assign_attributes(attributes)
+      save(context: context)
+    end
+  end
+
+  def update!(attributes, context = nil)
+    with_transaction_returning_status do
+      assign_attributes(attributes)
+      save!(context: context)
+    end
+  end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -123,8 +123,7 @@ class Consultation < ApplicationRecord
   end
 
   def send_consultee_emails(attributes)
-    self.attributes = attributes
-    return false unless save(context: :send_consultee_emails)
+    return false unless update(attributes, :send_consultee_emails)
 
     unless start_date?
       start_deadline


### PR DESCRIPTION
The standard Active Record `update` method doesn't allow passing of the validation context which means that we have to assign the attributes first and then call `save`. Given the standard generated controller for a resource uses `if @model.update` this seems an oversight so allow passing of the context as a second optional argument to `update` to streamline the cases where we need different contexts inside BOPS.
