### PR TITLE
Add rejection reason to time extension

### DIFF
--- a/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
@@ -29,7 +29,15 @@
       <% if @validation_request.open? %>
         Sent on <%= @validation_request.created_at.to_date.to_fs %>. Agent or applicant has not yet responded.
       <% else %>
+        <strong>Status:</strong><br>
         <%= @validation_request.approved? ? 'Approved' : 'Rejected' %>
+      <% end %>
+    </p>
+
+    <p class="govuk-body">
+      <% if @validation_request.rejected? && @validation_request.reason.present? %>
+        <strong>Rejection reason:</strong><br>
+        <%= @validation_request.rejection_reason %>
       <% end %>
     </p>
 

--- a/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
@@ -35,7 +35,7 @@
     </p>
 
     <p class="govuk-body">
-      <% if @validation_request.rejected? && @validation_request.reason.present? %>
+      <% if @validation_request.rejected? %>
         <strong>Rejection reason:</strong><br>
         <%= @validation_request.rejection_reason %>
       <% end %>

--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -102,4 +102,13 @@ RSpec.describe "Requesting time extension to a planning application" do
     expect(page).to have_content("Activity log")
     expect(page).to have_content("Sent")
   end
+
+  it "displays the rejection reason when applicant rejects the request" do
+    rejected_request = create(:time_extension_validation_request, :closed, approved: false, planning_application: planning_application, reason: "Took too long", rejection_reason: "I can't wait any longer")
+
+    visit "/planning_applications/#{planning_application.id}/validation/validation_requests/#{rejected_request.id}"
+
+    expect(page).to have_content("Rejected")
+    expect(page).to have_content("I can't wait any longer")
+  end
 end


### PR DESCRIPTION
### Description of change

Small fix to time extension story to ensure rejection reason is displayed on the show page

### Story Link

https://trello.com/c/nNApgOyZ/2515-as-a-planning-officer-i-need-to-be-able-to-request-an-extension-of-time-so-that-that-i-have-time-to-deal-with-new-more-informati

![rejection](https://github.com/unboxed/bops/assets/1880450/73e69d1f-902e-4694-aa1e-f5587c7db2a3)
