### PR TITLE
Add pre-commencement conditions to review

### DIFF
--- a/app/components/task_list_items/reviewing/condition_component.rb
+++ b/app/components/task_list_items/reviewing/condition_component.rb
@@ -15,11 +15,19 @@ module TaskListItems
       delegate :planning_application, to: :condition_set
 
       def link_text
-        t(".link_text")
+        if @condition_set.pre_commencement?
+          t(".pre_commencement.link_text")
+        else
+          t(".link_text")
+        end
       end
 
       def link_path
-        planning_application_review_conditions_path(planning_application)
+        if @condition_set.pre_commencement?
+          planning_application_review_pre_commencement_conditions_path(planning_application)
+        else
+          planning_application_review_conditions_path(planning_application)
+        end
       end
 
       def status_tag_component

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module PlanningApplications::Review
+  class PreCommencementConditionsController < AuthenticationController
+    include CommitMatchable
+    include PlanningApplicationAssessable
+
+    before_action :set_planning_application
+    before_action :ensure_planning_application_is_validated
+    before_action :ensure_user_is_reviewer
+
+    def show
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      respond_to do |format|
+        format.html do
+          if condition_set.update(review_params)
+            redirect_to planning_application_review_tasks_path(@planning_application),
+              notice: I18n.t("review.conditions.update.success")
+          else
+            render :show
+          end
+        end
+      end
+    end
+
+    private
+
+    def condition_set
+      @planning_application.pre_commencement_condition_set
+    end
+
+    def form_disabled?
+      condition_set&.current_review&.complete_or_to_be_reviewed?
+    end
+
+    def review_params
+      params.require(:condition_set)
+        .permit(reviews_attributes: %i[action comment],
+          conditions_attributes: %i[_destroy id standard title text reason])
+        .to_h
+        .deep_merge(
+          reviews_attributes: {
+            reviewed_at: Time.current,
+            reviewer: current_user,
+            status: status,
+            review_status:,
+            id: condition_set&.current_review&.id
+          }
+        )
+    end
+
+    def status
+      if return_to_officer?
+        :to_be_reviewed
+      elsif save_progress?
+        :in_progress
+      elsif mark_as_complete?
+        :complete
+      end
+    end
+
+    def review_status
+      save_progress? ? :review_in_progress : :review_complete
+    end
+
+    def return_to_officer?
+      params.dig(:condition_set, :reviews_attributes, :action) == "rejected"
+    end
+
+    helper_method :condition_set, :form_disabled?
+  end
+end

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -34,7 +34,7 @@ module PlanningApplications::Review
       @planning_application.pre_commencement_condition_set
     end
 
-    def form_disabled?
+    def review_complete?
       condition_set&.current_review&.complete_or_to_be_reviewed?
     end
 
@@ -72,6 +72,6 @@ module PlanningApplications::Review
       params.dig(:condition_set, :reviews_attributes, :action) == "rejected"
     end
 
-    helper_method :condition_set, :form_disabled?
+    helper_method :condition_set, :review_complete?
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -76,6 +76,10 @@ class Review < ApplicationRecord
     specific_attributes["decision"] == "No"
   end
 
+  def started?
+    status != "not_started"
+  end
+
   private
 
   def set_reviewed_at

--- a/app/views/planning_applications/assessment/conditions/_pre_commencement_conditions.erb
+++ b/app/views/planning_applications/assessment/conditions/_pre_commencement_conditions.erb
@@ -1,3 +1,7 @@
+  <% if review = @condition_set.current_review %>
+    <%= render "comment", review: review %>
+  <% end %>
+
   <h2 class="govuk-heading-m">Officer request</h2>
 
   <div class="govuk-inset-text">
@@ -6,7 +10,7 @@
     <p>
     <% @conditions.each_with_index do |condition, index| %>
       <% next if condition.current_validation_request.cancelled? %>
-      <p class="govuk-body"> 
+      <p class="govuk-body">
         <strong>Condition <%= index + 1 %></strong><br>
         <%= condition.title %>
       </p>
