### PR TITLE
Allow sending to neighbours who sent comments without validating resend_reason

### DIFF
--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -3,8 +3,8 @@
 class NeighbourLetter < ApplicationRecord
   belongs_to :neighbour
 
-  validates :resend_reason, absence: true, unless: :resend?
-  validates :resend_reason, presence: true, if: :resend?
+  validates :resend_reason, absence: true, unless: :allowed_resend_reason?
+  validates :resend_reason, presence: true, if: :needs_resend_reason?
 
   STATUSES = {
     technical_failure: "technical failure",
@@ -43,5 +43,13 @@ class NeighbourLetter < ApplicationRecord
 
   def resend?
     neighbour.last_letter_sent_at.present?
+  end
+
+  def needs_resend_reason?
+    resend? && !neighbour.sent_comment?
+  end
+
+  def allowed_resend_reason?
+    resend? || neighbour.sent_comment?
   end
 end

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -319,5 +319,25 @@ RSpec.describe "Send letters to neighbours", js: true do
         personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\r\n\r\nDear Resident/))).and_call_original
       click_button "Confirm and send letters"
     end
+
+    context "when the neighbour sent a comment" do
+      before do
+        neighbour.update!(source: "sent_comment")
+      end
+
+      it "allows setting a reason when resend letters" do
+        visit "/planning_applications/#{planning_application.id}"
+        click_link "Consultees, neighbours and publicity"
+        click_link "Send letters to neighbours"
+
+        select "Renotification"
+        fill_in("Resend reason",
+          with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
+
+        expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
+          personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\r\n\r\nDear Resident/))).and_call_original
+        click_button "Confirm and send letters"
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Neighbour letters must have a resend reason if being resent. We detect this by the presence of a `last_letter_sent_at` date. However, now we support sending letters to neighbours who sent in comments without having been sent a letter themselves. For resends to letters who sent comments, we should permit a resend reason to be added even when no sent date exists.

### Story Link

https://trello.com/c/iJxLX501/2189-when-re-consulting-with-neighbour-letters-include-addresses-of-non-identified-neighbours-who-have-made-comments
