### PR TITLE
Set up global admin infrastructure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
             }
           - { group: "bops_admin", pattern: "*_spec.rb", module: "engines" }
           - { group: "bops_api", pattern: "*_spec.rb", module: "engines" }
+          - { group: "bops_config", pattern: "*_spec.rb", module: "engines" }
       fail-fast: false
     with:
       name: "${{matrix.specs.group}}: ${{matrix.specs.pattern }}"

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "view_component"
 
 gem "bops_admin", path: "engines/bops_admin"
 gem "bops_api", path: "engines/bops_api"
+gem "bops_config", path: "engines/bops_config"
 
 group :development, :test do
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,12 @@ PATH
       rswag-specs (~> 2.11)
       rswag-ui (~> 2.11)
 
+PATH
+  remote: engines/bops_config
+  specs:
+    bops_config (0.1.0)
+      rails (>= 7.1.3, < 7.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -628,6 +634,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   bops_admin!
   bops_api!
+  bops_config!
   brakeman
   bullet
   business_time

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -71,9 +71,7 @@ class ApplicationController < ActionController::Base
   end
 
   def find_current_local_authority_from_subdomain
-    return if @current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)
-
-    render plain: "No Local Authority Found", status: :not_found
+    @current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)
   end
 
   def prevent_caching

--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -73,9 +73,17 @@ module AuthenticateWithOtpTwoFactor
 
   def find_user
     if session[:otp_user_id]
-      find_current_local_authority.users.find(session[:otp_user_id])
+      users_scope.find(session[:otp_user_id])
     elsif user_params[:email]
-      find_current_local_authority.users.find_for_authentication(email: user_params[:email], subdomain: request.subdomain)
+      users_scope.find_for_authentication(email: user_params[:email], subdomain: request.subdomain)
+    end
+  end
+
+  def users_scope
+    if request.subdomain == "config"
+      User.global_administrator
+    else
+      find_current_local_authority_from_subdomain.users
     end
   end
 
@@ -89,9 +97,5 @@ module AuthenticateWithOtpTwoFactor
 
   def otp_input?
     user_params[:otp_attempt].present? && session[:otp_user_id]
-  end
-
-  def find_current_local_authority
-    @find_current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,7 +10,6 @@ module Users
 
     include AuthenticateWithOtpTwoFactor
 
-    before_action :find_current_local_authority_from_subdomain
     prepend_before_action :authenticate_with_otp_two_factor, if: :otp_two_factor_enabled?, only: :create
     before_action :find_otp_user, only: %i[setup two_factor resend_code]
     skip_before_action :enforce_user_permissions
@@ -53,7 +52,7 @@ module Users
     end
 
     def find_otp_user
-      @user = find_current_local_authority.users.find_by(id: session[:otp_user_id])
+      @user = users_scope.find_by(id: session[:otp_user_id])
 
       redirect_to root_path unless @user
     end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -4,9 +4,11 @@
       home_path,
       class: "govuk-header__link govuk-header__link--homepage"
     ) do %>
-      <span class="govuk-header__service-name">
-        <%= current_local_authority.short_name %>
-      </span>
+      <% if @current_local_authority %>
+        <span class="govuk-header__service-name">
+          <%= current_local_authority.short_name %>
+        </span>
+      <% end %>
       <span class="govuk-header__product-name">
         <%= t(".back_office_planning") %>
       </span>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -6,12 +6,19 @@ Someone has requested a link to change your password. You can do this through th
 
 <% else %>
 
+<% if @user.local_authority %>
 Welcome to the Back-office Planning System for <%= @user.local_authority.council_name %>.
+<% end %>
 
 You can confirm your account and set a password through the link below:
 
 <% end %>
+
+<% if @user.local_authority %>
 <%= edit_password_url(@resource, subdomain: @resource.local_authority.subdomain, reset_password_token: @token) %>
+<% else %>
+<%= edit_password_url(@resource, subdomain: "config", reset_password_token: @token) %>
+<% end %>
 
 If you didn't request this, please ignore this email.
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,45 +3,49 @@
 <% end %>
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <% if current_local_authority %>
         Planning applications
-      </h1>
+      <% else %>
+        BOPS config
+      <% end %>
+    </h1>
 
-      <h2 class="govuk-tabs__title">
-        Log in
-      </h2>
+    <h2 class="govuk-tabs__title">
+      Log in
+    </h2>
 
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <div class="govuk-form-group">
-          <div class="field">
-            <%= f.label :email, class: "govuk-label" %>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input govuk-input--width-30", type: "text" %>
-          </div>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="govuk-form-group">
+        <div class="field">
+          <%= f.label :email, class: "govuk-label" %>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "govuk-input govuk-input--width-30", type: "text" %>
         </div>
-        <div class="govuk-form-group">
-          <div class="field">
-            <%= f.label :password, class: "govuk-label" %>
-            <%= f.password_field :password, autocomplete: "current-password", class: "govuk-input govuk-input--width-30", type: "password" %>
-          </div>
+      </div>
+      <div class="govuk-form-group">
+        <div class="field">
+          <%= f.label :password, class: "govuk-label" %>
+          <%= f.password_field :password, autocomplete: "current-password", class: "govuk-input govuk-input--width-30", type: "password" %>
         </div>
+      </div>
 
-       <% if devise_mapping.rememberable? %>
-         <div class="field">
-           <p class="govuk-body">
-             <%= f.check_box :remember_me %>
-             <%= f.label :remember_me %>
-           </p>
-          </div>
-       <% end %>
-
-        <div class="actions">
-          <%= f.submit "Log in", class: "govuk-button" %>
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <p class="govuk-body">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </p>
         </div>
       <% end %>
 
-      <p class="govuk-body">
-        <%= render "devise/shared/links" %>
-      </p>
-    </div>
- </div>
+      <div class="actions">
+        <%= f.submit "Log in", class: "govuk-button" %>
+      </div>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= render "devise/shared/links" %>
+    </p>
+  </div>
+</div>