@@ -39,7 +43,7 @@
 
               <% if response_been_truncated?(condition, (condition.text + condition.reason + "Reason: \n\n")) %>
                 <span class="govuk-!-display-none hidden-comment">
-                  <%= condition.text[truncated_length(condition)..-1] %><br><br><%= "Reason: #{condition.reason}" %>
+                  <%= condition.text[truncated_length(condition)..] %><br><br><%= "Reason: #{condition.reason}" %>
                 </span>
                 <a href="#" class="show-more" data-action="click->show-more-text#handleClick">View more</a>
               <% end %>
@@ -73,14 +77,14 @@
   <div class="govuk-button-group align-items-center">
     <% if @condition_set.current_review.status != "complete" && @condition_set.latest_active_validation_requests.all?(&:approved?) %>
       <%= form_with model: @condition_set,
-              url: planning_application_assessment_conditions_path(@planning_application, pre_commencement: @condition_set.pre_commencement),
-              html: { data: { controller: "conditions" } },
-              method: :patch do |form| %>
+            url: planning_application_assessment_conditions_path(@planning_application, pre_commencement: @condition_set.pre_commencement),
+            html: {data: {controller: "conditions"}},
+            method: :patch do |form| %>
         <%= form.hidden_field :id, value: @condition_set.id %>
         <%= form.submit(
               t("form_actions.save_and_mark_as_complete"),
               class: "govuk-button",
-              data: { module: "govuk-button" }
+              data: {module: "govuk-button"}
             ) %>
       <% end %>
     <% end %>

--- a/app/views/planning_applications/assessment/conditions/_pre_commencement_conditions.erb
+++ b/app/views/planning_applications/assessment/conditions/_pre_commencement_conditions.erb
@@ -60,7 +60,7 @@
           <td class="govuk-table__cell">
             <% if condition.current_validation_request.approved == false %>
               <%= link_to "Update condition", planning_application_assessment_condition_edit_path(@planning_application, condition, pre_commencement: true) %>
-            <% elsif condition.current_validation_request.approved.nil? && !condition.current_validation_request.cancelled? %>
+            <% elsif (condition.current_validation_request.approved.nil? || condition.condition_set.current_review.action == "rejected") && !condition.current_validation_request.cancelled? %>
               <%= link_to "Cancel", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, condition.current_validation_request) %>
             <% end %>
           </td>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
@@ -13,7 +13,7 @@
             :action, :edited_and_accepted, disabled: form_disabled?, checked: condition_set&.current_review&.edited_and_accepted?, label: {text: "Edit to accept", id: "edit-to-accept"}
           ) do %>
       <%= form.govuk_check_boxes_fieldset :conditions, multiple: false, legend: {text: "Conditions"} do %>
-        <%= form.fields_for :conditions, condition_set.conditions do |fields| %>
+        <%= form.fields_for :conditions, condition_set.approved_conditions do |fields| %>
           <div class="condition">
             <%= fields.hidden_field :_destroy, value: true %>
             <%= fields.govuk_check_box :_destroy, false, disabled: form_disabled?, multiple: false, label: {text: fields.object.review_title || "Other condition"}, checked: fields.object.checked? do %>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
@@ -6,22 +6,22 @@
   <%= form.fields_for :reviews_attributes, condition_set.current_review do |review_form| %>
     <%= review_form.govuk_radio_buttons_fieldset :action, legend: {text: "Actions"} do %>
       <%= review_form.govuk_radio_button(
-            :action, :accepted, disabled: form_disabled?, checked: condition_set&.current_review&.accepted?, label: {text: "Accept"}
+            :action, :accepted, disabled: disabled, checked: condition_set&.current_review&.accepted?, label: {text: "Accept"}
           ) %>
 
       <%= review_form.govuk_radio_button(
-            :action, :edited_and_accepted, disabled: form_disabled?, checked: condition_set&.current_review&.edited_and_accepted?, label: {text: "Edit to accept", id: "edit-to-accept"}
+            :action, :edited_and_accepted, disabled: disabled, checked: condition_set&.current_review&.edited_and_accepted?, label: {text: "Edit to accept", id: "edit-to-accept"}
           ) do %>
       <%= form.govuk_check_boxes_fieldset :conditions, multiple: false, legend: {text: "Conditions"} do %>
         <%= form.fields_for :conditions, condition_set.approved_conditions do |fields| %>
           <div class="condition">
             <%= fields.hidden_field :_destroy, value: true %>
