### PR TITLE
Add application type feature toggle for planning conditions

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -11,6 +11,11 @@ class ApplicationType < ApplicationRecord
 
   attribute :features, ApplicationTypeFeature.to_type
 
+  with_options to: :features do
+    delegate :planning_conditions?
+    delegate :permitted_development_rights?
+  end
+
   def full_name
     name.humanize
   end

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -3,5 +3,6 @@
 class ApplicationTypeFeature
   include StoreModel::Model
 
+  attribute :planning_conditions, :boolean, default: false
   attribute :permitted_development_rights, :boolean, default: true
 end

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -23,7 +23,7 @@
         )
       ) %>
     </li>
-    <% if @planning_application.type == "Householder Application for Planning Permission" %>
+    <% if @planning_application.application_type.planning_conditions? %>
       <%= render(
         TaskListItems::Assessment::ConditionsComponent.new(
           condition_set: @planning_application.condition_set

--- a/app/views/planning_applications/review/tasks/index.html.erb
+++ b/app/views/planning_applications/review/tasks/index.html.erb
@@ -66,12 +66,14 @@
           )
         )%>
       <% end %>
-      <% if @planning_application.condition_set.present? && @planning_application.condition_set.current_review&.status != "not_started" %>
-        <%= render(
-          TaskListItems::Reviewing::ConditionComponent.new(
-            condition_set: @planning_application.condition_set,
-          )
-        )%>
+      <% if @planning_application.application_type.planning_conditions? %>
+        <% if @planning_application.condition_set.present? && @planning_application.condition_set.current_review&.status != "not_started" %>
+          <%= render(
+            TaskListItems::Reviewing::ConditionComponent.new(
+              condition_set: @planning_application.condition_set,
+            )
+          )%>
+        <% end %>
       <% end %>
 
       <%= render partial: "policy_classes", locals: { planning_application: @planning_application, policy_class: @policy_class } %>

--- a/db/migrate/20240220085552_add_planning_conditions_to_application_type_feature.rb
+++ b/db/migrate/20240220085552_add_planning_conditions_to_application_type_feature.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddPlanningConditionsToApplicationTypeFeature < ActiveRecord::Migration[7.1]
+  class ApplicationType < ActiveRecord::Base; end
+
+  def change
+    up_only do
+      ApplicationType.find_each do |type|
+        if type.name == "planning_permission"
+          type.update!(features: type.features.merge("planning_conditions" => true))
+        else
+          type.update!(features: type.features.merge("planning_conditions" => false))
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_19_104723) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_085552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -140,7 +140,7 @@ FactoryBot.define do
     trait :planning_permission do
       name { "planning_permission" }
       steps { %w[validation consultation assessment review] }
-      features { {"permitted_development_rights" => false} }
+      features { {"planning_conditions" => true, "permitted_development_rights" => false} }
 
       assessment_details do
         %w[


### PR DESCRIPTION
Prior approvals and LDCs don't have planning conditions so don't present them as options during the assessment and review stages for those types.