### PR TITLE
Fixes to committee decision in review

### DIFF
--- a/app/components/status_tags/add_committee_decision_component.rb
+++ b/app/components/status_tags/add_committee_decision_component.rb
@@ -13,10 +13,10 @@ module StatusTags
     delegate :recommendation, to: :planning_application
 
     def status
-      if planning_application.in_committee?
-        :not_started
-      elsif (planning_application.recommendation_review_complete? && planning_application.committee_decision&.recommend?) || planning_application.to_be_reviewed?
+      if (planning_application.awaiting_determination? || planning_application.to_be_reviewed?) && planning_application.committee_decision.recommend? && planning_application.committee_decision.location.present?
         :complete
+      else
+        :not_started
       end
     end
   end

--- a/app/components/status_tags/add_committee_decision_component.rb
+++ b/app/components/status_tags/add_committee_decision_component.rb
@@ -13,7 +13,7 @@ module StatusTags
     delegate :recommendation, to: :planning_application
 
     def status
-      if (planning_application.awaiting_determination? || planning_application.to_be_reviewed?) && planning_application.committee_decision.recommend? && planning_application.committee_decision.location.present?
+      if (planning_application.awaiting_determination? || planning_application.to_be_reviewed?) && planning_application.committee_details_filled?
         :complete
       else
         :not_started

--- a/app/components/task_list_items/reviewing/condition_component.rb
+++ b/app/components/task_list_items/reviewing/condition_component.rb
@@ -29,8 +29,10 @@ module TaskListItems
       def status
         if condition_set.current_review&.status == "to_be_reviewed" || condition_set.current_review&.status == "updated"
           condition_set.current_review.status
-        else
+        elsif condition_set.current_review.present?
           condition_set.current_review&.review_status
+        else
+          :not_started
         end
       end
 

--- a/app/controllers/planning_applications/review/notifications_controller.rb
+++ b/app/controllers/planning_applications/review/notifications_controller.rb
@@ -21,6 +21,7 @@ module PlanningApplications
         ActiveRecord::Base.transaction do
           update_committee_decision!
           deliver_letters!
+          send_email_to_applicant!
           record_audit_for_letters_sent!
           @planning_application.send_to_committee! unless @planning_application.in_committee?
         end
@@ -47,6 +48,10 @@ module PlanningApplications
             LetterSendingService.new(neighbour, @committee_decision.notification_content, letter_type: :committee).deliver!
           end
         end
+      end
+
+      def send_email_to_applicant!
+        PlanningApplicationMailer.send_committee_decision_mail(@planning_application, Current.user)
       end
 
       private

--- a/app/form_models/recommendation_form.rb
+++ b/app/form_models/recommendation_form.rb
@@ -53,7 +53,7 @@ class RecommendationForm
   end
 
   def decisions
-    pa? ? prior_approval_decisions : granted_and_refused
+    planning_application.recommendation_options
   end
 
   def decisions_text
@@ -75,25 +75,6 @@ class RecommendationForm
   end
 
   private
-
-  def pa?
-    application_type_name == "prior_approval"
-  end
-
-  def granted_and_refused
-    [
-      [:refused, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type_name}.refused")],
-      [:granted, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type_name}.granted")]
-    ]
-  end
-
-  def prior_approval_decisions
-    granted_and_refused.push(granted_not_required)
-  end
-
-  def granted_not_required
-    [:granted_not_required, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type_name}.granted_not_required")]
-  end
 
   def committee_decision_present?
     planning_application.committee_decision.present?

--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -226,4 +226,16 @@ class PlanningApplicationMailer < ApplicationMailer
       reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
+
+  def send_committee_decision_mail(planning_application, user)
+    @planning_application = planning_application
+    @user = user
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:committee_decision_mail),
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
+    )
+  end
 end

--- a/app/models/committee_decision.rb
+++ b/app/models/committee_decision.rb
@@ -74,6 +74,14 @@ class CommitteeDecision < ApplicationRecord
     reviews.order(:created_at).last
   end
 
