### PR TITLE
Add SRI hash to feedback-fish tag

### DIFF
--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -16,7 +16,10 @@
   <%= javascript_include_tag 'application' %>
 
   <% if feedback_fish_id = Rails.configuration.feedback_fish_id %>
-    <%= tag.script(src: "https://feedback.fish/ff.js?pid=#{feedback_fish_id}", defer: "defer", nonce: request.content_security_policy_nonce) %>
+    <%= tag.script(src: "https://feedback.fish/ff.js?pid=#{feedback_fish_id}",
+          defer: "defer",
+          nonce: request.content_security_policy_nonce,
+          integrity: "sha512-HdG7a/XxJ6TQmGcje0DXdv3L76WRANcR1EU2aN+R6p+Uq8A6mUP/z8XLSMRCLGxE0WS4Q2gndGfVsqGgfjN19A==") %>
   <% end %>
 
   <% if gtmid = Rails.configuration.google_tag_manager_id %>


### PR DESCRIPTION
### Description of change

Adding an `integrity` attribute to the feedback-fish `script` tag, as recommended by the recent audit.

### Story Link

https://trello.com/c/fP6oyg1X/2527-unverified-subresource-integrity

### Decisions

It doesn't appear that the content of the script varies based on the feedback-fish project ID (i.e., the ID isn't embedded in the response, it looks like it reads it from the referring page) so I haven't tried to allow for multiple integrity hashes.

### Known issues

We have no way of knowing if they're likely to update the script periodically. If they did so, this would break — which is of course correct behaviour. As an alternative we could serve a copy of the script ourselves, but equally that could fail if they made a backwards-incompatible change on the server side and we didn't update to a compatible new version of the script. In either case there isn't an obvious way to know in advance, but this isn't a critical feature either.
