### PR TITLE
Request & receive more information about fee exemptions

### DIFF
--- a/app/controllers/api/v1/additional_document_validation_requests_controller.rb
+++ b/app/controllers/api/v1/additional_document_validation_requests_controller.rb
@@ -52,26 +52,8 @@ module Api
 
       private
 
-      def check_files_params_are_present
-        return unless params[:files].empty?
-
-        render json: {message: "At least one file must be selected to proceed."}, status: :bad_request
-      end
-
-      def check_files_size
-        params[:files].each do |file|
-          next unless file_size_over_30mb?(file)
-
-          render json: {message: "The file: '#{file.original_filename}' exceeds the limit of 30mb. " \
-                                  "Each file must be 30MB or less"},
-            status: :payload_too_large
-        end
-      end
-
-      def check_files_type
-        return unless params[:files].any? { |file| Document::PERMITTED_CONTENT_TYPES.exclude? file.content_type }
-
-        render json: {message: "The file type must be JPEG, PNG or PDF"}, status: :bad_request
+      def file_params
+        @file_params ||= params[:files]
       end
     end
   end

--- a/app/controllers/api/v1/fee_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/fee_change_validation_requests_controller.rb
@@ -2,9 +2,15 @@
 
 module Api
   module V1
-    class FeeChangeValidationRequestsController < Api::V1::ApplicationController
+    class FeeChangeValidationRequestsController < Api::V1::ValidationRequestsController
       skip_before_action :verify_authenticity_token
       before_action :check_token_and_set_application
+      before_action :check_files_size,
+        :check_files_type, only: :update
+
+      rescue_from ValidationRequest::UploadFilesError do |_exception|
+        render_failed_request
+      end
 
       def index
         respond_to do |format|
@@ -29,18 +35,27 @@ module Api
       end
 
       def update
-        @fee_change_validation_request =
-          @planning_application.fee_change_validation_requests.where(id: params[:id]).first
+        @fee_change_validation_request = @planning_application.fee_change_validation_requests.find_by(id: params[:id])
 
-        if params[:data][:response].present? &&
-            @fee_change_validation_request.update(response: params[:data][:response])
+        if @fee_change_validation_request.update(fee_change_validation_request_params)
           @fee_change_validation_request.close!
           @fee_change_validation_request.create_api_audit!
           @planning_application.send_update_notification_to_assessor
+
           render json: {message: "Change request updated"}, status: :ok
         else
-          render json: {message: "Unable to update request. Please ensure response is present"}, status: :bad_request
+          render json: {message: "Unable to update request."}, status: :bad_request
         end
+      end
+
+      private
+
+      def fee_change_validation_request_params
+        params.permit(:response, supporting_documents: [])
+      end
+
+      def file_params
+        params[:supporting_documents]
       end
     end
   end

--- a/app/controllers/api/v1/validation_requests_controller.rb
+++ b/app/controllers/api/v1/validation_requests_controller.rb
@@ -22,6 +22,31 @@ module Api
       def file_size_over_30mb?(file)
         file.size > 30.megabytes
       end
+
+      def check_files_params_are_present
+        return unless file_params.empty?
+
+        render json: {message: "At least one file must be selected to proceed."}, status: :bad_request
+      end
+
+      def check_files_size
+        return if file_params.blank?
+
+        file_params.each do |file|
+          next unless file_size_over_30mb?(file)
+
+          render json: {message: "The file: '#{file.original_filename}' exceeds the limit of 30mb. " \
+                                  "Each file must be 30MB or less"},
+            status: :payload_too_large
+        end
+      end
+
+      def check_files_type
+        return if file_params.blank?
+        return unless file_params.any? { |file| Document::PERMITTED_CONTENT_TYPES.exclude? file.content_type }
+
+        render json: {message: "The file type must be JPEG, PNG or PDF"}, status: :bad_request
+      end
     end
   end
 end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -46,7 +46,7 @@ class ApplicationType < ApplicationRecord
     when "evidence"
       Document::EVIDENCE_TAGS - document_tags[key]
     when "supporting_documents"
