### PR TITLE
Align case of BOPS with style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The easiest way to run the application is with Docker. First `cd` into the `bops
 git submodule update --init --recursive
 ```
 
-This links the main repo to the [BoPS applicants project](https://github.com/unboxed/bops-applicants/).
+This links the main repo to the [BOPS applicants project](https://github.com/unboxed/bops-applicants/).
 
 Then build and launch the images:
 
@@ -119,7 +119,7 @@ Versions 5+ of the [devise-two-factor](https://github.com/tinfoil/devise-two-fac
 
 Add in ./config/credentials a `development.key` (which can be found in 1password) or set a `RAILS_MASTER_KEY` env variable either natively or as part of `docker-compose.yml` with this value to enable 2FA to work in development.
 
-This key is set as an env `RAILS_MASTER_KEY` in production. See the [BoPS Terraform](https://github.com/unboxed/bops-terraform) repo for more information about BoPS infrastructure.
+This key is set as an env `RAILS_MASTER_KEY` in production. See the [BOPS Terraform](https://github.com/unboxed/bops-terraform) repo for more information about BOPS infrastructure.
 
 ## OS maps
 

--- a/app/components/environment_banner_component.html.erb
+++ b/app/components/environment_banner_component.html.erb
@@ -1,5 +1,5 @@
 <header class="environment-banner">
   <div class="govuk-width-container">
-    This is staging. Only process test cases on this version of BoPS
+    This is staging. Only process test cases on this version of BOPS
   </div>
 </header>

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -131,7 +131,7 @@ class PlanningApplicationCreationService
 
   def check_for_prior_approval
     return unless params[:application_type] == "Apply for prior approval"
-    raise CreateError, "BoPS does not accept this Prior Approval type" unless permitted_prior_approval_type?
+    raise CreateError, "BOPS does not accept this Prior Approval type" unless permitted_prior_approval_type?
 
     params[:application_type] = "prior_approval"
   end

--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -32,7 +32,7 @@
         </div>
       <% end %>
       <%= form.govuk_date_field :validated_at, legend: { size: 's' }, hint: { text: 'Enter valid date, for example, 28 12 2021' } %>
-      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BoPS Public Portal?' } do %>
+      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BOPS Public Portal?' } do %>
         <%= form.govuk_radio_button :make_public, true, label: { text: 'Yes' } %>
         <%= form.govuk_radio_button :make_public, false, label: { text: 'No' } %>
       <% end %>

--- a/app/views/planning_applications/make_public.html.erb
+++ b/app/views/planning_applications/make_public.html.erb
@@ -29,7 +29,7 @@
           </div>
         </div>
       <% end %>
-      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BoPS Public Portal?' } do %>
+      <%= form.govuk_radio_buttons_fieldset :make_public, legend: { text: 'Publish application on BOPS Public Portal?' } do %>
         <%= form.govuk_radio_button :make_public, true, label: { text: 'Yes' } %>
         <%= form.govuk_radio_button :make_public, false, label: { text: 'No' } %>
       <% end %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -83,7 +83,7 @@
     <% end %>
 
     <p class="govuk-body">
-      Public on BoPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
+      Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -410,7 +410,7 @@ en:
     scale: Missing scale bar or north arrow
   audit_user_name:
     applicant: Applicant / Agent via %{api_user_name}
-    bops_applicants: Applicant / Agent via BoPS applicants
+    bops_applicants: Applicant / Agent via BOPS applicants
     deleted: User deleted
     system: Automated by the system
   audits:
@@ -670,7 +670,7 @@ en:
       press_notice_mail: Request for press notice
       receipt_notice_mail: "%{application_type_name} application received"
       site_notice_mail: Display site notice for your application %{reference}
-      update_notification_mail: BoPS case %{reference} has a new update
+      update_notification_mail: BOPS case %{reference} has a new update
       validation_notice_mail: Your application for a %{application_type_name}
       validation_request_closure_mail: Changes to your %{application_type_name} application
       validation_request_mail: "%{application_type_name} application - further changes needed"
@@ -1102,7 +1102,7 @@ en:
         success: Addresses have been successfully added.
       send_letters:
         add_neighbours: Add some neighbours before sending letters
-        make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BoPS Public Portal</a> before you can send letters to neighbours.
+        make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BOPS Public Portal</a> before you can send letters to neighbours.
         require_resend_reason: Provide a reason when resending letters to previously-contacted neighbours
     neighbour_responses:
       create:
@@ -1243,7 +1243,7 @@ en:
     site_notices:
       create:
         assign_user_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">assigned to an officer</a> before you can create a site notice.
-        make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BoPS Public Portal</a> before you can create a site notice.
+        make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BOPS Public Portal</a> before you can create a site notice.
         success: Site notice was successfully %{action}
       update:
         success: Site notice was successfully updated
@@ -1651,13 +1651,13 @@ en:
   user_mailer:
     assigned_notification_mail:
       bops_case_reference: You have been assigned to a prior approval case %{reference}.
-      bops_updates: BoPS updates
-      view_reference_on: View %{reference} on BoPS
+      bops_updates: BOPS updates
+      view_reference_on: View %{reference} on BOPS
     otp_mail:
       otp_expires: It will expire in %{expires} minutes.
       otp_is_your: "%{otp} is your Back Office Planning System verification code."
     update_notification_mail:
-      bops_case_reference: BoPS case %{reference} has a new update.
-      bops_updates: BoPS updates
-      view_reference_on: View %{reference} on BoPS
+      bops_case_reference: BOPS case %{reference} has a new update.
+      bops_updates: BOPS updates
+      view_reference_on: View %{reference} on BOPS
   user_not_authorized: You are not authorized to perform this action.

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -18,8 +18,8 @@ Keep up to date with the latest ODP news and progress via our Show and Tell sess
 ### What is the code in this repo?
 The code is open-source and licensed under the [MIT License](https://en.wikipedia.org/wiki/MIT_License). The code required for deployment and hosting is in a separate repo, [BOPS infrastructure repo](https://github.com/unboxed/bops-terraform/), which is private.
 
-### Where can I find technical information about how to get my local authority's planning team up and running on BoPS?
-There is a BOPS handbook that provides a list of all the prerequisites and configuration instructions that are needed. To get access to this and to find out more information about the project, email [bops-team@unboxedconsulting.com](mailto:bops-team@unboxed.consulting.com) 
+### Where can I find technical information about how to get my local authority's planning team up and running on BOPS?
+There is a BOPS handbook that provides a list of all the prerequisites and configuration instructions that are needed. To get access to this and to find out more information about the project, email [bops-team@unboxedconsulting.com](mailto:bops-team@unboxed.consulting.com)
 
 ### With what other services is BOPS integrated?
 BOPS is integrated with:

--- a/public/api/docs/v1/swagger_doc.yaml
+++ b/public/api/docs/v1/swagger_doc.yaml
@@ -770,7 +770,7 @@ paths:
                         monument:
                           name: Scheduled monument
                           text: |-
-                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). 
+                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
 
                             This list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).
                           plural: Scheduled monuments
@@ -949,7 +949,7 @@ paths:
                         designated.SPA:
                           name: Special protection area
                           text: |-
-                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated 
+                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated
                             for the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).
                           plural: Special protection areas
                           prefix: ''
@@ -1954,7 +1954,7 @@ paths:
                         monument:
                           name: Scheduled monument
                           text: |-
-                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). 
+                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
 
                             This list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).
                           plural: Scheduled monuments
@@ -2133,7 +2133,7 @@ paths:
                         designated.SPA:
                           name: Special protection area
                           text: |-
-                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated 
+                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated
                             for the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).
                           plural: Special protection areas
                           prefix: ''
