### PR TITLE
Redesign administrator users index

### DIFF
--- a/app/controllers/administrator/users_controller.rb
+++ b/app/controllers/administrator/users_controller.rb
@@ -6,8 +6,8 @@ module Administrator
 
     def index
       @users = current_local_authority.users
-      @confirmed_users = current_local_authority.users.select { |u| u.confirmed? }
-      @unconfirmed_users = current_local_authority.users.select { |u| u.unconfirmed? }
+      @confirmed_users = current_local_authority.users.confirmed
+      @unconfirmed_users = current_local_authority.users.unconfirmed
     end
 
     def new

--- a/app/controllers/administrator/users_controller.rb
+++ b/app/controllers/administrator/users_controller.rb
@@ -2,10 +2,12 @@
 
 module Administrator
   class UsersController < ApplicationController
-    before_action :set_user, only: %i[edit update]
+    before_action :set_user, only: %i[edit update resend_invite]
 
     def index
       @users = current_local_authority.users
+      @confirmed_users = current_local_authority.users.select { |u| u.confirmed? }
+      @unconfirmed_users = current_local_authority.users.select { |u| u.unconfirmed? }
     end
 
     def new
@@ -38,6 +40,15 @@ module Administrator
         redirect_to administrator_users_path
       else
         render :edit
+      end
+    end
+
+    def resend_invite
+      if @user.send_confirmation_instructions
+        flash[:notice] = t(
+          "administrator.dashboards.show.confirmation_resent"
+        )
+        redirect_to administrator_users_path
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,8 @@ class User < ApplicationRecord
   validate :password_complexity
 
   scope :non_administrator, -> { where.not(role: "administrator") }
+  scope :confirmed, -> { where.not(confirmed_at: nil) }
+  scope :unconfirmed, -> { where(confirmed_at: nil) }
 
   class << self
     def menu(scope = User.all)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,10 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  def unconfirmed?
+    confirmed_at.nil?
+  end
+
   def confirmation_timeout
     6.hours
   end

--- a/app/views/administrator/users/_status_prompt.html.erb
+++ b/app/views/administrator/users/_status_prompt.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      <%= users.count %> users have not confirmed their email
+    </p>
+    <p>
+      Resend invites to unconfirmed users to add them to your team.
+    </p>
+  </div>
+</div>

--- a/app/views/administrator/users/_table.html.erb
+++ b/app/views/administrator/users/_table.html.erb
@@ -1,46 +1,33 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header"><%= t(".name") %></th>
-      <th scope="col" class="govuk-table__header"><%= t(".email") %></th>
-      <th scope="col" class="govuk-table__header">
-        <%= t(".mobile_number") %>
-      </th>
-      <th scope="col" class="govuk-table__header"><%= t(".role") %></th>
-      <th scope="col" class="govuk-table__header"><%= t(".confirmed") %></th>
-      <th scope="col" class="govuk-table__header">
-        <%= t(".otp_required_for_login") %>
-      </th>
-      <th scope="col" class="govuk-table__header">
-        <%= t(".otp_delivery_method") %>
-      </th>
-      <th scope="col" class="govuk-table__header"><%= t(".actions") %></th>
-    </tr>
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header">User details</th>
+    <th scope="col" class="govuk-table__header">2FA set up</th>
+    <th scope="col" class="govuk-table__header">2FA method</th>
+  </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% users.each do |user| %>
-      <tr class="govuk-table__row">
-        <th scope="row" class="govuk-table__header"><%= user.name %></th>
-        <td class="govuk-table__cell"><%= user.email %></td>
-        <td class="govuk-table__cell">
-          <%= number_to_phone(
-            user.mobile_number,
-            delimiter: " ",
-            pattern: /(\d{5})(\d{3})(\d{3})$/
-          ) %>
-        </td>
-        <td class="govuk-table__cell"><%= user.role.capitalize %></td>
-        <td class="govuk-table__cell"><%= t(".#{user.confirmed?}") %></td>
-        <td class="govuk-table__cell">
-          <%= t(".#{user.otp_required_for_login}") %>
-        </td>
-        <td class="govuk-table__cell">
-          <%= t(".#{user.otp_delivery_method}")%>
-        </td>
-        <td class="govuk-table__cell">
-          <%= link_to(t(".edit"), edit_administrator_user_path(user), class: "govuk-link") %>
-        </td>
-      </tr>
-    <% end %>
+
+  <% users.each do |user| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= user.name %><br/>
+        <%= user.role.capitalize %><br/>
+        <%= user.email %><br/>
+        <%= number_to_phone(
+              user.mobile_number,
+              delimiter: " ",
+              pattern: /(\d{5})(\d{3})(\d{3})$/
+            ) %><br/>
+        <%= link_to("Edit user", edit_administrator_user_path(user), class: "govuk-link") %> <%= link_to("Resend invite", resend_invite_administrator_user_path(user), class: "govuk-link") if user.unconfirmed? %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= t(".#{user.otp_required_for_login}") %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= t(".#{user.otp_delivery_method}") %>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>

