### PR TITLE
Account for neighbour responses with multiple tags

### DIFF
--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -15,13 +15,13 @@ class NeighbourResponse < ApplicationRecord
   enum(summary_tag: {supportive: "supportive", neutral: "neutral", objection: "objection"})
 
   scope :redacted, -> { where.not(redacted_response: "") }
-  scope :with_tags, -> { where.not("tags = '[]'") }
-  scope :without_tags, -> { where("tags = '[]'") }
+  scope :with_tags, -> { where.not(tags: []) }
+  scope :without_tags, -> { where(tags: []) }
 
   TAGS = %i[design new_use privacy disabled_access noise traffic other].freeze
 
   summary_tags.each do |tag|
-    scope :"#{tag}", -> { where(tag:) }
+    scope :"#{tag}", -> { where(tags: [tag]) }
   end
 
   before_save do

--- a/app/views/planning_applications/assessment/assessment_details/publicity_summary/_responses.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/publicity_summary/_responses.html.erb
@@ -3,77 +3,76 @@
     presenter: assessment_detail_error_presenter(category)
   ) %>
 
-  <% neighbour_responses.with_tags.group_by(&:tags).sort_by { |key, _value| key[0] }.reverse.each_with_index do |(tag, responses), index| %>
+  <% NeighbourResponse::TAGS.each_with_index do |tag, index| %>
+    <% next if neighbour_responses.select { |response| response.tags.include? tag.to_s }.none? %>
     <div class="bops-accordion" data-module="bops-accordion" data-remember-expanded="false" id="neighbour-response-accordion">
       <div class="govuk-accordion__section">
         <div class="govuk-accordion__section-header">
           <h2 class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id=<%= "accordion-default-heading-#{index}" %>>
-              <%= "#{tag.first.humanize} responses (#{responses.count})" %>
+              <%= "#{tag.to_s.humanize} responses (#{neighbour_responses.select { |response| response.tags.include? tag.to_s }.count})" %>
             </span>
           </h2>
         </div>
-        <div id=<%= "accordion-default-content-#{index}" %> class="govuk-accordion__section-content" aria-labelledby=<%= "accordion-default-heading-#{index}" %>>
-          <% responses.group_by { |response| response.neighbour.selected? }.sort_by { |key, _value| key ? 0 : 1 }.each do |selected, sorted_responses| %>
-            <% sorted_responses.group_by { |response| response.summary_tag }.each do |opinion, resp| %>
-              <div class="neighbour-response">
-                <% resp.each do |response| %>
-                  <div class="neighbour-response-section">
-                    <div class="govuk-inset-text">
-                      <div class="neighbour-response-top-section">
-                        <div class="neighbour-response-content">
-                          <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
-                          <% if response.neighbour.selected? %>
-                            <strong class="govuk-tag app-task-list__task-tag govuk-!-margin-left-1">Adjoining neighbour</strong>
-                          <% end %>
-                          <br><br>
-                          <ul class="govuk-list">
-                            <li>
-                              <strong><%= response.name %></strong> <span class="govuk-hint" style="display: inline;"><%= response.email %></span>
-                            </li>
-                            <li class="govuk-hint">
-                              <%= response.neighbour.address %>
-                            </li>
-                            <li class="govuk-hint">
-                              Received on <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
-                            </li>
-                          </ul>
-                          <div data-controller="show-more-text">
-                            <span class="truncated-comment">
-                              <%= simple_format(response.truncated_comment) %>
-                            </span>
+        <div id=<%= "accordion-default-content-#{index}" %> class="govuk-accordion__section-content" aria-labelledby=<%= "accordion-default-heading-no-tag" %>>
+          <% neighbour_responses.select { |response| response.tags.include? tag.to_s }.group_by { |response| response.summary_tag }.each do |opinion, resp| %>
+            <div class="neighbour-response">
+              <% resp.each do |response| %>
+                <div class="neighbour-response-section">
+                  <div class="govuk-inset-text">
+                    <div class="neighbour-response-top-section">
+                      <div class="neighbour-response-content">
+                        <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+                        <% if response.neighbour.selected? %>
+                          <strong class="govuk-tag app-task-list__task-tag govuk-!-margin-left-1">Adjoining neighbour</strong>
+                        <% end %>
+                        <br><br>
+                        <ul class="govuk-list">
+                          <li>
+                            <strong><%= response.name %></strong> <span class="govuk-hint" style="display: inline;"><%= response.email %></span>
+                          </li>
+                          <li class="govuk-hint">
+                            <%= response.neighbour.address %>
+                          </li>
+                          <li class="govuk-hint">
+                            Received on <%= response.received_at.to_formatted_s(:day_month_year_slashes) %>
+                          </li>
+                        </ul>
+                        <div data-controller="show-more-text">
+                          <span class="truncated-comment">
+                            <%= simple_format(response.truncated_comment) %>
+                          </span>
 
