### PR TITLE
Reduce noise in notifications channel by ignoring irrelevant exceptions

### DIFF
--- a/app/controllers/api/v1/heads_of_terms_validation_requests_controller.rb
+++ b/app/controllers/api/v1/heads_of_terms_validation_requests_controller.rb
@@ -41,8 +41,14 @@ module Api
 
       private
 
+      def validation_request_id
+        Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid validation request id: #{params[:id].inspect}"
+      end
+
       def set_heads_of_terms_validation_request
-        @heads_of_terms_validation_request = @planning_application.heads_of_terms_validation_requests.find(Integer(params[:id]))
+        @heads_of_terms_validation_request = @planning_application.heads_of_terms_validation_requests.find(validation_request_id)
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -39,12 +39,14 @@ class ApplicationController < ActionController::Base
     current_local_authority.planning_applications.accepted
   end
 
+  def planning_application_param
+    request.path_parameters.key?(:planning_application_id) ? :planning_application_id : :id
+  end
+
   def planning_application_id
-    if request.path_parameters.key?(:planning_application_id)
-      Integer(params[:planning_application_id].to_s)
-    else
-      Integer(params[:id].to_s)
-    end
+    Integer(params[planning_application_param])
+  rescue ArgumentError
+    raise ActionController::BadRequest, "Invalid planning application id: #{params[planning_application_param].inspect}"
   end
 
   def set_consultation

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -111,8 +111,14 @@ class DocumentsController < AuthenticationController
     @document = @planning_application.documents.find(document_id)
   end
 
+  def document_param
+    request.path_parameters.key?(:document_id) ? :document_id : :id
+  end
+
   def document_id
-    Integer(params[:document_id] || params[:id])
+    Integer(params[document_param])
+  rescue ArgumentError
+    raise ActionController::BadRequest, "Invalid document id: #{params[document_param].inspect}"
   end
 
   def ensure_document_edits_unlocked

--- a/app/controllers/os_places_api_controller.rb
+++ b/app/controllers/os_places_api_controller.rb
@@ -23,7 +23,13 @@ class OsPlacesApiController < ApplicationController
 
   private
 
+  def planning_application_id
+    Integer(params[:planning_application])
+  rescue ArgumentError
+    raise ActionController::BadRequest, "Invalid planning application id: #{params[:planning_application].inspect}"
+  end
+
   def set_planning_application
-    @planning_application = current_local_authority.planning_applications.find_by(id: Integer(params[:planning_application].to_s))
+    @planning_application = current_local_authority.planning_applications.find_by(id: planning_application_id)
   end
 end

--- a/app/controllers/planning_applications/assessment/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment/assessment_details_controller.rb
@@ -104,6 +104,8 @@ module PlanningApplications
 
       def assessment_detail_id
         Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid assessment detail id: #{params[:id].inspect}"
       end
 
       def assessment_details_params

--- a/app/controllers/planning_applications/assessment/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/assessment/heads_of_terms_controller.rb
@@ -43,8 +43,14 @@ module PlanningApplications
         @heads_of_term = @planning_application.heads_of_term
       end
 
