### PR TITLE
Add validation for neighbours being added before sending letters

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -149,6 +149,26 @@ html * {
   color: govuk-colour("red");
 }
 
+.govuk-notification-banner {
+  &--alert {
+    background-color: $govuk-error-colour;
+    border-color: $govuk-error-colour;
+
+    .govuk-notification-banner__link {
+      color: $govuk-error-colour;
+    }
+  }
+
+  &--notice {
+    background-color: $govuk-success-colour;
+    border-color: $govuk-success-colour;
+
+    .govuk-notification-banner__link {
+      color: $govuk-success-colour;
+    }
+  }
+}
+
 .audit_details {
   font-style: italic;
 }

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -92,7 +92,7 @@ class DocumentsController < AuthenticationController
       render :archive
     end
   rescue Document::NotArchiveableError => e
-    flash[:alert] = e
+    flash[:alert] = e.message
     render :archive
   end
 

--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -106,7 +106,7 @@ module PlanningApplications
     end
 
     def set_error_messages
-      flash.now[:error] = @neighbour_response.neighbour.errors.full_messages.join("\n") if @neighbour_response.neighbour&.errors&.any?
+      flash.now[:alert] = @neighbour_response.neighbour.errors.full_messages.join("\n") if @neighbour_response.neighbour&.errors&.any?
     end
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
 class PlanningApplicationsController < AuthenticationController
-  include ActionView::Helpers::SanitizeHelper
-
   before_action :set_planning_application, except: %i[new create index]
-
   before_action :ensure_user_is_reviewer_checking_assessment, only: %i[edit_public_comment]
-
   before_action :ensure_no_open_post_validation_requests, only: %i[submit]
-
   before_action :ensure_draft_recommendation_complete, only: :update
-
   before_action :ensure_site_notice_displayed_at, only: %i[determine]
-
   before_action :ensure_press_notice_published_at, only: %i[determine]
 
   rescue_from PlanningApplication::WithdrawRecommendationError do |_exception|
@@ -344,46 +337,28 @@ class PlanningApplicationsController < AuthenticationController
   def ensure_no_open_post_validation_requests
     return unless @planning_application.open_post_validation_requests?
 
-    link = view_context.link_to(
-      "review open requests",
-      post_validation_requests_planning_application_validation_validation_requests_path(@planning_application)
-    )
-    flash.now[:error] = sanitize "This application has open non-validation requests. Please
-        #{link} and resolve them before submitting to your manager."
+    flash.now[:alert] = t(".has_open_non_validation_requests_html", href: post_validation_requests_planning_application_validation_validation_requests_path(@planning_application))
     render :submit_recommendation and return
   end
 
   def ensure_draft_recommendation_complete
     return unless @planning_application.try(:assessment_in_progress?)
 
-    flash.now[:alert] = sanitize "Please save and mark as complete the
-        #{view_context.link_to "draft recommendation",
-          new_planning_application_assessment_recommendation_path(@planning_application)}
-        before updating application fields."
-
+    flash.now[:alert] = t(".save_and_mark_complete_html", href: new_planning_application_assessment_recommendation_path(@planning_application))
     render :edit and return
   end
 
   def ensure_site_notice_displayed_at
     return unless @planning_application.site_notice_needs_displayed_at?
 
-    flash.now[:alert] = sanitize "You must
-        #{view_context.link_to "confirm the site notice displayed at date",
-          edit_planning_application_site_notice_path(@planning_application,
-            @planning_application.site_notice)}
-        before determining the application."
-
+    flash.now[:alert] = t(".confirm_site_notice_displayed_at_html", href: edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))
     render :publish and return
   end
 
   def ensure_press_notice_published_at
     return unless @planning_application.press_notice_needs_published_at?
 
-    flash.now[:alert] = sanitize "You must
-        #{view_context.link_to "confirm the press notice published at date",
-          planning_application_press_notice_confirmation_path(@planning_application)}
-        before determining the application."
-
+    flash.now[:alert] = t(".confirm_press_notice_published_at_html", href: planning_application_press_notice_confirmation_path(@planning_application))
     render :publish and return
   end
 end

--- a/app/views/application/_flash_content.html.erb
+++ b/app/views/application/_flash_content.html.erb
@@ -1,36 +1,26 @@
 <% if alert %>
-  <div class="flash govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-    <svg class="alert__icon" fill="red" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 25 25" height="25" width="25">
-      <path d="M13.6,15.4h-2.3v-4.5h2.3V15.4z M13.6,19.8h-2.3v-2.2h2.3V19.8z M0,23.2h25L12.5,2L0,23.2z"></path>
-    </svg>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <%= alert %>
-      </ul>
+  <div class="govuk-notification-banner govuk-notification-banner--alert" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Error
+      </h2>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <h3 class="govuk-notification-banner__heading">
+        There is a problem
+      </h3>
+      <%= simple_format(alert, class: "govuk-body") %>
     </div>
   </div>
 <% elsif notice %>
