### PR TITLE
Add description validation to validation tasks

### DIFF
--- a/app/components/task_list_items/description_change.rb
+++ b/app/components/task_list_items/description_change.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class DescriptionChange < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+    end
+
+    private
+
+    attr_reader :planning_application
+
+    delegate(:description_change_validation_requests, to: :planning_application)
+
+    def link_text
+      t(".check_description")
+    end
+
+    def link_path
+      case status
+      when :valid, :not_started
+        planning_application_validation_description_changes_path(
+          planning_application
+        )
+      else
+        planning_application_validation_description_change_validation_request_path(
+          planning_application,
+          description_change_validation_requests.not_cancelled.last
+        )
+      end
+    end
+
+    def status
+      @status ||= if planning_application.valid_description?
+        :valid
+      elsif description_change_validation_requests.open_or_pending.any?
+        :invalid
+      elsif description_change_validation_requests.closed.any?
+        :updated
+      else
+        :not_started
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/validation/description_changes_controller.rb
+++ b/app/controllers/planning_applications/validation/description_changes_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Validation
+    class DescriptionChangesController < ValidationRequestsController
+      before_action :ensure_planning_application_not_validated, only: %i[show validate]
+
+      def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def validate
+        @planning_application.update(description_changes_params)
+
+        respond_to do |format|
+          format.html do
+            if @planning_application.valid_description?
+              redirect_to planning_application_validation_tasks_path(@planning_application),
+                notice: t(".success")
+            elsif @planning_application.valid_description.nil?
+              flash.now[:alert] = "Select Yes or No to continue."
+              render :show
+            else
+              redirect_to new_planning_application_validation_validation_request_path(@planning_application, type: "description_change")
+            end
+          end
+        end
+      end
+
+      private
+
+      def description_changes_params
+        params[:planning_application] ? params.require(:planning_application).permit(:valid_description) : params.permit(:valid_description)
+      end
+    end
+  end
+end

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -18,7 +18,7 @@
     <% else %>
       <p class="govuk-body">
         <% if @planning_application.description_change_validation_requests.open.any? %>
-          <%= link_to "View requested change", planning_application_validation_validation_request_path(@planning_application, @planning_application.description_changes_validation_request.id), class: "govuk-link" %>
+          <%= link_to "View requested change", planning_application_validation_validation_request_path(@planning_application, @planning_application.description_change_validation_request.id), class: "govuk-link" %>
         <% elsif !@planning_application.closed_or_cancelled? %>
           <%= link_to "Propose a change to the description", new_planning_application_validation_validation_request_path(@planning_application, type: "description_change"), class: "govuk-link" %>
         <% end %>

--- a/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
@@ -56,11 +56,15 @@
             </span>
           </p>
         <% end %>
-        <%= form.hidden_field(:return_to, value: @back_path) %>
         <%= form.hidden_field(:type, value: "DescriptionChangeValidationRequest") %>
         <%= form.govuk_text_area :proposed_description,
-      label: { text: 'Please suggest a new application description', class: 'govuk-label govuk-label--s'},
-      rows: 5 %>
+          label: { text: 'Suggest a new application description', class: 'govuk-label govuk-label--s'},
+          rows: 5 %>
+        <% if @planning_application.not_started? %>
+          <%= form.hidden_field(:return_to, value: planning_application_validation_tasks_path(@planning_application)) %>
+        <% else %>
+          <%= form.hidden_field(:return_to, value: @back_path) %>
+        <% end %>
         <div class="govuk-button-group">
           <%= form.govuk_submit "Send" %>
           <%= back_link %>

--- a/app/views/planning_applications/validation/description_change_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_show.html.erb
@@ -22,14 +22,16 @@
         <%= @validation_request.previous_description  %>
       </p>
       <p class="govuk-body"> <strong> Proposed description:</strong><br>
-        <%= render(FormattedContentComponent.new(text: @validation_request.proposed_description)) %>
+        <%= @validation_request.proposed_description %>
       </p>
     </div>
     <p class="govuk-body">
-      <% if @validation_request.open? %>
-        Sent on <%= @validation_request.created_at.to_date.to_fs %>. Agent or applicant has not yet responded.
-      <% else %>
-        <%= @validation_request.approved? ? 'Approved' : 'Rejected' %>
+      <% if @planning_application.invalidated? %>
+        <% if @validation_request.open? %>
+          Sent on <%= @validation_request.created_at.to_date.to_fs %>. Agent or applicant has not yet responded.
+        <% else %>
+          <%= @validation_request.approved? ? 'Approved' : 'Rejected' %>
+        <% end %>
       <% end %>
     </p>
 

