### PR TITLE
Extract common consultation logic for press/site notices

### DIFF
--- a/app/models/concerns/consultable.rb
+++ b/app/models/concerns/consultable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Consultable
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :start_deadline, unless: :consultation_started?
+
+    with_options allow_nil: true do
+      delegate :consultation, to: :planning_application
+      delegate :start_date, to: :consultation, prefix: true
+      delegate :end_date, to: :consultation, prefix: true
+      delegate :started?, to: :consultation, prefix: true
+      delegate :start_deadline, to: :consultation
+    end
+
+    private
+
+    def new_consultation_end_date
+      [event_at && (event_at + consultation.period_days).end_of_day, consultation_end_date].compact.max
+    end
+
+    def extend_consultation!
+      consultation.update!(end_date: new_consultation_end_date)
+    end
+
+    def event_at
+      case self.class.name
+      when "PressNotice"
+        published_at
+      when "SiteNotice"
+        displayed_at
+      else
+        raise ArgumentError "Method not supported for class: #{self.class.name}"
+      end
+    end
+  end
+end

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -2,6 +2,7 @@
 
 class SiteNotice < ApplicationRecord
   include DateValidateable
+  include Consultable
 
   belongs_to :planning_application
   has_many :documents, as: :owner, dependent: :destroy, autosave: true
@@ -19,13 +20,6 @@ class SiteNotice < ApplicationRecord
       }
   end
 
-  delegate :consultation, to: :planning_application
-  delegate :start_date, to: :consultation, prefix: true
-  delegate :end_date, to: :consultation, prefix: true
-  delegate :started?, to: :consultation, prefix: true
-  delegate :start_deadline, to: :consultation
-
-  before_validation :start_deadline, unless: :consultation_started?
   after_update :extend_consultation!, if: :saved_change_to_displayed_at?
 
   attr_reader :method
@@ -66,14 +60,6 @@ class SiteNotice < ApplicationRecord
     else
       "https://#{planning_application.local_authority.subdomain}.bops-applicants.services/planning_applications/#{planning_application.id}"
     end
-  end
-
-  def new_consultation_end_date
-    [displayed_at && (displayed_at + Consultation::DEFAULT_PERIOD).end_of_day, consultation_end_date].compact.max
-  end
-
-  def extend_consultation!
-    consultation.update!(end_date: new_consultation_end_date)
   end
 
   def eia_statement

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe PressNotice do
         end
       end
 
-      describe "::after_update #update_consultation_end_date!" do
+      describe "::after_update #extend_consultation!" do
         let(:default_local_authority) { create(:local_authority, :default) }
         let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
         let!(:consultation) { create(:consultation, planning_application:) }
@@ -159,6 +159,25 @@ RSpec.describe PressNotice do
             end.to change(consultation, :end_date)
               .from(Time.zone.local(2023, 3, 28, 23, 59, 59, 999999))
               .to(Time.zone.local(2023, 4, 5, 23, 59, 59, 999999))
+          end
+        end
+
+        context "when application has been marked as requiring an EIA and there is an update to the published_at date" do
+          let!(:environment_impact_assessment) { create(:environment_impact_assessment, planning_application:) }
+
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 3, 28, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is an update of 30 days added to the consultation end date" do
+            expect do
+              press_notice.update(published_at: Time.zone.local(2023, 3, 15))
+            end.to change(consultation, :end_date)
+              .from(Time.zone.local(2023, 3, 28, 23, 59, 59, 999999))
+              .to(Time.zone.local(2023, 4, 14, 23, 59, 59, 999999))
           end
         end
       end

--- a/spec/models/site_notice_spec.rb
+++ b/spec/models/site_notice_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SiteNotice do
+  describe "validations" do
+    subject(:site_notice) { described_class.new }
+
+    describe "#planning_application" do
+      it "validates presence" do
+        expect { site_notice.valid? }.to change { site_notice.errors[:planning_application] }.to ["must exist"]
+      end
+    end
+
+    describe "#required" do
+      it "validates inclusion in [true, false]" do
+        expect { site_notice.valid? }.to change { site_notice.errors[:required] }.to ["Choose 'Yes' or 'No'"]
+      end
+    end
+
+    describe "callbacks" do
+      describe "::after_update #extend_consultation!" do
+        let(:default_local_authority) { create(:local_authority, :default) }
+        let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
+        let!(:consultation) { create(:consultation, planning_application:) }
+        let(:site_notice) { create(:site_notice, planning_application:) }
+
+        context "when there is an update to the displayed_at date" do
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 3, 28, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is an update of 21 days added to the consultation end date" do
+            expect do
+              site_notice.update(displayed_at: Time.zone.local(2023, 3, 15))
+            end.to change(consultation, :end_date)
+              .from(Time.zone.local(2023, 3, 28, 23, 59, 59, 999999))
+              .to(Time.zone.local(2023, 4, 5, 23, 59, 59, 999999))
+          end
+        end
+
+        context "when there is an update to another field" do
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 3, 28, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is no update to the consultation end date" do
+            expect { site_notice.update(content: "bla") }.not_to change(consultation, :end_date)
+          end
+        end
+
+        context "when consultation end date is later than the displayed at date + 21 days" do
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 4, 10, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is no update to the consultation end date" do
+            expect { site_notice.update(displayed_at: Time.zone.local(2023, 3, 15)) }.not_to change(consultation, :end_date)
+          end
+        end
+
+        context "when consultation end date is less than the displayed at date + 21 days" do
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 3, 28, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is an update to the consultation end date" do
+            expect do
+              site_notice.update(displayed_at: Time.zone.local(2023, 3, 15))
+            end.to change(consultation, :end_date)
+              .from(Time.zone.local(2023, 3, 28, 23, 59, 59, 999999))
+              .to(Time.zone.local(2023, 4, 5, 23, 59, 59, 999999))
+          end
+        end
+
+        context "when application has been marked as requiring an EIA and there is an update to the displayed_at date" do
+          let!(:environment_impact_assessment) { create(:environment_impact_assessment, planning_application:) }
+
+          before do
+            consultation.update!(
+              start_date: Time.zone.local(2023, 3, 28),
+              end_date: Time.zone.local(2023, 3, 28, 23, 59, 59, 999999)
+            )
+          end
+
+          it "there is an update of 30 days added to the consultation end date" do
+            expect do
+              site_notice.update(displayed_at: Time.zone.local(2023, 3, 15))
+            end.to change(consultation, :end_date)
+              .from(Time.zone.local(2023, 3, 28, 23, 59, 59, 999999))
+              .to(Time.zone.local(2023, 4, 14, 23, 59, 59, 999999))
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Extract common consultation logic for press/site notices
- Use "period_days" to determine consultation period for site notice as this may be EIA applicable which has 30 days

