### PR TITLE
Add management of the document tags for application types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ api-docs:
 api-specs:
 	$(DOCKER-RUN) console rspec engines/bops_api/spec
 
+config-specs:
+	$(DOCKER-RUN) console rspec engines/bops_config/spec
+
 rspec:
 	$(DOCKER-RUN) console rspec
 

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -423,3 +423,33 @@ body {
 .autocomplete__menu {
   font-family: $govuk-font-family;
 }
+
+.max-lines {
+  cursor: pointer;
+  user-select: none;
+
+  &--clamped {
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+  }
+}
+
+.ga-document-tag {
+  margin: 0.25rem 0.25rem 0.25rem 0;
+}
+
+.ga-document-tags {
+  column-count: 2;
+  column-fill: balance;
+
+  & > .govuk-checkboxes__item {
+    break-inside: avoid;
+  }
+
+  .govuk-checkboxes__label {
+    text-wrap: balance;
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -34,6 +34,9 @@ application.register("heads-of-terms", HeadsofTermsController)
 import LocalPoliciesController from "./local_policies_controller.js"
 application.register("local-policies", LocalPoliciesController)
 
+import MaxLinesController from "./max_lines_controller.js"
+application.register("max-lines", MaxLinesController)
+
 import NeighboursController from "./neighbours_controller.js"
 application.register("neighbours", NeighboursController)
 

--- a/app/javascript/controllers/max_lines_controller.js
+++ b/app/javascript/controllers/max_lines_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle(event) {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.classes.toggle("max-lines--clamped")
+  }
+
+  get classes() {
+    return this.element.classList
+  }
+}

--- a/app/models/application_type_document_tags.rb
+++ b/app/models/application_type_document_tags.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationTypeDocumentTags
+  include StoreModel::Model
+
+  TAG_GROUPS = %w[plans evidence supporting_documents].freeze
+
+  TAG_GROUPS.each do |name|
+    attribute name.to_sym, :list, default: -> { [] }
+  end
+
+  TagGroup = Struct.new(:name, :selected_tags, :all_tags) do
+    def tags
+      selected_tags
+    end
+
+    def translated_tags
+      selected_tags.map(&method(:translate_tag)).sort_by(&:itself)
+    end
+
+    def irrelevant_tags
+      all_tags - selected_tags
+    end
+
+    def to_s
+      name
+    end
+
+    def tag_list
+      all_tags.map(&method(:build_tag_list)).sort_by(&:last)
+    end
+
+    private
+
+    def translate_tag(tag)
+      I18n.t("document_tags.#{tag}")
+    end
+
+    def build_tag_list(tag)
+      [tag, translate_tag(tag)]
+    end
+  end
+
+  def tag_groups
+    TAG_GROUPS.map(&method(:build_tag_group))
+  end
+
+  private
+
+  def build_tag_group(name)
+    TagGroup.new(name, attributes[name], Document.tags(name))
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -230,6 +230,23 @@ class Document < ApplicationRecord
     self.user ||= Current.user
   end
 
+  class << self
+    def tags(key)
+      case key.to_s
+      when "plans"
+        PLAN_TAGS
+      when "evidence"
+        EVIDENCE_TAGS
+      when "supporting_documents"
+        (SUPPORTING_DOCUMENT_TAGS - ["disabilityExemptionEvidence"])
+      when "other"
+        []
+      else
+        raise ArgumentError, "Unexpected document tag type: #{key}"
+      end
+    end
+  end
+
   def name
     file.filename.to_s if file.attached?
   end

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -3,7 +3,7 @@
   <%= render partial: 'documents/form_partials/upload', locals: {form: form} unless @validate_document %>
   <div class="govuk-form-group">
     <%= render partial: 'documents/form_partials/received_at', locals: {form: form} unless @validate_document %>
-    <%= render partial: 'documents/form_partials/tags', locals: {form: form} %>
+    <%= render partial: 'documents/form_partials/tags', locals: {form: form, document_tags: @planning_application.application_type.document_tags} %>
     <%= render partial: 'documents/form_partials/privacy', locals: {form: form} %>
     <%= render partial: 'documents/form_partials/validate_document', locals: {form: form} if @validate_document %>
 

--- a/app/views/documents/form_partials/_privacy.html.erb
+++ b/app/views/documents/form_partials/_privacy.html.erb
@@ -4,14 +4,14 @@
   hint: { text: t(".where_documents_contain") },
   class: "govuk-input--width-20"
 ) %>
-<div class="display govuk-!-padding-top-3">
+<div class="display govuk-!-margin-top-3">
   <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Do you want to list this document on the decision notice?' }) do %>
     <%= form.govuk_radio_button :referenced_in_decision_notice, 'true', label: { text: 'Yes' } %>
     <%= form.govuk_radio_button :referenced_in_decision_notice, 'false', label: { text: 'No' } %>
   <% end %>
 </div>
 
-<div class="publish govuk-!-padding-top-3">
+<div class="publish govuk-!-margin-top-3">
   <%= form.govuk_radio_buttons_fieldset(:status, legend: { size: 's', text: 'Should this document be made publicly available?' }) do %>
     <div id="event-name-hint" class="govuk-hint">
       Indicate whether this document should be made available for public viewing on the planning register or via the public API. Select "No" if the document contains any sensitive personal information.

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -1,4 +1,5 @@
-<hr>
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
 <div class="govuk-form-group <%= form.object.errors[:tags].any? ? 'govuk-form-group--error' : '' %>" data-controller="show-hide">
   <fieldset class="govuk-fieldset govuk-!-margin-top-4">
     <legend class="govuk-fieldset__legend">
@@ -14,57 +15,57 @@
       <% end %>
     <% end %>
 
-    <% @planning_application.application_type.document_tags.keys.each do |key| %>
+    <% document_tags.tag_groups.each do |group| %>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
           <h3 class="govuk-heading-s">
-            <%= key.humanize %>
+            <%= group.name.humanize %>
           </h3>
-          <% @planning_application.application_type.document_tags[key].in_groups(2, false) do |tags| %>
-            <div class="govuk-grid-column-one-half">
-              <div class="govuk-checkboxes govuk-checkboxes--small">
-                <%= form.collection_check_boxes :tags, tags, :itself, :itself do |b| %>
-                  <div class="govuk-checkboxes__item">
-                    <%= b.check_box class: "govuk-checkboxes__input" %>
-                    <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" do %>
-                      <%= I18n.t(:"#{b.value}", scope: :document_tags) %>
-                    <% end %>
-                  </div>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
-          <div>
-            <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
-              <a class="show-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#showDisplayNone">
-                Show all (<%= @planning_application.application_type.irrelevant_tags(key).count %>)
-              </a>
-            </div>
-            <div class="document-tags govuk-!-display-none">
-              <% @planning_application.application_type.irrelevant_tags(key).in_groups(2, false) do |tags| %>
-                <div class="govuk-grid-column-one-half">
-                  <div class="govuk-checkboxes govuk-checkboxes--small">
-                    <%= form.collection_check_boxes :tags, tags, :itself, :itself do |b| %>
-                      <div class="govuk-checkboxes__item">
-                        <%= b.check_box class: "govuk-checkboxes__input" %>
-                        <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" do %>
-                          <%= I18n.t(:"#{b.value}", scope: :document_tags) %>
-                        <% end %>
-                      </div>
-                    <% end %>
-                  </div>
+        </div>
+        <% group.tags.in_groups(2, false) do |column| %>
+          <div class="govuk-grid-column-one-half">
+            <div class="govuk-checkboxes govuk-checkboxes--small">
+              <%= form.collection_check_boxes :tags, column, :itself, :itself do |b| %>
+                <div class="govuk-checkboxes__item">
+                  <%= b.check_box class: "govuk-checkboxes__input" %>
+                  <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" do %>
+                    <%= I18n.t(:"#{b.value}", scope: :document_tags) %>
+                  <% end %>
                 </div>
               <% end %>
-              <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
-                <a class="remove-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#hideDisplayNone">
-                  Show less
-                </a>
-              </div>
             </div>
           </div>
-        </div>
+        <% end %>
+        <% if group.irrelevant_tags.any? %>
+          <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
+            <a class="show-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#showDisplayNone">
+              Show all (<%= group.irrelevant_tags.count %>)
+            </a>
+          </div>
+          <div class="document-tags govuk-!-display-none">
+            <% group.irrelevant_tags.in_groups(2, false) do |tags| %>
+              <div class="govuk-grid-column-one-half">
+                <div class="govuk-checkboxes govuk-checkboxes--small">
+                  <%= form.collection_check_boxes :tags, tags, :itself, :itself do |b| %>
+                    <div class="govuk-checkboxes__item">
+                      <%= b.check_box class: "govuk-checkboxes__input" %>
+                      <%= b.label class: "govuk-label govuk-checkboxes__label tag_checkbox_label" do %>
+                        <%= I18n.t(:"#{b.value}", scope: :document_tags) %>
+                      <% end %>
+                    </div>
+                  <% end %>
+                </div>
+              </div>
+            <% end %>
+            <div class="govuk-grid-column-full govuk-!-margin-bottom-3 govuk-!-margin-top-2">
+              <a class="remove-document-tags govuk-link govuk-body" href="#" data-action="click->show-hide#hideDisplayNone">
+                Show less
+              </a>
+            </div>
+          </div>
+        <% end %>
       </div>
-      <hr>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <% end %>
   </fieldset>
 </div>

--- a/db/migrate/20240322110154_add_default_to_application_type_document_tags.rb
+++ b/db/migrate/20240322110154_add_default_to_application_type_document_tags.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDefaultToApplicationTypeDocumentTags < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :application_types, :document_tags, false, {}
+    change_column_default :application_types, :document_tags, from: nil, to: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_155240) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_22_110154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -65,7 +65,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_155240) do
     t.string "assessment_details", array: true
     t.string "steps", default: ["validation", "consultation", "assessment", "review"], array: true
     t.string "consistency_checklist", array: true
