### PR TITLE
Refactor the api/validation_requests_controllers

### DIFF
--- a/app/controllers/api/v1/description_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_validation_requests_controller.rb
@@ -11,6 +11,11 @@ module Api
         render json: {message: error.message}, status: :bad_request
       end
 
+      rescue_from ActiveRecord::RecordNotFound do
+        render json: {message: "Unable to find description change validation request with id: #{params[:id]}"},
+          status: :not_found
+      end
+
       def index
         respond_to do |format|
           format.json do
@@ -23,18 +28,12 @@ module Api
         respond_to do |format|
           format.json
         end
-      rescue ActiveRecord::RecordNotFound
-        format.json do
-          render json: {message: "Unable to find description change validation request with id: #{params[:id]}"},
-            status: :not_found
-        end
       end
 
       def update
         ValidationRequestUpdateService.new(
           validation_request: @description_change_validation_request,
-          params:,
-          description_change: true
+          params:
         ).call!
 
         render json: {message: "Change request updated"}, status: :ok
@@ -43,7 +42,7 @@ module Api
       private
 
       def set_description_change_validation_request
-        @description_change_validation_request = @planning_application.description_change_validation_requests.where(id: params[:id]).first
+        @description_change_validation_request = @planning_application.description_change_validation_requests.find(params[:id])
       end
     end
   end

--- a/app/controllers/api/v1/description_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/description_change_validation_requests_controller.rb
@@ -5,6 +5,11 @@ module Api
     class DescriptionChangeValidationRequestsController < Api::V1::ApplicationController
       skip_before_action :verify_authenticity_token
       before_action :check_token_and_set_application
+      before_action :set_description_change_validation_request, only: %i[show update]
+
+      rescue_from ValidationRequestUpdateService::UpdateError do |error|
+        render json: {message: error.message}, status: :bad_request
+      end
 
       def index
         respond_to do |format|
@@ -16,44 +21,29 @@ module Api
 
       def show
         respond_to do |format|
-          if (@description_change_validation_request =
-                @planning_application.description_change_validation_requests.where(id: params[:id]).first)
-            format.json
-          else
-            format.json do
-              render json: {message: "Unable to find description change validation request with id: #{params[:id]}"},
-                status: :not_found
-            end
-          end
+          format.json
+        end
+      rescue ActiveRecord::RecordNotFound
+        format.json do
+          render json: {message: "Unable to find description change validation request with id: #{params[:id]}"},
+            status: :not_found
         end
       end
 
       def update
-        @description_change_validation_request =
-          @planning_application.description_change_validation_requests.where(id: params[:id]).first
+        ValidationRequestUpdateService.new(
+          validation_request: @description_change_validation_request,
+          params:,
+          description_change: true
+        ).call!
 
-        if @description_change_validation_request.update(description_change_params)
-          @description_change_validation_request.close!
-          if @description_change_validation_request.approved?
-            @planning_application.update!(description: @description_change_validation_request.proposed_description)
-          end
-          @description_change_validation_request.create_api_audit!
-          @planning_application.send_update_notification_to_assessor
-          render json: {message: "Description change request updated"}, status: :ok
-        else
-          render json: {message: "Unable to update request. " \
-                                  "Please ensure rejection_reason is present if approved is false."},
-            status: :bad_request
-        end
+        render json: {message: "Change request updated"}, status: :ok
       end
 
       private
 
-      def description_change_params
-        {
-          approved: params[:data][:approved],
-          rejection_reason: params[:data][:rejection_reason]
-        }
+      def set_description_change_validation_request
+        @description_change_validation_request = @planning_application.description_change_validation_requests.where(id: params[:id]).first
       end
     end
   end

--- a/app/controllers/api/v1/fee_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/fee_change_validation_requests_controller.rb
@@ -17,6 +17,11 @@ module Api
         render json: {message: error.message}, status: :bad_request
       end
 
+      rescue_from ActiveRecord::RecordNotFound do
+        render json: {message: "Unable to find fee change validation request with id: #{params[:id]}"},
+          status: :not_found
+      end
+
       def index
         respond_to do |format|
           format.json do
