### PR TITLE
Get rid of <strong> in email, doesn't work

### DIFF
--- a/app/views/planning_application_mailer/pre_commencement_condition_request_mail.text.erb
+++ b/app/views/planning_application_mailer/pre_commencement_condition_request_mail.text.erb
@@ -10,7 +10,7 @@ To review and accept or reject the changes, follow the link below:
 
 <%= @planning_application.secure_change_url %>
 
-If your response is not received by <strong><%= @validation_request.request_expiry_date.to_fs %></strong>, the proposed changes to your application will be automatically accepted. This is to avoid delays in making a determination on your application.
+If your response is not received by <%= @validation_request.request_expiry_date.to_fs %>, the proposed changes to your application will be automatically accepted. This is to avoid delays in making a determination on your application.
 
 Yours faithfully,
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the information about the validation request being auto accepted" do
       expect(mail_body).to include(
-        "If your response is not received by <strong>#{validation_request.request_expiry_date.to_fs}</strong>, the proposed changes to your application will be automatically accepted."
+        "If your response is not received by #{validation_request.request_expiry_date.to_fs}, the proposed changes to your application will be automatically accepted."
       )
       expect(mail_body).to include(
         "This is to avoid delays in making a determination on your application."


### PR DESCRIPTION
### Description of change

Get rid of `<strong>` in email, doesn't work