### PR TITLE
Restrict access to planning applications for inactive councils

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -55,4 +55,8 @@ module PlanningApplicationHelper
       raise ArgumentError, "Unexpected value for 'type': #{type.inspect}"
     end
   end
+
+  def inactive_local_authority_message
+    I18n.t("planning_applications.index.inactive_local_authority")
+  end
 end

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -2,68 +2,74 @@
   Planning Applications List - <%= t('page_title') %>
 <% end %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <% if @search.exclude_others? %>
-      <h1 class="govuk-heading-l">
-        Your planning applications
-      </h1>
-      <p class="govuk-body-m">
-        <strong><%= current_user.name %>,</strong> <%= role_name %>
-      </p>
-      <p class="govuk-body">
-        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
-      </p>
-      <p class="govuk-body"><%= link_to "View all applications", planning_applications_path(view: 'all'), class: "govuk-button" %></p>
-    <% else %>
-      <h1 class="govuk-heading-l">
-        All planning applications
-      </h1>
-      <p class="govuk-body-m">
-        <strong><%= current_user.name %>,</strong> <%= role_name %>
-      </p>
-      <p class="govuk-body">
-        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
-      </p>
-      <p class="govuk-body">
-        <%= link_to "View my applications", planning_applications_path, class: "govuk-button" %>
-      </p>
-    <% end %>
+<% if current_local_authority&.active? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @search.exclude_others? %>
+        <h1 class="govuk-heading-l">
+          Your planning applications
+        </h1>
+        <p class="govuk-body-m">
+          <strong><%= current_user.name %>,</strong> <%= role_name %>
+        </p>
+        <p class="govuk-body">
+          <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
+        </p>
+        <p class="govuk-body"><%= link_to "View all applications", planning_applications_path(view: 'all'), class: "govuk-button" %></p>
+      <% else %>
+        <h1 class="govuk-heading-l">
+          All planning applications
+        </h1>
+        <p class="govuk-body-m">
+          <strong><%= current_user.name %>,</strong> <%= role_name %>
+        </p>
+        <p class="govuk-body">
+          <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
+        </p>
+        <p class="govuk-body">
+          <%= link_to "View my applications", planning_applications_path, class: "govuk-button" %>
+        </p>
+      <% end %>
+    </div>
   </div>
-</div>
 
-<div class="status-bar-container">
-  <h2 class="govuk-heading-m">Status update:</h2>
-  <div class="status-bar">
-    <div class="status-panel<% if filter_enabled_uniquely?(status: 'to_be_reviewed') %> status-panel--highlighted<% end %>" id="reviewer-requests">
-      <a class="status-filter-link" href="<%= planning_applications_path(filter_enabled_uniquely?(status: "to_be_reviewed") ? {} : { status: [:to_be_reviewed] }) %>">
-        <h3 class="govuk-heading-s"><%= t ".reviewer_requests.title" %></h3>
-        <p class="govuk-heading-m"><%= t ".reviewer_requests", count: @search.current_planning_applications.to_be_reviewed.count %></p>
-      </a>
-    </div>
-    <div class="status-panel<% if filter_enabled_uniquely?(application_type: 'prior_approval') %> status-panel--highlighted<% end %>" id="not-started">
-      <a class="status-filter-link" href="<%= planning_applications_path(filter_enabled_uniquely?(application_type: "prior_approval") ? {} : { application_type: [:prior_approval] }) %>">
-        <h3 class="govuk-heading-s"><%= t ".prior_approvals.title" %></h3>
-        <p class="govuk-heading-m"><%= t ".prior_approvals", count: @search.current_planning_applications.prior_approvals.not_started.count %></p>
-      </a>
+  <div class="status-bar-container">
+    <h2 class="govuk-heading-m">Status update:</h2>
+    <div class="status-bar">
+      <div class="status-panel<% if filter_enabled_uniquely?(status: 'to_be_reviewed') %> status-panel--highlighted<% end %>" id="reviewer-requests">
+        <a class="status-filter-link" href="<%= planning_applications_path(filter_enabled_uniquely?(status: "to_be_reviewed") ? {} : { status: [:to_be_reviewed] }) %>">
+          <h3 class="govuk-heading-s"><%= t ".reviewer_requests.title" %></h3>
+          <p class="govuk-heading-m"><%= t ".reviewer_requests", count: @search.current_planning_applications.to_be_reviewed.count %></p>
+        </a>
+      </div>
+      <div class="status-panel<% if filter_enabled_uniquely?(application_type: 'prior_approval') %> status-panel--highlighted<% end %>" id="not-started">
+        <a class="status-filter-link" href="<%= planning_applications_path(filter_enabled_uniquely?(application_type: "prior_approval") ? {} : { application_type: [:prior_approval] }) %>">
+          <h3 class="govuk-heading-s"><%= t ".prior_approvals.title" %></h3>
+          <p class="govuk-heading-m"><%= t ".prior_approvals", count: @search.current_planning_applications.prior_approvals.not_started.count %></p>
+        </a>
+      </div>
     </div>
   </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div class="govuk-tabs" data-module="govuk-tabs">