@@ -28,11 +33,6 @@ module Api
       def show
         respond_to do |format|
           format.json
-        end
-      rescue ActiveRecord::RecordNotFound
-        format.json do
-          render json: {message: "Unable to find fee change validation request with id: #{params[:id]}"},
-            status: :not_found
         end
       end
 
@@ -51,7 +51,7 @@ module Api
       end
 
       def set_fee_change_validation_request
-        @fee_change_validation_request = @planning_application.fee_change_validation_requests.find_by(id: params[:id])
+        @fee_change_validation_request = @planning_application.fee_change_validation_requests.find(params[:id])
       end
     end
   end

--- a/app/controllers/api/v1/fee_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/fee_change_validation_requests_controller.rb
@@ -5,11 +5,16 @@ module Api
     class FeeChangeValidationRequestsController < Api::V1::ValidationRequestsController
       skip_before_action :verify_authenticity_token
       before_action :check_token_and_set_application
+      before_action :set_fee_change_validation_request, only: %i[show update]
       before_action :check_files_size,
         :check_files_type, only: :update
 
       rescue_from ValidationRequest::UploadFilesError do |_exception|
         render_failed_request
+      end
+
+      rescue_from ValidationRequestUpdateService::UpdateError do |error|
+        render json: {message: error.message}, status: :bad_request
       end
 
       def index
@@ -22,40 +27,31 @@ module Api
 
       def show
         respond_to do |format|
-          if (@fee_change_validation_request =
-                @planning_application.fee_change_validation_requests.where(id: params[:id]).first)
-            format.json
-          else
-            format.json do
-              render json: {message: "Unable to find fee change validation request with id: #{params[:id]}"},
-                status: :not_found
-            end
-          end
+          format.json
+        end
+      rescue ActiveRecord::RecordNotFound
+        format.json do
+          render json: {message: "Unable to find fee change validation request with id: #{params[:id]}"},
+            status: :not_found
         end
       end
 
       def update
-        @fee_change_validation_request = @planning_application.fee_change_validation_requests.find_by(id: params[:id])
-
-        if @fee_change_validation_request.update(fee_change_validation_request_params)
-          @fee_change_validation_request.close!
-          @fee_change_validation_request.create_api_audit!
-          @planning_application.send_update_notification_to_assessor
-
-          render json: {message: "Change request updated"}, status: :ok
-        else
-          render json: {message: "Unable to update request."}, status: :bad_request
-        end
+        ValidationRequestUpdateService.new(
+          validation_request: @fee_change_validation_request,
+          params:
+        ).call!
+        render json: {message: "Change request updated"}, status: :ok
       end
 
       private
 
-      def fee_change_validation_request_params
-        params.permit(:response, supporting_documents: [])
-      end
-
       def file_params
         params[:supporting_documents]
+      end
+
+      def set_fee_change_validation_request
+        @fee_change_validation_request = @planning_application.fee_change_validation_requests.find_by(id: params[:id])
       end
     end
   end

--- a/app/controllers/api/v1/other_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/other_change_validation_requests_controller.rb
@@ -11,6 +11,11 @@ module Api
         render json: {message: error.message}, status: :bad_request
       end
 
+      rescue_from ActiveRecord::RecordNotFound do
+        render json: {message: "Unable to find other change validation request with id: #{params[:id]}"},
+          status: :not_found
+      end
+
       def index
         respond_to do |format|
           format.json do
@@ -22,11 +27,6 @@ module Api
       def show
         respond_to do |format|
           format.json
-        end
-      rescue ActiveRecord::RecordNotFound
-        format.json do
-          render json: {message: "Unable to find other change validation request with id: #{params[:id]}"},
-            status: :not_found
         end
       end
 
@@ -45,7 +45,7 @@ module Api
       private
 
       def set_other_change_validation_request
