### PR TITLE
Mark application as requiring an EIA

### DIFF
--- a/app/controllers/planning_applications/validation/environment_impact_assessments_controller.rb
+++ b/app/controllers/planning_applications/validation/environment_impact_assessments_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Validation
+    class EnvironmentImpactAssessmentsController < AuthenticationController
+      before_action :set_planning_application
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @planning_application.update(environmental_impact_assessment_params)
+            success_message = @planning_application.environment_impact_assessment ? ".success_yes" : ".success_no"
+            format.html { redirect_to planning_application_validation_tasks_path(@planning_application), notice: t(success_message) }
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def environmental_impact_assessment_params
+        params.require(:planning_application).permit(:environment_impact_assessment)
+      end
+    end
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -77,6 +77,7 @@ class Document < ApplicationRecord
     "Contaminated Land Assessment",
     "Daylight and Sunlight Assessment",
     "Flood Risk Assessment/Drainage and SuDs Report",
+    "Environment Impact Assessment",
     "Landscape and Visual Impact Assessment",
     "Noise Impact Assessment",
     "Open Space Assessment",

--- a/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
+++ b/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
@@ -1,0 +1,39 @@
+<%= form_with model: [@planning_application], url: planning_application_validation_environment_impact_assessment_url(@planning_application) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+      :environment_impact_assessment,
+      legend: { size: "m" }
+    ) do %>
+      <p class="govuk-body">
+        <%= link_to(
+          "Check EIA guidance",
+          t("environment_impact_assessment.guidance_link"),
+          class: "govuk-link",
+          target: "_blank"
+        ) %>
+      </p>
+      <%= form.govuk_radio_button(
+        :environment_impact_assessment, 
+        true, 
+        checked: @planning_application.environment_impact_assessment, 
+        label: { text: t(".label.yes") }, 
+        hint: { text: t(".hint") }
+      ) %>
+      <%= form.govuk_radio_button(
+        :environment_impact_assessment, 
+        false, 
+        checked: @planning_application.environment_impact_assessment == false, 
+        label: { text: t(".label.no") }
+      ) %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= form.submit(
+      t("form_actions.save_and_mark_as_complete"),
+      class: "govuk-button",
+      data: { module: "govuk-button" }
+    ) %>
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/validation/environment_impact_assessments/edit.html.erb
+++ b/app/views/planning_applications/validation/environment_impact_assessments/edit.html.erb
@@ -1,0 +1,17 @@
+<% content_for :page_title do %>
+  Environment Impact Assessment (EIA) - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+  partial: "planning_applications/validation/validation_requests/validation_requests_breadcrumbs",
+  locals: { planning_application: @planning_application }
+) %>
+
+<% content_for :title, "Environment Impact Assessment (EIA)" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Environment Impact Assessment (EIA)" }
+) %>
+
+<%= render "form" %>

--- a/app/views/planning_applications/validation/tasks/_environment_impact_assessment.html.erb
+++ b/app/views/planning_applications/validation/tasks/_environment_impact_assessment.html.erb
@@ -1,0 +1,18 @@
+<li id="environment-impact-assessment-task">
+  <h2 class="app-task-list__section">
+    Environment Impact Assessment (EIA)
+  </h2>
+  <ul class="app-task-list__items">
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        <%= link_to "Check Environment Impact Assessment", edit_planning_application_validation_environment_impact_assessment_path(@planning_application), class: "govuk-link" %>
+      </span>
+
+      <%= render(
+        StatusTags::BaseComponent.new(
+          status: @planning_application.environment_impact_assessment_status
+        )
+      ) %>
+    </li>
+  </ul>
+</li>

--- a/app/views/planning_applications/validation/tasks/index.html.erb
+++ b/app/views/planning_applications/validation/tasks/index.html.erb
@@ -34,6 +34,8 @@
 
       <%= render "cil_liability" %>
 
+      <%= render "environment_impact_assessment" %>
+
       <%= render "ownership_certificate" %>
 
       <%= render "constraints" %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -8,6 +8,7 @@
         Not yet valid
       <% end %>
     </p>
+
     <% if @planning_application.consultation.present? %>
       <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>Consultation start date:</strong>
@@ -63,6 +64,11 @@
         </span>
       <% end %>
     </p>
+
+    <% if @planning_application.environment_impact_assessment %>
+      <p class="govuk-body govuk-!-margin-bottom-0"><strong>Subject to an EIA</strong></p>
+      <p class="govuk-body">The expiry date has been extended to 16 weeks</p>
+    <% end %>
 
     <% if @planning_application.in_progress? %>
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -682,6 +682,8 @@ en:
       validation_notice_mail: Your application for a %{application_type_name}
       validation_request_closure_mail: Changes to your %{application_type_name} application
       validation_request_mail: "%{application_type_name} application - further changes needed"
