### PR TITLE
Add show page for validating ownership certificates

### DIFF
--- a/app/components/task_list_items/validating/ownership_certificate_component.rb
+++ b/app/components/task_list_items/validating/ownership_certificate_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  module Validating
+    class OwnershipCertificateComponent < TaskListItems::BaseComponent
+      def initialize(planning_application:)
+        @planning_application = planning_application
+        @ownership_certificate = @planning_application.ownership_certificate
+      end
+
+      private
+
+      attr_reader :planning_application, :ownership_certificate
+
+      def link_text
+        t(".link_text")
+      end
+
+      def link_path
+        if @planning_application.valid_ownership_certificate.nil?
+          edit_planning_application_validation_ownership_certificate_path(@planning_application)
+        else
+          planning_application_validation_ownership_certificate_path(@planning_application)
+        end
+      end
+
+      def status_tag_component
+        StatusTags::OwnershipCertificateComponent.new(
+          planning_application:
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/validation/ownership_certificates_controller.rb
+++ b/app/controllers/planning_applications/validation/ownership_certificates_controller.rb
@@ -11,6 +11,12 @@ module PlanningApplications
         end
       end
 
+      def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
       def update
         if @planning_application.update(planning_application_params)
           if @planning_application.valid_ownership_certificate?

--- a/app/views/planning_applications/validation/ownership_certificates/show.html.erb
+++ b/app/views/planning_applications/validation/ownership_certificates/show.html.erb
@@ -1,0 +1,85 @@
+<% content_for :page_title do %>
+  Ownership certificate - <%= t('page_title') %>
+<% end %>
+
+<%= render "planning_applications/validation/validation_requests/validation_requests_breadcrumbs" %>
+<% content_for :title, "Ownership certificate" %>
+
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Check the ownership certificate" }
+) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson } %>
+
+    <%= render "relevant_documents_accordion" %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds govuk-!-margin-top-6">
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header">Certificate type</th>
+          <td class="govuk-table__cell">
+            <%= @planning_application.ownership_certificate.present? ? @planning_application.ownership_certificate.certificate_type.upcase : "Not specified" %>
+          </td>
+        </tr>
+        <% if @planning_application.ownership_certificate.present? && @planning_application.ownership_certificate.land_owners.any? %>
+          <% @planning_application.ownership_certificate.land_owners.each_with_index do |owner, i| %>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header" style="font-weight: normal;">Owner <%= i + 1 %></th>
+              <td class="govuk-table__cell">&nbsp</td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Name</th>
+              <td class="govuk-table__cell"><%= owner.name %></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Address</th>
+              <td class="govuk-table__cell"><%= owner.address %></td>
+            </tr>
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">Notice given</th>
+              <td class="govuk-table__cell"><%= owner.notice_given? ? "Yes" : "No" %></td>
+            </tr>
+            <% if owner.notice_given? %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Notice date</th>
+                <td class="govuk-table__cell"><%= owner.notice_given_at&.to_fs(:day_month_year_slashes) %></td>
+              </tr>
+            <% else %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header">Reason no notice given</th>
+                <td class="govuk-table__cell"><%= owner.notice_reason %></td>
+              </tr>
+            <% end %>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+    <% if @planning_application.ownership_certificate_validation_requests.open_or_pending.any? %>
+      <% if @planning_application.ownership_certificate_validation_requests.open.any? %>
+        <p class="govuk-body">Request for more information about ownership certificate has been sent to applicant</p>
+      <% else %>
+        <p class="govuk-body">Request for more information about ownership certificate will be sent once application has been made invalid</p>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <%  %>
+    <% elsif @planning_application.ownership_certificate_validation_requests.closed.any? %>
+      <div class="govuk-button-group">
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-link govuk-body" %>
+      </div>
+    <% else %>
+      <div class="govuk-button-group">
+        <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-link govuk-body" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
@@ -39,15 +39,10 @@
         )
       ) %>
     </li>
-    <li id="ownership-certificate-validation-task" class="app-task-list__item">
-      <span class="app-task-list__task-name">
-        <%= link_to "Check ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-link" %>
-      </span>
-      <%= render(
-            StatusTags::OwnershipCertificateComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-    </li>
+    <%= render(
+      TaskListItems::Validating::OwnershipCertificateComponent.new(
+        planning_application: @planning_application
+      )
+    ) %>
   </ul>
 </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1730,6 +1730,8 @@ en:
     validating:
       legislation_component:
         check_legislation: Check legislative requirements
+      ownership_certificate_component:
+        link_text: Check ownership certificate
     validation_decision_component:
       send_validation_decision: Send validation decision
   time:

--- a/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
@@ -46,9 +46,13 @@ RSpec.describe "Check ownership certificate type" do
 
         expect(page).to have_content "Ownership certificate successfully updated"
 
-        within("#ownership-certificate-validation-task") do
+        within("#check-ownership-certificate") do
           expect(page).to have_content("Valid")
         end
+
+        click_link "Check ownership certificate"
+
+        expect(page).not_to have_content("Save")
       end
     end
 
@@ -67,6 +71,10 @@ RSpec.describe "Check ownership certificate type" do
         click_button "Save request"
 
         expect(page).to have_content "Ownership certificate request successfully created"
+
+        click_link "Check ownership certificate"
+
+        expect(page).to have_content "Request for more information about ownership certificate will be sent once application has been made invalid"
       end
     end
   end

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Validation tasks" do
             end
           end
 
-          within("#ownership-certificate-validation-task") do
+          within("#check-ownership-certificate") do
             expect(page).to have_link(
               "Check ownership certificate",
               href: edit_planning_application_validation_ownership_certificate_path(planning_application)
@@ -317,7 +317,7 @@ RSpec.describe "Validation tasks" do
             end
           end
 
-          within("#ownership-certificate-validation-task") do
+          within("#check-ownership-certificate") do
             expect(page).to have_link(
               "Check ownership certificate",
               href: edit_planning_application_validation_ownership_certificate_path(planning_application)


### PR DESCRIPTION
### Description of change

Right now the journey is confusing as even if the task has been completed, the form still shows. This adds a show page to make it clearer for users
