### PR TITLE
Allow any subdomain of bops.localhost and bops-applicants.localhost to be used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER-RUN = docker compose run --rm
+DOCKER-RUN = docker compose --profile console run --rm
 
 .DEFAULT_GOAL := up
 
@@ -13,46 +13,49 @@ down:
 	docker compose down
 
 prompt:
-	$(DOCKER-RUN) web bash
+	$(DOCKER-RUN) console bash
 
 aprompt:
-	$(DOCKER-RUN) applicants bash
+	$(DOCKER-RUN) aconsole bash
 
 console:
-	$(DOCKER-RUN) web rails console
+	$(DOCKER-RUN) console rails console
+
+aconsole:
+	$(DOCKER-RUN) aconsole rails console
 
 migrate:
-	$(DOCKER-RUN) web rails db:migrate
+	$(DOCKER-RUN) console rails db:migrate
 
 rollback:
-	$(DOCKER-RUN) web rails db:rollback
+	$(DOCKER-RUN) console rails db:rollback
 
 locales:
-	$(DOCKER-RUN) web i18n-tasks normalize
+	$(DOCKER-RUN) console i18n-tasks normalize
 
 api-docs:
-	$(DOCKER-RUN) web rake api:docs:generate
+	$(DOCKER-RUN) console rake api:docs:generate
 
 api-specs:
-	$(DOCKER-RUN) web rspec engines/bops_api/spec
+	$(DOCKER-RUN) console rspec engines/bops_api/spec
 
 rspec:
-	$(DOCKER-RUN) web rspec
+	$(DOCKER-RUN) console rspec
 
 cucumber:
-	$(DOCKER-RUN) web cucumber
+	$(DOCKER-RUN) console cucumber
 
 guard:
-	$(DOCKER-RUN) web $(BUNDLE-EXEC) guard
+	$(DOCKER-RUN) console $(BUNDLE-EXEC) guard
 
 db-prompt:
-	$(DOCKER-RUN) web psql postgres://postgres:postgres@db
+	$(DOCKER-RUN) console psql postgres://postgres:postgres@db
 
 lint:
-	$(DOCKER-RUN) web rubocop
+	$(DOCKER-RUN) console rubocop
 
 lint-auto-correct:
-	$(DOCKER-RUN) web rubocop --auto-correct-all
+	$(DOCKER-RUN) console rubocop --auto-correct-all
 
 # this regenerates the Rubocop TODO and ensures that cops aren't
 # turned off over a max number of file offenses. Note: we don't want

--- a/README.md
+++ b/README.md
@@ -87,25 +87,18 @@ $ bin/dev
 
 ## Subdomains
 
-Because of the local authority being inferred on the request's
-subdomain, your options to get the application working locally include using Docker or
-using the `bops-care.link` domain which points back to your localhost:
+Because of the local authority being inferred on the request's subdomain,
+your options to get the application working locally include using Docker or
+using the `bops.localhost` domain which points back to your localhost:
 
 ```
-http://southwark.bops-care.link:3000/
-http://lambeth.bops-care.link:3000/
-http://buckinghamshire.bops-care.link:3000/
+http://southwark.bops.localhost:3000/
+http://lambeth.bops.localhost:3000/
+http://buckinghamshire.bops.localhost:3000/
 ```
 
-Otherwise you can use localhost though you'll have to double the
-subdomain since `localhost` is missing the second component found in
-`normal-domains.com`.
-
-```
-http://southwark.southwark.localhost:3000/
-http://lambeth.lambeth.localhost:3000/
-http://buckinghamshire.buckinghamshire.localhost:3000/
-```
+This should happen automatically but may require adding the hosts to `/etc/hosts`
+if your specific system/browser config doesn't work.
 
 ## GOV.UK Notify
 

--- a/bin/run
+++ b/bin/run
@@ -2,4 +2,4 @@
 
 set -e
 
-docker compose run --rm web "$@"
+docker compose --profile console run --rm console "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,8 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops.localhost"), port: 3000 }
 
-  config.hosts << "southwark.bops.localhost"
+  # Allow connections on any bops.localhost subdomain
+  config.hosts << /[a-z][-a-z0-9]{0,62}\.bops\.localhost/
 
   # Allow web-console connections into docker
   config.web_console.permissions = %w( 127.0.0.1 ::1 172.23.9.254 )

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,10 +72,8 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops-care.link"), port: 3000 }
+  config.action_mailer.default_url_options = { host: (ENV["DOMAIN"] || "bops.localhost"), port: 3000 }
 
