### PR TITLE
Allow offer to check ownership certificate in assessment

### DIFF
--- a/app/assets/stylesheets/components/_accordion.scss
+++ b/app/assets/stylesheets/components/_accordion.scss
@@ -116,8 +116,6 @@
     border: 1px solid;
     border-radius: 50%;
 
-    vertical-align: text-top;
-
     // IE8 fallback of icon
     // @include govuk-if-ie8 {
     //   display: inline-block;

--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -7,3 +7,8 @@
     margin-bottom: 0;
   }
 }
+
+.activity-log {
+  border: 1px solid black;
+  padding: 30px;
+}

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -32,14 +32,12 @@ module StatusTags
     def validation_status
       if planning_application.valid_ownership_certificate.nil?
         :not_started
-      elsif planning_application.valid_ownership_certificate?
+      elsif ownership_certificate.present?
         if planning_application.ownership_certificate_awaiting_validation?
           :updated
         else
-          :valid
+          planning_application.valid_ownership_certificate? ? :valid : :invalid
         end
-      else
-        :invalid
       end
     end
   end

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -38,6 +38,8 @@ module StatusTags
         else
           planning_application.valid_ownership_certificate? ? :valid : :invalid
         end
+      else
+        :invalid
       end
     end
   end

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -9,8 +9,27 @@ module StatusTags
     private
 
     attr_reader :planning_application
+    delegate :ownership_certificate, to: :planning_application
 
     def status
+      planning_application.in_assessment? ? assessment_status : validation_status
+    end
+
+    def assessment_status
+      if planning_application.validation_requests.ownership_certificates.open.any?
+        :invalid
+      elsif ownership_certificate.present?
+        if ownership_certificate.current_review.complete?
+          planning_application.valid_ownership_certificate? ? :valid : :invalid
+        else
+          :not_started
+        end
+      else
+        :not_started
+      end
+    end
+
+    def validation_status
       if planning_application.valid_ownership_certificate.nil?
         :not_started
       elsif planning_application.valid_ownership_certificate?

--- a/app/components/task_list_items/assessment/ownership_certificate_component.rb
+++ b/app/components/task_list_items/assessment/ownership_certificate_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  module Assessment
+    class OwnershipCertificateComponent < TaskListItems::BaseComponent
+      def initialize(planning_application:)
+        @planning_application = planning_application
+      end
+
+      private
+
+      attr_reader :planning_application
+
+      delegate :ownership_certificate, to: :planning_application
+
+      def link_text
+        "Check ownership certificate"
+      end
+
+      def link_path
+        if ownership_certificate.present? && ownership_certificate.current_review.status == "complete"
+          planning_application_assessment_ownership_certificate_path(planning_application)
+        else
+          edit_planning_application_assessment_ownership_certificate_path(planning_application)
+        end
+      end
+
+      def status_tag_component
+        StatusTags::OwnershipCertificateComponent.new(planning_application:)
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/assessment/ownership_certificates_controller.rb
+++ b/app/controllers/planning_applications/assessment/ownership_certificates_controller.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Assessment
+    class OwnershipCertificatesController < ApplicationController
+      include CommitMatchable
+
+      before_action :set_planning_application
+      before_action :set_valdiation_requests
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        if mark_as_complete?
+          @planning_application.update!(valid_ownership_certificate: true)
+          @planning_application.ownership_certificate&.update!(status:)
+          redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+        else
+          @planning_application.update!(valid_ownership_certificate: false)
+          @planning_application.ownership_certificate&.update!(status:)
+          redirect_to new_planning_application_validation_validation_request_path(@planning_application, type: "ownership_certificate")
+        end
+      end
+
+      private
+
+      def set_valdiation_requests
+        @validation_requests = @planning_application.validation_requests.where(type: "OwnershipCertificateValidationRequest")
+      end
+
+      def status
+        mark_as_complete? ? "complete" : "in_progress"
+      end
+
+      def valid_ownership_certificate
+        mark_as_complete?
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -172,7 +172,7 @@ module PlanningApplications
           params.dig(:validation_request, :return_to) ||
             @planning_application
         elsif @planning_application.validated?
-          @planning_application
+          planning_application_assessment_tasks_path(@planning_application)
         else
           planning_application_validation_tasks_path(@planning_application)
         end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -75,6 +75,7 @@ class Audit < ApplicationRecord
     ownership_certificate_validation_request_received: "ownership_certificate_validation_request_received",
     ownership_certificate_validation_request_sent: "ownership_certificate_validation_request_sent",
     ownership_certificate_validation_request_cancelled: "ownership_certificate_validation_request_cancelled",
+    ownership_certificate_validation_request_sent_post_validation: "ownership_certificate_validation_request_sent_post_validation",
     validation_requests_sent: "validation_requests_sent",
     additional_document_validation_request_cancelled: "additional_document_validation_request_cancelled",
     additional_document_validation_request_cancelled_post_validation:

--- a/app/models/ownership_certificate.rb
+++ b/app/models/ownership_certificate.rb
@@ -3,10 +3,13 @@
 class OwnershipCertificate < ApplicationRecord
   belongs_to :planning_application
   has_many :land_owners, dependent: :destroy
+  has_many :reviews, as: :owner, dependent: :destroy, class_name: "Review"
 
   accepts_nested_attributes_for :land_owners
 
   validates :certificate_type, presence: true