-            <%= fields.govuk_check_box :_destroy, false, disabled: form_disabled?, multiple: false, label: {text: fields.object.review_title || "Other condition"}, checked: fields.object.checked? do %>
+            <%= fields.govuk_check_box :_destroy, false, disabled: disabled, multiple: false, label: {text: fields.object.review_title || "Other condition"}, checked: fields.object.checked? do %>
               <%= fields.hidden_field :id %>
               <%= fields.hidden_field :standard, value: true %>
               <%= fields.hidden_field :title %>
-              <%= fields.govuk_text_area :text, disabled: form_disabled?, label: {text: "Condition", size: "s"} %>
-              <%= fields.govuk_text_area :reason, disabled: form_disabled?, label: {text: "Reason", size: "s"} %>
+              <%= fields.govuk_text_area :text, disabled: disabled, label: {text: "Condition", size: "s"} %>
+              <%= fields.govuk_text_area :reason, disabled: disabled, label: {text: "Reason", size: "s"} %>
             <% end %>
           </div>
         <% end %>
@@ -29,21 +29,25 @@
       <% end %>
 
       <%= review_form.govuk_radio_button(
-            :action, :rejected, disabled: form_disabled?, checked: condition_set&.current_review&.rejected?, label: {text: "Return to officer with comment"}
+            :action, :rejected, disabled: disabled, checked: condition_set&.current_review&.rejected?, label: {text: "Return to officer with comment"}
           ) do %>
         <%= review_form.govuk_text_area(
-              :comment, value: condition_set&.current_review&.comment, readonly: form_disabled?, rows: 6, label: {text: "Comment"}
+              :comment, value: condition_set&.current_review&.comment, readonly: disabled, rows: 6, label: {text: "Comment"}
             ) %>
       <% end %>
     <% end %>
   <% end %>
 
   <div class="govuk-button-group">
-    <% unless form_disabled? %>
+    <% unless disabled %>
       <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
       <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
     <% end %>
 
     <%= back_link %>