+  def all_details_present?
+    location.present? &&
+      link.present? &&
+      time.present? &&
+      date_of_committee.present? &&
+      late_comments_deadline.present?
+  end
+
   private
 
   def assigned_officer

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -872,6 +872,25 @@ class PlanningApplication < ApplicationRecord
     committee_decision.present? && committee_decision.recommend?
   end
 
+  def recommendation_options
+    prior_approval? ? prior_approval_decisions : granted_and_refused
+  end
+
+  def granted_and_refused
+    [
+      [:refused, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type.name}.refused")],
+      [:granted, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type.name}.granted")]
+    ]
+  end
+
+  def prior_approval_decisions
+    granted_and_refused.push(granted_not_required)
+  end
+
+  def granted_not_required
+    [:granted_not_required, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type.name}.granted_not_required")]
+  end
+
   private
 
   def create_fee_calculation

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -891,6 +891,15 @@ class PlanningApplication < ApplicationRecord
     [:granted_not_required, I18n.t(".planning_applications.assessment.recommendations.new.decision.#{application_type.name}.granted_not_required")]
   end
 
+  def user_friendly_recommendation
+    I18n.t(".planning_applications.decisions.#{decision}")
+  end
+
+  def committee_details_filled?
+    committee_decision.recommend? &&
+      committee_decision.all_details_present?
+  end
+
   private
 
   def create_fee_calculation

--- a/app/models/recommendation.rb
+++ b/app/models/recommendation.rb
@@ -45,8 +45,6 @@ class Recommendation < ApplicationRecord
 
       if challenged?
         planning_application.request_correction!(reviewer_comment) unless committee_overturned?
-      elsif planning_application.committee_decision&.recommend? && planning_application.awaiting_determination?
-        planning_application.send_to_committee!
       else
         planning_application.submit! if planning_application.in_committee?
         audit!(activity_type: "approved", audit_comment: reviewer_comment)

--- a/app/views/planning_application_mailer/send_committee_decision_mail.text.erb
+++ b/app/views/planning_application_mailer/send_committee_decision_mail.text.erb
@@ -1,0 +1,30 @@
+# Town and Country Planning Act 1990
+
+Dear <%= @planning_application.applicant_name %>
+
+Application number: <%= @planning_application.reference_in_full %>
+
+Site address: <%= @planning_application.full_address %>
+
+This application is scheduled to be determined by <%= @planning_application.local_authority.short_name %>'s Planning Committee. If you would like to speak at the meeting you will need to send a request in advance. Find out more at the link below.
+
+## Meeting details
+
+Date: <%= @planning_application.committee_decision.date_of_committee.to_date.to_fs %>
+Start time: <%= @planning_application.committee_decision.time %>
+Location: <%= @planning_application.committee_decision.location %>
+
+Please visit <%= @planning_application.committee_decision.link %> to: 
+
+* read more about how meetings are run
+* find out how to request to speak at the meeting
+* view the agenda
+* find out if you can join the meeting online
+
+The recommendation for this application is <%= @planning_application.user_friendly_recommendation %>
+
+Yours
+
+<%= @planning_application.user&.name || @user.name %>
+Case officer
+<%= @planning_application.user&.email || @user.email %>

--- a/app/views/planning_applications/review/committee_decisions/edit.html.erb
+++ b/app/views/planning_applications/review/committee_decisions/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  Committee Decision - <%= t('page_title') %>
+  Recommendation to committee - <%= t('page_title') %>
 <% end %>
 
 <%= render(
@@ -7,11 +7,11 @@
   locals: { planning_application: @planning_application  }
 ) %>
 
-<% content_for :title, "Committee Decision" %>
+<% content_for :title, "Recommendation to committee" %>
 
 <%= render(
   partial: "shared/proposal_header",
-  locals: { heading: "Committee Decision" }
+  locals: { heading: "Recommendation to committee" }
 ) %>
 
 <div class="govuk-grid-row">

