### PR TITLE
Chore/add administrator test for active council

### DIFF
--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     email_address { Faker::Internet.email }
     feedback_email { "feedback_email@buckinghamshire.gov.uk" }
     email_reply_to_id { "4896bb50-4f4c-4b4d-ad67-2caddddde125" }
+    active { true }
 
     trait :default do
       council_code { "PlanX" }

--- a/spec/system/administrator/managing_council_information_spec.rb
+++ b/spec/system/administrator/managing_council_information_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe "managing council information profile" do
     expect(page).to have_content("sending out emails, SMS and letters.")
   end
 
+  it "shows the council as active" do
+    visit "/"
+    expect(page).to have_content("Active")
+  end
+
   it "allows the administrator to edit council information profile" do
     click_link("Edit profile")
 


### PR DESCRIPTION
### Description of change

This PR adds some extra specs to ensure councils are tagged correctly with Inactive and Active status, and to ensure that partially editing an inactive council's details does not change it to Active. Also adds a spec for email validation and updates the factory to add an inactive council.

### Story Link

https://trello.com/c/UUPtXcRf/989-admin-can-update-council-specific-content-information-in-a-profile-page

