### PR TITLE
Fix header blue bar width

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,33 +1,35 @@
 <header class="govuk-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
-    <%= link_to(
-      home_path,
-      class: "govuk-header__link govuk-header__link--homepage"
-    ) do %>
-      <% if @current_local_authority %>
-        <span class="govuk-header__service-name">
-          <%= current_local_authority.short_name %>
+  <div class="govuk-header__container">
+    <div class="govuk-width-container">
+      <%= link_to(
+        home_path,
+        class: "govuk-header__link govuk-header__link--homepage"
+      ) do %>
+        <% if @current_local_authority %>
+          <span class="govuk-header__service-name">
+            <%= current_local_authority.short_name %>
+          </span>
+        <% end %>
+        <span class="govuk-header__product-name">
+          <%= t(".back_office_planning") %>
         </span>
       <% end %>
-      <span class="govuk-header__product-name">
-        <%= t(".back_office_planning") %>
-      </span>
-    <% end %>
-    <% if current_user.present? %>
-      <div class="header-session-info">
-        <div class="govuk-header__navigation-item">
-          <strong><%= current_user.name %></strong>
+      <% if current_user.present? %>
+        <div class="header-session-info">
+         <div class="govuk-header__navigation-item">
+           <strong><%= current_user.name %></strong>
+         </div>
+          <div class="govuk-header__navigation-item">
+            <%= link_to(
+               t(".log_out"),
+               main_app.destroy_user_session_path,
+               method: :delete,
+               class: "govuk-header__link"
+            ) %>
+          </div>
         </div>
-        <div class="govuk-header__navigation-item">
-          <%= link_to(
-             t(".log_out"),
-             main_app.destroy_user_session_path,
-             method: :delete,
-             class: "govuk-header__link"
-          ) %>
-        </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </header>
 


### PR DESCRIPTION
Separate govuk-header__container and govuk-width-container

This allows the blue bar to extend across the full width of the viewport, like the black bar above it.

<img width="1689" alt="Screenshot 2024-03-12 at 14 41 24" src="https://github.com/unboxed/bops/assets/3986/ae7a2c8c-b4f8-4022-9602-a872282879e2">