--- a/app/views/planning_applications/review/committee_decisions/show.html.erb
+++ b/app/views/planning_applications/review/committee_decisions/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  Committee Decision - <%= t('page_title') %>
+  Recommendation to committee - <%= t('page_title') %>
 <% end %>
 
 <%= render(
@@ -7,11 +7,11 @@
   locals: { planning_application: @planning_application  }
 ) %>
 
-<% content_for :title, "Committee Decision" %>
+<% content_for :title, "Recommendation to committee" %>
 
 <%= render(
   partial: "shared/proposal_header",
-  locals: { heading: "Committee Decision" }
+  locals: { heading: "Recommendation to committee" }
 ) %>
 
 <div class="govuk-grid-row">

--- a/app/views/planning_applications/review/notifications/edit.html.erb
+++ b/app/views/planning_applications/review/notifications/edit.html.erb
@@ -54,7 +54,7 @@
       <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
       <%= form.govuk_date_field :date_of_committee, legend: { text: "Enter date of meeting", size: "s" } %>
       <%= form.govuk_text_field :location, label: { text: "Enter location" }, hint: { text: "Enter the address where the meeting will be held. Include the name of the room, building number or hame, street, town and postcode." } %>
-      <%= form.govuk_text_field :link, label: { text: "Enter link" }, hint: { text: "Add a URL where neighbours can view agendas and more information about committee meetings." } %>
+      <%= form.govuk_text_field :link, label: { text: "Enter link" }, hint: { text: "Add a URL where neighbours can view agendas and more information about committee meetings, such as a link to join online." } %>
       <%= form.govuk_text_field :time, label: { text: "Enter time of meeting" }, hint: { text: "For example, 10:30am or 7pm. For midday enter 12pm." }, width: 5 %>
       <%= form.govuk_date_field :late_comments_deadline, legend: { text: "Enter deadline for late comments to be received by", size: "s" } %>
     </div>
@@ -64,8 +64,8 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">2. Check and send notification to neighbours</h2>
-      <p class="govuk-body">This will be sent to anyone who submitted a comment on this application</p>
+      <h2 class="govuk-heading-m">2. Check and send notification</h2>
+      <p class="govuk-body">This will be sent to the selected neighbours and anyone who submitted a comment on this application. A copy will be sent to the applicant and agent.</p>
 
       <details class="govuk-details">
         <summary class="govuk-details__summary">

--- a/app/views/planning_applications/review/notifications/show.html.erb
+++ b/app/views/planning_applications/review/notifications/show.html.erb
@@ -52,7 +52,7 @@
         Date of meeting
       </h3>
       <p class="govuk-body">
-        <%= @committee_decision.date_of_committee.to_date.to_fs %>
+        <%= @committee_decision.date_of_committee&.to_date&.to_fs %>
       </p>
 
       <h3 class="govuk-heading-s">

--- a/app/views/planning_applications/review/notifications/show.html.erb
+++ b/app/views/planning_applications/review/notifications/show.html.erb
@@ -52,7 +52,7 @@
         Date of meeting
       </h3>
       <p class="govuk-body">
-        <%= @committee_decision.date_of_committee&.to_date&.to_fs %>
+        <%= @committee_decision.date_of_committee.to_date.to_fs %>
       </p>
 
       <h3 class="govuk-heading-s">

--- a/app/views/planning_applications/review/recommendations/edit.html.erb
+++ b/app/views/planning_applications/review/recommendations/edit.html.erb
@@ -5,7 +5,7 @@
   partial: "shared/review_task_breadcrumbs",
   locals: {
     planning_application: @planning_application,
-    current_page: t(".recommendation")
+    current_page: t(".#{@planning_application.in_committee? ? "in_committee" : "not_in_committee"}.sign_off_recommendation")
   }
 ) %>
 

--- a/app/views/planning_applications/review/recommendations/new.html.erb
+++ b/app/views/planning_applications/review/recommendations/new.html.erb
@@ -59,17 +59,26 @@
         </div>
       <% end %>
 