-        @other_change_validation_request = @planning_application.other_change_validation_requests.where(id: params[:id]).first
+        @other_change_validation_request = @planning_application.other_change_validation_requests.find(params[:id])
       end
     end
   end

--- a/app/controllers/api/v1/ownership_certificate_validation_requests_controller.rb
+++ b/app/controllers/api/v1/ownership_certificate_validation_requests_controller.rb
@@ -32,7 +32,8 @@ module Api
       def update
         ValidationRequestUpdateService.new(
           validation_request: @ownership_certificate_validation_request,
-          params:
+          params:,
+          ownership_certificate: true
         ).call!
         render json: {message: "Change request updated"}, status: :ok
       end

--- a/app/controllers/api/v1/ownership_certificate_validation_requests_controller.rb
+++ b/app/controllers/api/v1/ownership_certificate_validation_requests_controller.rb
@@ -12,6 +12,11 @@ module Api
         render json: {message: error.message}, status: :bad_request
       end
 
+      rescue_from ActiveRecord::RecordNotFound do
+        render json: {message: "Unable to find ownership certificate validation request with id: #{params[:id]}"},
+          status: :not_found
+      end
+
       def index
         respond_to do |format|
           format.json
@@ -22,18 +27,12 @@ module Api
         respond_to do |format|
           format.json
         end
-      rescue ActiveRecord::RecordNotFound
-        format.json do
-          render json: {message: "Unable to find ownership certificate validation request with id: #{params[:id]}"},
-            status: :not_found
-        end
       end
 
       def update
         ValidationRequestUpdateService.new(
           validation_request: @ownership_certificate_validation_request,
-          params:,
-          ownership_certificate: true
+          params:
         ).call!
         render json: {message: "Change request updated"}, status: :ok
       end
@@ -46,7 +45,7 @@ module Api
 
       def set_ownership_certificate_validation_request
         @ownership_certificate_validation_request =
-          @planning_application.ownership_certificate_validation_requests.find(id: params[:id])
+          @planning_application.ownership_certificate_validation_requests.find(params[:id])
       end
     end
   end

--- a/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/api/v1/red_line_boundary_change_validation_requests_controller.rb
@@ -11,6 +11,11 @@ module Api
         render json: {message: error.message}, status: :bad_request
       end
 
+      rescue_from ActiveRecord::RecordNotFound do
+        render json: {message: "Unable to find red line boundary change validation request with id: #{params[:id]}"},
+          status: :not_found
+      end
+
       def index
         respond_to do |format|
           format.json do
@@ -24,18 +29,12 @@ module Api
         respond_to do |format|
           format.json
         end
-      rescue ActiveRecord::RecordNotFound
-        format.json do
-          render json: {message: "Unable to find red line boundary change validation request with id: #{params[:id]}"},
-            status: :not_found
-        end
       end
 
       def update
         ValidationRequestUpdateService.new(
           validation_request: @red_line_boundary_change_validation_request,
-          params:,
-          red_line_boundary_change: true
+          params:
         ).call!
 
         render json: {message: "Change request updated"}, status: :ok

--- a/app/models/description_change_validation_request.rb
+++ b/app/models/description_change_validation_request.rb
@@ -14,6 +14,10 @@ class DescriptionChangeValidationRequest < ValidationRequest
     RESPONSE_TIME_IN_DAYS.business_days.after(created_at).to_date
   end
 
+  def update_planning_application!(params)
+    planning_application.update!(description: proposed_description)
+  end
+
   private
 
   def create_audit!

--- a/app/models/ownership_certificate_validation_request.rb
+++ b/app/models/ownership_certificate_validation_request.rb
@@ -6,6 +6,14 @@ class OwnershipCertificateValidationRequest < ValidationRequest
   validates :cancel_reason, presence: true, if: :cancelled?
   validate :allows_only_one_open_ownership_certificate_change, on: :create
 
+  def update_planning_application!(params)
+    planning_application.update(valid_ownership_certificate: true)
+
+    OwnershipCertificateCreationService.new(
+      params: params[:params], planning_application:
+    ).call
+  end
+
   private
 
   def audit_api_comment

