### PR TITLE
Exclude site address from returned address list

### DIFF
--- a/app/controllers/os_places_api_controller.rb
+++ b/app/controllers/os_places_api_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class OsPlacesApiController < ApplicationController
+  before_action :set_planning_application, only: :search_addresses_by_polygon
+
   def index
     response = Apis::OsPlaces::Query.new.find_addresses(params[:query])
 
@@ -12,10 +14,16 @@ class OsPlacesApiController < ApplicationController
   def search_addresses_by_polygon
     geojson = JSON.parse(request.body.read)["geojson"]
 
-    response = Apis::OsPlaces::Query.new.find_addresses_by_polygon(geojson)
+    response = Apis::OsPlaces::Query.new.find_addresses_by_polygon(geojson, @planning_application.uprn)
 
     respond_to do |format|
       format.json { render json: response }
     end
+  end
+
+  private
+
+  def set_planning_application
+    @planning_application = current_local_authority.planning_applications.find_by(id: Integer(params[:planning_application].to_s))
   end
 end

--- a/app/javascript/controllers/polygon_search_controller.js
+++ b/app/javascript/controllers/polygon_search_controller.js
@@ -253,7 +253,7 @@ export default class extends Controller {
   showTotalResults(totalResults) {
     const paragraph = document.createElement("p")
     paragraph.classList.add("govuk-body", "govuk-!-font-weight-bold")
-    paragraph.textContent = `Your search has returned ${totalResults} results.`
+    paragraph.textContent = `Your search has returned ${totalResults} results. The site address is not included in these results.`
 
     if (totalResults > 1000) {
       paragraph.appendChild(

--- a/app/services/apis/os_places/client.rb
+++ b/app/services/apis/os_places/client.rb
@@ -14,8 +14,8 @@ module Apis
         end
       end
 
-      def post(body, params)
-        PolygonSearchService.new(body, params.merge(key)).call
+      def post(body, params, uprn)
+        PolygonSearchService.new(body, params.merge(key), uprn).call
       end
 
       private

--- a/app/services/apis/os_places/polygon_search_service.rb
+++ b/app/services/apis/os_places/polygon_search_service.rb
@@ -10,9 +10,10 @@ module Apis
 
       attr_reader :all_addresses
 
-      def initialize(body, params)
+      def initialize(body, params, uprn)
         @body = body
         @params = params
+        @uprn = uprn
         @all_addresses = []
         @offset = 0
       end
@@ -25,7 +26,7 @@ module Apis
 
       private
 
-      attr_reader :body, :params, :offset, :total_results
+      attr_reader :body, :params, :uprn, :offset, :total_results
 
       def fetch_all_addresses
         loop do
@@ -54,7 +55,9 @@ module Apis
       end
 
       def retrieve_addresses(data)
-        data["results"]&.map { |result| result["DPA"]["ADDRESS"] } || []
+        data["results"]
+          &.reject { |result| uprn.present? && result["DPA"]["UPRN"] == uprn }
+          &.map { |result| result["DPA"]["ADDRESS"] } || []
       end
 
       def end_of_results?

--- a/app/services/apis/os_places/query.rb
+++ b/app/services/apis/os_places/query.rb
@@ -12,8 +12,8 @@ module Apis
         handle_request { client.get("find", find_addresses_params(query)) }
       end
 
-      def find_addresses_by_polygon(body)
-        handle_request { client.post(body, find_addresses_by_polygon_params) }
+      def find_addresses_by_polygon(body, uprn)
+        handle_request { client.post(body, find_addresses_by_polygon_params, uprn) }
       end
 
       private

--- a/app/views/planning_applications/neighbours/index.html.erb
+++ b/app/views/planning_applications/neighbours/index.html.erb
@@ -18,7 +18,7 @@
     address_fill_url: os_places_api_index_path,
     address_fill_id: "neighbour-address",
     address_fill_name: "consultation[neighbours_attributes][][address]",
-    polygon_search_url: search_addresses_by_polygon_path,
+    polygon_search_url: search_addresses_by_polygon_path(planning_application: @planning_application),
     polygon_search_id: "neighbour-addresses",
     polygon_search_name: "consultation[neighbours_attributes][][address]"
   } do %>

--- a/spec/services/apis/os_places/client_spec.rb
+++ b/spec/services/apis/os_places/client_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: t
           geojson, {
             output_srs: "EPSG:27700",
             srs: "EPSG:27700"
-          }
+          },
+          uprn: "100021892955"
         )
 
         expect(result[:addresses]).to eq(["5, COXSON WAY, LONDON, SE1 2XB", "6, COXSON WAY, LONDON, SE1 2XB"])
@@ -97,7 +98,8 @@ RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: t
           geojson, {
             output_srs: "EPSG:27700",
             srs: "EPSG:27700"
-          }
+          },
+          uprn: "100021892955"
         )
 
         expect(result[:addresses].length).to eq(103)