+  environment_impact_assessment:
+    guidance_link: https://www.gov.uk/government/publications/environmental-impact-assessment-screening-checklist
   errors:
     messages:
       date_blank: is blank
@@ -748,6 +750,7 @@ en:
         removed: Have the permitted development rights relevant for this application been removed?
       planning_application:
         determination_date: Enter determination date
+        environment_impact_assessment: Does the application require an assessment?
         received_at: Date received
         valid_fee: Is the fee valid?
         valid_red_line_boundary: Is this red line boundary valid?
@@ -1324,6 +1327,15 @@ en:
         redactions:
           create:
             success: Redacted documents successfully uploaded
+      environment_impact_assessments:
+        form:
+          hint: This application is subject to an EIA. The determination period will be extended to 16 weeks.
+          label:
+            'no': 'No'
+            'yes': 'Yes'
+        update:
+          success_no: Application marked as not requiring an EIA
+          success_yes: Application marked as requiring an EIA. The determination period is extended to 16 weeks.
       fee_change_validation_requests:
         form:
           labels:
@@ -1573,6 +1585,7 @@ en:
     neutral: Neutral
     new: New
     not_cil_liable: Not liable
+    not_required: Not required
     not_started: Not started
     objection: Objection
     permanent_failure: Permanent failure
@@ -1581,6 +1594,7 @@ en:
     refused: To refuse
     rejected: Rejected
     removed: Removed
+    required: Required
     submitted: Submitted
     supportive: Supportive
     technical_failure: Technical failure

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,8 @@ Rails.application.routes.draw do
 
         resource :cil_liability, only: %i[edit update], controller: :cil_liability
 
+        resource :environment_impact_assessment, only: %i[edit update]
+
         resource :constraints, only: %i[show update]
 
         namespace :document, as: :documents do

--- a/db/migrate/20240111154441_add_environment_impact_assessment_to_planning_applications.rb
+++ b/db/migrate/20240111154441_add_environment_impact_assessment_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEnvironmentImpactAssessmentToPlanningApplications < ActiveRecord::Migration[7.0]
+  def change
+    add_column :planning_applications, :environment_impact_assessment, :boolean, null: true # rubocop:disable Rails/ThreeStateBooleanColumn
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -564,6 +564,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_12_123201) do
     t.datetime "not_started_at"
     t.boolean "valid_ownership_certificate"
     t.boolean "valid_description"
+    t.boolean "environment_impact_assessment"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/engines/bops_api/app/services/bops_api/application/documents_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/documents_service.rb
@@ -28,6 +28,7 @@ module BopsApi
         "proposal.document.councilTaxBill" => ["Council Tax Document"],
         "proposal.document.declaration" => ["Statutory Declaration"],
         "proposal.document.designAndAccess" => ["Design and Access Statement"],
+        "proposal.document.eia" => ["Environment Impact Assessment"],
         "proposal.document.fireSafety" => ["Other Supporting Document"],
         "proposal.document.floodRisk" => ["Flood Risk Assessment/Drainage and SuDs Report"],
         "proposal.document.heritageStatement" => ["Heritage Statement"],

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -399,6 +399,48 @@ RSpec.describe PlanningApplication do
       end
     end
 
