### PR TITLE
Identify applications with pre-validated ownership certificates

### DIFF
--- a/app/models/ownership_certificate_validation_request.rb
+++ b/app/models/ownership_certificate_validation_request.rb
@@ -14,6 +14,10 @@ class OwnershipCertificateValidationRequest < ValidationRequest
     ).call
   end
 
+  def not_yet_validated?
+    post_validation == false
+  end
+
   private
 
   def audit_api_comment

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -428,8 +428,9 @@ class PlanningApplication < ApplicationRecord
   def ownership_certificate_awaiting_validation?
     certificate_present = valid_ownership_certificate?
     has_requests = ownership_certificate_validation_requests.any?
+    not_yet_validated = ownership_certificate_validation_requests&.last&.not_yet_validated?
 
-    certificate_present && has_requests && ownership_certificate_validation_requests.last.approved.nil?
+    certificate_present && has_requests && not_yet_validated
   end
 
   def withdraw_last_recommendation!

--- a/spec/models/ownership_certificate_validation_request_spec.rb
+++ b/spec/models/ownership_certificate_validation_request_spec.rb
@@ -45,4 +45,21 @@ RSpec.describe OwnershipCertificateValidationRequest do
       end
     end
   end
+
+  describe "#not_yet_validated?" do
+    let(:planning_application) { create(:planning_application, :not_started) }
+    let!(:ownership_certificate_validation_request) do
+      create(:ownership_certificate_validation_request, planning_application:, state: "open")
+    end
+
+    it "returns true when post_validation is false" do
+      expect(ownership_certificate_validation_request.not_yet_validated?).to eq(true)
+    end
+
+    it "returns false when post_validation is true" do
+      ownership_certificate_validation_request.update!(post_validation: true)
+
+      expect(ownership_certificate_validation_request.not_yet_validated?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

This is a further update to the ownership certificate flow improvement. The previous PR set the Planning Application status to `updated` if the ownership certificate was not approved. However, this is not sufficient, as the Ownership Certificate also needs to have `post_validation: false` to work correctly. 

### Story Link

https://trello.com/c/9gLgifuS/2524-improvements-to-ownership-certificate-flow
