### PR TITLE
Set duration of consultee consultation period

### DIFF
--- a/app/components/consultee_email_component.html.erb
+++ b/app/components/consultee_email_component.html.erb
@@ -1,4 +1,5 @@
 <h2 class="govuk-heading-m">
+  <div class="govuk-hint govuk-!-margin-bottom-0">Step 2</div>
   <%= t(".header") %>
 </h2>
 

--- a/app/components/consultees_component.html.erb
+++ b/app/components/consultees_component.html.erb
@@ -1,4 +1,5 @@
 <h2 class="govuk-heading-m">
+  <div class="govuk-hint govuk-!-margin-bottom-0">Step 1</div>
   <%= t(".header") %>
 </h2>
 

--- a/app/components/reconsult_consultees_component.html.erb
+++ b/app/components/reconsult_consultees_component.html.erb
@@ -1,7 +1,10 @@
 <div class="govuk-form-group" id="resend-consultees">
   <fieldset class="govuk-fieldset" aria-describedby="reconsult-hint">
     <legend class="govuk-fieldset__legend">
-      <h2 class="govuk-heading-m"><%= t(".legend") %></h2>
+      <h2 class="govuk-heading-m">
+        <div class="govuk-hint govuk-!-margin-bottom-0">Step 3</div>
+        <%= t(".legend") %>
+      </h2>
     </legend>
     <div id="reconsult-hint" class="govuk-hint">
       <%= t(".hint") %>
@@ -17,7 +20,6 @@
       <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-reconsult">
         <%= form.govuk_text_area :reconsult_message, label: { text: t(".reconsult_message_label") }, rows: 5 %>
         <p class="govuk-hint"><%= t(".formatting_hint_html") %></p>
-        <%= form.govuk_date_field :reconsult_date, legend: { text: t(".reconsult_date_label"), size: "s" } %>
       </div>
     </div>
   </fieldset>

--- a/app/controllers/planning_applications/consultations_controller.rb
+++ b/app/controllers/planning_applications/consultations_controller.rb
@@ -11,18 +11,28 @@ module PlanningApplications
       end
     end
 
-    def update
-      @consultation.update!(consultation_params.merge(status: "in_progress"))
-
+    def edit
       respond_to do |format|
-        format.html { redirect_to planning_application_consultation_path(@planning_application) }
+        format.html
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @consultation.update(consultation_params.merge(status: "in_progress"))
+          format.html do
+            redirect_to planning_application_consultation_path(@planning_application), notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
       end
     end
 
     private
 
     def consultation_params
-      params.require(:consultation).permit(:neighbour_letter_text, :resend_existing, :resend_reason)
+      params.require(:consultation).permit(:neighbour_letter_text, :resend_existing, :resend_reason, :end_date)
     end
   end
 end

--- a/app/controllers/planning_applications/consultee/emails_controller.rb
+++ b/app/controllers/planning_applications/consultee/emails_controller.rb
@@ -40,10 +40,10 @@ module PlanningApplications
         [
           :consultee_message_subject,
           :consultee_message_body,
+          :consultee_response_period,
           :email_reason,
           :resend_message,
           :reconsult_message,
-          :reconsult_date,
           {consultees_attributes: consultee_params}
         ]
       end

--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -85,12 +85,14 @@ module PlanningApplications
     end
 
     def update_letter_statuses
-      return if @consultation.neighbour_letters.none?
+      letters = @consultation.neighbour_letters.includes(:neighbour).where.not(status: "received")
+
+      notify_key = @planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
 
       # This is not ideal for now as will block the page loading, if it becomes a problem this would be
       # a good place for optimisation
-      @consultation.neighbour_letters.each do |letter|
-        letter.update_status unless letter.status == "received"
+      letters.each do |letter|
+        letter.update_status(notify_key)
       end
     end
 

--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -65,6 +65,6 @@ class Consultee < ApplicationRecord
   private
 
   def default_expires_at
-    email_delivered_at && (email_delivered_at + Consultation::DEFAULT_PERIOD).end_of_day
+    email_delivered_at && (email_delivered_at + Consultation::DEFAULT_PERIOD_DAYS).end_of_day
   end
 end

--- a/app/models/neighbour.rb
+++ b/app/models/neighbour.rb
@@ -32,7 +32,7 @@ class Neighbour < ApplicationRecord
                        }
 
   def last_letter