-    t.jsonb "document_tags"
+    t.jsonb "document_tags", default: {}, null: false
     t.jsonb "features", default: {}
     t.string "status", default: "inactive", null: false
     t.string "code", null: false

--- a/engines/bops_config/app/controllers/bops_config/application_types/document_tags_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/document_tags_controller.rb
@@ -2,8 +2,9 @@
 
 module BopsConfig
   module ApplicationTypes
-    class FeaturesController < ApplicationController
+    class DocumentTagsController < ApplicationController
       before_action :set_application_type
+      before_action :set_document_tags
 
       def edit
         respond_to do |format|
@@ -13,7 +14,7 @@ module BopsConfig
 
       def update
         respond_to do |format|
-          if @application_type.update(application_type_features_params, :features)
+          if @application_type.update(application_type_params, :document_tags)
             format.html do
               redirect_to next_path, notice: t(".success")
             end
@@ -25,20 +26,24 @@ module BopsConfig
 
       private
 
-      def application_type_features_params
-        params.require(:application_type).permit(features: [:planning_conditions, :permitted_development_rights, {consultation_steps: []}])
+      def application_type_params
+        params.require(:application_type).permit(document_tags_attributes: document_tags_params)
+      end
+
+      def document_tags_params
+        {plans: [], evidence: [], supporting_documents: []}
       end
 
       def set_application_type
         @application_type = ApplicationType.find(application_type_id)
       end
 
