### PR TITLE
Add informatives

### DIFF
--- a/app/components/audits/activity_component.rb
+++ b/app/components/audits/activity_component.rb
@@ -10,13 +10,13 @@ module Audits
     attr_reader :audit, :activity_type
 
     def audit_template
-      # if activity_type.match?("/*_validation_request_cancelled")
-      #   "validation_request_cancelled"
-      # elsif activity_type.include?("auto_closed") || activity_type.include?("document_received_at_changed")
-      #   activity_type
-      # else
+      if activity_type.match?("/*_validation_request_cancelled")
+        "validation_request_cancelled"
+      elsif activity_type.include?("auto_closed") || activity_type.include?("document_received_at_changed")
+        activity_type
+      else
         "generic_audit_entry"
-      # end
+      end
     end
   end
 end

--- a/app/components/audits/activity_component.rb
+++ b/app/components/audits/activity_component.rb
@@ -10,13 +10,13 @@ module Audits
     attr_reader :audit, :activity_type
 
     def audit_template
-      if activity_type.match?("/*_validation_request_cancelled")
-        "validation_request_cancelled"
-      elsif activity_type.include?("auto_closed") || activity_type.include?("document_received_at_changed")
-        activity_type
-      else
+      # if activity_type.match?("/*_validation_request_cancelled")
+      #   "validation_request_cancelled"
+      # elsif activity_type.include?("auto_closed") || activity_type.include?("document_received_at_changed")
+      #   activity_type
+      # else
         "generic_audit_entry"
-      end
+      # end
     end
   end
 end

--- a/app/components/task_list_items/assessment/informatives_component.rb
+++ b/app/components/task_list_items/assessment/informatives_component.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  module Assessment
+    class InformativesComponent < TaskListItems::BaseComponent
+      def initialize(planning_application:)
+        @planning_application = planning_application
+      end
+
+      private
+
+      def link_text
+        "Add informatives"
+      end
+
+      def link_path
+        planning_application_assessment_informatives_path(@planning_application)
+      end
+
+      def status_tag_component
+        StatusTags::BaseComponent.new(status:)
+      end
+
+      def status
+        :not_started
+      end
+    end
+  end
+end

--- a/app/components/task_list_items/assessment/informatives_component.rb
+++ b/app/components/task_list_items/assessment/informatives_component.rb
@@ -22,7 +22,11 @@ module TaskListItems
       end
 
       def status
-        :not_started
+        if @planning_application.informative_set.current_review
+          @planning_application.informative_set.current_review.status.to_sym
+        else
+          :not_started
+        end
       end
     end
   end

--- a/app/controllers/planning_applications/assessment/informatives_controller.rb
+++ b/app/controllers/planning_applications/assessment/informatives_controller.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Assessment
+    class InformativesController < AuthenticationController
+      include CommitMatchable
+
+      before_action :set_planning_application
+      before_action :set_informatives, only: %i[index]
+      before_action :set_informative
+
+      def index
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def destroy
+        respond_to do |format|
+          format.html do
+            if @informative.destroy
+              redirect_to planning_application_assessment_informatives_path(@planning_application),
+                notice: I18n.t("informatives.destroy.success")
+            else
+              render :index
+            end
+          end
+        end
+      end
+
+      def update
+        respond_to do |format|
+          format.html do
+            if @informative.update(informatives_params)
+              redirect_to planning_application_assessment_informatives_path(@planning_application),
+                notice: I18n.t("informatives.update.success")
+            else
+              if request.referrer.include? "edit"
+                render :edit
+              else
+                set_informatives
+                render :index
+              end
+            end
+          end
+        end
+      end
+
+      private
+
+      def set_informatives
+        @informatives = @planning_application.informatives.select(&:persisted?)
+      end
+
+      def set_informative
+        if params[:informative_id]
+          @informative = @planning_application.informatives.find(params[:informative_id])
+        elsif params[:id].to_i > 0
+          @informative = @planning_application.informatives.find(params[:id])
+        else
+          @informative = @planning_application.informatives.new
+        end
+      end
+
+      def informatives_params
+        params.require(:informative)
+          .permit(
+            :id, :title, :text
+          )
+          # .to_h.merge(reviews_attributes: [status:, id: (@condition_set&.current_review&.id if !mark_as_complete?)])
+      end
+
+      def status
+        if mark_as_complete?
+          if @condition_set.current_review.present? && @condition_set.current_review.status == "to_be_reviewed"
+            "updated"
+          else
+            "complete"
+          end
+        else
+          "in_progress"
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/assessment/informatives_controller.rb
+++ b/app/controllers/planning_applications/assessment/informatives_controller.rb
@@ -3,10 +3,8 @@
 module PlanningApplications
   module Assessment
     class InformativesController < AuthenticationController
