### PR TITLE
Reviewer can review neighbour notifications

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -2,6 +2,8 @@
 
 module PlanningApplications
   class NeighbourLettersController < AuthenticationController
+    include CommitMatchable
+
     before_action :set_planning_application
     before_action :set_consultation
     before_action :set_neighbour, only: %i[update destroy]
@@ -44,6 +46,7 @@ module PlanningApplications
         update_consultation!
         deliver_letters!
         send_neighbour_consultation_letter_copy
+        create_review!
         record_audit_for_letters_sent!
       end
 
@@ -142,6 +145,10 @@ module PlanningApplications
 
     def resend_reason
       consultation_params[:resend_reason] if resend_existing?
+    end
+
+    def create_review!
+      @consultation.create_neighbour_review! if @consultation.neighbour_review.blank? || @consultation.neighbour_review.to_be_reviewed?
     end
 
     def redirect_after_rescue(error)

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -11,7 +11,16 @@ module PlanningApplications
       before_action :set_consultation
       before_action :set_neighbour_review
 
-      def index
+      def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
       end
 
       def update
@@ -20,7 +29,7 @@ module PlanningApplications
             if @neighbour_review.update(review_params) && @consultation.update(status: consultation_status)
               redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
             else
-              render :index
+              render :edit
             end
           end
         end
@@ -34,7 +43,7 @@ module PlanningApplications
             if @neighbour_review.save && @consultation.update(status: consultation_status)
               redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
             else
-              render :index
+              render :edit
             end
           end
         end

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -17,7 +17,7 @@ module PlanningApplications
       def update
         respond_to do |format|
           format.html do
-            if @neighbour_review.update(review_params)
+            if @neighbour_review.update(review_params) && @consultation.update(status: consultation_status)
               redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
             else
               render :index
@@ -31,7 +31,7 @@ module PlanningApplications
 
         respond_to do |format|
           format.html do
-            if @neighbour_review.save
+            if @neighbour_review.save && @consultation.update(status: consultation_status)
               redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
             else
               render :index
@@ -59,6 +59,14 @@ module PlanningApplications
           :to_be_reviewed
         elsif mark_as_complete?
           :complete
+        end
+      end
+
+      def consultation_status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          @consultation.status
         end
       end
 

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Review
+    class NeighbourResponsesController < AuthenticationController
+      include CommitMatchable
+
+      rescue_from ::Review::NotCreatableError, with: :redirect_failed_create_error
+
+      before_action :set_planning_application
+      before_action :set_consultation
+      before_action :set_neighbour_review
+
+      def index
+      end
+
+      def update
+        respond_to do |format|
+          format.html do
+            if @neighbour_review.update(review_params)
+              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+            else
+              render :index
+            end
+          end
+        end
+      end
+
+      def create
+        @neighbour_review = @consultation.reviews.new(review_params.merge(specific_attributes: {consultation_type: "neighbour"}))
+
+        respond_to do |format|
+          format.html do
+            if @neighbour_review.save
+              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+            else
+              render :index
+            end
+          end
+        end
+      end
+
+      private
+
+      def review_params
+        params.require(:review).permit(
+          :action, :comment, :id
+        ).to_h
+          .deep_merge(
+            reviewed_at: Time.current,
+            reviewer: current_user,
+            status:,
+            review_status:
+          )
+      end
+
+      def status
+        if return_to_officer?
+          :to_be_reviewed
+        elsif mark_as_complete?
+          :complete
+        end
+      end
+
+      def return_to_officer?
+        params.dig(:review, :action) == "rejected"
+      end
+
+      def review_status
+        save_progress? ? "review_in_progress" : "review_complete"
+      end
+
+      def set_neighbour_review
+        @neighbour_review = @consultation.neighbour_review || @consultation.reviews.new
+      end
+
+      def redirect_failed_create_error(error)
+        redirect_to planning_application_review_tasks_path(@planning_application), alert: error.message
+      end
+    end
+  end
+end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -111,7 +111,8 @@ class Consultation < ApplicationRecord
   enum status: {
     not_started: "not_started",
     in_progress: "in_progress",
-    complete: "complete"
+    complete: "complete",
+    to_be_reviewed: "to_be_reviewed"
   }
 
   before_update :audit_letter_copy_sent!, if: :letter_copy_sent_at_changed?

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -49,6 +49,11 @@ class Consultation < ApplicationRecord
     has_many :neighbour_responses
   end
 