+      def set_document_tags
+        @document_tags = @application_type.document_tags
+      end
+
       def next_path
-        if @application_type.configured?
-          application_type_path(@application_type)
-        else
-          edit_application_type_document_tags_path(@application_type)
-        end
+        application_type_path(@application_type)
       end
     end
   end

--- a/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title do %>
+  <%= t(".manage_document_tags") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".manage_document_tags") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".manage_document_tags") %>
+    </h1>
+
+    <h2 class="govuk-heading-m">
+      <%= @application_type.description %>
+    </h1>
+
+    <%= form_with model: @application_type, url: [@application_type, :document_tags] do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+      <div class="govuk-tabs govuk-!-margin-top-7" data-module="govuk-tabs">
+        <ul class="govuk-tabs__list">
+          <% @document_tags.tag_groups.each_with_index do |group, index| %>
+            <%= tag.li(class: class_names("govuk-tabs__list-item", "govuk-tabs__list-item--selected": index == 0)) do %>
+              <%= tag.a(class: "govuk-tabs__tab", href: "##{group}-tags") do %>
+                <%= t(".groups.#{group}") %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </ul>
+
+        <%= form.fields :document_tags do |fields| %>
+          <% @document_tags.tag_groups.each_with_index do |group, index| %>
+            <%= tag.div(class: class_names("govuk-tabs__panel", "govuk-tabs__panel--hidden": index != 0), id: "#{group}-tags") do %>
+              <%= fields.govuk_collection_check_boxes group.name, group.tag_list, :first, :last,
+                legend: {text: t(".groups.#{group}")}, hint: {text: t(".hints.#{group}")},
+                small: true, classes: "ga-document-tags" %>
+            <% end %>
+          <% end %>
+        <% end %>
+      </div>
+
+      <%= form.govuk_submit(t(".continue")) do %>
+        <%= link_to(t("back"), @application_type, class: "govuk-button govuk-button--secondary") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -109,6 +109,26 @@
         </dd>
       </div>
 