--- a/app/views/devise/sessions/two_factor.html.erb
+++ b/app/views/devise/sessions/two_factor.html.erb
@@ -19,11 +19,13 @@
 
         <%= link_to "Resend code", resend_code_path, class: "govuk-link" %>
 
-        <p class="govuk-phase-banner__content govuk-!-padding-top-3 govuk-!-padding-bottom-3">
-          <span class="govuk-phase-banner__text">
-            If you have an issue logging in, please send an email to <%= mail_to @user.local_authority.email_address, @user.local_authority.email_address, class: "govuk-link" %>
-          </span>
-        </p>
+        <% if @user.local_authority %>
+          <p class="govuk-phase-banner__content govuk-!-padding-top-3 govuk-!-padding-bottom-3">
+            <span class="govuk-phase-banner__text">
+              If you have an issue logging in, please send an email to <%= mail_to @user.local_authority.email_address, @user.local_authority.email_address, class: "govuk-link" %>
+            </span>
+          </p>
+        <% end %>
 
         <%= form.submit "Enter code", class: "govuk-button", data: { module: "govuk-button" } %>
       <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@
 
 require_relative "boot"
 require_relative "../lib/quiet_logger"
+require_relative "../lib/constraints/subdomain"
 
 require "rails"
 # Pick the frameworks you want:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -58,6 +58,29 @@
       "note": ""
     },
     {
+      "warning_type": "HTTP Verb Confusion",
+      "warning_code": 118,
+      "fingerprint": "713f84552953d2a9fdc5b7ca548ef91be96630ff38a470b5fd2dede70a9153ab",
+      "check_name": "VerbConfusion",
+      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
+      "file": "engines/bops_config/app/controllers/bops_config/application_controller.rb",
+      "line": 22,
+      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
+      "code": "session[:back_path] = request.referer if request.get?",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "BopsConfig::ApplicationController",
+        "method": "set_back_path"
+      },
+      "user_input": "request.get?",
+      "confidence": "Weak",
+      "cwe_id": [
+        352
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
       "fingerprint": "7db818492a354dcc125c250a78a18b6689d8fa8545c3e7c1a015440df0ea2094",
@@ -149,6 +172,6 @@
       "note": ""
     }
   ],
-  "updated": "2024-01-23 02:47:22 +0000",
+  "updated": "2024-03-01 12:02:20 +0000",
   "brakeman_version": "6.0.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,270 +2,272 @@
 
 # require "rswag-api"
 
-require "sidekiq/web"
-
 Rails.application.routes.draw do
-  root to: "planning_applications#index"
+  constraints Constraints::DeviseSubdomain do
+    devise_for :users, controllers: {
+      sessions: "users/sessions",
+      confirmations: "confirmations"
+    }
 
-  mount BopsApi::Engine, at: "/api"
-  get "/api-docs(/index)", to: redirect("/api/docs")
-
-  mount BopsAdmin::Engine, at: "/admin"
-
-  authenticate :user, ->(u) { u.administrator? } do
-    mount Sidekiq::Web, at: "/sidekiq"
-  end
-
-  devise_for :users, controllers: {
-    sessions: "users/sessions",
-    confirmations: "confirmations"
-  }
-
-  devise_scope :user do
-    get "setup", to: "users/sessions#setup", as: "setup"
-    get "two_factor", to: "users/sessions#two_factor", as: "two_factor"
-    get "resend_code", to: "users/sessions#resend_code", as: "resend_code"
-  end
-
-  defaults format: "json" do
-    get "/os_places_api",
-      to: "os_places_api#index",
-      as: "os_places_api_index"
-
-    post "/search_addresses_by_polygon",
-      to: "os_places_api#search_addresses_by_polygon",
-      as: "search_addresses_by_polygon"
-
-    scope "/contacts" do
-      get "/consultees", to: "contacts#index", defaults: {category: "consultee"}
+    devise_scope :user do
+      get "setup", to: "users/sessions#setup", as: "setup"
+      get "two_factor", to: "users/sessions#two_factor", as: "two_factor"
+      get "resend_code", to: "users/sessions#resend_code", as: "resend_code"
     end
   end
 
-  resources :planning_applications, except: %i[destroy] do
-    member do
-      get :confirm_validation
-      patch :validate
-      patch :invalidate
-      get :submit_recommendation
-      get :view_recommendation
-      patch :submit
-      patch :withdraw_recommendation
-      patch :assess
-      get :edit_public_comment
-      get :publish
-      patch :determine
-      get :decision_notice
-      get :validation_notice
-      get :validation_decision
-      get :supply_documents
-      post :clone
-      get :make_public
-    end
+  constraints Constraints::LocalAuthoritySubdomain do
+    root to: "planning_applications#index"
 
-    resources :documents, except: %i[destroy show] do
-      get :archive
+    mount BopsApi::Engine, at: "/api"
+    get "/api-docs(/index)", to: redirect("/api/docs")
 
-      patch :confirm_archive
-      patch :unarchive
-    end
+    mount BopsAdmin::Engine, at: "/admin"
 
-    resources :audits, only: :index
+    defaults format: "json" do
+      get "/os_places_api",
+        to: "os_places_api#index",
+        as: "os_places_api_index"
 
-    scope module: :planning_applications do
-      resources :assign_users, only: %i[index] do
-        patch :update, on: :collection
-      end
+      post "/search_addresses_by_polygon",
+        to: "os_places_api#search_addresses_by_polygon",
+        as: "search_addresses_by_polygon"
 