-    neighbour_letters.last
+    neighbour_letters.order(created_at: :desc).first
   end
 
   def letter_created?

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -21,11 +21,11 @@ class NeighbourLetter < ApplicationRecord
   scope :failed, -> { where(status: FAILURE_STATUSES) }
   scope :sent, -> { where.not(status: FAILURE_STATUSES) }
 
-  def update_status
+  def update_status(notify_key)
     return false if notify_id.blank?
 
     begin
-      response = Notifications::Client.new(notify_api_key).get_notification(notify_id)
+      response = Notifications::Client.new(notify_key).get_notification(notify_id)
     rescue Notifications::Client::RequestError
       return
     end

--- a/app/views/planning_applications/consultations/edit.html.erb
+++ b/app/views/planning_applications/consultations/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  Edit consultation
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% content_for :title, "Consultation" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Consultation" }
+) %>
+
+<%= form_with(
+  model: @consultation,
+  url: planning_application_consultation_path(@planning_application)
+) do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_date_field :end_date, legend: { text: "Set consultation end date", size: "m" } %>
+
+  <div class="govuk-button-group">
+    <%= form.submit "Save", class: "govuk-button" %>
+    <%= link_to "Back", planning_application_consultation_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/consultee/emails/index.html.erb
+++ b/app/views/planning_applications/consultee/emails/index.html.erb
@@ -32,6 +32,21 @@
       <%= render ConsulteeEmailComponent.new(form: form) %>
       <%= render ReconsultConsulteesComponent.new(form: form) if @consultees.consulted? %>
 
+      <div class="govuk-form-group" id="response-period">
+        <h2 class="govuk-heading-m">
+          <div class="govuk-hint govuk-!-margin-bottom-0">Step <%= @consultees.consulted? ? "4" : "3" %></div>
+          <%= form.label :consultee_response_period, "Set response period", class: "govuk-label govuk-label--m" %>
+        </h2>
+
+        <p class="govuk-hint">Enter the number of days that consultees have to respond.</p>
+
+        <div class="govuk-input__wrapper">
+          <%= form.govuk_text_field :consultee_response_period, placeholder: "", class: "govuk-input", label: -> {}, required: true %>
+
+          <div class="govuk-input__suffix" aria-hidden="true">days</div>
+        </div>
+      </div>
+
       <div class="govuk-button-group">
         <%= form.submit "Send emails to consultees", id: "send-emails-button", class: "govuk-button", data: { consultees_target: "submit" } %>
         <%= link_to "Back", planning_application_consultation_path(@planning_application), class: "govuk-button govuk-button--secondary" %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -30,6 +30,7 @@
                 <%= days_left > 0 ? t("planning_applications.days_left", count: days_left) : t("planning_applications.overdue", count: days_left.abs) %>
               </span>
             </span>
+            <span id="edit-consultation-end-date"><%= link_to "Change", edit_planning_application_consultation_path(@planning_application), class: "govuk-link" %></span>
           <% end %>
 
           <% if display_or_publish_required?(@planning_application, :site) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,10 +160,6 @@ en:
               invalidated: Emails can’t be sent out when a planning application is invalid
               not_public: Emails can’t be sent out when a planning application has not been made public
               not_started: Emails can’t be sent out when a planning application has not been started
-            reconsult_date:
-              date_blank: Please enter the date by which consultees need to respond by
-              date_invalid: Please enter a valid date
-              date_not_on_or_after: Please enter a date at least seven days from today
             reconsult_message:
               blank: Please enter the reasons for the reconsultation
               invalid: The reasons for reconsultation contains an invalid placeholder '{{%{placeholder}}}'
@@ -448,7 +444,7 @@ en:
     toggle_selection: Toggle selection
   consultee_email_component:
     formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <code>{{name}}</code> will be substituted when the email is sent.
-    header: 2) Send email to selected consultees
+    header: Send email to selected consultees
     message_body_label: Message body
     message_subject_label: Message subject
     reset_message_to_default: Reset message to default content
@@ -551,7 +547,7 @@ en:
     update:
       success: Consultee response has been updated
   consultees_component:
-    header: 1) Select the consultees to consult
+    header: Select the consultees to consult
     not_consulted: Not consulted
     select_consultee: Select consultee
   council_addresses:
@@ -996,6 +992,9 @@ en:
       success: Planning application was successfully cloned.
     confirm_validation:
       validate_application: Validate application
+    consultations:
+      update:
+        success: Consultation was successfully updated.
     consultee:
       emails:
         index:
@@ -1435,7 +1434,7 @@ en:
   reconsult_consultees_component:
     formatting_hint_html: The message is formatted using <a href="https://www.notifications.service.gov.uk/using-notify/formatting">GOV.UK Notify formatting rules</a>. Placeholders like <nobr><code>{{closing_date}}</code></nobr> will be substituted when the email is sent.
     hint: Choosing 'Yes' will allow you to add the reasons why this application is being reconsulted.
-    legend: 3) Is this a reconsultation?
+    legend: Is this a reconsultation?
     reconsult: Yes, I’m reconsulting existing consultees
     reconsult_date_label: Consultee reponse required by
     reconsult_message_hint: This text will go at the top of the new email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,7 +129,7 @@ Rails.application.routes.draw do
         resources :responses, only: %i[index]
       end
 
-      resource :consultation, only: %i[show update] do
+      resource :consultation, only: %i[show edit update] do
         resources :neighbours, only: %i[index create update destroy]
 
         resources :neighbour_letters, only: %i[index update destroy] do

--- a/spec/models/neighbour_letter_spec.rb
+++ b/spec/models/neighbour_letter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NeighbourLetter do
     it "updates the letter's status from notify" do
       notify_request = stub_get_notify_status(notify_id: neighbour_letter.notify_id)
 
-      neighbour_letter.update_status
+      neighbour_letter.update_status(Rails.configuration.default_notify_api_key)
       expect(notify_request).to have_been_requested
 
       expect(neighbour_letter.status).to eq("received")

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Press notice" do
+RSpec.describe "Consultation" do
   let!(:local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority:) }
   let!(:planning_application) do
@@ -12,7 +12,7 @@ RSpec.describe "Press notice" do
   before do
     sign_in assessor
 
-    planning_application.consultation.update(end_date: Time.zone.local(2023, 9, 15, 12))
+    planning_application.consultation.update(start_date: Time.zone.local(2023, 8, 15, 12), end_date: Time.zone.local(2023, 9, 15, 12))
     visit "/planning_applications/#{planning_application.id}"
   end
 
@@ -21,6 +21,38 @@ RSpec.describe "Press notice" do
       click_link "Consultees, neighbours and publicity"
 
       expect(page).to have_content("Consultation end date: 15 September 2023")
+    end
+
+    it "I can edit the consultation end date" do
+      click_link "Consultees, neighbours and publicity"
+
+      within("#edit-consultation-end-date") do
+        click_link "Change"
+      end
+
+      fill_in "Day", with: "03"
+      fill_in "Month", with: ""
+      fill_in "Year", with: ""
+
+      click_button "Save"
+      within(".govuk-error-summary") do
+        expect(page).to have_content("End date is not a valid date")
+      end
+
+      fill_in "Day", with: "03"
+      fill_in "Month", with: "01"
+      fill_in "Year", with: "2023"
+      click_button "Save"
+      within(".govuk-error-summary") do
+        expect(page).to have_content("End date is not on or after 15/08/2023")
+      end
+
+      fill_in "Day", with: "20"
+      fill_in "Month", with: "09"
+      fill_in "Year", with: "2023"
+      click_button "Save"
+      expect(page).to have_content("Consultation was successfully updated.")
+      expect(page).to have_content("Consultation end date: 20 September 2023")
     end
   end
 

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -143,9 +143,10 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Send emails to consultees"
     expect(page).to have_selector("h1", text: "Send emails to consultees")
-    expect(page).to have_selector("h2", text: "1) Select the consultees to consult")
-    expect(page).to have_selector("h2", text: "2) Send email to selected consultees")
-    expect(page).to have_selector("h2", text: "3) Is this a reconsultation?")
+    expect(page).to have_selector("h2", text: "Step 1 Select the consultees to consult")
+    expect(page).to have_selector("h2", text: "Step 2 Send email to selected consultees")
+    expect(page).to have_selector("h2", text: "Step 3 Is this a reconsultation?")
+    expect(page).to have_selector("h2", text: "Step 4 Set response period")
 
     within "#external-consultees" do
       within "table tbody tr:first-child" do
@@ -183,10 +184,9 @@ RSpec.describe "Consultation", js: true do
 
     within "#resend-consultees" do
       choose "Yes, I’m reconsulting existing consultees"
-
-      fill_in "Day", with: ""
-      fill_in "Month", with: ""
-      fill_in "Year", with: ""
+    end
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: 100
     end
 
     accept_confirm(text: "Send emails to consultees?") do
