### PR TITLE
Ensure that a constraint has an identified_by set

### DIFF
--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -28,7 +28,7 @@ class ConstraintsCreationService
             constraint_id: existing_constraint.id,
             planning_application_constraints_query: query,
             identified: true,
-            identified_by: planning_application.api_user&.name,
+            identified_by: planning_application.api_user&.name || "BOPS",
             data: v["data"],
             metadata:
           )

--- a/db/migrate/20240219104723_add_not_null_to_contraints_identified_by.rb
+++ b/db/migrate/20240219104723_add_not_null_to_contraints_identified_by.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddNotNullToContraintsIdentifiedBy < ActiveRecord::Migration[7.1]
+  class PlanningApplicationConstraint < ActiveRecord::Base; end
+
+  def change
+    up_only do
+      PlanningApplicationConstraint.where(identified_by: nil).update_all(identified_by: "BOPS")
+    end
+
+    change_column_null(:planning_application_constraints, :identified_by, false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_14_122132) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_19_104723) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -471,7 +471,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_122132) do
     t.jsonb "data"
     t.jsonb "metadata"
     t.boolean "identified", default: false, null: false
-    t.string "identified_by"
+    t.string "identified_by", null: false
     t.index ["constraint_id"], name: "ix_planning_application_constraints_on_constraint_id"
     t.index ["planning_application_constraints_query_id"], name: "ix_planning_application_constraints_on_planning_application_con"
     t.index ["planning_application_id"], name: "ix_planning_application_constraints_on_planning_application_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -115,7 +115,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_14_122132) do
     t.bigint "planning_application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "status", default: "not_started", null: false
     t.index ["planning_application_id"], name: "ix_condition_sets_on_planning_application_id"
   end
 

--- a/spec/factories/planning_application_constraint.rb
+++ b/spec/factories/planning_application_constraint.rb
@@ -5,5 +5,7 @@ FactoryBot.define do
     planning_application
     constraint
     planning_application_constraints_query
+
+    identified_by { "BOPS" }
   end
 end

--- a/spec/services/constraints_creation_service_spec.rb
+++ b/spec/services/constraints_creation_service_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe ConstraintsCreationService, type: :service do
       end
     end
 
+    context "when the planning application was created from within BOPS" do
+      let!(:api_user) { nil }
+      let!(:constraint1) { create(:constraint, local_authority: local_authority1) }
+
+      subject { planning_application.planning_application_constraints.first }
+
+      it "sets the constraint identified_by to BOPS" do
+        expect do
+          create_constraints
+        end.to change(PlanningApplicationConstraint, :count).by(1)
+
+        expect(subject.identified_by).to eq("BOPS")
+      end
+    end
+
     [ActiveRecord::RecordInvalid, NoMethodError].each do |error|
       context "when there is an error of type: #{error} creating the planning application constraints" do
         let(:planning_application_constraints) { double }


### PR DESCRIPTION
When an application is submitted from within BOPS the API user column isn't set which means that the identified_by column will be NULL. Fix by adding a migration that changes existing NULLs to 'BOPS' and ensure that it can't happen again by adding a NOT NULL constraint.