### PR TITLE
Display legislation dynamically 

### DIFF
--- a/app/controllers/planning_applications/validation/legislation_controller.rb
+++ b/app/controllers/planning_applications/validation/legislation_controller.rb
@@ -36,7 +36,7 @@ module PlanningApplications
       private
 
       def ensure_legislation_is_defined
-        return if @planning_application.application_type.legislation_description
+        return if @planning_application.application_type.legislation
 
         render plain: "Not found", status: :not_found
       end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -22,6 +22,7 @@ class ApplicationType < ApplicationRecord
   validates :name, :code, :suffix, presence: true
   validates :code, :suffix, uniqueness: true
   validates :features, store_model: {merge_errors: true}
+  validates :legislation, presence: true, if: :active?
 
   with_options allow_blank: true do
     validates :code, inclusion: {in: ODP_APPLICATION_TYPES.keys}
@@ -58,6 +59,12 @@ class ApplicationType < ApplicationRecord
     delegate :site_visits?
     delegate :include_bank_holidays?
     delegate :consultation_steps
+  end
+
+  with_options to: :legislation, prefix: true, allow_nil: true do
+    delegate :title
+    delegate :description
+    delegate :link
   end
 
   before_validation if: :code_changed? do
@@ -149,18 +156,6 @@ class ApplicationType < ApplicationRecord
     I18n.t("application_types.#{name}")
   end
 
-  def legislation_link
-    fetch_legislation_translation("link")
-  end
-
-  def legislation_link_text
-    fetch_legislation_translation("link_text")
-  end
-
-  def legislation_description
-    fetch_legislation_translation("description")
-  end
-
   def consultation?
     consultation_steps.any?
   end
@@ -196,14 +191,6 @@ class ApplicationType < ApplicationRecord
   end
 
   private
-
-  def part_and_section
-    "#{part}#{section}"
-  end
-
-  def fetch_legislation_translation(key)
-    I18n.t("application_types.legislation.#{name}.#{part_and_section}.#{key}", default: false)
-  end
 
   def existing_legislation?
     legislation_type == "existing"

--- a/app/models/committee_decision.rb
+++ b/app/models/committee_decision.rb
@@ -47,7 +47,7 @@ class CommitteeDecision < ApplicationRecord
   end
 
   def header
-    "Town and Country Planning Act 1990"
+    planning_application.application_type.legislation_title
   end
 
   def body
@@ -64,7 +64,7 @@ class CommitteeDecision < ApplicationRecord
       link: planning_application.committee_decision.link,
       assigned_officer:,
       late_comments_deadline: planning_application.committee_decision.late_comments_deadline.to_date.to_fs,
-      application_link: application_link(planning_application)
+      application_link:
     }
 
     replace_placeholders(new_body, defaults)
@@ -84,7 +84,7 @@ class CommitteeDecision < ApplicationRecord
     string.to_s.gsub(EMAIL_PLACEHOLDER) { variables.fetch($1.to_sym) }
   end
 
-  def application_link(planning_application)
+  def application_link
     "#{planning_application.local_authority.applicants_url}/planning_applications/#{planning_application.id}"
   end
 

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -291,7 +291,8 @@ class Consultation < ApplicationRecord
       eaves_height: planning_application&.proposal_measurement&.eaves_height,
       assigned_officer: assigned_officer,
       council_address: I18n.t("council_addresses.#{local_authority.subdomain}"),
-      application_link:
+      application_link:,
+      legislation_title: planning_application.application_type.legislation_title
     }
 
     replace_placeholders(body, defaults)

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -51,10 +51,11 @@ class SiteNotice < ApplicationRecord
       application_description: planning_application.description,
       site_address: planning_application.full_address,
       applicant_name: "#{planning_application.applicant_first_name} #{planning_application.applicant_last_name}",
-      application_link: application_link(planning_application),
+      application_link:,
       council_address: I18n.t("council_addresses.#{planning_application.local_authority.subdomain}"),
       consultation_end_date: consultation_end_date.to_date.to_fs,
       site_notice_display_date: displayed_at&.to_date&.to_fs || Time.zone.today.to_fs,
