### PR TITLE
Review whether application is CIL liable

### DIFF
--- a/app/controllers/planning_applications/review/cil_liability_controller.rb
+++ b/app/controllers/planning_applications/review/cil_liability_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Review
+    class CilLiabilityController < ApplicationController
+      include PlanningApplicationAssessable
+      before_action :set_planning_application
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        @previous_decision = @planning_application.cil_liable
+        if @planning_application.update(cil_liability_params)
+          record_audit_for_cil_liability!
+          redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+        else
+          render :edit
+        end
+      end
+
+      private
+
+      def cil_liability_params
+        params.require(:planning_application).permit([:cil_liable])
+      end
+
+      def record_audit_for_cil_liability!
+        Audit.create!(
+          planning_application_id: @planning_application.id,
+          user: Current.user,
+          activity_type: "review_cil_liability",
+          audit_comment:,
+          activity_information:
+        )
+      end
+
+      def audit_comment
+        if @previous_decision.nil?
+          "The validation officer had not confirmed whether the application was liable"
+        else
+          "Previously marked as#{" not" unless @previous_decision} liable by validation officer"
+        end
+      end
+
+      def activity_information
+        if @planning_application.cil_liable.nil?
+          "Reviewer marked application as not needing confirmation for CIL liability"
+        else
+          "Reviewer marked application as#{" not" unless @planning_application.cil_liable} liable for CIL"
+        end
+      end
+    end
+  end
+end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -125,7 +125,8 @@ class Audit < ApplicationRecord
     consultee_response_uploaded: "consultee_response_uploaded",
     consultee_response_edited: "consultee_response_edited",
     committee_details_sent: "committee_details_sent",
-    sent_to_committee: "sent_to_committee"
+    sent_to_committee: "sent_to_committee",
+    review_cil_liability: "review_cil_liability"
   }
 
   validates :activity_type, presence: true

--- a/app/views/planning_applications/review/cil_liability/_audit_trail.html.erb
+++ b/app/views/planning_applications/review/cil_liability/_audit_trail.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-inset-text">
+  <p class="govuk-body">
+    <% if @planning_application.audits.review_cil_liability.any? %>
+      <% @planning_application.audits.review_cil_liability.each do |audit| %>
+        <p class="govuk-body">
+          <strong><%= audit.created_at.to_fs %></strong><br>
+          <%= audit.activity_information %>. <%= audit.audit_comment %>
+        </p>
+      <% end %>
+    <% else %>
+      <% if @planning_application.cil_liable.nil? %>
+        The validation officer did not confirm whether the application is liable for CIL.
+      <% else %>
+        The validation officer marked this application as <%= "not" unless @planning_application.cil_liable %> liable for CIL.
+      <% end %>
+    <% end %>
+  </p>
+</div>

--- a/app/views/planning_applications/review/cil_liability/_form.html.erb
+++ b/app/views/planning_applications/review/cil_liability/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [@planning_application],
+              url: planning_application_review_cil_liability_url(@planning_application),
+              class: "govuk-!-margin-top-7" do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+        :cil_liability,
+        legend: { text: "Is the application liable for CIL?", size: "s" }
+      ) do %>
+    <% if @planning_application.cil_liable.nil? %>
+      <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.likely_cil_liable?, label: { text: "Yes" }) %>
+      <%= form.govuk_radio_button(:cil_liable, false, checked: @planning_application.cil_liability_planx_answer? && !@planning_application.likely_cil_liable?, label: { text: "No" }) %>
+    <% else %>
+      <%= form.govuk_radio_button(:cil_liable, true, checked: @planning_application.cil_liable, label: { text: "Yes" }) %>
+      <%= form.govuk_radio_button(:cil_liable, false, checked: !@planning_application.cil_liable, label: { text: "No" }) %>
+    <% end %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= form.submit(
+      t("form_actions.save_and_mark_as_complete"),
+      class: "govuk-button",
+      data: { module: "govuk-button" },
+      disabled: local_assigns.fetch(:disabled, false)
+    ) %>
+    <%= link_to "Back", planning_application_review_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/review/cil_liability/edit.html.erb
+++ b/app/views/planning_applications/review/cil_liability/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title do %>
+  CIL Liability - <%= t("page_title") %>
+<% end %>
+
+<%= render(partial: "shared/review_task_breadcrumbs", locals: {planning_application: @planning_application}) %>
+
+<% content_for :title, "Check Community Infrastructure Levy (CIL)" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Check Community Infrastructure Levy (CIL)" }
+    ) %>
+
+<p class="govuk-body">
+  <% if @planning_application.cil_liability_planx_answer? %>
+    According to PlanX the new floor area being added is:
+    <strong><%= @planning_application.cil_liability_proposal_detail.response_values.to_sentence %></strong>.
+    <br>
+    This might mean that the application is
+    <% unless @planning_application.likely_cil_liable? %>
+      not
+    <% end %>
+    liable for CIL.
+  <% else %>
+    No information on potential CIL liability from PlanX.
+  <% end %>
+</p>
+
+<%= render "audit_trail" %>
+
+<%= render partial: "form" %>