+
+    <% if disabled %>
+     <%= link_to "Edit recommendation", edit_planning_application_review_pre_commencement_conditions_path(@planning_application, @planning_application.pre_commencement_condition_set), class: "govuk-link govuk-body" %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
@@ -1,0 +1,49 @@
+<%= form_with model: @planning_application.pre_commencement_condition_set,
+      url: planning_application_review_pre_commencement_conditions_path(@planning_application),
+      class: "govuk-!-margin-top-7" do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.fields_for :reviews_attributes, condition_set.current_review do |review_form| %>
+    <%= review_form.govuk_radio_buttons_fieldset :action, legend: {text: "Actions"} do %>
+      <%= review_form.govuk_radio_button(
+            :action, :accepted, disabled: form_disabled?, checked: condition_set&.current_review&.accepted?, label: {text: "Accept"}
+          ) %>
+
+      <%= review_form.govuk_radio_button(
+            :action, :edited_and_accepted, disabled: form_disabled?, checked: condition_set&.current_review&.edited_and_accepted?, label: {text: "Edit to accept", id: "edit-to-accept"}
+          ) do %>
+      <%= form.govuk_check_boxes_fieldset :conditions, multiple: false, legend: {text: "Conditions"} do %>
+        <%= form.fields_for :conditions, condition_set.conditions do |fields| %>
+          <div class="condition">
+            <%= fields.hidden_field :_destroy, value: true %>
+            <%= fields.govuk_check_box :_destroy, false, disabled: form_disabled?, multiple: false, label: {text: fields.object.review_title || "Other condition"}, checked: fields.object.checked? do %>
+              <%= fields.hidden_field :id %>
+              <%= fields.hidden_field :standard, value: true %>
+              <%= fields.hidden_field :title %>
+              <%= fields.govuk_text_area :text, disabled: form_disabled?, label: {text: "Condition", size: "s"} %>
+              <%= fields.govuk_text_area :reason, disabled: form_disabled?, label: {text: "Reason", size: "s"} %>
+            <% end %>
+          </div>
+        <% end %>
+      <% end %>
+      <% end %>
+
+      <%= review_form.govuk_radio_button(
+            :action, :rejected, disabled: form_disabled?, checked: condition_set&.current_review&.rejected?, label: {text: "Return to officer with comment"}
+          ) do %>
+        <%= review_form.govuk_text_area(
+              :comment, value: condition_set&.current_review&.comment, readonly: form_disabled?, rows: 6, label: {text: "Comment"}
+            ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <% unless form_disabled? %>
+      <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
+      <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
+    <% end %>
+
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
@@ -1,0 +1,22 @@
+<h2 class="govuk-heading-m">Summary of pre-commencement conditions</h2>
+<% if @planning_application.pre_commencement_condition_set&.approved_conditions.present? %>
+  <ol class="govuk-list govuk-list--number">
+    <% @planning_application.pre_commencement_condition_set.approved_conditions.sorted.each do |condition| %>
+      <li>
+        <p class="govuk-body govuk-!-margin-bottom-2">
+          <% if condition.title? %>
+            <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
+            <%= condition.text %><br>
+          <% else %>
+            <span class="govuk-!-font-weight-bold"><%= condition.text %></span>
+          <% end %>
+        </p>
+        <p class="govuk-body">
+          <%= condition.reason %>
+        </p>
+      </li>
+    <% end %>
+  </ol>
+<% else %>
+  <p class="govuk-body">There are no pre-commencement conditions.</p>
+<% end %>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
@@ -5,12 +5,12 @@
       <li>
         <p class="govuk-body govuk-!-margin-bottom-2">
           <% if condition.title? %>
-            <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
+            <strong class="govuk-!-font-weight-bold"><%= condition.title %></strong><br>
             <%= render(FormattedContentComponent.new(text: condition.text)) %>
           <% else %>
-            <span class="govuk-!-font-weight-bold">
+            <strong class="govuk-!-font-weight-bold">
               <%= render(FormattedContentComponent.new(text: condition.text)) %>
-            </span>
+            </strong>
           <% end %>
         </p>
         <p class="govuk-body">

--- a/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_table.html.erb
@@ -6,13 +6,15 @@
         <p class="govuk-body govuk-!-margin-bottom-2">
           <% if condition.title? %>
             <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
-            <%= condition.text %><br>
+            <%= render(FormattedContentComponent.new(text: condition.text)) %>
           <% else %>
-            <span class="govuk-!-font-weight-bold"><%= condition.text %></span>
+            <span class="govuk-!-font-weight-bold">
+              <%= render(FormattedContentComponent.new(text: condition.text)) %>
+            </span>
           <% end %>
         </p>
         <p class="govuk-body">
-          <%= condition.reason %>
+          <%= render(FormattedContentComponent.new(text: condition.reason)) %>
         </p>
       </li>
     <% end %>

--- a/app/views/planning_applications/review/pre_commencement_conditions/edit.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/edit.html.erb
@@ -7,11 +7,11 @@
       locals: {planning_application: @planning_application}
     ) %>
 
-<% content_for :title, "Review pre-commencement conditions" %>
+<% content_for :title, "Review conditions" %>
 
 <%= render(
       partial: "shared/proposal_header",
-      locals: {heading: "Review pre-commencement conditions"}
+      locals: {heading: "Review conditions"}
     ) %>
 
 <div class="govuk-grid-row">
@@ -36,9 +36,9 @@
         <% end %>
       </ol>
     <% else %>
-      <p class="govuk-body">There are no pre-commencement conditions.</p>
+      <p class="govuk-body">There are no conditions.</p>
     <% end %>
 