+      legislation_title: planning_application.application_type.legislation_title,
       eia_statement: eia_statement)
   end
 
@@ -76,7 +77,7 @@ class SiteNotice < ApplicationRecord
 
   private
 
-  def application_link(planning_application)
+  def application_link
     if Bops.env.production?
       "https://planningapplications.#{planning_application.local_authority.subdomain}.gov.uk/planning_applications/#{planning_application.id}"
     else

--- a/app/presenters/application_type_status_error_presenter.rb
+++ b/app/presenters/application_type_status_error_presenter.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ApplicationTypeStatusErrorPresenter < ErrorPresenter
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::UrlHelper
+
+  private
+
+  def link_tag(text)
+    options = {
+      class: "govuk-link",
+      href: BopsConfig::Engine.routes.url_helpers.edit_application_type_legislation_path(record)
+    }
+
+    content_tag(:a, text, **options)
+  end
+
+  def link?
+    true
+  end
+end

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ErrorPresenter
-  def initialize(error_messages)
+  def initialize(error_messages, record = nil)
     @error_messages = error_messages
+    @record = record
   end
 
   def formatted_error_messages
@@ -13,7 +14,7 @@ class ErrorPresenter
 
   private
 
-  attr_reader :error_messages
+  attr_reader :error_messages, :record
 
   def formatted_message(message, attribute)
     attribute = attributes_map[attribute] || attribute
@@ -21,11 +22,17 @@ class ErrorPresenter
     if message.match?(/\A[A-Z].+\Z/)
       message
     else
-      "#{attribute.to_s.humanize.tr(".", " ")} #{message}"
+      text = "#{attribute.to_s.humanize.tr(".", " ")} #{message}"
+
+      link? ? link_tag(text) : text
     end
   end
 
   def attributes_map
     {}
+  end
+
+  def link?
+    false
   end
 end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -52,7 +52,7 @@ class LetterSendingService
     if consultation_letter?
       @consultation.neighbour_letter_header
     else
-      "Town and Country Planning Act 1990"
+      @consultation.planning_application.application_type.legislation_title
     end
   end
 

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -5,7 +5,7 @@
     </span>
     <br>
     <h3 class="govuk-heading-s">
-      <%= t("recommendation.#{planning_application.application_type.name}.legislation_html") %>
+      <%= planning_application.application_type.legislation_title %>
     </h3>
     <h2 class="govuk-heading-m">
       <%= t("recommendation.#{planning_application.application_type.name}.#{planning_application.decision}_html") %>

--- a/app/views/planning_applications/_validation_notice.html.erb
+++ b/app/views/planning_applications/_validation_notice.html.erb
@@ -5,7 +5,7 @@
         <%= planning_application.local_authority.council_name %>
       </span>
       <h3 class="govuk-heading-s">
-        Town and Country Planning Act 1990 (as amended) <br><br>
+        <%= @planning_application.application_type.legislation_title %> <br><br>
       </h3>
       <p class="govuk-body">
         Dear <%= @planning_application.agent_or_applicant_name %>,

--- a/app/views/planning_applications/validation/legislation/show.html.erb
+++ b/app/views/planning_applications/validation/legislation/show.html.erb
@@ -12,9 +12,16 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <%= link_to_if(@planning_application.application_type.legislation_link.present?, 
+                    @planning_application.application_type.legislation_title, 
+                    @planning_application.application_type.legislation_link, 
+                    target: "_blank") %>
+    </p>
 
