### PR TITLE
Avoid hardcoded date breaking spec

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -183,6 +183,10 @@ class Consultation < ApplicationRecord
     end_date_from(Time.zone.today)
   end
 
+  def letter_closing_date
+    end_date_from(Time.next_immediate_business_day(Time.zone.now).to_date)
+  end
+
   def days_left(now = Time.zone.today)
     (end_date - now).floor
   end
@@ -243,7 +247,7 @@ class Consultation < ApplicationRecord
     body = I18n.t("neighbour_letter_header.#{planning_application.application_type.name}")
 
     defaults = {
-      closing_date: end_date_from_now.to_fs,
+      closing_date: letter_closing_date.to_fs,
       default: ""
     }
 
@@ -260,7 +264,7 @@ class Consultation < ApplicationRecord
       applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
       description: planning_application.description,
       reference: planning_application.reference,
-      closing_date: end_date_from_now.to_fs,
+      closing_date: letter_closing_date.to_fs,
       rear_wall: planning_application&.proposal_measurement&.depth,
       max_height: planning_application&.proposal_measurement&.max_height,
       eaves_height: planning_application&.proposal_measurement&.eaves_height,

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -797,11 +797,9 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(mail_body).to include(
         "This is a copy of your neighbour consultation letter."
       )
-      travel_to(Time.zone.now.change(hour: 16)) do
-        expect(mail_body).to include(
-          "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs(:day_month_year)}"
-        )
-      end
+      expect(mail_body).to include(
+        "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs(:day_month_year)}"
+      )
       expect(mail_body).to include(
         "A prior approval application has been made for the development described below:"
       )

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -812,6 +812,19 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       expect(neighbour_consultation_letter_copy_mail.body.encoded).to include(planning_application.agent_first_name)
       expect(neighbour_consultation_letter_copy_mail.body.encoded).to include(planning_application.agent_last_name)
     end
+
+    context "when the letter is sent outside working hours" do
+      before do
+        travel_to("19:00")
+        consultation.update(start_date: 2.days.ago, end_date: (2.days.ago + 21.days))
+      end
+
+      it "correctly sets the response date based on the next business day" do
+        expect(mail_body).to include(
+          "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs(:day_month_year)}"
+        )
+      end
+    end
   end
 
   describe "#site_notice_mail" do

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application Assessment" do
+  let(:review_date) { Time.zone.local(2025, 4, 2) }
+
   let(:default_local_authority) do
     create(
       :local_authority,
@@ -13,9 +15,11 @@ RSpec.describe "Planning Application Assessment" do
   end
 
   let!(:planning_application) do
-    create(:planning_application, :awaiting_determination,
-      local_authority: default_local_authority,
-      decision: "granted")
+    travel_to 1.month.before review_date do
+      create(:planning_application, :awaiting_determination,
+        local_authority: default_local_authority,
+        decision: "granted")
+    end
   end
 
   context "when the planning application is awaiting determination" do
@@ -36,7 +40,7 @@ RSpec.describe "Planning Application Assessment" do
           reviewer:
         )
 
-        travel_to Time.zone.local(2025, 4, 2)
+        travel_to review_date
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.id}"
       end

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -408,11 +408,9 @@ RSpec.describe "Consultation", js: true do
     expect(page).to have_selector("h1", text: "Consultation")
 
     within "#dates-and-assignment-details" do
-      travel_to(Time.zone.now.change(hour: 16)) do
-        expect(page).to have_text("Consultation start date: #{start_date.to_date.to_fs}")
-        expect(page).to have_text("Consultation end date: #{end_date.to_date.to_fs}")
-        expect(page).to have_text("#{period} days remaining")
-      end
+      expect(page).to have_text("Consultation start date: #{start_date.to_date.to_fs}")
+      expect(page).to have_text("Consultation end date: #{end_date.to_date.to_fs}")
+      expect(page).to have_text("#{period} days remaining")
     end
 
     within "#consultee-tasks" do

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -345,11 +345,8 @@ RSpec.describe "Send letters to neighbours", js: true do
       fill_in("Resend reason",
         with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
-      travel_to(Time.zone.now.change(hour: 16)) do
-        expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-          personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
-      end
-
+      expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
+        personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
       click_button "Confirm and send letters"
     end
 
@@ -367,11 +364,8 @@ RSpec.describe "Send letters to neighbours", js: true do
         fill_in("Resend reason",
           with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
-        travel_to(Time.zone.now.change(hour: 16)) do
-          expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-            personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
-        end
-
+        expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
+          personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
         click_button "Confirm and send letters"
       end
     end


### PR DESCRIPTION
### Description of change

Ensure application creation date is before review date. Because the application was created outside the `travel_to`, it was getting a creation date based on the current date as the test was run. The review, however, happened at a specified date in the future: but once that date was passed, the review would again be happening before the application had been created and the test would fail. This led to 1e241ba7 where the date was updated to be in the future once more.

This could obviously be fixed simply by putting the `travel_to` date far enough in the future that we'll never have to worry about it, or by deriving the date from the current date so that it's always in the future, but creating the application in the past relative to the review seems cleanest.

This also reverts #1574, because this seemed to be ineffective: the times were being set outside of the `travel_to` block (in the test setup, not the test body), so they passed only because the tests were run in business hours ago. Instead the start and end dates are being calculated based on business hours.

### Story Link

https://trello.com/c/P50I0yiE/2535-remove-hard-coded-dates-from-specs
