### PR TITLE
Mark submissions via the v2 endpoint as accepted

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,7 @@ production:
 :queues:
   - low_priority
   - high_priority
+  - submissions
 
 :scheduler:
   :schedule:

--- a/engines/bops_api/app/jobs/bops_api/create_neighbour_boundary_geojson_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/create_neighbour_boundary_geojson_job.rb
@@ -2,7 +2,7 @@
 
 module BopsApi
   class CreateNeighbourBoundaryGeojsonJob < ApplicationJob
-    queue_as :low_priority
+    queue_as :submissions
     discard_on ActiveJob::DeserializationError
 
     def perform(planning_application)

--- a/engines/bops_api/app/jobs/bops_api/fetch_constraint_entities_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/fetch_constraint_entities_job.rb
@@ -5,7 +5,7 @@ require "uri"
 
 module BopsApi
   class FetchConstraintEntitiesJob < ApplicationJob
-    queue_as :low_priority
+    queue_as :submissions
     discard_on ActiveJob::DeserializationError
 
     def perform(planning_application_constraint, entities)

--- a/engines/bops_api/app/jobs/bops_api/mark_accepted_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/mark_accepted_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module BopsApi
+  class MarkAcceptedJob < ApplicationJob
+    queue_as :low_priority
+    discard_on ActiveJob::DeserializationError
+
+    def perform(planning_application)
+      if processed?
+        planning_application.with_lock do
+          if planning_application.pending?
+            planning_application.mark_accepted!
+          end
+        end
+      else
+        retry_job(wait: 5.minutes)
+      end
+    end
+
+    private
+
+    def processed?
+      submissions_queue.size == 0
+    end
+
+    def submissions_queue
+      Sidekiq::Queue.new("submissions")
+    end
+  end
+end

--- a/engines/bops_api/app/jobs/bops_api/upload_document_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/upload_document_job.rb
@@ -2,7 +2,7 @@
 
 module BopsApi
   class UploadDocumentJob < ApplicationJob
-    queue_as :low_priority
+    queue_as :submissions
     discard_on ActiveJob::DeserializationError
 
     def perform(planning_application, user, url, tags, description)

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -84,7 +84,9 @@ module BopsApi
             planning_application.send_receipt_notice_mail if send_email?(planning_application)
           end
         end
+
         CreateNeighbourBoundaryGeojsonJob.perform_later(planning_application) if planning_application.consultation
+        MarkAcceptedJob.set(wait: 5.minutes).perform_later(planning_application)
 
         planning_application
       end

--- a/engines/bops_api/spec/jobs/mark_accepted_job_spec.rb
+++ b/engines/bops_api/spec/jobs/mark_accepted_job_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::MarkAcceptedJob, type: :job do
+  around do |example|
+    freeze_time { example.run }
+  end
+
+  context "when the application is pending" do
+    let(:planning_application) { create(:planning_application, :pending) }
+
+    context "and the queue is not empty" do
+      let(:queue) { instance_double(Sidekiq::Queue) }
+
+      before do
+        expect(Sidekiq::Queue).to receive(:new).with("submissions").and_return(queue)
+        expect(queue).to receive(:size).and_return(5)
+      end
+
+      it "schedules the job to be retried in 5 minutes" do
+        expect {
+          described_class.perform_now(planning_application)
+        }.to have_enqueued_job(described_class).with(planning_application).at(5.minutes.from_now)
+      end
+    end
+
+    context "and the queue is empty" do
+      let(:queue) { instance_double(Sidekiq::Queue) }
+
+      before do
+        expect(Sidekiq::Queue).to receive(:new).with("submissions").and_return(queue)
+        expect(queue).to receive(:size).and_return(0)
+      end
+
+      it "doesn't schedule the job to be retried" do
+        expect {
+          described_class.perform_now(planning_application)
+        }.not_to have_enqueued_job(described_class).with(planning_application)
+      end
+
+      it "changes the application status to 'not_started'" do
+        expect {
+          described_class.perform_now(planning_application)
+        }.to change(planning_application, :status).from("pending").to("not_started")
+      end
+    end
+  end
+
+  context "when the application has already been accepted" do
+    let(:planning_application) { create(:planning_application, :not_started) }
+    let(:queue) { instance_double(Sidekiq::Queue) }
+
+    before do
+      expect(Sidekiq::Queue).to receive(:new).with("submissions").and_return(queue)
+      expect(queue).to receive(:size).and_return(0)
+    end
+
+    it "doesn't schedule the job to be retried" do
+      expect {
+        described_class.perform_now(planning_application)
+      }.not_to have_enqueued_job(described_class).with(planning_application)
+    end
+
+    it "doesn't change the application status" do
+      expect {
+        described_class.perform_now(planning_application)
+      }.not_to change(planning_application, :status)
+    end
+  end
+end

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
     around do |example|
       travel_to("2023-12-13") do
-        perform_enqueued_jobs { example.run }
+        example.run
       end
     end
 
@@ -103,7 +103,11 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         end
 
         it "uploads the documents" do
-          expect { create_planning_application }.to change(Document, :count).by(7)
+          expect {
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) {
+              create_planning_application
+            }
+          }.to change(Document, :count).by(7)
 
           expect(documents).to include(
             an_object_having_attributes(
@@ -169,7 +173,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
         it "creates the expected constraints" do
           expect {
-            perform_enqueued_jobs {
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) {
               create_planning_application
             }
           }.to change(PlanningApplicationConstraint, :count).by(3)
@@ -250,7 +254,11 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         end
 
         it "uploads the documents" do
-          expect { create_planning_application }.to change(Document, :count).by(8)
+          expect {
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) {
+              create_planning_application
+            }
+          }.to change(Document, :count).by(8)
 
           expect(documents).to include(
             an_object_having_attributes(
@@ -356,7 +364,11 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         end
 
         it "uploads the documents" do
-          expect { create_planning_application }.to change(Document, :count).by(4)
+          expect {
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) {
+              create_planning_application
+            }
+          }.to change(Document, :count).by(4)
 
           expect(documents).to include(
             an_object_having_attributes(
@@ -387,7 +399,10 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         end
 
         it "creates neighbour boundary geojson" do
-          create_planning_application
+          perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) {
+            create_planning_application
+          }
+
           expect(PlanningApplication.last.neighbour_boundary_geojson).not_to be nil
         end
       end
@@ -417,8 +432,11 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
         it "creates the immunity details for the planning application" do
           planning_application = nil
+
           expect do
-            planning_application = service.call!
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) do
+              planning_application = service.call!
+            end
           end.to change(ImmunityDetail, :count).by(1)
 
           immunity_detail = ImmunityDetail.last
@@ -433,8 +451,11 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
         it "creates the evidence groups for the planning application" do
           planning_application = nil
+
           expect do
-            planning_application = service.call!
+            perform_enqueued_jobs(except: BopsApi::MarkAcceptedJob) do
+              planning_application = service.call!
+            end
           end.to change(EvidenceGroup, :count).by(4)
 
           council_tax_bill = planning_application.immunity_detail.evidence_groups.where(tag: "councilTaxBill").first


### PR DESCRIPTION
Move all submission-related jobs to their own queue and then mark the application as accepted once the queue is empty. Note that this is a stop-gap measure and wont scale to concurrent processing for more than a few applications at a time.