-                            <% if response_been_truncated?(response) %>
-                              <span class="govuk-!-display-none hidden-comment">
-                                <%= simple_format(response.comment[truncated_length(response)..-1]) %>
-                              </span>
-                              <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>
-                            <% end %>
-                          </div>
-                        </div>
-                        <div class="neighbour-tags">
-                          <% response.tags.each do |tag| %>
-                            <div class="govuk-!-margin-bottom-3">
-                              <strong class="govuk-tag govuk-tag--grey"><%= tag.humanize.upcase %></strong>
-                            </div>
+                          <% if response_been_truncated?(response) %>
+                            <span class="govuk-!-display-none hidden-comment">
+                              <%= simple_format(response.comment[truncated_length(response)..-1]) %>
+                            </span>
+                            <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>
                           <% end %>
                         </div>
                       </div>
+                      <div class="neighbour-tags">
+                        <% response.tags.each do |tag| %>
+                          <div class="govuk-!-margin-bottom-3">
+                            <strong class="govuk-tag govuk-tag--grey"><%= tag.humanize.upcase %></strong>
+                          </div>
+                        <% end %>
+                      </div>
                     </div>
                   </div>
-                <% end %>
-              </div>
-            <% end %>
+                </div>
+              <% end %>
+            </div>
           <% end %>
         </div>
       </div>
     </div>
 
     <%= form.govuk_text_area(
-      :"#{tag.first}",
-      label: { text: "Summary of #{tag.first.humanize.downcase} comments", size: "m" },
+      :"#{tag}",
+      label: { text: "Summary of #{tag.to_s.humanize.downcase} comments", size: "m" },
       rows: 10,
-      value: (@assessment_detail.entry[/(?<=#{tag.first.humanize}:)(.*)/] unless @assessment_detail.entry.nil?)
+      value: (@assessment_detail.entry[/(?<=#{tag.to_s.humanize}:)(.*)/] unless @assessment_detail.entry.nil?)
     ) %>
 
     <%= form.hidden_field :category, value: category %>

--- a/db/migrate/20240214122132_add_array_true_to_tags.rb
+++ b/db/migrate/20240214122132_add_array_true_to_tags.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddArrayTrueToTags < ActiveRecord::Migration[7.1]
+  def change
+    add_column :neighbour_responses, :tags1, :string, array: true, default: []
+
+    NeighbourResponse.all.find_each do |response|
+      response.tags.each { |tag| response.tags1 << tag }
+      response.save!(validate: false)
+    end
+
+    remove_column :neighbour_responses, :tags, :jsonb
+    rename_column :neighbour_responses, :tags1, :tags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_12_203749) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_14_122132) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -405,9 +405,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_12_203749) do
     t.datetime "updated_at", null: false
     t.string "summary_tag"
     t.text "redacted_response"
-    t.jsonb "tags", default: [], null: false
     t.bigint "consultation_id"
     t.bigint "redacted_by_id"
+    t.string "tags", default: [], array: true
     t.index ["consultation_id"], name: "ix_neighbour_responses_on_consultation_id"
     t.index ["neighbour_id"], name: "ix_neighbour_responses_on_neighbour_id"
     t.index ["redacted_by_id"], name: "ix_neighbour_responses_on_redacted_by_id"

--- a/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_publicity_summary_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "neighbour responses" do
     let!(:neighbour1) { create(:neighbour, address: "1, Test Lane, AAA111", consultation:) }
     let!(:neighbour2) { create(:neighbour, address: "2, Test Lane, AAA111", consultation:) }
     let!(:neighbour3) { create(:neighbour, address: "3, Test Lane, AAA111", consultation:) }
-    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection", tags: ["design"]) }
+    let!(:objection_response) { create(:neighbour_response, neighbour: neighbour1, summary_tag: "objection", tags: ["design", "disabled_access"]) }
     let!(:supportive_response1) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive", tags: ["design"]) }
     let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive", tags: ["disabled_access"]) }
     let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
@@ -60,9 +60,10 @@ RSpec.describe "neighbour responses" do
       expect(page).to have_content(supportive_response1.redacted_response)
       click_button "Design responses (2)"
 
-      click_button "Disabled access responses (1)"
+      click_button "Disabled access responses (2)"
       expect(page).to have_content(supportive_response2.redacted_response)
-      click_button "Disabled access responses (1)"
+      expect(page).to have_content(objection_response.redacted_response)
+      click_button "Disabled access responses (2)"
 
       click_button "Untagged responses (1)"
       expect(page).to have_content(neutral_response.redacted_response)


### PR DESCRIPTION
### Description of change

When listing the neighbour responses and the comment boxes for each, hadn't accounted for responses which had multiple tags

### Story Link

https://trello.com/c/LFDH2ckS/2508-list-individual-neighbour-issues-and-address-each-one