-      include CommitMatchable
-
       before_action :set_planning_application
-      before_action :set_informatives, only: %i[index]
+      before_action :set_informative_set
       before_action :set_informative
 
       def index
@@ -37,48 +35,62 @@ module PlanningApplications
       def update
         respond_to do |format|
           format.html do
-            if @informative.update(informatives_params)
+            if @informative.update(informatives_params) && @informative_set.update(informative_set_params)
               redirect_to planning_application_assessment_informatives_path(@planning_application),
                 notice: I18n.t("informatives.update.success")
+            elsif request.referrer.include? "edit"
+              render :edit
             else
-              if request.referrer.include? "edit"
-                render :edit
-              else
-                set_informatives
-                render :index
-              end
+              render :index
             end
           end
         end
       end
 
+      def complete
+        review = @informative_set.current_review || @informative_set.reviews.create!(assessor: Current.user)
+
+        if review.update(status:)
+          redirect_to planning_application_assessment_tasks_path(@planning_application)
+        else
+          render :index
+        end
+      end
+
       private
 
-      def set_informatives
-        @informatives = @planning_application.informatives.select(&:persisted?)
+      def set_informative_set
+        @informative_set = @planning_application.informative_set
       end
 
       def set_informative
-        if params[:informative_id]
-          @informative = @planning_application.informatives.find(params[:informative_id])
+        @informative = if params[:informative_id]
+          @informative_set.informatives.find(params[:informative_id])
         elsif params[:id].to_i > 0
-          @informative = @planning_application.informatives.find(params[:id])
+          @informative_set.informatives.find(params[:id])
         else
-          @informative = @planning_application.informatives.new
+          @informative_set.informatives.new
         end
       end
 
       def informatives_params
         params.require(:informative)
           .permit(
-            :id, :title, :text
+            :id, :title, :text, :informative_set_id
           )
-          # .to_h.merge(reviews_attributes: [status:, id: (@condition_set&.current_review&.id if !mark_as_complete?)])
+      end
+
+      def informative_set_params
+        {reviews_attributes: [status:, id: (@informative_set&.current_review&.id if !mark_as_complete?)]}
+      end
+
+      def mark_as_complete?
+        params[:action] == "complete"
       end
 
       def status
         if mark_as_complete?
-          if @condition_set.current_review.present? && @condition_set.current_review.status == "to_be_reviewed"
+          if @informative_set.current_review.present? && @informative_set.current_review.status == "to_be_reviewed"
             "updated"
           else
             "complete"

--- a/app/models/informative.rb
+++ b/app/models/informative.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Informative < ApplicationRecord
+  belongs_to :planning_application
+
+  validates :title, :text, presence: true
+end

--- a/app/models/informative.rb
+++ b/app/models/informative.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Informative < ApplicationRecord
-  belongs_to :planning_application
+  belongs_to :informative_set
 
   validates :title, :text, presence: true
 end

--- a/app/models/informative_set.rb
+++ b/app/models/informative_set.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class InformativeSet < ApplicationRecord
+  belongs_to :planning_application
+  has_many :reviews, as: :owner, dependent: :destroy, class_name: "Review"
+  has_many :informatives, dependent: :destroy
+
+  accepts_nested_attributes_for :reviews
+
+  after_update :maybe_create_review
+
+  def current_review
+    reviews.order(:created_at).last
+  end
+
+  private
+
+  def maybe_create_review
+    return if current_review.nil?
+    return unless current_review.status == "updated" && current_review.review_status == "to_be_reviewed"
+
+    create_review
+  end
+
+  def create_review
+    Review.create!(assessor: Current.user, owner_type: "InformativeSet", owner_id: id, status: "complete")
+  end
+end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -43,7 +43,6 @@ class PlanningApplication < ApplicationRecord
     has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_many :site_notices
     has_many :policy_classes, -> { order(:section) }
-    has_many :informatives
 
     has_one :condition_set, -> { where(pre_commencement: false) }, required: false
     has_one :pre_commencement_condition_set, -> { where(pre_commencement: true) }, class_name: "ConditionSet", required: false
