### PR TITLE
Display form error instead of required tooltip

### DIFF
--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -108,23 +108,18 @@ module PlanningApplications
 
       def cancel
         respond_to do |format|
-          if @validation_request.may_cancel?
-            @validation_request.assign_attributes(cancel_validation_request_params)
-            @validation_request.cancel_request!
+          @validation_request.assign_attributes(cancel_validation_request_params)
+          @validation_request.cancel_request!
 
-            @validation_request.send_cancelled_validation_request_mail unless @planning_application.not_started?
+          @validation_request.send_cancelled_validation_request_mail unless @planning_application.not_started?
 
-            format.html do
-              redirect_to cancel_redirect_url,
-                notice: t(".#{@validation_request.type.underscore}.success")
-            end
-          else
-            format.html do
-              @validation_request = @planning_application.validation_requests.find(params[:id].to_i)
-              render :cancel_confirmation
-            end
+          format.html do
+            redirect_to cancel_redirect_url,
+              notice: t(".#{@validation_request.type.underscore}.success")
           end
         end
+      rescue ValidationRequest::RecordCancelError
+        render :cancel_confirmation
       end
 
       def post_validation_requests

--- a/app/views/planning_applications/validation/validation_requests/_cancel_confirmation_form.html.erb
+++ b/app/views/planning_applications/validation/validation_requests/_cancel_confirmation_form.html.erb
@@ -3,22 +3,9 @@
   scope: :validation_request,
   url: cancel_planning_application_validation_validation_request_path(@planning_application, validation_request) do |form| %>
 
-  <% if validation_request.errors.any? %>
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% validation_request.errors.full_messages.each do |error| %>
-            <li><%= error %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
-  <%= form.govuk_text_area :cancel_reason, label: { text: "Explain to the applicant why this request is being cancelled" }, rows: 5, required: true %>
+  <%= form.govuk_text_area :cancel_reason, label: { text: "Explain to the applicant why this request is being cancelled" }, rows: 5 %>
 
   <div class="govuk-button-group">
     <%= form.submit "Confirm cancellation", class: "govuk-button", data: { module: "govuk-button" } %>

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -421,6 +421,12 @@ RSpec.describe "Requesting a new document for a planning application" do
       click_link "Check missing documents"
       click_link "Cancel request"
 
+      click_button "Confirm cancellation"
+      within(".govuk-error-summary") do
+        expect(page).to have_content("There is a problem")
+        expect(page).to have_content("Cancel reason can't be blank")
+      end
+
       fill_in "Explain to the applicant why this request is being cancelled", with: "Mistake"
       click_button "Confirm cancellation"
 


### PR DESCRIPTION
### Description of change

Display form error from rails validation instead of the required tooltip

### Story Link

https://trello.com/c/5dx9cn7T/2569-cancel-validation-request-with-no-reason-there-was-a-tooltip-instead-of-the-govuk-error-summary