### PR TITLE
Add the ability to set the application type status

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -122,7 +122,7 @@ class ApplicationType < ApplicationRecord
     end
 
     def menu(scope = by_name)
-      scope.order(code: :asc).map do |application_type|
+      scope.active.order(code: :asc).map do |application_type|
         [application_type.description, application_type.id]
       end
     end

--- a/engines/bops_config/app/controllers/bops_config/application_types/statuses_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/statuses_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module ApplicationTypes
+    class StatusesController < ApplicationController
+      before_action :set_application_type
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @application_type.update(application_type_params)
+            format.html { redirect_to @application_type }
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def application_type_id
+        Integer(params[:application_type_id])
+      rescue
+        raise ActionController::BadRequest, "Invalid application type id: #{params[:application_type_id]}"
+      end
+
+      def application_type_params
+        params.require(:application_type).permit(:status)
+      end
+
+      def set_application_type
+        @application_type = ApplicationType.find(application_type_id)
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/views/bops_config/application_types/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= t(".update_application_type") %> - <%= t('page_title') %>
+  <%= t(".update_application_type") %> - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>

--- a/engines/bops_config/app/views/bops_config/application_types/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= t(".create_application_type") %> - <%= t('page_title') %>
+  <%= t(".create_application_type") %> - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= t(".review_application_type") %> - <%= t('page_title') %>
+  <%= t(".review_application_type") %> - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
@@ -42,6 +42,20 @@
             <%= link_to [:edit, @application_type], class: "govuk-link" do %>
               <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".suffix") %></span>
             <% end %>
+          <% end %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          <%= t(".status") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @application_type.status.humanize %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to [:edit, @application_type, :status], class: "govuk-link" do %>
+            <%= t(".edit") %><span class="govuk-visually-hidden"> <%= t(".status") %></span>
           <% end %>
         </dd>
       </div>

--- a/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  <%= t(".update_application_type_status") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".update_application_type_status") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_type, url: [@application_type, :status] do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+      <%= form.govuk_radio_buttons_fieldset :status, legend: {size: "l", tag: "h1", text: t(".update_application_type_status")} do %>
+        <% if @application_type.inactive? %>
+          <%= form.govuk_radio_button :status, "inactive", label: {text: t(".inactive")}, hint: {text: t(".inactive_hint")} %>
+        <% end %>
+
+        <%= form.govuk_radio_button :status, "active", label: {text: t(".active")}, hint: {text: t(".active_hint")} %>
+        <%= form.govuk_radio_button :status, "retired", label: {text: t(".retired")}, hint: {text: t(".retired_hint")} %>
+      <% end %>
+
+      <div class="button-row-group">
+        <%= form.govuk_submit t(".continue") %>
+        <%= link_to t(".cancel"), @application_type, class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -20,9 +20,22 @@ en:
       show:
         change: Change
         continue: Continue
+        edit: Edit
         name: Name
         review_application_type: Review the application type
+        status: Status
         suffix: Suffix
+      statuses:
+        edit:
+          active: Active
+          active_hint: Application type can be used to submit new planning application.
+          cancel: Cancel
+          continue: Continue
+          inactive: Inactive
+          inactive_hint: Application type is in the process of being configured and can't be used to submit planning applications.
+          retired: Retired
+          retired_hint: Application type was previously used to submit planning application but has been retired due to legislation changes, etc.
+          update_application_type_status: Update status
     dashboards:
       show:
         administrator_dashboard: Administrator dashboard

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -11,7 +11,11 @@ BopsConfig::Engine.routes.draw do
 
   resource :dashboard, only: %i[show]
 
-  resources :application_types
+  resources :application_types do
+    scope module: "application_types" do
+      resource :status, only: %i[edit update]
+    end
+  end
 
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -97,4 +97,66 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_selector("[role=alert] li", text: "The name can't be changed when the application type is retired")
     expect(page).to have_selector("[role=alert] li", text: "The suffix can't be changed when the application type is retired")
   end
+
+  it "allows activation of a new application type" do
+    application_type = create(:application_type, :ldc_proposed, status: "inactive")
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(3)" do
+      expect(page).to have_selector("dd", text: "Inactive")
+      click_link "Edit"
+    end
+
+    expect(page).to have_selector("h1", text: "Update status")
+
+    choose "Active"
+    click_button "Continue"
+
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(3) dd", text: "Active")
+  end
+
+  it "allows retirement of an application type" do
+    application_type = create(:application_type, :ldc_proposed, status: "active")
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(3)" do
+      expect(page).to have_selector("dd", text: "Active")
+      click_link "Edit"
+    end
+
+    expect(page).to have_selector("h1", text: "Update status")
+    expect(page).to have_no_field("Inactive")
+
+    choose "Retired"
+    click_button "Continue"
+
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(3) dd", text: "Retired")
+  end
+
+  it "allows an application type to be brought out of retirement" do
+    application_type = create(:application_type, :ldc_proposed, status: "retired")
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(3)" do
+      expect(page).to have_selector("dd", text: "Retired")
+      click_link "Edit"
+    end
+
+    expect(page).to have_selector("h1", text: "Update status")
+    expect(page).to have_no_field("Inactive")
+
+    choose "Active"
+    click_button "Continue"
+
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(3) dd", text: "Active")
+  end
 end


### PR DESCRIPTION
### Description of change

Adds a summary row with the application type status and a link to a page to update that status.

### Screenshots

**Summary Page**

![image](https://github.com/unboxed/bops/assets/6321/0e3cc130-8d15-45ee-bd32-56264c42a4a4)

**Form Page**

![image](https://github.com/unboxed/bops/assets/6321/391ae1ce-8bf1-4ce1-9049-89b08508a2f0)

### Decisions

Once an application type has been made active it can't be made inactive again - it has to be retired.