### PR TITLE
Add before travel_to block for all tests

### DIFF
--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
   end
   let(:token) { "Bearer #{api_user.token}" }
 
+  before do
+    travel_to(DateTime.new(2023, 12, 15))
+  end
+
   describe "#index" do
     let(:path) { "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests" }
     let!(:other_change_validation_request2) do
@@ -21,10 +25,6 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
     end
 
     context "when the request is successful" do
-      before do
-        travel_to(DateTime.new(2023, 12, 15))
-      end
-
       it "retrieves all other change validation requests for a given planning application" do
         get "#{path}?change_access_id=#{planning_application.change_access_id}",
           headers: {"CONTENT-TYPE": "application/json", Authorization: token}


### PR DESCRIPTION
Fix missing addition to https://github.com/unboxed/bops/pull/1429

The travel_to block was not being run for the `describe "#show"` test 