+
+  after_create :create_review
 
   enum certificate_type: {
     a: "A",
@@ -14,4 +17,14 @@ class OwnershipCertificate < ApplicationRecord
     c: "C",
     d: "D"
   }
+
+  def current_review
+    reviews.where.not(id: nil).order(:created_at).last
+  end
+
+  private
+
+  def create_review
+    Review.create!(assessor: Current.user, owner_type: "OwnershipCertificate", owner_id: id, status: "not_started")
+  end
 end

--- a/app/models/ownership_certificate_validation_request.rb
+++ b/app/models/ownership_certificate_validation_request.rb
@@ -6,6 +6,12 @@ class OwnershipCertificateValidationRequest < ValidationRequest
   validates :cancel_reason, presence: true, if: :cancelled?
   validate :allows_only_one_open_ownership_certificate_change, on: :create
 
+  after_update do
+    if approved_changed? && owner.planning_application.post_validation?
+      owner.current_review.update!(status: "in_progress")
+    end
+  end
+
   def update_planning_application!(params)
     planning_application.update!(valid_ownership_certificate: true)
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -684,6 +684,10 @@ class PlanningApplication < ApplicationRecord
     validation_requests.open.post_validation
   end
 
+  def closed_pre_validation_requests
+    validation_requests.closed - validation_requests.closed.post_validation
+  end
+
   def open_post_validation_requests?
     validation_requests.open.post_validation.any?
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -426,8 +426,8 @@ class PlanningApplication < ApplicationRecord
   end
 
   def ownership_certificate_awaiting_validation?
-    certificate_present = valid_ownership_certificate?
-    has_requests = ownership_certificate_validation_requests.any?
+    certificate_present = ownership_certificate.present?
+    has_requests = ownership_certificate_validation_requests.open.any?
     not_yet_validated = ownership_certificate_validation_requests&.last&.not_yet_validated?
 
     certificate_present && has_requests && not_yet_validated

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -426,11 +426,10 @@ class PlanningApplication < ApplicationRecord
   end
 
   def ownership_certificate_awaiting_validation?
-    certificate_present = ownership_certificate.present?
     has_requests = ownership_certificate_validation_requests.open.any?
     not_yet_validated = ownership_certificate_validation_requests&.last&.not_yet_validated?
 
-    certificate_present && has_requests && not_yet_validated
+    has_requests && not_yet_validated
   end
 
   def withdraw_last_recommendation!

--- a/app/views/planning_applications/assessment/ownership_certificates/_activity_log.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/_activity_log.html.erb
@@ -1,52 +1,54 @@
-<table class="govuk-table">
-  <caption class="govuk-table__caption govuk-table__caption--m">Activity log</caption>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Completed actions</th>
-      <td scope="row" class="govuk-table__header">Status</td>
-      <td scope="row" class="govuk-table__header">User</td>
-      <td scope="row" class="govuk-table__header">Date</td>
-    </tr>
-    <% if @planning_application.ownership_certificate.present? && @validation_requests.any? %>
-      <% @validation_requests.sort_by(&:created_at).reverse.each do |request| %>
-        <% if request.cancel_reason.present? %>
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">Request was cancelled</td>
-            <td scope="row" class="govuk-table__cell">Cancelled</td>
-            <td scope="row" class="govuk-table__cell"><%= request.user.name %></td>
-            <td scope="row" class="govuk-table__cell"><%= request.cancelled_at.to_fs(:day_month_year_slashes) %></td>
-          </tr>
-        <% else %>
-          <% if request.approved.nil? %>
+<div class="activity-log govuk-!-margin-bottom-6">
+  <table class="govuk-table govuk-!-margin-bottom-0">
+    <caption class="govuk-table__caption govuk-table__caption--m">Activity log</caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Completed actions</th>
+        <td scope="row" class="govuk-table__header">Status</td>
+        <td scope="row" class="govuk-table__header">User</td>
+        <td scope="row" class="govuk-table__header">Date</td>
+      </tr>
+      <% if @validation_requests.any? %>
+        <% @validation_requests.sort_by(&:created_at).reverse.each do |request| %>
+          <% if request.cancel_reason.present? %>
             <tr class="govuk-table__row">
-              <td scope="row" class="govuk-table__cell">Applicant has not responded</td>
-              <td scope="row" class="govuk-table__cell">&nbsp</td>
-              <td scope="row" class="govuk-table__cell">&nbsp</td>
-              <td scope="row" class="govuk-table__cell">&nbsp</td>
+              <td scope="row" class="govuk-table__cell">Request was cancelled</td>
+              <td scope="row" class="govuk-table__cell">Cancelled</td>
+              <td scope="row" class="govuk-table__cell"><%= request.user.name %></td>
+              <td scope="row" class="govuk-table__cell"><%= request.cancelled_at.to_fs(:day_month_year_slashes) %></td>
             </tr>
           <% else %>
+            <% if request.approved.nil? %>
+              <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell">Applicant has not responded</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+              </tr>
+            <% else %>
+              <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell"><%= request.approved? ? "Certificate submitted by applicant" : "Request rejected by applicant" %></td>
+                <td class="govuk-table__cell"><%= request.approved? ? "Submitted" : "Rejected" %></td>
+                <td class="govuk-table__cell">Applicant</td>
+                <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
+              </tr>
+            <% end %>
             <tr class="govuk-table__row">