-  config.hosts << ".bops-care.link"
-  config.hosts << "southwark.bops.web"
   config.hosts << "southwark.bops.localhost"
 
   # Allow web-console connections into docker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,8 @@ services:
     networks:
       default:
         aliases:
+          - buckinghamshire.bops.localhost
+          - lambeth.bops.localhost
           - southwark.bops.localhost
     volumes:
       - type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,6 +83,8 @@ services:
       OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
     ports:
       - "127.0.0.1:3001:3001"
+    depends_on:
+      - web
     volumes:
       - type: bind
         source: bops-applicants

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,10 +83,6 @@ services:
       OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
     ports:
       - "127.0.0.1:3001:3001"
-    networks:
-      default:
-        aliases:
-          - southwark.bops-applicants.localhost
     volumes:
       - type: bind
         source: bops-applicants

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,90 @@
 ---
+x-bops: &bops
+  image: bops/ruby
+  build: docker/ruby
+  working_dir: /home/rails/bops
+  init: true
+  stdin_open: true
+  tty: true
+  depends_on:
+    - db
+    - dnsmasq
+    - redis
+  dns:
+    - 172.23.9.53
+  environment:
+    DATABASE_URL: postgres://postgres:postgres@db:5432
+    GROVER_NO_SANDBOX: "true"
+    PIDFILE: /tmp/pids/server.pid
+    OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
+    REDIS_URL: redis://redis:6379/1
+    PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
+    NOTIFY_API_KEY: ${NOTIFY_API_KEY}
+    NOTIFY_LETTER_API_KEY: ${NOTIFY_LETTER_API_KEY}
+    RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION: "true"
+  volumes:
+    - type: bind
+      source: .
+      target: /home/rails/bops
+    - type: volume
+      source: bundle
+      target: /home/rails/bundle
+    - type: volume
+      source: node_modules
+      target: /home/rails/bops/node_modules
+    - type: tmpfs
+      target: /tmp/pids
+      tmpfs:
+        mode: 0777
+
+x-applicants: &applicants
+  image: bops/applicants
+  build: bops-applicants/docker/ruby
+  working_dir: /home/rails/bops-applicants
+  init: true
+  stdin_open: true
+  tty: true
+  depends_on:
+    - web
+  dns:
+    - 172.23.9.53
+  environment:
+    API_BEARER: 123
+    API_HOST: bops.localhost:3000
+    API_USER: api_user
+    PIDFILE: /tmp/pids/server.pid
+    PORT: 3001
+    PROTOCOL: http
+    OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
+  volumes:
+    - type: bind
+      source: bops-applicants
+      target: /home/rails/bops-applicants
+    - type: volume
+      source: applicants_bundle
+      target: /home/rails/bundle
+    - type: volume
+      source: applicants_node_modules
+      target: /home/rails/bops-applicants/node_modules
+    - type: tmpfs
+      target: /tmp/pids
+      tmpfs:
+        mode: 0777
+
 services:
+  dnsmasq:
+    image: bops/dnsmasq
+    build: docker/dnsmasq
+    volumes:
+      - type: bind
+        source: docker/dnsmasq/dnsmasq.conf
+        target: /etc/dnsmasq.conf
+    cap_add:
+      - NET_ADMIN
+    networks:
+      default:
+        ipv4_address: 172.23.9.53
+
   db:
     image: bops/postgis
     build: docker/postgis
@@ -24,83 +109,34 @@ services:
         target: /var/lib/redis/data
 
   web:
-    image: bops/ruby
-    build: docker/ruby
-    working_dir: /home/rails/bops
+    <<: *bops
     command: ["foreman", "start", "-f", "Procfile.dev"]
-    init: true
-    stdin_open: true
-    tty: true
-    environment:
-      DATABASE_URL: postgres://postgres:postgres@db:5432
-      GROVER_NO_SANDBOX: "true"
-      PIDFILE: /tmp/pids/server.pid
-      OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
-      REDIS_URL: redis://redis:6379/1
-      PUPPETEER_EXECUTABLE_PATH: /usr/bin/chromium
-      NOTIFY_API_KEY: ${NOTIFY_API_KEY}
-      NOTIFY_LETTER_API_KEY: ${NOTIFY_LETTER_API_KEY}
-      RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION: "true"
     ports:
       - "127.0.0.1:3000:3000"
