### PR TITLE
Fix invalidating planning applications 

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -76,9 +76,9 @@ class PlanningApplicationsController < AuthenticationController
   def validate
     if validation_date_fields_invalid?
       @planning_application.errors.add(:planning_application, "Please enter a valid date")
-    elsif @planning_application.validation_requests.open.any?
+    elsif @planning_application.validation_requests.pending.any?
       @planning_application.errors.add(:planning_application,
-        "Planning application cannot be validated if open validation requests exist.")
+        "Planning application cannot be validated if pending validation requests exist.")
     elsif @planning_application.invalid_documents.present?
       @planning_application.errors.add(
         :planning_application,

--- a/app/views/planning_applications/validation/description_change_validation_requests/_description_change_validation_request.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_description_change_validation_request.html.erb
@@ -15,7 +15,4 @@
     <%= t(".new_description") %>
     <%= render(FormattedContentComponent.new(text: description_change_validation_request.proposed_description)) %>
   </td>
-  <td class="govuk-table__cell change-request-list">
-    <%= t(".description_change") %>
-  </td>
 <% end %>

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -39,7 +39,7 @@
     <% elsif @planning_application.invalidated? %>
       <p class="govuk-body">
         <strong>
-          <%= "The application is marked as invalid. The applicant was notified on #{@planning_application.invalidated_at}" %>
+          <%= "The application is marked as invalid. The applicant was notified on #{@planning_application.invalidated_at.to_fs}" %>
         </strong>
       </p>
       <h2 class="govuk-heading-m">
@@ -62,7 +62,7 @@
       <p class="govuk-body">
         <strong>
           The application is marked as valid<%= @planning_application.may_invalidate? ? "." : " and cannot be marked as invalid." %><br/>
-          The applicant was notified on <%= @planning_application.validated_at %>
+          The applicant was notified on <%= @planning_application.validated_at.to_fs %>
         </strong>
       </p>
       <p class="govuk-body">

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @planning_application.not_started? && @planning_application.validation_requests.active.empty? %>
+    <% if @planning_application.not_started? && @planning_application.validation_requests.pending.none? %>
       <p class="govuk-body">
         <strong>
           The application has not been marked as valid or invalid yet.
@@ -27,7 +27,7 @@
         <%= link_to "Mark the application as valid", confirm_validation_planning_application_path(@planning_application), class: "govuk-button" %>
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>
-    <% elsif @planning_application.not_started? && @planning_application.validation_requests.active.any? %>
+    <% elsif @planning_application.not_started? && @planning_application.validation_requests.pending.any? %>
       <p class="govuk-body"><strong>You have marked items as invalid, so you cannot validate this application.</strong></p>
       <p class="govuk-body">If you mark the application as invalid then the applicant or agent will be sent an invalid notification. This notification will contain a link to allow the applicant or agent to view all validation requests and to accept and reject requests.</p>
       <%= form_with model: @planning_application, url: invalidate_planning_application_path(@planning_application), local:true do |form| %>

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -31,120 +31,13 @@ RSpec.describe "Planning Application Assessment" do
     visit "/"
   end
 
-  context "when planning application has no boundary geojson" do
-    let(:application) do
-      create(
-        :planning_application,
-        :not_started,
-        local_authority: default_local_authority,
-        boundary_geojson: nil
-      )
-    end
-
-    let(:boundary_geojson) do
-      {
-        type: "Feature",
-        properties: {},
-        geometry: {
-          type: "Polygon",
-          coordinates: [
-            [
-              [-0.054597, 51.537331],
-              [-0.054588, 51.537287],
-              [-0.054453, 51.537313],
-              [-0.054597, 51.537331]
-            ]
-          ]
-        }
-      }.to_json
-    end
-
-    it "blocks validation until boundary geojson has been added" do
-      visit "/planning_applications/#{application.id}/confirm_validation"
-      click_button("Mark the application as valid")
-
-      expect(page).to have_content(
-        "This application does not have a digital sitemap and cannot be validated. Please create a digital site map before validating this application."
-      )
-
-      click_link("create a digital site map")
-
-      expect(page).to have_content("Draw a digital red line boundary")
-
-      execute_script(
-        "document.getElementById(
-          'planning_application_boundary_geojson'
-        ).setAttribute(
-          'value',
-          '#{boundary_geojson}'
-        )"
-      )
-
-      click_button("Save")
-      click_link("Send validation decision")
-      click_link("Mark the application as valid")
-      click_button("Mark the application as valid")
-
-      expect(page).to have_content(
-        "Application is ready for assessment and an email notification has been sent."
-      )
-    end
-  end
-
-  context "when checking documents from Not Started status" do
-    it "can be invalidated and email is sent when there is an open validation request" do
-      create(:additional_document_validation_request, planning_application:, state: "pending",
-        created_at: 12.days.ago)
-
-      delivered_emails = ActionMailer::Base.deliveries.count
-
-      within(govuk_tab_all) do
-        click_link(planning_application.reference)
-      end
-
-      click_link "Check and validate"
-      click_link "Send validation decision"
-      click_button "Mark the application as invalid"
-
-      expect(page).to have_content("Application has been invalidated")
-
-      planning_application.reload
-      expect(planning_application.status).to eq("invalidated")
-
-      perform_enqueued_jobs
-      expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
-    end
-  end
-
-  context "when checking documents from Invalidated status" do
-    let!(:planning_application) do
-      create(:planning_application, :invalidated, local_authority: default_local_authority)
-    end
-
-    it "shows error if trying to mark as valid when open validation request exists on planning application" do
-      create(:additional_document_validation_request, planning_application:, state: "open")
-
-      within(govuk_tab_all) do
-        click_link(planning_application.reference)
-      end
-
-      click_link "Check and validate"
-      click_link "Send validation decision"
-
-      expect(page).to have_content("This application has 1 unresolved validation request and 1 resolved validation request")
-
-      click_link "Mark the application as valid"
-      click_button "Mark the application as valid"
-
-      expect(page).to have_content("Planning application cannot be validated if open validation requests exist")
-    end
-  end
-
   context "when planning application does not transition when expected inputs are not sent" do
     it "shows an error when invalid documents are present" do
