### PR TITLE
Set font correctly

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -1,4 +1,5 @@
-$govuk-assets-path: "~govuk-frontend/govuk/assets/";
+$govuk-assets-path: "govuk-frontend/dist/govuk/assets/";
+$govuk-font-family: open-sans, sans-serif;
 @import "govuk-frontend/dist/govuk/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 @import "components/buttons";
@@ -10,10 +11,6 @@ $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "consultation";
 @import "decision_notice";
 @import "components/documents";
-
-html * {
-  font-family: open-sans, sans-serif !important;
-}
 
 .accordion-tr:last-child > td {
   border-bottom: none !important;

--- a/app/javascript/controllers/pdf_controller.js
+++ b/app/javascript/controllers/pdf_controller.js
@@ -10,7 +10,6 @@ export default class extends Controller {
     const pdfjs = document.getElementById("site-notice-content")
     doc.html(pdfjs, {
       callback: function (doc) {
-        doc.setFont("Arial")
         doc.save(`site-notice-${applicationReference}.pdf`)
       },
     })

--- a/app/views/planning_applications/site_notices/_status.html.erb
+++ b/app/views/planning_applications/site_notices/_status.html.erb
@@ -17,7 +17,7 @@
 <div class="govuk-!-display-none">
   <span id="application-reference"><%= @planning_application.reference %></span>
   <div id="site-notice-content">
-    <div style="width: 430px;">
+    <div style="width: 430px; font-family: Arial;">
       <%= raw @planning_application.last_site_notice.preview_content %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1111,7 +1111,7 @@ en:
       send_letters:
         add_neighbours: Add some neighbours before sending letters
         make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BOPS Public Portal</a> before you can send letters to neighbours.
-        require_resend_reason: Provide a reason when resending letters to previously-contacted neighbours
+        require_resend_reason: Provide a reason when resending letters to previously contacted neighbours
     neighbour_responses:
       create:
         success: Neighbour response successfully created.

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe "Send letters to neighbours", js: true do
       select "Renotification"
 
       click_button "Confirm and send letters"
-      expect(page).to have_content "Provide a reason when resending letters to previously-contacted neighbours"
+      expect(page).to have_content "Provide a reason when resending letters to previously contacted neighbours"
       expect(neighbour.neighbour_letters.length).to eq(1)
     end
 


### PR DESCRIPTION
### Description of change

We shouldn't be overwriting $govuk-font-family by setting !important on font-family. This then fixes the site notice spacing too.
