### PR TITLE
Use custom email for pre-commencement condition validation requests

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -75,6 +75,19 @@ class PlanningApplicationMailer < ApplicationMailer
     )
   end
 
+  def pre_commencement_condition_request_mail(planning_application, validation_request)
+    @planning_application = planning_application
+    @validation_request = validation_request
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:pre_commencement_condition_notification,
+        application_type_name: @planning_application.application_type.human_name),
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
+    )
+  end
+
   def cancelled_validation_request_mail(planning_application)
     @planning_application = planning_application
 

--- a/app/models/pre_commencement_condition_validation_request.rb
+++ b/app/models/pre_commencement_condition_validation_request.rb
@@ -17,12 +17,19 @@ class PreCommencementConditionValidationRequest < ValidationRequest
   end
 
   def email_and_timestamp
-    send_post_validation_request_email if owner.condition_set.send_notification?
+    send_pre_commencement_condition_request_email if owner.condition_set.send_notification?
 
     mark_as_sent!
   end
 
   private
+
+  def send_pre_commencement_condition_request_email
+    PlanningApplicationMailer.pre_commencement_condition_request_mail(
+      planning_application,
+      self
+    ).deliver_now
+  end
 
   def audit_comment
     {

--- a/app/views/planning_application_mailer/pre_commencement_condition_request_mail.text.erb
+++ b/app/views/planning_application_mailer/pre_commencement_condition_request_mail.text.erb
@@ -1,0 +1,17 @@
+Application received: <%= @planning_application.received_at.to_date.to_fs %>
+
+At: <%= @planning_application.full_address %>
+
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
+<%= @planning_application.user ? "#{@planning_application.user.name}, the" : "The" %> officer working on your planning application, has added pre-commencement conditions to your application. These conditions must be met before any building or operation included in the development is started. You have 10 working days to accept or reject these conditions.
+
+To review and accept or reject the changes, follow the link below:
+
+<%= @planning_application.secure_change_url %>
+
+If your response is not received by <strong><%= @validation_request.request_expiry_date.to_fs %></strong>, the proposed changes to your application will be automatically accepted. This is to avoid delays in making a determination on your application.
+
+Yours faithfully,
+
+<%= @planning_application.local_authority.council_name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -615,6 +615,7 @@ en:
       otp_mail: Back Office Planning System verification code
       post_validation_request_mail: "%{application_type_name} application - changes needed"
       pre_commencement_condition_closure_notification_mail: Changes to your %{application_type_name} application
+      pre_commencement_condition_notification: "%{application_type_name} application - response needed"
       press_notice_confirmation_request_mail: Request for confirmation of a press notice for %{reference}
       press_notice_mail: Request for press notice
       receipt_notice_mail: "%{application_type_name} application received"
@@ -648,7 +649,7 @@ en:
     save_and_mark_as_complete: Save and mark as complete
   heads_of_terms:
     update:
-      success: Heads of terms successfully updated
+      success: Heads of terms successfully updated and sent to applicant
   helpers:
     hint:
       neighbour_response:

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -428,6 +428,100 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     end
   end
 
+  describe "#pre_commencement_condition_request_mail" do
+    let!(:validation_request) do
+      create(:pre_commencement_condition_validation_request, planning_application: invalid_planning_application,
+        user: assessor)
+    end
+    let(:pre_commencement_condition_request_mail) do
+      described_class.pre_commencement_condition_request_mail(planning_application, validation_request)
+    end
+
+    let(:mail_body) { pre_commencement_condition_request_mail.body.encoded }
+
+    context "when agent is present" do
+      it "emails only the agent when the agent is present" do
+        expect(pre_commencement_condition_request_mail.to).to eq([planning_application.agent_email])
+      end
+
+      it "includes the name of the agent in the body" do
+        expect(mail_body).to include(planning_application.agent_first_name)
+        expect(mail_body).to include(planning_application.agent_last_name)
+      end
+    end
+
+    context "when agent is missing" do
+      before do
+        planning_application.update!(agent_email: "")
+        planning_application.update!(agent_first_name: "")
+      end
+
+      it "emails only the applicant when the agent is missing" do
+        mail = described_class.post_validation_request_mail(planning_application, validation_request)
+
+        expect(mail.to).to eq([planning_application.applicant_email])
+      end
+
+      it "includes the name of the applicant in the body" do
+        mail = described_class.post_validation_request_mail(planning_application.reload, validation_request)
+
+        expect(mail.body.encoded).to include(planning_application.applicant_first_name)
+        expect(mail.body.encoded).to include(planning_application.applicant_last_name)
+      end
+    end
+
+    context "when there is an assigned officer to the case" do
+      before do
+        planning_application.user = assessor
+      end
+
+      it "includes the information about the validation request being auto accepted" do
+        expect(mail_body).to include(
+          "#{planning_application.user.name}, the officer working on your planning application, has added pre-commencement conditions to your application."
+        )
+      end
+    end
+
+    it "sets the subject" do
+      expect(pre_commencement_condition_request_mail.subject).to eq(
+        "Lawful Development Certificate application - response needed"
+      )
+    end
+
+    it "sets the recipient" do
+      expect(pre_commencement_condition_request_mail.to).to contain_exactly(
+        "cookie_crackers@example.com"
+      )
+    end
+
+    it "includes the application received at date" do
+      expect(mail_body).to include(
+        "Application received: 3 May 2022"
+      )
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include(
+        "At: 123 High Street, Big City, AB3 4EF"
+      )
+    end
+
+    it "includes the validation request url" do
+      expect(mail_body).to include(
+        "https://planx.bops-applicants.services/validation_requests?change_access_id=#{planning_application.change_access_id}&planning_application_id=#{planning_application.id}"
+      )
+    end
+
+    it "includes the information about the validation request being auto accepted" do
+      expect(mail_body).to include(
+        "If your response is not received by <strong>#{validation_request.request_expiry_date.to_fs}</strong>, the proposed changes to your application will be automatically accepted."
+      )
+      expect(mail_body).to include(
+        "This is to avoid delays in making a determination on your application."
+      )
+    end
+  end
+
   describe "#cancelled_validation_request_mail" do
     let(:cancelled_validation_request_mail) do
       described_class.cancelled_validation_request_mail(planning_application)


### PR DESCRIPTION
### Description of change

Use a custom email when sending pre-commencement condition validation requests to the applicant, to make it less generic