-    <%= render "form", disabled: review_complete? %>
+    <%= render "form", disabled: false %>
   </div>
 </div>

--- a/app/views/planning_applications/review/pre_commencement_conditions/edit.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/edit.html.erb
@@ -16,29 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Summary of pre-commencement conditions</h2>
-    <% if @planning_application.pre_commencement_condition_set&.approved_conditions.present? %>
-      <ol class="govuk-list govuk-list--number">
-        <% @planning_application.pre_commencement_condition_set.approved_conditions.sorted.each do |condition| %>
-          <li>
-            <p class="govuk-body govuk-!-margin-bottom-2">
-              <% if condition.title? %>
-                <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
-                <%= condition.text %><br>
-              <% else %>
-                <span class="govuk-!-font-weight-bold"><%= condition.text %></span>
-              <% end %>
-            </p>
-            <p class="govuk-body">
-              <%= condition.reason %>
-            </p>
-          </li>
-        <% end %>
-      </ol>
-    <% else %>
-      <p class="govuk-body">There are no conditions.</p>
-    <% end %>
-
+    <%= render "table" %>
     <%= render "form", disabled: false %>
   </div>
 </div>

--- a/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
@@ -1,0 +1,44 @@
+<% content_for :page_title do %>
+  Review conditions - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/review_task_breadcrumbs",
+      locals: {planning_application: @planning_application}
+    ) %>
+
+<% content_for :title, "Review pre-commencement conditions" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Review pre-commencement conditions"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">Summary of pre-commencement conditions</h2>
+    <% if @planning_application.pre_commencement_condition_set&.conditions.present? %>
+      <ol class="govuk-list govuk-list--number">
+        <% @planning_application.pre_commencement_condition_set.conditions.sorted.each do |condition| %>
+          <li>
+            <p class="govuk-body govuk-!-margin-bottom-2">
+              <% if condition.title? %>
+                <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
+                <%= condition.text %><br>
+              <% else %>
+                <span class="govuk-!-font-weight-bold"><%= condition.text %></span>
+              <% end %>
+            </p>
+            <p class="govuk-body">
+              <%= condition.reason %>
+            </p>
+          </li>
+        <% end %>
+      </ol>
+    <% else %>
+      <p class="govuk-body">There are no pre-commencement conditions.</p>
+    <% end %>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
@@ -16,29 +16,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Summary of pre-commencement conditions</h2>
-    <% if @planning_application.pre_commencement_condition_set&.approved_conditions.present? %>
-      <ol class="govuk-list govuk-list--number">
-        <% @planning_application.pre_commencement_condition_set.approved_conditions.sorted.each do |condition| %>
-          <li>
-            <p class="govuk-body govuk-!-margin-bottom-2">
-              <% if condition.title? %>
-                <span class="govuk-!-font-weight-bold"><%= condition.title %></span><br>
-                <%= condition.text %><br>
-              <% else %>
-                <span class="govuk-!-font-weight-bold"><%= condition.text %></span>
-              <% end %>
-            </p>
-            <p class="govuk-body">
-              <%= condition.reason %>
-            </p>
-          </li>
-        <% end %>
-      </ol>
-    <% else %>
-      <p class="govuk-body">There are no pre-commencement conditions.</p>
-    <% end %>
-
+    <%= render "table" %>
     <%= render "form", disabled: review_complete? %>
   </div>
 </div>

--- a/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/show.html.erb
@@ -17,9 +17,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">Summary of pre-commencement conditions</h2>
-    <% if @planning_application.pre_commencement_condition_set&.conditions.present? %>
+    <% if @planning_application.pre_commencement_condition_set&.approved_conditions.present? %>
       <ol class="govuk-list govuk-list--number">
-        <% @planning_application.pre_commencement_condition_set.conditions.sorted.each do |condition| %>
+        <% @planning_application.pre_commencement_condition_set.approved_conditions.sorted.each do |condition| %>
           <li>
             <p class="govuk-body govuk-!-margin-bottom-2">
               <% if condition.title? %>

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -44,7 +44,7 @@
     )%>
   <% end %>
   <% if @planning_application.application_type.planning_conditions? %>
