### PR TITLE
Choose features for application type builder

### DIFF
--- a/app/controllers/concerns/publicity_permittable.rb
+++ b/app/controllers/concerns/publicity_permittable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PublicityPermittable
+  extend ActiveSupport::Concern
+
+  def ensure_publicity_is_permitted
+    return if @planning_application.publicity_consultation_feature?
+
+    raise ActionController::RoutingError, "Not found"
+  end
+end

--- a/app/controllers/planning_applications/press_notices/confirmation_requests_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmation_requests_controller.rb
@@ -3,7 +3,10 @@
 module PlanningApplications
   module PressNotices
     class ConfirmationRequestsController < AuthenticationController
+      include PublicityPermittable
+
       before_action :set_planning_application
+      before_action :ensure_publicity_is_permitted
       before_action :set_press_notice
       before_action :set_assessment_detail, if: :assessment_detail_id?
 

--- a/app/controllers/planning_applications/press_notices/confirmations_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmations_controller.rb
@@ -3,7 +3,10 @@
 module PlanningApplications
   module PressNotices
     class ConfirmationsController < AuthenticationController
+      include PublicityPermittable
+
       before_action :set_planning_application
+      before_action :ensure_publicity_is_permitted
       before_action :set_press_notice
 
       def show

--- a/app/controllers/planning_applications/press_notices_controller.rb
+++ b/app/controllers/planning_applications/press_notices_controller.rb
@@ -2,7 +2,10 @@
 
 module PlanningApplications
   class PressNoticesController < AuthenticationController
+    include PublicityPermittable
+
     before_action :set_planning_application
+    before_action :ensure_publicity_is_permitted
     before_action :set_press_notice
 
     def show

--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -2,7 +2,10 @@
 
 module PlanningApplications
   class SiteNoticesController < AuthenticationController
+    include PublicityPermittable
+
     before_action :set_planning_application
+    before_action :ensure_publicity_is_permitted
     before_action :build_site_notice, only: %i[new create]
     before_action :set_site_notice, except: %i[new create]
     before_action :ensure_public_portal_is_active, only: :create

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -17,6 +17,7 @@ class ApplicationType < ApplicationRecord
 
   validates :name, :code, :suffix, presence: true
   validates :code, :suffix, uniqueness: true
+  validates :features, store_model: {merge_errors: true}
 
   with_options allow_blank: true do
     validates :code, inclusion: {in: ODP_APPLICATION_TYPES.keys}
@@ -54,6 +55,7 @@ class ApplicationType < ApplicationRecord
     delegate :permitted_development_rights?
     delegate :site_visits?
     delegate :include_bank_holidays?
+    delegate :consultation_steps
   end
 
   before_validation if: :code_changed? do
@@ -117,7 +119,13 @@ class ApplicationType < ApplicationRecord
   end
 
   def consultation?
-    steps.include?("consultation")
+    consultation_steps.any?
+  end
+
+  Consultation::STEPS.each do |feature|
+    define_method(:"#{feature}_consultation_feature?") do
+      consultation_steps.include?(feature)
+    end
   end
 
   def assessor_remarks

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -7,4 +7,17 @@ class ApplicationTypeFeature
   attribute :permitted_development_rights, :boolean, default: true
   attribute :site_visits, :boolean, default: false
   attribute :include_bank_holidays, :boolean, default: true
+  attribute :consultation_steps, default: -> { [] }
+
+  validate :consultation_steps_are_valid
+
+  private
+
+  def consultation_steps_are_valid
+    invalid_steps = consultation_steps.reject { |step| Consultation::STEPS.include?(step) }
+
+    unless invalid_steps.empty?
+      errors.add(:consultation_steps, "contains invalid steps: #{invalid_steps.join(", ")}")
+    end
+  end
 end

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -7,7 +7,7 @@ class ApplicationTypeFeature
   attribute :permitted_development_rights, :boolean, default: true
   attribute :site_visits, :boolean, default: false
   attribute :include_bank_holidays, :boolean, default: true
-  attribute :consultation_steps, default: -> { [] }
+  attribute :consultation_steps, :list, default: -> { [] }
 
   validate :consultation_steps_are_valid
 

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -17,6 +17,10 @@ class Consultation < ApplicationRecord
   EIA_PERIOD = 30
   EIA_PERIOD_DAYS = EIA_PERIOD.days
 
+  STEPS = %w[
+    neighbour consultee publicity
+  ].freeze
+
   attribute :consultee_message_subject, :string, default: -> { default_consultee_message_subject }
   attribute :consultee_message_body, :string, default: -> { default_consultee_message_body }
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -66,7 +66,13 @@ class PlanningApplication < ApplicationRecord
     has_one :committee_decision, required: false
   end
 
-  delegate :consultation?, to: :application_type
+  with_options to: :application_type do
+    delegate :consultation?
+    delegate :neighbour_consultation_feature?
+    delegate :consultee_consultation_feature?
+    delegate :publicity_consultation_feature?
+  end
+
   delegate :reviewer_group_email, to: :local_authority
   with_options prefix: true, allow_nil: true do
     delegate :email, to: :user
