### PR TITLE
Retry PlanX queries that time out

### DIFF
--- a/app/jobs/constraint_query_update_job.rb
+++ b/app/jobs/constraint_query_update_job.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require "faraday"
+
 class ConstraintQueryUpdateJob < ApplicationJob
   queue_as :high_priority
+  retry_on Faraday::TimeoutError, wait: 5.minutes, jitter: 0
 
   def perform(planning_application:)
     ConstraintQueryUpdateService.new(

--- a/app/services/apis/plan_x/query.rb
+++ b/app/services/apis/plan_x/query.rb
@@ -20,6 +20,8 @@ module Apis
         end
       rescue Faraday::ResourceNotFound, Faraday::ClientError
         {}
+      rescue Faraday::TimeoutError => e
+        raise e
       rescue Faraday::Error => e
         Appsignal.send_exception(e)
         {}

--- a/spec/jobs/constraint_query_update_job_spec.rb
+++ b/spec/jobs/constraint_query_update_job_spec.rb
@@ -3,20 +3,53 @@
 require "rails_helper"
 
 RSpec.describe ConstraintQueryUpdateJob do
-  let!(:planning_application) { create(:planning_application, :with_boundary_geojson) }
+  let(:planning_application) { create(:planning_application, :with_boundary_geojson) }
+  let(:query_service) { ConstraintQueryUpdateService.new(planning_application:) }
+  let(:query) { "POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))" }
 
   before do
-    stub_planx_api_response_for("POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))").to_return(
-      status: 200, body: "{}"
-    )
+    stub_planx_api_response_for(query).to_return(status: 200, body: "{}")
+  end
+
+  around do |example|
+    freeze_time { example.run }
   end
 
   describe "#perform" do
-    it "calls ConstraintQueryUpdateService" do
-      expect_any_instance_of(ConstraintQueryUpdateService).to receive(:call)
-        .and_call_original
+    before do
+      expect(ConstraintQueryUpdateService).to receive(:new).and_return(query_service)
+      expect(query_service).to receive(:call).and_call_original
 
-      described_class.perform_now(planning_application:)
+      described_class.perform_later(planning_application:)
+    end
+
+    context "when the query is successful" do
+      before do
+        stub_planx_api_response_for(query).to_return(status: 200, body: "{}")
+      end
+
+      it "processes the job" do
+        expect {
+          perform_enqueued_jobs
+        }.to change {
+          enqueued_jobs.size
+        }.from(1).to(0)
+      end
+    end
+
+    context "when the query times out" do
+      before do
+        stub_planx_api_response_for(query).to_raise(Faraday::TimeoutError)
+      end
+
+      it "enqueues the job to be retried" do
+        expect {
+          perform_enqueued_jobs
+        }.to have_enqueued_job(described_class)
+          .with(planning_application:)
+          .on_queue("high_priority")
+          .at(5.minutes.from_now)
+      end
     end
   end
 end


### PR DESCRIPTION
Faraday 5xx errors are reported to Appsignal but they're mostly timeouts so just retry the job a few times rather that spamming the Slack channel.