### PR TITLE
Avoid exception when find_by tag returns nil

### DIFF
--- a/engines/bops_api/app/jobs/bops_api/upload_document_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/upload_document_job.rb
@@ -13,15 +13,18 @@ module BopsApi
       file = user.file_downloader.get(url)
       name = URI.decode_uri_component(File.basename(URI.parse(url).path))
 
-      tags = tags.compact
-
       planning_application.documents.create! do |document|
         document.tags = tags
         document.applicant_description = description
         document.file.attach(io: file.open, filename: name)
 
-        tags.any? do |tag|
-          document.document_checklist_items_id = planning_application.document_checklist.document_checklist_items.find_by(tags: tag).id
+        document_checklist = planning_application.document_checklist
+
+        tags.each do |tag|
+          next if tag.blank?
+          next unless (item = document_checklist.document_checklist_items.find_by(tags: tag))
+
+          document.document_checklist_items_id = item.id
         end
       end
     end

--- a/engines/bops_api/spec/jobs/upload_document_job_spec.rb
+++ b/engines/bops_api/spec/jobs/upload_document_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BopsApi::UploadDocumentJob, type: :job do
     [planning_application, user, url, tags, description]
   end
 
-  let(:planning_application) { create(:planning_application) }
+  let(:planning_application) { create(:planning_application, document_checklist: DocumentChecklist.new) }
   let(:user) { create(:api_user) }
   let(:url) { "https://example.com/path/to/file.pdf" }
   let(:tags) { %w[sitePlan.proposed] }
@@ -27,8 +27,6 @@ RSpec.describe BopsApi::UploadDocumentJob, type: :job do
     before do
       stub_request(:get, url).to_return(status: 200, body: "")
     end
-
-    let(:tags) { [nil] }
 
     it "does not raise an error" do
       expect {

--- a/engines/bops_api/spec/jobs/upload_document_job_spec.rb
+++ b/engines/bops_api/spec/jobs/upload_document_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BopsApi::UploadDocumentJob, type: :job do
     [planning_application, user, url, tags, description]
   end
 
-  let(:planning_application) { create(:planning_application, document_checklist: DocumentChecklist.new) }
+  let(:planning_application) { create(:planning_application) }
   let(:user) { create(:api_user) }
   let(:url) { "https://example.com/path/to/file.pdf" }
   let(:tags) { %w[sitePlan.proposed] }

--- a/spec/factories/document_checklist.rb
+++ b/spec/factories/document_checklist.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :document_checklist do
+  end
+end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -87,6 +87,11 @@ FactoryBot.define do
       ]
     end
 
+    after(:create) do |planning_application|
+      planning_application.document_checklist = create(:document_checklist, planning_application:)
+      planning_application.save!
+    end
+
     trait :awaiting_determination do
       status { :awaiting_determination }
       awaiting_determination_at { Time.zone.now }


### PR DESCRIPTION
https://trello.com/c/wsWuZP9c/2692-planx-submissions-without-document-tags-cause-an-error