-    <p class="govuk-body"><%= @planning_application.application_type.legislation_description %></p>
-    <p class="govuk-body"><%= link_to @planning_application.application_type.legislation_link_text, @planning_application.application_type.legislation_link, target: "_blank" %></p>
+    <% if @planning_application.application_type.legislation_description %>
+      <p class="govuk-body"><%= @planning_application.application_type.legislation_description %></p>
+    <% end %>
 
     <%= render(
       AccordionComponent.new(planning_application: @planning_application, sections: ["proposal_details"])

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,8 @@ en:
               less_than_or_equal_to: The determination period must be no more than 99 days
               not_a_number: The determination period must be a number of days
               not_an_integer: The determination period must be a whole number of days
+            legislation:
+              blank: must be set when application type is made active
             legislation_id:
               blank: An existing legislation must be chosen
             suffix:
@@ -347,12 +349,6 @@ en:
   application_types:
     lawfulness_certificate: Lawful Development Certificate
     lawfulness_certificate_abbr: LDC
-    legislation:
-      prior_approval:
-        1A:
-          description: Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A.
-          link: https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made
-          link_text: The Town and Country Planning (General Permitted Development) (England) Order 2015
     planning_permission: Householder Application for Planning Permission
     planning_permission_abbr: PP
     prior_approval: Prior approval
@@ -1796,12 +1792,10 @@ en:
         refused: The proposal does not comply due to the following reason(s)
     lawfulness_certificate:
       granted_html: Certificate of Lawful Use or Development <br> <strong>Granted</strong>
-      legislation_html: 'Town and Country Planning Act 1990 (as amended): sections 191 and 192<br>Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39'
       refused_html: Certificate of Lawful Use or Development <br> Decision Notice <strong>Refused</strong>
     planning_permission:
       granted: Planning permission approved
       granted_html: "<strong>Planning permission approved</strong>"
-      legislation_html: Town and Country Planning Act 1990 (as amended)<br><br>Town and Country Planning (Development Management Procedure) (England) Order 2015
       refused: Planning permission refused
       refused_html: "<strong>Planning permission refused</strong>"
     prior_approval:
@@ -1809,7 +1803,6 @@ en:
       granted_html: "<strong>Prior approval required and approved</strong>"
       granted_not_required: Prior approval not required
       granted_not_required_html: "<strong>Prior approval not required</strong>"
-      legislation_html: Town and Country Planning Act 1990 (as amended)
       refused: Prior approval required and refused
       refused_html: "<strong>Prior approval required and refused</strong>"
   reconsult_consultees_component:

--- a/config/locales/neighbour_letters.yml
+++ b/config/locales/neighbour_letters.yml
@@ -2,7 +2,7 @@ en:
   neighbour_letter_template:
     consultation:
       planning_permission: |-
-        # Town and Country Planning Act 1990
+        # {{legislation_title}}
         
         Dear Resident
         
@@ -56,6 +56,8 @@ en:
         {{assigned_officer}}
         Planning officer
       prior_approval: |-
+        # {{legislation_title}}
+
         Dear Resident
         
         A prior approval application has been made for the development described below: 

--- a/config/locales/site_notices.yml
+++ b/config/locales/site_notices.yml
@@ -5,7 +5,7 @@ en:
       <div style="width: 420px; text-align: center">
         <h1 style="margin-bottom: 5px;">Planning notice</h1>
         <h2 style="margin-bottom: 3px;">%{council} Council</h2>
-        <h3 style="margin-bottom: 3px;">Town and Country Planning Act 1990</h3>
+        <h3 style="margin-bottom: 3px;">%{legislation_title}</h3>
         <p>We have received an application for the following development:</p>
       </div>
       <table>
@@ -40,7 +40,7 @@ en:
       <div style="width: 420px; text-align: center">
         <h1 style="margin-bottom: 5px;">Planning notice</h1>
         <h2 style="margin-bottom: 3px;">%{council} Council</h2>
-        <h3 style="margin-bottom: 3px;">Town and Country Planning Act 1990</h3>
+        <h3 style="margin-bottom: 3px;">%{legislation_title}</h3>
         <p>We have received an application for the following development:</p>
       </div>
       <table>

--- a/db/migrate/20240326135803_migrate_legislation_details_to_legislation.rb
+++ b/db/migrate/20240326135803_migrate_legislation_details_to_legislation.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class MigrateLegislationDetailsToLegislation < ActiveRecord::Migration[7.1]
+  LEGISLATION_DETAILS = {
+    "ldc.existing" => {
+      title: "Town and Country Planning Act 1990, Section 191",
+      link: "https://www.legislation.gov.uk/ukpga/1990/8/section/191"
+    },
+    "ldc.proposed" => {
+      title: "Town and Country Planning Act 1990, Section 192",
+      link: "https://www.legislation.gov.uk/ukpga/1990/8/section/192"
+    },
+    "pa.part1.classA" => {
+      title: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Part 1, Class A",
+      link: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made"
+    },
+    "pp.full.householder" => {
+      title: "The Town and Country Planning (Development Management Procedure) (England) Order 2015",
+      link: "https://www.legislation.gov.uk/uksi/2015/595/article/2/made"
+    },
+    "default" => {
+      title: "Town and Country Planning Act 1990",
+      link: "https://www.legislation.gov.uk/"
+    }
+  }.freeze
+
+  def change
+    up_only do
+      ApplicationType.find_each do |type|
+        next if type.legislation
+
+        create_or_update_legislation_for!(type)
+      end
+    end
+  end
+
+  private
+
+  def create_or_update_legislation_for!(type)
+    details = LEGISLATION_DETAILS[type.code] || LEGISLATION_DETAILS["default"]
+
+    legislation = Legislation.find_or_create_by!(title: details[:title])
+    legislation.update!(link: details[:link])
+
+    type.update!(legislation: legislation)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_22_110154) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_26_135803) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
@@ -16,6 +16,8 @@
         hint: {text: t(".legislation_hint")},
         legend: {text: t(".enter_legislation"), size: "l", tag: "h1"}) do %>
 
