### PR TITLE
Drop reply_to_notify_id on local_authorities

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -23,7 +23,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:validation_notice_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -35,7 +35,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:invalidation_notice_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -46,7 +46,7 @@ class PlanningApplicationMailer < ApplicationMailer
       NOTIFY_TEMPLATE_ID,
       subject: subject(:receipt_notice_mail, application_type_name: @planning_application.application_type.human_name),
       to: email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -58,7 +58,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:validation_request_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -71,7 +71,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:post_validation_request_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -83,7 +83,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:cancelled_validation_request_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -96,7 +96,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:description_change_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -109,7 +109,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:description_closure_notification_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -121,7 +121,7 @@ class PlanningApplicationMailer < ApplicationMailer
       subject: subject(:validation_request_closure_mail,
         application_type_name: @planning_application.application_type.human_name),
       to: @planning_application.applicant_and_agent_email.first,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -133,7 +133,7 @@ class PlanningApplicationMailer < ApplicationMailer
       NOTIFY_TEMPLATE_ID,
       subject: subject(:neighbour_consultation_letter_copy_mail),
       to: email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -145,7 +145,7 @@ class PlanningApplicationMailer < ApplicationMailer
       NOTIFY_TEMPLATE_ID,
       subject: subject(:site_notice_mail, reference: planning_application.reference),
       to: email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -157,7 +157,7 @@ class PlanningApplicationMailer < ApplicationMailer
       NOTIFY_TEMPLATE_ID,
       subject: subject(:internal_team_site_notice_mail, reference: planning_application.reference),
       to: email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 
@@ -169,7 +169,7 @@ class PlanningApplicationMailer < ApplicationMailer
       NOTIFY_TEMPLATE_ID,
       subject: subject(:press_notice_mail),
       to: press_notice.press_notice_email,
-      reply_to_id: @planning_application.local_authority.reply_to_notify_id
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
 end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -82,7 +82,6 @@ class LocalAuthority < ApplicationRecord
       reviewer_group_email
       notify_api_key
       notify_letter_template
-      reply_to_notify_id
       email_reply_to_id]
   end
 end

--- a/db/migrate/20240212134818_drop_reply_to_notify_id_on_local_authorities.rb
+++ b/db/migrate/20240212134818_drop_reply_to_notify_id_on_local_authorities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropReplyToNotifyIdOnLocalAuthorities < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :local_authorities, :reply_to_notify_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_171020) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_12_134818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -348,7 +348,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_171020) do
     t.string "signatory_job_title"
     t.text "enquiries_paragraph"
     t.string "email_address"
-    t.string "reply_to_notify_id"
     t.string "feedback_email"
     t.string "reviewer_group_email"
     t.string "council_code", null: false

--- a/engines/bops_admin/app/controllers/bops_admin/profiles_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/profiles_controller.rb
@@ -39,7 +39,6 @@ module BopsAdmin
         :reviewer_group_email,
         :notify_api_key,
         :notify_letter_template,
-        :reply_to_notify_id,
         :email_reply_to_id
       )
     end

--- a/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
@@ -66,13 +66,6 @@
      class: "govuk-input--width-30"
   ) %>
 