--- a/app/views/administrator/users/edit.html.erb
+++ b/app/views/administrator/users/edit.html.erb
@@ -20,7 +20,7 @@
             resend_invite_administrator_user_path,
             class: "govuk-button",
             data: { module: "govuk-button" }
-          ) %>
+          ) if @user.unconfirmed? %>
     </div>
 
     <%= render(partial: "form", locals: { user: @user }) %>

--- a/app/views/administrator/users/edit.html.erb
+++ b/app/views/administrator/users/edit.html.erb
@@ -14,6 +14,15 @@
       <%= t(".edit_user") %>
     </h1>
 
+    <div class="govuk-button-group">
+      <%= link_to(
+            "Resend invite",
+            resend_invite_administrator_user_path,
+            class: "govuk-button",
+            data: { module: "govuk-button" }
+          ) %>
+    </div>
+
     <%= render(partial: "form", locals: { user: @user }) %>
   </div>
 </div>

--- a/app/views/administrator/users/index.html.erb
+++ b/app/views/administrator/users/index.html.erb
@@ -6,23 +6,51 @@
 
 <% content_for :title, t(".users") %>
 
+<% if current_user.local_authority.users.any?(&:unconfirmed?) %>
+  <%= render(
+        partial: "status_prompt",
+        locals: { users: @unconfirmed_users }
+      ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
       <%= t(".users") %>
     </h1>
-    <%= render(
-      partial: "table",
-      locals: { users: @users }
-    ) %>
-
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#confirmed">
+            Confirmed
+          </a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#unconfirmed">
+            Unconfirmed
+          </a>
+        </li>
+      </ul>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="confirmed">
+        <%= render(
+              partial: "table",
+              locals: { users: @confirmed_users }
+            ) %>
+      </div>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="unconfirmed">
+        <%= render(
+              partial: "table",
+              locals: { users: @unconfirmed_users }
+            ) %>
+      </div>
+    </div>
     <div class="govuk-button-group">
       <%= link_to(
-        t(".add_user"),
-        new_administrator_user_path,
-        class: "govuk-button",
-        data: { module: "govuk-button" }
-      ) %>
+            t(".add_user"),
+            new_administrator_user_path,
+            class: "govuk-button",
+            data: { module: "govuk-button" }
+          ) %>
 
       <%= back_link %>
     </div>

--- a/app/views/administrator/users/index.html.erb
+++ b/app/views/administrator/users/index.html.erb
@@ -6,7 +6,7 @@
 
 <% content_for :title, t(".users") %>
 