-              <td scope="row" class="govuk-table__cell"><%= request.approved? ? "Certificate submitted by applicant" : "Request rejected by applicant" %></td>
-              <td class="govuk-table__cell"><%= request.approved? ? "Submitted" : "Rejected" %></td>
-              <td class="govuk-table__cell">Applicant</td>
+              <td scope="row" class="govuk-table__cell">New ownership certificate requested</td>
+              <td class="govuk-table__cell">Status</td>
+              <td class="govuk-table__cell"><%= request.user.name %></td>
               <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
             </tr>
           <% end %>
-          <tr class="govuk-table__row">
-            <td scope="row" class="govuk-table__cell">New ownership certificate requested</td>
-            <td class="govuk-table__cell">Status</td>
-            <td class="govuk-table__cell"><%= request.user.name %></td>
-            <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
-          </tr>
         <% end %>
+      <% else %>
+        <tr class="govuk-table__row">
+          <td scope="row" class="govuk-table__cell">No validation requests were made</td>
+          <td scope="row" class="govuk-table__cell">&nbsp</td>
+          <td scope="row" class="govuk-table__cell">&nbsp</td>
+          <td scope="row" class="govuk-table__cell">&nbsp</td>
+        </tr>
       <% end %>
-    <% else %>
-      <tr class="govuk-table__row">
-        <td scope="row" class="govuk-table__cell">No validation requests were made</td>
-        <td scope="row" class="govuk-table__cell">&nbsp</td>
-        <td scope="row" class="govuk-table__cell">&nbsp</td>
-        <td scope="row" class="govuk-table__cell">&nbsp</td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+    </tbody>
+  </table>
+</div>

--- a/app/views/planning_applications/assessment/ownership_certificates/_activity_log.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/_activity_log.html.erb
@@ -1,0 +1,52 @@
+<table class="govuk-table">
+  <caption class="govuk-table__caption govuk-table__caption--m">Activity log</caption>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Completed actions</th>
+      <td scope="row" class="govuk-table__header">Status</td>
+      <td scope="row" class="govuk-table__header">User</td>
+      <td scope="row" class="govuk-table__header">Date</td>
+    </tr>
+    <% if @planning_application.ownership_certificate.present? && @validation_requests.any? %>
+      <% @validation_requests.sort_by(&:created_at).reverse.each do |request| %>
+        <% if request.cancel_reason.present? %>
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell">Request was cancelled</td>
+            <td scope="row" class="govuk-table__cell">Cancelled</td>
+            <td scope="row" class="govuk-table__cell"><%= request.user.name %></td>
+            <td scope="row" class="govuk-table__cell"><%= request.cancelled_at.to_fs(:day_month_year_slashes) %></td>
+          </tr>
+        <% else %>
+          <% if request.approved.nil? %>
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">Applicant has not responded</td>
+              <td scope="row" class="govuk-table__cell">&nbsp</td>
+              <td scope="row" class="govuk-table__cell">&nbsp</td>
+              <td scope="row" class="govuk-table__cell">&nbsp</td>
+            </tr>
+          <% else %>
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell"><%= request.approved? ? "Certificate submitted by applicant" : "Request rejected by applicant" %></td>
+              <td class="govuk-table__cell"><%= request.approved? ? "Submitted" : "Rejected" %></td>
+              <td class="govuk-table__cell">Applicant</td>
+              <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
+            </tr>
+          <% end %>
+          <tr class="govuk-table__row">
+            <td scope="row" class="govuk-table__cell">New ownership certificate requested</td>
+            <td class="govuk-table__cell">Status</td>
+            <td class="govuk-table__cell"><%= request.user.name %></td>
+            <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
+          </tr>
+        <% end %>
+      <% end %>
+    <% else %>
+      <tr class="govuk-table__row">
+        <td scope="row" class="govuk-table__cell">No validation requests were made</td>
+        <td scope="row" class="govuk-table__cell">&nbsp</td>
+        <td scope="row" class="govuk-table__cell">&nbsp</td>
+        <td scope="row" class="govuk-table__cell">&nbsp</td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_applications/assessment/ownership_certificates/_relevant_documents_accordion.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/_relevant_documents_accordion.html.erb
@@ -1,0 +1,43 @@
+<div class="bops-accordion govuk-!-margin-top-6" data-module="bops-accordion" data-remember-expanded="false">
+  <div class="govuk-accordion__section">
+    <div class="govuk-accordion__section-header">
+      <h3 class="govuk-accordion__section-heading">
+        <button type="button" class="govuk-accordion__section-button" id="accordion-default-heading-documents">
+          Documents
+        </button>
+        <span class="govuk-accordion__icon"></span>
+      </h3>
+    </div>
+    <div class="govuk-accordion__section-content">
+      <div class="govuk-!-padding-left-2 govuk-!-padding-right-2">
+        <div class="scroll-docs">
+          <% @planning_application.documents.where("tags ?| array[:tags]", tags: Document::PLAN_TAGS).each do |document| %>
+            <hr>
+            <div class="govuk-grid-row">
+              <div class="govuk-grid-column-one-third">
+                <%= render(
+                  partial: "documents/document_row_image",
+                  locals: {
+                    planning_application: @planning_application,
+                    document: document,
+                    resize: "200x110",
+                    width: 90,
+                    height: 110,
+                    edit_and_archive: true
+                  }
+                ) %>
+              </div>
+              <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-6">
+                <%= render(
+                  partial: "documents/document_row_info",
+                  locals: { document: document }
+                ) %>
+              </div>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/app/views/planning_applications/assessment/ownership_certificates/_table.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/_table.html.erb
@@ -1,0 +1,43 @@
+<table class="govuk-table govuk-!-margin-bottom-6">
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Certificate type</th>
+      <td class="govuk-table__cell">
+        <%= @planning_application.ownership_certificate.present? ? @planning_application.ownership_certificate.certificate_type.upcase : "Not specified" %>
+      </td>
+    </tr>
+    <% if @planning_application.ownership_certificate.present? && @planning_application.ownership_certificate.land_owners.any? %>
+      <% @planning_application.ownership_certificate.land_owners.each_with_index do |owner, i| %>
+        <div class="govuk-margin-bottom-3">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header" style="font-weight: normal;">Owner <%= i + 1 %></th>
+            <td class="govuk-table__cell">&nbsp</td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Name</th>
+            <td class="govuk-table__cell"><%= owner.name %></td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Address</th>
+            <td class="govuk-table__cell"><%= owner.address %></td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">Notice given</th>
+            <td class="govuk-table__cell"><%= owner.notice_given? ? "Yes" : "No" %></td>
+          </tr>
+          <% if owner.notice_given? %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Notice date</th>
+              <td class="govuk-table__cell"><%= owner.notice_given_at&.to_fs(:day_month_year_slashes) %></td>
+            </tr>
+          <% else %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Reason no notice given</th>
+              <td class="govuk-table__cell"><%= owner.notice_reason %></td>
+            </tr>
+          <% end %>
+        </div>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_applications/assessment/ownership_certificates/edit.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/edit.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
-    <table class="govuk-table">
+    <table class="govuk-table govuk-!-margin-bottom-6">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header">Certificate type</th>
@@ -34,64 +34,89 @@
         </tr>
         <% if @planning_application.ownership_certificate.present? && @planning_application.ownership_certificate.land_owners.any? %>
           <% @planning_application.ownership_certificate.land_owners.each_with_index do |owner, i| %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header" style="font-weight: normal;">Owner <%= i + 1 %></th>