+  has_many :reviews, as: :owner, dependent: :destroy
+  has_many :neighbour_reviews, -> { where(specific_attributes: {consultation_type: "neighbour"}) }, as: :owner, class_name: "Review", dependent: :destroy
+
+  accepts_nested_attributes_for :reviews
+
   with_options if: :start_date do
     validates :end_date,
       presence: true,
@@ -192,7 +197,9 @@ class Consultation < ApplicationRecord
   end
 
   def neighbour_letters_status
-    if neighbour_letters.failed.present?
+    if neighbour_review&.to_be_reviewed?
+      "to_be_reviewed"
+    elsif neighbour_letters.failed.present?
       "failed"
     elsif neighbour_letters.sent.present?
       "complete"
@@ -369,6 +376,14 @@ class Consultation < ApplicationRecord
 
   def needs_site_visit?
     planning_application.prior_approval? ? neighbour_responses.objection.any? : planning_application.application_type.site_visits?
+  end
+
+  def neighbour_review
+    neighbour_reviews.order(:created_at).last
+  end
+
+  def create_neighbour_review!
+    reviews.create!(specific_attributes: {consultation_type: "neighbour"}, status: "complete", assessor: Current.user)
   end
 
   private

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -542,7 +542,8 @@ class PlanningApplication < ApplicationRecord
     assessment_details_for_review.any?(&:update_required?) ||
       permitted_development_right&.update_required? ||
       policy_classes.any?(&:update_required?) ||
-      (committee_decision.present? && committee_decision.current_review.rejected?)
+      (committee_decision.present? && committee_decision.current_review.rejected?) ||
+      neighbour_review_requested?
   end
 
   def review_in_progress?
@@ -1054,5 +1055,9 @@ class PlanningApplication < ApplicationRecord
     tags = Document::TAGS_MAP[tab]
 
     documents.select { |document| (tags & document.tags).any? }
+  end
+
+  def neighbour_review_requested?
+    consultation.present? && consultation.reviews.any? { |review| review.to_be_reviewed? }
   end
 end

--- a/app/views/planning_applications/neighbour_letters/index.html.erb
+++ b/app/views/planning_applications/neighbour_letters/index.html.erb
@@ -30,6 +30,18 @@
   </div>
 <% end %>
 
