### PR TITLE
Refactor consultable

### DIFF
--- a/app/models/concerns/consultable.rb
+++ b/app/models/concerns/consultable.rb
@@ -17,22 +17,11 @@ module Consultable
     private
 
     def new_consultation_end_date
-      [event_at && (event_at + consultation.period_days).end_of_day, consultation_end_date].compact.max
+      [consultable_event_at && (consultable_event_at + consultation.period_days).end_of_day, consultation_end_date].compact.max
     end
 
     def extend_consultation!
       consultation.update!(end_date: new_consultation_end_date)
-    end
-
-    def event_at
-      case self.class.name
-      when "PressNotice"
-        published_at
-      when "SiteNotice"
-        displayed_at
-      else
-        raise ArgumentError "Method not supported for class: #{self.class.name}"
-      end
     end
   end
 end

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -54,6 +54,8 @@ class PressNotice < ApplicationRecord
 
   scope :required, -> { where(required: true) }
 
+  alias_attribute :consultable_event_at, :published_at
+
   def reasons
     Array.wrap(super)
   end

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -24,6 +24,8 @@ class SiteNotice < ApplicationRecord
 
   attr_reader :method
 
+  alias_attribute :consultable_event_at, :displayed_at
+
   def documents=(files)
     files.select(&:present?).each do |file|
       documents.new(file: file, planning_application: planning_application, tags: ["Site Notice"])


### PR DESCRIPTION
### Description of change

A module shouldn't have to know which classes include it. This way, any class can include it just by implementing `consultable_event_at` rather than having to modify `Consultable`.