--- a/app/views/planning_applications/validation/description_changes/show.html.erb
+++ b/app/views/planning_applications/validation/description_changes/show.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title do %>
+  Check the description - <%= t('page_title') %>
+<% end %>
+
+<%= render "planning_applications/validation/validation_requests/validation_requests_breadcrumbs" %>
+<% content_for :title, "Check the description" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Check the description" }
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @planning_application, url: validate_planning_application_validation_description_changes_path(@planning_application) do |form| %>
+      <%= form.govuk_radio_buttons_fieldset :valid_description, legend: { text: "Does the description match the development or use in the plans?"} do %>
+        <%= form.govuk_radio_button :valid_description, true, label: { text: "Yes"} %>
+        <%= form.govuk_radio_button :valid_description, false, label: { text: "No" } %>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_applications/validation/tasks/_description.erb
+++ b/app/views/planning_applications/validation/tasks/_description.erb
@@ -1,0 +1,20 @@
+<li id="description-validation-task">
+  <h2 class="app-task-list__section">
+    Description
+  </h2>
+  <ul class="app-task-list__items">
+    <% if @planning_application.validated? %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          Planning application has already been validated
+        </span>
+      </li>
+    <% else %>
+      <%= render(
+        TaskListItems::DescriptionChange.new(
+          planning_application: @planning_application
+        )
+      ) %>
+    <% end %>
+  </ul>
+</li>

--- a/app/views/planning_applications/validation/tasks/index.html.erb
+++ b/app/views/planning_applications/validation/tasks/index.html.erb
@@ -28,6 +28,8 @@
     <ol class="app-task-list govuk-!-margin-top-8">
       <%= render "red_line_boundary" %>
 
+      <%= render "description" %>
+
       <%= render "fee_validation" %>
 
       <%= render "cil_liability" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1315,6 +1315,9 @@ en:
         show:
           back: Back
           cancel_this_request: Cancel this request
+      description_changes:
+        validate:
+          success: Description was marked as valid
       document:
         redactions:
           create:
@@ -1620,6 +1623,8 @@ en:
       link_text: Confirm site notice
     consultee_responses_component:
       consultee_responses: View consultee responses
+    description_change:
+      check_description: Check description
     document_component:
       check_document: Check document - %{document}
     email_consultees_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,6 +154,10 @@ Rails.application.routes.draw do
           patch :validate
         end
 
+        resource :description_changes, only: %i[show] do
+          patch :validate
+        end
+
         resource :fee_items, only: %i[show] do
           patch :validate
         end

--- a/db/migrate/20240112123201_add_valid_description_to_planning_application.rb
+++ b/db/migrate/20240112123201_add_valid_description_to_planning_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddValidDescriptionToPlanningApplication < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :valid_description, :boolean # rubocop:disable Rails/ThreeStateBooleanColumn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_08_134128) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_12_123201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -563,6 +563,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_08_134128) do
     t.geography "lonlat", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.datetime "not_started_at"
     t.boolean "valid_ownership_certificate"
+    t.boolean "valid_description"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -34,7 +34,7 @@ Feature: Creating a description change on the application
   Scenario: I cannot create a second description change request when an open one exists
     Given I create a description change request with "A yard full of bananas"
     When I visit the new description change request link
-    And I fill in "Please suggest a new application description" with "Mambo number 2"
+    And I fill in "Suggest a new application description" with "Mambo number 2"
     And I press "Send"
     Then the page contains "An open description change already exists for this planning application."
 

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -18,7 +18,7 @@ Given("I create a description change request with {string}") do |details|
     And I press "Check and validate"
     And I press "Application information"
     And I press "Propose a change to the description"
-    And I fill in "Please suggest a new application description" with "#{details}"
+    And I fill in "Suggest a new application description" with "#{details}"
     And I press "Send"
   )
 end

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -252,7 +252,7 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Please suggest a new application description",
+      "Suggest a new application description",
       with: "New description"
     )
 
@@ -284,7 +284,7 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Please suggest a new application description",
+      "Suggest a new application description",
       with: "New description 2"
     )
 
@@ -319,7 +319,7 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Please suggest a new application description",
+      "Suggest a new application description",
       with: "New description 3"
     )
 

--- a/spec/system/planning_applications/description_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/description_change_validation_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Requesting description changes to a planning application" do
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
   let!(:planning_application) do
