### PR TITLE
List all neighbour responses and respond

### DIFF
--- a/app/assets/stylesheets/consultation.scss
+++ b/app/assets/stylesheets/consultation.scss
@@ -134,3 +134,29 @@
   border: 1px solid $govuk-border-colour;
   padding: 0 5px;
 }
+
+#neighbour-response-accordion {
+  .govuk-accordion__controls {
+    display: none;
+  }
+
+  .govuk-accordion__section {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  .neighbour-response {
+    border-bottom: 1px solid $govuk-border-colour;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+
+  .neighbour-response-section {
+    border-bottom: none;
+  }
+
+  .govuk-accordion__section-content {
+    padding-bottom: 0px;
+  }
+}

--- a/app/helpers/assessment_detail_helper.rb
+++ b/app/helpers/assessment_detail_helper.rb
@@ -4,10 +4,20 @@ module AssessmentDetailHelper
   def neighbour_responses_summary_text(neighbour_responses_by_summary_tag)
     return "There are no neighbour responses" unless neighbour_responses_by_summary_tag.any?
 
-    summary_text = neighbour_responses_by_summary_tag.map do |tag, count|
-      "#{count} #{tag}"
+    summary_text = neighbour_responses_by_summary_tag.map.with_index do |(tag, count), i|
+      i.zero? ? t(:neighbour_responses_by_summary_tag, tag:, count:) : "#{count} #{tag}"
     end
 
-    "There is #{summary_text.join(", ")}."
+    "#{summary_text.join(", ")}."
+  end
+
+  def updated_neighbour_responses_summary_text(responses, detail)
+    count = if detail.created_at.nil?
+      responses.length
+    else
+      responses.where("neighbour_responses.created_at > ?", detail.updated_at).length
+    end
+
+    t(:neighbour_responses_by_summary_tag, tag: "new neighbour response", count:)
   end
 end

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -43,6 +43,7 @@ class AssessmentDetail < ApplicationRecord
 
   validates :assessment_status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
+  validate :tagged_entry, if: :publicity_summary?
 
   validates(
     :additional_information,
@@ -86,5 +87,15 @@ class AssessmentDetail < ApplicationRecord
 
   def set_user
     self.user = user || Current.user
+  end
+
+  def tagged_entry
+    return unless assessment_status == "complete"
+
+    tag_array = NeighbourResponse::TAGS.dup
+
+    entries = tag_array.push(:untagged).map { |tag| entry[/(?<=#{tag.to_s.humanize}:)\s\n/] }
+
+    errors.add(:entry, "Fill in all summaries of comments") if entries.any?
   end
 end

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -15,6 +15,8 @@ class NeighbourResponse < ApplicationRecord
   enum(summary_tag: {supportive: "supportive", neutral: "neutral", objection: "objection"})
 
   scope :redacted, -> { where.not(redacted_response: "") }
+  scope :with_tags, -> { where.not("tags = '[]'") }
+  scope :without_tags, -> { where("tags = '[]'") }
 
   TAGS = %i[design new_use privacy disabled_access noise traffic other].freeze
 

--- a/app/views/planning_applications/assessment/assessment_details/_fields.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/_fields.html.erb
@@ -1,1 +1,1 @@
-<p class="govuk-body"><%= render(FormattedContentComponent.new(text: assessment_detail.entry)) %></p>
+<%= render(FormattedContentComponent.new(text: assessment_detail.entry)) %>

--- a/app/views/planning_applications/assessment/assessment_details/_form.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/_form.html.erb
@@ -5,20 +5,32 @@
   rejected_assessment_detail: rejected_assessment_detail
 ) %>
 
-<%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-  <%= form.govuk_error_summary(
-    presenter: assessment_detail_error_presenter(category)
-  ) %>
+<% if @category == "publicity_summary" %>
+  <% if @planning_application.consultation.neighbour_responses.any? %>
+    <%= render "planning_applications/assessment/assessment_details/publicity_summary/responses",
+      neighbour_responses: @planning_application.consultation.neighbour_responses,
+      rejected_assessment_detail: rejected_assessment_detail,
+      category: "publicity_summary"
+    %>
+  <% else %>
+    <p class="govuk-body">There are no neighbour responses</p>
+  <% end %>
+<% else %>
+  <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
+    <%= form.govuk_error_summary(
+      presenter: assessment_detail_error_presenter(category)
+    ) %>
 
-  <%= render(
-    partial: "#{assessment_detail_fields_partial_path(category)}/form_fields",
-    locals: {
-      form: form,
-      rejected_assessment_detail: rejected_assessment_detail
-    }
-  ) %>
+    <%= render(
+      partial: "#{assessment_detail_fields_partial_path(category)}/form_fields",
+      locals: {
+        form: form,
+        rejected_assessment_detail: rejected_assessment_detail
+      }
+    ) %>
 
-  <%= form.hidden_field :category, value: category %>
+    <%= form.hidden_field :category, value: category %>
 
-  <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+    <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+  <% end %>
 <% end %>

--- a/app/views/planning_applications/assessment/assessment_details/publicity_summary/_information.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/publicity_summary/_information.html.erb
@@ -4,23 +4,12 @@
       banner_class: "govuk-notification-banner",
       role: "region",
       title: "View neighbour responses",
-      heading: neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %>
-
-    <p><%= link_to "View neighbour responses", planning_application_consultation_neighbour_responses_path(@planning_application) %></p>
+      heading: updated_neighbour_responses_summary_text(consultation.neighbour_responses, @assessment_detail) %>
   <% else %>
     <p>There is no existing consultation for this planning application.</p>
   <% end %>
 
   <% if action_name == "show" %>
-    <p><strong>Summary</strong></p>
-  <% end %>
-
-  <%= render "shared/warning_text",
-             message: "This information will be made publicly available." %>
-  <%= render(
-        partial: "comment",
-        locals: { comment: rejected_assessment_detail&.comment }
-      ) %>
-  <% unless action_name == "show" %>
+    <h3 class="govuk-heading-s">Summary</h3>
   <% end %>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/publicity_summary/_responses.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/publicity_summary/_responses.html.erb
@@ -1,0 +1,148 @@
+<%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
+  <%= form.govuk_error_summary(
+    presenter: assessment_detail_error_presenter(category)
+  ) %>
+
+  <% neighbour_responses.with_tags.group_by(&:tags).sort_by { |key, _value| key[0] }.reverse.each_with_index do |(tag, responses), index| %>
+    <div class="bops-accordion" data-module="bops-accordion" data-remember-expanded="false" id="neighbour-response-accordion">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id=<%= "accordion-default-heading-#{index}" %>>
+              <%= "#{tag.first.humanize} responses (#{responses.count})" %>
+            </span>
+          </h2>
+        </div>
+        <div id=<%= "accordion-default-content-#{index}" %> class="govuk-accordion__section-content" aria-labelledby=<%= "accordion-default-heading-#{index}" %>>
+          <% responses.group_by { |response| response.neighbour.selected? }.sort_by { |key, _value| key ? 0 : 1 }.each do |selected, sorted_responses| %>
+            <% sorted_responses.group_by { |response| response.summary_tag }.each do |opinion, resp| %>
+              <div class="neighbour-response">
+                <% resp.each do |response| %>
+                  <div class="neighbour-response-section">
+                    <div class="govuk-inset-text">
+                      <div class="neighbour-response-top-section">
+                        <div class="neighbour-response-content">
+                          <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+                          <% if response.neighbour.selected? %>
+                            <strong class="govuk-tag app-task-list__task-tag govuk-!-margin-left-1">Adjoining neighbour</strong>
+                          <% end %>
+                          <br><br>
+                          <ul class="govuk-list">
+                            <li>
+                              <strong><%= response.name %></strong> <span class="govuk-hint" style="display: inline;"><%= response.email %></span>
+                            </li>
+                            <li class="govuk-hint">
+                              <%= response.neighbour.address %>
+                            </li>
+                            <li class="govuk-hint">
+                              Received on <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
+                            </li>
+                          </ul>
+                          <div data-controller="show-more-text">
+                            <span class="truncated-comment">
+                              <%= simple_format(response.truncated_comment) %>
+                            </span>
+
+                            <% if response_been_truncated?(response) %>
+                              <span class="govuk-!-display-none hidden-comment">
+                                <%= simple_format(response.comment[truncated_length(response)..-1]) %>
+                              </span>
+                              <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>
+                            <% end %>
+                          </div>
+                        </div>
+                        <div class="neighbour-tags">
+                          <% response.tags.each do |tag| %>
+                            <div class="govuk-!-margin-bottom-3">
+                              <strong class="govuk-tag govuk-tag--grey"><%= tag.humanize.upcase %></strong>
+                            </div>
+                          <% end %>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <%= form.govuk_text_area(
+      :"#{tag.first}",
+      label: { text: "Summary of #{tag.first.humanize.downcase} comments", size: "m" },
+      rows: 10,
+      value: (@assessment_detail.entry[/(?<=#{tag.first.humanize}:)(.*)/] unless @assessment_detail.entry.nil?)
+    ) %>
+
+    <%= form.hidden_field :category, value: category %>
+  <% end %>
+
+  <% if neighbour_responses.without_tags.any? %>
+    <div class="bops-accordion" data-module="bops-accordion" data-remember-expanded="false" id="neighbour-response-accordion">
+      <div class="govuk-accordion__section">
+        <div class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id=<%= "accordion-default-heading-no-tag" %>>
+              <%= "Untagged responses (#{neighbour_responses.without_tags.count})" %>
+            </span>
+          </h2>
+        </div>
+        <% neighbour_responses.without_tags.each_with_index do |response, index| %>
+          <div class="neighbour-response">
+            <div id=<%= "accordion-default-content-#{index}" %> class="govuk-accordion__section-content" aria-labelledby=<%= "accordion-default-heading-no-tag" %>>
+              <div class="neighbour-response-section">
+                <div class="govuk-inset-text">
+                  <div class="neighbour-response-top-section">
+                    <div class="neighbour-response-content">
+                      <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+                      <% if response.neighbour.selected? %>
+                        <strong class="govuk-tag app-task-list__task-tag govuk-!-margin-left-1">Adjoining neighbour</strong>
+                      <% end %>
+                      <br><br>
+                      <ul class="govuk-list">
+                        <li>
+                          <strong><%= response.name %></strong> <span class="govuk-hint" style="display: inline;"><%= response.email %></span>
+                        </li>
+                        <li class="govuk-hint">
+                          <%= response.neighbour.address %>
+                        </li>
+                        <li class="govuk-hint">
+                          Received on <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
+                        </li>
+                      </ul>
+                      <div data-controller="show-more-text">
+                        <span class="truncated-comment">
+                          <%= simple_format(response.truncated_comment) %>
+                        </span>
+
+                        <% if response_been_truncated?(response) %>
+                          <span class="govuk-!-display-none hidden-comment">
+                            <%= simple_format(response.comment[truncated_length(response)..-1]) %>
+                          </span>
+                          <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>
+                        <% end %>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <%= form.govuk_text_area(
+      :untagged,
+      label: { text: "Summary of untagged comments", size: "m" },
+      rows: 10,
+      value: (@assessment_detail.entry[/(?<=untagged:)(.*)/] unless @assessment_detail.entry.nil?)
+    ) %>
+
+    <%= form.hidden_field :category, value: category %>
+  <% end %>
+
+  <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -685,6 +685,10 @@ en:
   neighbour_letter_header:
     planning_permission: Submit your comments by %{closing_date}
     prior_approval: Submit your comments by %{closing_date}
+  neighbour_responses_by_summary_tag:
+    one: There is 1 %{tag}
+    other: There are %{count} %{tag}s
+    zero: There are 0 %{tag}s
   no_consultees_component:
     no_consultees_yet: No consultees have been added to the consultation yet.
   page_title: BETA BOPs - GOV.UK

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe "neighbour responses" do
     let!(:neighbour1) { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }
     let!(:neighbour2) { create(:neighbour, address: "2, Test Lane, AAA111", consultation:) }
     let!(:neighbour3) { create(:neighbour, address: "3, Test Lane, AAA111", consultation:) }
-    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection") }
-    let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
-    let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
+    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection", tags: ["design"]) }
+    let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive", tags: ["design"]) }
+    let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive", tags: ["disabled_access"]) }
     let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
 
     it "I can view the information on the neighbour responses page" do
@@ -38,14 +38,9 @@ RSpec.describe "neighbour responses" do
         click_link "Summary of neighbour responses"
       end
 
-      expect(page).to have_link(
-        "View neighbour responses",
-        href: "/planning_applications/#{planning_application.id}/consultation/neighbour_responses"
-      )
-
       within(".govuk-notification-banner") do
         expect(page).to have_content("View neighbour responses")
-        expect(page).to have_content("There is 1 neutral, 1 objection, 2 supportive.")
+        expect(page).to have_content("There are 4 new neighbour responses")
       end
 
       expect(page).to have_current_path(
@@ -60,7 +55,17 @@ RSpec.describe "neighbour responses" do
       expect(page).to have_content(planning_application.reference)
       expect(page).to have_content(planning_application.full_address)
 
-      expect(page).to have_content("This information will be made publicly available.")
+      click_button "Design responses (2)"
+      expect(page).to have_content(objection_response.redacted_response)
+      expect(page).to have_content(supportive_response1.redacted_response)
+      click_button "Design responses (2)"
+
+      click_button "Disabled access responses (1)"
+      expect(page).to have_content(supportive_response2.redacted_response)
+      click_button "Disabled access responses (1)"
+
+      click_button "Untagged responses (1)"
+      expect(page).to have_content(neutral_response.redacted_response)
     end
 
     it "I can save and come back later when adding or editing neighbour responses" do
@@ -69,7 +74,12 @@ RSpec.describe "neighbour responses" do
       click_link "Check and assess"
       click_link "Summary of neighbour responses"
 
-      fill_in "assessment_detail[entry]", with: "A draft entry for the neighbour responses"
+      within(".govuk-notification-banner") do
+        expect(page).to have_content("View neighbour responses")
+        expect(page).to have_content("There are 4 new neighbour responses")
+      end
+
+      fill_in "assessment_detail[design]", with: "A draft entry for the neighbour responses"
       click_button "Save and come back later"
 
       expect(page).to have_content("neighbour responses was successfully created.")
@@ -88,7 +98,7 @@ RSpec.describe "neighbour responses" do
 
       within(".govuk-notification-banner") do
         expect(page).to have_content("View neighbour responses")
-        expect(page).to have_content("There is 1 neutral, 1 objection, 2 supportive.")
+        expect(page).to have_content("There are 0 new neighbour responses")
       end
 
       click_button "Save and come back later"
@@ -107,7 +117,9 @@ RSpec.describe "neighbour responses" do
       click_link "Check and assess"
       click_link "Summary of neighbour responses"
 
-      fill_in "assessment_detail[entry]", with: "A complete entry for the neighbour responses"
+      fill_in "assessment_detail[design]", with: "A complete entry for the design neighbour responses"
+      fill_in "assessment_detail[disabled_access]", with: "A complete entry for the disabled access neighbour responses"
+      fill_in "assessment_detail[untagged]", with: "A complete entry for the untagged neighbour responses"
       click_button "Save and mark as complete"
 
       expect(page).to have_content("neighbour responses was successfully created.")
@@ -118,13 +130,26 @@ RSpec.describe "neighbour responses" do
 
       click_link "Summary of neighbour responses"
       expect(page).to have_content("Summary of neighbour responses")
-      expect(page).to have_content("A complete entry for the neighbour responses")
+      expect(page).to have_content("Design: A complete entry for the design neighbour responses")
+      expect(page).to have_content("Disabled access: A complete entry for the disabled access neighbour responses")
+      expect(page).to have_content("Untagged: A complete entry for the untagged neighbour responses")
 
       expect(page).to have_link(
         "Edit summary of neighbour responses",
         href: edit_planning_application_assessment_assessment_detail_path(planning_application,
           AssessmentDetail.publicity_summary.last, category: "publicity_summary")
       )
+    end
+
+    it "shows errors" do
+      click_link "Check and assess"
+      click_link "Summary of neighbour responses"
+
+      fill_in "assessment_detail[design]", with: "A complete entry for the design neighbour responses"
+      fill_in "assessment_detail[disabled_access]", with: "A complete entry for the disabled access neighbour responses"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Fill in all summaries of comments"
     end
   end
 


### PR DESCRIPTION
### Description of change

Allow officer to respond to each category of neighbour objections

### Story Link

https://trello.com/c/LFDH2ckS/2508-list-individual-neighbour-issues-and-address-each-one

### Screenshots

![screencapture-southwark-bops-localhost-3000-planning-applications-2260-assessment-assessment-details-520-edit-2024-02-08-10_20_20](https://github.com/unboxed/bops/assets/35098639/f0dc557a-0d13-4bb7-bc43-d5f513d855d1)
