### PR TITLE
Retry downloading node and other packages if the request fails

### DIFF
--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -26,7 +26,7 @@ ARG NODE_VERSION=18.16.1
 ARG YARN_VERSION=1.22.19
 ARG SWAGGER_CLI_VERSION=4.0.4
 ENV PATH=/usr/local/node/bin:$PATH
-RUN bash -c "curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
+RUN bash -c "curl --retry 5 --retry-delay 5 --retry-max-time 60 -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz -C /tmp/ && \
     /tmp/node-build-master/bin/node-build '$NODE_VERSION' /usr/local/node && \
     npm install -g yarn@$YARN_VERSION && \
     npm install -g swagger-cli@$SWAGGER_CLI_VERSION && \


### PR DESCRIPTION
### Description of change

- Sometimes, we get an error "error: failed to download node-v18.16.1-linux-x64.tar.gz" but this could just be temporary so rather than fail the whole build we can retry the request to download