-              <td class="govuk-table__cell">&nbsp</td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">Name</th>
-              <td class="govuk-table__cell"><%= owner.name %></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">Address</th>
-              <td class="govuk-table__cell"><%= owner.address %></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">Notice given</th>
-              <td class="govuk-table__cell"><%= owner.notice_given? ? "Yes" : "No" %></td>
-            </tr>
-            <% if owner.notice_given? %>
+            <div class="govuk-margin-bottom-3">
               <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">Notice date</th>
-                <td class="govuk-table__cell"><%= owner.notice_given_at&.to_fs(:day_month_year_slashes) %></td>
+                <th scope="row" class="govuk-table__header" style="font-weight: normal;">Owner <%= i + 1 %></th>
+                <td class="govuk-table__cell">&nbsp</td>
               </tr>
-            <% else %>
               <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">Reason no notice given</th>
-                <td class="govuk-table__cell"><%= owner.notice_reason %></td>
+                <th scope="row" class="govuk-table__header">Name</th>
+                <td class="govuk-table__cell"><%= owner.name %></td>
               </tr>
-            <% end %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Address</th>
+                <td class="govuk-table__cell"><%= owner.address %></td>
+              </tr>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Notice given</th>
+                <td class="govuk-table__cell"><%= owner.notice_given? ? "Yes" : "No" %></td>
+              </tr>
+              <% if owner.notice_given? %>
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">Notice date</th>
+                  <td class="govuk-table__cell"><%= owner.notice_given_at&.to_fs(:day_month_year_slashes) %></td>
+                </tr>
+              <% else %>
+                <tr class="govuk-table__row">
+                  <th scope="row" class="govuk-table__header">Reason no notice given</th>
+                  <td class="govuk-table__cell"><%= owner.notice_reason %></td>
+                </tr>
+              <% end %>
+            </div>
           <% end %>
         <% end %>
       </tbody>
     </table>
+  </div>
 
+  <div class="govuk-grid-column-full">
     <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Activity log</caption>
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header">Activity log</th>
-          <td scope="row" class="govuk-table__header">&nbsp</td>
+          <th scope="row" class="govuk-table__header">Completed actions</th>
+          <td scope="row" class="govuk-table__header">Status</td>
+          <td scope="row" class="govuk-table__header">User</td>
+          <td scope="row" class="govuk-table__header">Date</td>
         </tr>
         <% if @planning_application.ownership_certificate.present? && @validation_requests.any? %>
-          <% @validation_requests.sort_by(&:created_at).each_with_index do |request, i| %>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">Amendments requested: <%= request.reason %></th>
-              <td class="govuk-table__cell"><%= request.approved? ? "Approved" : "Rejected" %></td>
-            </tr>
-            <tr class="govuk-table__row">
-              <th scope="row" class="govuk-table__header">State:</th>
-              <td class="govuk-table__cell"><%= request.state %></td>
-            </tr>
-            <% if request.rejection_reason.present? %>
+          <% @validation_requests.sort_by(&:created_at).reverse.each do |request| %>
+            <% if request.cancel_reason.present? %>
               <tr class="govuk-table__row">