-  <div class="flash flash-archive">
-    <div class="govuk-!-padding-2">
-      <svg class="moj-banner__icon" color="green" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 25 25" height="25" width="25">
-        <path d="M25,6.2L8.7,23.2L0,14.1l4-4.2l4.7,4.9L21,2L25,6.2z"></path>
-      </svg>
-      <%= notice %>
-    </div>
-  </div>
-<% elsif flash.key?(:error) %>
-  <div class="flash govuk-error-summary" aria-labelledby="error-summary-title" tabindex="-1" data-module="govuk-error-summary">
-    <div role="alert">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
+  <div class="govuk-notification-banner govuk-notification-banner--notice" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__header">
+      <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+        Success
       </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <a href="#error_message"><%= simple_format(flash[:error]) %></a>
-        </ul>
-      </div>
+    </div>
+    <div class="govuk-notification-banner__content">
+      <%= simple_format(notice, class: "govuk-body") %>
     </div>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -949,7 +949,7 @@ en:
             lawfulness_certificate: State the reasons why this application is, or is not lawful.
             planning_permission: State the reasons for your recommendation.
             prior_approval: State the reasons for your recommendation.
-          there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href='%{href}'>View all requests</a>.
+          there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href="%{href}">View all requests</a>.
           this_information_will: This information will appear on the decision notice.
           this_information_will_not: This information will not appear on the decision notice or the public register, but Freedom of Information requests will still apply.
           update_assessment: Update assessment
@@ -991,6 +991,8 @@ en:
       other: "%{count} days remaining"
       zero: "%{count} days overdue"
     determine:
+      confirm_press_notice_published_at_html: You must <a class="govuk-notification-banner__link" href="%{href}">confirm the press notice published at date</a> before determining the application.
+      confirm_site_notice_displayed_at_html: You must <a class="govuk-notification-banner__link" href="%{href}">confirm the site notice displayed at date</a> before determining the application.
       success: Decision Notice sent to applicant
     index:
       prior_approvals:
@@ -1009,7 +1011,9 @@ en:
         failure: 'Error adding neighbour addresses with message: %{message}'
         success: Addresses have been successfully added.
       send_letters:
-        require_resend_reason: Must provide a reason when resending letters to previously-contacted neighbours
+        add_neighbours: You must add some neighbours before sending letters
+        make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BoPS Public Portal</a> before you can send letters to neighbours.
+        require_resend_reason: You must provide a reason when resending letters to previously-contacted neighbours
     neighbour_responses:
       create:
         success: Neighbour response successfully created.
@@ -1163,6 +1167,7 @@ en:
       validation:
         check_and_validate: Check and validate
     submit:
+      has_open_non_validation_requests_html: This application has open non-validation requests. Please <a class="govuk-notification-banner__link" href="%{href}">review open requests</a> and resolve them before submitting to your manager.
       success: Recommendation was successfully submitted.
     submit_recommendation:
       back: Back
@@ -1184,6 +1189,7 @@ en:
     update:
       edit_payment_amount: Planning application payment amount was successfully updated.
       edit_public_comment: The information appearing on the decision notice was successfully updated.
+      save_and_mark_complete_html: Please save and mark as complete the <a class="govuk-notification-banner__link" href="%{href}">draft recommendation</a> before updating application fields.
       success: Planning application was successfully updated.
     validate:
       success: Application is ready for assessment and an email notification has been sent.

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -478,7 +478,7 @@ RSpec.describe "Sign in" do
       visit "/"
       expect(page).not_to have_content(user.name)
 
-      within(".flash") do
+      within(".govuk-notification-banner--alert") do
         expect(page).to have_content("Your session expired. Please sign in again to continue.")
       end
     end

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Planning Application Assessment" do
           click_link("Publish determination")
           click_button("Publish determination")
 