@@ -57,6 +56,7 @@ class PlanningApplication < ApplicationRecord
     has_one :ownership_certificate, required: false
     has_one :environment_impact_assessment, required: false
     has_one :consistency_checklist
+    has_one :informative_set
   end
 
   delegate :consultation?, to: :application_type
@@ -112,7 +112,6 @@ class PlanningApplication < ApplicationRecord
   accepts_nested_attributes_for :constraints
   accepts_nested_attributes_for :proposal_measurement
   accepts_nested_attributes_for :planx_planning_data
-  accepts_nested_attributes_for :informatives
 
   WORK_STATUSES = %w[proposed existing].freeze
 
@@ -651,6 +650,10 @@ class PlanningApplication < ApplicationRecord
 
   def pre_commencement_condition_set
     super || ConditionSet.create!(planning_application: self, pre_commencement: true)
+  end
+
+  def informative_set
+    super || create_informative_set!
   end
 
   def pending_validation_requests?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -43,6 +43,7 @@ class PlanningApplication < ApplicationRecord
     has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_many :site_notices
     has_many :policy_classes, -> { order(:section) }
+    has_many :informatives
 
     has_one :condition_set, -> { where(pre_commencement: false) }, required: false
     has_one :pre_commencement_condition_set, -> { where(pre_commencement: true) }, class_name: "ConditionSet", required: false
@@ -111,6 +112,7 @@ class PlanningApplication < ApplicationRecord
   accepts_nested_attributes_for :constraints
   accepts_nested_attributes_for :proposal_measurement
   accepts_nested_attributes_for :planx_planning_data
+  accepts_nested_attributes_for :informatives
 
   WORK_STATUSES = %w[proposed existing].freeze
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,7 +4,7 @@ class Review < ApplicationRecord
   class NotCreatableError < StandardError; end
   store_accessor :specific_attributes, %w[decision decision_reason summary decision_type removed review_type]
 
-  belongs_to :owner, polymorphic: true, autosave: true
+  belongs_to :owner, polymorphic: true
 
   has_many :local_policy_areas, through: :owner
 

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -11,7 +11,8 @@ module AssessmentTasksPresenter
       recommendation.present? ||
       immunity_validation_in_progress? ||
       pre_commencement_condition_set.conditions.any? ||
-      condition_set.conditions.any?
+      condition_set.conditions.any? ||
+      informative_set.informatives.any?
   end
 
   def multiple_policy_classes?

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -82,6 +82,19 @@
         <% end %>
       </ul>
     <% end %>
+    <% if @planning_application.informative_set.informatives.any? %>
+      <h3 class="govuk-heading-s">
+        Informatives:
+      </h3>
+      <ol class="govuk-list govuk-list--number">
+        <% @planning_application.informative_set.informatives.each do |informative| %>
+          <li>
+            <%= informative.title %><br>
+            <%= informative.text %>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
     <h3 class="govuk-heading-s">
       This decision is based on the following approved plans:
     </h3>

--- a/app/views/planning_applications/assessment/informatives/_form.html.erb
+++ b/app/views/planning_applications/assessment/informatives/_form.html.erb
@@ -1,0 +1,24 @@
+<%= form_with model: @informative,
+              class: "govuk-!-margin-top-7",
+              url:,
+              method: :patch do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <h2 class="govuk-heading-m">Add informative</h2>
+
+  <%= form.hidden_field :id %>
+  <%= form.govuk_text_field :title, label: { text: "Enter a title" } %>
+  <%= form.govuk_text_area :text, label: { text: "Enter details of the informative" } %>
+
+  <div class="govuk-button-group">
+    <%= form.submit(
+          text,
+          class: "govuk-button govuk-button--secondary",
+          data: { module: "govuk-button" }
+        ) %>
+    <% if text == "Save informative" %>
+      <%= back_link %>
+    <% end %>
+  </div>
+<% end %>
+

--- a/app/views/planning_applications/assessment/informatives/_form.html.erb
+++ b/app/views/planning_applications/assessment/informatives/_form.html.erb
@@ -7,6 +7,7 @@
   <h2 class="govuk-heading-m">Add informative</h2>
 
   <%= form.hidden_field :id %>
+  <%= form.hidden_field :informative_set_id, value: @informative_set.id %>
   <%= form.govuk_text_field :title, label: { text: "Enter a title" } %>
   <%= form.govuk_text_area :text, label: { text: "Enter details of the informative" } %>
 

