### PR TITLE
CRUD for legislation

### DIFF
--- a/app/models/legislation.rb
+++ b/app/models/legislation.rb
@@ -7,6 +7,8 @@ class Legislation < ApplicationRecord
   validates :title, uniqueness: true
   validates :link, url: true
 
+  attr_readonly :title
+
   class << self
     def by_title
       order(:title)

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -5,6 +5,7 @@ require "swagger_helper"
 RSpec.describe "BOPS API" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:southwark) { create(:local_authority, :southwark) }
+  let(:application_type) { create(:application_type) }
 
   before do
     create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
@@ -20,8 +21,8 @@ RSpec.describe "BOPS API" do
   let(:planning_application) { example_fixture("validPlanningPermission.json") }
   let(:send_email) { "true" }
 
-  let!(:planning_applications) { create_list(:planning_application, 8, local_authority: local_authority) }
-  let!(:determined_planning_applications) { create_list(:planning_application, 3, :determined, local_authority: local_authority) }
+  let!(:planning_applications) { create_list(:planning_application, 8, local_authority:, application_type:) }
+  let!(:determined_planning_applications) { create_list(:planning_application, 3, :determined, local_authority:, application_type:) }
   let(:page) { 2 }
   let(:maxresults) { 5 }
   let("ids[]") { [] }

--- a/engines/bops_config/app/controllers/bops_config/legislation_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/legislation_controller.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class LegislationController < ApplicationController
+    before_action :build_legislation, only: %i[new create]
+    before_action :set_legislations, only: %i[index]
+    before_action :set_legislation, only: %i[edit update destroy]
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      @legislation.attributes = legislation_params
+
+      respond_to do |format|
+        if @legislation.save
+          format.html { redirect_to legislation_index_path, notice: t(".success") }
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @legislation.update(legislation_params)
+          format.html do
+            redirect_to legislation_index_path, notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        format.html do
+          if @legislation.destroy
+            redirect_to legislation_index_path, notice: t(".success")
+          else
+            render :edit
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_legislations
+      @legislations = Legislation.all
+    end
+
+    def set_legislation
+      @legislation = Legislation.find(params[:id])
+    end
+
+    def build_legislation
+      @legislation = Legislation.new
+    end
+
+    def legislation_params
+      params.require(:legislation).permit(*legislation_attributes)
+    end
+
+    def legislation_attributes
+      %i[title description link]
+    end
+  end
+end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -19,6 +19,8 @@ module BopsConfig
     end
 
     def active_page_key
+      return "legislation" if controller_path == "bops_config/legislation"
+
       page_keys = {
         "dashboard" => "dashboard",
         "users" => "users",
@@ -36,7 +38,8 @@ module BopsConfig
       [
         {name: "Dashboard", url: root_path, key: "dashboard"},
         {name: "Users", url: users_path, key: "users"},
-        {name: "Application types", url: application_types_path, key: "application_types"}
+        {name: "Application types", url: application_types_path, key: "application_types"},
+        {name: "Legislation", url: legislation_index_path, key: "legislation"}
       ]
     end
   end

--- a/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
@@ -17,7 +17,7 @@
   </thead>
 
   <tbody class="govuk-table__body">
-    <% @application_types.each do |application_type| %>
+    <% application_types.each do |application_type| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <%= application_type.suffix %>

--- a/engines/bops_config/app/views/bops_config/legislation/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_with model: @legislation do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_text_field :title,
+    label: {text: t(".legislation_title_label")},
+    hint: {text: t(".legislation_title_hint")},
+    readonly: @legislation.persisted? %>
+
+  <%= form.govuk_text_area :description, rows: 3,
+    label: {text: t(".legislation_description_label")},
+    hint: {text: t(".legislation_description_hint")} %>
+
+  <%= form.govuk_text_field :link,
+    label: {text: t(".legislation_link_label")},
+    hint: {text: t(".legislation_link_hint")} %>
+
+  <%= form.govuk_submit(t(".save")) do %>
+    <% if action_name == "edit" && @legislation.application_types.none? %>
+      <%= link_to(t(".remove"), 
+        legislation_path, 
+        class: "govuk-button govuk-button--warning", 
+        method: :delete, 
+        data: {confirm: "Are you sure?"}
+      ) %>
+    <% end %>
+
+    <%= link_to(t("back"), legislation_index_path, class: "govuk-button govuk-button--secondary") %>
+  <% end %>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
@@ -1,0 +1,25 @@
+<table class="govuk-table legislation-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">
+        <%= t(".title") %>
+      </th>
+      <th scope="col" class="govuk-table__header">
+        <%= t(".action") %>
+      </th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @legislations.each do |legislation| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <%= legislation.title %>
+        </td>
+        <td class="govuk-table__cell">
+          <%= link_to t(".edit"), edit_legislation_path(legislation), class: "govuk-link" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/engines/bops_config/app/views/bops_config/legislation/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= t(".legislation") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Legislation", legislation_index_path %>
+
+<% content_for :title, t(".legislation") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".legislation") %>
+    </h1>
+
+    <%= render "form" %>
+  </div>
+</div>
+
+<% if @legislation.application_types.any? %>
+  <h2 class="govuk-heading-m">
+    <%= t(".application_types_with") %>
+  </h1>
+
+  <%= render "bops_config/application_types/table", application_types: @legislation.application_types %>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/legislation/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <%= t(".title") %> - <%= t('page_title') %>
+  <%= t(".title") %> - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
@@ -9,11 +9,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      Application Types
+      <%= t(".title") %>
     </h1>
