### PR TITLE
Show 'none' when appropriate for fee exemptions/reductions

### DIFF
--- a/app/views/planning_applications/validation/fee_items/show.html.erb
+++ b/app/views/planning_applications/validation/fee_items/show.html.erb
@@ -27,26 +27,30 @@
               £<%= @planning_application.fee_calculation.total_fee || 0 %>
             </td>
           </tr>
-          <% unless @planning_application.fee_calculation.exemptions.empty? %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                Exemptions
-              </th>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Exemptions
+            </th>
               <td class="govuk-table__cell">
+              <% if @planning_application.fee_calculation.exemptions.present? %>
                 <%= @planning_application.fee_calculation.exemptions.map(&:humanize).to_sentence %>
-              </td>
-            </tr>
-          <% end %>
-          <% unless @planning_application.fee_calculation.reductions.empty? %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">
-                Reductions
-              </th>
-              <td class="govuk-table__cell">
+              <% else %>
+                None
+              <% end %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">
+              Reductions
+            </th>
+            <td class="govuk-table__cell">
+              <% if @planning_application.fee_calculation.reductions.present? %>
                 <%= @planning_application.fee_calculation.reductions.map(&:humanize).to_sentence %>
-              </td>
-            </tr>
-          <% end %>
+              <% else %>
+                None
+              <% end %>
+            </td>
+          </tr>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">
               Discount


### PR DESCRIPTION
### Description of change

Make it clearer that there are no fee exemptions or reductions by showing 'none' rather than hiding the field.

### Story Link

https://trello.com/c/LcUWqL8i/2148-show-how-the-application-fee-has-been-calculated