-      Document::SUPPORTING_DOCUMENT_TAGS - document_tags[key]
+      (Document::SUPPORTING_DOCUMENT_TAGS - ["Fee Exemption"]) - document_tags[key]
     else
       raise ArgumentError, "Unexpected document tag type: #{key}"
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -89,6 +89,7 @@ class Document < ApplicationRecord
     "HMO statement",
     "Specialist Accommodation Statement",
     "Student Accommodation Statement",
+    "Fee Exemption",
     "Other Supporting Document"
   ].freeze
 
@@ -142,7 +143,7 @@ class Document < ApplicationRecord
   validate :numbered
   validate :created_date_is_in_the_past
 
-  default_scope -> { no_owner.or(not_excluded_owners) }
+  default_scope -> { no_owner.or(not_excluded_owners).not_for_fee_exemption }
 
   scope :no_owner, -> { where(owner_type: nil) }
   scope :not_excluded_owners, -> { where.not(owner_type: EXCLUDED_OWNERS) }
@@ -163,6 +164,8 @@ class Document < ApplicationRecord
   scope :with_tag, ->(tag) { where("tags @> ?", "\"#{tag}\"") }
   scope :with_file_attachment, -> { includes(file_attachment: :blob) }
   scope :for_site_visit, -> { where.not(site_visit_id: nil) }
+  scope :for_fee_exemption, -> { unscoped.with_tag("Fee Exemption") }
+  scope :not_for_fee_exemption, -> { where("NOT (tags @> ?)", "\"Fee Exemption\"") }
 
   before_validation on: :create do
     if owner.present?

--- a/app/models/fee_change_validation_request.rb
+++ b/app/models/fee_change_validation_request.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FeeChangeValidationRequest < ValidationRequest
+  has_many :supporting_documents, as: :owner, dependent: :destroy, class_name: "Document"
+
   validates :reason, presence: true
   validates :suggestion, presence: true
   validate :ensure_no_open_or_pending_fee_item_validation_request, on: :create
@@ -14,6 +16,12 @@ class FeeChangeValidationRequest < ValidationRequest
   before_create lambda {
                   reset_validation_requests_update_counter!(planning_application.fee_change_validation_requests)
                 }
+
+  def supporting_documents=(files)
+    files.select(&:present?).each do |file|
+      supporting_documents.new(file: file, planning_application: planning_application, tags: ["Fee Exemption"])
+    end
+  end
 
   private
 

--- a/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/invalidation_notice_mail.text.erb
@@ -4,13 +4,13 @@ Application reference number: <%= @planning_application.reference_in_full %>
 
 Address: <%= @planning_application.full_address %>
 
-Your application for a <%= @planning_application.application_type.human_name %> contains errors or missing information. We cannot continue with your application until you make the necessary changes.
+We need some more information to process your <%= @planning_application.application_type.human_name %>.
 
-To make changes, go to:
+Use this link to view requests from your case officer and update your application:
 
 <%= @planning_application.secure_change_url %>
 
-If no changes are made by <%= @planning_application.invalidation_response_due.to_fs %>, we may close your application and send you a refund.
+If we don't receive the information we need by <%= @planning_application.invalidation_response_due.to_fs %>, we may close your application and send you a refund.
 
 If you need help with your application, contact us at  <%= @planning_application.local_authority.email_address %>.
 

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_form.html.erb
@@ -7,6 +7,13 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "planning_applications/validation/fee_items/fee_item_table" %>
 
+    <% if @planning_application.documents.for_fee_exemption.any? %>
+      <%= render(
+        partial: "planning_applications/validation/fee_change_validation_requests/supporting_documents",
+        locals: { documents: @planning_application.documents.for_fee_exemption }
+      ) %>
+    <% end %>
+
     <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request  do |form| %>
       <%= form.hidden_field :fee_item, value: @validate_fee %>
       <%= hidden_field_tag(:validate_fee, "yes") %>
@@ -33,6 +40,7 @@
           class: "govuk-label govuk-label--s",
           text: "Tell the applicant why the fee is incorrect",
         },
+        hint: { text: "Use plain English to explain why the fee is wrong. This message will be shown to the applicant" }, 
         rows: 5,
         readonly: @planning_application.validated?
       ) %>