+
     <p class="govuk-body">
-      <%= link_to "Create new application type", new_application_type_path , class: "govuk-button govuk-button--primary" %>
+      <%= link_to t(".create_new_legislation"), new_legislation_path, class: "govuk-button govuk-button--primary" %>
     </p>
-    <%= render "table", application_types: @application_types %>
+
+    <%= render "table" %>
   </div>
 </div>

--- a/engines/bops_config/app/views/bops_config/legislation/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  <%= t(".legislation") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Legislation", legislation_index_path %>
+
+<% content_for :title, t(".legislation") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".legislation") %>
+    </h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -117,6 +117,37 @@ en:
       show:
         administrator_dashboard: Administrator dashboard
         welcome_message: Welcome %{name}
+    legislation:
+      create:
+        success: Legislation successfully created
+      destroy:
+        success: Legislation successfully removed
+      edit:
+        application_types_with: Application types with this legislation
+        legislation: Edit legislation
+      form:
+        back: Back
+        legislation_description_hint: Enter an optional description
+        legislation_description_label: Description
+        legislation_link_hint: Enter an optional link to legislation.gov.uk
+        legislation_link_label: Link
+        legislation_title_hint: Enter a title – this is usually the name of the act and the relevant section
+        legislation_title_label: Title
+        remove: Remove
+        save: Save
+      index:
+        create_new_legislation: Create new legislation
+        title: Legislation
+      new:
+        legislation: Add new legislation
+      table:
+        action: Action
+        description: Description
+        edit: Edit
+        link: Link
+        title: Title
+      update:
+        success: Legislation successfully updated
     users:
       create:
         user_successfully_created: User successfully created

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -23,6 +23,8 @@ BopsConfig::Engine.routes.draw do
     end
   end
 
+  resources :legislation, except: %i[show]
+
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member
   end

