### PR TITLE
Enable cloning of planning applications when created via v2 submissions

### DIFF
--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -680,5 +680,11 @@ FactoryBot.define do
         create(:immunity_detail, planning_application:)
       end
     end
+
+    trait :with_v2_params do
+      after(:build) do |planning_application|
+        planning_application.planx_planning_data = build(:planx_planning_data, params_v2: file_fixture("v2/valid_planning_permission.json").read, planning_application:)
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -19,68 +19,123 @@ RSpec.describe "cloning a planning application" do
   before do
     allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(true)
 
-    stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
-      .to_return(
-        status: 200,
-        body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
-        headers: {"Content-Type" => "application/pdf"}
-      )
-
     sign_in(assessor)
     visit "/planning_applications/#{planning_application.id}"
   end
 
-  context "when I am able to clone a planning application" do
-    it "I am successfully redirected to the cloned planning application" do
-      # It does not send a receipt notice mail
-      expect(PlanningApplicationMailer).not_to receive(:receipt_notice_mail)
+  context "when using v1 params" do
+    before do
+      stub_request(:get, "https://bops-upload-test.s3.eu-west-2.amazonaws.com/proposed-first-floor-plan.pdf")
+        .to_return(
+          status: 200,
+          body: Rails.root.join("spec/fixtures/images/proposed-first-floor-plan.pdf").read,
+          headers: {"Content-Type" => "application/pdf"}
+        )
+    end
 
-      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
-        click_link("Clone")
+    context "when I am able to clone a planning application" do
+      it "I am successfully redirected to the cloned planning application" do
+        # It does not send a receipt notice mail
+        expect(PlanningApplicationMailer).not_to receive(:receipt_notice_mail)
+
+        accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+          click_link("Clone")
+        end
+
+        expect(page).to have_content("Planning application was successfully cloned")
+
+        expect(PlanningApplication.all.count).to eq(2)
+
+        cloned_planning_application = PlanningApplication.last
+        expect(page).to have_current_path("/planning_applications/#{cloned_planning_application.id}")
+        expect(page).to have_content("Planning application was successfully cloned")
+
+        expect(JSON.parse(planning_application.params_v1)).to eq(JSON.parse(cloned_planning_application.params_v1))
+        expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
       end
+    end
 
-      expect(page).to have_content("Planning application was successfully cloned")
+    context "when there is an error cloning a planning application" do
+      before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
 
-      expect(PlanningApplication.all.count).to eq(2)
+      it "I am presented with the error" do
+        accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+          click_link("Clone")
+        end
 
-      cloned_planning_application = PlanningApplication.last
-      expect(page).to have_current_path("/planning_applications/#{cloned_planning_application.id}")
-      expect(page).to have_content("Planning application was successfully cloned")
+        within(".govuk-notification-banner--alert") do
+          expect(page).to have_content("Error cloning application with message: Record invalid.")
+        end
 
-      expect(JSON.parse(planning_application.params_v1)).to eq(JSON.parse(cloned_planning_application.params_v1))
-      expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
+        expect(PlanningApplication.all.count).to eq(1)
+      end
+    end
+
+    context "when can_clone? returns false" do
+      before { allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(false) }
+
+      it "I am unable to clone and presented with an error" do
+        accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+          click_link("Clone")
+        end
+
+        within(".govuk-notification-banner--alert") do
+          expect(page).to have_content("Cloning is not permitted in production")
+        end
+
+        expect(PlanningApplication.all.count).to eq(1)
+      end
     end
   end
 
-  context "when there is an error cloning a planning application" do
-    before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
-
-    it "I am presented with the error" do
-      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
-        click_link("Clone")
-      end
-
-      within(".govuk-notification-banner--alert") do
-        expect(page).to have_content("Error cloning application with message: Record invalid.")
-      end
-
-      expect(PlanningApplication.all.count).to eq(1)
+  context "when using v2 params" do
+    let!(:planning_application) do
+      create(
+        :planning_application,
+        :with_v2_params,
+        local_authority:,
+        api_user:
+      )
     end
-  end
 
-  context "when can_clone? returns false" do
-    before { allow_any_instance_of(PlanningApplication).to receive(:can_clone?).and_return(false) }
+    let!(:application_type_pp) { create(:application_type, :planning_permission) }
 
-    it "I am unable to clone and presented with an error" do
-      accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
-        click_link("Clone")
+    context "when I am able to clone a planning application" do
+      it "I am successfully redirected to the cloned planning application" do
+        # It does not send a receipt notice mail
+        expect(PlanningApplicationMailer).not_to receive(:receipt_notice_mail)
+
+        accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+          click_link("Clone")
+        end
+
+        expect(page).to have_content("Planning application was successfully cloned")
+
+        expect(PlanningApplication.all.count).to eq(2)
+
+        cloned_planning_application = PlanningApplication.last
+        expect(page).to have_current_path("/planning_applications/#{cloned_planning_application.id}")
+        expect(page).to have_content("Planning application was successfully cloned")
+
+        expect(JSON.parse(planning_application.params_v2)).to eq(JSON.parse(cloned_planning_application.params_v2))
+        expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
       end
+    end
 
-      within(".govuk-notification-banner--alert") do
-        expect(page).to have_content("Cloning is not permitted in production")
+    context "when there is an error cloning a planning application" do
+      before { allow_any_instance_of(PlanningApplication).to receive(:save!).and_raise(ActiveRecord::RecordInvalid) }
+
+      it "I am presented with the error" do
+        accept_confirm(text: "This will clone the planning application identical to how it was created via PlanX. Are you sure?") do
+          click_link("Clone")
+        end
+
+        within(".govuk-notification-banner--alert") do
+          expect(page).to have_content("Error cloning application with message: Record invalid.")
+        end
+
+        expect(PlanningApplication.all.count).to eq(1)
       end
-
-      expect(PlanningApplication.all.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
### Description of change

- Enable cloning applications (Staging only) when submission is created via [ODP schema submission ](https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/schema/schema.json)
- Since planning applications using the V2 creation service are currently created in a "pending" state we won't actually be able to test this unless we update the status to "not_started" manually in the db.

### Story Link

https://trello.com/c/zWfgeax7/2222-enable-cloning-applications-using-new-creation-service-staging-only
