### PR TITLE
Only send one email for a batch of pre-commencement condition validation requests

### DIFF
--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -27,6 +27,11 @@ class ConditionSet < ApplicationRecord
     latest_validation_requests.select { |vr| vr.state != "cancelled" }
   end
 
+  def send_notification?
+    validation_requests.open.none? { |request| request.notified_at.present? } ||
+      (validation_requests.open.any? && (validation_requests.open.order(:created_at).last&.notified_at&.<= 1.business_day.ago))
+  end
+
   private
 
   def should_create_review?

--- a/app/models/pre_commencement_condition_validation_request.rb
+++ b/app/models/pre_commencement_condition_validation_request.rb
@@ -16,6 +16,12 @@ class PreCommencementConditionValidationRequest < ValidationRequest
     10.business_days.after(created_at)
   end
 
+  def email_and_timestamp
+    send_post_validation_request_email if owner.condition_set.send_notification?
+
+    mark_as_sent!
+  end
+
   private
 
   def audit_comment

--- a/spec/models/pre_commencement_condition_validation_request_spec.rb
+++ b/spec/models/pre_commencement_condition_validation_request_spec.rb
@@ -25,4 +25,54 @@ RSpec.describe PreCommencementConditionValidationRequest do
       end
     end
   end
+
+  describe "callbacks" do
+    describe "::after_create #email_and_timestamp" do
+      let(:condition_set) { build(:condition_set) }
+
+      context "when first sending requests" do
+        let(:condition) { build(:condition, condition_set:) }
+        let(:condition2) { build(:condition, condition_set:) }
+        let(:request) { build(:pre_commencement_condition_validation_request, state: "pending", owner: condition) }
+        let(:request2) { build(:pre_commencement_condition_validation_request, state: "pending", owner: condition2) }
+
+        it "only sends one email for multiple requests" do
+          # First time it sends mail
+          expect { request.save }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+          # Second time, it does not
+          expect { request2.save }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
+
+      context "when sending requests again" do
+        let(:condition) { build(:condition, condition_set:) }
+        let(:condition2) { build(:condition, condition_set:) }
+        let(:request) { build(:pre_commencement_condition_validation_request, state: "closed", owner: condition) }
+        let(:request2) { build(:pre_commencement_condition_validation_request, state: "pending", owner: condition2) }
+
+        it "sends a new email if the requests are closed" do
+          expect { request2.save }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        end
+      end
+
+      context "when sending requests a few days later" do
+        let(:condition) { build(:condition, condition_set:) }
+        let(:condition2) { build(:condition, condition_set:) }
+        let(:request) { build(:pre_commencement_condition_validation_request, state: "closed", owner: condition) }
+        let(:request2) { build(:pre_commencement_condition_validation_request, state: "closed", owner: condition2) }
+
+        let(:request3) { build(:pre_commencement_condition_validation_request, state: "pending", owner: condition) }
+        let(:request4) { build(:pre_commencement_condition_validation_request, state: "pending", owner: condition2) }
+
+        it "sends a new email for the first batch" do
+          #  First time it sends an email
+          expect { request3.save }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+          # Second time it does not
+          expect { request4.save }.to change { ActionMailer::Base.deliveries.count }.by(0)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/validation_request_spec.rb
+++ b/spec/models/validation_request_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ValidationRequest do
     end
 
     %w[additional_document other_change red_line_boundary_change fee_change ownership_certificate
-      replacement_document pre_commencement_condition].each do |request_type|
+      replacement_document].each do |request_type|
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "pending", %i[open cancelled]
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "open", %i[cancelled closed]
       it_behaves_like "ValidationRequestStateMachineTransitions", request_type, "cancelled", %i[]


### PR DESCRIPTION
### Description of change

Only send one email for a batch of pre-commencement condition validation requests, instead of one email for each