+      <h2 class="govuk-heading-m">Add Committee recommendation</h2>
+
+      <%= render "shared/warning_text", message: "This information will appear on the decision notice." %>
+
+      <p class="govuk-body">
+        This will be reviewed before a decision is published.
+      </p>
+
       <%= form.govuk_collection_radio_buttons(
         :decision,
-        ["granted", "refused"],
-        :to_s,
-        :humanize,
-        legend: { text: "What was the committee's decision?", size: "s" }
+        @planning_application.recommendation_options,
+        :first,
+        :second,
+        legend: { text: "Enter Committee recommendation", size: "s" },
+        hint: {}
       ) %>
       <div class="govuk-form-group">
         <%= form.govuk_text_area(
           :public_comment,
-          label: { text: "Public comment" },
+          label: { text: "Enter the Committee's reasons for this recommendation" },
           rows: 9
         ) %>
       </div>

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -91,7 +91,7 @@
       <span class="app-task-list__task-name">
         <%= link_to_if(
               @planning_application.in_committee?,
-              "Add committee decision",
+              "Update decision notice after committee",
               edit_planning_application_review_recommendation_path(@planning_application, @planning_application.recommendation),
               aria: { describedby: "review_assessment-completed" },
               class: "govuk-link") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -641,6 +641,7 @@ en:
     subjects:
       assigned_notification_mail: You have been assigned to a prior approval case %{reference}
       cancelled_validation_request_mail: Update on your application for a %{application_type_name}
+      committee_decision_mail: Notification of Planning Committee Meeting
       decision_notice_mail: Decision on your %{application_type_name} application
       description_change_mail: "%{application_type_name} application - suggested changes"
       description_closure_notification_mail: Changes to your %{application_type_name} application
@@ -1246,6 +1247,10 @@ en:
       one: 1 day remaining
       other: "%{count} days remaining"
       zero: "%{count} days overdue"
+    decisions:
+      granted: to Grant Permission
+      granted_not_required: that Prior Approval should be granted but is not required
+      refused: to Refuse Permission
     determine:
       confirm_press_notice_published_at_html: <a class="govuk-notification-banner__link" href="%{href}">Confirm the press notice published at date</a> before determining the application.
       confirm_site_notice_displayed_at_html: <a class="govuk-notification-banner__link" href="%{href}">Confirm the site notice displayed at date</a> before determining the application.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1489,7 +1489,7 @@ en:
           edit_information_on: Edit information on the decision notice
           in_committee:
             recommendation: Committee recommendation
-            sign_off_recommendation: Add committee decision
+            sign_off_recommendation: Update decision notice after committee
           not_in_committee:
             recommendation: Assessor recommendation
             sign_off_recommendation: Sign off recommendation
@@ -1528,7 +1528,7 @@ en:
               granted: Prior approval required and approved
               granted_not_required: Prior approval not required
               refused: Prior approval required and refused
-          make_draft_recommendation: Add committee decision details
+          make_draft_recommendation: Update decision notice after committee details
         update:
           success: Recommendation was successfully reviewed.
       tasks:
@@ -2093,7 +2093,7 @@ en:
       assessment_details_component:
         review_assessment_summaries: Review assessment summaries
       committee_component:
-        link_text: Committee decision
+        link_text: Recommendation to committee
       condition_component:
         link_text: Review conditions
       documents_component:

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -110,7 +110,7 @@ FactoryBot.define do
       decision { "granted" }
 
       after(:create) do |pa|
-        create(:committee_decision, planning_application: pa, recommend: true, reasons: ["The first reason"])
+        create(:committee_decision, planning_application: pa, recommend: true, reasons: ["The first reason"], location: "Unboxed", time: "7.30pm", link: "unboxed.co", late_comments_deadline: 1.week.from_now, date_of_committee: 1.week.from_now)
         create(:recommendation, :reviewed, challenged: false, planning_application: pa, reviewer_comment: nil)
       end
     end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2538,4 +2538,34 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  describe "#recommendation_options" do
