### PR TITLE
Reorganise adding/emailing consultees into multiple pages

### DIFF
--- a/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
+++ b/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
@@ -33,7 +33,7 @@ module PlanningApplications
       end
 
       def permitted_params
-        params.require(:constraint).permit([:constraint, :consultee])
+        params.require(:planning_application_constraint).permit([:constraint, :consultee])
       end
     end
   end

--- a/app/controllers/planning_applications/consultees_controller.rb
+++ b/app/controllers/planning_applications/consultees_controller.rb
@@ -25,7 +25,7 @@ module PlanningApplications
     end
 
     def new
-      @constraint = Constraint.find(Integer(params[:constraint]))
+      @constraint = PlanningApplicationConstraint.find(Integer(params[:constraint]))
     end
 
     private

--- a/app/javascript/controllers/consultees_controller.js
+++ b/app/javascript/controllers/consultees_controller.js
@@ -6,6 +6,7 @@ export default class extends Controller {
   static targets = [
     "form",
     "accordian",
+    "allConsultees",
     "externalConsultees",
     "externalCount",
     "internalConsultees",
@@ -150,25 +151,38 @@ export default class extends Controller {
 
   appendConsultee(data) {
     const consultee = this.buildConsultee(data)
+    let consulteesTarget = null
+    if (data.origin === "external" && this.hasExternalConsulteesTarget) {
+      consulteesTarget = this.externalConsulteesTarget
+    } else if (data.origin === "internal" && this.hasInternalConsulteesTarget) {
+      consulteesTarget = this.internalConsulteesTarget
+    } else {
+      consulteesTarget = this.allConsulteesTarget
+    }
 
-    const consulteesTarget =
-      data.origin === "external"
-        ? this.externalConsulteesTarget
-        : this.internalConsulteesTarget
-
-    const countTarget =
-      data.origin === "external"
-        ? this.externalCountTarget
-        : this.internalCountTarget
+    let countTarget = null
+    if (data.origin === "external" && this.hasExternalCountTarget) {
+      countTarget = this.externalCountTarget
+    } else if (data.origin === "internal" && this.hasInternalCountTarget) {
+      countTarget = this.internalCountTarget
+    }
 
     const tableBody = consulteesTarget.querySelector("tbody")
     tableBody.appendChild(consultee)
 
     const newCount = tableBody.querySelectorAll("tr").length
-    countTarget.textContent = newCount
+    if (countTarget !== null) {
+      countTarget.textContent = newCount
+    }
 
-    this.noConsulteesTarget.style.display = "none"
-    this.accordianTarget.style.display = ""
+    if (this.hasNoConsulteesTarget) {
+      this.noConsulteesTarget.style.display = "none"
+    }
+
+    if (this.hasAccordionTarget) {
+      this.accordianTarget.style.display = ""
+    }
+
     consulteesTarget.style.display = ""
   }
 
@@ -193,13 +207,25 @@ export default class extends Controller {
     const domId = `consultation_consultees_attributes_${data.id}_selected`
 
     consultee.id = `consultee_${data.id}`
-    idInput.id = `consultation_consultees_attributes_${data.id}_id`
-    idInput.name = `consultation[consultees_attributes][${data.id}][id]`
-    idInput.value = data.id
-    hiddenInput.name = fieldName
-    checkboxInput.name = fieldName
-    checkboxInput.id = domId
-    inputLabel.htmlFor = domId
+
+    if (idInput !== null) {
+      idInput.id = `consultation_consultees_attributes_${data.id}_id`
+      idInput.name = `consultation[consultees_attributes][${data.id}][id]`
+      idInput.value = data.id
+    }
+
+    if (hiddenInput !== null) {
+      hiddenInput.name = fieldName
+    }
+
+    if (checkboxInput !== null) {
+      checkboxInput.name = fieldName
+      checkboxInput.id = domId
+    }
+
+    if (inputLabel !== null) {
+      inputLabel.htmlFor = domId
+    }
 
     const consulteeWrapper = document.createElement("div")
 
@@ -249,15 +275,17 @@ export default class extends Controller {
   }
 
   get externalConsulteeCheckboxes() {
-    return this.externalConsulteesTarget.querySelectorAll(
-      "input[type=checkbox]",
-    )
+    const element = this.hasExternalConsulteesTarget
+      ? this.externalConsulteesTarget
+      : this.allConsulteesTarget
+    return element.querySelectorAll("input[type=checkbox]")
   }
 
   get internalConsulteeCheckboxes() {
-    return this.internalConsulteesTarget.querySelectorAll(
-      "input[type=checkbox]",
-    )
+    const element = this.hasInternalConsulteesTarget
+      ? this.internalConsulteesTarget
+      : this.allConsulteesTarget
+    return element.querySelectorAll("input[type=checkbox]")
   }
 
   get autocompleteInput() {

--- a/app/views/planning_applications/consultees/_table.html.erb
+++ b/app/views/planning_applications/consultees/_table.html.erb
@@ -29,3 +29,10 @@
     <% end %>
   </tbody>
 </table>
+    <template id="consultee-template" data-consultees-target="template">
+      <tr class=" govuk-table__row just=added">
+        <td class=" govuk-table__cell ">Other</td>
+        <td class=" govuk-table__cell consultee-name">
+        </td>
+      </tr>
+    </template>

--- a/app/views/planning_applications/consultees/index.html.erb
+++ b/app/views/planning_applications/consultees/index.html.erb
@@ -13,7 +13,15 @@
     ) %>
 
 <div class="govuk-grid-row">
-  <%= content_tag :div, class: "govuk-grid-column-full", data: {} do %>
+  <%= content_tag :div, class: "govuk-grid-column-full", data: {
+        controller: "consultees",
+        consultees_planning_application_id: @planning_application.id,
+        consultees_confirmation_message: "Send emails to consulttes",
+        consultees_prompt_message: "Select a consultee",
+        consultees_error_message: "Unable to add consultee",
+        consultees_target: "allConsultees"
+
+      } do %>
     <% if @consultation.errors.any? %>
       <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
         <h2 class="govuk-error-summary__title" id="error-summary-title">
@@ -29,7 +37,14 @@
       </div>
     <% end %>
 
-    <%= render "table", planning_application: @planning_application, consultation: @consultation %>
+    <%= form_with(model: @consultation,
+          url: planning_application_consultees_emails_path(@planning_application),
+          data: {
+            consultees_target: "form"
+          }) do |form| %>
+      <%= render "table", planning_application: @planning_application, consultation: @consultation %>
+      <%= render AddConsulteeComponent.new(consultees: @consultees, form: form) %>
+    <% end %>
 
     <div class="submit-buttons display-flex">
       <%= link_to "Back", planning_application_consultation_path(@planning_application), class: "govuk-button govuk-button--secondary back-button" %>

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -33,11 +33,11 @@
           url: planning_application_consultees_assign_constraint_path(@planning_application),
           method: "POST",
           class: "govuk-!-margin-top-7" do |form| %>
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
-    <%= form.label "Select consultee for #{@constraint.type_code}", class: "govuk-label" %>
-    <%= form.hidden_field :constraint, value: @constraint.id %>
-    <%= form.govuk_select :consultee, options_for_select(@consultation.consultees.map { |c| [c.name, c.id] }) %>
+      <%= form.label "Select consultee for #{@constraint.type_code}", class: "govuk-label" %>
+      <%= form.hidden_field :constraint, value: @constraint.id %>
+      <%= form.govuk_select :consultee, options_for_select(@consultation.consultees.map { |c| [c.name, c.id] }) %>
 
       <div class="govuk-button-group">
         <%= form.submit "Assign consultee", class: "govuk-button", data: {module: "govuk-button"} %>

--- a/spec/system/planning_applications/consulting/add_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/add_consultees_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Consultation", js: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority:) }
+  let(:application_type) { create(:application_type, :planning_permission) }
+  let(:api_user) { create(:api_user, name: "PlanX") }
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :from_planx_prior_approval,
+      :with_boundary_geojson,
+      :with_constraints,
+      application_type:,
+      local_authority:,
+      api_user:,
+      agent_email: "agent@example.com",
+      applicant_email: "applicant@example.com",
+      make_public: true
+    )
+  end
+
+  before do
+    create(
+      :contact, :external,
+      name: "Consultations",
+      role: "Planning Department",
+      organisation: "GLA",
+      email_address: "planning@london.gov.uk"
+    )
+
+    create(
+      :contact, :internal,
+      local_authority:,
+      name: "Chris Wood",
+      role: "Tree Officer",
+      organisation: local_authority.council_name,
+      email_address: "chris.wood@#{local_authority.subdomain}.gov.uk"
+    )
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.id}/consultation"
+  end
+
+  it "lists constraints on the selection page" do
+    click_link "Select and add consultees"
+
+    within ".govuk-table" do
+      expect(page).to have_selector("tr:nth-child(1)", text: "Conservation area")
+      expect(page).to have_selector("tr:nth-child(1)", text: "Assign consultee")
+      expect(page).to have_selector("tr:nth-child(2)", text: "Listed building outline")
+      expect(page).to have_selector("tr:nth-child(2)", text: "Assign consultee")
+    end
+  end
+
+  it "allows adding a consultee" do
+    click_link "Select and add consultees"
+    fill_in "Search for consultees", with: "Tree Officer"
+    expect(page).to have_selector("#add-consultee__listbox li:first-child", text: "Chris Wood (Tree Officer, PlanX Council)")
+
+    pick "Chris Wood (Tree Officer, PlanX Council)", from: "#add-consultee"
+    expect(page).to have_field("Search for consultees", with: "Chris Wood")
+
+    click_button "Add consultee"
+
+    expect(page).to have_selector(".govuk-table__row", text: "Other Chris Wood")
+  end
+
+  it "allows associating a consultee with a constraint" do
+    click_link "Select and add consultees"
+
+    fill_in "Search for consultees", with: "Tree Officer"
+    pick "Chris Wood (Tree Officer, PlanX Council)", from: "#add-consultee"
+    click_button "Add consultee"
+
+    within "tbody tr:first-child" do
+      click_link "Assign consultee"
+    end
+    select "Chris Wood", from: "Consultee"
+    click_button "Assign consultee"
+
+    expect(page).to have_selector(".govuk-table__row", text: "Conservation area Chris Wood")
+  end
+end


### PR DESCRIPTION
### Description of change

As part of splitting the add consultee and email consultee steps onto separate pages, the add-consultee form needs to be moved onto the initial step.

### Story Link

https://trello.com/c/twXRQN1M/2194-see-constraints-when-selecting-consultees

### Screenshots

<img width="1023" alt="Screenshot 2024-03-11 at 15 15 00" src="https://github.com/unboxed/bops/assets/3986/2c620ba4-62b2-4861-9cf6-aae14a95790e">

### Known issues

The form has not yet been removed from the original page.