+        <h2 class="govuk-heading-m"><%= @application_type.description %></h2>
+
         <%= form.govuk_radio_button(:legislation_type, "existing",
           label: {text: t(".existing_legislation")}) do %>
 

--- a/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_type, url: [@application_type, :status] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+       <%= form.govuk_error_summary(presenter: ApplicationTypeStatusErrorPresenter.new(@application_type.errors.messages, @application_type)) %>
 
       <%= form.govuk_radio_buttons_fieldset :status, legend: {size: "l", tag: "h1", text: t(".update_application_type_status")} do %>
         <% if @application_type.inactive? %>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -57,7 +57,7 @@ en:
           legislation_description_label: Description
           legislation_hint: |
             Enter either the name of an existing legislation that relates to this application type
-            or a create a new one. This will appear in consultation letters, decision notices and
+            or create a new one. The title will appear in consultation letters, decision notices and
             other places that need to specify what the relevant legislation is.
           legislation_id_label: Legislation title
           legislation_link_hint: Enter an optional link to legislation.gov.uk

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     # Enter legislation
     expect(page).to have_selector("h1", text: "Enter legislation")
-    expect(page).to have_selector("div.govuk-hint", text: "Enter either the name of an existing legislation that relates to this application type or a create a new one.")
+    expect(page).to have_selector("div.govuk-hint", text: "Enter either the name of an existing legislation that relates to this application type or create a new one.")
+    expect(page).to have_selector("div.govuk-hint", text: "The title will appear in consultation letters, decision notices and other places that need to specify what the relevant legislation is.")
 
     choose "Choose an existing legislation"
     click_button "Continue"
@@ -214,6 +215,30 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(9) dd", text: "Active")
+  end
+
+  it "prevents activation of a new application type when legislation has not been set" do
+    application_type = create(:application_type, :without_legislation, status: "inactive")
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(9)" do
+      expect(page).to have_selector("dd", text: "Inactive")
+      click_link "Change"
+    end
+
+    choose "Active"
+    click_button "Continue"
+
+    expect(page).to have_selector("[role=alert] li", text: "Legislation must be set when application type is made active")
+    expect(page).to have_link(
+      "Legislation must be set when application type is made active",
+      href: "/application_types/#{application_type.id}/legislation/edit"
+    )
+
+    click_link "Legislation must be set when application type is made active"
+
+    expect(page).to have_selector("h1", text: "Enter legislation")
   end
 
   it "allows retirement of an application type" do

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :application_type do
     lawfulness_certificate
+    legislation
 
     trait :lawfulness_certificate do
       name { "lawfulness_certificate" }
@@ -82,6 +83,8 @@ FactoryBot.define do
           consultation_steps: []
         }
       }
