### PR TITLE
Add custom content for EIA neighbour letter - blocked

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -239,8 +239,37 @@ class Consultation < ApplicationRecord
       max_height: planning_application&.proposal_measurement&.max_height,
       eaves_height: planning_application&.proposal_measurement&.eaves_height,
       current_user: Current.user.name,
+      view_application: view_application,
       council_address: I18n.t("council_addresses.#{local_authority.subdomain}"),
       application_link:)
+  end
+
+  def view_application
+    if planning_application.environment_impact_assessment.present?
+      environment_impact_content
+    else
+      I18n.t("neighbour_letter_template.view_application_paragraph",
+        application_link:)
+    end
+  end
+
+  def environment_impact_content
+    if planning_application.environment_impact_assessment.with_address_email_and_fee?
+      I18n.t("neighbour_letter_template.eia_both_fields_content",
+        eia_email: planning_application.environment_impact_assessment.email_address,
+        eia_address: planning_application.environment_impact_assessment.address,
+        eia_fee: planning_application.environment_impact_assessment.fee,
+        application_link:)
+    elsif planning_application.environment_impact_assessment.with_address_and_fee?
+      I18n.t("neighbour_letter_template.eia_address_content",
+        eia_address: planning_application.environment_impact_assessment.address,
+        eia_fee: planning_application.environment_impact_assessment.fee,
+        application_link:)
+    else
+      I18n.t("neighbour_letter_template.eia_email_content",
+        eia_email: planning_application.environment_impact_assessment.email_address,
+        application_link:)
+    end
   end
 
   def neighbour_letter_content

--- a/config/locales/neighbour_letters.yml
+++ b/config/locales/neighbour_letters.yml
@@ -1,4 +1,4 @@
-en: 
+en:
   neighbour_letter_template:
     planning_permission: |-
       # Town and Country Planning Act 1990
@@ -21,11 +21,7 @@ en:
 
       # View, comment and track planning applications online
 
-      Use this link to:
-      * view the application documents
-      * submit your comments about the application
-
-      %{application_link}
+      %{view_application}
       
       # Commenting on this application
       
@@ -38,8 +34,6 @@ en:
       # If a decision is appealed
       
       If the Council's decision is appealed and you have commented, we will write to you to let you know. Your comments will be shared with the Planning Inspectorate. You will not be able to make any further comments if the decision is appealed.
-      
-      You will be notified of a decision about the appeal.
       
       # Commenting by post
       
@@ -112,3 +106,40 @@ en:
       
       %{current_user}
       Planning officer
+
+    view_application_paragraph: |-
+      Use this link to:
+      * view the application documents
+      * submit your comments about the application
+
+      %{application_link}
+    eia_both_fields_content: |-
+      Use this link to:
+      * view the application documents, including the Environmental Statement
+      * submit your comments about the application
+      
+      %{application_link}
+      
+      This application is subject to and Environmental Impact Assessment (EIA).
+      
+      You can request a hard copy for a fee of £%{eia_fee} by emailing %{eia_email} or in person at %{eia_address}
+    eia_address_content: |-
+      Use this link to:
+      * view the application documents, including the Environmental Statement
+      * submit your comments about the application
+      
+      %{application_link}
+      
+      This application is subject to and Environmental Impact Assessment (EIA).
+      
+      You can request a hard copy for a fee of £%{eia_fee} in person at %{eia_address}
+    eia_email_content: |-
+      Use this link to:
+      * view the application documents, including the Environmental Statement
+      * submit your comments about the application
+      
+      %{application_link}
+      
+      This application is subject to and Environmental Impact Assessment (EIA).
+      
+      You can request a copy by emailing %{eia_email}.

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -160,6 +160,46 @@ RSpec.describe Consultation do
     end
   end
 
+  describe "#view_application" do
+    let(:eia_planning_application) { create(:planning_application, :planning_permission) }
+    let(:consultation) { eia_planning_application.consultation }
+
+    context "when there is no environment impact assessment" do
+      it "should not include content about the environment impact assessment" do
+        Current.user = create(:user)
+
+        expect(consultation.neighbour_letter_body).not_to include("You can request a hard copy for a fee of 48")
+      end
+    end
+
+    context "when eia has address and email" do
+      it "includes address and email in neighbour letter" do
+        Current.user = create(:user)
+        create(:environment_impact_assessment, planning_application: eia_planning_application, address: "4 Sand Street", email_address: "eia@example.com", fee: 48)
+
+        expect(consultation.neighbour_letter_body).to include("You can request a hard copy for a fee of £48 by emailing eia@example.com or in person at 4 Sand Street")
+      end
+    end
+
+    context "when eia has address only" do
+      it "includes address in neighbour letter" do
+        Current.user = create(:user)
+        create(:environment_impact_assessment, planning_application: eia_planning_application, address: "4 Sand Street", fee: 48)
+
+        expect(consultation.neighbour_letter_body).to include("You can request a hard copy for a fee of £48 in person at 4 Sand Street")
+      end
+    end
+
+    context "when eia has email only" do
+      it "includes email in neighbour letter" do
+        Current.user = create(:user)
+        create(:environment_impact_assessment, planning_application: eia_planning_application, email_address: "eia@example.com")
+
+        expect(consultation.neighbour_letter_body).to include("You can request a copy by emailing eia@example.com")
+      end
+    end
+  end
+
   describe "#neighbour_responses_by_summary_tag" do
     let!(:consultation) { create(:consultation) }
     let!(:neighbour1) { create(:neighbour, address: "1, Random Lane, AAA111", consultation:) }


### PR DESCRIPTION
### Description of change

This adds three different versions of an environment impact assessment paragraph to the neighbour letter. We may not need this: POs are discussing.

### Story Link

https://trello.com/c/QdGuEz7i/2483-able-to-send-right-advice-in-neighbour-letter-for-eia-applications