-    depends_on:
-      - db
-      - redis
     networks:
       default:
-        aliases:
-          - buckinghamshire.bops.localhost
-          - lambeth.bops.localhost
-          - southwark.bops.localhost
-    volumes:
-      - type: bind
-        source: .
-        target: /home/rails/bops
-      - type: volume
-        source: bundle
-        target: /home/rails/bundle
-      - type: volume
-        source: node_modules
-        target: /home/rails/bops/node_modules
-      - type: tmpfs
-        target: /tmp/pids
-        tmpfs:
-          mode: 0777
+        ipv4_address: 172.23.9.30
+
+  console:
+    <<: *bops
+    command: ["/bin/bash"]
+    profiles:
+      - console
 
   applicants:
-    image: bops/applicants
-    build: bops-applicants/docker/ruby
-    working_dir: /home/rails/bops-applicants
+    <<: *applicants
     command: ["foreman", "start", "-f", "Procfile.dev"]
-    init: true
-    stdin_open: true
-    tty: true
-    environment:
-      API_BEARER: 123
-      API_HOST: bops.localhost:3000
-      API_USER: api_user
-      PIDFILE: /tmp/pids/server.pid
-      PORT: 3001
-      PROTOCOL: http
-      OS_VECTOR_TILES_API_KEY: ${OS_VECTOR_TILES_API_KEY}
     ports:
       - "127.0.0.1:3001:3001"
-    depends_on:
-      - web
-    volumes:
-      - type: bind
-        source: bops-applicants
-        target: /home/rails/bops-applicants
-      - type: volume
-        source: applicants_bundle
-        target: /home/rails/bundle
-      - type: volume
-        source: applicants_node_modules
-        target: /home/rails/bops-applicants/node_modules
-      - type: tmpfs
-        target: /tmp/pids
-        tmpfs:
-          mode: 0777
+    networks:
+      default:
+        ipv4_address: 172.23.9.31
+
+  aconsole:
+    <<: *applicants
+    command: ["/bin/bash"]
+    profiles:
+      - console
 
 networks:
   default:

--- a/docker/dnsmasq/Dockerfile
+++ b/docker/dnsmasq/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:bullseye-slim
+
+# Run security updates and install packages
+RUN bash -c "export DEBIAN_FRONTEND=noninteractive && \
+    apt-get update -qq && \
+    echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && \
+    apt-get install -y apt-utils curl locales dnsmasq && \
+    apt-get upgrade -y && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*"
+
+EXPOSE 53 53/udp
+
+ENTRYPOINT ["dnsmasq", "-k"]

--- a/docker/dnsmasq/dnsmasq.conf
+++ b/docker/dnsmasq/dnsmasq.conf
@@ -1,0 +1,2 @@
+address=/bops.localhost/172.23.9.30
+address=/bops-applicants.localhost/172.23.9.31


### PR DESCRIPTION
Makes testing onboarding easier and allows for additional engines on non-LPA subdomains such as admin.bops.localhost.

Conventionally a subdomain of localhost will resolve to 127.0.0.1 for IPv4 and ::1 for IPv6. This works fine for browsers outside of the docker network but where we have containers talking to each other such as bops-applicants querying the API of bops this will fail since 127.0.0.1 will point to the originating container.

To work around this limitation we need to override the default behaviour to make DNS requests for bops and bops-applicants return their respective container IP addresses. For a limited number of hosts, using network aliases works but becomes cumbersome quickly and network aliases don't support wildcards.

The solution to this is to add our own DNS service to the network and dnsmasq is ideally suited to this task. Since we need to specify the IP addresses in the config we need to assign static addresses to the bops and bops-applicants services (and also dnsmasq itself).

Now that bops and bops-applicants have static IP addresses we need to add additional services for running tasks since we can't run multiple instances of the existing services. To facilitate this we extract out common config to reusable YAML blocks. We also need to make sure that the new 'console' services don't boot when we run 'docker compose up', so we use the docker compose v2 profile feature to disable them by default and use '--profile console' when running tasks such as 'make lint' or 'make migrate'.