### PR TITLE
Sort documents received by tags group

### DIFF
--- a/app/components/tabs_component.html.erb
+++ b/app/components/tabs_component.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <% @tabs.each_with_index do |tab, index| %>
+      <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if index.zero? %>">
+        <a class="govuk-tabs__tab" href="#<%= tab[:id] %>">
+          <%= tab[:title] %> (<%= tab[:records].length.to_s %>)
+        </a>
+      </li>
+    <% end %>
+  </ul>
+  <% @tabs.each_with_index do |tab, index| %>
+    <div class="govuk-tabs__panel <%= 'govuk-tabs__panel--hidden' unless index.zero? %>" id="<%= tab[:id] %>">
+      <h2 class="govuk-heading-m"><%= tab[:content] %></h2>
+
+      <%= render_tab(tab) %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/tabs_component.rb
+++ b/app/components/tabs_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class TabsComponent < ViewComponent::Base
+  def initialize(partial:, tabs:, collection_key:)
+    @partial = partial
+    @tabs = tabs
+    @collection_key = collection_key
+  end
+
+  private
+
+  attr_reader :partial, :collection_key
+
+  def render_tab(tab)
+    render(partial, collection_key => tab[:records])
+  end
+end

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -29,10 +29,6 @@ module DocumentHelper
     "#{document.name}#{document.numbers? ? " - #{document.numbers}" : ""}"
   end
 
-  def titled_reference_or_file_name(document)
-    document.numbers? ? "Reference: #{document.numbers}" : "File name: #{document.name}"
-  end
-
   def reference_or_file_name(document)
     document.numbers.presence || document.name
   end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -129,6 +129,13 @@ class Document < ApplicationRecord
     other: ["What do these documents show?"]
   }.freeze
 
+  DEFAULT_TABS = ["All", "Plans", "Supporting documents", "Evidence"].freeze
+  TAGS_MAP = {
+    "Plans" => PLAN_TAGS,
+    "Supporting documents" => SUPPORTING_DOCUMENT_TAGS,
+    "Evidence" => EVIDENCE_TAGS
+  }.freeze
+
   TAGS = PLAN_TAGS + EVIDENCE_TAGS + SUPPORTING_DOCUMENT_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -735,6 +735,16 @@ class PlanningApplication < ApplicationRecord
     super || create_fee_calculation
   end
 
+  def generate_document_tabs(tabs = Document::DEFAULT_TABS)
+    all_documents = documents.with_file_attachment
+
+    tabs.map do |tab|
+      documents = (tab == "All") ? all_documents : filter_documents_for_tab(all_documents, tab)
+
+      {title: tab, id: tab.parameterize, content: tab, records: documents}
+    end
+  end
+
   private
 
   def create_fee_calculation
@@ -920,5 +930,11 @@ class PlanningApplication < ApplicationRecord
 
   def create_proposal_measurement
     ProposalMeasurement.create(planning_application: self, depth: 0, max_height: 0, eaves_height: 0)
+  end
+
+  def filter_documents_for_tab(documents, tab)
+    tags = Document::TAGS_MAP[tab]
+
+    documents.select { |document| (tags & document.tags).any? }
   end
 end

--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -28,24 +28,28 @@
     </p>
   <% end %>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    <%= titled_reference_or_file_name(document) %>
+    <% if document.numbers? %>
+      Reference: <strong><%= document.numbers %></strong>
+    <% else %>
+      File name: <strong><%= document.name %></strong>
+    <% end %>
   </p>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    Date received: <%= document.received_at_or_created %>
+    Date received: <strong><%= document.received_at_or_created %></strong>
   </p>
   <% if document.numbers.present? %>
     <p class="govuk-body govuk-!-margin-bottom-1">
-      Document reference(s): <%= document.numbers %>
+      Document reference(s): <strong><%= document.numbers %></strong>
     </p>
   <% end %>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    Included in decision notice: <%= document.referenced_in_decision_notice? ? "Yes" : "No" %>
+    Included in decision notice: <strong><%= document.referenced_in_decision_notice? ? "Yes" : "No" %></strong>
   </p>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    Public: <%= document.publishable? ? "Yes" : "No" %>