--- a/engines/bops_config/spec/system/legislation_spec.rb
+++ b/engines/bops_config/spec/system/legislation_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Legislation", type: :system, bops_config: true do
+  let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
+  let!(:legislation) { create(:legislation, title: "Town and Country Planning Act 1990, Section 192") }
+
+  before do
+    sign_in(user)
+    visit "/"
+  end
+
+  it "allows creating the new legislation" do
+    click_link "Legislation"
+    expect(page).to have_selector("h1", text: "Legislation")
+
+    within(".govuk-table") do
+      within "thead > tr:first-child" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Title")
+        expect(page).to have_selector("th:nth-child(2)", text: "Action")
+      end
+
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Town and Country Planning Act 1990, Section 192")
+          within "td:nth-child(2)" do
+            expect(page).to have_link(
+              "Edit",
+              href: "/legislation/#{legislation.id}/edit"
+            )
+          end
+        end
+      end
+    end
+
+    click_link "Create new legislation"
+    fill_in "Link", with: "Not a link"
+    click_button "Save"
+
+    expect(page).to have_selector("[role=alert] li", text: "Enter a title for the legislation")
+    expect(page).to have_selector("[role=alert] li", text: "Enter a valid url for the legislation")
+
+    fill_in "Title", with: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Part 1, Class A"
+    fill_in "Description", with: "A description about the legislation"
+    fill_in "Link", with: "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made"
+    click_button "Save"
+
+    expect(page).to have_content("Legislation successfully created")
+
+    within(".govuk-table") do
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Town and Country Planning Act 1990, Section 192")
+        end
+        within "tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "The Town and Country Planning (General Permitted Development) (England) Order 2015 Part 1, Class A")
+        end
+      end
+    end
+  end
+
+  it "allows editing the legislation" do
+    visit "/legislation/#{legislation.id}/edit"
+    expect(page).to have_selector("h1", text: "Edit legislation")
+    expect(page).to have_link("Back", href: "/legislation")
+    # Legislation title is readonly
+    expect(page).to have_selector("#legislation-title-field[readonly]")
+
+    fill_in "Description", with: "A description about the legislation"
+    fill_in "Link", with: "https://www.legislation.gov.uk/ukpga/1990/8/section/192"
+    click_button "Save"
+
+    expect(page).to have_content("Legislation successfully updated")
+    click_link "Edit"
+
+    expect(find_field("Description").value).to eq("A description about the legislation")
+    expect(find_field("Link").value).to eq("https://www.legislation.gov.uk/ukpga/1990/8/section/192")
+  end
+
+  it "allows deleting the legislation" do
+    visit "/legislation/#{legislation.id}/edit"
+    accept_confirm(text: "Are you sure?") do
+      click_link("Remove")
+    end
+
+    expect(page).to have_content("Legislation successfully removed")
+    expect(page).not_to have_content("Town and Country Planning Act 1990, Section 192")
+  end
+
+  it "allows viewing the associated application types" do
+    application_type = create(:application_type, :ldc_proposed, legislation:)
+
+    visit "/legislation/#{legislation.id}/edit"
+    expect(page).to have_selector("h2", text: "Application types with this legislation")
+    expect(page).not_to have_link("Remove")
+
+    within(".govuk-table.application-types-table") do
+      within "thead > tr:first-child" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Suffix")
+        expect(page).to have_selector("th:nth-child(2)", text: "Name")
+        expect(page).to have_selector("th:nth-child(3)", text: "Status")
+        expect(page).to have_selector("th:nth-child(4)", text: "Action")
+      end
+
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "LDCP")
+          expect(page).to have_selector("td:nth-child(2)", text: "Lawful Development Certificate - Proposed use")
+          expect(page).to have_selector("td:nth-child(3) .govuk-tag--green", text: "Active")
+
+          within "td:nth-child(4)" do
+            expect(page).to have_link(
+              "View and/or edit",
+              href: "/application_types/#{application_type.id}"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -378,6 +378,8 @@ FactoryBot.define do
 
       code { "pp.full.householder.retro" }
       suffix { "HRET" }
+
+      legislation { association :legislation, :pp_full_householder_retro }
     end
 
     trait :without_consultation do

--- a/spec/factories/legislation.rb
+++ b/spec/factories/legislation.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :legislation do
-    title { "Town and Country Planning Act 1990, Section #{rand(9999)}" }
+    sequence(:title, 200) { |n| "Town and Country Planning Act 1990, Section #{n}" }
 
     trait :ldc_existing do
       title { "Town and Country Planning Act 1990, Section 191" }
@@ -22,7 +22,12 @@ FactoryBot.define do
 
     trait :pp_full_householder do
       title { "The Town and Country Planning (Development Management Procedure) (England) Order 2015" }
-      link { "https://www.legislation.gov.uk/uksi/2015/595/article/2/made" }
+      link { "https://www.legislation.gov.uk/uksi/2015/596/contents/made" }
+    end
+
+    trait :pp_full_householder_retro do
+      title { "The Town and Country Planning (Development Management Procedure) (England) Order 2015 retro" }
+      link { "https://www.legislation.gov.uk/uksi/2015/596/contents/made" }
     end
   end
 end

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Legislation do
+  describe "#validations" do
+    subject(:legislation) { described_class.new }
+
+    describe "#title" do
+      it "validates presence" do
+        expect { legislation.valid? }.to change { legislation.errors[:title] }.to ["Enter a title for the legislation"]
+      end
+
+      it "is readonly" do
+        legislation = create(:legislation, title: "Legislation title")
+        legislation.update!(title: "A new legislation title")
+
+        expect(legislation.reload.title).to eq("Legislation title")
+      end
+    end
+
+    context "when destroying" do
+      let(:legislation) { create(:legislation) }
+      let(:application_type) { create(:application_type, legislation:) }
+
+      it "restricts with error when there are associated application types" do
+        application_type
+
+        expect { legislation.destroy }.to change { legislation.errors[:base] }.to ["Cannot delete record because dependent application types exist"]
+      end
+
+      it "allows deletion when there are no associated application types" do
+        expect { legislation.destroy }.not_to change { legislation.errors[:base] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add CRUD for legislation

- Show associated application types
- Allow deleting legislation when there are no associated application types
- Legislation title is readonly

### Story Link

https://trello.com/c/PCueJNCG/2714-as-a-global-admin-user-i-can-edit-the-legislation-description-and-link-for-an-existing-legislation-title

### Screenshots

![Screenshot 2024-04-03 at 09 42 04](https://github.com/unboxed/bops/assets/34001723/31fe408c-67a1-46d1-989f-0bf6ab062e6b)


![Screenshot 2024-04-02 at 13 25 29](https://github.com/unboxed/bops/assets/34001723/2dca921b-24c9-49fb-89e8-b72e9bbcfe31)
