### PR TITLE
Add 16 weeks to the later out of validated_at / received_at

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -16,6 +16,7 @@ class PlanningApplication < ApplicationRecord
   include PlanningApplication::Notification
 
   DAYS_TO_EXPIRE = 56
+  DAYS_TO_EXPIRE_EIA = 112
 
   enum user_role: {applicant: 0, agent: 1, proxy: 2}
 
@@ -754,7 +755,7 @@ class PlanningApplication < ApplicationRecord
 
   def modify_expiry_date
     if environment_impact_assessment.required?
-      self.expiry_date += 56.days
+      self.expiry_date = DAYS_TO_EXPIRE_EIA.days.after(validated_at || received_at)
     else
       set_key_dates
     end

--- a/spec/models/environment_impact_assessment_spec.rb
+++ b/spec/models/environment_impact_assessment_spec.rb
@@ -52,6 +52,21 @@ RSpec.describe EnvironmentImpactAssessment do
       end.not_to change(planning_application, :expiry_date)
     end
 
+    context "when planning application has been validated" do
+      let!(:planning_application) do
+        travel_to("2024-01-01") do
+          create(:planning_application, local_authority:, validated_at: "Mon, 8 Apr 2024".to_date)
+        end
+      end
+      let(:environment_impact_assessment) { create(:environment_impact_assessment, planning_application:) }
+
+      it "adds 16 weeks to the validated date instead of the received at date" do
+        expect do
+          environment_impact_assessment.update!(required: true)
+        end.to change(planning_application, :expiry_date).from("Mon, 03 June 2024".to_date).to("Mon, 29 July 2024".to_date)
+      end
+    end
+
     context "when planning application has been marked as requiring an EIA" do
       let!(:planning_application) do
         travel_to("2024-01-01") do


### PR DESCRIPTION
### Description of change

Add 16 weeks to the expiry date for an EIA application from the validated_at date if later than the received_at date

### Story Link

https://trello.com/c/U6EFzljs/2171-able-to-recognise-an-eia-application-so-the-expiry-date-is-16-weeks
### Screenshots