-    <% if @planning_application.condition_set && @planning_application.condition_set.current_review&.status != "not_started" %>
+    <% if @planning_application.condition_set&.current_review&.started? %>
       <%= render(
         TaskListItems::Reviewing::ConditionComponent.new(
           condition_set: @planning_application.condition_set
@@ -52,7 +52,7 @@
       ) %>
     <% end %>
 
-    <% if @planning_application.pre_commencement_condition_set && @planning_application.pre_commencement_condition_set.current_review&.status != "not_started" %>
+    <% if @planning_application.pre_commencement_condition_set&.current_review&.started? %>
       <%= render(
         TaskListItems::Reviewing::ConditionComponent.new(
           condition_set: @planning_application.pre_commencement_condition_set

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -44,12 +44,20 @@
     )%>
   <% end %>
   <% if @planning_application.application_type.planning_conditions? %>
-    <% if @planning_application.condition_set.present? && @planning_application.condition_set.current_review&.status != "not_started" %>
+    <% if @planning_application.condition_set && @planning_application.condition_set.current_review&.status != "not_started" %>
       <%= render(
         TaskListItems::Reviewing::ConditionComponent.new(
-          condition_set: @planning_application.condition_set,
+          condition_set: @planning_application.condition_set
         )
-      )%>
+      ) %>
+    <% end %>
+
+    <% if @planning_application.pre_commencement_condition_set && @planning_application.pre_commencement_condition_set.current_review&.status != "not_started" %>
+      <%= render(
+        TaskListItems::Reviewing::ConditionComponent.new(
+          condition_set: @planning_application.pre_commencement_condition_set
+        )
+      ) %>
     <% end %>
   <% end %>
 

--- a/config/locales/conditions_list.yml
+++ b/config/locales/conditions_list.yml
@@ -2,12 +2,12 @@ en:
   conditions_list:
     time:
       title: Time limit
-      text: The development herby permitted shall be commenced within three years of the date of this permission.
+      text: The development hereby permitted shall be commenced within three years of the date of this permission.
       reason: To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended).
       standard: true
     plans:
       title: In accordance with approved plans
-      text: The development herby permitted must be undertaken in accordance with the approved plans and documents.
+      text: The development hereby permitted must be undertaken in accordance with the approved plans and documents.
       reason: For the avoidance of doubt and in the interests of proper planning.
       standard: true
     materials:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2087,6 +2087,8 @@ en:
         link_text: Committee decision
       condition_component:
         link_text: Review conditions
+        pre_commencement:
+          link_text: Review pre-commencement conditions
       documents_component:
         review_documents_for: Review documents for recommendation
       immunity_details_component:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,8 @@ Rails.application.routes.draw do
           end
 
           resources :recommendations, only: %i[new create update edit]
+
+          resource :pre_commencement_conditions, only: %i[edit update show]
         end
       end
     end

--- a/spec/factories/condition.rb
+++ b/spec/factories/condition.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :condition do
     title { "Time limit" }
-    text { "The development herby permitted shall be commenced within three years of the date of this permission." }
+    text { "The development hereby permitted shall be commenced within three years of the date of this permission." }
     reason { "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)." }
     standard { true }
 

--- a/spec/factories/term.rb
+++ b/spec/factories/term.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory :term do
     title { "Time limit" }
-    text { "The development herby permitted shall be commenced within three years of the date of this permission." }
+    text { "The development hereby permitted shall be commenced within three years of the date of this permission." }
 
     heads_of_term
 

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Add conditions" do
       click_link "Add conditions"
 
       expect(page).to have_content "Time limit"
-      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
       expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
       expect(page).to have_content "Condition 1"
       expect(page).to have_content "Reason 1"
@@ -100,10 +100,10 @@ RSpec.describe "Add conditions" do
       click_link "Add conditions"
 
       expect(page).to have_content "Time limit"
