### PR TITLE
Wrap creation of validation requests in travel_to block

### DIFF
--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -109,7 +109,7 @@ class ValidationRequest < ApplicationRecord
   end
 
   def response_due
-    RESPONSE_TIME_IN_DAYS.business_days.after(created_at).to_date
+    RESPONSE_TIME_IN_DAYS.business_days.after(created_at.to_date)
   end
 
   def days_until_response_due

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -7,20 +7,24 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:additional_document_validation_request) do
-    create(:additional_document_validation_request, planning_application:)
+    travel_to(DateTime.new(2023, 12, 15)) { create(:additional_document_validation_request, planning_application:) }
   end
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
     let(:path) { "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests" }
     let!(:additional_document_validation_request2) do
-      create(:additional_document_validation_request, :closed, :with_documents, planning_application:)
+      travel_to(DateTime.new(2023, 12, 15)) { create(:additional_document_validation_request, :closed, :with_documents, planning_application:) }
     end
     let!(:additional_document_validation_request3) do
-      create(:additional_document_validation_request, :cancelled, planning_application:)
+      travel_to(DateTime.new(2023, 12, 15)) { create(:additional_document_validation_request, :cancelled, planning_application:) }
     end
 
     context "when the request is successful" do
+      before do
+        travel_to(DateTime.new(2023, 12, 15))
+      end
+
       it "retrieves all additional document validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}
@@ -93,6 +97,10 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
     end
 
     context "when the request is successful" do
+      before do
+        travel_to(DateTime.new(2023, 12, 15))
+      end
+
       it "retrieves a additional document validation request for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}

--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -7,20 +7,24 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
   let!(:other_change_validation_request) do
-    create(:other_change_validation_request, planning_application:)
+    travel_to(DateTime.new(2023, 12, 15)) { create(:other_change_validation_request, planning_application:) }
   end
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
     let(:path) { "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests" }
     let!(:other_change_validation_request2) do
-      create(:other_change_validation_request, :closed, planning_application:)
+      travel_to(DateTime.new(2023, 12, 15)) { create(:other_change_validation_request, :closed, planning_application:) }
     end
     let!(:other_change_validation_request3) do
-      create(:other_change_validation_request, :cancelled, planning_application:)
+      travel_to(DateTime.new(2023, 12, 15)) { create(:other_change_validation_request, :cancelled, planning_application:) }
     end
 
     context "when the request is successful" do
+      before do
+        travel_to(DateTime.new(2023, 12, 15))
+      end
+
       it "retrieves all other change validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}

--- a/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
@@ -7,17 +7,21 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:planning_application) { create(:planning_application, :invalidated, :with_boundary_geojson, local_authority: default_local_authority) }
   let!(:red_line_boundary_change_validation_request) do
-    create(:red_line_boundary_change_validation_request, planning_application:)
+    travel_to(DateTime.new(2023, 12, 15)) { create(:red_line_boundary_change_validation_request, planning_application:) }
   end
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
     let(:path) { "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests" }
     let!(:red_line_boundary_change_validation_request2) do
-      create(:red_line_boundary_change_validation_request, :closed, planning_application:)
+      travel_to(DateTime.new(2023, 12, 15)) { create(:red_line_boundary_change_validation_request, :closed, planning_application:) }
     end
 
     context "when the request is successful" do
+      before do
+        travel_to(DateTime.new(2023, 12, 15))
+      end
+
       it "retrieves all red line boundary change validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}
@@ -75,6 +79,10 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
     end
 
     context "when the request is successful" do
+      before do
+        travel_to(DateTime.new(2023, 12, 15))
+      end
+
       it "retrieves a red line boundary change validation request for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}


### PR DESCRIPTION
### Description of change

- response_due and days_until_response_due are dynamic based on time. Freezing time here means we can assert expectations more confidently