-      resource :press_notice, only: %i[show create update] do
-        resource :confirmation, only: %i[show update], controller: "press_notices/confirmations"
-        resources :confirmation_requests, only: %i[create], controller: "press_notices/confirmation_requests"
-      end
-
-      resources :site_notices do
-        resources :confirmation_requests, only: %i[create], controller: "site_notices/confirmation_requests"
-      end
-
-      resource :withdraw_or_cancel, only: %i[show update]
-      resources :notes, only: %i[index create]
-
-      namespace :assessment do
-        resource :report_download, only: :show
-        resources :assess_immunity_detail_permitted_development_rights, only: %i[new create]
-        resource :assess_immunity_detail_permitted_development_right, only: %i[show edit update]
-        resources :assessment_details, except: %i[destroy index]
-        resources :tasks, only: :index
-        resources :conditions, only: %i[index new] do
-          get :edit, on: :collection
-          get :edit
-          patch :update, on: :collection
-        end
-        resource :consistency_checklist, except: %i[destroy index]
-        resource :ownership_certificate, except: %i[destroy index]
-
-        resources :immunity_details, except: %i[destroy index] do
-          resources :evidence_groups do
-            resources :comments, only: %i[create update]
-          end
-        end
-
-        resources :local_policies, except: %i[destroy index]
-
-        resources :permitted_development_rights, except: %i[destroy index]
-
-        resource :planning_history, only: :show
-
-        resources :policy_classes, except: %i[index] do
-          get :part, on: :new
-
-          resources :policies, only: [] do
-            resources :comments, only: %i[create update]
-          end
-        end
-        resources :recommendations, only: %i[new create update]
-        resource :recommendations, only: %i[edit]
-      end
-
-      resources :consultees, only: %i[create show] do
-        resources :responses, controller: "consultee/responses", except: %i[show destroy]
-      end
-
-      namespace :consultee, as: :consultees do
-        resources :emails, only: %i[index create]
-        resources :responses, only: %i[index]
-      end
-
-      resource :consultation, only: %i[show edit update] do
-        resources :neighbours, only: %i[index create update destroy]
-
-        resources :neighbour_letters, only: %i[index update destroy] do
-          post :send_letters, on: :collection
-        end
-
-        resources :neighbour_responses, except: %i[show destroy]
-        resources :redact_neighbour_responses, only: %i[edit update]
-        resources :site_visits, except: %i[destroy]
-      end
-
-      namespace :validation do
-        resources :tasks, only: :index
-
-        resource :cil_liability, only: %i[edit update], controller: :cil_liability
-
-        resource :environment_impact_assessment, only: %i[new create edit show update]
-
-        resource :reporting_type, only: %i[edit update]
-
-        resource :constraints, only: %i[show update]
-
-        resource :documents, only: %i[edit update]
-
-        namespace :document, as: :documents do
-          resources :redactions, only: %i[index create]
-        end
-
-        resource :ownership_certificate do
-          patch :validate
-        end
-
-        resource :description_changes, only: %i[show] do
-          patch :validate
-        end
-
-        resource :fee_items, only: %i[show] do
-          patch :validate
-        end
-
-        resource :sitemap, only: %i[show edit update] do
-          patch :validate
-        end
-
-        resources :validation_requests do
-          get :post_validation_requests, on: :collection
-
-          member do
-            get :cancel_confirmation
-
-            patch :cancel
-          end
-        end
-
-        resources :additional_document_validation_requests, controller: :validation_requests
-        resources :replacement_document_validation_requests, controller: :validation_requests
-        resources :other_change_validation_requests, controller: :validation_requests
-        resources :fee_change_validation_requests, controller: :validation_requests
-        resources :red_line_boundary_change_validation_requests, controller: :validation_requests
-        resources :description_change_validation_requests, controller: :validation_requests
-        resources :ownership_certificate_validation_requests, controller: :validation_requests
-
-        resource :legislation, only: %i[show update]
-      end
-
-      namespace :review do
-        resource :assessment_details, only: %i[show edit update]
-
-        resource :conditions, only: %i[show update]
-
-        resources :documents, only: %i[index] do
-          patch :update, on: :collection
-        end
-
-        resources :immunity_details, only: %i[edit update show]
-
-        resources :immunity_enforcements, only: %i[show edit update]
-
-        resources :local_policies, only: %i[edit update show]
-
-        resources :permitted_development_rights, only: %i[show edit update]
-
-        resources :policy_classes, only: %i[edit update show]
-
-        resources :tasks, only: :index
+      scope "/contacts" do
+        get "/consultees", to: "contacts#index", defaults: {category: "consultee"}
       end
     end
-  end
 
-  namespace :public, path: "/" do
-    scope "/planning_guides" do
-      get "/", to: "planning_guides#index", as: :planning_guides
-      get "/*path", to: "planning_guides#show", as: nil
-    end
-  end
-
-  namespace :public do
-    resources :planning_applications, only: [] do
+    resources :planning_applications, except: %i[destroy] do
       member do
-        get "decision_notice"
+        get :confirm_validation
+        patch :validate
+        patch :invalidate
+        get :submit_recommendation
+        get :view_recommendation
+        patch :submit
+        patch :withdraw_recommendation
+        patch :assess
+        get :edit_public_comment
+        get :publish
+        patch :determine
+        get :decision_notice
+        get :validation_notice
+        get :validation_decision
+        get :supply_documents
+        post :clone
+        get :make_public
       end
-    end
-  end
 
-  namespace :api do
-    namespace :v1 do
-      resources :planning_applications, only: %i[index create show] do
-        member do
-          get :decision_notice
+      resources :documents, except: %i[destroy show] do
+        get :archive
+
+        patch :confirm_archive
+        patch :unarchive
+      end
+
+      resources :audits, only: :index
+
+      scope module: :planning_applications do
+        resources :assign_users, only: %i[index] do
+          patch :update, on: :collection
         end
-        resources :validation_requests, only: :index
-        resources :description_change_validation_requests, only: %i[index update show]
-        resources :replacement_document_validation_requests, only: %i[index update show]
-        resources :additional_document_validation_requests, only: %i[index update show]
-        resources :documents, only: %i[show]
-        resources :other_change_validation_requests, only: %i[index update show]
-        resources :fee_change_validation_requests, only: %i[index update show]
-        resources :ownership_certificate_validation_requests, only: %i[index update show]
-        resources :ownership_certificates, only: %i[create]
-        resources :red_line_boundary_change_validation_requests, only: %i[index update show]
-        resources :pre_commencement_condition_validation_requests, only: %i[index update show]
-        resources :neighbour_responses, only: :create
-      end
 