+<% if @consultation.neighbour_review&.to_be_reviewed? %>
+  <div class="govuk-inset-text" %>
+    <h3 class="govuk-heading-s">
+      Reviewer requested changes
+    </h3>
+
+    <p class="govuk-body">
+      <%= @consultation.neighbour_review.comment %>
+    </p>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with(

--- a/app/views/planning_applications/review/neighbour_responses/_form.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [@consultation, @neighbour_review], url: planning_application_review_consultation_neighbour_responses_path(@planning_application) do |form| %>
+  <%= form.govuk_radio_buttons_fieldset(:action, legend: { size: 'm', text: 'Do you accept that notifications have been completed within the correct period?' }) do %>
+    <% if @consultation.start_date && @consultation.end_date %>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the consultation period for this application is <%= (@consultation.end_date - @consultation.start_date).to_i %> days</li>
+        <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
+        <li>the consultation expiry date for this application is <%= @consultation.end_date.to_date.to_fs %></li>
+      </ul>
+    <% else %>
+      <p class="govuk-body">The consultation has not been started</p>
+    <% end %>
+    <%= form.govuk_radio_button :action, 'accepted', label: { text: 'Accept' }, disabled: disabled, link_errors: true %>
+    <%= form.govuk_radio_button :action, 'rejected', label: { text: 'Return to officer with comment' }, disabled: disabled do %>
+      <%= form.govuk_text_area :comment, label: { text: 'Explain why notifications are incomplete.' }, disabled: disabled %>
+    <% end %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <% unless disabled %>
+      <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+    <% end %>
+    <%= back_link %>
+
+    <% if disabled %>
+      <%= link_to "Edit review neighbour responses", edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-body govuk-link" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/review/neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/edit.html.erb
@@ -1,0 +1,80 @@
+<% content_for :page_title do %>
+  Check neighbour notifications - <%= t("page_title") %>
+<% end %>
+<% render(
+  partial: "shared/review_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: "Check neighbour notifications"
+  }
+) %>
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Check neighbour notifications" }
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <%= render(
+      partial: "shared/location_map",
+      locals: {
+        locals: {
+          in_accordion: false,
+          geojson: @planning_application.neighbour_geojson,
+          geojson_field: "consultation-polygon-geojson-field"
+        }
+      }
+    ) %>
+
+    <% if @consultation.neighbours.any? %>
+      <table class="govuk-table govuk-!-margin-top-6">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Address list</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Source</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Last contacted</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @consultation.neighbours.each do |neighbour| %>
+            <% next if neighbour.sent_comment? %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell govuk-!-width-one-third">
+                  <%= neighbour.address %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= neighbour.source&.humanize %>
+                </td>
+                <td class="govuk-table__cell">
+                  <% if neighbour.last_letter.blank? %>
+                    <%= render(StatusTags::LetterComponent.new(status: "new")) %>
+                  <% else %>
+                    <%= render(StatusTags::LetterComponent.new(status: NeighbourLetter::STATUSES[neighbour.last_letter.status&.to_sym])) %>
+                  <% end %>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-width-one-quarter">
+                  <% if neighbour.last_letter.blank? %>
+                    -
+                  <% elsif neighbour.last_letter.status_updated_at.present? %>
+                    <%= neighbour.last_letter.status_updated_at.to_date.to_fs(:day_month_year_slashes) %>
+                  <% else %>
+                    <%= neighbour.last_letter.created_at.to_fs(:day_month_year_slashes) %>
+                  <% end %>
+                </td>
+              </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      No neighbours were consulted
+    <% end %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", disabled: false %>
+  </div>
+</div>

--- a/app/views/planning_applications/review/neighbour_responses/index.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/index.html.erb
@@ -1,0 +1,102 @@
+<% content_for :page_title do %>
+  Check neighbour notifications - <%= t("page_title") %>
+<% end %>
+<% render(
+  partial: "shared/review_task_breadcrumbs",
+  locals: {
+    planning_application: @planning_application,
+    current_page: "Check neighbour notifications"
+  }
+) %>
+<%= render(
+  partial: "shared/proposal_header",
+  locals: { heading: "Check neighbour notifications" }
+) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <%= render(
+      partial: "shared/location_map",
+      locals: {
+        locals: {
+          in_accordion: false,
+          geojson: @planning_application.neighbour_geojson,
+          geojson_field: "consultation-polygon-geojson-field"
+        }
+      }
+    ) %>
+
+    <% if @consultation.neighbours.any? %>
+      <table class="govuk-table govuk-!-margin-top-6">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-half">Address list</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Source</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Last contacted</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @consultation.neighbours.each do |neighbour| %>
+            <% next if neighbour.sent_comment? %>
+              <tr class="govuk-table__row">
+                <td class="govuk-table__cell govuk-!-width-one-third">
+                  <%= neighbour.address %>
+                </td>
+                <td class="govuk-table__cell">
+                  <%= neighbour.source&.humanize %>
+                </td>
+                <td class="govuk-table__cell">
+                  <% if neighbour.last_letter.blank? %>
+                    <%= render(StatusTags::LetterComponent.new(status: "new")) %>
+                  <% else %>
+                    <%= render(StatusTags::LetterComponent.new(status: NeighbourLetter::STATUSES[neighbour.last_letter.status&.to_sym])) %>
+                  <% end %>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--numeric govuk-!-width-one-quarter">
+                  <% if neighbour.last_letter.blank? %>
+                    -
+                  <% elsif neighbour.last_letter.status_updated_at.present? %>
+                    <%= neighbour.last_letter.status_updated_at.to_date.to_fs(:day_month_year_slashes) %>
+                  <% else %>
+                    <%= neighbour.last_letter.created_at.to_fs(:day_month_year_slashes) %>
+                  <% end %>
+                </td>
+              </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      No neighbours were consulted
+    <% end %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with model: [@consultation, @neighbour_review], url: planning_application_review_consultation_neighbour_responses_path(@planning_application) do |form| %>
+      <%= form.govuk_radio_buttons_fieldset(:action, legend: { size: 'm', text: 'Do you accept that notifications have been completed within the correct period?' }) do %>
+        <% if @consultation.start_date && @consultation.end_date %>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>the consultation period for this application is <%= (@consultation.end_date - @consultation.start_date).to_i %> days</li>
+            <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
+            <li>the consultation expiry date for this application is <%= @consultation.end_date.to_date.to_fs %></li>
+          </ul>
+        <% else %>
+          <p class="govuk-body">The consultation has not been started</p>
+        <% end %>
+        <%= form.govuk_radio_button :action, 'accepted', label: { text: 'Accept' }, link_errors: true %>
+        <%= form.govuk_radio_button :action, 'rejected', label: { text: 'Return to officer with comment' } do %>
+          <%= form.govuk_text_area :comment, label: { text: 'Explain why notifications are incomplete.' } %>
+        <% end %>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
+        <%= back_link %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_applications/review/neighbour_responses/show.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/show.html.erb
@@ -75,28 +75,6 @@
   </div>
 
   <div class="govuk-grid-column-two-thirds">
