### PR TITLE
Remove duplicate and unused CSS classes

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -354,10 +354,6 @@ html * {
   border-bottom: none;
 }
 
-.width-80 {
-  width: 80%;
-}
-
 .status-bar-container {
   background-color: rgb(202, 222, 237);
   width: calc(100vw);

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -173,10 +173,6 @@ html * {
   font-style: italic;
 }
 
-.make-invisible {
-  display: none;
-}
-
 .limit-column-width {
   word-wrap: break-word;
   max-width: 150px;

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -346,10 +346,6 @@ html * {
   display: flex;
 }
 
-.justify-content-space-between {
-  justify-content: space-between;
-}
-
 .align-items-center {
   align-items: center;
 }

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -358,10 +358,6 @@ html * {
   border-bottom: none;
 }
 
-.govuk-link__no-underline {
-  text-decoration: none;
-}
-
 .width-80 {
   width: 80%;
 }

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -276,10 +276,6 @@ html * {
   justify-content: space-between;
 }
 
-.display-none {
-  display: none;
-}
-
 .button-as-link {
   border: none;
   background: none;

--- a/app/components/planning_applications/immunity_details_assessment_component.html.erb
+++ b/app/components/planning_applications/immunity_details_assessment_component.html.erb
@@ -27,7 +27,7 @@
       <h3>
         <%= link_to sanitize("#{evidence_group.name} (#{evidence_group.documents.count})<br>#{evidence_group.date_range}"),
                     new_planning_application_assessment_immunity_detail_path(planning_application) + "#accordion-default-heading-#{evidence_group.id}",
-                    class: "govuk-link govuk-link__no-underline" %>
+                    class: "govuk-link govuk-link--no-underline" %>
       </h3>
       <% if evidence_group.missing_evidence? %>
         <div class="govuk-warning-text govuk-!-margin-left-6 govuk-!-margin-top-2">

--- a/app/javascript/controllers/edit_form_controller.js
+++ b/app/javascript/controllers/edit_form_controller.js
@@ -10,10 +10,10 @@ export default class extends Controller {
     )
     event.currentTarget.parentElement.parentElement
       .querySelector(".govuk-body")
-      .classList.add("display-none")
+      .classList.add("govuk-!-display-none")
     event.currentTarget.parentElement.parentElement
       .querySelector("form")
-      .classList.remove("display-none")
-    event.currentTarget.parentElement.classList.add("display-none")
+      .classList.remove("govuk-!-display-none")
+    event.currentTarget.parentElement.classList.add("govuk-!-display-none")
   }
 }

--- a/app/javascript/controllers/show_hide_controller.js
+++ b/app/javascript/controllers/show_hide_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
 
   handleEvent(_event) {
     this.toggleableTargets.forEach((element) => {
-      element.classList.toggle("display-none")
+      element.classList.toggle("govuk-!-display-none")
     })
   }
 
@@ -21,10 +21,10 @@ export default class extends Controller {
     }
 
     this[`toggleableWhen${selectedDecisionValue}Targets`].forEach((element) => {
-      element.classList.remove("display-none")
+      element.classList.remove("govuk-!-display-none")
     })
     this[`toggleableWhen${oppositeValue}Targets`].forEach((element) => {
-      element.classList.add("display-none")
+      element.classList.add("govuk-!-display-none")
     })
   }
 }

--- a/app/javascript/controllers/show_hide_form_controller.js
+++ b/app/javascript/controllers/show_hide_form_controller.js
@@ -6,30 +6,30 @@ export default class extends Controller {
       if (
         !document
           .getElementById("site-notice-form-actions")
-          .classList.contains("display-none")
+          .classList.contains("govuk-!-display-none")
       ) {
         document
           .getElementById("site-notice-form-actions")
-          .classList.add("display-none")
+          .classList.add("govuk-!-display-none")
       }
 
       document
         .getElementById("site-notice-options")
-        .classList.remove("display-none")
+        .classList.remove("govuk-!-display-none")
     } else if (event.target.value === "false") {
       if (
         !document
           .getElementById("site-notice-options")
-          .classList.contains("display-none")
+          .classList.contains("govuk-!-display-none")
       ) {
         document
           .getElementById("site-notice-options")
-          .classList.add("display-none")
+          .classList.add("govuk-!-display-none")
       }
 
       document
         .getElementById("site-notice-form-actions")
-        .classList.remove("display-none")
+        .classList.remove("govuk-!-display-none")
     }
   }
 }