+    context "when householder" do
+      let(:planning_application) { create(:planning_application, :planning_permission) }
+
+      it "returns the right options" do
+        expect(planning_application.recommendation_options).to include([:granted, "Granted"], [:refused, "Refused"])
+      end
+    end
+
+    context "when LDC" do
+      let(:planning_application) { create(:planning_application, :lawfulness_certificate) }
+
+      it "returns the right options" do
+        expect(planning_application.recommendation_options).to include([:granted, "Yes"], [:refused, "No"])
+      end
+    end
+
+    context "when prior approval" do
+      let(:planning_application) { create(:planning_application, :prior_approval) }
+
+      it "returns the right options" do
+        expect(planning_application.recommendation_options).to include(
+          [:refused, "Prior approval required and refused"],
+          [:granted, "Prior approval required and approved"],
+          [:granted_not_required, "Prior approval not required"]
+        )
+      end
+    end
+  end
 end

--- a/spec/system/planning_applications/review/add_committee_decision_spec.rb
+++ b/spec/system/planning_applications/review/add_committee_decision_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add committee decision" do
+RSpec.describe "Update decision notice after committee" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:reviewer) do
     create(:user,
@@ -15,7 +15,7 @@ RSpec.describe "Add committee decision" do
       local_authority: default_local_authority)
   end
   let!(:planning_application) do
-    create(:planning_application, :in_committee, local_authority: default_local_authority, user: assessor)
+    create(:planning_application, :planning_permission, :in_committee, local_authority: default_local_authority, user: assessor)
   end
 
   before do
@@ -33,12 +33,12 @@ RSpec.describe "Add committee decision" do
       create(:recommendation, planning_application:)
     end
 
-    it "does not show the option to add committee decision" do
+    it "does not show the option to Update decision notice after committee" do
       visit "/planning_applications/#{planning_application.id}/review/tasks"
 
       expect(page).to have_content("Review and sign-off")
 
-      expect(page).not_to have_content "Add committee decision"
+      expect(page).not_to have_content "Update decision notice after committee"
     end
   end
 
@@ -48,13 +48,13 @@ RSpec.describe "Add committee decision" do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Not started"
         )
 
-        click_link "Add committee decision"
+        click_link "Update decision notice after committee"
 
-        expect(page).to have_content "Add committee decision"
+        expect(page).to have_content "Update decision notice after committee"
 
         choose "Yes"
 
@@ -64,7 +64,7 @@ RSpec.describe "Add committee decision" do
         expect(page).to have_content "Awaiting determination"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Completed"
         )
       end
@@ -75,13 +75,13 @@ RSpec.describe "Add committee decision" do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Not started"
         )
 
-        click_link "Add committee decision"
+        click_link "Update decision notice after committee"
 
-        expect(page).to have_content "Add committee decision"
+        expect(page).to have_content "Update decision notice after committee"
 
         choose "Yes, with amendments (return to case officer)"
 
@@ -93,7 +93,7 @@ RSpec.describe "Add committee decision" do
         expect(page).to have_content "To be reviewed"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Completed"
         )
       end
@@ -101,9 +101,9 @@ RSpec.describe "Add committee decision" do
       it "shows errors" do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
-        click_link "Add committee decision"
+        click_link "Update decision notice after committee"
 
-        expect(page).to have_content "Add committee decision"
+        expect(page).to have_content "Update decision notice after committee"
 
         choose "Yes, with amendments (return to case officer)"
 
@@ -118,22 +118,22 @@ RSpec.describe "Add committee decision" do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Not started"
         )
 
-        click_link "Add committee decision"
+        click_link "Update decision notice after committee"
 
-        expect(page).to have_content "Add committee decision"
+        expect(page).to have_content "Update decision notice after committee"
 
         choose "No"
 
         click_button "Save and mark as complete"
 
-        expect(page).to have_content "Add committee decision details"
+        expect(page).to have_content "Update decision notice after committee details"
         choose "Refused"
 
-        fill_in "Public comment", with: "This is the comment"
+        fill_in "Enter the Committee's reasons for this recommendation", with: "This is the comment"
 
         click_button "Save and mark as complete"
 