+
+      legislation { association :legislation, :ldc_existing }
     end
 
     trait :ldc_proposed do
@@ -95,6 +98,8 @@ FactoryBot.define do
           consultation_steps: []
         }
       }
+
+      legislation { association :legislation, :ldc_proposed }
     end
 
     trait :prior_approval do
@@ -221,6 +226,7 @@ FactoryBot.define do
         }
       end
 
+      legislation { association :legislation, :pa_part1_classA }
       status { "active" }
     end
 
@@ -363,6 +369,8 @@ FactoryBot.define do
 
     trait :householder do
       planning_permission
+
+      legislation { association :legislation, :pp_full_householder }
     end
 
     trait :householder_retrospective do
@@ -382,6 +390,18 @@ FactoryBot.define do
 
     trait :configured do
       configured { true }
+    end
+
+    trait :without_legislation do
+      legislation { nil }
+    end
+
+    trait :active do
+      status { "active" }
+    end
+
+    trait :inactive do
+      status { "inactive" }
     end
 
     initialize_with { ApplicationType.find_or_create_by(code:) }

--- a/spec/factories/legislation.rb
+++ b/spec/factories/legislation.rb
@@ -2,6 +2,27 @@
 
 FactoryBot.define do
   factory :legislation do
-    title { "Town and Country Planning Act 1990" }
+    title { "Town and Country Planning Act 1990, Section #{rand(9999)}" }
+
+    trait :ldc_existing do
+      title { "Town and Country Planning Act 1990, Section 191" }
+      link { "https://www.legislation.gov.uk/ukpga/1990/8/section/191" }
+    end
+
+    trait :ldc_proposed do
+      title { "Town and Country Planning Act 1990, Section 192" }
+      link { "https://www.legislation.gov.uk/ukpga/1990/8/section/192" }
+    end
+
+    trait :pa_part1_classA do
+      title { "The Town and Country Planning (General Permitted Development) (England) Order 2015 Part 1, Class A" }
+      link { "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made" }
+      description { "Review Condition A.4 of GPDO 2015 (as amended) Schedule 2, Part 1, Class A." }
+    end
+
+    trait :pp_full_householder do
+      title { "The Town and Country Planning (Development Management Procedure) (England) Order 2015" }
+      link { "https://www.legislation.gov.uk/uksi/2015/595/article/2/made" }
+    end
   end
 end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe UserMailer, type: :mailer do
 
   describe "#assigned_notification_mail" do
     let!(:prior_approval) { create(:application_type, :prior_approval) }
-    let(:planning_application) { create(:planning_application, :prior_approval) }
+    let(:planning_application) { create(:planning_application, :prior_approval, application_type: prior_approval) }
 
     let(:mail) do
       described_class.assigned_notification_mail(

--- a/spec/services/planning_application_search_spec.rb
+++ b/spec/services/planning_application_search_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe PlanningApplicationSearch do
     create(:user, :assessor, local_authority:)
   end
 
+  let!(:application_type_ldc_proposed) { create(:application_type, :ldc_proposed) }
+  let!(:application_type_prior_approval) { create(:application_type, :prior_approval) }
+  let!(:application_type_householder) { create(:application_type, :householder) }
+
   let!(:ldc_not_started) do
     travel_to("2022-01-01") do
       create(
@@ -19,7 +23,8 @@ RSpec.describe PlanningApplicationSearch do
         :ldc_proposed,
         description: "Add a chimney stack.",
         local_authority:,
-        received_at: nil
+        received_at: nil,
+        application_type: application_type_ldc_proposed
       )
     end
   end
@@ -32,7 +37,8 @@ RSpec.describe PlanningApplicationSearch do
         :ldc_proposed,
         description: "Something else entirely",
         local_authority:,
-        received_at: nil
+        received_at: nil,
+        application_type: application_type_ldc_proposed
       )
     end
   end
@@ -46,7 +52,8 @@ RSpec.describe PlanningApplicationSearch do
         description: "Skylight",
         local_authority:,
         user: assessor,
-        received_at: nil
+        received_at: nil,
+        application_type: application_type_ldc_proposed
       )
     end
   end