-    create(:planning_application, :not_started, local_authority: default_local_authority)
+    create(:planning_application, :in_assessment, local_authority: default_local_authority)
   end
 
   let!(:api_user) { create(:api_user, name: "Api Wizard") }
@@ -31,12 +31,12 @@ RSpec.describe "Requesting description changes to a planning application" do
     visit "/planning_applications/#{planning_application.id}/assessment/tasks"
     click_button("Application information")
     click_link("Propose a change to the description")
-    fill_in("Please suggest a new application description", with: "")
+    fill_in("Suggest a new application description", with: "")
     click_button("Send")
 
     expect(page).to have_content("Proposed description can't be blank")
 
-    fill_in("Please suggest a new application description", with: "description")
+    fill_in("Suggest a new application description", with: "description")
     click_button "Send"
 
     expect(page).to have_text("Description change request successfully sent.")

--- a/spec/system/planning_applications/validating/description_changes_validation_spec.rb
+++ b/spec/system/planning_applications/validating/description_changes_validation_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "DescriptionChangesValidation" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  before do
+    sign_in assessor
+  end
+
+  context "when application is not started" do
+    let!(:planning_application) do
+      create(
+        :planning_application, :not_started, :from_planx_prior_approval,
+        local_authority: default_local_authority
+      )
+    end
+
+    it "I can validate the description" do
+      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      within("#description-validation-task") do
+        expect(page).to have_content("Not started")
+      end
+
+      click_link "Check description"
+
+      within(".govuk-fieldset") do
+        expect(page).to have_content("Does the description match the development or use in the plans?")
+
+        within(".govuk-radios") { choose "Yes" }
+      end
+
+      click_button "Save"
+
+      expect(page).to have_content("Description was marked as valid")
+
+      within("#description-validation-task") do
+        expect(page).to have_content("Valid")
+      end
+
+      expect(planning_application.reload.valid_description).to be_truthy
+      expect(DescriptionChangeValidationRequest.all.length).to eq(0)
+    end
+
+    it "I get validation errors when I omit required information" do
+      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      click_link "Check description"
+      click_button "Save"
+
+      expect(page).to have_content("Select Yes or No to continue.")
+
+      within(".govuk-fieldset") do
+        within(".govuk-radios") { choose "No" }
+      end
+      click_button "Save"
+      click_button "Send"
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("Proposed description can't be blank")
+      end
+    end
+
+    it "I can invalidate the description" do
+      expect(PlanningApplicationMailer).to receive(:description_change_mail).and_call_original
+
+      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      click_link "Check description"
+
+      within(".govuk-fieldset") do
+        within(".govuk-radios") { choose "No" }
+      end
+
+      click_button "Save"
+
+      expect(page).to have_current_path(
+        "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=description_change"
+      )
+      expect(page).to have_content("Description change")
+      expect(page).to have_content("Application number: #{planning_application.reference}")
+
+      fill_in(
+        "Suggest a new application description",
+        with: "My better description"
+      )
+
+      click_button "Send"
+
+      expect(page).to have_content("Description change request successfully sent.")
+
+      within("#description-validation-task") do
+        expect(page).to have_content("Invalid")
+      end
+
+      expect(planning_application.reload.valid_description).to be_falsey
+      expect(DescriptionChangeValidationRequest.all.length).to eq(1)
+
+      click_link "Check description"
+
+      description_change_validation_request = DescriptionChangeValidationRequest.last
+
+      expect(page).to have_current_path(
+        "/planning_applications/#{planning_application.id}/validation/description_change_validation_requests/#{description_change_validation_request.id}"
+      )
+
+      expect(page).to have_content("My better description")
+
+      click_link "Back"
+      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/validation/tasks")
+    end
+  end
+
+  context "when an application has been validated" do
+    let!(:planning_application) do
+      create(:planning_application, :in_assessment, local_authority: default_local_authority)
+    end
+
+    it "does not allow you to validate documents" do
+      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+
+      within("#description-validation-task") do
+        expect(page).to have_content("Planning application has already been validated")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add validating the application description to the validation tasks 

### Story Link

https://trello.com/c/k6POLo4m/2172-officer-decides-the-description-and-advises-the-applicant

### Screenshots

![Screenshot 2024-01-12 at 15 59 35](https://github.com/unboxed/bops/assets/35098639/5b00bbec-2dda-4630-b61f-f41aababab73)
![Screenshot 2024-01-12 at 15 59 50](https://github.com/unboxed/bops/assets/35098639/e327380e-7e38-4799-a8a3-778b435defce)
