### PR TITLE
Avoid repeating validation request type in URLs/helpers

### DIFF
--- a/app/components/accordion_sections/application_information_component.rb
+++ b/app/components/accordion_sections/application_information_component.rb
@@ -22,12 +22,12 @@ module AccordionSections
 
     def description_change_link_path
       if description_change_request.present?
-        planning_application_validation_description_change_validation_request_path(
+        planning_application_validation_validation_request_path(
           planning_application,
           description_change_request
         )
       elsif !closed_or_cancelled?
-        new_planning_application_validation_description_change_validation_request_path(
+        new_planning_application_validation_validation_request_path(
           planning_application,
           type: "description_change"
         )

--- a/app/components/accordion_sections/site_map_component.rb
+++ b/app/components/accordion_sections/site_map_component.rb
@@ -11,12 +11,12 @@ module AccordionSections
     def change_request_link_path
       case change_request&.state
       when "open", "closed"
-        planning_application_validation_red_line_boundary_change_validation_request_path(
+        planning_application_validation_validation_request_path(
           planning_application,
           change_request
         )
       else
-        new_planning_application_validation_red_line_boundary_change_validation_request_path(
+        new_planning_application_validation_validation_request_path(
           planning_application,
           type: "red_line_boundary_change"
         )

--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -57,7 +57,7 @@
                   ) %>
                   <%= link_to(
                     "Request a new document",
-                    new_planning_application_validation_additional_document_validation_request_path(@planning_application, type: "additional_document"),
+                    new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"),
                     role: "button",
                     class: "govuk-link govuk-!-margin-top-",
                     data: { module: "govuk-button" },

--- a/app/components/evidence_groups/documents_component.html.erb
+++ b/app/components/evidence_groups/documents_component.html.erb
@@ -18,7 +18,7 @@
           <%= link_to "View document", url_for_document(document), target: :_new %><br>
           <%= link_to "Edit", edit_planning_application_document_path(document.planning_application, document), class: "govuk-link" %><br>
           <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
-          <%= link_to "Request replacement", new_planning_application_validation_replacement_document_validation_request_path(planning_application_id: document.planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
+          <%= link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: document.planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
         </div>
       </div>
     <% end %>

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -50,7 +50,7 @@ class DocumentsController < AuthenticationController
       format.html do
         if @document.update_or_replace(document_params)
           if validate_document? && @document.validated == false
-            redirect_to new_planning_application_validation_replacement_document_validation_request_path(document: @document, type: "replacement_document")
+            redirect_to new_planning_application_validation_validation_request_path(document: @document, type: "replacement_document")
           else
             redirect_to redirect_url, notice: t(".success")
           end

--- a/app/controllers/planning_applications/validation/fee_items_controller.rb
+++ b/app/controllers/planning_applications/validation/fee_items_controller.rb
@@ -23,7 +23,7 @@ module PlanningApplications
               flash.now[:alert] = "Select Yes or No to continue."
               render :show
             else
-              redirect_to new_planning_application_validation_fee_change_validation_request_path(@planning_application, type: "fee_change")
+              redirect_to new_planning_application_validation_validation_request_path(@planning_application, type: "fee_change")
             end
           end
         end

--- a/app/controllers/planning_applications/validation/sitemaps_controller.rb
+++ b/app/controllers/planning_applications/validation/sitemaps_controller.rb
@@ -23,7 +23,7 @@ module PlanningApplications
               flash.now[:alert] = t(".failure")
               render :show
             else
-              redirect_to new_planning_application_validation_red_line_boundary_change_validation_request_path(type: "red_line_boundary_change")
+              redirect_to new_planning_application_validation_validation_request_path(type: "red_line_boundary_change")
             end
           end
         end

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -27,7 +27,7 @@
                 <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
                   <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br>
                   <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
-                  <%= link_to "Request replacement", new_planning_application_validation_replacement_document_validation_request_path(planning_application_id: @planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
+                  <%= link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: @planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -27,7 +27,7 @@
     <p class="govuk-body">
       <%= link_to(
         "Request replacement",
-        new_planning_application_validation_replacement_document_validation_request_path(planning_application_id: planning_application.id, document: document, type: "replacement_document"),
+        new_planning_application_validation_validation_request_path(planning_application_id: planning_application.id, document: document, type: "replacement_document"),
         class: "govuk-link"
       ) %>
     </p>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -44,7 +44,7 @@
   <% if @planning_application.validated? %>
     <%= link_to(
        t(".request_a_new"),
-       new_planning_application_validation_additional_document_validation_request_path(@planning_application, type: "additional_document"),
+       new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"),
        role: "button",
        class: "govuk-button",
        data: { module: "govuk-button" }

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -10,7 +10,7 @@
       <div class="govuk-form-group govuk-!-margin-bottom-4">
         <%= form.govuk_select(:application_type_id, ApplicationType.menu, options: { include_blank: true }, label: { text: "Application type" }) %>
       </div>
-      
+
       <p class="govuk-body">
         <%= form.label :description, "Description", class: "govuk-heading-m govuk-!-margin-bottom-1" %>
         <%= form.text_area :description, class: "govuk-textarea", rows: "5" %>
@@ -18,9 +18,9 @@
     <% else %>
       <p class="govuk-body">
         <% if @planning_application.description_change_validation_requests.open.any? %>
-          <%= link_to "View requested change", planning_application_validation_description_change_validation_request_path(@planning_application, @planning_application.description_changes_validation_request.id), class: "govuk-link" %>
+          <%= link_to "View requested change", planning_application_validation_validation_request_path(@planning_application, @planning_application.description_changes_validation_request.id), class: "govuk-link" %>
         <% elsif !@planning_application.closed_or_cancelled? %>
-          <%= link_to "Propose a change to the description", new_planning_application_validation_description_change_validation_request_path(@planning_application, type: "description_change"), class: "govuk-link" %>
+          <%= link_to "Propose a change to the description", new_planning_application_validation_validation_request_path(@planning_application, type: "description_change"), class: "govuk-link" %>
         <% end %>
       </p>
 

--- a/app/views/planning_applications/assessment/consistency_checklists/_description_matches_documents.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_description_matches_documents.html.erb
@@ -19,7 +19,7 @@
       <% unless form.object.open_description_change_requests? %>
         <%= link_to(
           t(".request_description_change"),
-          new_planning_application_validation_description_change_validation_request_path(
+          new_planning_application_validation_validation_request_path(
             planning_application,
             type: "description_change"
           ),

--- a/app/views/planning_applications/assessment/consistency_checklists/_documents_consistent.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_documents_consistent.html.erb
@@ -18,7 +18,7 @@
     ) do %>
       <%= link_to(
         t(".request_additional_document"),
-        new_planning_application_validation_additional_document_validation_request_path(
+        new_planning_application_validation_validation_request_path(
           planning_application,
           type: "additional_document"
         ),

--- a/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
@@ -19,7 +19,7 @@
       <% unless form.object.open_red_line_boundary_change_requests? %>
         <%= link_to(
           t(".request_red_line_boundary_change"),
-          new_planning_application_validation_red_line_boundary_change_validation_request_path(
+          new_planning_application_validation_validation_request_path(
             planning_application,
             type: "red_line_boundary_change"
           ),

--- a/app/views/planning_applications/validation/tasks/_other_validation_request.html.erb
+++ b/app/views/planning_applications/validation/tasks/_other_validation_request.html.erb
@@ -6,7 +6,7 @@
     <% unless @planning_application.validated? %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <%= link_to "Add another validation request", new_planning_application_validation_other_change_validation_request_path(type: "other_change"), class: "govuk-link" %>
+          <%= link_to "Add another validation request", new_planning_application_validation_validation_request_path(type: "other_change"), class: "govuk-link" %>
         </span>
       </li>
     <% end %>

--- a/app/views/planning_applications/validation_documents.html.erb
+++ b/app/views/planning_applications/validation_documents.html.erb
@@ -43,7 +43,7 @@
 
     <p class="govuk-!-margin-bottom-6 govuk-!-margin-top-0">
       <%= link_to "Add a request for a missing document",
-        new_planning_application_validation_additional_document_validation_request_path(@planning_application, type: "additional_document"), class: "govuk-link govuk-body-m" %>
+        new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"), class: "govuk-link govuk-body-m" %>
     </p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/spec/components/accordion_sections/application_information_component_spec.rb
+++ b/spec/components/accordion_sections/application_information_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe AccordionSections::ApplicationInformationComponent, type: :compon
 
     expect(page).to have_link(
       "Propose a change to the description",
-      href: "/planning_applications/#{planning_application.id}/validation/description_change_validation_requests/new?type=description_change"
+      href: "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=description_change"
     )
   end
 
@@ -138,7 +138,7 @@ RSpec.describe AccordionSections::ApplicationInformationComponent, type: :compon
 
       expect(page).to have_link(
         "View requested change",
-        href: "/planning_applications/#{planning_application.id}/validation/description_change_validation_requests/#{description_change_validation_request.id}"
+        href: "/planning_applications/#{planning_application.id}/validation/validation_requests/#{description_change_validation_request.id}"
       )
     end
   end

--- a/spec/components/accordion_sections/site_map_component_spec.rb
+++ b/spec/components/accordion_sections/site_map_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
       expect(page).to have_link(
         "Request approval for a change to red line boundary",
-        href: "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/new?type=red_line_boundary_change"
+        href: "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=red_line_boundary_change"
       )
     end
 
@@ -34,7 +34,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
         expect(page).to have_link(
           "View requested red line boundary change",
-          href: "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+          href: "/planning_applications/#{planning_application.id}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
         )
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
         expect(page).to have_link(
           "View applicants response to requested red line boundary change",
-          href: "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+          href: "/planning_applications/#{planning_application.id}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
         )
       end
     end

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe "Requesting a new document for a planning application" do
       expect(page).to have_content("Check all necessary documents have been provided and add requests for any missing documents.")
       expect(page).to have_link(
         "Add a request for a missing document",
-        href: new_planning_application_validation_additional_document_validation_request_path(planning_application, type: "additional_document")
+        href: new_planning_application_validation_validation_request_path(planning_application, type: "additional_document")
       )
 
       within(".govuk-table.current-documents") do

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe "FeeItemsValidation" do
       click_button "Save"
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/fee_change_validation_requests/new?type=fee_change"
+        "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=fee_change"
       )
       expect(page).to have_content("Request other validation change (fee)")
       expect(page).to have_content("Application number: #{planning_application.reference}")

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Validation tasks" do
           expect(page).to have_content("Other validation issues")
           expect(page).to have_link(
             "Add another validation request",
-            href: new_planning_application_validation_other_change_validation_request_path(planning_application, type: "other_change")
+            href: new_planning_application_validation_validation_request_path(planning_application, type: "other_change")
           )
         end
 


### PR DESCRIPTION
### Description of change

Now that the validation request classes use the same model/controller we can avoid repeating the type in both the method name and parameter (with equivalent repetition in the URL path and parameters).

### Story Link

https://trello.com/c/aye2wXhP/2224-refactor-validation-requests