### PR TITLE
Update press notice when application requires an EIA

### DIFF
--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -78,7 +78,7 @@ module PlanningApplications
     end
 
     def calculate_consultation_end_date
-      new_end_date = @site_notice.displayed_at + 21.days
+      new_end_date = @site_notice.displayed_at + Consultation::DEFAULT_PERIOD
 
       @planning_application.consultation.update!(end_date: new_end_date)
     end

--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module MailerHelper
+  def request_eia_copy(eia)
+    return unless eia.required?
+
+    fee_copy = "for a fee of #{number_to_currency(eia.fee, unit: "£")}"
+    email_copy = "by emailing #{eia.email_address}"
+    address_copy = "in person at #{eia.address}"
+    request_copy = "You can request a hard copy"
+
+    if eia.with_address_email_and_fee?
+      "#{request_copy} #{fee_copy} #{email_copy} or #{address_copy}"
+    elsif eia.with_address_and_fee?
+      "#{request_copy} #{fee_copy} #{address_copy}"
+    elsif eia.with_email_and_fee?
+      "#{request_copy} #{fee_copy} #{email_copy}"
+    end
+  end
+end

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -2,6 +2,7 @@
 
 class PlanningApplicationMailer < ApplicationMailer
   helper :planning_application
+  helper :mailer
 
   def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application

--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -65,6 +65,6 @@ class Consultee < ApplicationRecord
   private
 
   def default_expires_at
-    email_delivered_at && (email_delivered_at + 21.days).end_of_day
+    email_delivered_at && (email_delivered_at + Consultation::DEFAULT_PERIOD).end_of_day
   end
 end

--- a/app/models/environment_impact_assessment.rb
+++ b/app/models/environment_impact_assessment.rb
@@ -21,6 +21,18 @@ class EnvironmentImpactAssessment < ApplicationRecord
     delegate :modify_expiry_date
   end
 
+  def with_address_email_and_fee?
+    address && email_address && fee
+  end
+
+  def with_address_and_fee?
+    address && fee
+  end
+
+  def with_email_and_fee?
+    email_address && fee
+  end
+
   private
 
   def create_audit!

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -75,6 +75,7 @@ class PlanningApplication < ApplicationRecord
     delegate :name, to: :user
     delegate :required?, to: :press_notice
     delegate :required?, to: :site_notice
+    delegate :required?, to: :environment_impact_assessment
   end
   delegate :params_v1, to: :planx_planning_data, allow_nil: true
   delegate :params_v2, to: :planx_planning_data, allow_nil: true
@@ -797,7 +798,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def set_key_dates
-    return if environment_impact_assessment&.required?
+    return if environment_impact_assessment_required?
 
     self.expiry_date = DAYS_TO_EXPIRE.days.after(validated_at || received_at)
     self.target_date = 35.days.after(validated_at || received_at)

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -54,6 +54,7 @@ class PressNotice < ApplicationRecord
 
   with_options allow_nil: true do
     delegate :consultation, to: :planning_application
+    delegate :environment_impact_assessment, to: :planning_application
     delegate :start_date, to: :consultation, prefix: true
     delegate :end_date, to: :consultation, prefix: true
     delegate :started?, to: :consultation, prefix: true
@@ -107,7 +108,7 @@ class PressNotice < ApplicationRecord
   end
 
   def new_consultation_end_date
-    [published_at && (published_at + 21.days).end_of_day, consultation_end_date].compact.max
+    [published_at && (published_at + consultation.period_days).end_of_day, consultation_end_date].compact.max
   end
 
   def extend_consultation!

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -66,7 +66,7 @@ class SiteNotice < ApplicationRecord
   end
 
   def new_consultation_end_date
-    [displayed_at && (displayed_at + 21.days).end_of_day, consultation_end_date].compact.max
+    [displayed_at && (displayed_at + Consultation::DEFAULT_PERIOD).end_of_day, consultation_end_date].compact.max
   end
 
   def extend_consultation!

--- a/app/views/planning_application_mailer/press_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/press_notice_mail.text.erb
@@ -12,4 +12,12 @@ This application requires a press notice with the following reasons:
 <% end -%>
 <% end -%>
 
