### PR TITLE
Send back the entire DPA object not only address

### DIFF
--- a/app/javascript/controllers/polygon_search_controller.js
+++ b/app/javascript/controllers/polygon_search_controller.js
@@ -91,9 +91,9 @@ export default class extends Controller {
     const container = this.getAddressContainer()
 
     addresses.forEach((address, index) => {
-      const addressDiv = this.createAddressElement(address, index)
+      const addressDiv = this.createAddressElement(address.ADDRESS, index)
 
-      const hiddenInput = this.createHiddenInputElement(address, index)
+      const hiddenInput = this.createHiddenInputElement(address.ADDRESS, index)
       this.getConsultationNeighbourAddressesForm().appendChild(hiddenInput)
 
       container.appendChild(addressDiv)

--- a/app/services/apis/os_places/client.rb
+++ b/app/services/apis/os_places/client.rb
@@ -22,7 +22,7 @@ module Apis
         end
 
         data = JSON.parse(response.body)
-        data["results"]&.map { |result| result["DPA"]["ADDRESS"] } || []
+        data["results"]&.map { |result| result["DPA"] } || []
       end
 
       private

--- a/spec/services/apis/os_places/client_spec.rb
+++ b/spec/services/apis/os_places/client_spec.rb
@@ -59,7 +59,8 @@ RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: t
         }
       )
 
-      expect(result).to eq(["5, COXSON WAY, LONDON, SE1 2XB", "6, COXSON WAY, LONDON, SE1 2XB"])
+      expect(result).to contain_exactly(hash_including("ADDRESS" => "5, COXSON WAY, LONDON, SE1 2XB"),
+        hash_including("ADDRESS" => "6, COXSON WAY, LONDON, SE1 2XB"))
     end
   end
 end


### PR DESCRIPTION
### Description of change

Send back the whole DPA object from the OS Places query to the UI AJAX request, rather than limiting it only to the address field.

This will allow using further details of the selected addresses in the map.

### Story Link

https://trello.com/c/gLz6SXiu/2160-ability-to-confidently-identify-the-right-neighbours

### Known issues

This doesn't include changing the upstream API request to request a response in `EPSG:4326`. However, this change seems to be necessary in order to get a latitude and longitude for the address as part of the response. It's a one-line change in `Api::OsPlaces::Query`, but I'm cautious about making it without confirming that the data points still align correctly when shown on the map.

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
