### PR TITLE
Update decision notice

### DIFF
--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -28,11 +28,11 @@ module StatusTags
         "govuk-tag--grey"
       when :in_progress, :awaiting_responses, :review_complete, :sending
         "govuk-tag--blue"
-      when :checked, :granted, :valid, :completed, :posted, :supportive, :approved, :auto_approved
+      when :checked, :granted, :valid, :completed, :posted, :supportive, :approved, :auto_approved, :granted_legal_agreement
         "govuk-tag--green"
       when :updated, :to_be_reviewed, :submitted, :neutral, :amendments_needed
         "govuk-tag--yellow"
-      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection, :failed
+      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection, :failed, :refused_legal_agreement
         "govuk-tag--red"
       when :printing, :awaiting_response
         "govuk-tag--purple"

--- a/app/components/status_tags/decision_component.rb
+++ b/app/components/status_tags/decision_component.rb
@@ -11,7 +11,11 @@ module StatusTags
     attr_reader :planning_application
 
     def status
-      planning_application.decision&.to_sym
+      if planning_application.heads_of_term&.terms&.any?
+        :"#{planning_application.decision}_legal_agreement"
+      else
+        planning_application.decision&.to_sym
+      end
     end
 
     def task_list?

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -100,6 +100,21 @@
         <% end %>
       </ol>
     <% end %>
+    <% if @planning_application.committee_decision&.recommend? %>
+      <h3 class="govuk-heading-s">
+        Committee recommendation
+      </h3>
+      <p class="govuk-body">
+        This application requires decision by Committee for the following reasons:
+      </p>
+      <ol class="govuk-list govuk-list--number">
+        <% @planning_application.committee_decision.reasons.each do |reason| %>
+          <li>
+            <%= reason %>
+          </li>
+        <% end %>
+      </ol>
+    <% end %>
     <h3 class="govuk-heading-s">
       This decision is based on the following approved plans:
     </h3>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -172,3 +172,6 @@
     </p>
   <% end %>
 </div>
+<p class="govuk-body">
+  <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
+</p>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -1,5 +1,10 @@
 <div class="decision-notice">
   <div class="decision-notice-main-section">
+    <% unless planning_application.determined? %>
+      <span class="govuk-tag govuk-tag--yellow app-task-list__task-tag">
+        Draft
+      </span>
+    <% end %>
     <span class="govuk-caption-xl">
       <%= planning_application.local_authority.council_name %>
     </span>

--- a/app/views/planning_applications/decision_notice.html.erb
+++ b/app/views/planning_applications/decision_notice.html.erb
@@ -17,10 +17,6 @@
     <%= render "decision_notice", planning_application: @planning_application %>
 
     <p class="govuk-body">
-      <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
-    </p>
-
-    <p class="govuk-body">
       <%= back_link %>
     </p>
   </div>

--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -16,9 +16,7 @@
   <p class="govuk-body">The following decision notice was created based on the planning officer's recommendation and comment. You can review and publish it.</p>
 
   <%= render "decision_notice", planning_application: @planning_application %>
-  <p class="govuk-body">
-    <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
-  </p>
+
   <% if @planning_application.awaiting_determination? %>
     <p class="govuk-body">By determining the application, the applicant will receive this decision notice. The decision notice will also be made publicly available. </p>
 

--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -21,16 +21,6 @@
     <h2 class="govuk-heading-m"><%= t(".decision_notice") %></h2>
     <p class="govuk-body"><%= t(".the_following_decision", report_or_notice: report_or_notice?(@planning_application)) %></p>
     <%= render "decision_notice", planning_application: @planning_application %>
-    <p class="govuk-body">
-      <%= link_to(
-        t(".download_as_pdf"),
-        decision_notice_api_v1_planning_application_path(
-          @planning_application,
-          format: "pdf"
-        ),
-        class: "govuk-link"
-      ) %>
-    </p>
     <h2 class="govuk-heading-m"><%= t(".submit_recommendation") %></h2>
     <p class="govuk-body"><%= t(".if_you_agree", report_or_notice: report_or_notice?(@planning_application)) %></p>
     <p class="govuk-body"><%= t(".if_your_manager") %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2014,7 +2014,9 @@ en:
     emailed: Emailed
     failed: Failed
     granted: To grant
+    granted_legal_agreement: To grant with Legal agreement
     granted_not_required: Prior approval not required
+    granted_not_required_legal_agreement: Prior approval not required with Legal agreement
     in_progress: In progress
     invalid: Invalid
     neutral: Neutral
@@ -2022,12 +2024,14 @@ en:
     not_cil_liable: Not liable
     not_consulted: Not consulted
     not_required: Not required
+    not_required_legal_agreement: Not required
     not_started: Not started
     objection: Objection
     permanent_failure: Permanent failure
     posted: Posted
     printing: Printing
     refused: To refuse
+    refused_legal_agreement: To refuse with Legal agreement
     rejected: Rejected
     removed: Removed
     required: Required

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe "Planning Application Assessment" do
 
       click_link("Check and assess")
       click_link("Review and submit recommendation")
+      expect(page).to have_content "Draft"
       click_button("Submit recommendation")
 
       visit "/planning_applications/#{planning_application.id}"


### PR DESCRIPTION
### Description of change

- Mark a decision notice as draft until the planning application has been determined
- Show committee reasons on the decision notice
- Show in the planning application status on the review page that there needs to be a legal agreement

### Story Link

https://trello.com/c/yHzxXFC9/2668-able-to-produce-a-draft-decision-notice-for-committee-or-legal-agreement