--- a/app/javascript/controllers/show_more_text_controller.js
+++ b/app/javascript/controllers/show_more_text_controller.js
@@ -14,8 +14,8 @@ export default class extends Controller {
 
     // Show the rest of the comment and hide "show more"
     event.target.parentElement
-      .getElementsByClassName("hidden-comment display-none")[0]
-      .classList.remove("display-none")
-    event.target.classList.add("display-none")
+      .getElementsByClassName("hidden-comment govuk-!-display-none")[0]
+      .classList.remove("govuk-!-display-none")
+    event.target.classList.add("govuk-!-display-none")
   }
 }

--- a/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/_form.html.erb
@@ -71,7 +71,7 @@
                   value: @review_immunity_detail.try(:decision_is_not_immune?) ? @review_immunity_detail.decision_reason : nil
                 ) %>
               <% end %>
-              <div data-show-hide-target="toggleableWhenYes" class=<%= "display-none" if action_name == "new" || action_name == "create" || @review_immunity_detail.try(:decision_is_not_immune?) %>>
+              <div data-show-hide-target="toggleableWhenYes" class=<%= "govuk-!-display-none" if action_name == "new" || action_name == "create" || @review_immunity_detail.try(:decision_is_not_immune?) %>>
                 <%= review_immunity_detail.govuk_text_area(
                   :summary,
                   rows: 6,
@@ -82,7 +82,7 @@
               </div>
             </div>
 
-            <div data-show-hide-target="toggleableWhenNo" id="permitted-development-right-section" class=<%= "display-none" if action_name == "new" || action_name == "create" || @review_immunity_detail.try(:decision_is_immune?) %>>
+            <div data-show-hide-target="toggleableWhenNo" id="permitted-development-right-section" class=<%= "govuk-!-display-none" if action_name == "new" || action_name == "create" || @review_immunity_detail.try(:decision_is_immune?) %>>
               <h3 class="govuk-heading-m govuk-!-padding-top-4">
                 Permitted development rights
               </h3>

--- a/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
@@ -7,7 +7,7 @@
       method: "post"
     ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <%= form.label :neighbour_letter_text, "Neighbour letter", class: "display-none" %>
+  <%= form.label :neighbour_letter_text, "Neighbour letter", class: "govuk-!-display-none" %>
   <div class="govuk-inset-text">
     <p class="govuk-body">Text marked with a # (hashtag) will appear as a header in the printed letter.</p>
     <p class="govuk-body">Text marked with a * (asterisk) will appear as a bullet point in the printed letter.</p>

--- a/app/views/planning_applications/neighbour_letters/_neighbour_addresses_form.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_neighbour_addresses_form.html.erb
@@ -10,7 +10,7 @@
                             class: "govuk-visually-hidden" %>
 
   <div id="address-container">
-    <div class="width-80 govuk-!-margin-top-1">
+    <div class="govuk-!-width-three-quarters govuk-!-margin-top-1">
       <p class="govuk-body address">
       </p>
     </div>

--- a/app/views/planning_applications/neighbour_letters/_selected_list.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_selected_list.html.erb
@@ -15,7 +15,7 @@
           model: neighbour,
           data: { action: "submit->submit-form#handleSubmit" },
           url: planning_application_consultation_neighbour_letter_path(planning_application, neighbour),
-          class: "display-none"
+          class: "govuk-!-display-none"
         ) do |form| %>
           <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
           <%= form.govuk_text_field :address %>

--- a/app/views/planning_applications/neighbour_letters/_selected_list.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_selected_list.html.erb
@@ -5,7 +5,7 @@
     <% @consultation.neighbours.without_letters.each do |neighbour| %>
       <hr>
       <div class="proposal-details-sub-heading" data-controller="edit-form">
-        <div class="width-80 govuk-!-margin-top-1">
+        <div class="govuk-!-width-three-quarters govuk-!-margin-top-1">
           <p class="govuk-body">
             <%= neighbour.address %>
           </p>

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -37,7 +37,7 @@
                       </span>
 
                       <% if response_been_truncated?(response) %>
-                        <span class="display-none hidden-comment">
+                        <span class="govuk-!-display-none hidden-comment">
                           <%= simple_format(response.comment[truncated_length(response)..-1]) %>
                         </span>
                         <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>

