### PR TITLE
Additional UK Bank holidays

### DIFF
--- a/config/business_time.yml
+++ b/config/business_time.yml
@@ -22,6 +22,30 @@ business_time:
     - August 28th, 2023
     - December 25th, 2023
     - December 26th, 2023
+    - Jan 01, 2024
+    - March 29, 2024
+    - April 1, 2024
+    - May 6, 2024
+    - May 27, 2024
+    - August 26, 2024
+    - December 25, 2024
+    - December 26, 2024
+    - January 1, 2025
+    - April 18, 2025
+    - April 21, 2025
+    - May 5, 2025
+    - May 26, 2025
+    - August 25, 2025
+    - December 25, 2025
+    - December 26, 2025
+    - January 1, 2026
+    - April 3, 2026
+    - April 6, 2026
+    - May 4, 2026
+    - May 25, 2026
+    - August 31, 2026
+    - December 25, 2026
+    - December 28, 2026
   work_week:
     - mon
     - tue


### PR DESCRIPTION
### Description of change

Adding the UK Bank holidays for 2024-2026, [source](https://www.gov.uk/bank-holidays).

I've also realised that adding `th` at the end it doesn't change at all.