-                <th scope="row" class="govuk-table__header">Amendments rejected</th>
-                <td class="govuk-table__cell"><%= request.rejection_reason %></td>
+                <td scope="row" class="govuk-table__cell">Request was cancelled</td>
+                <td scope="row" class="govuk-table__cell">Cancelled</td>
+                <td scope="row" class="govuk-table__cell"><%= request.user.name %></td>
+                <td scope="row" class="govuk-table__cell"><%= request.cancelled_at.to_fs(:day_month_year_slashes) %></td>
               </tr>
             <% end %>
+            <% if request.approved.nil? %>
+              <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell">Applicant has not responded</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+                <td scope="row" class="govuk-table__cell">&nbsp</td>
+              </tr>
+            <% else %>
+              <tr class="govuk-table__row">
+                <td scope="row" class="govuk-table__cell"><%= request.approved? ? "Certificate submitted by applicant" : "Request rejected by applicant" %></td>
+                <td class="govuk-table__cell"><%= request.approved? ? "Submitted" : "Rejected" %></td>
+                <td class="govuk-table__cell">Applicant</td>
+                <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
+              </tr>
+            <% end %>
+            <tr class="govuk-table__row">
+              <td scope="row" class="govuk-table__cell">New ownership certificate requested</td>
+              <td class="govuk-table__cell">Status</td>
+              <td class="govuk-table__cell"><%= request.user.name %></td>
+              <td class="govuk-table__cell"><%= request.created_at.to_fs(:day_month_year_slashes) %></td>
+            </tr>
           <% end %>
         <% else %>
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">No validation requests were made</th>
+            <td scope="row" class="govuk-table__cell">No validation requests were made</td>
+            <td scope="row" class="govuk-table__cell">&nbsp</td>
+            <td scope="row" class="govuk-table__cell">&nbsp</td>
+            <td scope="row" class="govuk-table__cell">&nbsp</td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/planning_applications/assessment/ownership_certificates/edit.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/edit.html.erb
@@ -2,8 +2,14 @@
   Ownership certificate - <%= t('page_title') %>
 <% end %>
 
-<%= render "planning_applications/validation/validation_requests/validation_requests_breadcrumbs" %>
-<% content_for :title, "Ownership certificate" %>
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title do %>
+  Check ownership certificate
+<% end %>
 
 <%= render(
   partial: "shared/proposal_header",
@@ -59,14 +65,46 @@
         <% end %>
       </tbody>
     </table>
-    <%= form_with model: @planning_application, url: planning_application_validation_ownership_certificate_path(@planning_application) do |form| %>
-      <%= form.govuk_radio_buttons_fieldset :ownership_certificate_type, legend: { text: "Is this declaration correct?" } do %>
-        <%= form.govuk_radio_button :valid_ownership_certificate, true, label: { text: "Yes"} %>
-        <%= form.govuk_radio_button :valid_ownership_certificate, false, label: { text: "No" } %>
-      <% end %>
 
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Activity log</th>
+          <td scope="row" class="govuk-table__header">&nbsp</td>
+        </tr>
+        <% if @planning_application.ownership_certificate.present? && @validation_requests.any? %>
+          <% @validation_requests.sort_by(&:created_at).each_with_index do |request, i| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Amendments requested: <%= request.reason %></th>
+              <td class="govuk-table__cell"><%= request.approved? ? "Approved" : "Rejected" %></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">State:</th>
+              <td class="govuk-table__cell"><%= request.state %></td>
+            </tr>
+            <% if request.rejection_reason.present? %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Amendments rejected</th>
+                <td class="govuk-table__cell"><%= request.rejection_reason %></td>
+              </tr>
+            <% end %>
+          <% end %>
+        <% else %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header">No validation requests were made</th>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= form_with model: @planning_application,
+      url: planning_application_assessment_ownership_certificate_path(@planning_application),
+      method: :patch do |form| %>
       <div class="govuk-button-group">
-        <%= form.submit "Save", class: "govuk-button", data: { module: "govuk-button" } %>
+        <%= form.hidden_field :ownership_certificate_valid %>
+
+        <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+        <%= form.submit "Request a new ownership certificate", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
 
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>

--- a/app/views/planning_applications/assessment/ownership_certificates/show.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/show.html.erb
@@ -30,17 +30,9 @@
   <div class="govuk-grid-column-full">
     <%= render "activity_log" %>
 
-    <%= form_with model: @planning_application,
-      url: planning_application_assessment_ownership_certificate_path(@planning_application),
-      method: :patch do |form| %>
-      <div class="govuk-button-group">
-        <%= form.hidden_field :ownership_certificate_valid %>
-
-        <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
-        <%= form.submit "Request a new ownership certificate", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
-
-        <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-      </div>
-    <% end %>
+    <div class="govuk-button-group">
+      <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      <%= link_to "Edit ownership certificate", edit_planning_application_assessment_ownership_certificate_path(@planning_application), class: "govuk-body govuk-link" %>
+    </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -23,20 +23,11 @@
         category: :past_applications
       )
     ) %>