--- a/app/views/planning_applications/assessment/informatives/edit.html.erb
+++ b/app/views/planning_applications/assessment/informatives/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title do %>
+  Edit informative - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Edit informative" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Edit informative" }
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", url: planning_application_assessment_informative_path(@planning_application, @informative), text: "Save informative" %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/informatives/index.html.erb
+++ b/app/views/planning_applications/assessment/informatives/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title do %>
+  Add informatives - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/assessment_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Add informatives" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Add informatives" }
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Title</th>
+          <th scope="col" class="govuk-table__header">Detail</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Action</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% if @informatives.any? %>
+          <% @informatives.each do |informative| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= informative.title %></td>
+              <td class="govuk-table__cell"><%= informative.text %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric">
+                <%= link_to "Edit", edit_planning_application_assessment_informative_path(@planning_application, informative), class: "govuk-link" %>
+                <%= link_to "Remove", planning_application_assessment_informative_path(@planning_application, informative), method: :delete, class: "govuk-link" %>
+              </td>
+            </tr>
+          <% end %>
+        <% else %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"><strong>No informatives added yet</strong></td>
+            <td class="govuk-table__cell">&nbsp</td>
+            <td class="govuk-table__cell">&nbsp</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", url: new_planning_application_assessment_informative_path(@planning_application), text: "Add informative" %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/informatives/index.html.erb
+++ b/app/views/planning_applications/assessment/informatives/index.html.erb
@@ -25,8 +25,8 @@
         </tr>
       </thead>
       <tbody class="govuk-table__body">
-        <% if @informatives.any? %>
-          <% @informatives.each do |informative| %>
+        <% if @informative_set.informatives.select(&:persisted?).any? %>
+          <% @informative_set.informatives.select(&:persisted?).each do |informative| %>
             <tr class="govuk-table__row">
               <td class="govuk-table__cell"><%= informative.title %></td>
               <td class="govuk-table__cell"><%= informative.text %></td>
@@ -48,6 +48,15 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-    <%= render "form", url: new_planning_application_assessment_informative_path(@planning_application), text: "Add informative" %>
+    <% unless @informative_set.current_review&.complete? %>
+      <%= render "form", url: new_planning_application_assessment_informative_path(@planning_application), text: "Add informative" %>
+    <% end %>
+
+    <div class="govuk-button-group">
+      <% unless @informative_set.current_review&.complete? %>
+        <%= link_to "Save and mark as complete", complete_planning_application_assessment_informatives_path(@planning_application), class: "govuk-button", method: :post %>
+      <% end %>
+      <%= back_link %>
+    </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -34,6 +34,11 @@
           condition_set: @planning_application.pre_commencement_condition_set
         )
       ) %>