@@ -3031,7 +3031,7 @@ paths:
                         monument:
                           name: Scheduled monument
                           text: |-
-                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). 
+                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
 
                             This list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).
                           plural: Scheduled monuments
@@ -3210,7 +3210,7 @@ paths:
                         designated.SPA:
                           name: Special protection area
                           text: |-
-                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated 
+                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated
                             for the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).
                           plural: Special protection areas
                           prefix: ''
@@ -3429,7 +3429,7 @@ paths:
                     postcode: SE16 3RQ
                     latitude: '51.4842536'
                     longitude: '-0.0764165'
-                  description: 'Alterations to roof to create a loft conversion using an ''L'' shaped dormer, to provide additional residential accommodation.'
+                  description: "Alterations to roof to create a loft conversion using an 'L' shaped dormer, to provide additional residential accommodation."
                   payment_amount: 20600
                   payment_reference: fb4v6c47coecjk40seh3ima37k
                   applicant_first_name: Albert
@@ -3693,7 +3693,7 @@ paths:
                         monument:
                           name: Scheduled monument
                           text: |-
-                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport). 
+                            Historic buildings or sites such as Roman remains, burial mounds, castles, bridges, earthworks, the remains of deserted villages and industrial sites can be designated scheduled monuments by the Secretary of State for [Digital, Culture, Media and Sport](https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport).
 
                             This list of scheduled monuments is kept and maintained by [Historic England](https://historicengland.org.uk/).
                           plural: Scheduled monuments
@@ -3872,7 +3872,7 @@ paths:
                         designated.SPA:
                           name: Special protection area
                           text: |-
-                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated 
+                            [Special protection areas](https://naturalengland-defra.opendata.arcgis.com/maps/Defra::special-protection-areas-england/about) is an area designated
                             for the protection of birds and wildlife. This dataset is provided by [Natural England](https://www.gov.uk/government/organisations/natural-england).
                           plural: Special protection areas
                           prefix: ''
@@ -4141,7 +4141,7 @@ paths:
           schema:
             type: string
             minimum: 1
-          description: The local authority's subdomain on BoPS
+          description: The local authority's subdomain on BOPS
       security:
         - bearerAuth: []
       responses:

--- a/spec/components/environment_banner_component_spec.rb
+++ b/spec/components/environment_banner_component_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe EnvironmentBannerComponent, type: :component do
   it "displays warning in the staging environment" do
     render_inline(described_class.new(display: true))
 
-    expect(page).to have_content "This is staging. Only process test cases on this version of BoPS"
+    expect(page).to have_content "This is staging. Only process test cases on this version of BOPS"
   end
 end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "sets subject" do
       travel_to("2022-01-01 00:00:00 GMT") do
         expect(mail.subject).to eq(
-          "BoPS case BUC-22-00100-LDCP has a new update"
+          "BOPS case BUC-22-00100-LDCP has a new update"
         )
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe UserMailer, type: :mailer do
     it "includes planning application reference" do
       travel_to("2022-01-01 00:00:00 GMT") do
         expect(mail_body).to include(
-          "BoPS case BUC-22-00100-LDCP has a new update."
+          "BOPS case BUC-22-00100-LDCP has a new update."
         )
       end
     end

--- a/spec/services/planning_application_creation_service_spec.rb
+++ b/spec/services/planning_application_creation_service_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe PlanningApplicationCreationService, type: :service do
           end
 
           it "raises an error" do
-            expect { create_planning_application }.to raise_error(described_class::CreateError, "BoPS does not accept this Prior Approval type")
+            expect { create_planning_application }.to raise_error(described_class::CreateError, "BOPS does not accept this Prior Approval type")
           end
         end
       end

--- a/spec/system/environmental_banner_spec.rb
+++ b/spec/system/environmental_banner_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe "Environmental banner" do
   end
 
   it "is not displayed in the test environment" do
-    expect(page).not_to have_content "Only process test cases on this version of BoPS"
+    expect(page).not_to have_content "Only process test cases on this version of BOPS"
   end
 end

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Requesting a new document for a planning application" do
 
     expect(page).to have_text("Received: request for change (new document#1)")
     expect(page).to have_text("roof_plan.pdf")
-    expect(page).to have_text("Applicant / Agent via BoPS applicants")
+    expect(page).to have_text("Applicant / Agent via BOPS applicants")
   end
 
   context "when invalidation updates an additional document validation request" do

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "assigning planning application" do
       expect(update_notification.to).to contain_exactly(assessor.email)
 
       expect(update_notification.subject).to eq(
-        "BoPS case PlanX-22-00100-LDCP has a new update"
+        "BOPS case PlanX-22-00100-LDCP has a new update"
       )
 
       expect(Audit.last).to have_attributes(

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -34,20 +34,20 @@ RSpec.describe "Auditing changes to a planning application" do
   it "displays details of other change validation request in the audit log" do
     expect(page).to have_text("Received: request for change (other validation#1)")
     expect(page).to have_text("I have sent the fee")
-    expect(page).to have_text("Applicant / Agent via BoPS applicants")
+    expect(page).to have_text("Applicant / Agent via BOPS applicants")
   end
 
   it "displays the details of a red line boundary request in the audit log" do
     expect(page).to have_text("Received: request for change (red line boundary#1)")
     expect(page).to have_text("The boundary was too small")
     expect(page).to have_text("rejected")
-    expect(page).to have_text("Applicant / Agent via BoPS applicants")
+    expect(page).to have_text("Applicant / Agent via BOPS applicants")
   end
 
   it "displays the details of replacement boundary requests in the audit log" do
     expect(page).to have_text("Received: request for change (replacement document#1)")
     expect(page).to have_text("floor_plan.pdf")
-    expect(page).to have_text("Applicant / Agent via BoPS applicants")
+    expect(page).to have_text("Applicant / Agent via BOPS applicants")
   end
 
   context "when red line boundary change request is auto closed" do

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe "Send letters to neighbours", js: true do
         .to include("This is some content I'm putting in")
     end
 
-    context "when planning application has not been made public on the BoPS Public Portal" do
+    context "when planning application has not been made public on the BOPS Public Portal" do
       let(:planning_application) do
         create(:planning_application,
           :from_planx_prior_approval,
@@ -222,8 +222,8 @@ RSpec.describe "Send letters to neighbours", js: true do
         click_button "Print and send letters"
 
         within(".govuk-notification-banner--alert") do
-          expect(page).to have_content("The planning application must be made public on the BoPS Public Portal before you can send letters to neighbours.")
-          expect(page).to have_link("made public on the BoPS Public Portal", href: "/planning_applications/#{planning_application.id}/make_public")
+          expect(page).to have_content("The planning application must be made public on the BOPS Public Portal before you can send letters to neighbours.")
+          expect(page).to have_link("made public on the BOPS Public Portal", href: "/planning_applications/#{planning_application.id}/make_public")
         end
       end
     end

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "making planning application public" do
 
     visit "/planning_applications/#{planning_application.id}"
 
-    expect(page).to have_content("Public on BoPS Public Portal: No")
+    expect(page).to have_content("Public on BOPS Public Portal: No")
 
     visit "/planning_applications/#{planning_application.id}/make_public"
 
@@ -37,7 +37,7 @@ RSpec.describe "making planning application public" do
 
     click_button "Update application"
 
-    expect(page).to have_content("Public on BoPS Public Portal: Yes")
+    expect(page).to have_content("Public on BOPS Public Portal: Yes")
 
     visit "/planning_applications/#{planning_application.id}/make_public"
 
@@ -45,6 +45,6 @@ RSpec.describe "making planning application public" do
 
     click_button "Update application"
 
-    expect(page).to have_content("Public on BoPS Public Portal: No")
+    expect(page).to have_content("Public on BOPS Public Portal: No")
   end
 end

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe "Planning Application Assessment" do
           )
 
           expect(update_notification.subject).to eq(
-            "BoPS case PlanX-22-00100-LDCP has a new update"
+            "BOPS case PlanX-22-00100-LDCP has a new update"
           )
 
           planning_application.reload
@@ -882,7 +882,7 @@ RSpec.describe "Planning Application Assessment" do
           )
 
           expect(update_notification.subject).to eq(
-            "BoPS case PlanX-22-00100-PA has a new update"
+            "BOPS case PlanX-22-00100-PA has a new update"
           )
 
           planning_application.reload

--- a/spec/system/planning_applications/review/sign_off_spec.rb
+++ b/spec/system/planning_applications/review/sign_off_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Reviewing sign-off" do
     expect(update_notification.to).to contain_exactly(user.email)
 
     expect(update_notification.subject).to eq(
-      "BoPS case PlanX-22-00100-LDCP has a new update"
+      "BOPS case PlanX-22-00100-LDCP has a new update"
     )
 
     click_button "Audit log"

--- a/swagger/v1/swagger_doc.yaml
+++ b/swagger/v1/swagger_doc.yaml
@@ -4279,7 +4279,7 @@ paths:
           schema:
             type: string
             minimum: 1
-          description: The local authority's subdomain on BoPS
+          description: The local authority's subdomain on BOPS
       security:
         - bearerAuth: []
       responses:


### PR DESCRIPTION
### Description of change

The correct spelling of BOPS is BOPS

### Slack link

https://ubxd.slack.com/archives/CFJDHE5TK/p1702389289422769