### PR TITLE
Allow selecting consultee and associating with constraint

### DIFF
--- a/app/components/task_list_items/select_consultees_component.rb
+++ b/app/components/task_list_items/select_consultees_component.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  class SelectConsulteesComponent < TaskListItems::BaseComponent
+    def initialize(planning_application:)
+      @planning_application = planning_application
+    end
+
+    private
+
+    attr_reader :planning_application
+
+    delegate :consultation, to: :planning_application
+    delegate :consultee_emails_status, to: :consultation
+
+    def link_text
+      t(".select_consultees")
+    end
+
+    def link_path
+      planning_application_consultees_path(planning_application)
+    end
+
+    def status_tag_component
+      StatusTags::BaseComponent.new(status: consultee_emails_status)
+    end
+  end
+end

--- a/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
+++ b/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Consultee
+    class AssignConstraintsController < AuthenticationController
+      before_action :set_planning_application
+      before_action :set_consultation
+
+      def create
+        respond_to do |format|
+          if planning_application_constraint.update(consultee_id: consultee_id)
+            format.html do
+              redirect_to planning_application_consultees_url(@planning_application)
+            end
+          else
+            format.html { render :index }
+          end
+        end
+      end
+
+      private
+
+      def planning_application_constraint
+        PlanningApplicationConstraint.find(constraint_id)
+      end
+
+      def constraint_id
+        Integer(permitted_params[:constraint])
+      end
+
+      def consultee_id
+        Integer(permitted_params[:consultee])
+      end
+
+      def permitted_params
+        params.require(:constraint).permit([:constraint, :consultee])
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/consultees_controller.rb
+++ b/app/controllers/planning_applications/consultees_controller.rb
@@ -24,6 +24,10 @@ module PlanningApplications
     def index
     end
 
+    def new
+      @constraint = Constraint.find(Integer(params[:constraint]))
+    end
+
     private
 
     def set_consultees
@@ -43,7 +47,7 @@ module PlanningApplications
     end
 
     def consultee_attributes
-      %i[origin name email_address role organisation]
+      %i[origin name email_address role organisation constraint]
     end
   end
 end

--- a/app/controllers/planning_applications/consultees_controller.rb
+++ b/app/controllers/planning_applications/consultees_controller.rb
@@ -21,6 +21,9 @@ module PlanningApplications
       end
     end
 
+    def index
+    end
+
     private
 
     def set_consultees

--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -5,6 +5,7 @@ class Consultee < ApplicationRecord
 
   belongs_to :consultation
   has_many :emails, dependent: :destroy
+  has_many :planning_application_constraints, dependent: :destroy
   has_many :responses, dependent: :destroy
 
   validates :name, presence: true

--- a/app/models/consultee.rb
+++ b/app/models/consultee.rb
@@ -29,6 +29,8 @@ class Consultee < ApplicationRecord
     end
   end
 
+  scope :unassigned, -> { where.not(id: PlanningApplicationConstraint.pluck(:consultee_id)) } # rubocop:disable Rails/PluckInWhere
+
   def suffix?
     role? || organisation?
   end

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -6,6 +6,7 @@ class PlanningApplicationConstraint < ApplicationRecord
   belongs_to :planning_application
   belongs_to :planning_application_constraints_query, optional: true
   belongs_to :constraint
+  belongs_to :consultee, optional: true
 
   after_create :audit_constraint_added!
   after_update :audit_constraint_removed!, if: :identified_and_removed?