-View the application at <%= planning_application_press_notice_confirmation_url(@planning_application, subdomain: @planning_application.local_authority.subdomain) %>.
+<% if @planning_application.environment_impact_assessment_required? %>
+This application is subject to an Environmental Impact Assessment (EIA).
+<% end -%>
+
+You can view the application<% if @planning_application.environment_impact_assessment_required? %> and Environmental Statement<% end %> at <%= planning_application_press_notice_confirmation_url(@planning_application, subdomain: @planning_application.local_authority.subdomain) %>.
+
+<% if @planning_application.environment_impact_assessment_required? %>
+<%= request_eia_copy(@planning_application.environment_impact_assessment) %>
+<% end -%>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -65,7 +65,7 @@
       <% end %>
     </p>
 
-    <% if @planning_application.environment_impact_assessment&.required? %>
+    <% if @planning_application.environment_impact_assessment_required? %>
       <p class="govuk-body govuk-!-margin-bottom-0"><strong>Subject to an EIA</strong></p>
       <p class="govuk-body">The expiry date has been extended to 16 weeks</p>
     <% end %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1286,8 +1286,61 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the bops request url" do
       expect(mail_body).to include(
-        "View the application at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.id}/press_notice/confirmation."
+        "You can view the application at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.id}/press_notice/confirmation."
       )
+    end
+
+    context "when application has been marked as requiring an EIA" do
+      let!(:environment_impact_assessment) do
+        create(
+          :environment_impact_assessment,
+          planning_application:
+        )
+      end
+
+      it "includes EIA specific content" do
+        expect(mail_body).to include(
+          "This application is subject to an Environmental Impact Assessment (EIA)."
+        )
+        expect(mail_body).to include(
+          "You can view the application and Environmental Statement at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.id}/press_notice/confirmation."
+        )
+      end
+    end
+
+    context "when address, email address and fee have been provided" do
+      let!(:environment_impact_assessment) do
+        create(
+          :environment_impact_assessment,
+          address: "1 Random Lane",
+          email_address: "test@example.com",
+          fee: 25,
+          planning_application:
+        )
+      end
+
+      it "shows the correct copy in the email" do
+        expect(mail_body).to include(
+          "You can request a hard copy for a fee of £25.00 by emailing test@example.com or in person at 1 Random Lane"
+        )
+      end
+    end
+
+    context "when address and fee have been provided" do
+      let!(:environment_impact_assessment) do
+        create(
+          :environment_impact_assessment,
+          address: "1 Random Lane",
+          fee: 25,
+          planning_application:
+        )
+      end
+
+      it "shows the correct copy in the email" do
+        expect(mail_body).to include(
+          "You can request a hard copy for a fee of £25.00 in person at 1 Random Lane"
+        )
+      end
     end
   end
 end

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -558,6 +558,32 @@ RSpec.describe "Press notice" do
           published_at: Time.zone.local(2023, 9, 29),
           comment: "Press notice comment"
         )
+
+        expect(consultation.reload.end_date.to_date).to eq("Fri, 20 Oct 2023".to_date)
+      end
+
+      context "when application has been marked as requiring an EIA" do
+        let!(:environment_impact_assessment) { create(:environment_impact_assessment, planning_application:) }
+
+        it "I can confirm the press notice details and consultation period is extended by 30 days" do
+          click_link "Consultees, neighbours and publicity"
+          click_link "Confirm press notice"
+
+          within("#press-sent-at-field") do
+            fill_in "Day", with: "25"
+            fill_in "Month", with: "9"
+            fill_in "Year", with: "2023"
+          end
+
+          within("#published-at-field") do
+            fill_in "Day", with: "29"
+            fill_in "Month", with: "9"
+            fill_in "Year", with: "2023"
+          end
+
+          click_button "Save"
+          expect(consultation.reload.end_date.to_date).to eq("Sun, 29 Oct 2023".to_date)
+        end
       end
     end
 


### PR DESCRIPTION
### Description of change

- Update press notice mail when application is marked as requiring an EIA.
- Extend consultation period for 30 days instead of 21

### Story Link

https://trello.com/c/FJVFDUq3/2480-update-press-notice-for-applications-requiring-an-eia