### PR TITLE
Separate notify_api_key for letters

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -85,7 +85,7 @@ module PlanningApplications
     end
 
     def update_letter_statuses
-      notify_key = @planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
+      notify_key = @planning_application.local_authority.notify_api_key_for_letters
 
       NeighbourLetterStatusUpdateJob.perform_later(@consultation, notify_key)
     end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -44,11 +44,19 @@ class LocalAuthority < ApplicationRecord
   end
 
   def notify_api_key
-    super || set_notify_api_key
+    super || Rails.configuration.default_notify_api_key
   end
 
   def letter_template_id
     super || Rails.configuration.default_letter_template_id
+  end
+
+  def notify_api_key_for_letters
+    if Bops.env.production?
+      notify_api_key
+    else
+      Rails.configuration.notify_letter_api_key
+    end
   end
 
   private
@@ -74,14 +82,6 @@ class LocalAuthority < ApplicationRecord
 
   def set_active
     self.active = active_attributes?
-  end
-
-  def set_notify_api_key
-    if Bops.env.production?
-      Rails.configuration.default_notify_api_key
-    else
-      Rails.configuration.notify_letter_api_key
-    end
   end
 
   def active_attributes?

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -38,7 +38,7 @@ class NeighbourLetter < ApplicationRecord
   private
 
   def notify_api_key
-    neighbour.consultation.planning_application.local_authority.notify_api_key || Rails.configuration.default_notify_api_key
+    neighbour.consultation.planning_application.local_authority.notify_api_key_for_letters
   end
 
   def resend?

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -48,7 +48,7 @@ class LetterSendingService
   private
 
   def client
-    @client ||= Notifications::Client.new(@local_authority.notify_api_key)
+    @client ||= Notifications::Client.new(@local_authority.notify_api_key_for_letters)
   end
 
   def update_letter!(letter_record, response)


### PR DESCRIPTION
### Description of change

Separate `notify_api_key` for letters

We want to use a separate notify_api_key on staging when we're using a feature to send letters as we don't want to actual send them. This is something missed from current logic refactored in this PR #1555 