### PR TITLE
Add temporary error handling to fee calculation

### DIFF
--- a/app/models/fee_calculation.rb
+++ b/app/models/fee_calculation.rb
@@ -17,6 +17,11 @@ class FeeCalculation < ApplicationRecord
         exemptions: odp_data[:exemption]&.select { |k, v| v }&.keys,
         reductions: odp_data[:reduction]&.select { |k, v| v }&.keys
       )
+    # FIXME
+    rescue ActionView::Template::Error
+      Appsignal.send_error(error) do |transaction|
+        transaction.params = {params: odp_data}
+      end
     end
 
     def from_planx_data(planx_data)


### PR DESCRIPTION
### Description of change

- The odp_data is not being passed in as a Hash so it is raising an error. For now, just rescue this and send the object to appsignal for debugging

