### PR TITLE
BUG: Show "Invalidate" button if active validation requests

### DIFF
--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @planning_application.not_started? && @planning_application.validation_requests.empty? %>
+    <% if @planning_application.not_started? && @planning_application.validation_requests.active.empty? %>
       <p class="govuk-body">
         <strong>
           The application has not been marked as valid or invalid yet.
@@ -27,7 +27,7 @@
         <%= link_to "Mark the application as valid", confirm_validation_planning_application_path(@planning_application), class: "govuk-button" %>
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>
-    <% elsif @planning_application.not_started? && @planning_application.validation_requests.any? %>
+    <% elsif @planning_application.not_started? && @planning_application.validation_requests.active.any? %>
       <p class="govuk-body"><strong>You have marked items as invalid, so you cannot validate this application.</strong></p>
       <p class="govuk-body">If you mark the application as invalid then the applicant or agent will be sent an invalid notification. This notification will contain a link to allow the applicant or agent to view all validation requests and to accept and reject requests.</p>
       <%= form_with model: @planning_application, url: invalidate_planning_application_path(@planning_application), local:true do |form| %>
@@ -35,7 +35,7 @@
           <%= form.submit "Mark the application as invalid", class: "govuk-button", data: { module: "govuk-button"} %>
           <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
         </div>
-      <% end%>
+      <% end %>
     <% elsif @planning_application.invalidated? %>
       <p class="govuk-body">
         <strong>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -357,6 +357,7 @@ en:
       description_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (description#%{sequence})'
       description_change_validation_request_cancelled: 'Cancelled: validation request (applicant approval for description change #%{args})'
+      description_change_validation_request_cancelled_post_validation: 'Cancelled: validation request (applicant approval for description change #%{args})'
       description_change_validation_request_received: 'Received: request for change (description#%{args})'
       description_change_validation_request_sent: 'Sent: description change request (description#%{args})'
       description_change_validation_request_sent_post_validation: 'Sent: description change request (description#%{args})'


### PR DESCRIPTION
### Description of change

We were showing the "Mark planning application as invalid" if there were any validation requests, rather than if there were active ones. This meant that cancelled requests were throwing the whole thing off