-      resources :local_authorities, only: %i[show], param: :subdomain
+        resource :press_notice, only: %i[show create update] do
+          resource :confirmation, only: %i[show update], controller: "press_notices/confirmations"
+          resources :confirmation_requests, only: %i[create], controller: "press_notices/confirmation_requests"
+        end
 
-      resources :documents, only: :show do
-        get :tags, on: :collection
+        resources :site_notices do
+          resources :confirmation_requests, only: %i[create], controller: "site_notices/confirmation_requests"
+        end
+
+        resource :withdraw_or_cancel, only: %i[show update]
+        resources :notes, only: %i[index create]
+
+        namespace :assessment do
+          resource :report_download, only: :show
+          resources :assess_immunity_detail_permitted_development_rights, only: %i[new create]
+          resource :assess_immunity_detail_permitted_development_right, only: %i[show edit update]
+          resources :assessment_details, except: %i[destroy index]
+          resources :tasks, only: :index
+          resources :conditions, only: %i[index new] do
+            get :edit, on: :collection
+            get :edit
+            patch :update, on: :collection
+          end
+          resource :consistency_checklist, except: %i[destroy index]
+          resource :ownership_certificate, except: %i[destroy index]
+
+          resources :immunity_details, except: %i[destroy index] do
+            resources :evidence_groups do
+              resources :comments, only: %i[create update]
+            end
+          end
+
+          resources :local_policies, except: %i[destroy index]
+
+          resources :permitted_development_rights, except: %i[destroy index]
+
+          resource :planning_history, only: :show
+
+          resources :policy_classes, except: %i[index] do
+            get :part, on: :new
+
+            resources :policies, only: [] do
+              resources :comments, only: %i[create update]
+            end
+          end
+          resources :recommendations, only: %i[new create update]
+          resource :recommendations, only: %i[edit]
+        end
+
+        resources :consultees, only: %i[create show] do
+          resources :responses, controller: "consultee/responses", except: %i[show destroy]
+        end
+
+        namespace :consultee, as: :consultees do
+          resources :emails, only: %i[index create]
+          resources :responses, only: %i[index]
+        end
+
+        resource :consultation, only: %i[show edit update] do
+          resources :neighbours, only: %i[index create update destroy]
+
+          resources :neighbour_letters, only: %i[index update destroy] do
+            post :send_letters, on: :collection
+          end
+
+          resources :neighbour_responses, except: %i[show destroy]
+          resources :redact_neighbour_responses, only: %i[edit update]
+          resources :site_visits, except: %i[destroy]
+        end
+
+        namespace :validation do
+          resources :tasks, only: :index
+
+          resource :cil_liability, only: %i[edit update], controller: :cil_liability
+
+          resource :environment_impact_assessment, only: %i[new create edit show update]
+
+          resource :reporting_type, only: %i[edit update]
+
+          resource :constraints, only: %i[show update]
+
+          resource :documents, only: %i[edit update]
+
+          namespace :document, as: :documents do
+            resources :redactions, only: %i[index create]
+          end
+
+          resource :ownership_certificate do
+            patch :validate
+          end
+
+          resource :description_changes, only: %i[show] do
+            patch :validate
+          end
+
+          resource :fee_items, only: %i[show] do
+            patch :validate
+          end
+
+          resource :sitemap, only: %i[show edit update] do
+            patch :validate
+          end
+
+          resources :validation_requests do
+            get :post_validation_requests, on: :collection
+
+            member do
+              get :cancel_confirmation
+
+              patch :cancel
+            end
+          end
+
+          resources :additional_document_validation_requests, controller: :validation_requests
+          resources :replacement_document_validation_requests, controller: :validation_requests
+          resources :other_change_validation_requests, controller: :validation_requests
+          resources :fee_change_validation_requests, controller: :validation_requests
+          resources :red_line_boundary_change_validation_requests, controller: :validation_requests
+          resources :description_change_validation_requests, controller: :validation_requests
+          resources :ownership_certificate_validation_requests, controller: :validation_requests
+
+          resource :legislation, only: %i[show update]
+        end
+
+        namespace :review do
+          resource :assessment_details, only: %i[show edit update]
+
+          resource :conditions, only: %i[show update]
+
+          resources :documents, only: %i[index] do
+            patch :update, on: :collection
+          end
+
+          resources :immunity_details, only: %i[edit update show]
+
+          resources :immunity_enforcements, only: %i[show edit update]
+
+          resources :local_policies, only: %i[edit update show]
+
+          resources :permitted_development_rights, only: %i[show edit update]
+
+          resources :policy_classes, only: %i[edit update show]
+
+          resources :tasks, only: :index
+        end
       end
     end
+
+    namespace :public, path: "/" do
+      scope "/planning_guides" do
+        get "/", to: "planning_guides#index", as: :planning_guides
+        get "/*path", to: "planning_guides#show", as: nil
+      end
+    end
+
+    namespace :public do
+      resources :planning_applications, only: [] do
+        member do
+          get "decision_notice"
+        end
+      end
+    end
+
+    namespace :api do
+      namespace :v1 do
+        resources :planning_applications, only: %i[index create show] do
+          member do
+            get :decision_notice
+          end
+          resources :validation_requests, only: :index
+          resources :description_change_validation_requests, only: %i[index update show]
+          resources :replacement_document_validation_requests, only: %i[index update show]
+          resources :additional_document_validation_requests, only: %i[index update show]
+          resources :documents, only: %i[show]
+          resources :other_change_validation_requests, only: %i[index update show]
+          resources :fee_change_validation_requests, only: %i[index update show]
+          resources :ownership_certificate_validation_requests, only: %i[index update show]
+          resources :ownership_certificates, only: %i[create]
+          resources :red_line_boundary_change_validation_requests, only: %i[index update show]
+          resources :pre_commencement_condition_validation_requests, only: %i[index update show]
+          resources :neighbour_responses, only: :create
+        end
+
+        resources :local_authorities, only: %i[show], param: :subdomain
+
+        resources :documents, only: :show do
+          get :tags, on: :collection
+        end
+      end
+    end
+
+    get :healthcheck, to: proc { [200, {}, %w[OK]] }
   end
 