-<% if current_user.local_authority.users.any?(&:unconfirmed?) %>
+<% if @unconfirmed_users.any? %>
   <%= render(
         partial: "status_prompt",
         locals: { users: @unconfirmed_users }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -284,6 +284,7 @@ en:
     dashboards:
       show:
         administrator_dashboard: Administrator dashboard
+        confirmation_resent: User will receive a reminder email
         local_authority_successfully_updated: Council information successfully updated
         user_successfully_created: User successfully created
         user_successfully_updated: User successfully updated
@@ -348,7 +349,7 @@ en:
         submit: Submit
       index:
         add_user: Add user
-        users: Users
+        users: Manage users
       new:
         add_user: Add a new user
       sessions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,10 @@ Rails.application.routes.draw do
   namespace :administrator do
     resource :dashboard, only: %i[show]
     resource :local_authority, only: %i[show edit update]
-    resources :users, only: %i[index new create edit update]
+    resources :users, only: %i[index new create edit update] do
+      member do
+        get :resend_invite
+      end
+    end
   end
 end

--- a/spec/system/administrator/managing_users_spec.rb
+++ b/spec/system/administrator/managing_users_spec.rb
@@ -19,6 +19,90 @@ RSpec.describe "managing users" do
       )
     end
 
+    it "shows a warning when users are unconfirmed" do
+      create(
+        :user,
+        :assessor,
+        :unconfirmed,
+        name: "Andrea Khan",
+        local_authority:
+      )
+
+      create(
+        :user,
+        :assessor,
+        :unconfirmed,
+        name: "Rosie Starr",
+        local_authority:
+      )
+
+      visit "/administrator/users"
+
+      expect(page).to have_content("2 users have not confirmed their email")
+      expect(page).to have_content("Resend invites to unconfirmed users to add them to your team.")
+    end
+
+    it "displays different links for confirmed and unconfirmed users" do
+      create(
+        :user,
+        :reviewer,
+        name: "Dieter Waldbeck",
+        local_authority:
+      )
+
+      create(
+        :user,
+        :assessor,
+        :unconfirmed,
+        name: "Andrea Khan",
+        local_authority:
+      )
+
+      create(
+        :user,
+        :assessor,
+        :unconfirmed,
+        name: "Rosie Starr",
+        local_authority:
+      )
+
+      visit "/administrator/users"
+
+      row = row_with_content("Dieter Waldbeck")
+      expect(row).to have_content("Edit user")
+      expect(row).not_to have_content("Resend invite")
+
+      click_link("Unconfirmed")
+
+      row2 = row_with_content("Andrea Khan")
+      expect(row2).to have_content("Edit user")
+      expect(row2).to have_content("Resend invite")
+    end
+
+    it "allows the administrator to resend an invite from the index page" do
+      create(
+        :user,
+        :assessor,
+        :unconfirmed,
+        name: "Rosie Starr",
+        local_authority:
+      )
+
+      visit "/administrator/users"
+      click_link("Unconfirmed")
+
+      row = row_with_content("Rosie Starr")
+      within(row) do
+        click_link("Resend invite")
+      end
+
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq("Set password instructions")
+      expect(mail.body).to include(
+        "Welcome to the Back-office Planning System"
+      )
+    end
+
     it "allows adding of new user" do
       visit "/administrator/users"
       click_link("Add user")


### PR DESCRIPTION
### Description of change

This PR updates the users index page seen by the admin. There are now tabs to separate confirmed and unconfirmed users, and the user info has been condensed into three columns. A status bar appears if there are unconfirmed users, prompting the admin to resend confirmation emails.

A new path has been added which calls the action to resend the confirmation email, and links have been added on the index table and edit user table to allow admins to do this.

### Story Link

https://trello.com/c/QAQlm4WO/2320-update-users-page-in-bops-admin

### Screenshots

![new_users](https://github.com/unboxed/bops/assets/1880450/2bd2a8fa-6af2-4a46-90a0-a09cdb9d84eb)

### Decisions 

Made an additional decision (not on Figma designs) to additionally add the Resend Invite to the Edit User page and provide a feedback flash to let the admin know the action was successful. Omitted the Inactive tab from the Users index as we don't currently inactivate users.