### PR TITLE
Restart web and applicants containers if they fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-bops: &bops
   init: true
   stdin_open: true
   tty: true
+  restart: always
   depends_on:
     - db
     - dnsmasq
@@ -44,6 +45,7 @@ x-applicants: &applicants
   init: true
   stdin_open: true
   tty: true
+  restart: always
   depends_on:
     - web
   dns:


### PR DESCRIPTION
Sometimes one of the background processes like yarn causes a service to exit and you have to manually stop the stack and restart it. This seems to be mainly on first booting the stack after docker has started and is visible in the log output like this:

```
An unexpected error occurred: "ENOSYS: function not implemented, fstat".
```

This appears to be down to the filesystem not being fully initialised in the container so it's fine to just restart the container.