-   <%= form.govuk_text_field(
-      :reply_to_notify_id,
-      label: { text: t(".reply_to_notify_id"), class: "govuk-label govuk-label--m" },
-      hint: { text: t(".reply_to_notify_id_hint") },
-      class: "govuk-input--width-30"
-   ) %>
-
   <%= form.govuk_text_field(
      :email_reply_to_id,
      label: { text: t(".email_reply_to_id"), class: "govuk-label govuk-label--m" },

--- a/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
@@ -81,13 +81,6 @@
           </p>
         </li>
         <li>
-          <h2 class="govuk-heading-m"><%= t(".reply_to_notify_id") %></h2>
-          <span class="govuk-hint"><%= t(".reply_to_notify_id_hint") %></span>
-          <p class="govuk-body">
-            <%= current_local_authority.reply_to_notify_id %>
-          </p>
-        </li>
-        <li>
           <h2 class="govuk-heading-m"><%= t(".email_reply_to_id") %></h2>
           <span class="govuk-hint"><%= t(".email_reply_to_id_hint") %></span>
           <p class="govuk-body">

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -56,7 +56,7 @@ en:
         email_address: Email
         email_address_hint: This is the email address that appears on decision notices.
         email_reply_to_id: "'Email to' Notify ID"
-        email_reply_to_id_hint: This is the ID for the email address that applicants and consultees can reply to. It may be included in letters or emails sent out by your local authority through BOPS. Find this key in your Notify account.
+        email_reply_to_id_hint: This is the ID for the email address that applicants and consultees can reply to. It may be included in letters or emails sent out by your local authority through BOPS. Find this key in your Notify account, by clicking Manage in the Reply-to email addresses under Email settings section in Settings.
         enquiries_paragraph: Contact address
         enquiries_paragraph_hint: This is the contact address that will appear on decision notices and other correspondence.
         feedback_email: Feedback email
@@ -69,8 +69,6 @@ en:
         notify_notion_link: https://oasis-marsupial-465.notion.site/Guide-to-Notify-set-up-7c18a8f3d43444d098c1f79eab48016c?pvs=74
         press_notice_email: Press notice email
         press_notice_email_hint: Enter the email of the person or team who will prepare press notices. This email will be used when a planning officer requests a press notice.
-        reply_to_notify_id: "'Reply to' Notify ID"
-        reply_to_notify_id_hint: Find this in your Notify account.
         reviewer_group_email: BOPS lead email
         reviewer_group_email_hint: This is the email of the person who will be responsible for managing the planning process in BOPS at your council.
         signatory_job_title: Job title
@@ -82,7 +80,7 @@ en:
         email_address: Email
         email_address_hint: This is the email address that appears on decision notices.
         email_reply_to_id: "'Email to' Notify ID"
-        email_reply_to_id_hint: This is the ID for the email address that applicants and consultees can reply to. It may be included in letters or emails sent out by your local authority through BOPS. Find this key in your Notify account.
+        email_reply_to_id_hint: This is the ID for the email address that applicants and consultees can reply to. It may be included in letters or emails sent out by your local authority through BOPS. Find this key in your Notify account, by clicking Manage in the Reply-to email addresses under Email settings section in Settings.
         enquiries_paragraph: Contact address
         enquiries_paragraph_hint: This is the contact address that will appear on decision notices and other correspondence.
         feedback_email: Feedback email
@@ -96,8 +94,6 @@ en:
         press_notice_email: Press notice email
         press_notice_email_hint: Enter the email of the person or team who will prepare press notices. This email will be used when a planning officer requests a press notice.
         profile: Profile
-        reply_to_notify_id: "'Reply to' Notify ID"
-        reply_to_notify_id_hint: Find this in your Notify account.
         reviewer_group_email: BOPS lead email
         reviewer_group_email_hint: This is the email of the person who will be responsible for managing the planning process in BOPS at your council.
         signatory_job_title: Job title

--- a/engines/bops_admin/spec/system/profile_spec.rb
+++ b/engines/bops_admin/spec/system/profile_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Profile", type: :system do
     expect(page).to have_content("BOPS lead email")
     expect(page).to have_content("Press notice email")
     expect(page).to have_content("Notify API key")
-    expect(page).to have_content("'Reply to' Notify ID")
     expect(page).to have_content("'Email to' Notify ID")
   end
 
@@ -42,7 +41,6 @@ RSpec.describe "Profile", type: :system do
     expect(page).to have_content("who will prepare press notices")
     expect(page).to have_content("ID number of the letter template you will use in Notify")
     expect(page).to have_content("API key used by the GOV.UK Notify service for sending emails")
-    expect(page).to have_content("Find this in your Notify account.")
   end
 
   it "allows the administrator to edit council's profile" do
@@ -60,7 +58,6 @@ RSpec.describe "Profile", type: :system do
     fill_in("BOPS lead email", with: "manager_email@buckinghamshire.gov.uk")
     fill_in("Press notice email", with: "press_notice_email@buckinghamshire.gov.uk")
     fill_in("Notify API key", with: "fake-fd74e59d-8939-4d28-bc1b-95b8a6c7d413")
-    fill_in("'Reply to' Notify ID", with: "ddff1650-ab33-496d-b731-ff8e65bc836f")
     fill_in("'Email to' Notify ID", with: "550e8400-e29b-41d4-a716-446655440000")
 
     click_button("Submit")


### PR DESCRIPTION
### Description of change

Replace `email_reply_to_id` with `reply_to_notify_id`

We have found that `reply_to_notify_id` and `email_reply_to_id` are both serving the same purpose. Thus, we will use everywhere `email_reply_to_id` as it's also stored as UUID and drop the column