+      <% @application_type.document_tags.tag_groups.each do |group| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= t(".tags") %> – <%= t(".groups.#{group}") %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <p class="govuk-body max-lines max-lines--clamped" data-controller="max-lines" data-action="click->max-lines#toggle">
+              <% group.translated_tags.each do |tag| %>
+                <span class="govuk-tag govuk-tag--grey ga-document-tag"><%= tag %></span>
+              <% end %>
+            </p>
+          </dd>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to [:edit, @application_type, :document_tags, anchor: "#{group}-tags"], class: "govuk-link" do %>
+              <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".links.#{group}") %></span>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
           <%= t(".status") %>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -16,6 +16,20 @@ en:
           set_determination_period: Set determination period
         update:
           success: Determination period successfully updated
+      document_tags:
+        edit:
+          continue: Continue
+          groups:
+            evidence: Evidence
+            plans: Plans
+            supporting_documents: Supporting documents
+          hints:
+            evidence: Select the relevant tags for evidence documents
+            plans: Select the relevant tags for plans
+            supporting_documents: Select the relevant tags for supporting documents
+          manage_document_tags: Manage document tags
+        update:
+          success: Document tags successfully updated
       edit:
         application_profile: Application profile
         update_application_type: Update the application type
@@ -64,11 +78,20 @@ en:
           other: "%{count} days - bank holidays included"
         edit: Edit
         features: Features
+        groups:
+          evidence: Evidence
+          plans: Plans
+          supporting_documents: Supporting documents
         legislation: Legislation
+        links:
+          evidence: evidence tags
+          plans: plan tags
+          supporting_documents: supporting document tags
         name: Name
         review_application_type: Review the application type
         status: Status
         suffix: Suffix
+        tags: Tags
       statuses:
         edit:
           active: Active

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -15,6 +15,7 @@ BopsConfig::Engine.routes.draw do
     scope module: "application_types" do
       with_options only: %i[edit update] do
         resource :determination_period
+        resource :document_tags
         resource :features
         resource :legislation
         resource :status

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     fill_in "Name", with: "Planning Permission - Major application"
     fill_in "Suffix", with: "MAJR"