@@ -770,6 +776,8 @@ class PlanningApplication < ApplicationRecord
   end
 
   def check_publicity?
+    return unless application_type.publicity_consultation_feature?
+
     application_type.assessment_details.include?("check_publicity")
   end
 

--- a/app/views/planning_applications/consultations/show.html.erb
+++ b/app/views/planning_applications/consultations/show.html.erb
@@ -34,82 +34,91 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <ol class="app-task-list govuk-!-margin-top-8">
-      <li id="neighbour-tasks">
-        <h2 class="govuk-heading-m">Neighbours</h2>
-        <ul class="app-task-list__items" id="neighbour-section">
-          <%= render(
-            TaskListItems::SelectNeighboursComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-          <%= render(
-            TaskListItems::SendLettersToNeighboursComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-          <%= render(
-            TaskListItems::NeighbourResponsesComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-          <% if @consultation.site_visits.any? || @consultation.needs_site_visit? %>
+      <% if @planning_application.neighbour_consultation_feature? %>
+        <li id="neighbour-tasks">
+          <h2 class="govuk-heading-m">Neighbours</h2>
+          <ul class="app-task-list__items" id="neighbour-section">
             <%= render(
-              TaskListItems::SiteVisitComponent.new(
+              TaskListItems::SelectNeighboursComponent.new(
                 planning_application: @planning_application
               )
             ) %>
-          <% end %>
-        </ul>
-      </li>
-      <li id="consultee-tasks">
-        <h2 class="govuk-heading-m">Consultees</h2>
-        <ul class="app-task-list__items" id="consultation-section">
-          <%= render(
-                TaskListItems::SelectConsulteesComponent.new(
-                  planning_application: @planning_application
-                )
-              ) %>
-          <%= render(
-                TaskListItems::EmailConsulteesComponent.new(
-                  planning_application: @planning_application
-                )
-              ) %>
-          <%= render(
-                TaskListItems::ConsulteeResponsesComponent.new(
-                  planning_application: @planning_application
-                )
-              ) %>
-        </ul>
-      </li>
-      <li id="publicity-tasks">
-        <h2 class="govuk-heading-m">Publicity</h2>
-        <ul class="app-task-list__items" id="publicity-section">
-          <%= render(
-            TaskListItems::SiteNoticeComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-          <% if @planning_application.site_notices&.last&.required %>
             <%= render(
-              TaskListItems::ConfirmSiteNoticeComponent.new(
+              TaskListItems::SendLettersToNeighboursComponent.new(
                 planning_application: @planning_application
               )
             ) %>
-          <% end %>
-          <%= render(
-            TaskListItems::PressNoticeComponent.new(
-              planning_application: @planning_application
-            )
-          ) %>
-          <% if @planning_application.press_notice.try(:required) %>
             <%= render(
-              TaskListItems::ConfirmPressNoticeComponent.new(
+              TaskListItems::NeighbourResponsesComponent.new(
                 planning_application: @planning_application
               )
             ) %>
-          <% end %>
-        </ul>
-      </li>
+            <% if @consultation.site_visits.any? || @consultation.needs_site_visit? %>
+              <%= render(
+                TaskListItems::SiteVisitComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
+
+      <% if @planning_application.consultee_consultation_feature? %>
+        <li id="consultee-tasks">
+          <h2 class="govuk-heading-m">Consultees</h2>
+          <ul class="app-task-list__items" id="consultation-section">
+            <%= render(
+                  TaskListItems::SelectConsulteesComponent.new(
+                    planning_application: @planning_application
+                  )
+                ) %>
+            <%= render(
+                  TaskListItems::EmailConsulteesComponent.new(
+                    planning_application: @planning_application
+                  )
+                ) %>
+            <%= render(
+                  TaskListItems::ConsulteeResponsesComponent.new(
+                    planning_application: @planning_application
+                  )
+                ) %>
+          </ul>
+        </li>
+      <% end %>
+
+      <% if @planning_application.publicity_consultation_feature? %>
+        <li id="publicity-tasks">
+          <h2 class="govuk-heading-m">Publicity</h2>
+          <ul class="app-task-list__items" id="publicity-section">
+            <%= render(
+              TaskListItems::SiteNoticeComponent.new(
+                planning_application: @planning_application
+              )
+            ) %>
+            <% if @planning_application.site_notices&.last&.required %>
+              <%= render(
+                TaskListItems::ConfirmSiteNoticeComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
+            <% end %>
+
+            <%= render(
+              TaskListItems::PressNoticeComponent.new(
+                planning_application: @planning_application
+              )
+            ) %>
+            <% if @planning_application.press_notice.try(:required) %>
+              <%= render(
+                TaskListItems::ConfirmPressNoticeComponent.new(
+                  planning_application: @planning_application
+                )
+              ) %>
+            <% end %>
+          </ul>
+        </li>
+      <% end %>
     </ol>
     <%= link_to "Back", planning_application_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
   </div>

--- a/db/migrate/20240319114011_add_consultation_steps_to_application_types.rb
+++ b/db/migrate/20240319114011_add_consultation_steps_to_application_types.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddConsultationStepsToApplicationTypes < ActiveRecord::Migration[7.1]
+  class ApplicationType < ActiveRecord::Base; end
+
+  STEPS = %w[neighbour consultee publicity].freeze
+
+  def change
+    up_only do
+      ApplicationType.find_each do |type|
+        if type.steps.include?("consultation")
+          type.update!(features: type.features.merge("consultation_steps" => STEPS))
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20240321103410_add_configured_to_application_types.rb
+++ b/db/migrate/20240321103410_add_configured_to_application_types.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddConfiguredToApplicationTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_types, :configured, :boolean
+
+    up_only do
+      ApplicationType.find_each do |type|
+        type.update!(configured: true)
+      end
+
+      change_column_default :application_types, :configured, false
+      change_column_null :application_types, :configured, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -72,6 +72,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_155240) do
     t.string "suffix", null: false
     t.integer "determination_period_days"
     t.bigint "legislation_id"
+    t.boolean "configured", default: false, null: false
     t.index ["code"], name: "ix_application_types_on_code", unique: true
     t.index ["legislation_id"], name: "ix_application_types_on_legislation_id"
     t.index ["suffix"], name: "ix_application_types_on_suffix", unique: true

--- a/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
@@ -2,7 +2,7 @@
 
 module BopsConfig
   module ApplicationTypes
-    class DeterminationPeriodsController < ApplicationController
+    class FeaturesController < ApplicationController
       before_action :set_application_type
 
       def edit
@@ -13,7 +13,7 @@ module BopsConfig
 
       def update
         respond_to do |format|
-          if @application_type.update(application_type_params, :determination_period)
+          if @application_type.update(application_type_features_params.merge(configured: true))
             format.html do
               redirect_to next_path, notice: t(".success")
             end
@@ -25,8 +25,8 @@ module BopsConfig
 
       private
 
-      def application_type_params
-        params.require(:application_type).permit(:determination_period_days)
+      def application_type_features_params
+        params.require(:application_type).permit(features: [:planning_conditions, :permitted_development_rights, {consultation_steps: []}])
       end
 
       def set_application_type
@@ -34,11 +34,7 @@ module BopsConfig
       end
 
       def next_path
-        if @application_type.configured?
-          application_type_path(@application_type)
-        else
-          edit_application_type_features_path(@application_type)
-        end
+        application_type_path(@application_type)
       end
     end
   end

--- a/engines/bops_config/app/controllers/bops_config/application_types/legislation_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/legislation_controller.rb
@@ -57,7 +57,7 @@ module BopsConfig
       end
 
       def next_path
-        if @application_type.determination_period_days?
+        if @application_type.configured?
           application_type_path(@application_type)
         else
           edit_application_type_determination_period_path(@application_type)

--- a/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
@@ -65,10 +65,10 @@ module BopsConfig
     end
 
     def next_path
-      if @application_type.previously_new_record?
-        edit_application_type_legislation_path(@application_type)
-      else
+      if @application_type.configured?
         application_type_path(@application_type)
+      else
+        edit_application_type_legislation_path(@application_type)
       end
     end
 

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -19,20 +19,17 @@ module BopsConfig
     end
 
     def active_page_key
-      case controller_name
-      when "dashboard"
-        "dashboard"
-      when "users"
-        "users"
-      when "application_types"
-        "application_types"
-      when "determination_periods"
-        "application_types"
-      when "legislation"
-        "application_types"
-      else
-        "dashboard"
-      end
+      page_keys = {
+        "dashboard" => "dashboard",
+        "users" => "users",
+        "application_types" => "application_types",
+        "determination_periods" => "application_types",
+        "legislation" => "application_types",
+        "features" => "application_types",
+        "statuses" => "application_types"
+      }
+
+      page_keys.fetch(controller_name, "dashboard")
     end
 
     def nav_items

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -18,42 +18,18 @@
       <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
       <%= form.fields_for :features, @application_type.features do |ff| %>
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-              <%= t("legends.check_application_details", scope: :application_type_features) %>
-            </legend>
+        <%= ff.govuk_fieldset legend: { text: t("legends.check_application_details", scope: :application_type_features), size: "s" } do %>
+          <%= ff.govuk_check_box :planning_conditions, 1, 0, multiple: false, label: { text: t("labels.planning_conditions", scope: :application_type_features) } %>
 
-            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-              <div class="govuk-checkboxes__item">
-                <%= ff.check_box :planning_conditions, class: "govuk-checkboxes__input" %>
-                <%= ff.label :planning_conditions, t("labels.planning_conditions", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
-              </div>
+          <%= ff.govuk_check_box :permitted_development_rights, 1, 0, multiple: false, label: { text: t("labels.permitted_development_rights", scope: :application_type_features) } %>
+        <% end %>
 
-              <div class="govuk-checkboxes__item">
-                <%= ff.check_box :permitted_development_rights, class: "govuk-checkboxes__input" %>
-                <%= ff.label :permitted_development_rights, t("labels.permitted_development_rights", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
-              </div>
-            </div>
-          </fieldset>
-        </div>
-
-        <div class="govuk-form-group">
-          <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-              <%= t("legends.consultation", scope: :application_type_features) %>
-            </legend>
-                          
-            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
-              <% Consultation::STEPS.each do |step| %>
-                <div class="govuk-checkboxes__item">
-                  <%= check_box_tag "application_type[features][consultation_steps][]", step, @application_type.features.consultation_steps.include?(step), id: "application_type_features_consultation_steps_#{step}", class: "govuk-checkboxes__input" %>
-                  <%= label_tag "application_type_features_consultation_steps_#{step}", t("labels.consultation_steps.#{step}", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
-                </div>
-              <% end %>
-            </div>
-          </fieldset>
-        </div>
+        <%= ff.govuk_fieldset legend: { text: t("legends.consultation", scope: :application_type_features), size: "s" } do %>
+          <%= ff.govuk_collection_check_boxes :consultation_steps,
+              Consultation::STEPS.map { |step| OpenStruct.new(id: step, name: t("labels.consultation_steps.#{step}", scope: :application_type_features)) }, 
+              :id, :name,
+              legend: { text: "Consultation steps", tag: "span", class: "govuk-visually-hidden" } %>
+        <% end %>
       <% end %>
 
       <%= form.govuk_submit(t(".continue")) do %>

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title do %>
+  <%= t(".choose_features") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".choose_features") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l"><%= t(".choose_features") %></h1>
+    <h2 class="govuk-heading-m"><%= @application_type.description %></h2>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <%= form_with model: @application_type, url: [@application_type, :features] do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+      <%= form.fields_for :features, @application_type.features do |ff| %>
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              <%= t("legends.check_application_details", scope: :application_type_features) %>
+            </legend>
+
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <div class="govuk-checkboxes__item">
+                <%= ff.check_box :planning_conditions, class: "govuk-checkboxes__input" %>
+                <%= ff.label :planning_conditions, t("labels.planning_conditions", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+
+              <div class="govuk-checkboxes__item">
+                <%= ff.check_box :permitted_development_rights, class: "govuk-checkboxes__input" %>
+                <%= ff.label :permitted_development_rights, t("labels.permitted_development_rights", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group">
+          <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+              <%= t("legends.consultation", scope: :application_type_features) %>
+            </legend>
+                          
+            <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+              <% Consultation::STEPS.each do |step| %>
+                <div class="govuk-checkboxes__item">
+                  <%= check_box_tag "application_type[features][consultation_steps][]", step, @application_type.features.consultation_steps.include?(step), id: "application_type_features_consultation_steps_#{step}", class: "govuk-checkboxes__input" %>
+                  <%= label_tag "application_type_features_consultation_steps_#{step}", t("labels.consultation_steps.#{step}", scope: :application_type_features), class: "govuk-label govuk-checkboxes__label" %>
+                </div>
+              <% end %>
+            </div>
+          </fieldset>
+        </div>
+      <% end %>
+
+      <%= form.govuk_submit(t(".continue")) do %>
+        <%= link_to(t("back"), @application_type, class: "govuk-button govuk-button--secondary") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -80,6 +80,37 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          <%= t(".features") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <p class="govuk-body"><strong>Application details</strong></p>
+          <ul class="govuk-list govuk-list--bullet">
+            <% if @application_type.permitted_development_rights? %>
+              <li>Check permitted development rights</li>
+            <% end %>
+            <% if @application_type.planning_conditions? %>
+              <li>Check planning conditions</li>
+            <% end %>
+          </ul>
+
+          <% if @application_type.consultation? %>
+            <p class="govuk-body"><strong>Consultation</strong></p>
+            <ul class="govuk-list govuk-list--bullet">
+              <% @application_type.consultation_steps.each do |step| %>
+                <li><%= step.humanize %></li>
+              <% end %>
+            </ul>
+          <% end %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to [:edit, @application_type, :features], class: "govuk-link" do %>
+            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".features") %></span>
+          <% end %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           <%= t(".status") %>
         </dt>
         <dd class="govuk-summary-list__value">

--- a/engines/bops_config/config/locales/application_type_features.yml
+++ b/engines/bops_config/config/locales/application_type_features.yml
@@ -1,0 +1,12 @@
+en:
+  application_type_features:
+    labels:
+      planning_conditions: "Check planning conditions"
+      permitted_development_rights: "Check permitted development rights"
+      consultation_steps:
+        neighbour: Neighbours consultation
+        consultee: Consultees
+        publicity: Publicity (site notice and press notice)
+    legends:
+      check_application_details: "Check application details"
+      consultation: "Consultation"

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -18,6 +18,13 @@ en:
           success: Determination period successfully updated
       edit:
         application_profile: Application profile
+        update_application_type: Update the application type
+      features:
+        edit:
+          choose_features: Choose features
+          continue: Continue
+        update:
+          success: Features successfully updated
       form:
         code_hint: Enter the name of this application type, such as 'Prior Approval - change of use from takeaway to dwelling'
         code_label: Name
@@ -56,6 +63,7 @@ en:
           one: 1 day - bank holidays included
           other: "%{count} days - bank holidays included"
         edit: Edit
+        features: Features
         legislation: Legislation
         name: Name
         review_application_type: Review the application type

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -15,6 +15,7 @@ BopsConfig::Engine.routes.draw do
     scope module: "application_types" do
       with_options only: %i[edit update] do
         resource :determination_period
+        resource :features
         resource :legislation
         resource :status
       end

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -70,17 +70,26 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
     expect(page).to have_content("Determination period successfully updated")
 
+    check "Check permitted development rights"
+    check "Neighbours consultation"
+    click_button "Continue"
+    expect(page).to have_content("Features successfully updated")
+
     # Review application type
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(1) dd", text: "Planning Permission - Major application")
     expect(page).to have_selector("dl div:nth-child(2) dd", text: "MAJR")
     expect(page).to have_selector("dl div:nth-child(3) dd", text: "Town and Country Planning Act 1990")
     expect(page).to have_selector("dl div:nth-child(4) dd", text: "25 days - bank holidays included")
-    expect(page).to have_selector("dl div:nth-child(5) dd", text: "Inactive")
+    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
+      expect(page).to have_selector("li", text: "Check permitted development rights")
+      expect(page).to have_selector("li", text: "Neighbour")
+    end
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Inactive")
   end
 
   it "allows editing of an inactive application type" do
-    application_type = create(:application_type, :ldc_proposed, status: "inactive")
+    application_type = create(:application_type, :configured, :ldc_proposed, status: "inactive")
 
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
@@ -156,7 +165,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(5)" do
+    within "dl div:nth-child(6)" do
       expect(page).to have_selector("dd", text: "Inactive")
       click_link "Change"
     end
@@ -167,7 +176,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(5) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Active")
   end
 
   it "allows retirement of an application type" do
@@ -176,7 +185,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(5)" do
+    within "dl div:nth-child(6)" do
       expect(page).to have_selector("dd", text: "Active")
       click_link "Change"
     end
@@ -188,7 +197,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(5) dd", text: "Retired")
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Retired")
   end
 
   it "allows an application type to be brought out of retirement" do
@@ -197,7 +206,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(5)" do
+    within "dl div:nth-child(6)" do
       expect(page).to have_selector("dd", text: "Retired")
       click_link "Change"
     end
@@ -209,13 +218,13 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(5) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Active")
   end
 
   it "allows editing of the legislation" do
     legislation = create(:legislation, title: "Town and Country Planning Act 1990")
     determination_period_days = 25
-    application_type = create(:application_type, :ldc_proposed, legislation:, determination_period_days:)
+    application_type = create(:application_type, :configured, :ldc_proposed, legislation:, determination_period_days:)
 
     visit "/application_types/#{application_type.id}"
 
@@ -245,7 +254,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
   end
 
   it "allows editing of the determination period days" do
-    application_type = create(:application_type, :ldc_proposed, determination_period_days: 25)
+    application_type = create(:application_type, :configured, :ldc_proposed, determination_period_days: 25)
 
     visit "/application_types/#{application_type.id}"
 
@@ -261,6 +270,71 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_content("Determination period successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(4) dd", text: "35 days - bank holidays included")
+  end
+
+  it "allows editing of the features" do
+    application_type = create(
+      :application_type, :configured, :ldc_proposed,
+      features: {
+        "planning_conditions" => true,
+        "permitted_development_rights" => false,
+        :consultation_steps => ["neighbour", "publicity"]
+      }
+    )
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
+      expect(page).to have_selector("p strong", text: "Application details")
+      expect(page).to have_selector("li", text: "Check planning conditions")
+      expect(page).not_to have_selector("li", text: "Check permitted development rights")
+
+      expect(page).to have_selector("p strong", text: "Consultation")
+      expect(page).to have_selector("li", text: "Neighbour")
+      expect(page).to have_selector("li", text: "Publicity")
+      expect(page).not_to have_selector("li", text: "Consultee")
+    end
+
+    within "dl div:nth-child(5)" do
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Choose features")
+    expect(page).to have_selector("h2", text: application_type.description)
+
+    expect(page).to have_selector("fieldset legend", text: "Check application details")
+    expect(page).to have_checked_field("Check planning conditions")
+    expect(page).to have_unchecked_field("Check permitted development rights")
+
+    expect(page).to have_selector("fieldset legend", text: "Consultation")
+    expect(page).to have_checked_field("Neighbours consultation")
+    expect(page).to have_checked_field("Publicity (site notice and press notice)")
+    expect(page).to have_unchecked_field("Consultees")
+
+    uncheck("Check planning conditions")
+    check("Check permitted development rights")
+    check("Consultees")
+
+    click_button "Continue"
+
+    expect(page).to have_content("Features successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
+      expect(page).to have_selector("p strong", text: "Application details")
+      expect(page).not_to have_selector("li", text: "Check planning conditions")
+      expect(page).to have_selector("li", text: "Check permitted development rights")
+
+      expect(page).to have_selector("p strong", text: "Consultation")
+      expect(page).to have_selector("li", text: "Neighbour")
+      expect(page).to have_selector("li", text: "Publicity")
+      expect(page).to have_selector("li", text: "Consultee")
+    end
+
+    application_type.reload
+    expect(application_type.planning_conditions?).to eq(false)
+    expect(application_type.permitted_development_rights?).to eq(true)
+    expect(application_type.consultation_steps).to eq(["neighbour", "consultee", "publicity"])
   end
 
   it "displays application types" do

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
       features: {
         "planning_conditions" => true,
         "permitted_development_rights" => false,
-        :consultation_steps => ["neighbour", "publicity"]
+        "consultation_steps" => ["neighbour", "publicity"]
       }
     )
 

--- a/spec/components/accordion_sections/key_application_dates_component_spec.rb
+++ b/spec/components/accordion_sections/key_application_dates_component_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
   let(:planning_application) do
     create(
       :planning_application,
+      :prior_approval,
       validated_at: Date.new(2022, 11, 12),
       received_at: Date.new(2022, 11, 11)
     )
   end
+  let(:consultation) { planning_application.consultation }
 
   let(:component) do
     described_class.new(planning_application:)
@@ -50,12 +52,8 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
   end
 
   context "when there's a consultation" do
-    let(:consultation) { create(:consultation) }
-
     before do
       consultation.start_deadline
-      planning_application.consultation = consultation
-      planning_application.save!
 
       render_inline(component)
     end
@@ -70,18 +68,20 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
   end
 
   context "when there's no consultation" do
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :ldc_proposed
+      )
+    end
+
     it "does not render consultation deadline" do
       expect(page).not_to have_content("Publicity deadline:")
     end
   end
 
   context "when the consultation has not started" do
-    let(:consultation) { create(:consultation, start_date: nil) }
-
     before do
-      planning_application.consultation = consultation
-      planning_application.save!
-
       render_inline(component)
     end
 
@@ -91,11 +91,8 @@ RSpec.describe AccordionSections::KeyApplicationDatesComponent, type: :component
   end
 
   context "when the consultation has finished" do
-    let(:consultation) { create(:consultation, start_date: 4.weeks.ago, end_date: 1.week.ago) }
-
     before do
-      planning_application.consultation = consultation
-      planning_application.save!
+      consultation.update!(start_date: 4.weeks.ago, end_date: 1.week.ago)
 
       render_inline(component)
     end

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -76,6 +76,12 @@ FactoryBot.define do
 
     trait :ldc_existing do
       lawfulness_certificate
+
+      features {
+        {
+          consultation_steps: []
+        }
+      }
     end
 
     trait :ldc_proposed do
@@ -83,13 +89,24 @@ FactoryBot.define do
 
       code { "ldc.proposed" }
       suffix { "LDCP" }
+
+      features {
+        {
+          consultation_steps: []
+        }
+      }
     end
 
     trait :prior_approval do
       name { "prior_approval" }
       code { "pa.part1.classA" }
       suffix { "PA" }
-      features { {"site_visits" => true} }
+      features {
+        {
+          "site_visits" => true,
+          :consultation_steps => ["neighbour", "publicity", "consultee"]
+        }
+      }
       steps { %w[validation consultation assessment review] }
 
       assessment_details do
@@ -221,7 +238,14 @@ FactoryBot.define do
       code { "pp.full.householder" }
       suffix { "HAPP" }
       steps { %w[validation consultation assessment review] }
-      features { {"planning_conditions" => true, "permitted_development_rights" => false, "site_visits" => true} }
+      features {
+        {
+          "planning_conditions" => true,
+          "permitted_development_rights" => false,
+          "site_visits" => true,
+          :consultation_steps => ["neighbour", "publicity", "consultee"]
+        }
+      }
 
       assessment_details do
         %w[
@@ -346,6 +370,18 @@ FactoryBot.define do
 
       code { "pp.full.householder.retro" }
       suffix { "HRET" }
+    end
+
+    trait :without_consultation do
+      features {
+        {
+          consultation_steps: []
+        }
+      }
+    end
+
+    trait :configured do
+      configured { true }
     end
 
     initialize_with { ApplicationType.find_or_create_by(code:) }

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -104,7 +104,7 @@ FactoryBot.define do
       features {
         {
           "site_visits" => true,
-          :consultation_steps => ["neighbour", "publicity", "consultee"]
+          "consultation_steps" => ["neighbour", "publicity", "consultee"]
         }
       }
       steps { %w[validation consultation assessment review] }
@@ -243,7 +243,7 @@ FactoryBot.define do
           "planning_conditions" => true,
           "permitted_development_rights" => false,
           "site_visits" => true,
-          :consultation_steps => ["neighbour", "publicity", "consultee"]
+          "consultation_steps" => ["neighbour", "publicity", "consultee"]
         }
       }
 

--- a/spec/form_models/review_assessment_details_form_spec.rb
+++ b/spec/form_models/review_assessment_details_form_spec.rb
@@ -4,8 +4,8 @@ require "rails_helper"
 
 RSpec.describe ReviewAssessmentDetailsForm do
   describe "#save" do
-    let(:planning_application) { create(:planning_application) }
-    let(:consultation) { create(:consultation, planning_application:) }
+    let(:planning_application) { create(:planning_application, :prior_approval) }
+    let(:consultation) { planning_application.consultation }
     let(:user) { create(:user) }
 
     let(:review_assessment_details) do

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1342,6 +1342,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         press_notice_email: "pressnotice@example.com"
       )
     end
+    let(:application_type) { create(:application_type, :planning_permission) }
     let(:press_notice) do
       create(
         :press_notice,
@@ -1370,7 +1371,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     it "includes the reference" do
       travel_to("2022-01-01") do
         expect(mail_body).to include(
-          "Application reference number: PlanX-22-00100-LDCP"
+          "Application reference number: PlanX-22-00100-HAPP"
         )
       end
     end

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -151,6 +151,16 @@ RSpec.describe ApplicationType do
         end
       end
     end
+
+    describe "#features" do
+      describe "#consultation_steps" do
+        let(:application_type) { described_class.new(features: {consultation_steps: ["Invalid"]}) }
+
+        it "validates the steps" do
+          expect { application_type.valid? }.to change { application_type.features.errors[:consultation_steps] }.to ["contains invalid steps: Invalid"]
+        end
+      end
+    end
   end
 
   describe "class methods" do

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -36,11 +36,9 @@ RSpec.describe Consultation do
   describe "callbacks" do
     describe "::after_update #audit_letter_copy_sent!" do
       let!(:planning_application) do
-        create(:planning_application, :not_started, agent_email: "agent@example.com", applicant_email: "applicant@example.com")
+        create(:planning_application, :prior_approval, :not_started, agent_email: "agent@example.com", applicant_email: "applicant@example.com")
       end
-      let!(:consultation) do
-        create(:consultation, planning_application:)
-      end
+      let(:consultation) { planning_application.consultation }
 
       context "when the letter copy sent at is updated" do
         before { Current.user = planning_application.user }
@@ -128,7 +126,8 @@ RSpec.describe Consultation do
     end
 
     context "when there isn't already a start date" do
-      let(:consultation) { create(:consultation) }
+      let(:planning_application) { create(:planning_application, :prior_approval) }
+      let(:consultation) { planning_application.consultation }
 
       before do
         consultation.start_deadline
@@ -161,7 +160,8 @@ RSpec.describe Consultation do
   end
 
   describe "#neighbour_responses_by_summary_tag" do
-    let!(:consultation) { create(:consultation) }
+    let!(:planning_application) { create(:planning_application, :planning_permission) }
+    let!(:consultation) { planning_application.consultation }
     let!(:neighbour1) { create(:neighbour, address: "1, Random Lane, AAA111", consultation:) }
     let!(:neighbour2) { create(:neighbour, address: "2, Random Lane, AAA111", consultation:) }
     let!(:neighbour3) { create(:neighbour, address: "3, Random Lane, AAA111", consultation:) }

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 RSpec.describe "Creating a planning application via the API", show_exceptions: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, local_authority: default_local_authority) }
-  let!(:planning_application) { create(:planning_application, local_authority: default_local_authority) }
-  let!(:consultation) { create(:consultation, planning_application:) }
+  let!(:planning_application) { create(:planning_application, :planning_permission, local_authority: default_local_authority) }
 
   let(:path) do
     "/api/v1/planning_applications/#{planning_application.id}/neighbour_responses"

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -94,12 +94,12 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
 
       context "when granted planning application" do
         let!(:planning_application) do
-          create(:planning_application, :determined, :with_constraints, local_authority: default_local_authority, decision: "granted", api_user:)
+          create(:planning_application, :determined, :planning_permission, :with_constraints, local_authority: default_local_authority, decision: "granted", api_user:)
         end
         let!(:document_with_number) { create(:document, :public, planning_application:) }
         let!(:document_without_number) { create(:document, planning_application:) }
         let!(:document_archived) { create(:document, :public, :archived, planning_application:) }
-        let!(:consultation) { create(:consultation, planning_application:) }
+        let!(:consultation) { planning_application.consultation }
         let!(:neighbour) { create(:neighbour, consultation:) }
         let!(:neighbour_response) { create(:neighbour_response, neighbour:, redacted_response: "It's fine", received_at: 1.day.ago, summary_tag: "supportive") }
 
@@ -109,7 +109,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
           expect(planning_application_json["id"]).to eq(planning_application.id)
           expect(planning_application_json["reference"]).to eq(planning_application.reference)
           expect(planning_application_json["reference_in_full"]).to eq(planning_application.reference_in_full)
-          expect(planning_application_json["application_type"]).to eq("lawfulness_certificate")
+          expect(planning_application_json["application_type"]).to eq("planning_permission")
           expect(planning_application_json["description"]).to eq(planning_application.description)
           expect(planning_application_json["received_date"]).to eq(json_time_format(planning_application.received_at))
           expect(planning_application_json["determined_at"]).to eq(json_time_format(planning_application.determined_at))

--- a/spec/services/neighbour_response_creation_service_spec.rb
+++ b/spec/services/neighbour_response_creation_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe NeighbourResponseCreationService, type: :service do
   include ActionDispatch::TestProcess::FixtureFile
 
   describe "#call" do
-    let!(:planning_application) { create(:planning_application) }
-    let!(:consultation) { create(:consultation, planning_application:) }
+    let!(:planning_application) { create(:planning_application, :planning_permission) }
+    let!(:consultation) { planning_application.consultation }
 
     let!(:params) do
       ActionController::Parameters.new(

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -449,6 +449,17 @@ RSpec.describe "assessment against legislation" do
   end
 
   context "when planning application is planning permission" do
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :planning_permission,
+        :in_assessment,
+        :with_constraints,
+        local_authority:,
+        api_user:
+      )
+    end
+
     before do
       assessor =
         create(
@@ -457,10 +468,6 @@ RSpec.describe "assessment against legislation" do
           local_authority:,
           name: "Alice Smith"
         )
-
-      planning_permission = create(:application_type, :planning_permission)
-      planning_application.update(application_type: planning_permission)
-      planning_application.create_consultation!
 
       sign_in(assessor)
       visit "/planning_applications/#{planning_application.id}"

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -122,10 +122,16 @@ RSpec.describe "checking consistency" do
   end
 
   context "when the application is a prior approval" do
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :prior_approval,
+        :in_assessment,
+        local_authority:
+      )
+    end
+
     before do
-      type = create(:application_type, :prior_approval)
-      planning_application.update(application_type: type)
-      planning_application.create_consultation!
       create(:proposal_measurement, planning_application:)
     end
 

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "viewing assessment report" do
   let!(:planning_application) do
     create(
       :planning_application,
+      :prior_approval,
       :in_assessment,
       :with_constraints,
       local_authority:,
@@ -32,10 +33,6 @@ RSpec.describe "viewing assessment report" do
       referenced_in_decision_notice: true,
       numbers: "REF1"
     )
-  end
-
-  let!(:consultation) do
-    create(:consultation, planning_application:)
   end
 
   before do
@@ -75,7 +72,7 @@ RSpec.describe "viewing assessment report" do
 
     create(
       :consultee,
-      consultation:,
+      consultation: planning_application.consultation,
       name: "Alice Smith",
       origin: :external
     )

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -54,10 +54,12 @@ RSpec.describe "assigning planning application" do
   end
 
   context "when a prior approval type" do
-    before do
-      prior_approval = create(:application_type, :prior_approval)
-      planning_application.update(application_type: prior_approval)
-      planning_application.create_consultation!
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :prior_approval,
+        local_authority:
+      )
     end
 
     it "lets a planning application be assigned to a user" do

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Send notification to neighbours of committee" do
       local_authority: default_local_authority)
   end
   let!(:planning_application) do
-    create(:planning_application, :awaiting_determination, :with_recommendation, local_authority: default_local_authority, user: assessor)
+    create(:planning_application, :planning_permission, :awaiting_determination, :with_recommendation, local_authority: default_local_authority, user: assessor)
   end
 
   before do
@@ -38,7 +38,7 @@ RSpec.describe "Send notification to neighbours of committee" do
 
   context "when the assessor has recommended the application go to committee" do
     before do
-      consultation = create(:consultation, planning_application:)
+      consultation = planning_application.consultation
       planning_application.committee_decision.update(recommend: true, reasons: ["The first reason"])
       planning_application.committee_decision.current_review.update(review_status: "review_complete", action: "accepted")
 


### PR DESCRIPTION
### Description of change

- Add "Choose feature" page for building an application type
- Split this into "Application details" and "Consultation" for now
- Use ApplicationTypeFeature to store these features
- Add "configured" to determine whether the application type has been initially set up or not

### Story Link

https://trello.com/c/BnlExwXe/2449-choose-features-landing-page

### Screenshots

![Screenshot 2024-03-21 at 16 14 18](https://github.com/unboxed/bops/assets/34001723/36234e04-cb7e-42ea-8bea-1db19099ae72)
![Screenshot 2024-03-22 at 11 51 11](https://github.com/unboxed/bops/assets/34001723/1957786c-b138-4b02-a685-751e1dc43b0e)
