### PR TITLE
Allow overriding neighbour letter response period

### DIFF
--- a/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
@@ -1,9 +1,9 @@
 <div data-controller="neighbours">
    <div class="govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-8">Step 3</div>
-  <%= form.govuk_collection_select :template, 
-    ["Notification", "Renotification"], 
-    :itself, 
-    :itself, 
+  <%= form.govuk_collection_select :template,
+    ["Notification", "Renotification"],
+    :itself,
+    :itself,
     label: { text: "Choose which letter to send", size: "m" },
     data: {
       action: "change->neighbours#toggleTemplates"
@@ -37,3 +37,13 @@
   </div>
 </details>
 
+<div class="govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-8">Step 4</div>
+<div class="govuk-form-group">
+  <%= form.label :deadline_extension, "Set response period", class: "govuk-label govuk-label--m" %>
+  <p class="govuk-hint">Enter the number of days that neighbours have to respond.</p>
+
+ <div class="govuk-input__wrapper">
+    <%= form.govuk_text_field :deadline_extension, placeholder: "", class: "govuk-input", label: -> {}, value: 21, required: true %>
+    <div class="govuk-input__suffix" aria-hidden="true">days</div>
+  </div>
+</div>


### PR DESCRIPTION
### Description of change

Allow user to specify a deadline for neighbour responses, defaulting to the existing 21 days, and extend the consultation period as necessary if this is longer than the current consultation period.

### Story Link

https://trello.com/c/7gIhVzv1/2474-able-to-change-the-duration-of-neighbour-consultation-period

### Screenshots

<img width="668" alt="Screenshot 2024-01-23 at 16 55 37" src="https://github.com/unboxed/bops/assets/3986/2aa85bc3-0dfa-4c19-853b-8bb7cfdcfc8b">

### Known issues

I'm not entirely happy with the way that the consultation is updated, it feels a little tangled due to the consultation potentially not having started when the letters are sent. I'm not sure if this is just an artefact of the test setup though.