### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Save screenshots
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-screenshots
           path: ${{ github.workspace }}/tmp/capybara/*.png
@@ -122,7 +122,7 @@ jobs:
 
       - name: Save rails logs
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rails-logs
           path: ${{ github.workspace }}/log/test.log


### PR DESCRIPTION
This is to stop the Node.js v16 being deprecated warnings.
