### PR TITLE
Fix applicants URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ rake local_authority:create -- --subdomain 'lambeth' \
   --feedback_email 'mail@lambeth.gov.uk' \
   --council_name 'Lambeth Council' \
   --short_name 'Lambeth' \
-  --applicants_url 'https://lambeth.planningapplications.gov.uk' \
+  --applicants_url 'https://planningapplications.lambeth.gov.uk' \
   --admin_email 'admin@lambeth.gov.uk'
 ```
 

--- a/db/migrate/20231023085212_add_extra_fields_to_local_authorities.rb
+++ b/db/migrate/20231023085212_add_extra_fields_to_local_authorities.rb
@@ -21,7 +21,7 @@ class AddExtraFieldsToLocalAuthorities < ActiveRecord::Migration[7.0]
         la.applicants_url = \
           case ENV.fetch("APPLICANTS_APP_HOST", nil)
           when "planningapplications"
-            "https://#{la.subdomain}.planningapplications.gov.uk"
+            "https://planningapplications.#{la.subdomain}.gov.uk"
           when "bops-applicants-staging.services"
             "https://#{la.subdomain}.bops-applicants-staging.services"
           else


### PR DESCRIPTION
The order of 'planningapplications' and the subdomain was reversed.
