### PR TITLE
Set correct closing date for consultees

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -368,7 +368,7 @@ class Consultation < ApplicationRecord
       description: planning_application.description,
       address: planning_application.address,
       link: application_link,
-      closing_date: end_date.to_fs
+      closing_date: consultee_response_required_by.to_fs
     }
 
     subject = consultee_message_subject
@@ -392,12 +392,10 @@ class Consultation < ApplicationRecord
         body: replace_placeholders(body, variables)
       )
 
-      expires_at = [end_date, consultee_response_required_by].max
-
       consultee.update!(
         selected: false,
         status: "sending",
-        expires_at: expires_at.end_of_day,
+        expires_at: consultee_response_required_by.end_of_day,
         last_email_sent_at: nil,
         last_email_delivered_at: nil
       )

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -166,6 +166,10 @@ RSpec.describe "Consultation", js: true do
 
     click_button "Reset message to default content"
 
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: 10
+    end
+
     expect do
       accept_confirm(text: "Send emails to consultees?") do
         click_button "Send emails to consultees"
@@ -312,7 +316,7 @@ RSpec.describe "Consultation", js: true do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Chris Wood")
         expect(page).to have_selector("td:nth-child(2)", text: "Tree Officer, PlanX Council")
-        expect(page).to have_selector("td:nth-child(3)", text: "#{period} days")
+        expect(page).to have_selector("td:nth-child(3)", text: "10 days")
         expect(page).to have_selector("td:nth-child(4)", text: current_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
       end
@@ -327,6 +331,10 @@ RSpec.describe "Consultation", js: true do
     toggle "View/edit email template"
 
     fill_in "Message subject", with: "Resend: Consultation for planning application {{reference}}"
+
+    within "#response-period" do
+      fill_in "consultation[consultee_response_period]", with: 15
+    end
 
     expect do
       accept_confirm(text: "Send emails to consultees?") do
@@ -417,7 +425,7 @@ RSpec.describe "Consultation", js: true do
         expect(page).to have_unchecked_field("Select consultee")
         expect(page).to have_selector("td:nth-child(2)", text: "Consultations")
         expect(page).to have_selector("td:nth-child(2)", text: "Planning Department, GLA")
-        expect(page).to have_selector("td:nth-child(3)", text: "#{period} days")
+        expect(page).to have_selector("td:nth-child(3)", text: "15 days")
         expect(page).to have_selector("td:nth-child(4)", text: current_date)
         expect(page).to have_selector("td:nth-child(5)", text: "Awaiting response")
       end


### PR DESCRIPTION
### Description of change

We want the dates in the email to match what the consultee response period has been set as

### Story Link

https://trello.com/c/DcoYObRH/2479-able-to-change-the-duration-of-internal-external-consultee-consultation-period

