### PR TITLE
Remove :only option from :verify_request callback

### DIFF
--- a/app/controllers/concerns/active_storage/set_disk_blob.rb
+++ b/app/controllers/concerns/active_storage/set_disk_blob.rb
@@ -5,7 +5,7 @@ module ActiveStorage
     extend ActiveSupport::Concern
 
     included do
-      before_action :verify_request, only: %i[set_disk_blob]
+      before_action :verify_request
       before_action :set_disk_blob, if: :not_from_bops?
     end
 


### PR DESCRIPTION
Rails 7.1 now raises an exception for actions that don't exist and `set_disk_blob` isn't defined yet and isn't an action.

Note this only affects development and test environments since that's the only place where the disk controller is used.