@@ -141,7 +141,7 @@ RSpec.describe "Add committee decision" do
         expect(page).to have_content "Awaiting determination"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Completed"
         )
       end
@@ -150,19 +150,19 @@ RSpec.describe "Add committee decision" do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
         expect(page).to have_list_item_for(
-          "Add committee decision",
+          "Update decision notice after committee",
           with: "Not started"
         )
 
-        click_link "Add committee decision"
+        click_link "Update decision notice after committee"
 
-        expect(page).to have_content "Add committee decision"
+        expect(page).to have_content "Update decision notice after committee"
 
         choose "No"
 
         click_button "Save and mark as complete"
 
-        expect(page).to have_content "Add committee decision details"
+        expect(page).to have_content "Update decision notice after committee details"
 
         click_button "Save and mark as complete"
 

--- a/spec/system/planning_applications/review/review_committee_decision_spec.rb
+++ b/spec/system/planning_applications/review/review_committee_decision_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe "Review committee decision" do
     visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Not started"
     )
 
-    click_link "Committee decision"
+    click_link "Recommendation to committee"
 
     expect(page).to have_content "The case officer has marked this application as requiring decision by Committee for the following reasons:"
     expect(page).to have_content "The first reason"
@@ -46,7 +46,7 @@ RSpec.describe "Review committee decision" do
     expect(page).to have_content "Review of committee decision recommendation updated successfully"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Completed"
     )
   end
@@ -55,11 +55,11 @@ RSpec.describe "Review committee decision" do
     visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Not started"
     )
 
-    click_link "Committee decision"
+    click_link "Recommendation to committee"
 
     expect(page).to have_content "The case officer has marked this application as requiring decision by Committee for the following reasons:"
     expect(page).to have_content "The first reason"
@@ -73,7 +73,7 @@ RSpec.describe "Review committee decision" do
     expect(page).to have_content "Review of committee decision recommendation updated successfully"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Completed"
     )
 
@@ -111,11 +111,11 @@ RSpec.describe "Review committee decision" do
     click_link "Review and sign-off"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Not started"
     )
 
-    click_link "Committee decision"
+    click_link "Recommendation to committee"
 
     expect(page).to have_content "The case officer has marked this application as not requiring decision by Committee."
 
@@ -126,7 +126,7 @@ RSpec.describe "Review committee decision" do
     expect(page).to have_content "Review of committee decision recommendation updated successfully"
 
     expect(page).to have_list_item_for(
-      "Committee decision",
+      "Recommendation to committee",
       with: "Completed"
     )
   end

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -73,6 +73,8 @@ RSpec.describe "Send notification to neighbours of committee" do
         fill_in "Year", with: "2022"
       end
 
+      expect(PlanningApplicationMailer).to receive(:send_committee_decision_mail).once.and_call_original
+
       click_button "Send notification"
 
       expect(page).to have_content "Notifications sent to neighbours and application in committee"
@@ -92,6 +94,8 @@ RSpec.describe "Send notification to neighbours of committee" do
 
       fill_in "Enter link", with: "www.unboxed.co"
 
+      expect(PlanningApplicationMailer).to receive(:send_committee_decision_mail).once
+
       click_button "Send notification"
 
       expect(page).to have_content "Notifications sent to neighbours and application in committee"
@@ -105,6 +109,9 @@ RSpec.describe "Send notification to neighbours of committee" do
       visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
 
       click_link "Notify neighbours of committee meeting"
+
+      expect(PlanningApplicationMailer).not_to receive(:send_committee_decision_mail)
+      expect(SendCommitteeDecisionEmailJob).not_to have_been_enqueued
 
       click_button "Send notification"
 


### PR DESCRIPTION
### Description of change

- Content changes
- Add correct recommendation options to different planning application types
- Send email to applicant about committee

### Story link
https://trello.com/c/TonFXDEI/2704-improvements-to-sending-applications-to-committee
