### PR TITLE
Decrement total results if site address omitted from search

### DIFF
--- a/app/services/apis/os_places/polygon_search_service.rb
+++ b/app/services/apis/os_places/polygon_search_service.rb
@@ -55,9 +55,15 @@ module Apis
       end
 
       def retrieve_addresses(data)
-        data["results"]
-          &.reject { |result| uprn.present? && result["DPA"]["UPRN"] == uprn }
-          &.map { |result| result["DPA"]["ADDRESS"] } || []
+        results = data["results"] || []
+
+        results.each_with_object([]) do |result, addresses|
+          if uprn.present? && result["DPA"]["UPRN"] == uprn
+            @total_results -= 1
+          else
+            addresses << result["DPA"]["ADDRESS"]
+          end
+        end
       end
 
       def end_of_results?

--- a/spec/services/apis/os_places/polygon_search_service_spec.rb
+++ b/spec/services/apis/os_places/polygon_search_service_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_
       end
 
       it "excludes this address" do
-        expect(total_results).to eq(2)
+        expect(total_results).to eq(1)
         expect(addresses.length).to eq(1)
         expect(addresses).to eq(["6, COXSON WAY, LONDON, SE1 2XB"])
       end

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe "Send letters to neighbours", js: true do
       it "excludes this address from the returned address list" do
         within("#address-container") do
           expect(page).to have_content(
-            "Your search has returned 2 results. The site address is not included in these results."
+            "Your search has returned 1 results. The site address is not included in these results."
           )
 
           within(".address-entry#neighbour-addresses-0") do


### PR DESCRIPTION
- We need the actual total results number shown to match the number of addresses returned in the list.
Since we are removing the site address, we need to decrement the total number by one