+      request = create(:replacement_document_validation_request, state: :pending, planning_application:)
       create(:document, :with_file,
         planning_application:,
-        validated: false, invalidated_document_reason: "Missing a lazy Suzan")
+        validated: false, invalidated_document_reason: "Missing a lazy Suzan",
+        owner: request)
 
       within(govuk_tab_all) do
         click_link(planning_application.reference)
@@ -255,6 +148,176 @@ RSpec.describe "Planning Application Assessment" do
     end
   end
 
+  context "when application not started" do
+    it "shows text and links when application has not been started" do
+      visit "/planning_applications/#{planning_application.id}"
+      click_link "Check and validate"
+      click_link "Review validation requests"
+
+      expect(page).to have_content("The following requests will be sent when the application is invalidated.")
+      expect(page).to have_content("The application has not been marked as valid or invalid yet.")
+      expect(page).to have_content("When all parts of the application have been checked and are correct, mark the application as valid.")
+    end
+
+    context "when planning application has no boundary geojson" do
+      let(:application) do
+        create(
+          :planning_application,
+          :not_started,
+          local_authority: default_local_authority,
+          boundary_geojson: nil
+        )
+      end
+
+      let(:boundary_geojson) do
+        {
+          type: "Feature",
+          properties: {},
+          geometry: {
+            type: "Polygon",
+            coordinates: [
+              [
+                [-0.054597, 51.537331],
+                [-0.054588, 51.537287],
+                [-0.054453, 51.537313],
+                [-0.054597, 51.537331]
+              ]
+            ]
+          }
+        }.to_json
+      end
+
+      it "blocks validation until boundary geojson has been added" do
+        visit "/planning_applications/#{application.id}/confirm_validation"
+        click_button("Mark the application as valid")
+
+        expect(page).to have_content(
+          "This application does not have a digital sitemap and cannot be validated. Please create a digital site map before validating this application."
+        )
+
+        click_link("create a digital site map")
+
+        expect(page).to have_content("Draw a digital red line boundary")
+
+        execute_script(
+          "document.getElementById(
+            'planning_application_boundary_geojson'
+          ).setAttribute(
+            'value',
+            '#{boundary_geojson}'
+          )"
+        )
+
+        click_button("Save")
+        click_link("Send validation decision")
+        click_link("Mark the application as valid")
+        click_button("Mark the application as valid")
+
+        expect(page).to have_content(
+          "Application is ready for assessment and an email notification has been sent."
+        )
+      end
+    end
+
+    context "when checking documents from Not Started status" do
+      it "can be invalidated and email is sent when there is an open validation request" do
+        create(:additional_document_validation_request, planning_application:, state: "pending",
+          created_at: 12.days.ago)
+
+        delivered_emails = ActionMailer::Base.deliveries.count
+
+        within(govuk_tab_all) do
+          click_link(planning_application.reference)
+        end
+
+        click_link "Check and validate"
+        click_link "Send validation decision"
+        click_button "Mark the application as invalid"
+
+        expect(page).to have_content("Application has been invalidated")
+
+        planning_application.reload
+        expect(planning_application.status).to eq("invalidated")
+
+        perform_enqueued_jobs
+        expect(ActionMailer::Base.deliveries.count).to eq(delivered_emails + 1)
+      end
+    end
+
+    context "when a description change request has been sent" do
+      it "allows validation of the planning application" do
+        planning_application = create(:planning_application, :with_boundary_geojson, :not_started, local_authority: default_local_authority)
+        create(:description_change_validation_request, planning_application:, state: "open")
+        visit "/planning_applications/#{planning_application.id}"
+
+        click_link "Check and validate"
+        click_link "Send validation decision"
+        click_link "Mark the application as valid"
+
+        expect(page).to have_content "Validate application"
+
+        click_button "Mark the application as valid"
+
+        expect(page).to have_content("Application is ready for assessment")
+      end
+    end
+  end
+
+  context "when application has been invalidated" do
+    it "does not show the invalidate button when application is invalid" do
+      invalid_planning_application = create(:planning_application, :invalidated,
+        local_authority: default_local_authority)
+
+      visit "/planning_applications/#{invalid_planning_application.id}"
+      click_link "Check and validate"
+      click_link "Send validation decision"
+
+      expect(page).to have_content("The application is marked as invalid. The applicant was notified on #{invalid_planning_application.invalidated_at.to_fs}")
+    end
+
+    context "when checking documents from Invalidated status" do
+      let!(:planning_application) do
+        create(:planning_application, :with_boundary_geojson, :invalidated, local_authority: default_local_authority)
+      end
+
+      it "allows planning application to be made valid when open validation request exists" do
+        create(:additional_document_validation_request, planning_application:, state: "open")
+
+        within(govuk_tab_all) do
+          click_link(planning_application.reference)
+        end
+
+        click_link "Check and validate"
+        click_link "Send validation decision"
+
+        expect(page).to have_content("This application has 1 unresolved validation request and 1 resolved validation request")
+
+        click_link "Mark the application as valid"
+        click_button "Mark the application as valid"
+
+        expect(page).to have_content("Application is ready for assessment")
+      end
+    end
+  end
+
+  context "when application has been validated" do
+    before do
+      planning_application = create(:planning_application, :in_assessment, local_authority: default_local_authority)
+
+      visit "/planning_applications/#{planning_application.id}"
+    end
+
+    it "does not allow you to add requests if application has been validated" do
+      click_link "Check and validate"
+      click_link "Send validation decision"
+      expect(page).to have_content("The application is marked as valid and cannot be marked as invalid.")
+
+      click_link "Back"
+      click_link "Review validation requests"
+      expect(page).not_to have_link("Add new request")
+    end
+  end
+
   context "when planning application is in determined state" do
     let!(:determined_planning_application) do
       create(:planning_application, :determined, local_authority: default_local_authority)