+      <%= render(
+        TaskListItems::Assessment::InformativesComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
     <% end %>
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,6 +183,12 @@ en:
               blank: You have entered a fee but not provided an address. Enter an address where the fee can be paid.
             fee:
               blank: Fee can't be blank if the address has been entered. Enter a fee or enter '0' if there is no fee.
+        informative:
+          attributes:
+            text:
+              blank: Fill in the text of the informative
+            title:
+              blank: Fill in the title of the informative
         local_policy_area:
           attributes:
             assessment:
@@ -693,6 +699,11 @@ en:
       review_immunity_detail:
         accepted: Is the application immune from enforcement?
         removed: Is the application immune from enforcement?
+  informatives:
+    destroy:
+      success: Informative was successfully removed
+    update:
+      success: Informative successfully added
   local_policies:
     successfully_created: Check against policy and guidance response was sucessfully created
     successfully_updated: Check against policy and guidance response was successfully updated

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,8 @@ Rails.application.routes.draw do
           end
           resources :recommendations, only: %i[new create update]
           resource :recommendations, only: %i[edit]
+
+          resources :informatives, except: %i[show]
         end
 
         resources :consultees, only: %i[create show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,9 @@ Rails.application.routes.draw do
           resources :recommendations, only: %i[new create update]
           resource :recommendations, only: %i[edit]
 
-          resources :informatives, except: %i[show]
+          resources :informatives, except: %i[show] do
+            post :complete, on: :collection
+          end
         end
 
         resources :consultees, only: %i[create show] do

--- a/db/migrate/20240304111101_create_informatives.rb
+++ b/db/migrate/20240304111101_create_informatives.rb
@@ -1,0 +1,10 @@
+class CreateInformatives < ActiveRecord::Migration[7.1]
+  def change
+    create_table :informatives do |t|
+      t.string :title
+      t.text :text
+      t.references :planning_application
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240304111101_create_informatives.rb
+++ b/db/migrate/20240304111101_create_informatives.rb
@@ -1,9 +1,16 @@
+# frozen_string_literal: true
+
 class CreateInformatives < ActiveRecord::Migration[7.1]
   def change
+    create_table :informative_sets do |t|
+      t.references :planning_application
+      t.timestamps
+    end
+
     create_table :informatives do |t|
       t.string :title
       t.text :text
-      t.references :planning_application
+      t.references :informative_set
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -43,9 +43,24 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "additional_document_validation_requests", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "new_document_id"
+    t.string "state", default: "open", null: false
+    t.string "document_request_type"
+    t.string "document_request_reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "sequence"
+    t.index ["new_document_id"], name: "index_document_create_requests_on_new_document_id"
+    t.index ["planning_application_id"], name: "index_document_create_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_document_create_requests_on_user_id"
+  end
+
   create_table "api_users", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "token", null: false
+    t.string "name"
+    t.string "token"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "local_authority_id"
@@ -244,6 +259,21 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.index ["search"], name: "ix_contacts_on_search", using: :gin
   end
 
+  create_table "description_change_validation_requests", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.string "state", default: "open", null: false
+    t.text "proposed_description"
+    t.boolean "approved"
+    t.string "rejection_reason"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "previous_description"
+    t.integer "sequence"
+    t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_description_change_requests_on_user_id"
+  end
+
   create_table "documents", force: :cascade do |t|
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
@@ -315,12 +345,28 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.index ["planning_application_id"], name: "ix_fee_calculations_on_planning_application_id"
   end
 
+  create_table "heads_of_terms", force: :cascade do |t|
+    t.bigint "planning_application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_heads_of_terms_on_planning_application_id"
+  end
+
   create_table "immunity_details", force: :cascade do |t|
     t.date "end_date"
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["planning_application_id"], name: "ix_immunity_details_on_planning_application_id"
+  end
+
+  create_table "informatives", force: :cascade do |t|
+    t.string "title"
+    t.text "text"
+    t.bigint "planning_application_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_informatives_on_planning_application_id"
   end
 
   create_table "land_owners", force: :cascade do |t|
@@ -657,6 +703,34 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"
   end
 
+  create_table "red_line_boundary_change_validation_requests", force: :cascade do |t|
+    t.integer "planning_application_id", null: false
+    t.integer "user_id", null: false
+    t.string "state", default: "open", null: false
+    t.string "new_geojson"
+    t.string "reason"
+    t.string "rejection_reason"
+    t.boolean "approved"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "sequence"
+  end
+
+  create_table "replacement_document_validation_requests", force: :cascade do |t|
+    t.bigint "planning_application_id", null: false
+    t.bigint "user_id", null: false
+    t.bigint "old_document_id", null: false
+    t.bigint "new_document_id"
+    t.string "state", default: "open", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "sequence"
+    t.index ["new_document_id"], name: "index_document_change_requests_on_new_document_id"
+    t.index ["old_document_id"], name: "index_document_change_requests_on_old_document_id"
+    t.index ["planning_application_id"], name: "index_document_change_requests_on_planning_application_id"
+    t.index ["user_id"], name: "index_document_change_requests_on_user_id"
+  end
+
   create_table "reviews", force: :cascade do |t|
     t.string "action"
     t.bigint "assessor_id"
@@ -701,6 +775,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.index ["consultation_id"], name: "ix_site_visits_on_consultation_id"
     t.index ["created_by_id"], name: "ix_site_visits_on_created_by_id"
     t.index ["neighbour_id"], name: "ix_site_visits_on_neighbour_id"
+  end
+
+  create_table "terms", force: :cascade do |t|
+    t.string "title"
+    t.text "text"
+    t.bigint "heads_of_term_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["heads_of_term_id"], name: "ix_terms_on_heads_of_term_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -756,9 +839,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_29_153828) do
     t.bigint "old_document_id"
     t.integer "sequence"
     t.jsonb "specific_attributes"
-    t.bigint "condition_id"
-    t.index ["condition_id"], name: "ix_validation_requests_on_condition_id"
+    t.string "owner_type"
+    t.bigint "owner_id"
     t.index ["old_document_id"], name: "ix_validation_requests_on_old_document_id"
+    t.index ["owner_type", "owner_id"], name: "index_validation_requests_on_owner"
     t.index ["planning_application_id"], name: "ix_validation_requests_on_planning_application_id"
     t.index ["user_id"], name: "ix_validation_requests_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,24 +43,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "additional_document_validation_requests", force: :cascade do |t|
-    t.bigint "planning_application_id", null: false
-    t.bigint "user_id", null: false
-    t.bigint "new_document_id"
-    t.string "state", default: "open", null: false
-    t.string "document_request_type"
-    t.string "document_request_reason"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "sequence"
-    t.index ["new_document_id"], name: "index_document_create_requests_on_new_document_id"
-    t.index ["planning_application_id"], name: "index_document_create_requests_on_planning_application_id"
-    t.index ["user_id"], name: "index_document_create_requests_on_user_id"
-  end
-
   create_table "api_users", force: :cascade do |t|
-    t.string "name"
-    t.string "token"
+    t.string "name", null: false
+    t.string "token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "local_authority_id"
@@ -259,21 +244,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["search"], name: "ix_contacts_on_search", using: :gin
   end
 
-  create_table "description_change_validation_requests", force: :cascade do |t|
-    t.bigint "planning_application_id", null: false
-    t.bigint "user_id", null: false
-    t.string "state", default: "open", null: false
-    t.text "proposed_description"
-    t.boolean "approved"
-    t.string "rejection_reason"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "previous_description"
-    t.integer "sequence"
-    t.index ["planning_application_id"], name: "index_description_change_requests_on_planning_application_id"
-    t.index ["user_id"], name: "index_description_change_requests_on_user_id"
-  end
-
   create_table "documents", force: :cascade do |t|
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
@@ -345,13 +315,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["planning_application_id"], name: "ix_fee_calculations_on_planning_application_id"
   end
 
-  create_table "heads_of_terms", force: :cascade do |t|
-    t.bigint "planning_application_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["planning_application_id"], name: "ix_heads_of_terms_on_planning_application_id"
-  end
-
   create_table "immunity_details", force: :cascade do |t|
     t.date "end_date"
     t.bigint "planning_application_id"
@@ -360,13 +323,20 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["planning_application_id"], name: "ix_immunity_details_on_planning_application_id"
   end
 
-  create_table "informatives", force: :cascade do |t|
-    t.string "title"
-    t.text "text"
+  create_table "informative_sets", force: :cascade do |t|
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["planning_application_id"], name: "ix_informatives_on_planning_application_id"
+    t.index ["planning_application_id"], name: "ix_informative_sets_on_planning_application_id"
+  end
+
+  create_table "informatives", force: :cascade do |t|
+    t.string "title"
+    t.text "text"
+    t.bigint "informative_set_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["informative_set_id"], name: "ix_informatives_on_informative_set_id"
   end
 
   create_table "land_owners", force: :cascade do |t|
@@ -703,34 +673,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"
   end
 
-  create_table "red_line_boundary_change_validation_requests", force: :cascade do |t|
-    t.integer "planning_application_id", null: false
-    t.integer "user_id", null: false
-    t.string "state", default: "open", null: false
-    t.string "new_geojson"
-    t.string "reason"
-    t.string "rejection_reason"
-    t.boolean "approved"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "sequence"
-  end
-
-  create_table "replacement_document_validation_requests", force: :cascade do |t|
-    t.bigint "planning_application_id", null: false
-    t.bigint "user_id", null: false
-    t.bigint "old_document_id", null: false
-    t.bigint "new_document_id"
-    t.string "state", default: "open", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "sequence"
-    t.index ["new_document_id"], name: "index_document_change_requests_on_new_document_id"
-    t.index ["old_document_id"], name: "index_document_change_requests_on_old_document_id"
-    t.index ["planning_application_id"], name: "index_document_change_requests_on_planning_application_id"
-    t.index ["user_id"], name: "index_document_change_requests_on_user_id"
-  end
-
   create_table "reviews", force: :cascade do |t|
     t.string "action"
     t.bigint "assessor_id"
@@ -775,15 +717,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.index ["consultation_id"], name: "ix_site_visits_on_consultation_id"
     t.index ["created_by_id"], name: "ix_site_visits_on_created_by_id"
     t.index ["neighbour_id"], name: "ix_site_visits_on_neighbour_id"
-  end
-
-  create_table "terms", force: :cascade do |t|
-    t.string "title"
-    t.text "text"
-    t.bigint "heads_of_term_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["heads_of_term_id"], name: "ix_terms_on_heads_of_term_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -839,10 +772,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_04_111101) do
     t.bigint "old_document_id"
     t.integer "sequence"
     t.jsonb "specific_attributes"