@@ -57,7 +64,8 @@ RSpec.describe PlanningApplicationSearch do
       :not_started,
       :prior_approval,
       local_authority:,
-      received_at: nil
+      received_at: nil,
+      application_type: application_type_prior_approval
     )
   end
 
@@ -67,7 +75,8 @@ RSpec.describe PlanningApplicationSearch do
       :in_assessment,
       :prior_approval,
       local_authority:,
-      received_at: nil
+      received_at: nil,
+      application_type: application_type_prior_approval
     )
   end
 
@@ -77,7 +86,8 @@ RSpec.describe PlanningApplicationSearch do
       :in_assessment,
       :planning_permission,
       local_authority:,
-      received_at: nil
+      received_at: nil,
+      application_type: application_type_householder
     )
   end
 

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -103,8 +103,7 @@ RSpec.describe "Planning Application Assessment" do
           "Certificate of Lawful Use or Development Granted"
         )
 
-        expect(page).to have_content("Town and Country Planning Act 1990 (as amended): sections 191 and 192")
-        expect(page).to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39")
+        expect(page).to have_content(planning_application.application_type.legislation_title)
 
         expect(page).to have_content("Jane Smith, Director")
 
@@ -189,8 +188,7 @@ RSpec.describe "Planning Application Assessment" do
           click_button("Publish determination")
 
           click_link("View decision notice")
-          expect(page).to have_content("Town and Country Planning Act 1990 (as amended)")
-          expect(page).not_to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015 (as amended): Article 39")
+          expect(page).to have_content("The Town and Country Planning (General Permitted Development) (England) Order 2015 Part 1, Class A")
         end
       end
 
@@ -247,7 +245,7 @@ RSpec.describe "Planning Application Assessment" do
       end
 
       context "when the decision is for a householder application" do
-        let(:application_type) { create(:application_type, :planning_permission) }
+        let(:application_type) { create(:application_type, :householder) }
         let!(:planning_application) do
           create(:planning_application, :awaiting_determination,
             :from_planx_prior_approval,
@@ -271,10 +269,7 @@ RSpec.describe "Planning Application Assessment" do
 
         it "lists different legislation in the decision notice" do
           click_link("View decision notice")
-          expect(page).to have_content("Town and Country Planning Act 1990 (as amended)")
-          expect(page).to have_content("Town and Country Planning (Development Management Procedure) (England) Order 2015")
-          expect(page).not_to have_content("sections 191 and 192")
-          expect(page).not_to have_content("Article 39")
+          expect(page).to have_content("The Town and Country Planning (Development Management Procedure) (England) Order 2015")
         end
       end
     end

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Send letters to neighbours", js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
-  let(:application_type) { create(:application_type, :prior_approval) }
+  let!(:application_type) { create(:application_type, :prior_approval) }
 
   let(:planning_application) do
     create(:planning_application,
@@ -346,7 +346,7 @@ RSpec.describe "Send letters to neighbours", js: true do
         with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
       expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-        personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
+        personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A\n\nDear Resident/))).and_call_original
       click_button "Confirm and send letters"
     end
 
@@ -365,7 +365,7 @@ RSpec.describe "Send letters to neighbours", js: true do
           with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
         expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-          personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\nDear Resident/))).and_call_original
+          personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A\n\nDear Resident/))).and_call_original
         click_button "Confirm and send letters"
       end
     end

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -4,10 +4,16 @@ require "rails_helper"
 
 RSpec.describe "Planning Application index page" do
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:planning_application_1) { create(:planning_application, :ldc_proposed, :in_assessment, local_authority: default_local_authority) }
-  let!(:planning_application_2) { create(:planning_application, :ldc_proposed, :in_assessment, local_authority: default_local_authority) }
+  let!(:application_type_ldc_proposed) { create(:application_type, :ldc_proposed) }
+  let!(:application_type_prior_approval) { create(:application_type, :prior_approval) }
+  let!(:planning_application_1) {
+    create(:planning_application, :ldc_proposed, :in_assessment, local_authority: default_local_authority, application_type: application_type_ldc_proposed)
+  }
+  let!(:planning_application_2) {
+    create(:planning_application, :ldc_proposed, :in_assessment, local_authority: default_local_authority, application_type: application_type_ldc_proposed)
+  }
   let!(:planning_application_started) do
