### PR TITLE
Don't minify javascript in dev mode

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: bin/rails server -b 0.0.0.0 -p 3000
 css: bin/rails dartsass:watch
-js: yarn build --watch
+js: yarn build:dev --watch
 worker: bin/sidekiq

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@biomejs/biome": "1.0.0"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets --minify"
+    "build:dev": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
+    "build": "yarn build:dev --minify"
   }
 }


### PR DESCRIPTION
Use a separate task from foreman without the minify option being passed, to make js debugging slightly easier.