### PR TITLE
Convert proposal details json string to json object

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -312,7 +312,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def proposal_details
-    JSON.parse(super || "[]").each_with_index.map do |hash, index|
+    Array(super).each_with_index.map do |hash, index|
       ProposalDetail.new(hash, index)
     end
   end

--- a/app/services/planning_application_creation_service.rb
+++ b/app/services/planning_application_creation_service.rb
@@ -33,7 +33,6 @@ class PlanningApplicationCreationService
       planning_application_params.merge!(
         local_authority_id: local_authority.id,
         boundary_geojson: (params[:boundary_geojson].to_json if params[:boundary_geojson].present?),
-        proposal_details: (params[:proposal_details].to_json if params[:proposal_details].present?),
         api_user:,
         user_role: params[:user_role].presence,
         payment_amount: params[:payment_amount].presence && payment_amount_in_pounds(params[:payment_amount]),
@@ -90,13 +89,21 @@ class PlanningApplicationCreationService
       :agent_phone,
       :agent_email,
       :user_role,
-      :proposal_details,
       :files,
       :payment_reference,
       :work_status,
       :planx_debug_data,
       :from_production,
-      {feedback: %i[result find_property planning_constraints]}]
+      {feedback: %i[result find_property planning_constraints]},
+      proposal_details: [
+        :question,
+        {
+          responses: [:value, metadata: {}]
+        },
+        {
+          metadata: {}
+        }
+      ]]
 
     params.permit permitted_keys
   end

--- a/db/migrate/20231228104357_migrate_planning_application_proposal_details_json_string_to_json.rb
+++ b/db/migrate/20231228104357_migrate_planning_application_proposal_details_json_string_to_json.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class MigratePlanningApplicationProposalDetailsJsonStringToJson < ActiveRecord::Migration[7.0]
+  def change
+    up_only do
+      PlanningApplication.find_each do |pa|
+        next if pa.proposal_details.blank?
+
+        if pa.proposal_details.is_a?(String)
+          begin
+            parsed_json = JSON.parse(pa.proposal_details)
+            pa.update_column(:proposal_details, parsed_json)
+          rescue JSON::ParserError => e
+            puts "There was an issue parsing the JSON in planning application #{pa.id}: #{e.message}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_21_162919) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_28_104357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/engines/bops_api/app/services/bops_api/application/parsers/proposal_details_parser.rb
+++ b/engines/bops_api/app/services/bops_api/application/parsers/proposal_details_parser.rb
@@ -14,7 +14,7 @@ module BopsApi
           return {} if params.blank?
 
           {
-            proposal_details: params.to_json
+            proposal_details: params
           }
         end
       end

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
             boundary_geojson: "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.7085376977920632,51.699564621757816],[-0.7086127996444802,51.69965605327502],[-0.708982944488535,51.699654390885456],[-0.7089909911155797,51.699673508361855],[-0.7089319825172521,51.699683482694184],[-0.7089520990848638,51.69973002954916],[-0.7091867923736667,51.69968930105364],[-0.7092216610908603,51.699688469859495],[-0.709239095449457,51.69968514508267],[-0.709253847599039,51.6997134056779],[-0.7093128561973666,51.69970176896433],[-0.7092699408531282,51.699610337539525],[-0.7096253335476013,51.699648572521454],[-0.7098613679409116,51.69958457046823],[-0.7098962366581053,51.69955049141595],[-0.7098090648651213,51.6994216557425],[-0.7099243998527616,51.699390070166544],[-0.7098264992237182,51.699238791576136],[-0.7097460329532714,51.699236297968724],[-0.7095716893673034,51.69927536446852],[-0.7095421850681398,51.69927619567025],[-0.7092954218387698,51.69931941814053],[-0.7090929150581455,51.69937427737031],[-0.709021836519251,51.69938923896689],[-0.7089574635028936,51.6994008757608],[-0.7088904082775213,51.69942082454341],[-0.7086691260337761,51.699501450783515],[-0.7086181640624932,51.699517243535354],[-0.7085457444191079,51.699541348251245],[-0.7085350155830483,51.69954799782576],[-0.7085376977920632,51.699564621757816]]]},\"properties\":null}"
           )
 
-          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses].to_json)
+          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses])
         end
 
         it "creates a new planx planning data record with expected attributes" do
@@ -159,7 +159,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
             boundary_geojson: "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.646633654832832,51.61556919642334],[-0.6466296315193095,51.61554504700152],[-0.6465049088001171,51.61551173743314],[-0.6464512646198194,51.61522027766699],[-0.6463131308555524,51.61522943785954],[-0.6463037431240002,51.61520695374722],[-0.6462487578391951,51.615222775901515],[-0.6462393701076429,51.61520861923739],[-0.6459456682205124,51.615292726412235],[-0.6460489332675857,51.61561499701554],[-0.646633654832832,51.61556919642334]]]},\"properties\":null}"
           )
 
-          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses].to_json)
+          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses])
         end
 
         it "creates a new planx planning data record with expected attributes" do
@@ -251,7 +251,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
             boundary_geojson: "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.1186569035053321,51.465703531871384],[-0.1185938715934822,51.465724418998775],[-0.1184195280075143,51.46552473766957],[-0.11848390102387167,51.4655038504508],[-0.1186569035053321,51.465703531871384]]]},\"properties\":null}"
           )
 