+    Public: <strong><%= document.publishable? ? "Yes" : "No" %></strong>
   </p>
   <p class="govuk-body govuk-!-margin-bottom-1">
-    Redacted: <%= document.redacted? ? "Yes" : "No" %>
+    Redacted: <strong><%= document.redacted? ? "Yes" : "No" %></strong>
   </p>
 <% else %>
   <p class="govuk-body">

--- a/app/views/planning_applications/validation_documents.html.erb
+++ b/app/views/planning_applications/validation_documents.html.erb
@@ -11,7 +11,7 @@
 ) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <p class="govuk-body-m">
       Check all necessary documents have been provided and add requests for any missing documents.
     </p>
@@ -26,7 +26,14 @@
       <a href="<%= t("council_documents.#{@planning_application.local_authority.subdomain}.document_checklist")%>" target="_blank" class="govuk-link govuk-body-m">
         Checklist for <%= @planning_application.application_type.name.humanize.downcase %> (opens in a new tab)
       </a>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <% end %>
+
+    <%= render TabsComponent.new(
+      partial: "documents/active_documents_table", 
+      tabs: @planning_application.generate_document_tabs,
+      collection_key: :documents
+    ) %>
 
     <% if @additional_document_validation_requests.any? %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
@@ -35,10 +42,6 @@
           validation_requests: @additional_document_validation_requests %>
     <% else %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-    <% end %>
-
-    <% if @documents.any? %>
-      <%= render "documents/active_documents_table", documents: @documents.with_file_attachment %>
     <% end %>
 
     <p class="govuk-!-margin-bottom-6 govuk-!-margin-top-0">

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -3,21 +3,6 @@
 require "rails_helper"
 
 RSpec.describe DocumentHelper do
-  describe "#titled_refrence_or_file_name" do
-    it "returns the document reference if present" do
-      document = create(:document, numbers: "REF123")
-
-      expect(titled_reference_or_file_name(document)).to eq "Reference: REF123"
-    end
-
-    it "returns if reference missing the document name" do
-      document = create(:document, numbers: "")
-
-      # I can't control the name of the document name so always proposed-flooplan.png
-      expect(titled_reference_or_file_name(document)).to eq "File name: proposed-floorplan.png"
-    end
-  end
-
   describe "#refrence_or_file_name" do
     it "returns the document reference if present" do
       document = create(:document, numbers: "REF123")

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2305,4 +2305,61 @@ RSpec.describe PlanningApplication do
       )
     end
   end
+
+  describe "#generate_document_tabs" do
+    let!(:document_no_tag) { create(:document, tags: [], planning_application:) }
+    let!(:document_evidence_tag) { create(:document, tags: ["Photograph"], planning_application:) }
+    let!(:document_plan_tag) { create(:document, tags: ["Proposed"], planning_application:) }
+    let!(:document_supporting_tag) { create(:document, tags: ["Noise Impact Assessment"], planning_application:) }
+    let!(:document_evidence_and_plan_tags) { create(:document, tags: ["Photograph", "Proposed"], planning_application:) }
+    let!(:document_plan_and_supporting_tags) { create(:document, tags: ["Proposed", "Other Supporting Document"], planning_application:) }
+
+    def find_tab(title)
+      planning_application.generate_document_tabs.find { |tab| tab[:title] == title }
+    end
+
+    it "returns all documents for the 'All' tab" do
+      all_tab = find_tab("All")
+
+      expect(all_tab).to eq({
+        title: "All",
+        id: "all",
+        content: "All",
+        records: [document_no_tag, document_evidence_tag, document_plan_tag, document_supporting_tag, document_evidence_and_plan_tags, document_plan_and_supporting_tags]
+      })
+    end
+
+    it "filters documents for the 'Evidence' tab" do
+      evidence_tab = find_tab("Evidence")
+
+      expect(evidence_tab).to eq({
+        title: "Evidence",
+        id: "evidence",
+        content: "Evidence",
+        records: [document_evidence_tag, document_evidence_and_plan_tags]
+      })
+    end
+
+    it "filters documents for the 'Plans' tab" do
+      plans_tab = find_tab("Plans")
+
+      expect(plans_tab).to eq({
+        title: "Plans",
+        id: "plans",
+        content: "Plans",
+        records: [document_plan_tag, document_evidence_and_plan_tags, document_plan_and_supporting_tags]
+      })
+    end
+
+    it "filters documents for the 'Supporting documents' tab" do
+      supporting_documents_tab = find_tab("Supporting documents")
+
+      expect(supporting_documents_tab).to eq({
+        title: "Supporting documents",
+        id: "supporting-documents",
+        content: "Supporting documents",
+        records: [document_supporting_tag, document_plan_and_supporting_tags]
+      })
+    end
+  end
 end

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -93,6 +93,62 @@ RSpec.describe "Requesting a new document for a planning application" do
     end
   end
 