--- a/app/models/red_line_boundary_change_validation_request.rb
+++ b/app/models/red_line_boundary_change_validation_request.rb
@@ -15,6 +15,10 @@ class RedLineBoundaryChangeValidationRequest < ValidationRequest
     reset_validation_requests_update_counter!(planning_application.red_line_boundary_change_validation_requests)
   }
 
+  def update_planning_application!(params)
+    planning_application.update!(boundary_geojson: new_geojson)
+  end
+
   private
 
   def rejected_reason_is_present?

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -239,6 +239,11 @@ class ValidationRequest < ApplicationRecord
     !approved && rejection_reason.present?
   end
 
+  def update_planning_application!(params)
+    # Specific types of validation request use this method, which is overwritten in those models.
+    #  A couple don't hence the empty method
+  end
+
   private
 
   def send_and_add_events

--- a/app/services/validation_request_update_service.rb
+++ b/app/services/validation_request_update_service.rb
@@ -9,14 +9,16 @@ class ValidationRequestUpdateService
     @planning_application = validation_request.planning_application
   end
 
+  attr_reader :validation_request, :params, :planning_application
+
   def call!
     ActiveRecord::Base.transaction do
-      @validation_request.update!(validation_request_params)
-      @validation_request.close!
-      @validation_request.create_api_audit!
-      @planning_application.send_update_notification_to_assessor
+      validation_request.update!(validation_request_params)
+      validation_request.close!
+      validation_request.create_api_audit!
+      planning_application.send_update_notification_to_assessor
 
-      update_planning_application if @validation_request.approved?
+      validation_request.update_planning_application!(ownership_certificate_params) if validation_request.approved?
     end
   rescue => exception
     raise UpdateError, (exception.message || "Unable to update request. Please ensure response is present")
@@ -24,27 +26,13 @@ class ValidationRequestUpdateService
 
   private
 
-  def update_planning_application
-    case @validation_request.type
-    when "RedLineBoundaryChangeValidationRequest"
-      @planning_application.update!(boundary_geojson: @validation_request.new_geojson)
-    when "DescriptionChangeValidationRequest"
-      @planning_application.update!(description: @validation_request.proposed_description)
-    when "OwnershipCertificateValidationRequest"
-      @planning_application.update(valid_ownership_certificate: true)
-      OwnershipCertificateCreationService.new(
-        params: ownership_certificate_params[:params], planning_application: @planning_application
-      ).call
-    end
-  end
-
   def ownership_certificate_params
