### PR TITLE
Create ImmunityDetails in new API

### DIFF
--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -136,6 +136,10 @@ module BopsApi
           end
         end
       end
+
+      def possibly_immune?(planning_application)
+        planning_application.immune_proposal_details.many?
+      end
     end
   end
 end

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -80,8 +80,8 @@ module BopsApi
             DocumentsService.new(planning_application:, user:, files:).call!
 
             # TODO: create constraints
-            # TODO: create immunity details
             process_ownership_certificate_details(planning_application)
+            process_immunity_details(planning_application) if possibly_immune?(planning_application)
 
             planning_application.send_receipt_notice_mail if send_email?(planning_application)
           end
@@ -139,6 +139,40 @@ module BopsApi
 
       def possibly_immune?(planning_application)
         planning_application.immune_proposal_details.many?
+      end
+
+      def process_immunity_details(planning_application)
+        ActiveRecord::Base.transaction do
+          immunity_detail = ImmunityDetail.new(planning_application: planning_application)
+          immunity_detail.end_date = planning_application
+            .find_proposal_detail("When were the works completed?")
+            .first.response_values.first
+          immunity_detail.save!
+        end
+
+        Document::EVIDENCE_TAGS.each do |tag|
+          next if planning_application.documents.with_tag(tag).empty?
+
+          planning_application.documents.with_tag(tag).each do |doc|
+            planning_application.immunity_detail.add_document(doc)
+          end
+        end
+
+        planning_application.immunity_detail.evidence_groups.each do |eg|
+          Document::EVIDENCE_QUESTIONS[eg.tag.to_sym].each do |question|
+            case question
+            when /show/
+              eg.applicant_comment = planning_application.find_proposal_detail(question).first.response_values.first
+            when /(start|issued)/
+              eg.start_date = planning_application.find_proposal_detail(question).first.response_values.first
+            when /run/
+              eg.end_date = planning_application.find_proposal_detail(question).first.response_values.first
+            end
+            eg.save!
+          end
+        end
+      rescue ActiveRecord::RecordInvalid, NoMethodError => e
+        Appsignal.send_error(e)
       end
     end
   end

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -333,6 +333,17 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect { create_planning_application }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
+
+      context "when application may be immune" do
+        let(:params) { ActionController::Parameters.new(JSON.parse(file_fixture("v2/valid_lawful_development_certificate_existing.json").read)) }
+        let(:service) { described_class.new(local_authority:, user:, params:) }
+
+        it "returns true for possibly_immune?" do
+          # TODO remove this disgusting invasion of privacy
+          planning_application = service.send(:build_planning_application)
+          expect(service.send(:possibly_immune?, planning_application)).to be true
+        end
+      end
     end
 
     context "when a planning application is provided" do

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         end
 
         it "uploads the documents" do
-          expect { create_planning_application }.to change(Document, :count).by(6)
+          expect { create_planning_application }.to change(Document, :count).by(7)
 
           expect(documents).to include(
             an_object_having_attributes(
@@ -355,39 +355,35 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect(immunity_detail).to have_attributes(
             planning_application_id: planning_application.id,
             status: "not_started",
-            end_date: "2015-02-01 00:00:00.000000000 +0000".to_datetime
+            end_date: "1959-01-01".to_date
           )
 
-          expect(EvidenceGroup.count).to eq 2
+          expect(EvidenceGroup.count).to eq 4
         end
 
         it "creates the evidence groups for the planning application" do
           planning_application = nil
           expect do
             planning_application = service.call!
-          end.to change(EvidenceGroup, :count).by(2)
+          end.to change(EvidenceGroup, :count).by(4)
 
-          utility_bills = planning_application.immunity_detail.evidence_groups.where(tag: "utility_bill").first
+          council_tax_bill = planning_application.immunity_detail.evidence_groups.where(tag: "council_tax_document").first
 
-          expect(utility_bills).to have_attributes(
+          expect(council_tax_bill).to have_attributes(
             immunity_detail_id: planning_application.immunity_detail.id,
             start_date: "2013-03-02 00:00:00.000000000 +0000".to_time,
             end_date: "2019-04-01 00:00:00.000000000 +0100".to_time,
-            applicant_comment: "That i was paying water bills"
+            applicant_comment: "That I was paying council tax"
           )
 
-          expect(utility_bills.documents).to include(document1, document2)
+          other_document = planning_application.immunity_detail.evidence_groups.where(tag: "other").first
 
-          building_certificate = planning_application.immunity_detail.evidence_groups.where(tag: "building_control_certificate").first
-
-          expect(building_certificate).to have_attributes(
+          expect(other_document).to have_attributes(
             immunity_detail_id: planning_application.immunity_detail.id,
-            start_date: "2016-02-01 00:00:00.000000000 +0000".to_time,
+            start_date: nil,
             end_date: nil,
-            applicant_comment: "that it was certified"
+            applicant_comment: "Nothing really, this is just a test. "
           )
-
-          expect(building_certificate.documents).to eq [document3]
         end
       end
     end

--- a/spec/fixtures/files/v2/valid_lawful_development_certificate_existing.json
+++ b/spec/fixtures/files/v2/valid_lawful_development_certificate_existing.json
@@ -1458,10 +1458,46 @@
       "metadata": {}
     },
     {
+      "question": "What do these photographs show?",
+      "responses": [
+        {
+          "value": "Nothing, it's a test photo. "
+        }
+      ],
+      "metadata": {}
+    },
+    {
       "question": "What do these documents show?",
       "responses": [
         {
           "value": "Nothing really, this is just a test. "
+        }
+      ],
+      "metadata": {}
+    },
+    {
+      "question": "What do these Council Tax documents show?",
+      "responses": [
+        {
+          "value": "That I was paying council tax"
+        }
+      ],
+      "metadata": {}
+    },
+    {
+      "question": "What date do these council tax bills start from?",
+      "responses": [
+        {
+          "value": "2013-03-02"
+        }
+      ],
+      "metadata": {}
+    },
+    {
+      "question": "When do these councils tax bills run until?",
+      "responses": [
+        {
+          "value": "2019-04-01"
         }
       ],
       "metadata": {}
@@ -1846,6 +1882,16 @@
         }
       ],
       "description": "Nothing, it's a test document. "
+    },
+    {
+      "name": "https://api.editor.planx.dev/file/private/uz72iu40/Test%20document.pdf",
+      "type": [
+        {
+          "value": "proposal.document.councilTaxBill",
+          "description": "Council Tax Document"
+        }
+      ],
+      "description": "Council tax bill"
     }
   ],
   "metadata": {


### PR DESCRIPTION
### Description of change

Create ImmunityDetails when processing an application through the new API and ODP schema

### Story Link

https://trello.com/c/7GoEzWoN/2220-handle-immunity-detail-creation-using-new-odp-schema
