### PR TITLE
Fix map not showing

### DIFF
--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -23,7 +23,7 @@
     markerLatitude="<%= @planning_application.latitude %>"
     markerLongitude="<%= @planning_application.longitude %>"
     markerImage="circle"
-    <% if @planning_application.neighbour_boundary_geojson %>
+    <% if @planning_application.neighbour_boundary_geojson && !locals[:invalid_red_line_boundary].present? %>
       showGeojsonDataMarkers
     <% end %>
   <% end %>


### PR DESCRIPTION
When redrawing for red line validation request, map was not showing. 

Think it's something to do with the geojson data at this point, but this fixes it for now and still shows the neighbour points when you get to consultation