-  get :healthcheck, to: proc { [200, {}, %w[OK]] }
+  constraints Constraints::ConfigSubdomain do
+    mount BopsConfig::Engine => "/"
+  end
 end

--- a/engines/bops_config/app/assets/config/manifest.js
+++ b/engines/bops_config/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_tree ../builds
+//= link_tree ../images

--- a/engines/bops_config/app/controllers/bops_config/application_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class ApplicationController < ActionController::Base
+    default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
+    before_action :authenticate_user!
+    before_action :require_global_administrator!
+    before_action :set_back_path
+
+    layout "application"
+
+    private
+
+    def require_global_administrator!
+      unless current_user&.global_administrator?
+        redirect_to root_url
+      end
+    end
+
+    def set_back_path
+      session[:back_path] = request.referer if request.get?
+      @back_path = session[:back_path]
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/dashboards_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/dashboards_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class DashboardsController < ApplicationController
+    def show
+      respond_to do |format|
+        format.html
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/users_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/users_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class UsersController < ApplicationController
+    before_action :set_users, only: %i[index]
+    before_action :build_user, only: %i[new create]
+    before_action :set_user, only: %i[edit update resend_invite]
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      respond_to do |format|
+        if @user.save
+          format.html do
+            redirect_to users_path, notice: t(".user_successfully_created")
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @user.update(user_params)
+          format.html do
+            redirect_to users_path, notice: t(".user_successfully_updated")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def resend_invite
+      respond_to do |format|
+        if @user.send_confirmation_instructions
+          format.html do
+            redirect_to users_path, notice: t(".confirmation_resent")
+          end
+        else
+          format.html do
+            redirect_to users_path, alert: t(".confirmation_failed_to_resend")
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_users
+      @users = user_scope.by_name
+    end
+
+    def build_user
+      @user = User.new(user_params)
+    end
+
+    def set_user
+      @user = user_scope.find(params[:id])
+    end
+
+    def user_scope
+      User.global_administrator
+    end
+
+    def user_params
+      if action_name == "new"
+        {}
+      else
+        params.require(:user).permit(*user_attributes).merge(role: "global_administrator")
+      end
+    end
+
+    def user_attributes
+      %i[name email otp_delivery_method password mobile_number role]
+    end
+  end
+end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module ApplicationHelper
+    include BreadcrumbNavigationHelper
+
+    attr_reader :back_path
+
+    def back_link(classname: "govuk-button govuk-button--secondary")
+      link_to(t("back"), back_path, class: classname)
+    end
+
+    def home_path
+      main_app.root_path
+    end
+
+    def otp_delivery_method_options
+      User.otp_delivery_methods.keys.map { |key| [key, t(".#{key}")] }
+    end
+  end
+end

--- a/engines/bops_config/app/views/bops_config/application/_navigation_items.html.erb
+++ b/engines/bops_config/app/views/bops_config/application/_navigation_items.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-header__navigation-item">
+  <%= link_to(t(".users"), users_path, class: "govuk-header__link") %>
+</div>

--- a/engines/bops_config/app/views/bops_config/dashboards/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/dashboards/show.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= t(".administrator_dashboard") %> - <%= t('page_title') %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      BOPS config
+    </h1>
+    <p class="govuk-body">
+      <strong><%= t(".welcome_message", name: current_user.name) %></strong>
+    </p>
+
+    <p class="govuk-body">Use this global admin portal to manage BOPS config and global admin users.</p>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/users/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: @user do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_fieldset(legend: { text: nil }) do %>
+    <%= form.govuk_text_field :name, class: "govuk-input--width-30" %>
+    <%= form.govuk_text_field :email, class: "govuk-input--width-30" %>
+    <%= form.govuk_text_field :mobile_number, class: "govuk-input--width-30" %>
+    <%= form.govuk_collection_select(
+      :otp_delivery_method,
+      otp_delivery_method_options,
+      :first,
+      :last
+    ) %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= form.govuk_submit(t(".submit")) %>
+    <%= back_link %>
+  </div>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/users/_status_prompt.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/_status_prompt.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-notification-banner">
+  <div class="govuk-notification-banner__header">
+    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+      Important
+    </h2>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <p class="govuk-notification-banner__heading">
+      <%= users.size %> users have not confirmed their email
+    </p>
+    <p>
+      Resend invites to unconfirmed users.
+    </p>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/users/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/_table.html.erb
@@ -1,0 +1,31 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+  <tr class="govuk-table__row">
+    <th scope="col" class="govuk-table__header">User details</th>
+    <th scope="col" class="govuk-table__header">2FA set up</th>
+    <th scope="col" class="govuk-table__header">2FA method</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+
+  <% users.each do |user| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= user.name %><br>
+        <%= user.email %><br>
+        <%= number_to_phone(user.mobile_number, delimiter: " ", pattern: /(\d{5})(\d{3})(\d{3})$/) %><br>
+        <%= link_to("Edit user", edit_user_path(user), class: "govuk-link") %>
+        <% if user.unconfirmed? %>
+          <%= link_to("Resend invite", resend_invite_user_path(user), class: "govuk-link") %>
+        <% end %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= t(".#{user.otp_required_for_login}") %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= t(".#{user.otp_delivery_method}") %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/engines/bops_config/app/views/bops_config/users/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".edit_user") %> - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Users", users_path %>
+
+<% content_for :title, t(".edit_user") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".edit_user") %>
+    </h1>
+
+    <% if @user.unconfirmed? %>
+      <div class="govuk-button-group">
+        <%= link_to("Resend invite", resend_invite_user_path(@user), class: "govuk-button", data: { module: "govuk-button" }) %>
+      </div>
+    <% end %>
+
+    <%= render("form", user: @user) %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/users/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :page_title do %>
+  <%= t(".users") %> - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".users") %>
+
+<% if @users.any?(&:unconfirmed?) %>
+  <%= render("status_prompt", users: @users.select(&:unconfirmed?)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".users") %>
+    </h1>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#confirmed">
+            Confirmed
+          </a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#unconfirmed">
+            Unconfirmed
+          </a>
+        </li>
+      </ul>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="confirmed">
+        <%= render("table", users: @users.select(&:confirmed?)) %>
+      </div>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="unconfirmed">
+        <%= render("table", users: @users.select(&:unconfirmed?)) %>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <%= link_to(t(".add_user"), new_user_path, class: "govuk-button", data: { module: "govuk-button" }) %>
+      <%= back_link %>
+    </div>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/users/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  <%= t(".add_user") %> - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Users", users_path %>
+
+<% content_for :title, t(".add_user") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".add_user") %>
+    </h1>
+
+    <%= render("form", user: @user) %>
+  </div>
+</div>

