### PR TITLE
Move healthcheck outside domain constraints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# require "rswag-api"
-
 Rails.application.routes.draw do
+  get :healthcheck, to: proc { [200, {}, %w[OK]] }
+
   constraints Constraints::DeviseSubdomain do
     devise_for :users, controllers: {
       sessions: "users/sessions",
@@ -220,7 +220,6 @@ Rails.application.routes.draw do
         end
       end
     end
-
     namespace :public, path: "/" do
       scope "/planning_guides" do
         get "/", to: "planning_guides#index", as: :planning_guides
@@ -263,8 +262,6 @@ Rails.application.routes.draw do
         end
       end
     end
-
-    get :healthcheck, to: proc { [200, {}, %w[OK]] }
   end
 
   constraints Constraints::ConfigSubdomain do

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /healthcheck" do
+  let!(:local_authority) { create(:local_authority, :default) }
+
+  shared_examples "a healthcheck response" do
+    it "returns 200 OK" do
+      get "/healthcheck"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context "when on the config subdomain" do
+    before do
+      host! "config.example.com"
+    end
+
+    it_behaves_like "a healthcheck response"
+  end
+
+  context "when on a local authority subdomain" do
+    before do
+      host! "default.example.com"
+    end
+
+    it_behaves_like "a healthcheck response"
+  end
+
+  context "when on an internal hostname" do
+    before do
+      host! "ip-192-168-0-1.example.internal"
+    end
+
+    it_behaves_like "a healthcheck response"
+  end
+end


### PR DESCRIPTION
The AWS ECS healthcheck uses an internal hostname which fails to route and causes the cycling of tasks due to healthcheck failures.
