### PR TITLE
Add cancel action to time extensions

### DIFF
--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -201,7 +201,9 @@ module PlanningApplications
       end
 
       def cancel_redirect_url
-        if params.dig(:validation_request, :return_to)
+        if @validation_request.time_extension_request?
+          planning_application_path(@planning_application)
+        elsif params.dig(:validation_request, :return_to)
           params.dig(:validation_request, :return_to) ||
             @planning_application
         elsif @planning_application.validated?

--- a/app/views/planning_applications/validation/time_extension_validation_requests/_cancel_confirmation.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_cancel_confirmation.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  Cancel other validation request - <%= t('page_title') %>
+<% end %>
+
+<%= render "planning_applications/validation/validation_requests/validation_requests_breadcrumbs" %>
+
+<% content_for :title, "Cancel validation request" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Cancel time extension request
+    </h1>
+
+    <h2 class="govuk-heading-m">
+      Request to be cancelled
+    </h2>
+
+    <h3 class="govuk-heading-s">
+      You requested an extension to this application's expiry date <%= @validation_request.created_at.to_fs %>
+    </h3>
+
+    <%= render "planning_applications/validation/validation_requests/cancel_confirmation_form",
+               validation_request: @validation_request %>
+  </div>
+</div>

--- a/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
@@ -34,24 +34,10 @@
     </p>
 
     <% if @validation_request.open? %>
-      <%= form_with(
-        model: [@planning_application, @validation_request],
-        url: cancel_planning_application_validation_validation_request_path(
-          @planning_application,
-          @validation_request
-        ),
-        scope: :validation_request,
-        method: :patch
-      ) do |form| %>
-        <%= form.hidden_field(:return_to, value: @back_path) %>
-        <div class="govuk-button-group">
-          <%= link_to("Back", @back_path, class: "govuk-button") %>
-          <%= form.submit(
-            "Cancel this request",
-            class: "govuk-button govuk-button--secondary"
-          ) %>
-        </div>
-      <% end %>
+      <div class="govuk-button-group">
+        <%= link_to("Back", @back_path, class: "govuk-button") %>
+        <%= link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, @validation_request), class: "govuk-button govuk-button--secondary" %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -431,6 +431,8 @@ en:
       started: Application validated
       submitted: Recommendation submitted
       time_extension_validation_request_added: 'Added: time extension request'
+      time_extension_validation_request_cancelled: 'Cancelled: time extension request'
+      time_extension_validation_request_cancelled_post_validation: 'Cancelled: time extension request'
       time_extension_validation_request_received: 'Received: time extension request'
       time_extension_validation_request_sent_post_validation: 'Sent: time extension request'
       unarchived: Document unarchived
@@ -1551,6 +1553,8 @@ en:
             success: Red line boundary change request was successfully cancelled.
           replacement_document_validation_request:
             success: Replacement document validation request successfully cancelled.
+          time_extension_validation_request:
+            success: Time extension request successfully cancelled.
         create:
           additional_document_validation_request:
             success: Additional document request successfully created.

--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Requesting time extension to a planning application" do
     expect(page).to have_content(planning_application.reference)
   end
 
-  it "lets user create request" do
+  it "lets user create and cancel request" do
     visit "/planning_applications/#{planning_application.id}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
@@ -51,6 +51,15 @@ RSpec.describe "Requesting time extension to a planning application" do
     click_link("Extension requested")
 
     expect(page).to have_content("Review time extension request")
+
+    click_link("Cancel request")
+
+    expect(page).to have_content("You requested an extension")
+
+    fill_in "Explain to the applicant why this request is being cancelled", with: "We need more time"
+    click_button "Confirm cancellation"
+
+    expect(page).to have_content("Time extension request successfully cancelled.")
   end
 
   it "displays the expected error message when there is a time extension request already open" do


### PR DESCRIPTION
### Description of change

Allow officers to cancel an open time extension request. Unlike validation requests, the redirect on cancellation takes the user back to the main application page.

### Story Link

https://trello.com/c/nNApgOyZ/2515-as-a-planning-officer-i-need-to-be-able-to-request-an-extension-of-time-so-that-that-i-have-time-to-deal-with-new-more-informati