--- a/app/views/planning_applications/review/cil_liability/show.html.erb
+++ b/app/views/planning_applications/review/cil_liability/show.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title do %>
+  CIL Liability - <%= t("page_title") %>
+<% end %>
+
+<%= render(
+      partial: "shared/review_task_breadcrumbs",
+      locals: { planning_application: @planning_application }
+    ) %>
+
+<% content_for :title, "Check Community Infrastructure Levy (CIL)" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: { heading: "Check Community Infrastructure Levy (CIL)" }
+    ) %>
+
+<p class="govuk-body">
+  <% if @planning_application.cil_liability_planx_answer? %>
+      According to PlanX the new floor area being added is:
+      <strong><%= @planning_application.cil_liability_proposal_detail.response_values.to_sentence %></strong>.
+      <br>
+      This might mean that the application is
+      <% unless @planning_application.likely_cil_liable? %>
+        not
+      <% end %>
+      liable for CIL.
+  <% else %>
+    No information on potential CIL liability from PlanX.
+  <% end %>
+</p>
+
+<%= render "audit_trail" %>
+
+<%= form_with model: [@planning_application],
+              url: planning_application_review_cil_liability_url(@planning_application),
+              class: "govuk-!-margin-top-7" do |form| %>
+  <%= form.hidden_field :cil_liable, value: @planning_application.cil_liable %>
+
+  <div class="govuk-button-group">
+    <% unless @planning_application.audits.review_cil_liability.any? %>
+      <%= form.submit(
+        t("form_actions.save_and_mark_as_complete"),
+        class: "govuk-button",
+        data: { module: "govuk-button" },
+        disabled: local_assigns.fetch(:disabled, false)
+      ) %>
+    <% end %>
+    <%= link_to "Back", planning_application_review_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+    <%= link_to "Change CIL liability", edit_planning_application_review_cil_liability_path(@planning_application), class: "govuk-link govuk-body" %>
+  </div>
+<% end %>
+
+

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -10,6 +10,19 @@
 ) %>
 </span>
 <ul class="app-task-list__items" id="review-assessment-section">