@@ -194,34 +194,13 @@ RSpec.describe "Consultation", js: true do
     end
 
     expect(page).to have_selector("[role=alert] li", text: "Please enter the reasons for the reconsultation")
-    expect(page).to have_selector("[role=alert] li", text: "Please enter the date by which consultees need to respond by")
-
-    within "#resend-consultees" do
-      fill_in "Day", with: today.day
-      fill_in "Month", with: today.month
-      fill_in "Year", with: today.year
-    end
-
-    accept_confirm(text: "Send emails to consultees?") do
-      click_button "Send emails to consultees"
-    end
-
-    expect(page).to have_selector("[role=alert] li", text: "Please enter a date at least seven days from today")
-
-    within "#resend-consultees" do
-      fill_in "Day", with: "50"
-      fill_in "Month", with: today.month
-      fill_in "Year", with: today.year
-    end
-
-    accept_confirm(text: "Send emails to consultees?") do
-      click_button "Send emails to consultees"
-    end
-
-    expect(page).to have_selector("[role=alert] li", text: "Please enter a valid date")
+    expect(page).to have_selector("[role=alert] li", text: "Consultee response period must be less than or equal to 99")
 
     within "#resend-consultees" do
       fill_in "Reasons for reconsultation", with: "Application has changes - please respond by {{close_date}}"
+    end
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: "not an integer"
     end
 
     accept_confirm(text: "Send emails to consultees?") do
@@ -229,12 +208,14 @@ RSpec.describe "Consultation", js: true do
     end
 
     expect(page).to have_selector("[role=alert] li", text: "The reasons for reconsultation contains an invalid placeholder '{{close_date}}'")
+    expect(page).to have_selector("[role=alert] li", text: "Consultee response period is not a number")
 
     within "#resend-consultees" do
       fill_in "Reasons for reconsultation", with: "Application has changes - please respond by {{closing_date}}"
-      fill_in "Day", with: future.day
-      fill_in "Month", with: future.month
-      fill_in "Year", with: future.year
+    end
+
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: 14
     end
 
     expect do

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -139,9 +139,9 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Send emails to consultees"
     expect(page).to have_selector("h1", text: "Send emails to consultees")
-    expect(page).to have_selector("h2", text: "1) Select the consultees to consult")
-    expect(page).to have_selector("h2", text: "2) Send email to selected consultees")
-    expect(page).to have_selector("h2", text: "3) Is this a reconsultation?")
+    expect(page).to have_selector("h2", text: "Step 1 Select the consultees to consult")
+    expect(page).to have_selector("h2", text: "Step 2 Send email to selected consultees")
+    expect(page).to have_selector("h2", text: "Step 3 Is this a reconsultation?")
 
     within "#external-consultees" do
       within "table tbody tr:first-child" do
@@ -191,6 +191,10 @@ RSpec.describe "Consultation", js: true do
 
     within "#resend-consultees" do
       fill_in "Additional message to include in the email", with: "Please respond to the message below by {{closing_date}}"
+    end
+
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: 7
     end
 
     expect do

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -95,9 +95,10 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Send emails to consultees"
     expect(page).to have_selector("h1", text: "Send emails to consultees")
-    expect(page).to have_selector("h2", text: "1) Select the consultees to consult")
-    expect(page).to have_selector("h2", text: "2) Send email to selected consultees")
-    expect(page).not_to have_selector("h2", text: "3) Is this a reconsultation?")
+    expect(page).to have_selector("h2", text: "Step 1 Select the consultees to consult")
+    expect(page).to have_selector("h2", text: "Step 2 Send email to selected consultees")
+    expect(page).to have_selector("h2", text: "Step 3 Set response period")
+    expect(page).not_to have_selector("h2", text: "Step 3 Is this a reconsultation?")
 
     accept_confirm(text: "Send emails to consultees?") do
       click_button "Send emails to consultees"

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -466,6 +466,8 @@ RSpec.describe "Press notice" do
       end
 
       it "I can confirm the press notice details" do
+        expect(consultation.end_date.to_date).to eq("Thu, 12 Oct 2023".to_date)
+
         click_link "Consultees, neighbours and publicity"
         click_link "Confirm press notice"
 


### PR DESCRIPTION
### Description of change

- Avoid N+1 queries when updating neighbour letter status
- Allow officer to set duration for consultee consultation period. Extend the consultation deadline if this exceed the current end date
- Allow officer to manually set the consultation end date

### Story Link

https://trello.com/c/DcoYObRH/2479-able-to-change-the-duration-of-internal-external-consultee-consultation-period