--- a/app/views/planning_applications/consultations/show.html.erb
+++ b/app/views/planning_applications/consultations/show.html.erb
@@ -65,15 +65,20 @@
         <h2 class="govuk-heading-m">Consultees</h2>
         <ul class="app-task-list__items" id="consultation-section">
           <%= render(
-            TaskListItems::EmailConsulteesComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
+                TaskListItems::SelectConsulteesComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
           <%= render(
-            TaskListItems::ConsulteeResponsesComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
+                TaskListItems::EmailConsulteesComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
+          <%= render(
+                TaskListItems::ConsulteeResponsesComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
         </ul>
       </li>
       <li id="publicity-tasks">

--- a/app/views/planning_applications/consultees/_table.html.erb
+++ b/app/views/planning_applications/consultees/_table.html.erb
@@ -1,0 +1,19 @@
+<h3 class="govuk-body">Assign consultees based on identified constraints</h3>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Reason/constraint</th>
+      <th class="govuk-table__header">Consultee</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% @consultation.planning_application.constraints.each do |constraint| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= constraint.type_code %></td>
+        <td class="govuk-table__cell">
+          <%= link_to "Assign consultee", "#", class: "govuk-link" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_applications/consultees/_table.html.erb
+++ b/app/views/planning_applications/consultees/_table.html.erb
@@ -7,11 +7,15 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% @consultation.planning_application.constraints.each do |constraint| %>
+    <% @planning_application.planning_application_constraints.each do |constraint| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= constraint.type_code %></td>
         <td class="govuk-table__cell">
-          <%= link_to "Assign consultee", "#", class: "govuk-link" %>
+          <% if constraint.consultee.present? %>
+            <%= constraint.consultee.name %>
+          <% else %>
+          <%= link_to "Assign consultee", new_planning_application_consultee_path(@planning_application, constraint: constraint), class: "govuk-link" %>
+        <% end %>
         </td>
       </tr>
     <% end %>

--- a/app/views/planning_applications/consultees/_table.html.erb
+++ b/app/views/planning_applications/consultees/_table.html.erb
@@ -19,5 +19,13 @@
         </td>
       </tr>
     <% end %>
+    <% @planning_application.consultation.consultees.unassigned.find_each do |consultee| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">Other</td>
+        <td class="govuk-table__cell">
+          <%= consultee.name %>
+        </td>
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/planning_applications/consultees/index.html.erb
+++ b/app/views/planning_applications/consultees/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title do %>
+  Select and add consultees - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultation_path(@planning_application) %>
+<% content_for :title, "Select and add consultees" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Select and add consultees"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <%= content_tag :div, class: "govuk-grid-column-full", data: {} do %>
+    <% if @consultation.errors.any? %>
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% @consultation.errors.each do |error| %>
+              <li><%= error.message.html_safe %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <%= render "table", planning_application: @planning_application, consultation: @consultation %>
+
+    <div class="submit-buttons display-flex">
+      <%= link_to "Back", planning_application_consultation_path(@planning_application), class: "govuk-button govuk-button--secondary back-button" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -1,0 +1,48 @@
+<% content_for :page_title do %>
+  Select and add consultees - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultation_path(@planning_application) %>
+<% content_for :title, "Add consultee for constraint" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Add consultee for constraint"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <%= content_tag :div, class: "govuk-grid-column-full", data: {} do %>
+    <% if @consultation.errors.any? %>
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+        <h2 class="govuk-error-summary__title" id="error-summary-title">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% @consultation.errors.each do |error| %>
+              <li><%= error.message.html_safe %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <%= form_with model: @constraint,
+          url: planning_application_consultees_assign_constraint_path(@planning_application),
+          method: "POST",
+          class: "govuk-!-margin-top-7" do |form| %>
+    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+    <%= form.label "Select consultee for #{@constraint.type_code}", class: "govuk-label" %>
+    <%= form.hidden_field :constraint, value: @constraint.id %>
+    <%= form.govuk_select :consultee, options_for_select(@consultation.consultees.map { |c| [c.name, c.id] }) %>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Assign consultee", class: "govuk-button", data: {module: "govuk-button"} %>
+        <%= link_to "Back", planning_application_consultation_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1928,6 +1928,8 @@ en:
         link_text: Review assessment against policies and guidance
       permitted_development_right_component:
         review_permitted_development_rights: Review permitted development rights
+    select_consultees_component:
+      select_consultees: Select and add consultees
     select_neighbours_component:
       select_neighbours: Select and add neighbours
     send_letters_to_neighbours_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,13 +135,14 @@ Rails.application.routes.draw do
           end
         end
 
-        resources :consultees, only: %i[index create show] do
+        resources :consultees, only: %i[index create show new] do
           resources :responses, controller: "consultee/responses", except: %i[show destroy]
         end
 
         namespace :consultee, as: :consultees do
           resources :emails, only: %i[index create]
           resources :responses, only: %i[index]
+          resource :assign_constraint, only: %i[create]
         end
 
         resource :consultation, only: %i[show edit update] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,7 @@ Rails.application.routes.draw do
           end
         end
 
-        resources :consultees, only: %i[create show] do
+        resources :consultees, only: %i[index create show] do
           resources :responses, controller: "consultee/responses", except: %i[show destroy]
         end
 

--- a/db/migrate/20240305105250_add_consultee_to_planning_application_constraints.rb
+++ b/db/migrate/20240305105250_add_consultee_to_planning_application_constraints.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddConsulteeToPlanningApplicationConstraints < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :planning_application_constraints, :consultee, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -496,7 +496,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_05_154930) do
     t.jsonb "metadata"
     t.boolean "identified", default: false, null: false
     t.string "identified_by", null: false
+    t.bigint "consultee_id"
     t.index ["constraint_id"], name: "ix_planning_application_constraints_on_constraint_id"
+    t.index ["consultee_id"], name: "ix_planning_application_constraints_on_consultee_id"
     t.index ["planning_application_constraints_query_id"], name: "ix_planning_application_constraints_on_planning_application_con"
     t.index ["planning_application_id"], name: "ix_planning_application_constraints_on_planning_application_id"
   end
@@ -840,6 +842,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_05_154930) do
   add_foreign_key "permitted_development_rights", "users", column: "assessor_id"
   add_foreign_key "permitted_development_rights", "users", column: "reviewer_id"
   add_foreign_key "planning_application_constraints", "constraints"
+  add_foreign_key "planning_application_constraints", "consultees"
   add_foreign_key "planning_application_constraints", "planning_application_constraints_queries"
   add_foreign_key "planning_application_constraints", "planning_applications"
   add_foreign_key "planning_application_constraints_queries", "planning_applications"

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"
@@ -233,8 +233,8 @@ RSpec.describe "Consultation", js: true do
       )).to exist
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -137,8 +137,8 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"
@@ -216,8 +216,8 @@ RSpec.describe "Consultation", js: true do
       )).to exist
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 
@@ -295,7 +295,7 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+      expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
     end
 
     click_link "Send emails to consultees"