-      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
       expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
       expect(page).to have_content "In accordance with approved plans"
-      expect(page).to have_content "The development herby permitted must be undertaken in accordance with the approved plans and documents."
+      expect(page).to have_content "The development hereby permitted must be undertaken in accordance with the approved plans and documents."
       expect(page).to have_content "For the avoidance of doubt and in the interests of proper planning."
       expect(page).to have_content "Condition 1"
       expect(page).to have_content "Reason 1"
@@ -123,13 +123,13 @@ RSpec.describe "Add conditions" do
       click_link "Add conditions"
 
       expect(page).to have_content "In accordance with approved plans"
-      expect(page).to have_content "The development herby permitted must be undertaken in accordance with the approved plans and documents."
+      expect(page).to have_content "The development hereby permitted must be undertaken in accordance with the approved plans and documents."
       expect(page).to have_content "For the avoidance of doubt and in the interests of proper planning."
       expect(page).to have_content "Custom condition 1"
       expect(page).to have_content "Custom reason 1"
 
       expect(page).not_to have_content "Time limit"
-      expect(page).not_to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).not_to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
       expect(page).not_to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
       expect(page).not_to have_content "Condition 1"
       expect(page).not_to have_content "Reason 1"
@@ -163,7 +163,7 @@ RSpec.describe "Add conditions" do
       click_link "Review and submit recommendation"
 
       expect(page).to have_content "Conditions"
-      expect(page).to have_content "The development herby permitted shall be commenced within three years of the date of this permission."
+      expect(page).to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
       expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
     end
   end

--- a/spec/system/planning_applications/review/conditions_spec.rb
+++ b/spec/system/planning_applications/review/conditions_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Reviewing conditions" do
           with: "Completed"
         )
 
-        condition_set = ConditionSet.last
+        condition_set = planning_application.condition_set
         expect(condition_set.current_review.action).to eq "accepted"
         expect(condition_set.current_review.review_status).to eq "review_complete"
       end
@@ -80,7 +80,7 @@ RSpec.describe "Reviewing conditions" do
           with: "Completed"
         )
 
-        condition_set = ConditionSet.last
+        condition_set = planning_application.condition_set
         expect(condition_set.current_review.action).to eq "edited_and_accepted"
         expect(condition_set.conditions.last.reason).to eq "This is different reason"
         expect(condition_set.current_review.review_status).to eq "review_complete"
@@ -107,7 +107,7 @@ RSpec.describe "Reviewing conditions" do
           with: "To be reviewed"
         )
 
-        condition_set = ConditionSet.last
+        condition_set = planning_application.condition_set
         expect(condition_set.current_review.action).to eq "rejected"
         expect(condition_set.current_review.comment).to eq "I don't think you've assessed conditions correctly"
         expect(condition_set.current_review.status).to eq "to_be_reviewed"

--- a/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "Reviewing pre-commencement conditions" do
     create(:planning_application, :awaiting_determination, :planning_permission, local_authority: default_local_authority, pre_commencement_condition_set: condition_set)
   end
 
-  let!(:condition_set) { build(:condition_set, pre_commencement: true, planning_application: nil) }
+  let!(:condition_set) { create(:condition_set, pre_commencement: true) }
   let!(:standard_condition) { create(:condition, condition_set:, title: "foo", validation_requests: [validate]) }
   let!(:other_condition) { create(:condition, :other, condition_set:, title: "bar", validation_requests: [validate]) }
 
   def validate
-    create(:pre_commencement_condition_validation_request, approved: true)
+    create(:pre_commencement_condition_validation_request, approved: true, planning_application:)
   end
 
   context "when signed in as a reviewer" do
@@ -129,6 +129,10 @@ RSpec.describe "Reviewing pre-commencement conditions" do
         click_link "Add pre-commencement conditions"
 
         expect(page).to have_content("I don't think you've assessed conditions correctly")
+
+        within "tbody tr:first-child" do
+          click_link "Cancel"
+        end
       end
     end
   end

