### PR TITLE
Allow only determined applications in API

### DIFF
--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -9,7 +9,7 @@ module Api
       skip_before_action :set_default_format, only: %i[decision_notice]
 
       def show
-        @planning_application = current_local_authority.planning_applications.where(id: params[:id]).first
+        @planning_application = current_local_authority.planning_applications.determined.where(id: params[:id]).first
         if @planning_application
           respond_to(:json)
         else

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -89,6 +89,7 @@ class PlanningApplication < ApplicationRecord
   scope :for_user_and_null_users, ->(user_id) { where(user_id: [user_id, nil]) }
   scope :prior_approvals, -> { joins(:application_type).where(application_type: {name: :prior_approval}) }
   scope :accepted, -> { where.not(status: "pending") }
+  scope :determined, -> { where(status: "determined") }
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create


### PR DESCRIPTION
### Description of change

Fixes the API call to display individual applications so it returns 404 for pre-determined applications.

### Story Link

https://trello.com/c/GdxDvWit/2555-swagger-retrieve-function-api-v1-planningapplications-id-states-it-returns-only-determined-planning-applications-when-it-infact