--- a/app/views/planning_applications/review/immunity_details/_comment.html.erb
+++ b/app/views/planning_applications/review/immunity_details/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if comment.present? %>
   <div data-controller="show-hide submit-form">
-    <div data-show-hide-target="toggleable" class=<%= "display-none" if new_comment.errors.any? %>>
+    <div data-show-hide-target="toggleable" class=<%= "govuk-!-display-none" if new_comment.errors.any? %>>
       <h4 class="govuk-heading-s govuk-!-margin-bottom-0">
         <%= existing_policy_comment_label(comment) %>
       </h4>
@@ -15,7 +15,7 @@
         }
       ) %>
     </div>
-    <div data-show-hide-target="toggleable" class=<%= "display-none" unless new_comment.errors.any? %>>
+    <div data-show-hide-target="toggleable" class=<%= "govuk-!-display-none" unless new_comment.errors.any? %>>
       <%= form_with(
         model: [planning_application, :assessment, planning_application.immunity_detail, evidence_group, new_comment],
         data: { action: "submit->submit-form#handleSubmit" }

--- a/app/views/planning_applications/review/policy_classes/_comment.html.erb
+++ b/app/views/planning_applications/review/policy_classes/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if comment.present? %>
   <div data-controller="show-hide submit-form">
-    <div data-show-hide-target="toggleable" class=<%= "display-none" if new_comment.errors.any? %>>
+    <div data-show-hide-target="toggleable" class=<%= "govuk-!-display-none" if new_comment.errors.any? %>>
       <h4 class="govuk-heading-s govuk-!-margin-bottom-0">
         <%= existing_policy_comment_label(comment) %>
       </h4>
@@ -15,7 +15,7 @@
         }
       ) %>
     </div>
-    <div data-show-hide-target="toggleable" class=<%= "display-none" unless new_comment.errors.any? %>>
+    <div data-show-hide-target="toggleable" class=<%= "govuk-!-display-none" unless new_comment.errors.any? %>>
       <%= form_with(
         model: [planning_application, :assessment, policy_class, policy, new_comment],
         data: { action: "submit->submit-form#handleSubmit" }

--- a/app/views/planning_applications/site_notices/_status.html.erb
+++ b/app/views/planning_applications/site_notices/_status.html.erb
@@ -14,7 +14,7 @@
   </div>
 </div>
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-7">
-<div class="display-none">
+<div class="govuk-!-display-none">
   <span id="application-reference"><%= @planning_application.reference %></span>
   <div id="site-notice-content">
     <div style="width: 430px;">

--- a/app/views/planning_applications/site_notices/new.html.erb
+++ b/app/views/planning_applications/site_notices/new.html.erb
@@ -32,7 +32,7 @@
       <%= form.govuk_radio_button :required, false, label: { text: "No" }, data: { action: "change->show-hide-form#handleEvent" } %>
     <% end %>
 
-    <div class="display-none" id="site-notice-options">
+    <div class="govuk-!-display-none" id="site-notice-options">
       <div class="grey-box" id="email-site-notice">
         <%= form.govuk_radio_buttons_fieldset(
           :method,
@@ -60,7 +60,7 @@
       </div>
     </div>
 
-    <div class="govuk-button-group govuk-!-padding-top-7 display-none" id="site-notice-form-actions">
+    <div class="govuk-button-group govuk-!-padding-top-7 govuk-!-display-none" id="site-notice-form-actions">
       <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary" %>
       <%= back_link %>
     </div>

--- a/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
@@ -35,7 +35,7 @@
           class: "govuk-label govuk-label--s",
           text: (t(".labels.summary") if @validate_fee)
         },
-        hint: { class: ("make-invisible" if @validate_fee) },
+        hint: { class: ("display-none" if @validate_fee) },
         rows: 5,
         readonly: @planning_application.validated?
       ) %>

--- a/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
@@ -35,7 +35,7 @@
           class: "govuk-label govuk-label--s",
           text: (t(".labels.summary") if @validate_fee)
         },
-        hint: { class: ("display-none" if @validate_fee) },
+        hint: { class: ("govuk-!-display-none" if @validate_fee) },
         rows: 5,
         readonly: @planning_application.validated?
       ) %>


### PR DESCRIPTION
The problem with utility classes is that it's easy to end up with the same ones multiple times if you're not careful.

~~In this case `make-invisible` is older, but `display-none` is more widely-used and has a clearer name so I've kept that one.~~ Both of these duplicate an existing override class in the GOV.UK design system.