### PR TITLE
Write out existing boundary as a JSON string

### DIFF
--- a/app/controllers/planning_applications/validation/sitemaps_controller.rb
+++ b/app/controllers/planning_applications/validation/sitemaps_controller.rb
@@ -48,10 +48,6 @@ module PlanningApplications
             render :show
           end
         end
-      rescue ConstraintQueryUpdateService::SaveError => e
-        Appsignal.send_error(e)
-        redirect_to planning_application_validation_sitemap_path(@planning_application),
-          alert: t(".error")
       end
 
       private

--- a/app/views/planning_applications/validation/sitemaps/_draw_red_line_boundary.html.erb
+++ b/app/views/planning_applications/validation/sitemaps/_draw_red_line_boundary.html.erb
@@ -23,7 +23,7 @@
 <h3 class="govuk-heading-s">Draw the red line site boundary</h3>
 
 <%= form_with model: @planning_application, url: planning_application_validation_sitemap_path(@planning_application) do |form| %>
-  <%= form.hidden_field :boundary_geojson %>
+  <%= form.hidden_field :boundary_geojson, value: @planning_application.boundary_geojson.to_json %>
   <%= render "shared/location_map", locals: { geojson: @planning_application.boundary_geojson, geojson_field: 'planning_application_boundary_geojson' } %>
   <div class="govuk-button-group govuk-!-margin-top-3">
     <%= form.govuk_submit "Save" %>


### PR DESCRIPTION
Without this it's converted by Hash#to_s which is a source of data corruption.