### PR TITLE
Allow officer to upload site visits anytime

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -14,6 +14,7 @@ class ApplicationType < ApplicationRecord
   with_options to: :features do
     delegate :planning_conditions?
     delegate :permitted_development_rights?
+    delegate :site_visits?
   end
 
   def full_name

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -5,4 +5,5 @@ class ApplicationTypeFeature
 
   attribute :planning_conditions, :boolean, default: false
   attribute :permitted_development_rights, :boolean, default: true
+  attribute :site_visits, :boolean, default: false
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -363,6 +363,10 @@ class Consultation < ApplicationRecord
     end
   end
 
+  def needs_site_visit?
+    planning_application.prior_approval? ? neighbour_responses.objection.any? : true
+  end
+
   private
 
   def unknown_placeholders(string)

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -364,7 +364,7 @@ class Consultation < ApplicationRecord
   end
 
   def needs_site_visit?
-    planning_application.prior_approval? ? neighbour_responses.objection.any? : true
+    planning_application.prior_approval? ? neighbour_responses.objection.any? : planning_application.application_type.site_visits?
   end
 
   private

--- a/app/views/planning_applications/consultations/show.html.erb
+++ b/app/views/planning_applications/consultations/show.html.erb
@@ -52,7 +52,7 @@
               planning_application: @planning_application
             )
           ) %>
-          <% if @consultation.site_visits.any? || @consultation.neighbour_responses.objection.any? %>
+          <% if @consultation.site_visits.any? || @consultation.needs_site_visit? %>
             <%= render(
               TaskListItems::SiteVisitComponent.new(
                 planning_application: @planning_application

--- a/app/views/planning_applications/site_visits/index.html.erb
+++ b/app/views/planning_applications/site_visits/index.html.erb
@@ -12,8 +12,10 @@
   locals: { heading: "View site visits" }
 ) %>
 
-<h2 class="govuk-heading-m">Objected neighbour responses</h2>
-<%= render "planning_applications/neighbour_responses/responses", neighbour_responses: @consultation.neighbour_responses.objection %>
+<% if @consultation.neighbour_responses.objection.any? %>
+  <h2 class="govuk-heading-m">Objected neighbour responses</h2>
+  <%= render "planning_applications/neighbour_responses/responses", neighbour_responses: @consultation.neighbour_responses.objection %>
+<% end %>
 
 <% if @site_visits.any? %>
   <h2 class="govuk-heading-m">Site visits</h2>

--- a/app/views/planning_applications/site_visits/new.html.erb
+++ b/app/views/planning_applications/site_visits/new.html.erb
@@ -12,7 +12,9 @@
   locals: { heading: "Add a site visit" }
 ) %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-7">Objected neighbour responses</h2>
-<%= render "planning_applications/neighbour_responses/responses", neighbour_responses: @consultation.neighbour_responses.objection %>
+<% if @consultation.neighbour_responses.objection.any? %>
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">Objected neighbour responses</h2>
+  <%= render "planning_applications/neighbour_responses/responses", neighbour_responses: @consultation.neighbour_responses.objection %>
+<% end %>
 
 <%= render "form" %>

--- a/db/migrate/20240308151556_add_site_visits_to_attribute_features.rb
+++ b/db/migrate/20240308151556_add_site_visits_to_attribute_features.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddSiteVisitsToAttributeFeatures < ActiveRecord::Migration[7.1]
+  class ApplicationType < ActiveRecord::Base; end
+
+  def change
+    up_only do
+      ApplicationType.find_each do |type|
+        next if type.name == "lawfulness_certificate"
+
+        type.update!(features: type.features.merge("site_visits" => true))
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_07_130239) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_151556) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -88,6 +88,7 @@ application_types = [
   },
   {
     name: "prior_approval", part: 1, section: "A",
+    features: {"site_visits" => true},
     steps: %w[validation consultation assessment review],
     assessment_details: %w[
       summary_of_work
@@ -107,7 +108,7 @@ application_types = [
   },
   {
     name: "planning_permission",
-    features: {"permitted_development_rights" => false},
+    features: {"permitted_development_rights" => false, "site_visits" => true},
     steps: %w[validation consultation assessment review],
     assessment_details: %w[
       summary_of_work

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -72,6 +72,7 @@ FactoryBot.define do
 
     trait :prior_approval do
       name { "prior_approval" }
+      features { {"site_visits" => true} }
       steps { %w[validation consultation assessment review] }
 
       assessment_details do
@@ -190,7 +191,7 @@ FactoryBot.define do
     trait :planning_permission do
       name { "planning_permission" }
       steps { %w[validation consultation assessment review] }
-      features { {"planning_conditions" => true, "permitted_development_rights" => false} }
+      features { {"planning_conditions" => true, "permitted_development_rights" => false, "site_visits" => true} }
 
       assessment_details do
         %w[

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -58,6 +58,18 @@ RSpec.describe "Site visit" do
         expect(page).not_to have_css("#site-visit")
       end
     end
+
+    context "when it is not a prior approval application" do
+      let!(:planning_application) { create(:planning_application, :planning_permission, local_authority:) }
+      let!(:consultation) { planning_application.consultation }
+
+      it "allows officers to upload site visits any time" do
+        visit "/planning_applications/#{planning_application.id}"
+        click_link "Consultees, neighbours and publicity"
+
+        expect(page).to have_css("#site-visit")
+      end
+    end
   end
 
   describe "viewing site visits" do


### PR DESCRIPTION
### Description of change

Allow planning officers to upload site visits at any point, not just if there are neighbour objections (as is the case for prior approvals)

### Story Link

https://trello.com/c/obyo7YJb/2657-able-to-add-site-visit-evidence-at-any-point-for-planning-applications#1612 