--- a/engines/bops_config/bin/rails
+++ b/engines/bops_config/bin/rails
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path("..", __dir__)
+ENGINE_PATH = File.expand_path("../lib/bops_admin/engine", __dir__)
+APP_PATH = File.expand_path("../../../config/application", __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../../Gemfile", __dir__)
+require "bundler/setup" if File.exist?(ENV["BUNDLE_GEMFILE"])
+
+require "rails"
+
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "rails/engine/commands"

--- a/engines/bops_config/bops_config.gemspec
+++ b/engines/bops_config/bops_config.gemspec
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Gem::Specification.new do |spec|
+  spec.name = "bops_config"
+  spec.version = "0.1.0"
+  spec.authors = ["Unboxed Consulting Ltd"]
+  spec.email = ["bops@unboxedconsulting.com"]
+  spec.homepage = "https://unboxed.co/"
+  spec.summary = "Provides the global admin and system config functionality for BOPS"
+
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
+    Dir["{app,config,db,lib}/**/*"]
+  end
+
+  spec.add_dependency "rails", ">= 7.1.3", "< 7.2"
+end

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -1,0 +1,34 @@
+---
+en:
+  bops_config:
+    application:
+      navigation_items:
+        users: Users
+    dashboards:
+      show:
+        administrator_dashboard: Administrator dashboard
+        welcome_message: Welcome %{name}
+    users:
+      create:
+        user_successfully_created: User successfully created
+      edit:
+        edit_user: Edit user
+      form:
+        email: Email
+        sms: SMS
+        submit: Submit
+      index:
+        add_user: Add user
+        users: Manage global admin users
+      new:
+        add_user: Add a new user
+      resend_invite:
+        confirmation_failed_to_resend: Unable to send a reminder email - please contact support
+        confirmation_resent: User will receive a reminder email
+      table:
+        email: Email
+        'false': 'No'
+        sms: SMS
+        'true': 'Yes'
+      update:
+        user_successfully_updated: User successfully updated

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "sidekiq/web"
+
+BopsConfig::Engine.routes.draw do
+  root to: redirect("dashboard")
+
+  authenticate :user, ->(u) { u.global_administrator? } do
+    mount Sidekiq::Web, at: "/sidekiq"
+  end
+
+  resource :dashboard, only: %i[show]
+
+  resources :users, except: %i[show destroy] do
+    get :resend_invite, on: :member
+  end
+end

--- a/engines/bops_config/lib/bops_config.rb
+++ b/engines/bops_config/lib/bops_config.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "bops_config/engine"
+
+module BopsConfig
+  class << self
+    def table_name_prefix
+      ""
+    end
+
+    def env
+      ActiveSupport::StringInquirer.new(ENV.fetch("BOPS_ENVIRONMENT", "development"))
+    end
+  end
+end

--- a/engines/bops_config/lib/bops_config/engine.rb
+++ b/engines/bops_config/lib/bops_config/engine.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class Engine < ::Rails::Engine
+    isolate_namespace BopsConfig
+  end
+end

--- a/engines/bops_config/spec/system/dashboard_spec.rb
+++ b/engines/bops_config/spec/system/dashboard_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Dashboard", type: :system, bops_config: true do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  before do
+    visit "/"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+  end
+
+  context "when the user is an assessor" do
+    let(:user) { create(:user, :assessor, local_authority:) }
+
+    it "doesn't allow access to the dashboard" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is a reviewer" do
+    let(:user) { create(:user, :reviewer, local_authority:) }
+
+    it "doesn't allow access to the dashboard" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is an administrator for a local authority" do
+    let(:user) { create(:user, :administrator, local_authority:) }
+
+    it "doesn't allow access to the dashboard" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is a global administrator" do
+    let(:user) { create(:user, :global_administrator, otp_required_for_login: false, local_authority: nil, name: "Gordon Global Administrator") }
+
+    it "shows the dashboard" do
+      expect(page).to have_current_path("/dashboard")
+      expect(page).to have_content("Welcome Gordon Global Administrator")
+      expect(page).to have_link("Users", href: "/users")
+    end
+  end
+end

--- a/engines/bops_config/spec/system/users_spec.rb
+++ b/engines/bops_config/spec/system/users_spec.rb
@@ -1,0 +1,230 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users", type: :system, bops_config: true do
+  let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
+  let(:last_email) { ActionMailer::Base.deliveries.last }
+  let(:secure_password) { PasswordGenerator.call }
+  let(:last_user) { User.last }
+  let(:last_user_reset_token) { last_user.send_reset_password_instructions }
+
+  before do
+    sign_in(user)
+    visit "/"
+  end
+
+  it "does not allow a user to update own role" do
+    click_link "Users"
+
+    within("#confirmed tbody tr:nth-child(1)") do
+      expect(page).to have_content("Clark Kent")
+      click_link("Edit user")
+    end
+
+    expect(page).to have_no_field("Role")
+  end
+
+  it "allows adding a new user" do
+    click_link "Users"
+    expect(page).to have_selector("h1", text: "Manage global admin users")
+
+    click_link("Add user")
+    expect(page).to have_selector("h1", text: "Add a new user")
+
+    click_button("Submit")
+    expect(page).to have_content("Email can't be blank")
+
+    fill_in("Email", with: "alice")
+    fill_in("Mobile number", with: "not a number")
+
+    click_button("Submit")
+    expect(page).to have_content("Email is invalid")
+    expect(page).to have_content("Mobile number is invalid")
+
+    fill_in("Name", with: "Alice Smith")
+    fill_in("Email", with: "alice@example.com")
+    fill_in("Mobile number", with: "01234123123")
+    select("Email", from: "Verification code delivery method")
+
+    click_button("Submit")
+    expect(page).to have_content("User successfully created")
+
+    within("#unconfirmed tbody tr:nth-child(1)") do
+      expect(page).to have_content("Alice Smith")
+      expect(page).to have_content("alice@example.com")
+      expect(page).to have_content("01234 123 123")
+      expect(page).to have_content("Email")
+    end
+
+    click_link("Log out")
+    expect(page).to have_current_path("/users/sign_in")
+
+    visit "/users/password/edit?reset_password_token=#{last_user_reset_token}"
+    expect(page).to have_selector("h1", text: "Create your password")
+
+    fill_in("New password", with: secure_password)
+    fill_in("Confirm new password", with: secure_password)
+
+    click_button("Change password")
+    expect(page).to have_current_path("/users/sign_in")
+    expect(page).to have_content("Your password has been changed successfully")
+
+    fill_in("Email", with: "alice@example.com")
+    fill_in("Password", with: secure_password)
+
+    click_button("Log in")
+    expect(page).to have_content("Enter the code you have received by email")
+
+    fill_in("Security code", with: last_user.current_otp)
+
+    click_button("Enter code")
+    expect(page).to have_current_path("/dashboard")
+    expect(page).to have_content("Signed in successfully")
+  end
+
+  it "allows adding a new user without a mobile number" do
+    click_link "Users"
+    click_link "Add user"
+    expect(page).to have_selector("h1", text: "Add a new user")
+
+    fill_in("Name", with: "Alice Smith")
+    fill_in("Email", with: "alice@example.com")
+
+    click_button("Submit")
+    expect(page).to have_content("User successfully created")
+
+    click_link("Log out")
+    expect(page).to have_current_path("/users/sign_in")
+
+    visit "/users/password/edit?reset_password_token=#{last_user_reset_token}"
+    expect(page).to have_selector("h1", text: "Create your password")
+
+    fill_in("New password", with: secure_password)
+    fill_in("Confirm new password", with: secure_password)
+
+    click_button("Change password")
+    expect(page).to have_current_path("/users/sign_in")
+    expect(page).to have_content("Your password has been changed successfully")
+
+    fill_in("Email", with: "alice@example.com")
+    fill_in("Password", with: secure_password)
+
+    click_button("Log in")
+    expect(page).to have_selector("h1", text: "Enter your phone number")
+
+    fill_in("Mobile number", with: "01234123123")
+
+    click_button("Send code")
+    expect(page).to have_selector("h1", text: "Enter the code you have received by text message")
+
+    fill_in("Security code", with: last_user.current_otp)
+
+    click_button("Enter code")
+    expect(page).to have_current_path("/dashboard")
+    expect(page).to have_content("Signed in successfully")
+  end
+
+  it "allows editing of an existing user" do
+    create(:user, :global_administrator, name: "Wonder Woman", otp_delivery_method: :email, local_authority: nil)
+
+    visit "/"
+    click_link "Users"
+    expect(page).to have_selector("h1", text: "Manage global admin users")
+
+    within("#confirmed tbody tr:nth-child(2)") do
+      expect(page).to have_content("Wonder Woman")
+      click_link("Edit user")
+    end
+
+    expect(page).to have_selector("h1", text: "Edit user")
+
+    fill_in("Email", with: "")
+
+    click_button("Submit")
+    expect(page).to have_content("Email can't be blank")
+
+    fill_in("Email", with: "bella")
+    fill_in("Mobile number", with: "not a number")
+
+    click_button("Submit")
+    expect(page).to have_content("Email is invalid")
+    expect(page).to have_content("Mobile number is invalid")
+
+    fill_in("Name", with: "Belle Jones")
+    fill_in("Email", with: "belle@example.com")
+    fill_in("Mobile number", with: "01234456456")
+    select("SMS", from: "Verification code delivery method")
+
+    click_button("Submit")
+    expect(page).to have_content("User successfully updated")
+
+    within("#confirmed tbody tr:nth-child(1)") do
+      expect(page).to have_content("Belle Jones")
+      expect(page).to have_content("belle@example.com")
+      expect(page).to have_content("01234 456 456")
+      expect(page).to have_content("SMS")
+    end
+  end
+
+  context "when users are unconfirmed" do
+    before do
+      2.times do
+        create(:user, :global_administrator, :unconfirmed, local_authority: nil)
+      end
+    end
+
+    it "shows a warning" do
+      visit "/users"
+
+      expect(page).to have_content("2 users have not confirmed their email")
+      expect(page).to have_content("Resend invites to unconfirmed users.")
+    end
+  end
+
+  context "when there are a mix of confirmed and unconfirmed users" do
+    before do
+      create(:user, :global_administrator, local_authority: nil, name: "Dieter Waldbeck")
+      create(:user, :global_administrator, :unconfirmed, local_authority: nil, name: "Andrea Khan")
+      create(:user, :global_administrator, :unconfirmed, local_authority: nil, name: "Rosie Starr")
+    end
+
+    it "breaks them into two lists" do
+      visit "/users"
+
+      expect(page).to have_selector("h1", text: "Manage global admin users")
+      expect(page).to have_selector("li.govuk-tabs__list-item--selected", text: "Confirmed")
+      expect(page).to have_link("Confirmed", href: "#confirmed")
+      expect(page).to have_link("Unconfirmed", href: "#unconfirmed")
+
+      within("#confirmed table.govuk-table") do
+        expect(page).to have_selector("tr:nth-child(2)", text: "Dieter Waldbeck")
+      end
+
+      click_link("Unconfirmed")
+      expect(page).to have_selector("li.govuk-tabs__list-item--selected", text: "Unconfirmed")
+
+      within("#unconfirmed table.govuk-table") do
+        expect(page).to have_selector("tr:nth-child(1)", text: "Andrea Khan")
+        expect(page).to have_selector("tr:nth-child(2)", text: "Rosie Starr")
+      end
+    end
+
+    it "allows resending an invite from the index page" do
+      visit "/users"
+      expect(page).to have_selector("li.govuk-tabs__list-item--selected", text: "Confirmed")
+
+      click_link("Unconfirmed")
+      expect(page).to have_selector("li.govuk-tabs__list-item--selected", text: "Unconfirmed")
+
+      within("#unconfirmed tbody tr:nth-child(2)") do
+        expect(page).to have_content("Rosie Starr")
+        click_link("Resend invite")
+      end
+
+      expect(page).to have_content("User will receive a reminder email")
+      expect(last_email.subject).to eq("Set password instructions")
+      expect(last_email.body).to include("http://config.bops.services/users/password/edit?reset_password_token=")
+    end
+  end
+end

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -9,18 +9,14 @@ Given("I am logged out") do
 end
 
 Given("I am logged in as a(n) {}") do |role|
-  step("I am logged out")
-
   southwark = LocalAuthority.find_by(subdomain: "southwark")
   @officer = FactoryBot.create(:user, role.to_sym, local_authority: southwark, mobile_number: "07788446542")
   @api_user = FactoryBot.create(:api_user, name: "PlanX")
 
   domain = @officer.local_authority.subdomain
-
-  visit "/"
-
   Capybara.app_host = "http://#{domain}.#{domain}.localhost:#{Capybara.server_port}"
 
+  step("I am logged out")
   visit "/users/sign_in"
 
   fill_in "Email", with: @officer.email

--- a/lib/constraints/subdomain.rb
+++ b/lib/constraints/subdomain.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Constraints
+  class LocalAuthoritySubdomain
+    class << self
+      def matches?(request)
+        LocalAuthority.pluck(:subdomain).include?(request.subdomain)
+      end
+    end
+  end
+
+  class ConfigSubdomain
+    class << self
+      def matches?(request)
+        request.subdomain == "config"
+      end
+    end
+  end
+
+  class DeviseSubdomain
+    class << self
+      def matches?(request)
+        Constraints::ConfigSubdomain.matches?(request) || Constraints::LocalAuthoritySubdomain.matches?(request)
+      end
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
     role { :administrator }
   end
 
+  trait :global_administrator do
+    role { :global_administrator }
+  end
+
   trait :unconfirmed do
     confirmed_at { nil }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,16 +8,6 @@ RSpec.describe User do
     let(:attribute) { :mobile_number }
   end
 
-  describe "validations" do
-    subject(:user) { described_class.new }
-
-    describe "#local_authority" do
-      it "validates presence" do
-        expect { user.valid? }.to change { user.errors[:local_authority] }.to ["must exist"]
-      end
-    end
-  end
-
   describe "scopes" do
     before do
       create(:user, :administrator)
@@ -107,11 +97,6 @@ RSpec.describe User do
   it "is not created without an email" do
     email = build(:user, email: nil)
     expect(email).not_to be_valid
-  end
-
-  it "is not created without a local authority" do
-    user_without_local_authority = build(:user, local_authority: nil)
-    expect(user_without_local_authority).not_to be_valid
   end
 
   it "does not allow for duplicate users within the same domain" do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -35,8 +35,13 @@ RSpec.configure do |config|
     Capybara.server = :puma, {Silent: true}
   end
 
-  config.before type: :system do
+  config.before type: :system do |example|
     driven_by(ENV.fetch("JS_DRIVER", "chrome_headless").to_sym)
-    Capybara.app_host = "http://planx.example.com"
+
+    Capybara.app_host = if example.metadata[:bops_config]
+      "http://config.bops.services"
+    else
+      "http://planx.example.com"
+    end
   end
 end

--- a/spec/system/api_index_spec.rb
+++ b/spec/system/api_index_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe "Swagger index file" do
+  let!(:local_authority) { create(:local_authority, :default) }
+
   before do
     visit "/api/docs/index.html"
   end

--- a/spec/system/local_authorities_spec.rb
+++ b/spec/system/local_authorities_spec.rb
@@ -35,8 +35,10 @@ RSpec.describe "Accessing correct local authority" do
     end
 
     it "visit non existing path" do
-      visit "/"
-      expect(page).to have_content("No Local Authority Found")
+      expect do
+        visit "/"
+        expect(page).to have_selector("h1", text: "Does not exist")
+      end.to raise_error(ActionController::RoutingError)
     end
   end
 end


### PR DESCRIPTION
### Description of change

- Add BopsConfig engine
- Scope this engine to when "config" is in the subdomain
- Wrap main application routes with local authority subdomain constraint
- Allow both LA and config subdomain to access shared devise resources
- Global admin users do not have an associated local authority
- Reuse admin user management for managing global admin users

### Story Link

https://trello.com/c/5RJfvTzj/2446-create-global-admin-infrastructure