-    t.string "owner_type"
-    t.bigint "owner_id"
+    t.bigint "condition_id"
+    t.index ["condition_id"], name: "ix_validation_requests_on_condition_id"
     t.index ["old_document_id"], name: "ix_validation_requests_on_old_document_id"
-    t.index ["owner_type", "owner_id"], name: "index_validation_requests_on_owner"
     t.index ["planning_application_id"], name: "ix_validation_requests_on_planning_application_id"
     t.index ["user_id"], name: "ix_validation_requests_on_user_id"
   end

--- a/spec/factories/informative.rb
+++ b/spec/factories/informative.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :informative do
+    planning_application
+
+    title { "Section 106 undertaking" }
+    text { "This planning permission is pursuant to a planning obligation under Section 106 of the Town and Country Planning Act 1990." }
+  end
+end

--- a/spec/factories/informative.rb
+++ b/spec/factories/informative.rb
@@ -2,8 +2,7 @@
 
 FactoryBot.define do
   factory :informative do
-    planning_application
-
+    informative_set
     title { "Section 106 undertaking" }
     text { "This planning permission is pursuant to a planning obligation under Section 106 of the Town and Country Planning Act 1990." }
   end

--- a/spec/factories/informative_set.rb
+++ b/spec/factories/informative_set.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :informative_set do
+    planning_application
+  end
+end

