### PR TITLE
Display updated status before ownership certificate validated

### DIFF
--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -13,6 +13,8 @@ module StatusTags
     def status
       if planning_application.valid_ownership_certificate.nil?
         :not_started
+      elsif planning_application.valid_ownership_certificate? && planning_application.ownership_certificate_awaiting_validation?
+        :updated
       elsif planning_application.valid_ownership_certificate?
         :valid
       else

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -13,10 +13,12 @@ module StatusTags
     def status
       if planning_application.valid_ownership_certificate.nil?
         :not_started
-      elsif planning_application.valid_ownership_certificate? && planning_application.ownership_certificate_awaiting_validation?
-        :updated
       elsif planning_application.valid_ownership_certificate?
-        :valid
+        if planning_application.ownership_certificate_awaiting_validation?
+          :updated
+        else
+          :valid
+        end
       else
         :invalid
       end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -425,6 +425,13 @@ class PlanningApplication < ApplicationRecord
     raise SubmitRecommendationError, e.message
   end
 
+  def ownership_certificate_awaiting_validation?
+    certificate_present = valid_ownership_certificate?
+    has_requests = ownership_certificate_validation_requests.any?
+
+    certificate_present && has_requests && ownership_certificate_validation_requests.last.approved.nil?
+  end
+
   def withdraw_last_recommendation!
     transaction do
       withdraw_recommendation!

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -220,6 +220,16 @@ RSpec.describe PlanningApplication do
         end
       end
 
+      describe "#ownership_certificate_awaiting_validation?" do
+        it "sets planning application status to updated when certificate is added" do
+          certificate_request = create(:ownership_certificate_validation_request)
+          planning_application = certificate_request.planning_application
+
+          planning_application.update!(valid_ownership_certificate: true)
+          expect(planning_application.ownership_certificate_awaiting_validation?).to be(true)
+        end
+      end
+
       describe "#reference" do
         let(:planning_application) do
           build(:planning_application, work_status: "proposed")


### PR DESCRIPTION
### Description of change

Currently when an applicant or agent responds to an ownership certificate change request, the planning application is automatically updated with the ownership certificate and appears valid in the task list (see screenshot). This PR adds a condition that if the change request is not approved but the ownership certificate is present, then the task list shows 'Updated'. Note that this only applies if `approved` is `nil` rather than the change request being rejected.

### Story Link

https://trello.com/c/9gLgifuS/2524-improvements-to-ownership-certificate-flow

### Screenshots

![change_request](https://github.com/unboxed/bops/assets/1880450/3b5a25db-8c0d-454c-b9cf-03966836af13)
![change_request_2](https://github.com/unboxed/bops/assets/1880450/6fa2eaf9-cd6c-4bf0-a8dd-661f63996ab1)