-          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses].to_json)
+          expect(planning_application.read_attribute(:proposal_details)).to eq(params[:responses])
         end
 
         it "creates a new planx planning data record with expected attributes" do

--- a/engines/bops_api/spec/services/application/parsers/proposal_details_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/proposal_details_parser_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe BopsApi::Application::Parsers::ProposalDetailsParser do
 
       it "returns a correctly formatted proposal_details hash" do
         expect(parse_proposal_details).to eq(
-          proposal_details: params.to_json
+          proposal_details: params
         )
       end
     end

--- a/spec/components/accordion_sections/pre_assessment_outcome_component_spec.rb
+++ b/spec/components/accordion_sections/pre_assessment_outcome_component_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AccordionSections::PreAssessmentOutcomeComponent, type: :componen
     end
 
     let(:result_override) { nil }
-    let(:proposal_details) { [].to_json }
+    let(:proposal_details) { [] }
     let(:updated_address_or_boundary_geojson) { false }
     let(:feedback) { {} }
 
@@ -106,7 +106,7 @@ RSpec.describe AccordionSections::PreAssessmentOutcomeComponent, type: :componen
               }
             ]
           }
-        ].to_json
+        ]
       end
 
       it "renders question" do

--- a/spec/components/accordion_sections/proposal_details_component_spec.rb
+++ b/spec/components/accordion_sections/proposal_details_component_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe AccordionSections::ProposalDetailsComponent, type: :component do
             }
           ]
         }
-      ].to_json
+      ]
     end
 
     let(:planning_application) do

--- a/spec/components/proposal_details/list_component_spec.rb
+++ b/spec/components/proposal_details/list_component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProposalDetails::ListComponent, type: :component do
         responses: [{value: "Test response 3"}],
         metadata: {auto_answered: true, section_name: "group_a"}
       }
-    ].to_json
+    ]
   end
 
   let(:planning_application) do

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -83,7 +83,7 @@ FactoryBot.define do
             }
           }
         ]
-      ].to_json
+      ]
     end
 
     trait :awaiting_determination do
@@ -276,7 +276,7 @@ FactoryBot.define do
               }
             ]
           }
-        ].to_json
+        ]
       end
 
       application_type { association :application_type, :prior_approval }
@@ -550,7 +550,7 @@ FactoryBot.define do
             },
             question: "Has enforcement action been taken about these changes?"
           }
-        ].to_json
+        ]
       end
 
       after(:build) do |planning_application|
@@ -673,7 +673,7 @@ FactoryBot.define do
             },
             question: "Has enforcement action been taken about these changes?"
           }
-        ].to_json
+        ]
       end
 
       after(:create) do |planning_application|

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -741,7 +741,7 @@ RSpec.describe PlanningApplication do
               flags: ["Test flag"]
             }
           }
-        ].to_json
+        ]
       end
 
       let(:planning_application) do
@@ -767,7 +767,7 @@ RSpec.describe PlanningApplication do
 
     context "when there's a proposal detail with multiple responses" do
       before do
-        planning_application.proposal_details = File.read("./spec/fixtures/files/multiple_responses_proposal_details.json")
+        planning_application.proposal_details = JSON.parse(File.read("./spec/fixtures/files/multiple_responses_proposal_details.json"))
       end
 
       it "does not crash" do
@@ -805,7 +805,7 @@ RSpec.describe PlanningApplication do
             flags: ["Test flag"]
           }
         }
-      ].to_json
+      ]
     end
 
     let(:planning_application) do
@@ -820,7 +820,7 @@ RSpec.describe PlanningApplication do
 
     context "when there's a proposal detail with multiple responses" do
       before do
-        planning_application.proposal_details = File.read("./spec/fixtures/files/multiple_responses_proposal_details.json")
+        planning_application.proposal_details = JSON.parse(File.read("./spec/fixtures/files/multiple_responses_proposal_details.json"))
       end
 
       it "does not crash" do
@@ -850,7 +850,7 @@ RSpec.describe PlanningApplication do
             portal_name: "immunity-check"
           }
         }
-      ].to_json
+      ]
     end
 
     let(:planning_application) do

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
           responses: [{value: "Answer 5"}],
           metadata: {section_name: "Birdfeed Related"}
         }
-      ].to_json
+      ]
     end
 
     let(:planning_application) do

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Assessment tasks" do
           question: "Question 4",
           responses: [{value: "Answer 4"}]
         }
-      ].to_json
+      ]
     end
 
     it "displays the proposal details by group" do

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Planning Application show page" do
         question: "Is the property in a world heritage site?",
         responses: [{value: "No"}]
       }
-    ].to_json
+    ]
   end
 
   let(:application_type) { create(:application_type) }

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "FeeItemsValidation" do
             ]
           }
         }
-      ].to_json
+      ]
     end
 
     let(:fee_calculation) do


### PR DESCRIPTION
### Description of change

Migrate the proposal details data which is stored as a string to an object so that we're not double parsing

### Story Link

https://trello.com/c/oQGJmWpG/2235-migrate-proposaldetails-column-data-to-json