@@ -272,59 +335,6 @@ RSpec.describe "Planning Application Assessment" do
       expect(page).not_to have_button("Mark the application as invalid")
       expect(page).not_to have_button("New request")
       expect(page).not_to have_content("Add all required validation requests for this application")
-    end
-  end
-
-  context "with invalidation with no requests" do
-    it "shows correct errors and status when there are no open validation requests" do
-      visit "/planning_applications/#{new_planning_application.id}"
-      click_link "Check and validate"
-      click_link "Review validation requests"
-
-      expect(planning_application.status).to eql("not_started")
-    end
-  end
-
-  context "when application not started" do
-    it "shows text and links when application has not been started" do
-      visit "/planning_applications/#{planning_application.id}"
-      click_link "Check and validate"
-      click_link "Review validation requests"
-
-      expect(page).to have_content("The following requests will be sent when the application is invalidated.")
-      expect(page).to have_content("The application has not been marked as valid or invalid yet.")
-      expect(page).to have_content("When all parts of the application have been checked and are correct, mark the application as valid.")
-    end
-  end
-
-  context "when application invalidated" do
-    it "does not show the invalidate button when application is invalid" do
-      invalid_planning_application = create(:planning_application, :invalidated,
-        local_authority: default_local_authority)
-
-      visit "/planning_applications/#{invalid_planning_application.id}"
-      click_link "Check and validate"
-      click_link "Send validation decision"
-
-      expect(page).to have_content("The application is marked as invalid. The applicant was notified on #{invalid_planning_application.invalidated_at}")
-    end
-  end
-
-  context "when application validated" do
-    before do
-      planning_application = create(:planning_application, :in_assessment, local_authority: default_local_authority)
-
-      visit "/planning_applications/#{planning_application.id}"
-    end
-
-    it "does not allow you to add requests if application has been validated" do
-      click_link "Check and validate"
-      click_link "Send validation decision"
-      expect(page).to have_content("The application is marked as valid and cannot be marked as invalid.")
-
-      click_link "Back"
-      click_link "Review validation requests"
-      expect(page).not_to have_link("Add new request")
     end
   end
 end


### PR DESCRIPTION
### Description of change

Fun bug. If there were any open validation requests then the system thought we needed to invalidate the application. However, when you did that, because the description change wasn't in a pending state, it said you couldn't invalidate it because there weren't any pending validation requests.

This fixes it so that you can validate with an open description change request (discussed with PO)