-
-    <%= form_with model: [@consultation, @neighbour_review], url: planning_application_review_consultation_neighbour_responses_path(@planning_application) do |form| %>
-      <%= form.govuk_radio_buttons_fieldset(:action, legend: { size: 'm', text: 'Do you accept that notifications have been completed within the correct period?' }) do %>
-        <% if @consultation.start_date && @consultation.end_date %>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>the consultation period for this application is <%= (@consultation.end_date - @consultation.start_date).to_i %> days</li>
-            <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
-            <li>the consultation expiry date for this application is <%= @consultation.end_date.to_date.to_fs %></li>
-          </ul>
-        <% else %>
-          <p class="govuk-body">The consultation has not been started</p>
-        <% end %>
-        <%= form.govuk_radio_button :action, 'accepted', label: { text: 'Accept' }, link_errors: true %>
-        <%= form.govuk_radio_button :action, 'rejected', label: { text: 'Return to officer with comment' } do %>
-          <%= form.govuk_text_area :comment, label: { text: 'Explain why notifications are incomplete.' } %>
-        <% end %>
-      <% end %>
-
-      <div class="govuk-button-group">
-        <%= form.submit "Save and mark as complete", class: "govuk-button", data: { module: "govuk-button" } %>
-        <%= back_link %>
-      </div>
-    <% end %>
+    <%= render "form", disabled: true %>
   </div>
 </div>

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -1,0 +1,93 @@
+<h2 class="app-task-list__section govuk-!-margin-top-8">
+  Review assessment
+</h2>
+<span class="govuk-body govuk-!-font-weight-bold">
+  Assessor recommendation
+  <%= render(
+  StatusTags::DecisionComponent.new(
+    planning_application: @planning_application
+  )
+) %>
+</span>
+<ul class="app-task-list__items" id="review-assessment-section">
+  <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.evidence.any? %>
+      <%= render(
+        TaskListItems::Reviewing::ImmunityDetailsComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
+  <% end %>
+  <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.enforcement.any? %>
+      <%= render(
+        TaskListItems::Reviewing::ImmunityEnforcementComponent.new(
+          planning_application: @planning_application
+        )
+      ) %>
+  <% end %>
+  <% if @planning_application.review_permitted_development_rights? %>
+    <%= render(
+      TaskListItems::Reviewing::PermittedDevelopmentRightComponent.new(
+        planning_application: @planning_application
+      )
+    ) %>
+  <% end %>
+  <%= render(
+    TaskListItems::Reviewing::AssessmentDetailsComponent.new(
+      planning_application: @planning_application,
+    )
+  )%>
+  <% if @planning_application.local_policy.present? %>
+    <%= render(
+      TaskListItems::Reviewing::LocalPolicyComponent.new(
+        planning_application: @planning_application,
+      )
+    )%>
+  <% end %>
+  <% if @planning_application.application_type.planning_conditions? %>
+    <% if @planning_application.condition_set.present? && @planning_application.condition_set.current_review&.status != "not_started" %>
+      <%= render(
+        TaskListItems::Reviewing::ConditionComponent.new(
+          condition_set: @planning_application.condition_set,
+        )
+      )%>
+    <% end %>
+  <% end %>
+
+  <%= render partial: "policy_classes", locals: { planning_application: @planning_application, policy_class: @policy_class } %>
+
+  <% if @planning_application.committee_decision.present? %>
+    <%= render(
+      TaskListItems::Reviewing::CommitteeComponent.new(
+        planning_application: @planning_application,
+      )
+    )%>
+  <% end %>
+
+  <%= render "sign_off_recommendation" %>
+
+  <% if @planning_application.committee_decision.present? && @planning_application.committee_decision.recommend? %>
+    <%= render(
+      TaskListItems::Reviewing::NotifyCommitteeComponent.new(
+        planning_application: @planning_application,
+      )
+    )%>
+  <% end %>
+
+  <% if @planning_application.committee_decision.present? && @planning_application.committee_decision.recommend? %>
+    <li class="app-task-list__item">
+      <span class="app-task-list__task-name">
+        <%= link_to_if(
+              @planning_application.in_committee?,
+              "Add committee decision",
+              edit_planning_application_review_recommendation_path(@planning_application, @planning_application.recommendation),
+              aria: { describedby: "review_assessment-completed" },
+              class: "govuk-link") %>
+      </span>
+      <%= render(
+            StatusTags::AddCommitteeDecisionComponent.new(
+              planning_application: @planning_application
+            )
+      )%>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -6,7 +6,9 @@
     <span class="app-task-list__task-name">
       <%= link_to(
             "Check neighbour notifications",
-            planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation),
+            (@planning_application.consultation&.neighbour_review&.review_complete? ?
+              planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation) :
+              edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation)),
             class: "govuk-link") %>
     </span>
     <%= render(

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -1,0 +1,18 @@
+<h2 class="app-task-list__section govuk-!-margin-top-8">
+  Review consultation
+</h2>
+<ul class="app-task-list__items" id="review-consultation-section">
+  <li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+      <%= link_to(
+            "Check neighbour notifications",
+            planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation),
+            class: "govuk-link") %>
+    </span>
+    <%= render(
+          StatusTags::BaseComponent.new(
+            status: (@planning_application.consultation.neighbour_review.present? ? @planning_application.consultation.neighbour_review.review_status : :not_started)
+          )
+    )%>
+  </li>
+</ul>

