### PR TITLE
Don't raise an error when max attempts have been exceeded

### DIFF
--- a/app/jobs/constraint_query_update_job.rb
+++ b/app/jobs/constraint_query_update_job.rb
@@ -4,7 +4,10 @@ require "faraday"
 
 class ConstraintQueryUpdateJob < ApplicationJob
   queue_as :high_priority
-  retry_on Faraday::TimeoutError, wait: 5.minutes, jitter: 0
+
+  retry_on(Faraday::TimeoutError, attempts: 12, wait: 5.minutes, jitter: 0) do |error|
+    Appsignal.send_exception(error)
+  end
 
   def perform(planning_application:)
     ConstraintQueryUpdateService.new(

--- a/spec/jobs/constraint_query_update_job_spec.rb
+++ b/spec/jobs/constraint_query_update_job_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe ConstraintQueryUpdateJob do
 
   describe "#perform" do
     before do
-      expect(ConstraintQueryUpdateService).to receive(:new).and_return(query_service)
-      expect(query_service).to receive(:call).and_call_original
+      allow(ConstraintQueryUpdateService).to receive(:new).and_return(query_service)
+      allow(query_service).to receive(:call).and_call_original
 
       described_class.perform_later(planning_application:)
     end
@@ -49,6 +49,14 @@ RSpec.describe ConstraintQueryUpdateJob do
           .with(planning_application:)
           .on_queue("high_priority")
           .at(5.minutes.from_now)
+      end
+
+      it "doesn't raise an error when the maximum number of attempts has been exceeded" do
+        expect {
+          13.times {
+            perform_enqueued_jobs
+          }
+        }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
The default for `retry_on` is to retry for five times and then raise an error but this triggers a doom loop with the default of retrying a job when it fails with an unhandled exception.

Fix this by setting the number of attempts to twelve and then using a block to send an error to Appsignal. This gives a job an hour to be successfully finished - if it's not then it's likely something is down somewhere.