+      def heads_of_term_id
+        Integer(params[:heads_of_term_id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid heads of terms id: #{params[:heads_of_term_id].inspect}"
+      end
+
       def set_heads_of_term
-        @term = @heads_of_term.terms.find(Integer(params[:heads_of_term_id]))
+        @term = @heads_of_term.terms.find(heads_of_term_id)
       end
 
       def heads_of_terms_params

--- a/app/controllers/planning_applications/assessment/recommendations_controller.rb
+++ b/app/controllers/planning_applications/assessment/recommendations_controller.rb
@@ -84,6 +84,8 @@ module PlanningApplications
 
       def recommendation_id
         Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid recommendation id: #{params[:id].inspect}"
       end
 
       def recommendation_params

--- a/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
+++ b/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
@@ -26,10 +26,14 @@ module PlanningApplications
 
       def constraint_id
         Integer(permitted_params[:constraint])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid constraint id: #{permitted_params[:constraint].inspect}"
       end
 
       def consultee_id
         Integer(permitted_params[:consultee])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid consultee id: #{permitted_params[:consultee].inspect}"
       end
 
       def permitted_params

--- a/app/controllers/planning_applications/consultee/responses_controller.rb
+++ b/app/controllers/planning_applications/consultee/responses_controller.rb
@@ -55,6 +55,8 @@ module PlanningApplications
 
       def consultee_id
         Integer(params[:consultee_id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid consultee id: #{params[:consultee_id].inspect}"
       end
 
       def set_consultees
@@ -67,6 +69,8 @@ module PlanningApplications
 
       def consultee_response_id
         Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid consultee response id: #{params[:id].inspect}"
       end
 
       def consultee_response_params

--- a/app/controllers/planning_applications/consultees_controller.rb
+++ b/app/controllers/planning_applications/consultees_controller.rb
@@ -22,10 +22,17 @@ module PlanningApplications
     end
 
     def index
+      respond_to do |format|
+        format.html
+      end
     end
 
     def new
-      @constraint = PlanningApplicationConstraint.find(Integer(params[:constraint]))
+      @constraint = PlanningApplicationConstraint.find(constraint_id)
+
+      respond_to do |format|
+        format.html
+      end
     end
 
     private
@@ -38,8 +45,16 @@ module PlanningApplications
       @consultee = @consultees.find(consultee_id)
     end
 
+    def constraint_id
+      Integer(params[:constraint])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid constraint id: #{params[:constraint].inspect}"
+    end
+
     def consultee_id
       Integer(params[:id])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid consultee id: #{params[:id].inspect}"
     end
 
     def consultee_params

--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -62,7 +62,9 @@ module PlanningApplications
     private
 
     def neighbour_id
-      Integer(params[:id].to_s)
+      Integer(params[:id])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid neighbour id: #{params[:id].inspect}"
     end
 
     def set_neighbour

--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -77,8 +77,14 @@ module PlanningApplications
       ).select(&:persisted?)
     end
 
+    def neighbour_response_id
+      Integer(params[:id])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid neighbour response id: #{params[:id].inspect}"
+    end
+
     def set_neighbour_response
-      @neighbour_response = @consultation.neighbour_responses.find(Integer(params[:id]))
+      @neighbour_response = @consultation.neighbour_responses.find(neighbour_response_id)
     end
 
     def neighbour_response_params

--- a/app/controllers/planning_applications/neighbours_controller.rb
+++ b/app/controllers/planning_applications/neighbours_controller.rb
@@ -54,7 +54,9 @@ module PlanningApplications
     private
 
     def neighbour_id
-      Integer(params[:id].to_s)
+      Integer(params[:id])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid neighbour id: #{params[:id].inspect}"
     end
 
     def set_neighbour

--- a/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
@@ -34,8 +34,14 @@ module PlanningApplications
       )
     end
 
+    def neighbour_response_id
+      Integer(params[:id])
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid neighbour response id: #{params[:id].inspect}"
+    end
+
     def set_neighbour_response
-      @neighbour_response = @consultation.neighbour_responses.find(Integer(params[:id]))
+      @neighbour_response = @consultation.neighbour_responses.find(neighbour_response_id)
     end
 
     def neighbour_responses_path

--- a/app/controllers/planning_applications/validation/constraints_controller.rb
+++ b/app/controllers/planning_applications/validation/constraints_controller.rb
@@ -66,6 +66,8 @@ module PlanningApplications
 
       def constraint_ids
         @constraint_ids ||= Array.wrap(params[:constraint_ids]).map { |id| Integer(id) }
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid constraint ids: #{params[:constraint_ids].inspect}"
       end
 
       def existing_constraint_ids

--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -218,7 +218,9 @@ module PlanningApplications
       end
 
       def validation_request_id
-        Integer(params[:id].to_s)
+        Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid validation request ids: #{params[:id].inspect}"
       end
 
       def set_type

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -19,6 +19,7 @@ default: &defaults
     - ActionDispatch::Http::MimeNegotiation::InvalidType
     - ActionController::BadRequest
     - ActionController::InvalidAuthenticityToken
+    - ActionController::ParameterMissing
     - ActionController::RoutingError
     - ActionController::UnknownFormat
     - ActionController::UnknownHttpMethod

--- a/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
@@ -27,7 +27,7 @@ module BopsApi
       end
 
       def show
-        @planning_application = planning_applications_scope.find(Integer(params[:id]))
+        @planning_application = planning_applications_scope.find(planning_application_id)
 
         respond_to do |format|
           format.json
@@ -43,6 +43,12 @@ module BopsApi
       end
 
       private
+
+      def planning_application_id
+        Integer(params[:id])
+      rescue ArgumentError
+        raise ActionController::BadRequest, "Invalid planning application id: #{params[:id].inspect}"
+      end
 
       def send_email
         query_parameters[:send_email] == "true"


### PR DESCRIPTION
These are due to malformed requests and there's nothing we can do other than return a `400 Bad Request` error.