@@ -185,8 +185,8 @@ RSpec.describe "Consultation", js: true do
       )).to exist
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "In progress")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "In progress")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:twice)
 
@@ -294,7 +294,7 @@ RSpec.describe "Consultation", js: true do
     expect(page).to have_selector("h1", text: "Consultation")
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Failed")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Failed")
     end
 
     click_link "Send emails to consultees"
@@ -345,8 +345,8 @@ RSpec.describe "Consultation", js: true do
       expect(page).to have_selector("[role=alert] h3", text: "Emails have been sent to the selected consultees.")
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 
@@ -468,8 +468,8 @@ RSpec.describe "Consultation", js: true do
       end
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
       end
 
       click_link "Send emails to consultees"
@@ -518,8 +518,8 @@ RSpec.describe "Consultation", js: true do
       end
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
       end
 
       click_link "Send emails to consultees"
@@ -569,8 +569,8 @@ RSpec.describe "Consultation", js: true do
       end
 
       within "#consultee-tasks" do
-        expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
       end
 
       click_link "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       expect(page).to have_selector("li:last-child a", text: "View consultee responses")
       expect(page).to have_selector("li:last-child .govuk-tag", text: "Not started")
     end


### PR DESCRIPTION
### Description of change

This associates a Consultee with a PlanningApplicationConstraint and adds an extra step to the consultee workflow (see [figma](https://www.figma.com/file/AXJ7hvBaXVyJnh74Grwbml/BoPS-Prototype?type=design&node-id=8804-10481&mode=design&t=iaomaW64tY9N2fVY-4)).

### Story Link

https://trello.com/c/twXRQN1M/2194-see-constraints-when-selecting-consultees

### Screenshots

<img width="883" alt="Screenshot 2024-03-06 at 12 21 15" src="https://github.com/unboxed/bops/assets/3986/654017a1-ddd3-4e78-b0d4-1e883a61c1a6">

### Known issues

- The transition to the new workflow is unfinished here. Currently the 'add consultee' form is still on the original page, which is now the second step. However it seemed easiest to break it up here and make the change in two stages.
- There are no designs in Figma for the form for actually selecting a consultee for a constraint, so there might be further refinement needed to that page.