### PR TITLE
Fix sass deprecation warnings

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -375,7 +375,7 @@ $govuk-page-width: 1100px;
 }
 
 .status-panel {
-  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  background-color: govuk-colour("light-grey");
   margin-top: 1rem;
   margin-bottom: 1rem;
 
@@ -409,12 +409,12 @@ body {
 }
 
 .grey-box {
-  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  background-color: govuk-colour("light-grey");
   margin-top: 1rem;
   margin-bottom: 1rem;
   padding: 2rem;
 }
 
 .background-light-grey {
-  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  background-color: govuk-colour("light-grey");
 }

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 # govuk-frontend triggers sass deprecation warnings that we can't control
-Rails.application.config.dartsass.build_options << " --quiet-deps"
+# see https://github.com/alphagov/govuk-frontend/issues/2238
+#
+# the docs suggest quiet-deps alone should be enough but quiet seems to be needed too
+Rails.application.config.dartsass.build_options << " --quiet-deps --quiet"


### PR DESCRIPTION
- Remove deprecated $legacy parameter from govuk-colour
- Fully suppress deprecation warnings from dartsass
