### PR TITLE
Remove created_at from fee calculation audit

### DIFF
--- a/app/models/fee_calculation.rb
+++ b/app/models/fee_calculation.rb
@@ -57,7 +57,7 @@ class FeeCalculation < ApplicationRecord
     saved_changes.keys.map do |attribute_name|
       next if saved_change_to_attribute(attribute_name).all? { |value| value.blank? || value.try(:zero?) }
 
-      next if %w[updated_at].include? attribute_name
+      next if %w[created_at updated_at].include? attribute_name
 
       original_attribute = saved_change_to_attribute(attribute_name).first
       new_attribute = saved_change_to_attribute(attribute_name).second


### PR DESCRIPTION
### Description of change

Keep seeing this warning in our CI builds:

DEPRECATION WARNING: Using a :default format for TimeWithZone#to_s is deprecated. Please use TimeWithZone#to_fs instead. If you fixed all places inside your application that you see this deprecation, you can set `ENV['RAILS_DISABLE_DEPRECATED_TO_S_CONVERSION']` to `"true"` in the `config/application.rb` file before the `Bundler.require` call to fix all the callers outside of your application. (called from block in audit_updated! at /home/runner/work/bops/bops/app/models/fee_calculation.rb:69)