+  context "when viewing the documents tabs" do
+    let!(:planning_application) do
+      create(:planning_application, :not_started, local_authority: default_local_authority)
+    end
+    let!(:document_no_tag) { create(:document, tags: [], planning_application:) }
+    let!(:document_evidence_tag) { create(:document, tags: ["Photograph"], planning_application:) }
+    let!(:document_plan_tag) { create(:document, tags: ["Proposed"], planning_application:) }
+    let!(:document_supporting_tag) { create(:document, tags: ["Noise Impact Assessment"], planning_application:) }
+    let!(:document_evidence_and_plan_tags) { create(:document, tags: ["Photograph", "Proposed"], planning_application:) }
+    let!(:document_plan_and_supporting_tags) { create(:document, tags: ["Proposed", "Other Supporting Document"], planning_application:) }
+
+    it "I can view the documents separated by their tag category" do
+      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      click_link "Check required documents are on application"
+
+      within(".govuk-tabs") do
+        within("#tab_all") do
+          expect(page).to have_content("All (6)")
+        end
+        within("#all") do
+          expect(page).to have_css(".govuk-table__row#document_#{document_no_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_evidence_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_plan_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_supporting_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_evidence_and_plan_tags.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_plan_and_supporting_tags.id}")
+        end
+
+        within("#tab_plans") do
+          expect(page).to have_content("Plans (3)")
+        end
+        within("#plans") do
+          expect(page).to have_css(".govuk-table__row#document_#{document_plan_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_evidence_and_plan_tags.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_plan_and_supporting_tags.id}")
+        end
+
+        within("#tab_supporting-documents") do
+          expect(page).to have_content("Supporting documents (2)")
+        end
+        within("#supporting-documents") do
+          expect(page).to have_css(".govuk-table__row#document_#{document_supporting_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_plan_and_supporting_tags.id}")
+        end
+
+        within("#tab_evidence") do
+          expect(page).to have_content("Evidence (2)")
+        end
+        within("#evidence") do
+          expect(page).to have_css(".govuk-table__row#document_#{document_evidence_tag.id}")
+          expect(page).to have_css(".govuk-table__row#document_#{document_evidence_and_plan_tags.id}")
+        end
+      end
+    end
+  end
+
   context "when application is not started" do
     let!(:planning_application) do
       create(:planning_application, :not_started, local_authority: default_local_authority)
@@ -124,7 +180,7 @@ RSpec.describe "Requesting a new document for a planning application" do
         href: new_planning_application_validation_validation_request_path(planning_application, type: "additional_document")
       )
 
-      within(".govuk-table.current-documents") do
+      within("#all .govuk-table.current-documents") do
         within(".govuk-table__body") do
           rows = page.all(".govuk-table__row")
 
@@ -440,7 +496,7 @@ RSpec.describe "Requesting a new document for a planning application" do
 
         click_link "Check required documents are on application"
 
-        within(".govuk-table.current-documents") do
+        within("#all .govuk-table.current-documents") do
           within(".govuk-table__body") do
             within(".govuk-table__row") do
               cells = page.all(".govuk-table__cell")


### PR DESCRIPTION
### Description of change

- Sort documents by their tags group on the "Check documents provided" validation task screen
- Make a reusable tabs component

- Since we render the "All" documents tab first, we can just query all documents for the planning application and then filter in memory per tag group for the other tabs rather than making separate queries

### Story Link

https://trello.com/c/jNca0ChV/2151-able-to-sort-through-the-types-of-document-received

### Screenshots

![Screenshot 2024-01-05 at 10 14 24](https://github.com/unboxed/bops/assets/34001723/1aaefde1-06c5-4b66-9895-fc5612945d07)