-    <li class="app-task-list__item">
-      <span class="app-task-list__task-name">
-        <%= link_to(
-        "Check ownership certificate",
-        edit_planning_application_assessment_ownership_certificate_path(@planning_application),
-        class: "govuk-link"
-        ) %>
-      </span>
-      <%= render(
-        StatusTags::OwnershipCertificateComponent.new(
-          planning_application: @planning_application
-        )
-      ) %>
-    </li>
+    <%= render(
+      TaskListItems::Assessment::OwnershipCertificateComponent.new(
+        planning_application: @planning_application
+      )
+    ) %>
     <% if @planning_application.planning_history_enabled? %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -23,6 +23,20 @@
         category: :past_applications
       )
     ) %>
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        <%= link_to(
+        "Check ownership certificate",
+        edit_planning_application_assessment_ownership_certificate_path(@planning_application),
+        class: "govuk-link"
+        ) %>
+      </span>
+      <%= render(
+        StatusTags::OwnershipCertificateComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
+    </li>
     <% if @planning_application.planning_history_enabled? %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">

--- a/app/views/planning_applications/validation/ownership_certificate_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/ownership_certificate_validation_requests/_form.html.erb
@@ -33,8 +33,7 @@
           class: "govuk-label govuk-label--s",
           text: "Tell the applicant why their ownership certificate type is wrong"
         },
-        rows: 5,
-        readonly: @planning_application.validated?
+        rows: 5
       ) %>
 
       <%= form.hidden_field :type, value: "OwnershipCertificateValidationRequest" %>

--- a/app/views/planning_applications/validation/ownership_certificate_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/ownership_certificate_validation_requests/_show.html.erb
@@ -19,7 +19,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Certificate type: <%= @planning_application.ownership_certificate.present? ? @planning_application.ownership_certificate.certificate_type : "Not specified" %></p>
+    <p class="govuk-body">Certificate type: <%= @planning_application.ownership_certificate.present? ? @planning_application.ownership_certificate.certificate_type.upcase : "Not specified" %></p>
     <h2 class="govuk-heading-m">Officer request</h2>
     <div class="govuk-inset-text">
       <p class="govuk-body">
@@ -30,7 +30,7 @@
       </p>
     </div>
 
-    <% if @validation_request.closed? && @planning_application.invalidated?  %>
+    <% if @validation_request.closed? %>
       <h2 class="govuk-heading-m">Applicant response</h2>
       <% if @validation_request.approved? %>
         <p class="govuk-body">The applicant provided this information:</p>

--- a/app/views/shared/_assessment_dashboard.html.erb
+++ b/app/views/shared/_assessment_dashboard.html.erb
@@ -17,7 +17,7 @@
   <% if @planning_application.overdue_validation_requests.any? %>
     <%= render "shared/overdue_banner" %>
   <% end %>
-  <% if @planning_application.validation_requests.closed.any? %>
+  <% if @planning_application.closed_pre_validation_requests.any? %>
     <%= render "shared/response_banner" %>
   <% end %>
 <% end %>

--- a/app/views/shared/_response_banner.html.erb
+++ b/app/views/shared/_response_banner.html.erb
@@ -7,7 +7,7 @@
       <div class="moj-banner__message">
         <span class="moj-banner__assistive">
           Warning