-    create(:planning_application, :ldc_proposed, :awaiting_determination, user: assessor, local_authority: default_local_authority)
+    create(:planning_application, :ldc_proposed, :awaiting_determination, user: assessor, local_authority: default_local_authority, application_type: application_type_ldc_proposed)
   end
   let!(:reviewer_planning_application_started) do
     create(:planning_application, :awaiting_determination, user: reviewer, local_authority: default_local_authority)
@@ -17,8 +23,6 @@ RSpec.describe "Planning Application index page" do
   end
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
-
-  let(:application_type_prior_approval) { create(:application_type, :prior_approval) }
 
   context "as an assessor" do
     before do
@@ -118,7 +122,8 @@ RSpec.describe "Planning Application index page" do
           :planning_application,
           :not_started,
           :prior_approval,
-          local_authority: default_local_authority
+          local_authority: default_local_authority,
+          application_type: application_type_prior_approval
         )
       end
 
@@ -127,7 +132,8 @@ RSpec.describe "Planning Application index page" do
           :planning_application,
           :in_assessment,
           :prior_approval,
-          local_authority: default_local_authority
+          local_authority: default_local_authority,
+          application_type: application_type_prior_approval
         )
       end
 
@@ -446,7 +452,8 @@ RSpec.describe "Planning Application index page" do
           :planning_application,
           :not_started,
           :ldc_proposed,
-          local_authority: default_local_authority
+          local_authority: default_local_authority,
+          application_type: application_type_ldc_proposed
         )
       end
 
@@ -455,7 +462,8 @@ RSpec.describe "Planning Application index page" do
           :planning_application,
           :not_started,
           :prior_approval,
-          local_authority: default_local_authority
+          local_authority: default_local_authority,
+          application_type: application_type_prior_approval
         )
       end
 

--- a/spec/system/planning_applications/updated_tab_spec.rb
+++ b/spec/system/planning_applications/updated_tab_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe "Planning application updated tab spec" do
   let!(:audit5) { create(:audit, created_at: 5.days.ago, planning_application: planning_application3) }
   let!(:audit6) { create(:audit, created_at: 6.days.ago, planning_application: planning_application3) }
   let!(:audit7) { create(:audit, created_at: 5.days.ago, planning_application: planning_application4, user:) }
-
+  let!(:application_type) { create(:application_type, :ldc_proposed) }
   let(:planning_application1) do
-    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:) }
+    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:, application_type:) }
   end
   let(:planning_application2) do
-    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:) }
+    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:, application_type:) }
   end
   let(:planning_application3) do
-    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:) }
+    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, local_authority:, application_type:) }
   end
   # Create planning application that has an officer assigned
   let(:planning_application4) do
-    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, user:) }
+    travel_to(10.days.ago) { create(:planning_application, :ldc_proposed, user:, application_type:) }
   end
 
   before do

--- a/spec/system/planning_applications/validating/check_legislation_spec.rb
+++ b/spec/system/planning_applications/validating/check_legislation_spec.rb
@@ -81,9 +81,10 @@ RSpec.describe "Check legislation" do
     end
   end
 
-  context "when planning application type has no legislation en.yml translation details" do
-    let!(:planning_application) do
-      create(:planning_application, :not_started, local_authority: default_local_authority)
+  context "when planning application type has no legislation details" do
+    let(:application_type) { create(:application_type, :inactive, :without_legislation) }
+    let(:planning_application) do
+      create(:planning_application, :not_started, local_authority: default_local_authority, application_type:)
     end
 
     before do


### PR DESCRIPTION
### Description of change

Use legislation dynamically

- Add legislation to site notices, consultation letters and decision notices
- Validate that legislation exists for an application type before it is made active

### Story Link

https://trello.com/c/2xJYVlT6/2681-use-legislation-dynamically-for-consultation-site-notice-decision-notice

