### PR TITLE
Name assigned officer in neighbour letter

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -268,7 +268,7 @@ class Consultation < ApplicationRecord
       rear_wall: planning_application&.proposal_measurement&.depth,
       max_height: planning_application&.proposal_measurement&.max_height,
       eaves_height: planning_application&.proposal_measurement&.eaves_height,
-      current_user: Current.user.name,
+      assigned_officer: assigned_officer,
       council_address: I18n.t("council_addresses.#{local_authority.subdomain}"),
       application_link:
     }
@@ -286,6 +286,10 @@ class Consultation < ApplicationRecord
     else
       super.presence
     end
+  end
+
+  def assigned_officer
+    planning_application.user.present? ? planning_application.user.name : Current.user.name
   end
 
   def site_visit

--- a/config/locales/neighbour_letters.yml
+++ b/config/locales/neighbour_letters.yml
@@ -52,7 +52,7 @@ en:
 
       Yours
       
-      {{current_user}}
+      {{assigned_officer}}
       Planning officer
     prior_approval: |-
       Dear Resident
@@ -110,5 +110,5 @@ en:
 
       Yours
       
-      {{current_user}}
+      {{assigned_officer}}
       Planning officer


### PR DESCRIPTION
### Description of change

Fixes a bug where the sign-off on the neighbour letter and email always default to the current user rather than the assigned officer.

### Story Link

https://trello.com/c/45pZjBJr/2650-incorrect-officer-name-on-neighbour-letters