--- a/spec/models/informative_spec.rb
+++ b/spec/models/informative_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Informative do
+  describe "validations" do
+    subject(:informative) { described_class.new }
+
+    it "has a valid factory" do
+      informative = create(:informative)
+
+      expect(informative).to be_valid
+    end
+
+    describe "#title" do
+      it "validates presence" do
+        expect do
+          informative.valid?
+        end.to change {
+          informative.errors[:title]
+        }.to ["Fill in the title of the informative"]
+      end
+    end
+
+    describe "#text" do
+      it "validates presence" do
+        expect do
+          informative.valid?
+        end.to change {
+          informative.errors[:text]
+        }.to ["Fill in the text of the informative"]
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/assessing/adding_informatives_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_informatives_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Add informatives" do
   end
 
   before do
+    allow(Current).to receive(:user).and_return assessor
+
     sign_in assessor
     visit "/planning_applications/#{planning_application.id}"
     click_link "Check and assess"
@@ -46,14 +48,25 @@ RSpec.describe "Add informatives" do
       expect(page).to have_content "Consider the park"
     end
 
-    # Check in progress
+    click_link "Assess application"
+
+    within("#add-informatives") do
+      expect(page).to have_content "In progress"
+    end
+
+    click_link "Add informatives"
+
+    click_link "Save and mark as complete"
+
+    within("#add-informatives") do
+      expect(page).to have_content "Completed"
+    end
   end
 
   it "I can edit informatives" do
-    informative = create(:informative, planning_application:)
+    informative = create(:informative, informative_set: planning_application.informative_set)
 
     within("#add-informatives") do
-      # expect(page).to have_content "Not started"
       click_link "Add informatives"
     end
 
@@ -78,10 +91,9 @@ RSpec.describe "Add informatives" do
   end
 
   it "I can delete informatives" do
-    informative = create(:informative, planning_application:)
+    informative = create(:informative, informative_set: planning_application.informative_set)
 
     within("#add-informatives") do
-      # expect(page).to have_content "Not started"
       click_link "Add informatives"
     end
 
@@ -141,17 +153,27 @@ RSpec.describe "Add informatives" do
   end
 
   it "I can mark the task as complete" do
-    informative = create(:informative, planning_application:)
-
     within("#add-informatives") do
-      expect(page).to have_content "In progress"
       click_link "Add informatives"
     end
 
-    click_button "Save and mark as complete"
+    click_link "Save and mark as complete"
 
     within("#add-informatives") do
       expect(page).to have_content "Complete"
     end
+  end
+
+  it "shows informatives on the decision notice" do
+    create(:recommendation, :assessment_in_progress, planning_application:)
+    informative = create(:informative, informative_set: planning_application.informative_set)
+
+    visit "/planning_applications/#{planning_application.id}"
+    click_link "Check and assess"
+    click_link "Review and submit recommendation"
+
+    expect(page).to have_content "Informatives"
+    expect(page).to have_content informative.title
+    expect(page).to have_content informative.text
   end
 end

