### PR TITLE
Move neighbour letter status updates into a background job

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -85,15 +85,9 @@ module PlanningApplications
     end
 
     def update_letter_statuses
-      letters = @consultation.neighbour_letters.includes(:neighbour).where.not(status: "received")
-
       notify_key = @planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
 
-      # This is not ideal for now as will block the page loading, if it becomes a problem this would be
-      # a good place for optimisation
-      letters.each do |letter|
-        letter.update_status(notify_key)
-      end
+      NeighbourLetterStatusUpdateJob.perform_later(@consultation, notify_key)
     end
 
     def ensure_public_portal_is_active

--- a/app/jobs/neighbour_letter_status_update_job.rb
+++ b/app/jobs/neighbour_letter_status_update_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NeighbourLetterStatusUpdateJob < ApplicationJob
+  def perform(consultation, notify_key)
+    letters = consultation.neighbour_letters.includes(:neighbour).where.not(status: "received")
+
+    letters.each do |letter|
+      letter.update_status(notify_key)
+    end
+  end
+end

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -221,6 +221,10 @@ RSpec.describe "Send letters to neighbours", js: true do
     click_link "Consultees, neighbours and publicity"
     click_link "Send letters to neighbours"
 
+    # TODO the page does not get automatically updated with the result of the job, so here it needs to be refreshed
+    perform_enqueued_jobs
+    visit current_path
+
     expect(page).to have_content(neighbour.address)
     expect(page).to have_content("Posted")
   end


### PR DESCRIPTION
### Description of change

`update_letter_statuses` currently runs synchronously on page load, blocking the loading until it completes, which is increasingly slow. Instead, it should be run as a background job.

### Story Link

https://trello.com/c/f911lGyE/2536-move-letter-status-updates-to-background-job

### Known issues

Currently this still _triggers_ during page load, but runs in the background and so won't complete until later. This leads to a [test failure](https://github.com/unboxed/bops/actions/runs/7845326671/job/21409820440?pr=1551#step:11:247) when we check that the page is updated but the job hasn't completed yet.

Ideally it should be triggered a short time _before_ page load, and then be ready for rendering when the page loads. Unfortunately predicting the future is not possible. Alternatively the page could periodically poll for the statuses with javascript and update the table when the results have come back.
