### PR TITLE
Show total search results and specify max when over 1000 records returned

### DIFF
--- a/app/javascript/controllers/polygon_search_controller.js
+++ b/app/javascript/controllers/polygon_search_controller.js
@@ -47,7 +47,8 @@ export default class extends Controller {
       const response = await this.fetchGeojsonData(geoJSON, this.getCSRFToken())
       const data = await response.json()
 
-      this.appendAddressesToPage(data)
+      this.appendAddressesToPage(data.addresses)
+      this.showTotalResults(data.total_results)
     } catch (error) {
       console.error("There was an error calling the OS Places API:", error)
     } finally {
@@ -247,6 +248,28 @@ export default class extends Controller {
     )
 
     hiddenInputs.forEach((input) => input.parentNode.removeChild(input))
+  }
+
+  showTotalResults(totalResults) {
+    const paragraph = document.createElement("p")
+    paragraph.classList.add("govuk-body", "govuk-!-font-weight-bold")
+    paragraph.textContent = `Your search has returned ${totalResults} results.`
+
+    if (totalResults > 1000) {
+      paragraph.appendChild(
+        document.createTextNode(
+          " The first 1000 results are shown below. Check your search area or contact support at ",
+        ),
+      )
+      const emailLink = document.createElement("a")
+      emailLink.href = "mailto:bops-team@unboxed.co"
+      emailLink.textContent = "bops-team@unboxed.co"
+      paragraph.appendChild(emailLink)
+      paragraph.appendChild(
+        document.createTextNode(" if you need to see more than 1000 results."),
+      )
+    }
+    this.getAddressContainer().prepend(paragraph)
   }
 
   debounce(func, wait) {

--- a/app/services/apis/os_places/polygon_search_service.rb
+++ b/app/services/apis/os_places/polygon_search_service.rb
@@ -20,7 +20,7 @@ module Apis
       def call
         fetch_all_addresses
 
-        all_addresses
+        {total_results: @total_results, addresses: all_addresses}
       end
 
       private

--- a/spec/services/apis/os_places/client_spec.rb
+++ b/spec/services/apis/os_places/client_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: t
           }
         )
 
-        expect(result).to eq(["5, COXSON WAY, LONDON, SE1 2XB", "6, COXSON WAY, LONDON, SE1 2XB"])
+        expect(result[:addresses]).to eq(["5, COXSON WAY, LONDON, SE1 2XB", "6, COXSON WAY, LONDON, SE1 2XB"])
       end
     end
 
@@ -100,10 +100,11 @@ RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: t
           }
         )
 
-        expect(result.length).to eq(103)
-        expect(result).to include(
+        expect(result[:addresses].length).to eq(103)
+        expect(result[:addresses]).to include(
           "1, Example Street, LONDON, SE1 2XB", "2, Example Street, LONDON, SE1 2XB", "102, Example Street, LONDON, SE1 2XB", "103, Example Street, LONDON, SE1 2XB"
         )
+        expect(result[:total_results]).to eq(103)
       end
     end
   end

--- a/spec/services/apis/os_places/polygon_search_service_spec.rb
+++ b/spec/services/apis/os_places/polygon_search_service_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
         key: Rails.configuration.os_vector_tiles_api_key
       }
     }
+    let(:data) { described_class.new(geojson, params).call }
+    let(:addresses) { data[:addresses] }
+    let(:total_results) { data[:total_results] }
 
     context "when total addresses found is less than 100" do
       before do
@@ -40,9 +43,8 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
       end
 
       it "returns all the addresses with one API request" do
-        addresses = described_class.new(geojson, params).call
-
         expect(addresses).to eq(["5, COXSON WAY, LONDON, SE1 2XB", "6, COXSON WAY, LONDON, SE1 2XB"])
+        expect(total_results).to eq(2)
       end
     end
 
@@ -56,12 +58,11 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
         expect(Faraday).to receive(:new).once.and_call_original
         expect_any_instance_of(Faraday::Connection).to receive(:post).twice.and_call_original
 
-        addresses = described_class.new(geojson, params).call
-
         expect(addresses.length).to eq(103)
         expect(addresses).to include(
           "1, Example Street, LONDON, SE1 2XB", "2, Example Street, LONDON, SE1 2XB", "102, Example Street, LONDON, SE1 2XB", "103, Example Street, LONDON, SE1 2XB"
         )
+        expect(total_results).to eq(103)
       end
     end
   end

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -187,6 +187,23 @@ RSpec.describe "Send letters to neighbours", js: true do
         expect(page).to have_content("Red line boundary")
         expect(page).to have_content("Area of selected neighbours")
       end
+
+      within("#address-container") do
+        expect(page).to have_content("Your search has returned 2 results.")
+      end
+    end
+
+    context "when search returns more than 100 addresses" do
+      before do
+        allow_any_instance_of(Apis::OsPlaces::PolygonSearchService).to receive(:call).and_return({total_results: 1001, addresses: []})
+      end
+
+      it "shows that the max total results returned for a search is 1000" do
+        within("#address-container") do
+          expect(page).to have_content("Your search has returned 1001 results. The first 1000 results are shown below. Check your search area or contact support at bops-team@unboxed.co if you need to see more than 1000 results.")
+          expect(page).to have_link("bops-team@unboxed.co", href: "mailto:bops-team@unboxed.co")
+        end
+      end
     end
 
     it "I can add the neighbour addresses that are returned" do


### PR DESCRIPTION
### Description of change

Show total results returned from polygon search. If results exceed 1000, then show message that we've limited to just returning the first 1000 but that the user should check their search or contact support if necessary.

We might want to add some more formatting to the message if deemed necessary from user testing

### Story Link

https://trello.com/c/ve4KXoVO/1902-allow-for-more-than-100-addresses-to-be-added-as-part-of-searching-neighbour-addresses-using-polygon

### Screenshots

![Screenshot 2024-01-15 at 13 32 04](https://github.com/unboxed/bops/assets/34001723/f4bbe8e1-85ba-404e-98dc-fd0205128496)
![Screenshot 2024-01-15 at 13 41 34](https://github.com/unboxed/bops/assets/34001723/5ff4c0f7-1efc-4bcd-a807-1666d6af2833)

