### PR TITLE
Chore/redact notify key

### DIFF
--- a/app/views/administrator/local_authorities/_form.html.erb
+++ b/app/views/administrator/local_authorities/_form.html.erb
@@ -58,7 +58,8 @@
      :notify_api_key,
      label: { text: t(".notify_api_key"), class: "govuk-label govuk-label--m" },
      hint: { text: t(".notify_api_key_hint") },
-     class: "govuk-input--width-30"
+     class: "govuk-input--width-30",
+     type: "password"
   ) %>
 
   <%= form.govuk_text_field(

--- a/app/views/administrator/local_authorities/show.html.erb
+++ b/app/views/administrator/local_authorities/show.html.erb
@@ -70,7 +70,7 @@
           <h2 class="govuk-heading-m"><%= t(".notify_api_key") %></h2>
           <span class="govuk-hint"><%= t(".notify_api_key_hint") %></span>
           <p class="govuk-body">
-            <%= current_local_authority.notify_api_key %>
+            Redacted for security
           </p>
         </li>
         <li>


### PR DESCRIPTION
### Description of change

We do not want to display the Notify API key in plain text on the admin dashboard, and it should also be obfuscated when entering it in the Edit page.

### Story Link

https://trello.com/c/UUPtXcRf/989-admin-can-update-council-specific-content-information-in-a-profile-page