--- a/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reviewing pre-commencement conditions" do
+  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
+
+  let!(:planning_application) do
+    create(:planning_application, :awaiting_determination, :planning_permission, local_authority: default_local_authority, pre_commencement_condition_set: condition_set)
+  end
+
+  let!(:condition_set) { build(:condition_set, pre_commencement: true, planning_application: nil) }
+  let!(:standard_condition) { create(:condition, condition_set:, title: "foo", validation_requests: [validate]) }
+  let!(:other_condition) { create(:condition, :other, condition_set:, title: "bar", validation_requests: [validate]) }
+
+  def validate
+    create(:pre_commencement_condition_validation_request, approved: true)
+  end
+
+  context "when signed in as a reviewer" do
+    before do
+      create(:recommendation, status: "assessment_complete", planning_application:)
+      create(:review, owner: condition_set, status: "complete")
+      sign_in(reviewer)
+      visit "/planning_applications/#{planning_application.id}/review/tasks"
+    end
+
+    context "when planning application is awaiting determination" do
+      it "I can accept the planning officer's decision" do
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "Not started"
+        )
+
+        click_link "Review pre-commencement conditions"
+
+        expect(page).to have_content("Review pre-commencement conditions")
+
+        expect(page).to have_content(standard_condition.title)
+        expect(page).to have_content(standard_condition.text)
+        expect(page).to have_content(standard_condition.reason)
+
+        expect(page).to have_content(other_condition.text)
+        expect(page).to have_content(other_condition.reason)
+
+        choose "Accept"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review conditions successfully updated")
+
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "Completed"
+        )
+
+        condition_set = planning_application.pre_commencement_condition_set
+        expect(condition_set.current_review.action).to eq "accepted"
+        expect(condition_set.current_review.review_status).to eq "review_complete"
+      end
+
+      it "I can edit to accept the planning officer's decision" do
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "Not started"
+        )
+
+        click_link "Review pre-commencement conditions"
+
+        choose "Edit to accept"
+
+        within("#condition-set-conditions-attributes-1--destroy-conditional") do
+          fill_in "Reason", with: "This is different reason"
+        end
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review conditions successfully updated")
+
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "Completed"
+        )
+
+        condition_set = planning_application.pre_commencement_condition_set
+        expect(condition_set.current_review.action).to eq "edited_and_accepted"
+        expect(condition_set.conditions.last.reason).to eq "This is different reason"
+        expect(condition_set.current_review.review_status).to eq "review_complete"
+      end
+
+      it "I can return to officer with comment" do
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "Not started"
+        )
+
+        click_link "Review pre-commencement conditions"
+
+        choose "Return to officer with comment"
+
+        fill_in "Comment", with: "I don't think you've assessed conditions correctly"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Review conditions successfully updated")
+
+        expect(page).to have_list_item_for(
+          "Review pre-commencement conditions",
+          with: "To be reviewed"
+        )
+
+        condition_set = planning_application.pre_commencement_condition_set
+        expect(condition_set.current_review.action).to eq "rejected"
+        expect(condition_set.current_review.comment).to eq "I don't think you've assessed conditions correctly"
+        expect(condition_set.current_review.status).to eq "to_be_reviewed"
+
+        sign_out(reviewer)
+        sign_in(assessor)
+
+        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+
+        expect(page).to have_list_item_for(
+          "Add pre-commencement conditions",
+          with: "Updated"
+        )
+
+        click_link "Add pre-commencement conditions"
+
+        expect(page).to have_content("I don't think you've assessed conditions correctly")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Allow reviewing pre-commencement conditions.

### Story Link

https://trello.com/c/8b0c3dOQ/2665-reviewer-is-able-to-see-that-pre-commencement-conditions-have-been-agreed

### Screenshots

<img width="834" alt="Screenshot 2024-03-26 at 14 57 41" src="https://github.com/unboxed/bops/assets/3986/4ae64b7e-53e0-47c8-a5b2-69b1f31689c0">

### Decisions [OPTIONAL]

If you had to make any decisions between different ways of doing things, what where they and why?

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
