### PR TITLE
Use value from ODP schema for immunity date

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -747,7 +747,7 @@ class PlanningApplication < ApplicationRecord
 
   def create_fee_calculation
     calc = if planx_planning_data&.params_v2.present?
-      FeeCalculation.from_odp_data(JSON.parse(planx_planning_data.params_v2, symbolize_names: true))
+      FeeCalculation.from_odp_data(planx_planning_data.params_v2)
     elsif planx_planning_data&.params_v1.present?
       FeeCalculation.from_planx_data(JSON.parse(planx_planning_data.params_v1, symbolize_names: true))
     else

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -171,7 +171,9 @@ module BopsApi
       def process_immunity_details(planning_application)
         ActiveRecord::Base.transaction do
           immunity_detail = ImmunityDetail.new(planning_application: planning_application)
-          immunity_detail.end_date = planning_application
+
+          immunity_detail.end_date = params.dig("data", "proposal", "date", "completion")
+          immunity_detail.end_date ||= planning_application
             .find_proposal_detail("When were the works completed?")
             .first.response_values.first
           immunity_detail.save!

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -95,7 +95,7 @@ module BopsApi
       def initialize_from_planning_application(planning_application)
         params_v2 = planning_application.params_v2 || raise_not_permitted_to_clone_error
 
-        @params = ActionController::Parameters.new(JSON.parse(params_v2))
+        @params = params_v2.with_indifferent_access
         @local_authority = planning_application.local_authority
         @user = planning_application.api_user
         @send_email = false

--- a/engines/bops_api/app/services/bops_api/application/parsers/submission_parser.rb
+++ b/engines/bops_api/app/services/bops_api/application/parsers/submission_parser.rb
@@ -13,7 +13,7 @@ module BopsApi
         def parse
           {
             session_id: params[:metadata][:id],
-            params_v2: params.to_json
+            params_v2: params
           }
         end
       end

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect { create_planning_application }.to change(PlanxPlanningData, :count).by(1)
 
           expect(PlanxPlanningData.last).to have_attributes(
-            params_v2: params.to_json,
+            params_v2: params,
             session_id: "95f90e21-93f5-4761-90b3-815c673e041f"
           )
         end
@@ -237,7 +237,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect { create_planning_application }.to change(PlanxPlanningData, :count).by(1)
 
           expect(PlanxPlanningData.last).to have_attributes(
-            params_v2: params.to_json,
+            params_v2: params,
             session_id: "8da51c5b-a2a0-4386-a15d-29d66f9c121c"
           )
         end
@@ -343,7 +343,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect { create_planning_application }.to change(PlanxPlanningData, :count).by(1)
 
           expect(PlanxPlanningData.last).to have_attributes(
-            params_v2: params.to_json,
+            params_v2: params,
             session_id: "81bcaa0f-baf5-4573-ba0a-ea868c573faf"
           )
         end

--- a/engines/bops_api/spec/services/application/parsers/submission_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/submission_parser_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe BopsApi::Application::Parsers::SubmissionParser do
       it "returns a correctly formatted submission hash" do
         expect(parse_submission).to eq(
           session_id: "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
-          params_v2: params.to_json
+          params_v2: params
         )
       end
     end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -683,7 +683,7 @@ FactoryBot.define do
 
     trait :with_v2_params do
       after(:build) do |planning_application|
-        planning_application.planx_planning_data = build(:planx_planning_data, params_v2: file_fixture("v2/valid_planning_permission.json").read, planning_application:)
+        planning_application.planx_planning_data = build(:planx_planning_data, params_v2: JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access, planning_application:)
       end
     end
   end

--- a/spec/system/planning_applications/clone_spec.rb
+++ b/spec/system/planning_applications/clone_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "cloning a planning application" do
         expect(page).to have_current_path("/planning_applications/#{cloned_planning_application.id}")
         expect(page).to have_content("Planning application was successfully cloned")
 
-        expect(JSON.parse(planning_application.params_v2)).to eq(JSON.parse(cloned_planning_application.params_v2))
+        expect(planning_application.params_v2).to eq(cloned_planning_application.params_v2)
         expect(planning_application.reference).not_to eq(cloned_planning_application.reference)
       end
     end


### PR DESCRIPTION
### Description of change

Rather than parsing the proposal-details array we can use the value in the schema as-is.

### Story Link

https://link-to-issue

### Decisions [OPTIONAL]

I've left the previous code (using proposal details) in place as a fallback. I'm not sure whether it will ever occur in practice but it seems to be the case for the test data.