### PR TITLE
Authenticate with unique token per local authority

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class LocalAuthority < ApplicationRecord
-  has_many :users, dependent: :destroy
-  has_many :planning_applications, dependent: :destroy
+  with_options dependent: :destroy do
+    has_many :users
+    has_many :planning_applications
+    has_many :constraints
+    has_many :api_users
+  end
+
   has_many :audits, through: :planning_applications
-  has_many :constraints, dependent: :destroy
-  has_one :api_user, dependent: :destroy
 
   with_options presence: true do
     validates :council_code, :subdomain

--- a/db/migrate/20231214155652_update_unique_indexes_on_api_user.rb
+++ b/db/migrate/20231214155652_update_unique_indexes_on_api_user.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class UpdateUniqueIndexesOnApiUser < ActiveRecord::Migration[7.0]
+  class LocalAuthority < ActiveRecord::Base
+    has_many :api_users
+  end
+
+  class ApiUser < ActiveRecord::Base
+    belongs_to :local_authority, optional: true
+
+    has_secure_token :token, length: 36
+  end
+
+  def up
+    remove_index :api_users, :name
+    remove_index :api_users, :token
+
+    add_index :api_users, [:name, :local_authority_id], unique: true, name: "index_api_users_on_name_and_local_authority_id"
+    add_index :api_users, [:token, :local_authority_id], unique: true, name: "index_api_users_on_token_and_local_authority_id"
+
+    planx = ApiUser.find_or_create_by!(name: "PlanX")
+    LocalAuthority.find_each do |authority|
+      authority.api_users.create!(name: planx.name, token: planx.token)
+    end
+
+    # We do not want to create swagger api user tokens for production
+    unless Bops.env.production?
+      swagger = ApiUser.find_or_create_by!(name: "swagger")
+      LocalAuthority.find_each do |authority|
+        authority.api_users.create!(name: swagger.name, token: swagger.token)
+      end
+    end
+  end
+
+  def down
+    LocalAuthority.find_each do |authority|
+      authority.api_users.where(name: "PlanX").delete_all
+      authority.api_users.where(name: "swagger").delete_all
+    end
+
+    remove_index :api_users, name: "index_api_users_on_name_and_local_authority_id"
+    remove_index :api_users, name: "index_api_users_on_token_and_local_authority_id"
+
+    add_index :api_users, :name, unique: true
+    add_index :api_users, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,8 +51,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_14_161701) do
     t.bigint "local_authority_id"
     t.jsonb "file_downloader"
     t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"
-    t.index ["name"], name: "ix_api_users_on_name", unique: true
-    t.index ["token"], name: "ix_api_users_on_token", unique: true
+    t.index ["name", "local_authority_id"], name: "index_api_users_on_name_and_local_authority_id", unique: true
+    t.index ["token", "local_authority_id"], name: "index_api_users_on_token_and_local_authority_id", unique: true
   end
 
   create_table "application_types", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,54 +2,52 @@
 
 require "faker"
 
-lambeth = LocalAuthority.find_or_create_by!(
-  council_code: "LBH",
-  subdomain: "lambeth",
-  short_name: "Lambeth",
-  council_name: "Lambeth Council",
-  applicants_url: "http://lambeth.bops-applicants.localhost:3001",
-  signatory_name: "Christina Thompson",
-  signatory_job_title: "Director of Finance & Property",
-  enquiries_paragraph: "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG",
-  email_address: "planning@lambeth.gov.uk",
-  feedback_email: "digitalplanning@lambeth.gov.uk",
-  press_notice_email: "digitalplanning@lambeth.gov.uk"
-)
-southwark = LocalAuthority.find_or_create_by!(
-  council_code: "SWK",
-  subdomain: "southwark",
-  short_name: "Southwark",
-  council_name: "Southwark Council",
-  applicants_url: "http://southwark.bops-applicants.localhost:3001",
-  signatory_name: "Stephen Platts",
-  signatory_job_title: "Director of Planning and Growth",
-  enquiries_paragraph: "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG",
-  email_address: "planning@southwark.gov.uk",
-  feedback_email: "digital.projects@southwark.gov.uk",
-  press_notice_email: "digital.projects@southwark.gov.uk"
-)
+LocalAuthority.find_or_create_by!(subdomain: "lambeth") do |la|
+  la.council_code = "LBH"
+  la.short_name = "Lambeth"
+  la.council_name = "Lambeth Council"
+  la.applicants_url = "http://lambeth.bops-applicants.localhost:3001"
+  la.signatory_name = "Christina Thompson"
+  la.signatory_job_title = "Director of Finance & Property"
+  la.enquiries_paragraph = "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG"
+  la.email_address = "planning@lambeth.gov.uk"
+  la.feedback_email = "digitalplanning@lambeth.gov.uk"
+  la.press_notice_email = "digitalplanning@lambeth.gov.uk"
+end
 
-buckinghamshire = LocalAuthority.find_or_create_by!(
-  council_code: "BUC",
-  subdomain: "buckinghamshire",
-  short_name: "Buckinghamshire",
-  council_name: "Buckinghamshire Council",
-  applicants_url: "http://buckinghamshire.bops-applicants.localhost:3001",
-  signatory_name: "Steve Bambick",
-  signatory_job_title: "Director of Planning",
-  enquiries_paragraph: "Planning, Buckinghamshire Council, Gatehouse Rd, Aylesbury HP19 8FF",
-  email_address: "planning@buckinghamshire.gov.uk",
-  feedback_email: "planning.digital@buckinghamshire.gov.uk",
-  press_notice_email: "planning.digital@buckinghamshire.gov.uk"
-)
+LocalAuthority.find_or_create_by!(subdomain: "southwark") do |la|
+  la.council_code = "SWK"
+  la.short_name = "Southwark"
+  la.council_name = "Southwark Council"
+  la.applicants_url = "http://southwark.bops-applicants.localhost:3001"
+  la.signatory_name = "Stephen Platts"
+  la.signatory_job_title = "Director of Planning and Growth"
+  la.enquiries_paragraph = "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG"
+  la.email_address = "planning@southwark.gov.uk"
+  la.feedback_email = "digital.projects@southwark.gov.uk"
+  la.press_notice_email = "digital.projects@southwark.gov.uk"
+end
 
-ApiUser.find_or_create_by!(name: "api_user", token: (ENV["API_TOKEN"] || "123"))
+LocalAuthority.find_or_create_by!(subdomain: "buckinghamshire") do |la|
+  la.council_code = "BUC"
+  la.short_name = "Buckinghamshire"
+  la.council_name = "Buckinghamshire Council"
+  la.applicants_url = "http://buckinghamshire.bops-applicants.localhost:3001"
+  la.signatory_name = "Steve Bambick"
+  la.signatory_job_title = "Director of Planning"
+  la.enquiries_paragraph = "Planning, Buckinghamshire Council, Gatehouse Rd, Aylesbury HP19 8FF"
+  la.email_address = "planning@buckinghamshire.gov.uk"
+  la.feedback_email = "planning.digital@buckinghamshire.gov.uk"
+  la.press_notice_email = "planning.digital@buckinghamshire.gov.uk"
+end
 
 admin_roles = %i[assessor reviewer administrator]
-local_authorities = [southwark, lambeth, buckinghamshire]
+local_authorities = LocalAuthority.all
 
 local_authorities.each do |authority|
   authority.readonly!
+
+  authority.api_users.find_or_create_by!(name: authority.subdomain)
 
   admin_roles.each do |admin_role|
     User.find_or_create_by!(email: "#{authority.subdomain}_#{admin_role}@example.com") do |user|

--- a/engines/bops_api/app/controllers/bops_api/v2/authenticated_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/authenticated_controller.rb
@@ -9,7 +9,7 @@ module BopsApi
 
       def authenticate
         user = authenticate_with_http_token do |token, options|
-          ApiUser.authenticate(token)
+          @local_authority.api_users.authenticate(token)
         end
 
         if user

--- a/engines/bops_api/spec/requests/v2/ping_spec.rb
+++ b/engines/bops_api/spec/requests/v2/ping_spec.rb
@@ -3,9 +3,12 @@
 require "swagger_helper"
 
 RSpec.describe "BOPS API" do
+  let(:local_authority) { create(:local_authority, :default) }
+
   before do
-    create(:local_authority, :default)
-    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss")
+    create(:api_user, :planx, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
+    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx")
+    create(:api_user, :swagger, token: "tBJDVFzPjabRPkCUYpZExpss", local_authority:)
   end
 
   path "/api/v2/ping" do
@@ -26,6 +29,19 @@ RSpec.describe "BOPS API" do
         run_test!
       end
 
+      response "200", "with valid swagger credentials" do
+        schema "$ref" => "#/components/schemas/Healthcheck"
+
+        example "application/json", :default, {
+          message: "OK",
+          timestamp: "2023-11-22T20:00:00.000Z"
+        }
+
+        let(:Authorization) { "Bearer tBJDVFzPjabRPkCUYpZExpss" }
+
+        run_test!
+      end
+
       response "401", "with missing or invalid credentials" do
         schema "$ref" => "#/components/schemas/UnauthorizedError"
 
@@ -37,6 +53,21 @@ RSpec.describe "BOPS API" do
         }
 
         let(:Authorization) { "Bearer invalid-credentials" }
+
+        run_test!
+      end
+
+      response "401", "with a token from another api user" do
+        schema "$ref" => "#/components/schemas/UnauthorizedError"
+
+        example "application/json", :default, {
+          error: {
+            code: 401,
+            message: "Unauthorized"
+          }
+        }
+
+        let(:Authorization) { "Bearer pUYptBJDVFzssbRPkCPjaZEx" }
 
         run_test!
       end

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -3,9 +3,11 @@
 require "swagger_helper"
 
 RSpec.describe "BOPS API" do
+  let(:local_authority) { create(:local_authority, :default) }
+
   before do
-    create(:local_authority, :default)
-    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss")
+    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
+    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx")
     create(:application_type, :planning_permission)
   end
 
@@ -71,6 +73,21 @@ RSpec.describe "BOPS API" do
         }
 
         let(:Authorization) { "Bearer invalid-credentials" }
+
+        run_test!
+      end
+
+      response "401", "with a token from another api user" do
+        schema "$ref" => "#/components/schemas/UnauthorizedError"
+
+        example "application/json", :default, {
+          error: {
+            code: 401,
+            message: "Unauthorized"
+          }
+        }
+
+        let(:Authorization) { "Bearer pUYptBJDVFzssbRPkCPjaZEx" }
 
         run_test!
       end

--- a/spec/factories/api_users.rb
+++ b/spec/factories/api_users.rb
@@ -11,5 +11,13 @@ FactoryBot.define do
         "value" => "G41sAys9uPMUVBH5WUKsYE4H"
       }
     end
+
+    trait :swagger do
+      name { "swagger" }
+    end
+
+    trait :planx do
+      name { "PlanX" }
+    end
   end
 end


### PR DESCRIPTION
### Description of change

- Using one token per environment (staging/production) for a multi tenanted architecture is not the most secure approach and we should have individual and unique tokens for each local authority
- Add a unique token for swagger which will work with all instances (for staging only)
- Update local authority to have many api users and scope the tokens through this association. Therefore we drop the globally unique constraint on name and token and add a composite index including the local authority

We can give PlanX the relevant tokens and they will be able to start using them without any code changes from our end. Once we are happy that they can submit to all local authorities with the individual tokens, we can drop the global token associated with each local authority manually from the database

### Story Link

https://trello.com/c/6QvdcEul/2221-add-unique-token-per-local-authority-and-environment