-        </span><strong><%= pluralize(@planning_application.validation_requests.closed.count, "new response") %></strong> to a validation request.<br/>
+        </span><strong><%= pluralize(@planning_application.closed_pre_validation_requests.count, "new response") %></strong> to a validation request.<br/>
           <%= link_to "View all validation requests", planning_application_validation_validation_requests_path(@planning_application), class: "govuk-link" %>
       </div>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -383,6 +383,7 @@ en:
       ownership_certificate_validation_request_cancelled: 'Cancelled: validation request (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_received: 'Received: request for change (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_sent: 'Sent: request for change (ownership certificate validation#%{args})'
+      ownership_certificate_validation_request_sent_post_validation: 'Sent: request for change (ownership certificate validation#%{args})'
       press_notice: Press notice response added
       press_notice_mail: Request made for press notice
       proposal_measurements_updated: Proposal measurements were updated
@@ -616,6 +617,7 @@ en:
     publish_decision: Publish decision
     review_and_publish_decision: Review and publish decision
     save_and_come_back_later: Save and come back later
+    save_and_mark_as_checked: Save and mark as checked
     save_and_mark_as_complete: Save and mark as complete
   helpers:
     hint:
@@ -879,6 +881,9 @@ en:
       immunity_details:
         update:
           success: Evidence of immunity successfully updated
+      ownership_certificates:
+        update:
+          success: Ownership certificate was checked
       policy_classes:
         comment:
           delete_comment: Delete comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,6 +95,7 @@ Rails.application.routes.draw do
           patch :update, on: :collection
         end
         resource :consistency_checklist, except: %i[destroy index]
+        resource :ownership_certificate, except: %i[destroy index]
 
         resources :immunity_details, except: %i[destroy index] do
           resources :evidence_groups do

--- a/db/migrate/20240214172353_create_reviews_for_ownership_certificates.rb
+++ b/db/migrate/20240214172353_create_reviews_for_ownership_certificates.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateReviewsForOwnershipCertificates < ActiveRecord::Migration[7.1]
+  def change
+    OwnershipCertificate.all.find_each do |certificate|
+      next if certificate.reviews.any?
+
+      Review.create!(owner_type: "OwnershipCertificate", owner_id: certificate.id, status: "not_started")
+    end
+  end
+end

--- a/spec/components/status_tags/ownership_certificate_component_spec.rb
+++ b/spec/components/status_tags/ownership_certificate_component_spec.rb
@@ -54,6 +54,22 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
       end
     end
 
+    context "when ownership certificate is missing and has been marked as invalid" do
+      let(:valid_ownership_certificate) { false }
+
+      before do
+        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid")
+
+        render_inline(
+          described_class.new(planning_application:)
+        )
+      end
+
+      it "renders 'Invalid' status" do
+        expect(page).to have_content("Invalid")
+      end
+    end
+
     context "when ownership certificate has an updated validation request" do
       let(:valid_ownership_certificate) { false }
 

--- a/spec/components/status_tags/ownership_certificate_component_spec.rb
+++ b/spec/components/status_tags/ownership_certificate_component_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
+  context "when planning application is not validated" do
+    let(:planning_application) do
+      build(:planning_application, :not_started, valid_ownership_certificate:)
+    end
+
+    context "when ownership certificate has not been marked as valid" do
+      let(:valid_ownership_certificate) { nil }
+
+      before do
+        render_inline(
+          described_class.new(planning_application:)
+        )
+      end
+
+      it "renders 'Not started' status" do
+        expect(page).to have_content("Not started")
+      end
+    end
+
+    context "when ownership certificate has been marked as valid" do
+      let(:valid_ownership_certificate) { true }
+
+      before do
+        create(:ownership_certificate, planning_application:)
+
+        render_inline(
+          described_class.new(planning_application:)
+        )
+      end
+
+      it "renders 'Valid' status" do
+        expect(page).to have_content("Valid")
+      end
+    end
+
+    context "when ownership certificate has been marked as invalid" do
+      let(:valid_ownership_certificate) { false }
+
+      before do
+        create(:ownership_certificate, planning_application:)
+
+        render_inline(
+          described_class.new(planning_application:)
+        )
+      end
+
+      it "renders 'Invalid' status" do
+        expect(page).to have_content("Invalid")
+      end
+    end
+
+    context "when ownership certificate has an updated validation request" do
+      let(:valid_ownership_certificate) { false }
+
+      before do
+        create(:ownership_certificate, planning_application:)
+        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid")
+
+        render_inline(
+          described_class.new(planning_application:)
+        )
+      end
+
+      it "renders 'Updated' status" do
+        expect(page).to have_content("Updated")
+      end
+    end
+  end
+
+  context "when planning application is in assessment" do
+    let(:planning_application) do
+      build(:planning_application, :in_assessment, valid_ownership_certificate:)
+    end
+
+    context "when ownership certificate is not present" do
+      let(:valid_ownership_certificate) { true }
+
+      it "renders 'Not started' status" do
+        render_inline(
+          described_class.new(planning_application:)
+        )
+
+        expect(page).to have_content("Not started")
+      end
+    end
+
+    context "when assessor has marked certificate as valid" do
+      let(:valid_ownership_certificate) { true }
+
+      before do
+        ownership_certificate = create(:ownership_certificate, planning_application:)
+        ownership_certificate.current_review.update(status: "complete")
+      end
+
+      it "renders 'Valid' status" do
+        render_inline(
+          described_class.new(planning_application:)
+        )
+
+        expect(page).to have_content("Valid")
+      end
+    end
+
+    context "when ownership certificate has been marked as invalid" do
+      context "when the applicant has accepted the changes" do
+        let(:valid_ownership_certificate) { true }
+
+        before do
+          ownership_certificate = create(:ownership_certificate, planning_application:)
+          ownership_certificate.current_review.update(status: "complete")
+        end
+
+        it "renders 'Invalid' status" do
+          render_inline(
+            described_class.new(planning_application:)
+          )
+
+          expect(page).to have_content("Valid")
+        end
+      end
+
+      context "when the applicant has not accepted the changes" do
+        let(:valid_ownership_certificate) { false }
+
+        before do
+          ownership_certificate = create(:ownership_certificate, planning_application:)
+          ownership_certificate.current_review.update(status: "complete")
+        end
+
+        it "renders 'Invalid' status" do
+          render_inline(
+            described_class.new(planning_application:)
+          )
+
+          expect(page).to have_content("Invalid")
+        end
+      end
+    end
+
+    context "when ownership certificate has open validation requests" do
+      let(:valid_ownership_certificate) { false }
+
+      before do
+        create(:ownership_certificate, planning_application:)
+        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid")
+      end
+
+      it "renders 'Updated' status" do
+        render_inline(
+          described_class.new(planning_application:)
+        )
+
+        expect(page).to have_content("Invalid")
+      end
+    end
+  end
+end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1018,6 +1018,22 @@ RSpec.describe PlanningApplication do
     end
   end
 
+  describe "#closed_pre_validation_requests" do
+    let(:planning_application) { create(:planning_application, :not_started) }
+    let!(:red_line_boundary_change_validation_request) { create(:red_line_boundary_change_validation_request, :closed, planning_application:) }
+    let!(:other_change_validation_request) { create(:other_change_validation_request, :pending, planning_application:) }
+
+    before do
+      planning_application.validate!
+    end
+
+    it "returns closed validation requests made in validation, rather than assessment" do
+      create(:description_change_validation_request, :closed, post_validation: true, planning_application:)
+
+      expect(planning_application.closed_pre_validation_requests).to contain_exactly(red_line_boundary_change_validation_request)
+    end
+  end
+
   describe "#overdue_validation_requests" do
     let(:planning_application) { create(:planning_application, :invalidated) }
     let!(:not_overdue_validation_request1) { create(:red_line_boundary_change_validation_request, :open, created_at: Time.zone.now, planning_application:) }

--- a/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check ownership certificate" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :in_assessment,
+      local_authority: default_local_authority
+    )
+  end
+
+  before do
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+  end
+
+  context "when there is an ownership certificate" do
+    let!(:ownership_certificate) { create(:ownership_certificate, planning_application:) }
+    let!(:land_owner) { create(:land_owner, ownership_certificate:) }
+
+    it "I can mark it as valid" do
+      expect(list_item("Check ownership certificate")).to have_content("Not started")
+
+      click_link "Check ownership certificate"
+
+      expect(page).to have_content(ownership_certificate.certificate_type.upcase)
+      expect(page).to have_content(land_owner.name)
+      expect(page).to have_content(land_owner.address)
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Ownership certificate was checked")
+
+      expect(list_item("Check ownership certificate")).to have_content("Valid")
+
+      click_link "Check ownership certificate"
+
+      expect(page).to have_link("Edit ownership certificate", href: "/planning_applications/#{planning_application.id}/assessment/ownership_certificate/edit")
+    end
+
+    it "I can request a new certificate" do
+      click_link "Check ownership certificate"
+
+      click_button "Request a new ownership certificate"
+
+      fill_in "Tell the applicant why their ownership certificate type is wrong", with: "Not enough owners"
+
+      click_button "Send request"
+
+      expect(page).to have_content("Ownership certificate request successfully created")
+
+      expect(list_item("Check ownership certificate")).to have_content("Invalid")
+
+      click_link "Check ownership certificate"
+
+      expect(page).to have_content "New ownership certificate requested"
+      expect(page).to have_content "Applicant has not responded"
+
+      # # Applicant responds
+      ValidationRequest.last.update(state: "closed", approved: "true")
+
+      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+
+      expect(list_item("Check ownership certificate")).to have_content("Not started")
+
+      click_link "Check ownership certificate"
+      expect(page).to have_content "Certificate submitted by applicant"
+
+      click_button "Save and mark as complete"
+
+      expect(list_item("Check ownership certificate")).to have_content("Valid")
+    end
+  end
+
+  context "when there is not an ownership certificate" do
+    it "I can request one" do
+      expect(list_item("Check ownership certificate")).to have_content("Not started")
+
+      click_link "Check ownership certificate"
+
+      expect(page).to have_content "Not specified"
+
+      click_button "Request a new ownership certificate"
+
+      fill_in "Tell the applicant why their ownership certificate type is wrong", with: "Not enough owners"
+
+      click_button "Send request"
+
+      expect(page).to have_content("Ownership certificate request successfully created")
+
+      expect(list_item("Check ownership certificate")).to have_content("Invalid")
+
+      click_link "Check ownership certificate"
+
+      expect(page).to have_content "New ownership certificate requested"
+      expect(page).to have_content "Applicant has not responded"
+
+      # # Applicant responds
+      ValidationRequest.last.update(state: "closed", approved: "true")
+      OwnershipCertificate.create(planning_application:, certificate_type: "a")
+
+      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+
+      expect(list_item("Check ownership certificate")).to have_content("Not started")
+
+      click_link "Check ownership certificate"
+      expect(page).to have_content "Certificate type A"
+      expect(page).to have_content "Certificate submitted by applicant"
+
+      click_button "Save and mark as complete"
+
+      expect(list_item("Check ownership certificate")).to have_content("Valid")
+    end
+  end
+end

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -478,7 +478,6 @@ RSpec.describe "checking consistency" do
       "Validation request for red line boundary successfully created."
     )
 
