### PR TITLE
Fix issue where duplicate text displayed

### DIFF
--- a/app/views/administrator/local_authorities/_form.html.erb
+++ b/app/views/administrator/local_authorities/_form.html.erb
@@ -3,7 +3,7 @@
    id: "profile-form",
 ) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
-  <%= form.govuk_fieldset(legend: { text: t(".legend") }) do %>
+  <%= form.govuk_fieldset(legend: { text: nil }) do %>
 
   <%= form.govuk_text_field(
      :signatory_name,

--- a/app/views/administrator/local_authorities/edit.html.erb
+++ b/app/views/administrator/local_authorities/edit.html.erb
@@ -13,7 +13,7 @@
       <%= t(".profile") %>
     </h1>
     <p class="govuk-body">
-      Some councils use several teams to complete key tasks within the assessment and review process. Add the correct email addresses for each task. If the planning officer completes this task themselves, leave it blank.
+      Some councils use several teams to complete key tasks within the assessment and review process. Add the correct email addresses for each task.
     </p>
 
     <%= render "form" %>

--- a/app/views/administrator/local_authorities/show.html.erb
+++ b/app/views/administrator/local_authorities/show.html.erb
@@ -12,7 +12,7 @@
       <%= t(".profile") %>
     </h1>
     <p class="govuk-body">
-      Some councils use several teams to complete key tasks within the assessment and review process. Add the correct email addresses for each task. If the planning officer completes this task themselves, leave it blank.
+      Some councils use several teams to complete key tasks within the assessment and review process. Add the correct email addresses for each task.
     </p>
 
     <div class="govuk-form-group govuk-!-margin-top-5">


### PR DESCRIPTION
### Description of change

This is a content fix to ensure intro text is not duplicated at the top of the local authority admin form, and also removes the line about leaving fields blank, because all fields need to be populated before councils can be activated.

### Story Link

https://trello.com/c/UUPtXcRf/989-admin-can-update-council-specific-content-information-in-a-profile-page