-
     click_button "Continue"
+
+    expect(page).to have_content("Application profile successfully created")
 
     # Enter legislation
     expect(page).to have_selector("h1", text: "Enter legislation")
@@ -68,12 +69,44 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     fill_in "Set determination period", with: "25"
     click_button "Continue"
+
     expect(page).to have_content("Determination period successfully updated")
+
+    # Choose features
+    expect(page).to have_selector("h1", text: "Choose features")
+    expect(page).to have_selector("h2", text: "Planning Permission - Major application")
 
     check "Check permitted development rights"
     check "Neighbours consultation"
     click_button "Continue"
+
     expect(page).to have_content("Features successfully updated")
+
+    # Manage document tags
+    expect(page).to have_selector("h1", text: "Manage document tags")
+    expect(page).to have_selector("h2", text: "Planning Permission - Major application")
+    expect(page).to have_selector("legend", text: "Plans")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for plans")
+
+    check "Elevations - proposed"
+    check "Elevations - existing"
+    click_link "Evidence"
+
+    expect(page).to have_selector("legend", text: "Evidence")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for evidence documents")
+
+    check "Utility bill"
+    check "Bank statement"
+    click_link "Supporting documents"
+
+    expect(page).to have_selector("legend", text: "Evidence")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for evidence documents")
+
+    check "Sustainability statement"
+    check "Environmental Impact Assessment (EIA)"
+    click_button "Continue"
+
+    expect(page).to have_content("Document tags successfully updated")
 
     # Review application type
     expect(page).to have_selector("h1", text: "Review the application type")
@@ -81,11 +114,15 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_selector("dl div:nth-child(2) dd", text: "MAJR")
     expect(page).to have_selector("dl div:nth-child(3) dd", text: "Town and Country Planning Act 1990")
     expect(page).to have_selector("dl div:nth-child(4) dd", text: "25 days - bank holidays included")
-    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
-      expect(page).to have_selector("li", text: "Check permitted development rights")
-      expect(page).to have_selector("li", text: "Neighbour")
-    end
-    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Inactive")
+    expect(page).to have_selector("dl div:nth-child(5) dd li", text: "Check permitted development rights")
+    expect(page).to have_selector("dl div:nth-child(5) dd li", text: "Neighbour")
+    expect(page).to have_selector("dl div:nth-child(6) dd span:nth-child(1)", text: "Elevations - existing")
+    expect(page).to have_selector("dl div:nth-child(6) dd span:nth-child(2)", text: "Elevations - proposed")
+    expect(page).to have_selector("dl div:nth-child(7) dd span:nth-child(1)", text: "Bank statement")
+    expect(page).to have_selector("dl div:nth-child(7) dd span:nth-child(2)", text: "Utility bill")
+    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(1)", text: "Environmental Impact Assessment (EIA)")
+    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(2)", text: "Sustainability statement")
+    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Inactive")
   end
 
   it "allows editing of an inactive application type" do
@@ -165,7 +202,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(6)" do
+    within "dl div:nth-child(9)" do
       expect(page).to have_selector("dd", text: "Inactive")
       click_link "Change"
     end
@@ -176,7 +213,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Active")
   end
 
   it "allows retirement of an application type" do
@@ -185,7 +222,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(6)" do
+    within "dl div:nth-child(9)" do
       expect(page).to have_selector("dd", text: "Active")
       click_link "Change"
     end
@@ -197,7 +234,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Retired")
+    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Retired")
   end
 
   it "allows an application type to be brought out of retirement" do
@@ -206,7 +243,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(6)" do
+    within "dl div:nth-child(9)" do
       expect(page).to have_selector("dd", text: "Retired")
       click_link "Change"
     end
@@ -218,7 +255,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(6) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Active")
   end
 
   it "allows editing of the legislation" do
