### PR TITLE
Update actions for node 20

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get github commit sha
         id: github
@@ -144,7 +144,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: matrix.service_type == 'web'
 
       - name: Get github commit sha
@@ -214,7 +214,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get current date
         id: date

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -50,7 +50,7 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Build, tag, and push ${{ inputs.environment-name }} image to Amazon ECR based github sha
         id: build-image

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -47,7 +47,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Expose GitHub Runtime for Docker build
-        uses: crazy-max/ghaction-github-runtime@v2
+        uses: crazy-max/ghaction-github-runtime@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -35,7 +35,7 @@ jobs:
           bundler-cache: true
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
       - run: yarn install

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup ruby and install gems
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -139,7 +139,7 @@ jobs:
           bundle exec cucumber
 
       - name: Expose GitHub Runtime for Docker build
-        uses: crazy-max/ghaction-github-runtime@v2
+        uses: crazy-max/ghaction-github-runtime@v3
         if: ${{ inputs.test-runner == 'docker' }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -67,7 +67,7 @@ jobs:
           bundler-cache: true
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         if: hashFiles('yarn.lock') != ''
         with:
           node-version-file: .node-version

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ inputs.test-runner == 'docker' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
         if: ${{ inputs.test-runner == 'docker' }}
 
       - name: Ensure ${{ inputs.dockerfile }} builds


### PR DESCRIPTION
The GitHub Actions runs are complaining about node 16 actions being deprecated.