### PR TITLE
Migrate old documents for press and site notices to new owner association

### DIFF
--- a/db/migrate/20231130104814_migrate_press_and_site_notice_documents.rb
+++ b/db/migrate/20231130104814_migrate_press_and_site_notice_documents.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MigratePressAndSiteNoticeDocuments < ActiveRecord::Migration[7.0]
+  def up
+    execute <<~SQL
+      UPDATE documents
+      SET owner_id = press_notice_id, owner_type = 'PressNotice', press_notice_id = NULL
+      WHERE press_notice_id IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE documents
+      SET owner_id = site_notice_id, owner_type = 'SiteNotice', site_notice_id = NULL
+      WHERE site_notice_id IS NOT NULL
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE documents
+      SET press_notice_id = owner_id, owner_id = NULL, owner_type = NULL
+      WHERE owner_type = 'PressNotice'
+    SQL
+
+    execute <<~SQL
+      UPDATE documents
+      SET site_notice_id = owner_id, owner_id = NULL, owner_type = NULL
+      WHERE owner_type = 'SiteNotice'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_24_183052) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_30_104814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"


### PR DESCRIPTION
TODO: Drop press_notice_id and site_notice_id columns once this has been deployed to production