@@ -42,12 +50,28 @@
         label: {
           size: "s",
           class: "govuk-label govuk-label--s",
-          text: "Tell the applicant how the fee can be made valid"
+          text: "Tell the applicant what they need to do"
         },
-        hint: { text: "Add all information that they will need to complete this action" },
+        hint: { text: "If the applicant needs to provide evidence, give examples of what you can accept. If the fee exemption relates to disability, use the phrase 'documents to support your fee exemption' rather than 'evidence of your disability'." },
         rows: 5,
         readonly: @planning_application.validated?
       ) %>
+
+      <details class="govuk-details" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            View guidance on supporting documents
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <ul class="govuk-list govuk-list--bullet">
+            <li>PIP award letters</li>
+            <li>supporting statements, such as from a council or therapist</li>
+            <li>NHS letters</li>
+            <li>disabled person's bus pass, blue badges or related documents</li>
+          </ul>
+        </div>
+      </details>
 
       <%= form.hidden_field :type, value: "FeeChangeValidationRequest" %>
 

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_show.html.erb
@@ -8,7 +8,7 @@
 <% if @validation_request.closed? %>
   <%= render(
     partial: "shared/proposal_header",
-    locals: { heading: "Check the response to fee change request"}
+    locals: { heading: "Check applicant response and update fee paid"}
   ) %>
 <% else %>
   <%= render(
@@ -17,63 +17,74 @@
   ) %>
 <% end %>
 
+<p class="govuk-body">
+  Invalid fee previously paid: <%= number_to_currency (@planning_application.invalid_payment_amount), unit: '£' %>
+</p>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Officer request</h2>
 
-    <p class="govuk-body">
-      <strong>Invalid fee previously paid </strong> <%= number_to_currency (@planning_application.invalid_payment_amount), unit: '£' %>
-    </p>
-
     <div class="govuk-inset-text">
       <p class="govuk-body">
-        <strong>Reason it is invalid: </strong><%= render(FormattedContentComponent.new(text: @validation_request.reason)) %>
+        <strong>Reason fee is invalid: </strong><%= render(FormattedContentComponent.new(text: @validation_request.reason)) %>
       </p>
       <p class="govuk-body">
-        <strong>How it can be made valid: </strong><%= render(FormattedContentComponent.new(text: @validation_request.suggestion)) %>
+        <strong>What the applicant needs to do </strong><%= render(FormattedContentComponent.new(text: @validation_request.suggestion)) %>
       </p>
       <p class="govuk-body">
       <%= @validation_request.created_at.to_fs %>
       </p>
     </div>
 
-      <% if @validation_request.closed? && @planning_application.invalidated?  %>
-        <h2 class="govuk-heading-m">Applicant response</h2>
-        <div class="govuk-inset-text">
+    <% if @planning_application.documents.for_fee_exemption.any? %>
+      <%= render(
+        partial: "planning_applications/validation/fee_change_validation_requests/supporting_documents",
+        locals: { documents: @planning_application.documents.for_fee_exemption }
+      ) %>
+    <% end %>
+
+    <% if @validation_request.closed? && @planning_application.invalidated?  %>
+      <h2 class="govuk-heading-m">Applicant response</h2>
+      <div class="govuk-inset-text">
+        <p class="govuk-body">
+          <%= @validation_request.response %>
+        </p>
+        <p class="govuk-body">
+          <%= @validation_request.updated_at.to_fs %>
+        </p>
+      </div>
+
+      <%= form_with model: @planning_application do |form| %>
+        <div class="govuk-form-group">
+          <h2 class="govuk-heading-m">
+            Confirm total fee paid
+          </h2>
           <p class="govuk-body">
-            <%= @validation_request.response %>
+            Check any extra fee has been received and update the total fee now paid.
           </p>
-          <p class="govuk-body">
-            <%= @validation_request.updated_at.to_fs %>
-          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>check that the correct fee has been received</li>
+            <li>update the total fee paid</li>
+          </ul>
+          <div class="govuk-input__wrapper">
+            <div class="govuk-input__prefix" aria-hidden="true">£</div>
+            <%= form.text_field :payment_amount, value: number_to_currency(@planning_application.payment_amount, unit: ""), class: "govuk-textarea govuk-input" %>
+            <%= hidden_field_tag(:edit_action, "edit_payment_amount") %>
+            <%= hidden_field_tag(:validation_request_id, @validation_request.id) %>
+          </div>
         </div>
 
