### PR TITLE
Small fixes for publicity review

### DIFF
--- a/app/components/concerns/assessment_detailable.rb
+++ b/app/components/concerns/assessment_detailable.rb
@@ -5,7 +5,7 @@ module AssessmentDetailable
 
   included do
     def assessment_details
-      @assessment_details ||= planning_application.assessment_details_for_review.reject { |detail| detail.category == "check_publicity" }
+      @assessment_details ||= planning_application.assessment_details_for_review.reject(&:check_publicity?)
     end
 
     def assessment_details_updated?

--- a/app/components/concerns/assessment_detailable.rb
+++ b/app/components/concerns/assessment_detailable.rb
@@ -5,7 +5,7 @@ module AssessmentDetailable
 
   included do
     def assessment_details
-      @assessment_details ||= planning_application.assessment_details_for_review
+      @assessment_details ||= planning_application.assessment_details_for_review.reject { |detail| detail.category == "check_publicity" }
     end
 
     def assessment_details_updated?

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -160,6 +160,7 @@ class Review < ApplicationRecord
   def ensure_consultation_has_finished!
     return unless owner.planning_application.awaiting_determination?
     return if owner.end_date.nil? || owner.end_date <= Time.zone.now
+    return unless review_complete? && complete?
 
     raise NotCreatableError,
       "Consultation expiry date must be in the past. You cannot mark this as complete until the consultation period is complete."

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
@@ -129,7 +129,7 @@
 
       <% if @press_notice.nil? %>
         <p class="govuk-body">
-          <%= t(".site_notice_incomplete") %>
+          <%= t(".press_notice_incomplete") %>
           <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
         </p>
       <% elsif @press_notice.required? %>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
@@ -128,7 +128,7 @@
 
       <% if @press_notice.nil? %>
         <p class="govuk-body">
-          <%= t(".site_notice_incomplete") %>
+          <%= t(".press_notice_incomplete") %>
           <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
         </p>
       <% elsif @press_notice.required? %>

--- a/app/views/planning_applications/review/neighbour_responses/_form.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/_form.html.erb
@@ -3,7 +3,7 @@
     <% if @consultation.start_date && @consultation.end_date %>
       <ul class="govuk-list govuk-list--bullet">
         <li>the consultation period for this application is <%= (@consultation.end_date - @consultation.start_date).to_i %> days</li>
-        <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
+        <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.sent.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
         <li>the consultation expiry date for this application is <%= @consultation.end_date.to_date.to_fs %></li>
       </ul>
     <% else %>

--- a/app/views/planning_applications/review/publicities/edit.html.erb
+++ b/app/views/planning_applications/review/publicities/edit.html.erb
@@ -137,7 +137,6 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".press_notice_not_required") %><br>
-          <%= link_to(t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
         </p>
       <% end %>
     </div>

--- a/app/views/planning_applications/review/publicities/show.html.erb
+++ b/app/views/planning_applications/review/publicities/show.html.erb
@@ -137,7 +137,6 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".press_notice_not_required") %><br>
-          <%= link_to(t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
         </p>
       <% end %>
     </div>

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Review do
 
         context "when the consultation has not yet finished" do
           let(:consultation) { create(:consultation, end_date: 1.day.from_now, planning_application:) }
-          let(:new_review) { create(:review, owner: consultation) }
+          let(:new_review) { create(:review, owner: consultation, status: :complete, review_status: :review_complete) }
 
           it "raises an error" do
             expect do


### PR DESCRIPTION
### Description of change

Fixes for publicity review
- can send a case back to an officer while consultation is happening
- don't show assessment details as started when check publicity is started