### PR TITLE
Remove audit_log from planning applications

### DIFF
--- a/db/migrate/20231214161701_remove_audit_log_from_planning_applications.rb
+++ b/db/migrate/20231214161701_remove_audit_log_from_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveAuditLogFromPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :planning_applications, :audit_log, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_12_114641) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_14_161701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -461,7 +461,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_114641) do
     t.datetime "in_assessment_at", precision: nil
     t.datetime "to_be_reviewed_at", precision: nil
     t.jsonb "proposal_details"
-    t.jsonb "audit_log"
     t.string "agent_first_name"
     t.string "agent_last_name"
     t.string "agent_phone"


### PR DESCRIPTION
### Description of change

- This now exists as params_v1 or params_v2 on the planx_data table
- https://github.com/unboxed/bops/pull/1390