--- a/spec/services/apis/os_places/polygon_search_service_spec.rb
+++ b/spec/services/apis/os_places/polygon_search_service_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
         key: Rails.configuration.os_vector_tiles_api_key
       }
     }
-    let(:data) { described_class.new(geojson, params).call }
+    let(:uprn) { "100021892955" }
+    let(:data) { described_class.new(geojson, params, uprn).call }
     let(:addresses) { data[:addresses] }
     let(:total_results) { data[:total_results] }
 
@@ -63,6 +64,20 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
           "1, Example Street, LONDON, SE1 2XB", "2, Example Street, LONDON, SE1 2XB", "102, Example Street, LONDON, SE1 2XB", "103, Example Street, LONDON, SE1 2XB"
         )
         expect(total_results).to eq(103)
+      end
+    end
+
+    context "when site address uprn is included in the search results" do
+      let(:uprn) { "200003357029" }
+
+      before do
+        stub_os_places_api_request_for_polygon(geojson)
+      end
+
+      it "excludes this address" do
+        expect(total_results).to eq(2)
+        expect(addresses.length).to eq(1)
+        expect(addresses).to eq(["6, COXSON WAY, LONDON, SE1 2XB"])
       end
     end
   end

--- a/spec/services/apis/os_places/query_spec.rb
+++ b/spec/services/apis/os_places/query_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Apis::OsPlaces::Query, exclude_stub_any_os_places_api_request: tr
         "properties" => nil
       }
     end
+    let(:uprn) { "100021892955" }
 
     it "initializes a Client object and invokes #find_addresses_by_polygon" do
       expect_any_instance_of(
@@ -73,10 +74,11 @@ RSpec.describe Apis::OsPlaces::Query, exclude_stub_any_os_places_api_request: tr
         {
           output_srs: "EPSG:27700",
           srs: "EPSG:27700"
-        }
+        },
+        uprn
       ).and_call_original
 
-      described_class.new.find_addresses_by_polygon(geojson)
+      described_class.new.find_addresses_by_polygon(geojson, uprn)
     end
 
     context "when Faraday::Error is raised" do
@@ -87,7 +89,7 @@ RSpec.describe Apis::OsPlaces::Query, exclude_stub_any_os_places_api_request: tr
       it "sends exception to Appsignal" do
         expect(Appsignal).to receive(:send_exception).with(instance_of(Faraday::Error))
 
-        result = described_class.new.find_addresses_by_polygon(geojson)
+        result = described_class.new.find_addresses_by_polygon(geojson, uprn)
         expect(result).to eq([])
       end
     end


### PR DESCRIPTION
### Description of change

- When searching by polygon, we want to exclude the site address from this returned address list as we don't want to send a consultation letter to this address.
- The reliable way to do this is to match on UPRN as addresses are formatted slightly differently depending on how we've added/queried it to the system

### Story Link

https://trello.com/c/mqpi5kDx/2482-exclude-the-address-of-the-application-site-in-select-the-neighbours