+  <li class="app-task-list__item">
+    <span class="app-task-list__task-name">
+      <%= link_to(
+        "Check Community Infrastructure Levy (CIL)",
+        planning_application_review_cil_liability_path(@planning_application),
+        class: "govuk-link") %>
+    </span>
+    <%= render(
+      StatusTags::BaseComponent.new(
+        status: (@planning_application.audits.review_cil_liability.any? ? :complete : :not_started)
+      )
+    )%>
+  </li>
   <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.evidence.any? %>
       <%= render(
         TaskListItems::Reviewing::ImmunityDetailsComponent.new(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -450,6 +450,7 @@ en:
       replacement_document_validation_request_sent: 'Sent: validation request (replacement document#%{args})'
       replacement_document_validation_request_sent_post_validation: 'Sent: Post-validation request (replacement document#%{args})'
       returned: Application returned
+      review_cil_liability: 'Reviewed: CIL liability'
       sent_to_committee: Application sent to committee
       site_notice_created: Site notice created
       started: Application validated
@@ -1369,6 +1370,9 @@ en:
           assessor_remarks: Assessor's remarks
           review_assessment_summaries: Review assessment summaries
           this_information_will: This information will be made publicly available.
+      cil_liability:
+        update:
+          success: Review of CIL liability successfully updated
       committee_decisions:
         update:
           success: Review of committee decision recommendation updated successfully

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,8 @@ Rails.application.routes.draw do
 
           resources :tasks, only: :index
 
+          resource :cil_liability, only: %i[edit update show], controller: :cil_liability
+
           resources :committee_decisions, only: %i[edit show update] do
             resources :notifications do
               get :edit, on: :collection

--- a/spec/system/planning_applications/review/check_cil_liability_spec.rb
+++ b/spec/system/planning_applications/review/check_cil_liability_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "checking publicity" do
+  let!(:local_authority) { create(:local_authority, :default, press_notice_email: "pressnotices@example.com") }
+
+  let!(:assessor) do
+    create(:user, :assessor, name: "Alice Smith", local_authority: local_authority)
+  end
+
+  let!(:reviewer) do
+    create(:user, :reviewer, local_authority: local_authority)
+  end
+
+  let!(:planning_application) do
+    create(:planning_application, :awaiting_determination, :planning_permission, local_authority: local_authority)
+  end
+
+  before do
+    create(:recommendation, planning_application:)
+
+    sign_in reviewer
+  end
+
+  context "when the validation officer has not filled in CIL liability" do
+    before do
+      planning_application.update(cil_liable: nil)
+    end
+
+    it "the reviewer can mark it as not needing confirmation" do
+      visit "planning_applications/#{planning_application.id}/review/tasks"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Not started"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer did not confirm whether the application is liable for CIL."
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Review of CIL liability successfully updated"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Completed"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer had not confirmed whether the application was liable"
+      expect(page).to have_content "Reviewer marked application as not needing confirmation for CIL liability"
+    end
+
+    it "the reviewer can update it" do
+      visit "planning_applications/#{planning_application.id}/review/tasks"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Not started"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer did not confirm whether the application is liable for CIL."
+
+      click_link "Change CIL liability"
+
+      choose "Yes"
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Review of CIL liability successfully updated"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Completed"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer had not confirmed whether the application was liable"
+      expect(page).to have_content "Reviewer marked application as liable for CIL"
+    end
+  end
+
+  context "when the validation officer has filled in CIL liability" do
+    before do
+      planning_application.update(cil_liable: true)
+    end
+
+    it "the reviewer can mark it as correct" do
+      visit "planning_applications/#{planning_application.id}/review/tasks"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Not started"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer marked this application as liable for CIL"
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Review of CIL liability successfully updated"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Completed"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "Previously marked as liable by validation officer"
+      expect(page).to have_content "Reviewer marked application as liable for CIL"
+    end
+
+    it "the reviewer can change it" do
+      visit "planning_applications/#{planning_application.id}/review/tasks"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Not started"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "The validation officer marked this application as liable for CIL"
+
+      click_link "Change CIL liability"
+
+      choose "No"
+
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content "Review of CIL liability successfully updated"
+
+      expect(page).to have_list_item_for(
+        "Check Community Infrastructure Levy (CIL)",
+        with: "Completed"
+      )
+
+      click_link "Check Community Infrastructure Levy (CIL)"
+
+      expect(page).to have_content "Previously marked as liable by validation officer"
+      expect(page).to have_content "Reviewer marked application as not liable for CIL"
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Reviewer can review CIL liability, and change it if needed

### Story Link

https://trello.com/c/WPXpQs97/2667-reviewer-able-to-confirm-cil-liability

### Screenshots

![screencapture-lambeth-bops-localhost-3000-planning-applications-2436-review-cil-liability-2024-03-25-14_37_43](https://github.com/unboxed/bops/assets/35098639/3afdf4de-e63a-44e6-b832-eb6524994719)
![screencapture-lambeth-bops-localhost-3000-planning-applications-2436-review-cil-liability-edit-2024-03-25-14_37_52](https://github.com/unboxed/bops/assets/35098639/eb72bc7f-3be0-4aff-9357-af9e9e866b33)
