### PR TITLE
Update tag style to fix alignment in table

### DIFF
--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -22,7 +22,7 @@
         <% if constraint.consultee.present? %>
           <%= render StatusTags::BaseComponent.new(status: constraint.consultee.status) %>
         <% else %>
-          <span class="govuk-tag govuk-tag--grey"><%= "Not assigned" %></span>
+          <span class="govuk-tag govuk-tag--grey app-task-list__task-tag"><%= "Not assigned" %></span>
         <% end %>
       </td>
     </tr>


### PR DESCRIPTION
### Description of change

This fixes an alignment issue in the consultees table. We can't add `not_assigned` to the `StatusTags::BaseComponent` as it's not an actual status on any object, so this fix simply applies the same class that the base component uses so they look the same.