### PR TITLE
Remove omission of fee exemption documents from default scope

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -124,6 +124,8 @@ class DocumentsController < AuthenticationController
   end
 
   def replacement_document_validation_request
+    return unless @document.owner&.type == "ReplacementDocumentValidationRequest"
+
     @replacement_document_validation_request ||= @document.owner
   end
 

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -47,6 +47,8 @@ class ApplicationType < ApplicationRecord
       Document::EVIDENCE_TAGS - document_tags[key]
     when "supporting_documents"
       (Document::SUPPORTING_DOCUMENT_TAGS - ["Fee Exemption"]) - document_tags[key]
+    when "other"
+      []
     else
       raise ArgumentError, "Unexpected document tag type: #{key}"
     end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -143,7 +143,7 @@ class Document < ApplicationRecord
   validate :numbered
   validate :created_date_is_in_the_past
 
-  default_scope -> { no_owner.or(not_excluded_owners).not_for_fee_exemption }
+  default_scope -> { no_owner.or(not_excluded_owners) }
 
   scope :no_owner, -> { where(owner_type: nil) }
   scope :not_excluded_owners, -> { where.not(owner_type: EXCLUDED_OWNERS) }
@@ -164,7 +164,7 @@ class Document < ApplicationRecord
   scope :with_tag, ->(tag) { where("tags @> ?", "\"#{tag}\"") }
   scope :with_file_attachment, -> { includes(file_attachment: :blob) }
   scope :for_site_visit, -> { where.not(site_visit_id: nil) }
-  scope :for_fee_exemption, -> { unscoped.with_tag("Fee Exemption") }
+  scope :for_fee_exemption, -> { with_tag("Fee Exemption") }
   scope :not_for_fee_exemption, -> { where("NOT (tags @> ?)", "\"Fee Exemption\"") }
 
   before_validation on: :create do


### PR DESCRIPTION
### Description of change

- Using 'unscoped' on the `for_fee_exemption` scope removed the association with planning applications so other planning application documents were being returned
- Probably should look to remove use of `default_scope` as it inevitably will cause issues

### Story Link

https://trello.com/c/TAK50xEW/2424-fee-validation-page-showing-odd-documents