-    click_link("Check and assess")
     click_link("Check description, documents and proposal details")
 
     form_group = form_group_with_legend(

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -528,6 +528,7 @@ RSpec.describe "Requesting document changes to a planning application" do
 
       fill_in "List all issues with the document", with: "This is very invalid"
       click_button "Send request"
+      click_link "Application"
       click_link "Review non-validation requests"
 
       within ".validation-requests-table" do
@@ -566,7 +567,6 @@ RSpec.describe "Requesting document changes to a planning application" do
       request.save!
       request.old_document.archive("replaced by new document")
 
-      click_link "Check and assess"
       click_button "Documents"
       click_link "Manage documents"
 

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -308,11 +308,12 @@ RSpec.describe "Drawing a sitemap on a planning application" do
       expect(page).to have_content("Validation request for red line boundary successfully created.")
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}"
+        "/planning_applications/#{planning_application.id}/assessment/tasks"
       )
 
       expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
 
+      click_link "Application"
       click_button "Audit log"
       click_link "View all audits"
 


### PR DESCRIPTION
### Description of change

Allow offer to check ownership certificate in assessment

### Story Link

https://trello.com/c/rV4pUD8I/2506-when-there-is-more-than-one-owner-of-the-application-site-i-want-to-check-the-right-ownership-certificate-has-been-signed-so-tha

### Screenshots
![screencapture-lambeth-bops-localhost-3000-planning-applications-2302-assessment-ownership-certificate-edit-2024-02-16-09_39_54](https://github.com/unboxed/bops/assets/35098639/7cb8db69-653f-4b63-9f4c-e5765e243d8f)