-          within(".govuk-error-summary") do
+          within(".govuk-notification-banner--alert") do
             expect(page).to have_content("You must confirm the site notice displayed at date before determining the application")
             expect(page).to have_link(
               "confirm the site notice displayed at date", href: edit_planning_application_site_notice_path(planning_application, site_notice)
@@ -217,7 +217,7 @@ RSpec.describe "Planning Application Assessment" do
           click_link("Publish determination")
           click_button("Publish determination")
 
-          within(".govuk-error-summary") do
+          within(".govuk-notification-banner--alert") do
             expect(page).to have_content("You must confirm the press notice published at date before determining the application")
             expect(page).to have_link(
               "confirm the press notice published at date", href: "/planning_applications/#{planning_application.id}/press_notice/confirmation"

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "cloning a planning application" do
         click_link("Clone")
       end
 
-      within(".govuk-error-summary") do
+      within(".govuk-notification-banner--alert") do
         expect(page).to have_content("Error cloning application with message: Record invalid.")
       end
 
@@ -76,7 +76,7 @@ RSpec.describe "cloning a planning application" do
         click_link("Clone")
       end
 
-      within(".govuk-error-summary") do
+      within(".govuk-notification-banner--alert") do
         expect(page).to have_content("Cloning is not permitted in production")
       end
 
@@ -94,7 +94,7 @@ RSpec.describe "cloning a planning application" do
         click_link("Clone")
       end
 
-      within(".govuk-error-summary") do
+      within(".govuk-notification-banner--alert") do
         expect(page).to have_content("Planning application can not be cloned as it was not created via PlanX")
       end
 

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "View neighbour responses", js: true do
 
     click_button "Save response"
 
-    within(".flash.govuk-error-summary") do
+    within(".govuk-notification-banner--alert") do
       expect(page).to have_content("There is a problem")
       expect(page).to have_content("'123 Street' is invalid")
       expect(page).to have_content("Enter the property name or number, followed by a comma")
@@ -212,7 +212,7 @@ RSpec.describe "View neighbour responses", js: true do
 
     click_button "Update response"
 
-    within(".flash.govuk-error-summary") do
+    within(".govuk-notification-banner--alert") do
       expect(page).to have_content("There is a problem")
       expect(page).to have_content("'124, Made up' is invalid")
       expect(page).to have_content("Enter the property name or number, followed by a comma")

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -221,9 +221,9 @@ RSpec.describe "Send letters to neighbours", js: true do
 
         click_button "Print and send letters"
 
-        within(".govuk-error-summary__body") do
+        within(".govuk-notification-banner--alert") do
           expect(page).to have_content("The planning application must be made public on the BoPS Public Portal before you can send letters to neighbours.")
-          expect(page).to have_link("made public on the BoPS Public Portal", href: make_public_planning_application_path(planning_application))
+          expect(page).to have_link("made public on the BoPS Public Portal", href: "/planning_applications/#{planning_application.id}/make_public")
         end
       end
     end
@@ -239,17 +239,18 @@ RSpec.describe "Send letters to neighbours", js: true do
       click_link "Send letters to neighbours"
     end
 
+    it "I can not send letters without neighbours" do
+      click_button "Print and send letters"
+
+      within(".govuk-notification-banner--alert") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("You must add some neighbours before sending letters")
+      end
+    end
+
     it "I can not add an invalid address" do
       fill_in "Search for neighbours by address", with: "Biscuit town"
       page.find(:xpath, "//input[@value='Add neighbour']").click.click
-
-      within(".govuk-error-summary") do
-        expect(page).to have_content("There is a problem")
-        expect(page).to have_content("'Biscuit town' is invalid")
-        expect(page).to have_content("Enter the property name or number, followed by a comma")
-        expect(page).to have_content("Enter the street name, followed by a comma")
-        expect(page).to have_content("Enter a postcode, like AA11AA")
-      end
 
       within(".govuk-error-message") do
         expect(page).to have_content("'Biscuit town' is invalid")
@@ -266,15 +267,8 @@ RSpec.describe "Send letters to neighbours", js: true do
 
       click_button "Print and send letters"
 
-      within(".govuk-error-summary") do
+      within(".govuk-notification-banner--alert") do
         expect(page).to have_content("There is a problem")
-        expect(page).to have_content("'Cheese cottage' is invalid")
-        expect(page).to have_content("Enter the property name or number, followed by a comma")
-        expect(page).to have_content("Enter the street name, followed by a comma")
-        expect(page).to have_content("Enter a postcode, like AA11AA")
-      end
-
-      within(".govuk-error-message") do
         expect(page).to have_content("'Cheese cottage' is invalid")
         expect(page).to have_content("Enter the property name or number, followed by a comma")
         expect(page).to have_content("Enter the street name, followed by a comma")
@@ -560,7 +554,7 @@ RSpec.describe "Send letters to neighbours", js: true do
 
       click_button "Add neighbours"
 
-      within(".govuk-error-summary") do
+      within(".govuk-error-message") do
         expect(page).to have_content(
           "Neighbours address 5, COXSON WAY, LONDON, SE1 2XB has already been added."
         )

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -427,7 +427,7 @@ RSpec.describe "Planning Application Assessment" do
           click_link("Review and submit recommendation")
           click_button("Submit recommendation")
 
-          within(".govuk-error-summary") do
+          within(".govuk-notification-banner--alert") do
             expect(page).to have_content("There is a problem")
             expect(page).to have_content("This application has open non-validation requests. Please review open requests and resolve them before submitting to your manager.")
             expect(page).to have_link("review open requests", href: post_validation_requests_planning_application_validation_validation_requests_path(planning_application))


### PR DESCRIPTION
### Description of change

Following the existing pattern within the controller, add a `before_action` callback that checks for the presence of `neighbours_to_contact`

### Story Link

https://trello.com/c/40n0fHFJ

### Screenshots

![image](https://github.com/unboxed/bops/assets/6321/b0c8c106-22b7-4944-bc00-057336e8c36f)

### Decisions

The flash banner styling was inconsistent so standardised on the GOV.UK Design System [Notification Banner][1] component

### Known issues

Much of the validation and transactional code should be moved to the model layer but neighbour letters page is to be revisited in response to user testing so minimal changes for now.

[1]: https://design-system.service.gov.uk/components/notification-banner/