--- a/app/views/planning_applications/review/tasks/index.html.erb
+++ b/app/views/planning_applications/review/tasks/index.html.erb
@@ -21,99 +21,12 @@
     <%= render(
       AccordionComponent.new(planning_application: @planning_application)
     ) %>
-    <h2 class="app-task-list__section govuk-!-margin-top-8">
-      Review assessment
-    </h2>
-    <span class="govuk-body govuk-!-font-weight-bold">
-      Assessor recommendation
-      <%= render(
-      StatusTags::DecisionComponent.new(
-        planning_application: @planning_application
-      )
-    ) %>
-    </span>
-    <ul class="app-task-list__items" id="review-assessment-section">
-      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.evidence.any? %>
-          <%= render(
-            TaskListItems::Reviewing::ImmunityDetailsComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-      <% end %>
-      <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.enforcement.any? %>
-          <%= render(
-            TaskListItems::Reviewing::ImmunityEnforcementComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-      <% end %>
-      <% if @planning_application.review_permitted_development_rights? %>
-        <%= render(
-          TaskListItems::Reviewing::PermittedDevelopmentRightComponent.new(
-            planning_application: @planning_application
-          )
-        ) %>
-      <% end %>
-      <%= render(
-        TaskListItems::Reviewing::AssessmentDetailsComponent.new(
-          planning_application: @planning_application,
-        )
-      )%>
-      <% if @planning_application.local_policy.present? %>
-        <%= render(
-          TaskListItems::Reviewing::LocalPolicyComponent.new(
-            planning_application: @planning_application,
-          )
-        )%>
-      <% end %>
-      <% if @planning_application.application_type.planning_conditions? %>
-        <% if @planning_application.condition_set.present? && @planning_application.condition_set.current_review&.status != "not_started" %>
-          <%= render(
-            TaskListItems::Reviewing::ConditionComponent.new(
-              condition_set: @planning_application.condition_set,
-            )
-          )%>
-        <% end %>
-      <% end %>
 
-      <%= render partial: "policy_classes", locals: { planning_application: @planning_application, policy_class: @policy_class } %>
+    <% if @planning_application.application_type.consultation? %>
+      <%= render "review_consultation" %>
+    <% end %>
 
-      <% if @planning_application.committee_decision.present? %>
-        <%= render(
-          TaskListItems::Reviewing::CommitteeComponent.new(
-            planning_application: @planning_application,
-          )
-        )%>
-      <% end %>
-
-      <%= render "sign_off_recommendation" %>
-
-      <% if @planning_application.committee_decision.present? && @planning_application.committee_decision.recommend? %>
-        <%= render(
-          TaskListItems::Reviewing::NotifyCommitteeComponent.new(
-            planning_application: @planning_application,
-          )
-        )%>
-      <% end %>
-
-      <% if @planning_application.committee_decision.present? && @planning_application.committee_decision.recommend? %>
-        <li class="app-task-list__item">
-          <span class="app-task-list__task-name">
-            <%= link_to_if(
-                  @planning_application.in_committee?,
-                  "Add committee decision",
-                  edit_planning_application_review_recommendation_path(@planning_application, @planning_application.recommendation),
-                  aria: { describedby: "review_assessment-completed" },
-                  class: "govuk-link") %>
-          </span>
-          <%= render(
-                StatusTags::AddCommitteeDecisionComponent.new(
-                  planning_application: @planning_application
-                )
-          )%>
-        </li>
-      <% end %>
-    </ul>
+    <%= render "review_assessment" %>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,8 +261,10 @@ en:
               updates_required: You have requested officer changes, resolve these before agreeing with the recommendation
         review:
           attributes:
-            reviewer_comment:
-              blank: Reviewer comment must be added
+            action:
+              blank: Select an option
+            comment:
+              blank: Explain to the case officer why
         review_policy_class:
           attributes:
             base:
@@ -1357,6 +1359,11 @@ en:
           success: Documents were successfully updated.
       immunity_details:
         successfully_updated: Review immunity details was successfully updated
+      neighbour_responses:
+        create:
+          success: Review of neighbour responses successfully added
+        update:
+          success: Review of neighbour responses successfully added
       notifications:
         update:
           success: Notifications sent to neighbours and application in committee

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -225,6 +225,13 @@ Rails.application.routes.draw do
             patch :update, on: :collection
           end
 
+          resources :consultation do
+            resources :neighbour_responses, only: %i[index] do
+              patch :update, on: :collection
+              post :create, on: :collection
+            end
+          end
+
           resources :immunity_details, only: %i[edit update show]
 
           resources :immunity_enforcements, only: %i[show edit update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,7 +226,9 @@ Rails.application.routes.draw do
           end
 
           resources :consultation do
-            resources :neighbour_responses, only: %i[index] do
+            resource :neighbour_responses do
+              get :edit, on: :collection
+              get :show, on: :collection
               patch :update, on: :collection
               post :create, on: :collection
             end

--- a/spec/components/reviewing/policy_class/link_component_spec.rb
+++ b/spec/components/reviewing/policy_class/link_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Reviewing::PolicyClass::LinkComponent, type: :component do
   end
 
   it "displays show link when status complete" do
-    review_policy_class.update(review_status: "review_complete")
+    review_policy_class.update(review_status: "review_complete", action: "accepted")
     render_inline(described_class.new(policy_class: policy_class.reload))
 
     expect(page).to have_link("Review assessment of Part 1, Class D",

--- a/spec/factories/review.rb
+++ b/spec/factories/review.rb
@@ -5,6 +5,12 @@ FactoryBot.define do
     assessor { association :user, :assessor }
     owner { association :policy_class }
 
+    before :create do |review|
+      if review.review_complete?
+        review.action = "accepted"
+      end
+    end
+
     trait :evidence do
       specific_attributes do
         {

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2137,6 +2137,17 @@ RSpec.describe PlanningApplication do
         expect(planning_application.updates_required?).to be(true)
       end
     end
+
+    context "when changes to the neighbour responses requested" do
+      before do
+        consultation = create(:consultation, planning_application:)
+        create(:review, owner: consultation, status: "to_be_reviewed")
+      end
+
+      it "returns true" do
+        expect(planning_application.updates_required?).to be(true)
+      end
+    end
   end
 
   describe "#review_in_progress?" do

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check neighbour notifications" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:planning_application) do
+    create(:planning_application, :planning_permission, :awaiting_determination, local_authority: default_local_authority, user: assessor, make_public: true)
+  end
+  let!(:recommendation) { create(:recommendation, planning_application:) }
+  let!(:consultation) { planning_application.consultation }
+
+  before do
+    allow(Current).to receive(:user).and_return(reviewer)
+
+    sign_in reviewer
+  end
+
+  context "when the planning application's type does not include consultation" do
+    let!(:planning_application) do
+      create(:planning_application, :awaiting_determination, local_authority: default_local_authority, user: assessor)
+    end
+
+    it "does not show the option to check neighbour notifications" do
+      visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+      expect(page).to have_content("Review and sign-off")
+
+      expect(page).not_to have_content "Check neighbour notifications"
+    end
+  end
+
+  context "when the planning application's type does include consultation" do
+    let!(:neighbour) { create(:neighbour, consultation:, address: "60-62, Commercial Street, E16LT") }
+    let!(:neighbour_letter) { create(:neighbour_letter, neighbour:, sent_at: 21.days.ago) }
+
+    context "when the consultation has finished" do
+      before do
+        consultation.update(start_date: 21.days.ago, end_date: Time.zone.now)
+      end
+
+      it "you can accept that the assessor has notified the correct people" do
+        visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Not started"
+        )
+
+        click_link "Check neighbour notifications"
+
+        expect(page).to have_content "Check neighbour notifications"
+
+        expect(page).to have_content("60-62, Commercial Street")
+
+        expect(page).to have_content("the consultation period for this application is 21 days")
+        expect(page).to have_content("the last letter was sent 21 days ago")
+        expect(page).to have_content("the consultation expiry date for this application is #{consultation.end_date.to_date.to_fs}")
+
+        within_fieldset("Do you accept that notifications have been completed within the correct period?") do
+          choose "Accept"
+        end
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review of neighbour responses successfully added")
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Completed"
+        )
+      end
+
+      it "you can send it back for assessment" do
+        visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Not started"
+        )
+
+        click_link "Check neighbour notifications"
+
+        expect(page).to have_content "Check neighbour notifications"
+
+        within_fieldset("Do you accept that notifications have been completed within the correct period?") do
+          choose "Return to officer with comment"
+
+          fill_in "Explain why notifications are incomplete.", with: "Notify more people"
+        end
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review of neighbour responses successfully added")
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Completed"
+        )
+
+        click_link "Sign off recommendation"
+
+        expect(page).to have_content "You have suggested changes to be made by the officer."
+
+        choose "No (return the case for assessment)"
+
+        fill_in "Explain to the officer why the case is being returned", with: "Notify more"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "To be reviewed"
+
+        click_link "Application"
+
+        # expect(page).to have_list_item_for(
+        #   "Consultation",
+        #   with: "To be reviewed"
+        # )
+
+        click_link "Consultees, neighbours and publicity"
+
+        expect(page).to have_list_item_for(
+          "Send letters to neighbours",
+          with: "To be reviewed"
+        )
+
+        click_link "Send letters to neighbours"
+
+        expect(page).to have_content "Notify more people"
+
+        click_button "Confirm and send letters"
+
+        click_link "Consultation"
+
+        expect(page).to have_list_item_for(
+          "Send letters to neighbours",
+          with: "Complete"
+        )
+      end
+
+      it "shows errors" do
+        visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+        click_link "Check neighbour notifications"
+
+        expect(page).to have_content "Check neighbour notifications"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "Select an option"
+
+        choose "Return to officer with comment"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content "Explain to the case officer why"
+      end
+    end
+
+    context "when the consultation has not been started" do
+      it "you can accept that the assessor has notified the correct people" do
+        visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Not started"
+        )
+
+        click_link "Check neighbour notifications"
+
+        expect(page).to have_content "Check neighbour notifications"
+
+        expect(page).to have_content("60-62, Commercial Street")
+
+        expect(page).to have_content("The consultation has not been started")
+
+        within_fieldset("Do you accept that notifications have been completed within the correct period?") do
+          choose "Return to officer with comment"
+          fill_in "Explain why notifications are incomplete", with: "People need to be consulted"
+        end
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review of neighbour responses successfully added")
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Completed"
+        )
+      end
+    end
+
+    context "when the consultation has not ended" do
+      let!(:neighbour) { create(:neighbour, consultation:, address: "60-62, Commercial Street, E16LT") }
+      let!(:neighbour_letter) { create(:neighbour_letter, neighbour:, sent_at: 1.day.ago) }
+
+      before do
+        consultation.update(start_date: 10.days.ago, end_date: 11.days.from_now)
+      end
+
+      it "you can't accept or reject the officer's work" do
+        visit "/planning_applications/#{planning_application.id}/review/tasks"
+
+        expect(page).to have_list_item_for(
+          "Check neighbour notifications",
+          with: "Not started"
+        )
+
+        click_link "Check neighbour notifications"
+
+        expect(page).to have_content "Check neighbour notifications"
+
+        expect(page).to have_content("60-62, Commercial Street")
+
+        expect(page).to have_content("the consultation period for this application is 21 days")
+        expect(page).to have_content("the last letter was sent 1 days ago")
+        expect(page).to have_content("the consultation expiry date for this application is #{consultation.end_date.to_date.to_fs}")
+
+        within_fieldset("Do you accept that notifications have been completed within the correct period?") do
+          choose "Accept"
+        end
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Consultation expiry date must be in the past. You cannot mark this as complete until the consultation period is complete.")
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -114,10 +114,10 @@ RSpec.describe "Check neighbour notifications" do
 
         click_link "Application"
 
