### PR TITLE
Add hints to local authority management page

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -293,52 +293,52 @@ en:
         profile: Edit profile
       form:
         email_address: Decision notice email
-        email_address_hint: ''
+        email_address_hint: Enter the email address that appears on decision notices.
         email_reply_to_id: Email reply_to_id
-        email_reply_to_id_hint: ''
+        email_reply_to_id_hint: Enter the email address to which planning applicants and consultees can reply. It may be included in correspondence sent out by the local authority.
         enquiries_paragraph: Enquiries paragraph
-        enquiries_paragraph_hint: ''
+        enquiries_paragraph_hint: Enter the paragraph containing the local authority address and contact details that appears at the bottom of decision notices and other correspondence.
         feedback_email: Feedback email
-        feedback_email_hint: ''
+        feedback_email_hint: Enter the email of the person or team who will deal with any queries about BOPS at your council.
         notify_api_key: Notify API key
-        notify_api_key_hint: ''
+        notify_api_key_hint: Enter the API key used by the Government's Notify service for sending out emails, SMS and letters. Note that in all environments other than Production, a generic Notify key is used, so you will not see changes in your Notify account reflected in communications you send out.
         notify_letter_template: Notify letter template
-        notify_letter_template_hint: ''
+        notify_letter_template_hint: Enter the ID number of the letter template you will use within Notify
         press_notice_email: Press notice email
-        press_notice_email_hint: ''
+        press_notice_email_hint: Enter the email of the person or team who will prepare press notices. This email will be used when a planning officer requests a press notice.
         reply_to_notify_id: Reply to_notify_id
-        reply_to_notify_id_hint: ''
+        reply_to_notify_id_hint: Enter your Notify reply ID. You will need to go to Notify to set this up.
         reviewer_group_email: Manager group email
-        reviewer_group_email_hint: ''
+        reviewer_group_email_hint: Enter the email of the person who will be responsible for managing the planning process.
         signatory_job_title: Signatory job title
-        signatory_job_title_hint: ''
+        signatory_job_title_hint: Enter the job title of the person whose signature appears at the bottom of decision notices.
         signatory_name: Signatory name
-        signatory_name_hint: ''
+        signatory_name_hint: Enter the name of the person whose signature appears at the bottom of decision notices.
         submit: Submit
       show:
         email_address: Decision notice email
-        email_address_hint: ''
+        email_address_hint: This is the email address that appears on decision notices.
         email_reply_to_id: Email reply_to_id
-        email_reply_to_id_hint: ''
+        email_reply_to_id_hint: This is the email address to which planning applicants and consultees can reply. It may be included in correspondence sent out by the local authority.
         enquiries_paragraph: Enquiries paragraph
-        enquiries_paragraph_hint: ''
+        enquiries_paragraph_hint: This is the paragraph containing the local authority address and contact details that appears at the bottom of decision notices and other correspondence.
         feedback_email: Feedback email
-        feedback_email_hint: ''
+        feedback_email_hint: This is the email of the person or team who will deal with any queries about BOPS at your council.
         notify_api_key: Notify API key
-        notify_api_key_hint: ''
+        notify_api_key_hint: This is the API key used by the Government's Notify service for sending out emails, SMS and letters. Note that in all environments other than Production, a generic Notify key is used, so you will not see changes in your Notify account reflected in communications you send out.
         notify_letter_template: Notify letter template
-        notify_letter_template_hint: ''
+        notify_letter_template_hint: This is the ID number of the letter template you will use within Notify
         press_notice_email: Press notice email
-        press_notice_email_hint: ''
+        press_notice_email_hint: This is the email of the person or team who will prepare press notices. This email will be used when a planning officer requests a press notice.
         profile: Profile
         reply_to_notify_id: Reply to_notify_id
-        reply_to_notify_id_hint: ''
+        reply_to_notify_id_hint: This is your Notify reply ID. You will need to go to Notify to set this up.
         reviewer_group_email: Manager group email
-        reviewer_group_email_hint: ''
+        reviewer_group_email_hint: This is the email of the person who will be responsible for managing the planning process.
         signatory_job_title: Signatory job title
-        signatory_job_title_hint: ''
+        signatory_job_title_hint: This is the job title of the person whose signature appears at the bottom of decision notices.
         signatory_name: Signatory name
-        signatory_name_hint: ''
+        signatory_name_hint: This is the name of the person whose signature appears at the bottom of decision notices.
     users:
       edit:
         edit_user: Edit user

--- a/spec/system/administrator/managing_council_information_spec.rb
+++ b/spec/system/administrator/managing_council_information_spec.rb
@@ -33,6 +33,26 @@ RSpec.describe "managing council information profile" do
     expect(page).to have_content("Email reply_to_id")
   end
 
+  it "displays the correct hint text on the council information profile" do
+    expect(page).to have_content("name of the person whose signature")
+
+    expect(page).to have_content("job title of the person whose signature")
+
+    expect(page).to have_content("paragraph containing the local authority address")
+
+    expect(page).to have_content("email address that appears on decision notices.")
+
+    expect(page).to have_content("deal with any queries about BOPS")
+
+    expect(page).to have_content("person who will be responsible for managing")
+
+    expect(page).to have_content("who will prepare press notices")
+
+    expect(page).to have_content("Notify reply ID. You will need to go to Notify")
+
+    expect(page).to have_content("sending out emails, SMS and letters.")
+  end
+
   it "allows the administrator to edit council information profile" do
     click_link("Edit profile")
 


### PR DESCRIPTION
### Description of change

This is a minor change to add explanatory content to the council settings page.

### Story Link

https://trello.com/c/SMY9z7Wl/2377-content-updates-for-la-profile-page

### Screenshots

![local_authority](https://github.com/unboxed/bops/assets/1880450/3eb1dcfd-112d-4f5f-bce5-d475fdaf355f)

### Decisions

While councils do not have to enter Notify information in Staging as non-Production environments use the default API key, there is no impact if they do, and it ensures there is no difference between Staging and Production that could potentially be confusing. This is covered in messaging in the hints, rather than by disabling fields etc.