--- a/spec/system/planning_applications/assessing/adding_informatives_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_informatives_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add informatives" do
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, :planning_permission, :in_assessment, local_authority: default_local_authority, api_user:, decision: "granted")
+  end
+
+  before do
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.id}"
+    click_link "Check and assess"
+  end
+
+  it "I can add informatives" do
+    within("#add-informatives") do
+      expect(page).to have_content "Not started"
+      click_link "Add informatives"
+    end
+
+    expect(page).to have_content "Add informatives"
+    expect(page).to have_content "No informatives added yet"
+
+    fill_in "Enter a title", with: "Informative 1"
+    fill_in "Enter details of the informative", with: "Consider the trees"
+
+    click_button "Add informative"
+
+    expect(page).to have_content "Informative successfully added"
+
+    within("tr", text: "Informative 1") do
+      expect(page).to have_content "Consider the trees"
+    end
+
+    fill_in "Enter a title", with: "Informative 2"
+    fill_in "Enter details of the informative", with: "Consider the park"
+
+    click_button "Add informative"
+
+    within("tr", text: "Informative 2") do
+      expect(page).to have_content "Consider the park"
+    end
+
+    # Check in progress
+  end
+
+  it "I can edit informatives" do
+    informative = create(:informative, planning_application:)
+
+    within("#add-informatives") do
+      # expect(page).to have_content "Not started"
+      click_link "Add informatives"
+    end
+
+    within("tr", text: informative.title) do
+      expect(page).to have_content informative.text
+
+      click_link "Edit"
+    end
+
+    expect(page).to have_content "Edit informative"
+
+    fill_in "Enter a title", with: "My new title"
+    fill_in "Enter details of the informative", with: "The new detail"
+
+    click_button "Save informative"
+
+    expect(page).to have_content "Informative successfully added"
+
+    within("tr", text: "My new title") do
+      expect(page).to have_content "The new detail"
+    end
+  end
+
+  it "I can delete informatives" do
+    informative = create(:informative, planning_application:)
+
+    within("#add-informatives") do
+      # expect(page).to have_content "Not started"
+      click_link "Add informatives"
+    end
+
+    within("tr", text: informative.title) do
+      expect(page).to have_content informative.text
+
+      click_link "Remove"
+    end
+
+    expect(page).to have_content "Informative was successfully removed"
+    expect(page).to have_content "No informatives added yet"
+  end
+
+  it "shows errors" do
+    click_link "Add informatives"
+
+    expect(page).to have_content "No informatives added yet"
+
+    click_button "Add informative"
+
+    expect(page).to have_content "Fill in the title of the informative"
+    expect(page).to have_content "Fill in the text of the informative"
+
+    fill_in "Enter a title", with: "My new title"
+    fill_in "Enter details of the informative", with: "The new detail"
+
+    click_button "Add informative"
+
+    expect(page).to have_content "Informative successfully added"
+
+    within("tr", text: "My new title") do
+      expect(page).to have_content "The new detail"
+
+      click_link "Edit"
+    end
+
+    expect(page).to have_content "Edit informative"
+
+    fill_in "Enter a title", with: ""
+    fill_in "Enter details of the informative", with: ""
+
+    click_button "Save informative"
+
+    expect(page).to have_content "Fill in the title of the informative"
+    expect(page).to have_content "Fill in the text of the informative"
+
+    fill_in "Enter a title", with: "My newer title"
+    fill_in "Enter details of the informative", with: "The newer detail"
+
+    click_button "Save informative"
+
+    expect(page).to have_content "Informative successfully added"
+
+    within("tr", text: "My newer title") do
+      expect(page).to have_content "The newer detail"
+    end
+  end
+
+  it "I can mark the task as complete" do
+    informative = create(:informative, planning_application:)
+
+    within("#add-informatives") do
+      expect(page).to have_content "In progress"
+      click_link "Add informatives"
+    end
+
+    click_button "Save and mark as complete"
+
+    within("#add-informatives") do
+      expect(page).to have_content "Complete"
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Allow officer to add informatives to a planning application

### Story Link

https://trello.com/c/1vkMmzzo/2514-when-i-make-a-decision-i-want-to-include-advisory-notes-informatives-so-that-the-applicant-is-warned-of-other-requirements