-      <h2 class="govuk-tabs__title">
-        Contents
-      </h2>
-      <%= render "planning_application_tabs" %>
-      <%= render(
-        PlanningApplications::PanelsComponent.new(
-          planning_applications: @planning_applications,
-          search: @search,
-          local_authority: current_local_authority
-        )
-      ) %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-tabs" data-module="govuk-tabs">
+        <h2 class="govuk-tabs__title">
+          Contents
+        </h2>
+        <%= render "planning_application_tabs" %>
+        <%= render(
+          PlanningApplications::PanelsComponent.new(
+            planning_applications: @planning_applications,
+            search: @search,
+            local_authority: current_local_authority
+          )
+        ) %>
+      </div>
     </div>
   </div>
-</div>
+<% else %>
+  <p class="govuk-body-m">
+    <%= inactive_local_authority_message %>
+  </p>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1013,6 +1013,7 @@ en:
       confirm_site_notice_displayed_at_html: <a class="govuk-notification-banner__link" href="%{href}">Confirm the site notice displayed at date</a> before determining the application.
       success: Decision Notice sent to applicant
     index:
+      inactive_local_authority: Planning applications will be shown here once your local authority has been fully activated within the Back-office Planning System
       prior_approvals:
         one: "%{count} prior approval"
         other: "%{count} prior approvals"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,8 @@ LocalAuthority.find_or_create_by!(subdomain: "lambeth") do |la|
   la.email_address = "planning@lambeth.gov.uk"
   la.feedback_email = "digitalplanning@lambeth.gov.uk"
   la.press_notice_email = "digitalplanning@lambeth.gov.uk"
+  la.email_reply_to_id = "550e8400-e29b-41d4-a716-446655440000"
+  la.active = true
 end
 
 LocalAuthority.find_or_create_by!(subdomain: "southwark") do |la|
@@ -24,8 +26,14 @@ LocalAuthority.find_or_create_by!(subdomain: "southwark") do |la|
   la.signatory_job_title = "Director of Planning and Growth"
   la.enquiries_paragraph = "Planning, London Borough of Southwark, PO Box 734, Winchester SO23 5DG"
   la.email_address = "planning@southwark.gov.uk"
+  la.reviewer_group_email = "planning@southwark.gov.uk"
   la.feedback_email = "digital.projects@southwark.gov.uk"
   la.press_notice_email = "digital.projects@southwark.gov.uk"
+  la.email_reply_to_id = "550e8400-e29b-41d4-a716-446655440000"
+  la.notify_api_key = "550e8400-e29b-41d4-a716-446655440000"
+  la.notify_letter_template = "550e8400-e29b-41d4-a716-446655440000"
+  la.reply_to_notify_id = "550e8400-e29b-41d4-a716-446655440000"
+  la.active = true
 end
 
 LocalAuthority.find_or_create_by!(subdomain: "buckinghamshire") do |la|
@@ -39,6 +47,8 @@ LocalAuthority.find_or_create_by!(subdomain: "buckinghamshire") do |la|
   la.email_address = "planning@buckinghamshire.gov.uk"
   la.feedback_email = "planning.digital@buckinghamshire.gov.uk"
   la.press_notice_email = "planning.digital@buckinghamshire.gov.uk"
+  la.email_reply_to_id = "550e8400-e29b-41d4-a716-446655440000"
+  la.active = true
 end
 
 admin_roles = %i[assessor reviewer administrator]

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -603,6 +603,19 @@ RSpec.describe "Planning Application index page" do
     end
   end
 
+  context "when local authority is inactive" do
+    before do
+      default_local_authority.update!(active: false)
+      sign_in assessor
+      visit "/"
+    end
+
+    it "Does not show the planning applications table" do
+      expect(page).to have_no_content "Your live applications"
+      expect(page).to have_content "Planning applications will be shown here once your local authority has been fully activated within the Back-office Planning System"
+    end
+  end
+
   context "as a reviewer" do
     before do
       sign_in reviewer


### PR DESCRIPTION
### Description of change

We do not want assessors or reviewers to see the index page containing planning applications before the local authority is activated, because missing information will lead to broken views. 

We discussed simply redirecting users to the administrator pages on login, but this does not work as the user is stuck in a redirect loop when the existing method tries to send them back to the root path.

Instead, I have gone for the simpler option of allowing them to see the index page (so they still have access to navigation and can log out) but with a custom message explaining why it is blank.

We do not need to worry about planners accessing other pages, as we are not going to allow active councils to be edited to be inactive, so this only applies to newly configured councils who are in the process of being activated.

### Story Link

https://trello.com/c/8NN0YtXu/2378-do-not-allow-assessors-and-reviewers-to-access-the-system-when-a-local-authority-is-inactive