+    describe "::before_update #modify_expiry_date" do
+      let(:local_authority) { create(:local_authority) }
+      let(:assessor) { create(:user, :assessor, local_authority:) }
+      let!(:planning_application) do
+        travel_to("2024-01-01") { create(:planning_application, local_authority:) }
+      end
+
+      it "adds 8 weeks to the expiry date if an EIA is required" do
+        expect do
+          planning_application.update!(environment_impact_assessment: true)
+        end.to change(planning_application, :expiry_date).from("Mon, 26 Feb 2024".to_date).to("Mon, 22 Apr 2024".to_date)
+          .and change(Audit, :count).by(1)
+      end
+
+      it "does not get called unless the environment impact assessment value has changed" do
+        expect do
+          planning_application.update!(postcode: "111XXX")
+        end.not_to change(planning_application, :expiry_date)
+      end
+
+      context "when planning application has been marked as requiring an EIA" do
+        let!(:planning_application) do
+          travel_to("2024-01-01") do
+            create(:planning_application, local_authority:, environment_impact_assessment: true, target_date: "Mon, 22 Apr 2024".to_date, expiry_date: "Mon, 22 Apr 2024".to_date)
+          end
+        end
+
+        it "sets the original expiry date if the EIA is no longer required" do
+          expect do
+            planning_application.update!(environment_impact_assessment: false)
+          end.to change(planning_application, :expiry_date).from("Mon, 22 Apr 2024".to_date).to("Mon, 26 Feb 2024".to_date)
+            .and change(Audit, :count).by(1)
+        end
+
+        it "does not add an additional 8 weeks to the expiry date if an EIA has already been marked as required" do
+          expect do
+            planning_application.update!(environment_impact_assessment: true)
+          end.not_to change(planning_application, :expiry_date)
+        end
+      end
+    end
+
     describe "::after_update #update_constraints" do
       let(:boundary_geojson) do
         {

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -191,7 +191,7 @@ RSpec.describe "Requesting document changes to a planning application" do
         click_link("Check document - proposed-roofplan.png")
       end
 
-      click_link "Show all (29)"
+      click_link "Show all (30)"
 
       check "Sustainability and Energy Statement"
 

--- a/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
+++ b/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Validation tasks" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    travel_to(DateTime.new(2024, 1, 15)) { create(:planning_application, :invalidated, local_authority: default_local_authority) }
+  end
+
+  before do
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+  end
+
+  context "when application is not started or invalidated" do
+    it "displays the content when checking for the environment impact assessment" do
+      expect(page).to have_content("Expiry date: 11 March 2024")
+      click_link "Check Environment Impact Assessment"
+
+      expect(page).to have_content("Environment Impact Assessment (EIA)")
+      expect(page).to have_content(planning_application.full_address)
+      expect(page).to have_content(planning_application.reference)
+      expect(page).to have_content(planning_application.description)
+
+      expect(page).to have_content("Does the application require an assessment?")
+      expect(page).to have_link(
+        "Check EIA guidance", href: "https://www.gov.uk/government/publications/environmental-impact-assessment-screening-checklist"
+      )
+      within(".govuk-hint") do
+        expect(page).to have_content("This application is subject to an EIA. The determination period will be extended to 16 weeks.")
+      end
+    end
+
+    it "I can mark the application as requiring an environment impact assessment" do
+      click_link "Check Environment Impact Assessment"
+
+      choose "Yes"
+      click_button "Save and mark as complete"
+
+      within(".govuk-notification-banner--notice") do
+        expect(page).to have_content("Application marked as requiring an EIA. The determination period is extended to 16 weeks.")
+      end
+      within("#dates-and-assignment-details") do
+        expect(page).to have_content("Expiry date: 6 May 2024")
+        expect(page).to have_content("Subject to an EIA")
+        expect(page).to have_content("The expiry date has been extended to 16 weeks")
+      end
+      within("#environment-impact-assessment-task") do
+        within(".govuk-tag") do
+          expect(page).to have_content("Required")
+        end
+      end
+
+      visit "/planning_applications/#{planning_application.id}/audits"
+      within("#audit_#{Audit.last.id}") do
+        expect(page).to have_content("Changed to: true")
+        expect(page).to have_content("Environment impact assessment updated")
+        expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+      end
+    end
+
+    context "when application has been marked as requiring an environment impact assessment" do
+      it "I can mark as it not being required if it's no longer necessary" do
+        click_link "Check Environment Impact Assessment"
+        choose "Yes"
+        click_button "Save and mark as complete"
+        expect(page).to have_content("Expiry date: 6 May 2024")
+
+        click_link "Check Environment Impact Assessment"
+        choose "No"
+        click_button "Save and mark as complete"
+
+        within("#environment-impact-assessment-task") do
+          within(".govuk-tag") do
+            expect(page).to have_content("Not required")
+          end
+        end
+
+        expect(page).to have_content("Expiry date: 11 March 2024")
+        expect(page).not_to have_content("Subject to an EIA")
+
+        visit "/planning_applications/#{planning_application.id}/audits"
+        within("#audit_#{Audit.last.id}") do
+          expect(page).to have_content("Changed from: true Changed to: false")
+          expect(page).to have_content("Environment impact assessment updated")
+          expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+        end
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -46,6 +46,17 @@ RSpec.describe "Validation tasks" do
 
     it "displays the validation tasks list" do
       within(".app-task-list") do
+        within("#environment-impact-assessment-task") do
+          expect(page).to have_content("Environment Impact Assessment (EIA)")
+          expect(page).to have_link(
+            "Check Environment Impact Assessment",
+            href: planning_application_validation_environment_impact_assessments_path(planning_application)
+          )
+          within(".govuk-tag--grey") do
+            expect(page).to have_content("Not started")
+          end
+        end
+
         within("#fee-validation-task") do
           expect(page).to have_content("Fee")
           expect(page).to have_link(


### PR DESCRIPTION
### Description of change

- If EIA (Environment Impact Assessment) is required, then extend the expiry date by another 8 weeks.
- Add this change to the audit log too.
- If application has been marked as requiring an EIA and then no longer needs it, set expiry date back to its original

### Story Link

https://trello.com/c/U6EFzljs/2171-able-to-recognise-an-eia-application-so-the-expiry-date-is-16-weeks