-          <%= form_with model: @planning_application do |form| %>
-            <div class="govuk-form-group">
-              <h2 class="govuk-heading-m">
-                Total fee paid
-              </h2>
-              <p class="govuk-body">
-                Check any extra fee has been received and update the total fee now paid.
-              </p>
-              <div class="govuk-input__wrapper">
-                <div class="govuk-input__prefix" aria-hidden="true">£</div>
-                <%= form.text_field :payment_amount, value: number_to_currency(@planning_application.payment_amount, unit: ""), class: "govuk-textarea govuk-input" %>
-                <%= hidden_field_tag(:edit_action, "edit_payment_amount") %>
-                <%= hidden_field_tag(:validation_request_id, @validation_request.id) %>
-              </div>
-            </div>
-
-            <%= render "shared/validation_request_show_actions",
-              planning_application: @planning_application, validation_request: @validation_request, form: form %>
-        <% end %>
-      <% else %>
-        <% if @planning_application.invalidated? %>
-          <h2 class="govuk-heading-m">Applicant has not responded yet</h2>
-        <% end %>
-
         <%= render "shared/validation_request_show_actions",
-          planning_application: @planning_application, validation_request: @validation_request, form: nil %>
+          planning_application: @planning_application, validation_request: @validation_request, form: form %>
       <% end %>
+    <% else %>
+      <% if @planning_application.invalidated? %>
+        <h2 class="govuk-heading-m">Applicant has not responded to the latest request</h2>
+      <% end %>
+
+      <%= render "shared/validation_request_show_actions",
+        planning_application: @planning_application, validation_request: @validation_request, form: nil %>
+    <% end %>
   </div>
 </div>

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
@@ -1,0 +1,30 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <h2>Documents provided by applicant</h2>
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half"></th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half"></th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% documents.with_file_attachment.each do |document| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-width-one-half">
+          <p class="govuk-body govuk-!-margin-bottom-1">
+            <%= link_to image_tag(document.file.representation(resize: "300x212")),
+                        url_for_document(document), target: :_blank %>
+          </p>
+          <p class="govuk-body">
+            <%= link_to "View in new window", url_for_document(document), target: :_new %>
+          </p>
+        </td>
+        <td class="govuk-table__cell govuk-!-width-one-half">
+          <p><strong>Document reference:</strong> <%= document.numbers %></p>
+          <p><strong>File name:</strong> <%= document.name %></p>
+          <p><strong>Date received:</strong> <%= document.received_at_or_created %></p>
+          <p>This document was uploaded by the applicant</p>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
+++ b/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table">
+<table class="govuk-table fee-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header"><%= t(".item") %></th>

--- a/app/views/planning_applications/validation/fee_items/show.html.erb
+++ b/app/views/planning_applications/validation/fee_items/show.html.erb
@@ -77,6 +77,13 @@
       }
     ) %>
 
+    <% if @planning_application.documents.for_fee_exemption.any? %>
+      <%= render(
+        partial: "planning_applications/validation/fee_change_validation_requests/supporting_documents",
+        locals: { documents: @planning_application.documents.for_fee_exemption }
+      ) %>
+    <% end %>
+
     <%= form_with model: @planning_application, url: validate_planning_application_validation_fee_items_path(@planning_application) do |form| %>
       <%= form.govuk_radio_buttons_fieldset :valid_fee do %>
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-4">


### PR DESCRIPTION
### Description of change

Allow officer to request additional information (e.g. proof of occupier's disability) so that they can decide if it qualifies for an exemption. 
Use bops applicants to allow the applicant to submit the documents - https://github.com/unboxed/bops-applicants/pull/190

### Story Link

https://trello.com/c/WMqJ1xzB/2149-able-to-request-receive-more-information-about-fee-exemptions
https://www.figma.com/file/AXJ7hvBaXVyJnh74Grwbml/BoPS-Prototype?type=design&node-id=7252-16381&mode=design&t=6TsFoowiRbq8Ri4L-0

