### PR TITLE
Don't show "check permitted development" for planning permission applications

### DIFF
--- a/app/controllers/concerns/permitted_development_rights.rb
+++ b/app/controllers/concerns/permitted_development_rights.rb
@@ -3,11 +3,26 @@
 module PermittedDevelopmentRights
   extend ActiveSupport::Concern
 
+  included do
+    before_action :set_planning_application
+    before_action :raise_routing_error, unless: :permitted_development_rights_can_be_checked?
+  end
+
+  def permitted_development_rights_can_be_checked?
+    @planning_application.check_permitted_development_rights?
+  end
+
   def set_permitted_development_right
     @permitted_development_right = @planning_application.permitted_development_right
   end
 
   def set_permitted_development_rights
     @permitted_development_rights = @planning_application.permitted_development_rights.returned
+  end
+
+  private
+
+  def raise_routing_error
+    raise ActionController::RoutingError, "Not found"
   end
 end

--- a/app/controllers/planning_applications/assessment/assess_immunity_detail_permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/assessment/assess_immunity_detail_permitted_development_rights_controller.rb
@@ -9,7 +9,6 @@ module PlanningApplications
 
       rescue_from ReviewImmunityDetail::NotCreatableError, with: :redirect_failed_create_error
 
-      before_action :set_planning_application
       before_action :ensure_planning_application_is_validated
       before_action :ensure_planning_application_is_possibly_immune
       before_action :set_permitted_development_right, only: %i[show edit update]

--- a/app/controllers/planning_applications/assessment/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/assessment/permitted_development_rights_controller.rb
@@ -9,7 +9,6 @@ module PlanningApplications
 
       rescue_from PermittedDevelopmentRight::NotCreatableError, with: :redirect_failed_create_error
 
-      before_action :set_planning_application
       before_action :ensure_planning_application_is_validated
       before_action :set_permitted_development_right, only: %i[show edit update]
       before_action :set_permitted_development_rights, only: %i[new show edit]

--- a/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
@@ -7,7 +7,6 @@ module PlanningApplications
       include PlanningApplicationAssessable
       include PermittedDevelopmentRights
 
-      before_action :set_planning_application
       before_action :ensure_planning_application_is_validated
       before_action :set_permitted_development_right, only: %i[show edit update]
       before_action :set_permitted_development_rights, only: %i[show edit]

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -9,6 +9,8 @@ class ApplicationType < ApplicationRecord
 
   validates :name, presence: true
 
+  attribute :features, ApplicationTypeFeature.to_type
+
   def full_name
     name.humanize
   end

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApplicationTypeFeature
+  include StoreModel::Model
+
+  attribute :permitted_development_rights, :boolean, default: true
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -715,6 +715,14 @@ class PlanningApplication < ApplicationRecord
     validation_requests.open.select(&:overdue?)
   end
 
+  def check_permitted_development_rights?
+    application_type.features.permitted_development_rights?
+  end
+
+  def review_permitted_development_rights?
+    check_permitted_development_rights? && permitted_development_right
+  end
+
   private
 
   def update_measurements

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -41,18 +41,20 @@
         )
       ) %>
     <% end %>
-    <% if @planning_application.possibly_immune? %>
-      <%= render(
-        TaskListItems::Assessment::AssessImmunityDetailPermittedDevelopmentRightComponent.new(
-          planning_application: @planning_application
-        )
-      ) %>
-    <% else %>
-      <%= render(
-        TaskListItems::Assessment::PermittedDevelopmentRightComponent.new(
-          planning_application: @planning_application
-        )
-      ) %>
+    <% if @planning_application.check_permitted_development_rights? %>
+      <% if @planning_application.possibly_immune? %>
+        <%= render(
+          TaskListItems::Assessment::AssessImmunityDetailPermittedDevelopmentRightComponent.new(
+            planning_application: @planning_application
+          )
+        ) %>
+      <% else %>
+        <%= render(
+          TaskListItems::Assessment::PermittedDevelopmentRightComponent.new(
+            planning_application: @planning_application
+          )
+        ) %>
+      <% end %>
     <% end %>
   </ul>
 </li>

--- a/app/views/planning_applications/review/tasks/index.html.erb
+++ b/app/views/planning_applications/review/tasks/index.html.erb
@@ -47,7 +47,7 @@
             )
           ) %>
       <% end %>
-      <% if @planning_application.permitted_development_right %>
+      <% if @planning_application.review_permitted_development_rights? %>
         <%= render(
           TaskListItems::Reviewing::PermittedDevelopmentRightComponent.new(
             planning_application: @planning_application

--- a/db/migrate/20231212114641_add_features_to_application_types.rb
+++ b/db/migrate/20231212114641_add_features_to_application_types.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddFeaturesToApplicationTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_types, :features, :jsonb, default: {}
+
+    up_only do
+      ApplicationType.reset_column_information
+
+      ApplicationType.find_each do |application_type|
+        if application_type.name == "planning_permission"
+          application_type.update!(features: {"permitted_development_rights" => false})
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_11_125913) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_12_114641) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -65,6 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_11_125913) do
     t.string "steps", default: ["validation", "consultation", "assessment", "review"], array: true
     t.string "consistency_checklist", array: true
     t.jsonb "document_tags"
+    t.jsonb "features", default: {}
   end
 
   create_table "assessment_details", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -109,6 +109,7 @@ application_types = [
   },
   {
     name: "planning_permission",
+    features: {"permitted_development_rights" => false},
     steps: %w[validation consultation assessment review],
     assessment_details: %w[
       summary_of_work

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -140,6 +140,7 @@ FactoryBot.define do
     trait :planning_permission do
       name { "planning_permission" }
       steps { %w[validation consultation assessment review] }
+      features { {"permitted_development_rights" => false} }
 
       assessment_details do
         %w[

--- a/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
@@ -383,4 +383,22 @@ RSpec.describe "Permitted development right" do
       expect(page).to have_content("forbidden")
     end
   end
+
+  context "when application type is planning permission" do
+    let!(:planning_application) do
+      create(:planning_application, :planning_permission, local_authority: default_local_authority)
+    end
+
+    it "returns 404" do
+      sign_in assessor
+      visit "/planning_applications/#{planning_application.id}"
+
+      expect(page).not_to have_link("Permitted development rights")
+
+      expect do
+        visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+        expect(page).to have_selector("h1", text: "Does not exist")
+      end.to raise_error(ActionController::RoutingError, "Not found")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Don't show "check permitted development" for planning permission applications

### Story Link

https://trello.com/c/xuotTlC9/2205-dont-show-check-permitted-development-for-planning-applications