-    @params.require(:data).permit(
+    params.require(:data).permit(
       params: [:certificate_type, land_owners: %i[name address_1 address_2 town city postcode notice_given notice_given_at]]
     )
   end
 
   def validation_request_params
-    @params.require(:data).permit(:approved, :rejection_reason, :response, supporting_documents: [])
+    params.require(:data).permit(:approved, :rejection_reason, :response, supporting_documents: [])
   end
 end

--- a/app/services/validation_request_update_service.rb
+++ b/app/services/validation_request_update_service.rb
@@ -3,11 +3,12 @@
 class ValidationRequestUpdateService
   class UpdateError < StandardError; end
 
-  def initialize(validation_request:, params:, ownership_certificate: false)
+  def initialize(validation_request:, params:, ownership_certificate: false, red_line_boundary_change: false)
     @validation_request = validation_request
     @params = params
     @planning_application = validation_request.planning_application
     @ownership_certificate = ownership_certificate
+    @red_line_boundary_change = red_line_boundary_change
   end
 
   def call!
@@ -17,7 +18,8 @@ class ValidationRequestUpdateService
       @validation_request.create_api_audit!
       @planning_application.send_update_notification_to_assessor
 
-      further_update if @ownership_certificate
+      further_update if @ownership_certificate && @validation_request.approved?
+      another_update if @red_line_boundary_change && @validation_request.approved?
     end
   rescue => exception
     raise UpdateError, (exception.message || "Unable to update request. Please ensure response is present")
@@ -26,12 +28,14 @@ class ValidationRequestUpdateService
   private
 
   def further_update
-    if @validation_request.approved?
-      @planning_application.update(valid_ownership_certificate: true)
-      OwnershipCertificateCreationService.new(
-        params: ownership_certificate_params[:params], planning_application: @planning_application
-      ).call
-    end
+    @planning_application.update(valid_ownership_certificate: true)
+    OwnershipCertificateCreationService.new(
+      params: ownership_certificate_params[:params], planning_application: @planning_application
+    ).call
+  end
+
+  def another_update
+    @planning_application.update!(boundary_geojson: @validation_request.new_geojson)
   end
 
   def ownership_certificate_params

--- a/spec/requests/api/description_change_validation_request_put_spec.rb
+++ b/spec/requests/api/description_change_validation_request_put_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   it "creates audit associated with API user" do
     patch(path, params:, headers:)
 
-    expect(planning_application.audits.reload.last).to have_attributes(
+    expect(planning_application.audits[-2]).to have_attributes(
       activity_type: "description_change_validation_request_received",
       audit_comment: {response: "approved"}.to_json,
       activity_information: "1",

--- a/spec/requests/api/fee_change_validation_request_put_spec.rb
+++ b/spec/requests/api/fee_change_validation_request_put_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API request to list change requests", show_exceptions: true do
+  let!(:api_user) { create(:api_user) }
+
+  let(:path) do
+    "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}"
+  end
+
+  let(:params) do
+    {
+      change_access_id: planning_application.change_access_id,
+      data: {response: "I will send an extra payment"}
+    }
+  end
+
+  let(:headers) do
+    {Authorization: "Bearer #{api_user.token}"}
+  end
+
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user) }
+
+  let!(:planning_application) do
+    create(
+      :planning_application,
+      :invalidated,
+      user:,
+      local_authority: default_local_authority
+    )
+  end
+
+  let!(:fee_change_validation_request) do
+    create(:fee_change_validation_request,
+      planning_application:)
+  end
+
+  valid_response = '{
+    "data": {
+      "response": "I will send an extra payment"
+    }
+  }'
+
+  missing_response = '{
+    "data": {
+      "response": ""
+    }
+  }'
+
+  it "successfully accepts a response" do
+    patch(path, params:, headers:)
+
+    expect(response).to be_successful
+
+    fee_change_validation_request.reload
+    planning_application.reload
+    expect(fee_change_validation_request.state).to eq("closed")
+    expect(fee_change_validation_request.response).to eq("I will send an extra payment")
+  end
+
+  it "creates audit associated with API user" do
+    patch(path, params:, headers:)
+
+    expect(planning_application.audits.reload.last).to have_attributes(
+      activity_type: "fee_change_validation_request_received",
+      audit_comment: {response: "I will send an extra payment"}.to_json,
+      activity_information: "1",
+      api_user:
+    )
+  end
+
+  it "sends notification to assigned user" do
+    expect { patch(path, params:, headers:) }
+      .to have_enqueued_job
+      .on_queue("low_priority")
+      .with(
+        "UserMailer",
+        "update_notification_mail",
+        "deliver_now",
+        args: [planning_application, user.email]
+      )
+  end
+
+  it "returns a 401 if API key is wrong" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+      params: valid_response,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it "returns a 401 if change_access_id is wrong" do
+    patch "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=CHANGEISGOOD",
+      params: valid_response,
+      headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+end

--- a/spec/requests/api/fee_change_validation_request_put_spec.rb
+++ b/spec/requests/api/fee_change_validation_request_put_spec.rb
@@ -43,12 +43,6 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
     }
   }'
 
-  missing_response = '{
-    "data": {
-      "response": ""
-    }
-  }'
-
   it "successfully accepts a response" do
     patch(path, params:, headers:)
 


### PR DESCRIPTION
### Description of change

There is now a ValidationRequestUpdateService, so the other validation requests should use it

I haven't done replacement_documents and additional_documents because they seemed too different?