-        # expect(page).to have_list_item_for(
-        #   "Consultation",
-        #   with: "To be reviewed"
-        # )
+        expect(page).to have_list_item_for(
+          "Consultees, neighbours and publicity",
+          with: "To be reviewed"
+        )
 
         click_link "Consultees, neighbours and publicity"
 

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Send notification to neighbours of committee" do
     before do
       consultation = create(:consultation, planning_application:)
       planning_application.committee_decision.update(recommend: true, reasons: ["The first reason"])
-      planning_application.committee_decision.current_review.update(review_status: "review_complete")
+      planning_application.committee_decision.current_review.update(review_status: "review_complete", action: "accepted")
 
       neighbour = create(:neighbour, consultation:)
       create(:neighbour_response, email: "my.email@example.com", neighbour:)


### PR DESCRIPTION
### Description of change

Reviewer can check what neighbour notifications were sent and the relevant dates

### Story Link

https://trello.com/c/Lg9ucw88/2662-reviewer-is-able-to-quickly-check-neighbour-notifications

### Screenshots
![screencapture-lambeth-bops-localhost-3000-planning-applications-2437-review-consultation-351-neighbour-responses-2024-03-20-17_09_09](https://github.com/unboxed/bops/assets/35098639/1d29b4fe-56ed-48d4-b7ac-ab25445c0e31)