### PR TITLE
Fee calculation fixes

### DIFF
--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -16,7 +16,15 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
   end
 
   def example_request_json_for(path, http_method, example_name)
-    document.paths[path][http_method].request_body.content["application/json"].examples[example_name].value.to_h.to_json
+    value = document.paths[path][http_method].request_body.content["application/json"].examples[example_name].value.merge(
+      planx_debug_data: {passport: {data: {
+        "application.fee.calculated": 206,
+        "application.fee.payable": 103,
+        "application.fee.reduction.parishCouncil": ["true"]
+      }}}
+    )
+
+    value.to_json
   end
 
   def example_response_json_for(path, http_method, response_code, example_name)

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -80,6 +80,10 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
     expect(result.result_heading).to eq("It looks like these changes will need planning permission")
     expect(result.result_description).to eq("Based on the information you have provided, we do not think this is eligible for a Lawful Development Certificate")
     expect(result.result_override).to eq("This was my reason for rejecting the result")
+
+    expect(result.fee_calculation.total_fee).to eq(206)
+    expect(result.fee_calculation.payable_fee).to eq(103)
+    expect(result.fee_calculation.requested_fee).to be_nil
   end
 
   it "successfully returns the listing of applications as specified" do

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
   let!(:api_user) { create(:api_user) }
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:application_type) { create(:application_type) }
+  let(:result) { PlanningApplication.last }
 
   before do
     stub_planx_api_response_for("POLYGON ((-0.07716178894042969 51.50094238217541, -0.07645905017852783 51.50053497847238, -0.07615327835083008 51.50115276135022, -0.07716178894042969 51.50094238217541))").to_return(
@@ -52,33 +53,33 @@ RSpec.describe "The Open API Specification document", show_exceptions: true do
         headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     end.to change(PlanningApplication, :count).by(1)
     expect(response.code).to eq("200")
-    expect(PlanningApplication.last.application_type.name).to eq("lawfulness_certificate")
-    expect(PlanningApplication.last.description).to eq("Add a chimney stack")
-    expect(PlanningApplication.last.payment_reference).to eq("PAY1")
-    expect(PlanningApplication.last.payment_amount).to eq(103.00)
-    expect(PlanningApplication.last.applicant_first_name).to eq("Albert")
-    expect(PlanningApplication.last.applicant_last_name).to eq("Manteras")
-    expect(PlanningApplication.last.applicant_phone).to eq("23432325435")
-    expect(PlanningApplication.last.applicant_email).to eq("applicant@example.com")
-    expect(PlanningApplication.last.agent_first_name).to eq("Jennifer")
-    expect(PlanningApplication.last.agent_last_name).to eq("Harper")
-    expect(PlanningApplication.last.agent_phone).to eq("237878889")
-    expect(PlanningApplication.last.agent_email).to eq("agent@example.com")
-    expect(PlanningApplication.last.user_role).to eq("agent")
-    expect(PlanningApplication.last.address_1).to eq("11 Abbey Gardens")
-    expect(PlanningApplication.last.address_2).to eq("Southwark")
-    expect(PlanningApplication.last.uprn).to eq("100081043511")
-    expect(PlanningApplication.last.town).to eq("London")
-    expect(PlanningApplication.last.postcode).to eq("SE16 3RQ")
-    expect(PlanningApplication.last.work_status).to eq("proposed")
-    expect(PlanningApplication.last.boundary_geojson).to eq({"type" => "Feature", "geometry" => {"type" => "Polygon", "coordinates" => [[[-0.07716178894042969, 51.50094238217541], [-0.07645905017852783, 51.50053497847238], [-0.07615327835083008, 51.50115276135022], [-0.07716178894042969, 51.50094238217541]]]}})
-    expect(PlanningApplication.last.proposal_details.first.question).to eq("What do you want to do?")
-    expect(PlanningApplication.last.documents.first.file).to be_present
-    expect(PlanningApplication.last.documents.first.applicant_description).to eq("This is the side plan")
-    expect(PlanningApplication.last.result_flag).to eq("Planning permission / Permission needed")
-    expect(PlanningApplication.last.result_heading).to eq("It looks like these changes will need planning permission")
-    expect(PlanningApplication.last.result_description).to eq("Based on the information you have provided, we do not think this is eligible for a Lawful Development Certificate")
-    expect(PlanningApplication.last.result_override).to eq("This was my reason for rejecting the result")
+    expect(result.application_type.name).to eq("lawfulness_certificate")
+    expect(result.description).to eq("Add a chimney stack")
+    expect(result.payment_reference).to eq("PAY1")
+    expect(result.payment_amount).to eq(103.00)
+    expect(result.applicant_first_name).to eq("Albert")
+    expect(result.applicant_last_name).to eq("Manteras")
+    expect(result.applicant_phone).to eq("23432325435")
+    expect(result.applicant_email).to eq("applicant@example.com")
+    expect(result.agent_first_name).to eq("Jennifer")
+    expect(result.agent_last_name).to eq("Harper")
+    expect(result.agent_phone).to eq("237878889")
+    expect(result.agent_email).to eq("agent@example.com")
+    expect(result.user_role).to eq("agent")
+    expect(result.address_1).to eq("11 Abbey Gardens")
+    expect(result.address_2).to eq("Southwark")
+    expect(result.uprn).to eq("100081043511")
+    expect(result.town).to eq("London")
+    expect(result.postcode).to eq("SE16 3RQ")
+    expect(result.work_status).to eq("proposed")
+    expect(result.boundary_geojson).to eq({"type" => "Feature", "geometry" => {"type" => "Polygon", "coordinates" => [[[-0.07716178894042969, 51.50094238217541], [-0.07645905017852783, 51.50053497847238], [-0.07615327835083008, 51.50115276135022], [-0.07716178894042969, 51.50094238217541]]]}})
+    expect(result.proposal_details.first.question).to eq("What do you want to do?")
+    expect(result.documents.first.file).to be_present
+    expect(result.documents.first.applicant_description).to eq("This is the side plan")
+    expect(result.result_flag).to eq("Planning permission / Permission needed")
+    expect(result.result_heading).to eq("It looks like these changes will need planning permission")
+    expect(result.result_description).to eq("Based on the information you have provided, we do not think this is eligible for a Lawful Development Certificate")
+    expect(result.result_override).to eq("This was my reason for rejecting the result")
   end
 
   it "successfully returns the listing of applications as specified" do


### PR DESCRIPTION
### Description of change

Applications created through the API (e.g., cloning, Swagger, but therefore probably also from PlanX directly) weren't getting the FeeCalculation created properly because of how the parameters were handled. 

### Story Link

https://trello.com/c/LcUWqL8i/2148-show-how-the-application-fee-has-been-calculated

### Known issues 

This might make [`PlanningApplication#create_fee_calculation`](https://github.com/unboxed/bops/blob/main/app/models/planning_application.rb#L752) superfluous.