@@ -335,6 +372,108 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(application_type.planning_conditions?).to eq(false)
     expect(application_type.permitted_development_rights?).to eq(true)
     expect(application_type.consultation_steps).to eq(["neighbour", "consultee", "publicity"])
+  end
+
+  it "allows editing of the tags for plans" do
+    application_type = create(
+      :application_type, :configured, :ldc_proposed,
+      document_tags: {
+        "plans" => %w[elevations.existing]
+      }
+    )
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(6) dd:nth-child(2)" do
+      expect(page).to have_selector("span", text: "Elevations - existing")
+      expect(page).not_to have_selector("span", text: "Elevations - proposed")
+    end
+
+    within "dl div:nth-child(6) dd:nth-child(3)" do
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Manage document tags")
+    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("legend", text: "Plans")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for plans")
+
+    uncheck "Elevations - existing"
+    check "Elevations - proposed"
+    click_button "Continue"
+
+    expect(page).to have_content("Document tags successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(6) dd span", text: "Elevations - proposed")
+    expect(page).not_to have_selector("dl div:nth-child(6) dd span", text: "Elevations - existing")
+  end
+
+  it "allows editing of the tags for evidence" do
+    application_type = create(
+      :application_type, :configured, :ldc_proposed,
+      document_tags: {
+        "evidence" => %w[bankStatement]
+      }
+    )
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(7) dd:nth-child(2)" do
+      expect(page).to have_selector("span", text: "Bank statement")
+      expect(page).not_to have_selector("span", text: "Utility bill")
+    end
+
+    within "dl div:nth-child(7) dd:nth-child(3)" do
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Manage document tags")
+    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("legend", text: "Evidence")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for evidence documents")
+
+    uncheck "Bank statement"
+    check "Utility bill"
+    click_button "Continue"
+
+    expect(page).to have_content("Document tags successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(7) dd span", text: "Utility bill")
+    expect(page).not_to have_selector("dl div:nth-child(7) dd span", text: "Bank statement")
+  end
+
+  it "allows editing of the tags for supporting documents" do
+    application_type = create(
+      :application_type, :configured, :ldc_proposed,
+      document_tags: {
+        "supporting_documents" => %w[environmentalImpactAssessment]
+      }
+    )
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(8) dd:nth-child(2)" do
+      expect(page).to have_selector("span", text: "Environmental Impact Assessment (EIA)")
+      expect(page).not_to have_selector("span", text: "Sustainability statement")
+    end
+
+    within "dl div:nth-child(8) dd:nth-child(3)" do
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Manage document tags")
+    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("legend", text: "Supporting documents")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for supporting documents")
+
+    uncheck "Environmental Impact Assessment (EIA)"
+    check "Sustainability statement"
+    click_button "Continue"
+
+    expect(page).to have_content("Document tags successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+    expect(page).to have_selector("dl div:nth-child(8) dd span", text: "Sustainability statement")
+    expect(page).not_to have_selector("dl div:nth-child(8) dd span", text: "Environmental Impact Assessment (EIA)")
   end
 
   it "displays application types" do


### PR DESCRIPTION
### Description of change

Allows a global admin user to configure the default tags shown on the document page for an application type.

### Story Link

https://trello.com/c/n3EMQfiY

### Summary page

![summary](https://github.com/unboxed/bops/assets/6321/7631d4dc-1c49-40e5-bfcc-6f94677aeb20)

### Edit page

![tags](https://github.com/unboxed/bops/assets/6321/237a9962-e47b-43e4-bf19-f54b9761afa9)

### Decisions

Since there's so many tags the summary page defaults to only showing three lines for each category but clicking on the tags expands the view to show all of them. This is done using a CSS feature that is behind a `-webkit-*` flag but is [widely supported by all modern browsers including Firefox][1].

### Known issues

To ensure that all columns are filled in there are callbacks on the `ApplicationType` to set `assessment_details` and `consistency_checklist` if they are null based on the application name. These settings should be probably migrated to the `features` model rather than adding additional steps in the wizard.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp