### PR TITLE
Allow selection of reporting types when setting up an application type

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -453,3 +453,7 @@ body {
     text-wrap: balance;
   }
 }
+
+.govuk-\!-text-wrap-balance {
+  text-wrap: balance;
+}

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -437,19 +437,19 @@ body {
   }
 }
 
-.ga-document-tag {
-  margin: 0.25rem 0.25rem 0.25rem 0;
-}
+.govuk-\!-column-count-2 {
+  @include govuk-media-query($from: tablet) {
+    column-count: 2;
+    column-fill: balance;
+  }
 
-.ga-document-tags {
-  column-count: 2;
-  column-fill: balance;
-
+  & > .govuk-checkboxes__item,
   & > .govuk-checkboxes__item {
     break-inside: avoid;
   }
 
-  .govuk-checkboxes__label {
+  .govuk-checkboxes__label,
+  .govuk-radios__label {
     text-wrap: balance;
   }
 }

--- a/app/helpers/reporting_type_helper.rb
+++ b/app/helpers/reporting_type_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module ReportingTypeHelper
-  def reporting_types(application_type)
-    I18n.t(application_type, scope: :reporting_type).flat_map do |type, information|
-      [[type.to_s] + information.values]
-    end
-  end
-end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -10,6 +10,23 @@ class ApplicationType < ApplicationRecord
   attribute :document_tags, ApplicationTypeDocumentTags.to_type
   attribute :features, ApplicationTypeFeature.to_type
 
+  enum :category, {
+    advertisment: "advertisment",
+    certificate_of_lawfulness: "certificate-of-lawfulness",
+    change_of_use: "change-of-use",
+    conservation_area: "conservation-area",
+    full: "full",
+    hedgerows: "hedgerows",
+    householder: "householder",
+    listed_building: "listed-building",
+    non_material_amendment: "non-material-amendment",
+    outline: "outline",
+    prior_approval: "prior-approval",
+    reserved_matters: "reserved-matters",
+    tree_works: "tree-works",
+    other: "other"
+  }, scopes: false, instance_methods: false, validate: { on: :category }
+
   enum :status, {inactive: "inactive", active: "active", retired: "retired"}
 
   belongs_to :legislation, optional: true

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -39,7 +39,11 @@ class ApplicationType < ApplicationRecord
   validates :name, :code, :suffix, presence: true
   validates :code, :suffix, uniqueness: true
   validates :features, store_model: {merge_errors: true}
-  validates :legislation, presence: true, if: :active?
+
+  with_options presence: {message: :blank_when_activating} do
+    validates :category, :legislation, if: :activating?
+    validates :reporting_types, if: -> { category? && activating? }
+  end
 
   with_options allow_blank: true do
     validates :code, inclusion: {in: ODP_APPLICATION_TYPES.keys}
@@ -141,6 +145,10 @@ class ApplicationType < ApplicationRecord
 
   before_validation on: :document_tags, unless: :configured? do
     self.configured = true
+  end
+
+  def activating?
+    status_changed? && active?
   end
 
   def existing_or_new_legislation

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -57,6 +57,10 @@ class ApplicationType < ApplicationRecord
     end
   end
 
+  with_options on: :reporting do
+    validates :reporting_types, presence: true
+  end
+
   with_options on: :legislation do
     validate if: :existing_legislation? do
       errors.add(:legislation_id, :blank) unless legislation&.persisted?
@@ -189,6 +193,22 @@ class ApplicationType < ApplicationRecord
 
   def type_name
     self.class.type_mapping[code]
+  end
+
+  def reporting_types=(values)
+    super(Array.wrap(values).reject(&:blank?))
+  end
+
+  def all_reporting_types
+    @all_reporting_types ||= ReportingType.for_category(category)
+  end
+
+  def all_reporting_type_codes
+    all_reporting_types.map(&:code)
+  end
+
+  def selected_reporting_types
+    @selected_reporting_types || ReportingType.for_codes(reporting_types)
   end
 
   class << self

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -237,6 +237,20 @@ class ApplicationType < ApplicationRecord
         [application_type.description, application_type.id]
       end
     end
+
+    def reporting_type_used?(codes)
+      where(reporting_types.contains(normalize_codes(codes))).exists?
+    end
+
+    private
+
+    def reporting_types
+      arel_table[:reporting_types]
+    end
+
+    def normalize_codes(codes)
+      Array.wrap(codes).compact_blank
+    end
   end
 
   private

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -25,7 +25,7 @@ class ApplicationType < ApplicationRecord
     reserved_matters: "reserved-matters",
     tree_works: "tree-works",
     other: "other"
-  }, scopes: false, instance_methods: false, validate: { on: :category }
+  }, scopes: false, instance_methods: false, validate: {on: :category}
 
   enum :status, {inactive: "inactive", active: "active", retired: "retired"}
 
@@ -196,7 +196,7 @@ class ApplicationType < ApplicationRecord
   end
 
   def reporting_types=(values)
-    super(Array.wrap(values).reject(&:blank?))
+    super(Array.wrap(values).compact_blank)
   end
 
   def all_reporting_types

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -211,6 +211,10 @@ class ApplicationType < ApplicationRecord
     @selected_reporting_types || ReportingType.for_codes(reporting_types)
   end
 
+  def selected_reporting_types?
+    selected_reporting_types.present?
+  end
+
   class << self
     def by_name
       in_order_of(:name, NAME_ORDER).order(:name, :code)

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class ReportingType < ApplicationRecord
+  enum :category, ApplicationType.categories
+
+  with_options presence: true do
+    validates :code, uniqueness: true
+    validates :category, :description
+  end
+
+  with_options if: :prior_approval? do
+    validates :code, format: { with: /\APA\d{1,2}\z/, message: :invalid_pa_code }
+    validates :legislation, presence: true
+  end
+
+  with_options unless: :prior_approval? do
+    validates :code, format: { with: /\AQ\d{2}\z/, message: :invalid_q_code }
+  end
+
+  with_options allow_blank: true do
+    validates :guidance_link, url: true
+  end
+
+  class << self
+    def by_code
+      order(:code)
+    end
+
+    def for_category(category)
+      where(category: category).order(:code)
+    end
+
+    def for_codes(codes)
+      where(code: Array.wrap(codes)).order(:code)
+    end
+  end
+end

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -21,6 +21,12 @@ class ReportingType < ApplicationRecord
     validates :guidance_link, url: true
   end
 
+  before_destroy do
+    if ApplicationType.reporting_type_used?(code)
+      errors.add(:base, :used) and throw(:abort)
+    end
+  end
+
   class << self
     def by_code
       order(:code_prefix, :code_suffix)

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -23,15 +23,15 @@ class ReportingType < ApplicationRecord
 
   class << self
     def by_code
-      order(:code)
+      order(:code_prefix, :code_suffix)
     end
 
     def for_category(category)
-      where(category: category).order(:code)
+      where(category: category).by_code
     end
 
     def for_codes(codes)
-      where(code: Array.wrap(codes)).order(:code)
+      where(code: Array.wrap(codes)).by_code
     end
   end
 

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -9,12 +9,12 @@ class ReportingType < ApplicationRecord
   end
 
   with_options if: :prior_approval? do
-    validates :code, format: { with: /\APA\d{1,2}\z/, message: :invalid_pa_code }
+    validates :code, format: {with: /\APA\d{1,2}\z/, message: :invalid_pa_code}
     validates :legislation, presence: true
   end
 
   with_options unless: :prior_approval? do
-    validates :code, format: { with: /\AQ\d{2}\z/, message: :invalid_q_code }
+    validates :code, format: {with: /\AQ\d{2}\z/, message: :invalid_q_code}
   end
 
   with_options allow_blank: true do

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -34,4 +34,8 @@ class ReportingType < ApplicationRecord
       where(code: Array.wrap(codes)).order(:code)
     end
   end
+
+  def full_description
+    "#{code} – #{description}"
+  end
 end

--- a/app/presenters/application_type_status_error_presenter.rb
+++ b/app/presenters/application_type_status_error_presenter.rb
@@ -1,18 +1,27 @@
 # frozen_string_literal: true
 
 class ApplicationTypeStatusErrorPresenter < ErrorPresenter
+  include Rails.application.routes.url_helpers
+  include Rails.application.routes.mounted_helpers
   include ActionView::Helpers::TagHelper
-  include ActionView::Helpers::UrlHelper
 
   private
 
-  def link_tag(text)
-    options = {
-      class: "govuk-link",
-      href: BopsConfig::Engine.routes.url_helpers.edit_application_type_legislation_path(record)
-    }
+  def link_tag(text, attribute)
+    content_tag(:a, text, href: href_for(attribute), class: "govuk-link")
+  end
 
-    content_tag(:a, text, **options)
+  def href_for(attribute)
+    case attribute
+    when :legislation
+      bops_config.edit_application_type_legislation_path(record)
+    when :reporting_types
+      bops_config.edit_application_type_reporting_path(record)
+    when :category
+      bops_config.edit_application_type_category_path(record)
+    else
+      bops_config.application_type_path(record)
+    end
   end
 
   def link?

--- a/app/presenters/error_presenter.rb
+++ b/app/presenters/error_presenter.rb
@@ -19,13 +19,11 @@ class ErrorPresenter
   def formatted_message(message, attribute)
     attribute = attributes_map[attribute] || attribute
 
-    if message.match?(/\A[A-Z].+\Z/)
-      message
-    else
-      text = "#{attribute.to_s.humanize.tr(".", " ")} #{message}"
-
-      link? ? link_tag(text) : text
+    unless message.match?(/\A[A-Z].+\Z/)
+      message = "#{attribute.to_s.humanize.tr(".", " ")} #{message}"
     end
+
+    link? ? link_tag(message, attribute) : message
   end
 
   def attributes_map
@@ -34,5 +32,9 @@ class ErrorPresenter
 
   def link?
     false
+  end
+
+  def link_tag(text, attribute)
+    raise NotImplementedError, "Subclasses must implement a link_tag(text, attribute) method"
   end
 end

--- a/app/views/planning_applications/validation/reporting_types/_form.html.erb
+++ b/app/views/planning_applications/validation/reporting_types/_form.html.erb
@@ -1,35 +1,28 @@
 <%= form_with model: @planning_application, local: true, url: planning_application_validation_reporting_type_url(@planning_application) do |form| %>
   <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
-  <%= form.govuk_radio_buttons_fieldset(
-      :reporting_type,
-      legend: { size: "m" }
-    ) do %>
-      <% reporting_types(@planning_application.application_type.name.to_sym).each do | category, description, guidance, guidance_link, legislation| %>
-        <%= form.govuk_radio_button(:reporting_type, category, label: { text: "#{category} - #{description}" }, data: { "aria-controls": "conditional-#{category}" }) %>
-
-        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id=<%="conditional-#{category}"%>>
-          <% if guidance.present? %>
-            <p class="govuk-body"><strong>Guidance</strong></p>
-            <p class="govuk-hint"><%= guidance %></p>
-            <% if guidance_link.present? %>
-              <%= link_to("Read more guidance GOV.UK (opens in new tab)", guidance_link, target: '_blank', class: "govuk-link") %>
+  <%= form.govuk_radio_buttons_fieldset(:reporting_type, legend: {size: "m"}) do %>
+    <% if @planning_application.application_type.selected_reporting_types? %>
+      <% @planning_application.application_type.selected_reporting_types.each do |reporting_type| %>
+        <%= form.govuk_radio_button(:reporting_type, reporting_type.code, label: { text: reporting_type.full_description }) do %>
+          <% if reporting_type.guidance? %>
+            <%= render FormattedContentComponent.new(text: reporting_type.guidance, classname: "govuk-hint") %>
+            <% if reporting_type.guidance_link? %>
+              <p class="govuk-hint"><%= link_to(t(".read_more"), reporting_type.guidance_link, target: "_blank", class: "govuk-link") %></p>
             <% end %>
           <% end %>
-          <% if legislation.present? %>
-            <p class="govuk-body"><strong>Legislation</strong></p>
-            <p class="govuk-hint"><%= legislation %></p>
+          <% if reporting_type.legislation? %>
+            <p class="govuk-body"><strong><%= t(".legislation") %></strong></p>
+            <p class="govuk-hint"><%= reporting_type.legislation %></p>
           <% end %>
-        </div>
+        <% end %>
       <% end %>
+    <% else %>
+      <p class="govuk-body"><%= t(".no_applicable_reporting_types") %></p>
+    <% end %>
   <% end %>
 
-  <div class="govuk-button-group">
-    <%= form.submit(
-      t("form_actions.save_and_mark_as_complete"),
-      class: "govuk-button",
-      data: { module: "govuk-button" }
-    ) %>
+  <%= form.govuk_submit(t("form_actions.save_and_mark_as_complete")) do %>
     <%= back_link %>
-  </div>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,6 +123,8 @@ en:
       models:
         application_type:
           attributes:
+            category:
+              inclusion: Select a category from the list
             code:
               blank: Select an application type name
               inclusion: Select a valid application type name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,7 +124,7 @@ en:
         application_type:
           attributes:
             category:
-              inclusion: Select a category from the list
+              inclusion: Choose a category from the list
             code:
               blank: Select an application type name
               inclusion: Select a valid application type name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,6 +140,8 @@ en:
               blank: must be set when application type is made active
             legislation_id:
               blank: An existing legislation must be chosen
+            reporting_types:
+              blank: A least one reporting type must be selected
             suffix:
               blank: Enter a suffix for the application number
               invalid: The suffix must only use uppercase letters and numbers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -286,18 +286,20 @@ en:
               updates_required: You have requested officer changes, resolve these before agreeing with the recommendation
         reporting_type:
           attributes:
+            base:
+              used: You can't remove a reporting type that's being used by an application type
             category:
-              blank: You must choose a category for a reporting type
+              blank: Choose a category for this reporting type
             code:
-              blank: You must enter a code for a reporting type
+              blank: Enter a code for this reporting type
               invalid_pa_code: The code must be in the form 'PAX' or 'PAXX' where 'X' is a number
               invalid_q_code: The code must be in the form 'QXX' where 'X' is a number
             description:
-              blank: You must enter a description for a reporting type
+              blank: Enter a description for this reporting type
             guidance_link:
               invalid: The link to the guidance must be a valid URL
             legislation:
-              blank: You must enter the legislation for prior approval reporting types
+              blank: Enter the legislation for prior approval reporting types
         review:
           attributes:
             action:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1672,6 +1672,10 @@ en:
         update:
           success: Ownership certificate successfully updated
       reporting_types:
+        form:
+          legislation: Legislation
+          no_applicable_reporting_types: No applicable reporting types
+          read_more: Read more guidance on GOV.UK (opens in a new tab)
         update:
           failure: Please select a development type for reporting
           success: Planning application's development type for reporting was successfully selected
@@ -1808,109 +1812,6 @@ en:
     resend: No, I’m chasing existing consultees
     resend_message_label: Additional message to include in the email (optional)
     send: No, I’m sending to new consultees
-  reporting_type:
-    lawfulness_certificate:
-      Q26:
-        description: Certificate of Lawful Development
-        guidance: Includes both Existing & Proposed applications
-    planning_permission:
-      Q01:
-        description: Major Dwellings
-        guidance: |
-          Record any applications for development in use class C3 (dwelling houses) in Town and Country Planning (Use Classes) Order 1987 (SI 1987/764) (as amended) under the relevant question according to the size of the application.
-          Exclude residential uses that fall in other use classes e.g. hotels (C1), residential institutions such as hospitals and nursing homes, houses in multiple occupation (C4 or Sui Generis) and caravan sites.
-          Although the guidance notes for April to June 2014 and previous quarters have asked for granny annexes to be included under Q1 or Q13 as appropriate, the department has reviewed this part of the guidance and concluded that granny annexes should now be recorded at question Q21 (householder developments).
-        guidance_link: https://www.gov.uk/government/publications/district-planning-matters-return-ps1-and-ps2/ps1-and-ps2-district-planning-matters-return-guidance-notes#viewing-saving-and-submitting
-      Q02:
-        description: Major Offices/R&amp;D/Light Ind
-        guidance: |
-          Please record any relevant applications for development in use classes E in Town and Country Planning (Use Classes) Order 1987 (as amended) (e.g. financial and professional services and businesses) (under the relevant question according to the size of the application.
-          Examples of applications that should be recorded here include banks, building societies, estate agents, general offices and those for research and non-polluting industrial processes.
-      Q03:
-        description: Major General Ind/Stor/Ware
-        guidance: Please record any applications for development in use classes B2 (general industrial) and B8 (storage or distribution) in Town and Country Planning (Use Classes) Order 1987 (as amended) under the relevant question according to the size of the application.
-      Q04:
-        description: Major Retail and services
-        guidance: Please record any relevant applications for development in use classes E in Town and Country Planning (Use Classes) Order 1987 (as amended) (e.g. shops, restaurants and cafes) or which are sui generis (drinking establishments and hot food takeaways only) under the relevant question according to the size of the application.
-      Q05:
-        description: Major  Traveller caravan pitches
-        guidance: Decisions on applications in relation to Traveller caravan sites should be recorded in the relevant category of development of major or minor development. There is a requirement to separately record these types of applications in order to help monitor the effectiveness of the department’s Planning Policy for Traveller Sites. Although applications may refer to ‘sites’, please record the number of pitches the local authority believes the site would provide. An application determined for between 1 - 9 pitches should be recorded as a minor development, and 10 or more pitches as a major development.
-      Q06:
-        description: All Other Major Development
-      Q07:
-        description: Major Public Service Infrastructure Projects
-        guidance: Major developments for schools, hospitals and criminal justice accommodation have been subject to an accelerated decision-making timetable. For more details on Major Public Service Infrastructure developments please refer to pages 5-6 of the July 2021 Planning Newsletter.
-        guidance_link: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1004896/Chief_Planners_Newsletter_-_July_2021.pdf
-      Q13:
-        description: Minor Dwellings
-        guidance: |
-          Record any applications for development in use class C3 (dwelling houses) in Town and Country Planning (Use Classes) Order 1987 (SI 1987/764) (as amended) under the relevant question according to the size of the application.
-          Exclude residential uses that fall in other use classes e.g. hotels (C1), residential institutions such as hospitals and nursing homes, houses in multiple occupation (C4 or Sui Generis) and caravan sites.
-          Although the guidance notes for April to June 2014 and previous quarters have asked for granny annexes to be included under Q1 or Q13 as appropriate, the department has reviewed this part of the guidance and concluded that granny annexes should now be recorded at question Q21 (householder developments).
-        guidance_link: https://www.gov.uk/government/publications/district-planning-matters-return-ps1-and-ps2/ps1-and-ps2-district-planning-matters-return-guidance-notes#viewing-saving-and-submitting
-      Q14:
-        description: Minor Offices/Rsearch Development/Light Industry
-        guidance: |
-          Please record any relevant applications for development in use classes E in Town and Country Planning (Use Classes) Order 1987 (as amended) (e.g. financial and professional services and businesses) (under the relevant question according to the size of the application.
-          Examples of applications that should be recorded here include banks, building societies, estate agents, general offices and those for research and non-polluting industrial processes.
-      Q15:
-        description: Minor General Industry/Storage/Warehouse
-        guidance: Please record any applications for development in use classes B2 (general industrial) and B8 (storage or distribution) in Town and Country Planning (Use Classes) Order 1987 (as amended) under the relevant question according to the size of the application.
-      Q16:
-        description: Minor Retail and services
-        guidance: Please record any relevant applications for development in use classes E in Town and Country Planning (Use Classes) Order 1987 (as amended) (e.g. shops, restaurants and cafes) or which are sui generis (drinking establishments and hot food takeaways only) under the relevant question according to the size of the application.
-      Q17:
-        description: Minor  Traveller caravan pitches
-        guidance: Decisions on applications in relation to Traveller caravan sites should be recorded in the relevant category of development of major or minor development. There is a requirement to separately record these types of applications in order to help monitor the effectiveness of the department’s Planning Policy for Traveller Sites. Although applications may refer to ‘sites’, please record the number of pitches the local authority believes the site would provide. An application determined for between 1 - 9 pitches should be recorded as a minor development, and 10 or more pitches as a major development
-      Q18:
-        description: All Other Minor Development
-        guidance: |-
-          Record any decisions on applications other than those already captured in Questions 1 to 5 and 13 to 17 according to the size of the application.
-          This includes developments in the following use classes:
-          C1 (hotels) C2 (residential institutions) C4 (houses in multiple occupations for 3 to 6 residents) E (gymnasiums, indoor recreations not involving motorised vehicles or firearms) F1 (non-residential institutions) Sui generis uses except drinking establishments and hot food takeaways): Certain uses do not fall within any use class and are considered ‘sui generis’. Such uses include: betting offices/shops, payday loan shops, theatres, houses in multiple occupation for more than 6 residents, hostels providing no significant element of care, scrap yards, petrol filling stations and shops selling and/or displaying motor vehicles, retail warehouse clubs, nightclubs, launderettes, taxi businesses, amusement centres, casinos, cinemas, concert halls, bingo halls and dance halls
-      Q19:
-        description: Minerals Processing
-        guidance: The former Question 19 (minerals processing) was removed from the form with effect from April 2014.
-        guidance_link: https://www.gov.uk/government/publications/district-planning-matters-return-ps1-and-ps2/ps1-and-ps2-district-planning-matters-return-guidance-notes#viewing-saving-and-submitting
-      Q20:
-        description: Change of Use
-      Q21:
-        description: Householder Development
-    prior_approval:
-      PA1:
-        description: Householders Extensions
-        guidance: "' Householder developments (as referred to in some of the live tables, such as P123) are defined as those within the curtilage of a dwelling house which require an application for planning permission and are not a change of use. Included in householder developments are extensions, conservatories, loft conversions, dormer windows, alterations, garages, car ports or outbuildings, swimming pools, walls, fences, domestic vehicular accesses including footway crossovers, porches and satellite dishes. Granny annexes have been included with effect from 1 July 2014, having previously been recorded under dwellings. Excluded from householder developments are: applications relating to any work to 1 or more flats, applications to change the number of dwellings (flat conversions, building a separate house in the garden), changes of use to part or all of the property to non-residential (including business) uses, or anything outside the garden of the property (including stables if in a separate paddock). By definition, householder developments that do not require an application for planning permission are also excluded – e.g. for extensions, these include those for which permitted development rights exist, including larger householder extensions (as defined under ‘Permitted development rights’) for which local authority prior approval is needed, and those that satisfy other conditions within the General Permitted Development Order, for which prior approval is not needed, and for which data are therefore not collected.'"
-        guidance_link: https://www.gov.uk/government/publications/district-planning-matters-return-ps1-and-ps2/ps1-and-ps2-district-planning-matters-return-guidance-notes#viewing-saving-and-submitting
-        legislation: Class A of Part 1 of Schedule 2 to the General Permitted Development Order (GPDO 2015)
-      PA15:
-        description: AA New Dwelling Detached Commer/Mix use
-        legislation: Class AA of Part 20 of Schedule 2 to GPDO 2015
-      PA16:
-        description: AD New Dwelling Detached Dwellinghouse
-        legislation: Class AD of Part 20 of Schedule 2 to GPDO 2015
-      PA17:
-        description: A New Dwelling Detached Block of flats
-        legislation: Class A of Part 20 of Schedule 2 to GPDO 2015
-      PA18:
-        description: AA Enlarge dwelling additional storey
-        legislation: Class AA of Part 1 of Schedule 2 to the General Permitted Development Order (GPDO 2015)
-      PA19:
-        description: ZA New Dwelling/Block flats Demolition
-        legislation: Class ZA of Part 20 of Schedule 2 to GPDO 2015
-      PA2:
-        description: Office to Residential
-        legislation: Class O of Part 3 of Schedule 2 to GPDO 2015
-      PA20:
-        description: AB New Dwelling Terrace Commercial/Mixed
-        legislation: Class AB of Part 20 of Schedule 2 to GPDO 2015
-      PA7:
-        description: Specified sui generis uses to C3
-        legislation: |
-          Class N of Part 3 of Schedule 2 to GPDO 2015; AND
-          Class M of Part 3 of Schedule 2 to GPDO 2015;
-      PA8:
-        description: Agricultural buildings to dwellinghouses
-        legislation: Class Q of Part 3 of Schedule 2 to GPDO 2015;
   response_tag_component:
     privacy: Privacy
   review:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -279,6 +279,20 @@ en:
           attributes:
             challenged:
               updates_required: You have requested officer changes, resolve these before agreeing with the recommendation
+        reporting_type:
+          attributes:
+            category:
+              blank: You must choose a category for a reporting type
+            code:
+              blank: You must enter a code for a reporting type
+              invalid_pa_code: The code must be in the form 'PAX' or 'PAXX' where 'X' is a number
+              invalid_q_code: The code must be in the form 'QXX' where 'X' is a number
+            description:
+              blank: You must enter a description for a reporting type
+            guidance_link:
+              invalid: The link to the guidance must be a valid URL
+            legislation:
+              blank: You must enter the legislation for prior approval reporting types
         review:
           attributes:
             action:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,8 @@ en:
         application_type:
           attributes:
             category:
+              blank: A category must be chosen
+              blank_when_activating: A category must be set when an application type is made active
               inclusion: Choose a category from the list
             code:
               blank: Select an application type name
@@ -137,11 +139,12 @@ en:
               not_a_number: The determination period must be a number of days
               not_an_integer: The determination period must be a whole number of days
             legislation:
-              blank: must be set when application type is made active
+              blank_when_activating: The legislation must be set when an application type is made active
             legislation_id:
               blank: An existing legislation must be chosen
             reporting_types:
               blank: A least one reporting type must be selected
+              blank_when_activating: A least one reporting type must be selected when an application type is made active
             suffix:
               blank: Enter a suffix for the application number
               invalid: The suffix must only use uppercase letters and numbers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,10 +19,10 @@ Rails.application.routes.draw do
   constraints Constraints::LocalAuthoritySubdomain do
     root to: "planning_applications#index"
 
-    mount BopsApi::Engine, at: "/api"
+    mount BopsApi::Engine, at: "/api", as: :bops_api
     get "/api-docs(/index)", to: redirect("/api/docs")
 
-    mount BopsAdmin::Engine, at: "/admin"
+    mount BopsAdmin::Engine, at: "/admin", as: :bops_admin
 
     defaults format: "json" do
       get "/os_places_api",
@@ -325,6 +325,6 @@ Rails.application.routes.draw do
   end
 
   constraints Constraints::ConfigSubdomain do
-    mount BopsConfig::Engine => "/"
+    mount BopsConfig::Engine, at: "/", as: :bops_config
   end
 end

--- a/db/migrate/20240328105343_add_category_to_application_type.rb
+++ b/db/migrate/20240328105343_add_category_to_application_type.rb
@@ -8,7 +8,7 @@ class AddCategoryToApplicationType < ActiveRecord::Migration[7.1]
 
     up_only do
       ApplicationType.find_each do |type|
-        type.category = \
+        type.category =
           case type.code
           when /\Aldc\z/, /\Aldc\./
             "certificate-of-lawfulness"

--- a/db/migrate/20240328105343_add_category_to_application_type.rb
+++ b/db/migrate/20240328105343_add_category_to_application_type.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class AddCategoryToApplicationType < ActiveRecord::Migration[7.1]
+  class ApplicationType < ActiveRecord::Base; end
+
+  def change
+    add_column :application_types, :category, :string
+
+    up_only do
+      ApplicationType.find_each do |type|
+        type.category = \
+          case type.code
+          when /\Aldc\z/, /\Aldc\./
+            "certificate-of-lawfulness"
+          when /\Apa\z/, /\Apa\./
+            "prior-approval"
+          when /\App\.full\.householder\z/, /\App.full.householder\./
+            "householder"
+          when /\App\.full\z/, /\App.full\./
+            "full"
+          when /\App\.outline\z/, /\App.outline\./
+            "outline"
+          when /\App\z/, /\App\./
+            "full"
+          when "advertConsent"
+            "advertisment"
+          when "hedgerowRemovalNotice"
+            "hedgerows"
+          when "listed"
+            "listed-building"
+          when "nonMaterialAmendment"
+            "non-material-amendment"
+          when "treeWorksConsent"
+            "tree-works"
+          else
+            "other"
+          end
+
+        type.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20240328110518_create_reporting_types.rb
+++ b/db/migrate/20240328110518_create_reporting_types.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateReportingTypes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :reporting_types do |t|
+      t.string :code, null: false
+      t.string :category, null: false
+      t.string :description, null: false
+      t.string :guidance
+      t.string :guidance_link
+      t.string :legislation
+
+      t.timestamps
+    end
+
+    add_index :reporting_types, :code, unique: true
+  end
+end

--- a/db/migrate/20240402154327_add_reporting_types_to_application_types.rb
+++ b/db/migrate/20240402154327_add_reporting_types_to_application_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddReportingTypesToApplicationTypes < ActiveRecord::Migration[7.1]
   class ApplicationType < ActiveRecord::Base; end
 

--- a/db/migrate/20240402154327_add_reporting_types_to_application_types.rb
+++ b/db/migrate/20240402154327_add_reporting_types_to_application_types.rb
@@ -1,0 +1,16 @@
+class AddReportingTypesToApplicationTypes < ActiveRecord::Migration[7.1]
+  class ApplicationType < ActiveRecord::Base; end
+
+  def change
+    add_column :application_types, :reporting_types, :string, array: true
+
+    up_only do
+      ApplicationType.find_each do |type|
+        type.update!(reporting_types: [])
+      end
+
+      change_column_default :application_types, :reporting_types, []
+      change_column_null :application_types, :reporting_types, false
+    end
+  end
+end

--- a/db/migrate/20240403111114_convert_reporting_type_locale_data_to_records.rb
+++ b/db/migrate/20240403111114_convert_reporting_type_locale_data_to_records.rb
@@ -1,0 +1,50 @@
+class ConvertReportingTypeLocaleDataToRecords < ActiveRecord::Migration[7.1]
+  class ReportingType < ActiveRecord::Base; end
+
+  REPORTING_TYPES = [
+    ["Q01", "full", "Dwellings (major)", nil],
+    ["Q02", "full", "Offices, R&D, and light industry (major)", nil],
+    ["Q03", "full", "General Industry, storage and warehousing (major)", nil],
+    ["Q04", "full", "Retail and services (major)", nil],
+    ["Q05", "full", "Traveller caravan pitches (major)", nil],
+    ["Q06", "full", "All other developments (major)", nil],
+    ["Q07", "full", "Major Public Service infrastructure developments", nil],
+    ["Q13", "full", "Dwellings (minor)", nil],
+    ["Q14", "full", "Offices, R&D, and light industry (minor)", nil],
+    ["Q15", "full", "General Industry, storage and warehousing (minor)", nil],
+    ["Q16", "full", "Retail and services (minor)", nil],
+    ["Q17", "full", "Traveller caravan pitches (minor)", nil],
+    ["Q18", "full", "All other developments (minor)", nil],
+    ["Q20", "change-of-use", "Change of use", nil],
+    ["Q21", "householder", "Householder developments", nil],
+    ["Q22", "advertisment", "Advertisements", nil],
+    ["Q23", "listed-building", "Listed building consents to alter/extend", nil],
+    ["Q24", "listed-building", "Listed building consents to demolish", nil],
+    ["Q25", "conservation-area", "Relevant demolition in a conservation area", nil],
+    ["Q26", "certificate-of-lawfulness", "Certificates of lawful development", nil],
+    ["PA1", "prior-approval", "Larger householder extensions", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A"],
+    ["PA2", "prior-approval", "Offices to residential", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A"],
+    ["PA7", "prior-approval", "Launderette, betting office, pay day loan shop, hot food takeaway, amusement arcade or centre, or casino to residential", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 3, Classes M and N"],
+    ["PA8", "prior-approval", "Agricultural to residential", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A"],
+    ["PA15", "prior-approval", "Building upwards to create dwellinghouses on detached commercial or mixed-use buildings", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class AA"],
+    ["PA16", "prior-approval", "Building upwards to create dwellinghouses on detached dwellinghouses", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class AD"],
+    ["PA17", "prior-approval", "Building upwards to create dwellinghouses on detached blocks of flats", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class A"],
+    ["PA18", "prior-approval", "Building upwards householder extensions", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class AA"],
+    ["PA19", "prior-approval", "Demolition of buildings and construction of dwellinghouses", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class ZA"],
+    ["PA20", "prior-approval", "Building upwards to create dwellinghouses on commercial or mixed-use buildings in a terrace", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class AB"],
+  ]
+
+  def change
+    reversible do |dir|
+      dir.up do
+        REPORTING_TYPES.each do |code, category, description, legislation|
+          ReportingType.create!(code:, category:, description:, legislation:)
+        end
+      end
+
+      dir.down do
+        ReportingType.delete_all
+      end
+    end
+  end
+end

--- a/db/migrate/20240403111114_convert_reporting_type_locale_data_to_records.rb
+++ b/db/migrate/20240403111114_convert_reporting_type_locale_data_to_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConvertReportingTypeLocaleDataToRecords < ActiveRecord::Migration[7.1]
   class ReportingType < ActiveRecord::Base; end
 
@@ -31,7 +33,7 @@ class ConvertReportingTypeLocaleDataToRecords < ActiveRecord::Migration[7.1]
     ["PA17", "prior-approval", "Building upwards to create dwellinghouses on detached blocks of flats", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class A"],
     ["PA18", "prior-approval", "Building upwards householder extensions", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class AA"],
     ["PA19", "prior-approval", "Demolition of buildings and construction of dwellinghouses", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class ZA"],
-    ["PA20", "prior-approval", "Building upwards to create dwellinghouses on commercial or mixed-use buildings in a terrace", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class AB"],
+    ["PA20", "prior-approval", "Building upwards to create dwellinghouses on commercial or mixed-use buildings in a terrace", "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 20, Class AB"]
   ]
 
   def change

--- a/db/migrate/20240403120056_add_code_prefix_and_suffix_columns.rb
+++ b/db/migrate/20240403120056_add_code_prefix_and_suffix_columns.rb
@@ -1,7 +1,11 @@
+# frozen_string_literal: true
+
 class AddCodePrefixAndSuffixColumns < ActiveRecord::Migration[7.1]
   def change
-    add_column :reporting_types, :code_prefix, :virtual, type: :text, as: "regexp_replace(code, '[0-9]+$', '')::text", stored: true
-    add_column :reporting_types, :code_suffix, :virtual, type: :integer, as: "regexp_replace(code, '^[A-Z]+', '')::int", stored: true
+    change_table :reporting_types, bulk: true do |t|
+      t.virtual :code_prefix, type: :text, as: "regexp_replace(code, '[0-9]+$', '')::text", stored: true
+      t.virtual :code_suffix, type: :integer, as: "regexp_replace(code, '^[A-Z]+', '')::int", stored: true
+    end
 
     add_index :reporting_types, %i[code_prefix code_suffix]
   end

--- a/db/migrate/20240403120056_add_code_prefix_and_suffix_columns.rb
+++ b/db/migrate/20240403120056_add_code_prefix_and_suffix_columns.rb
@@ -1,0 +1,8 @@
+class AddCodePrefixAndSuffixColumns < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reporting_types, :code_prefix, :virtual, type: :text, as: "regexp_replace(code, '[0-9]+$', '')::text", stored: true
+    add_column :reporting_types, :code_suffix, :virtual, type: :integer, as: "regexp_replace(code, '^[A-Z]+', '')::int", stored: true
+
+    add_index :reporting_types, %i[code_prefix code_suffix]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_03_111114) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_120056) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -749,7 +749,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_03_111114) do
     t.string "legislation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.virtual "code_prefix", type: :text, as: "regexp_replace((code)::text, '[0-9]+$'::text, ''::text)", stored: true
+    t.virtual "code_suffix", type: :integer, as: "(regexp_replace((code)::text, '^[A-Z]+'::text, ''::text))::integer", stored: true
     t.index ["code"], name: "ix_reporting_types_on_code", unique: true
+    t.index ["code_prefix", "code_suffix"], name: "ix_reporting_types_on_code_prefix__code_suffix"
   end
 
   create_table "reviews", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_02_154327) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_03_111114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_28_134519) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_02_154327) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -74,6 +74,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_134519) do
     t.bigint "legislation_id"
     t.boolean "configured", default: false, null: false
     t.string "category"
+    t.string "reporting_types", default: [], null: false, array: true
     t.index ["code"], name: "ix_application_types_on_code", unique: true
     t.index ["legislation_id"], name: "ix_application_types_on_legislation_id"
     t.index ["suffix"], name: "ix_application_types_on_suffix", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_134519) do
     t.integer "determination_period_days"
     t.bigint "legislation_id"
     t.boolean "configured", default: false, null: false
+    t.string "category"
     t.index ["code"], name: "ix_application_types_on_code", unique: true
     t.index ["legislation_id"], name: "ix_application_types_on_legislation_id"
     t.index ["suffix"], name: "ix_application_types_on_suffix", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -739,6 +739,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_134519) do
     t.index ["reviewer_id"], name: "index_recommendations_on_reviewer_id"
   end
 
+  create_table "reporting_types", force: :cascade do |t|
+    t.string "code", null: false
+    t.string "category", null: false
+    t.string "description", null: false
+    t.string "guidance"
+    t.string "guidance_link"
+    t.string "legislation"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "ix_reporting_types_on_code", unique: true
+  end
+
   create_table "reviews", force: :cascade do |t|
     t.string "action"
     t.bigint "assessor_id"

--- a/engines/bops_config/app/controllers/bops_config/application_types/category_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/category_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module ApplicationTypes
+    class CategoryController < ApplicationController
+      before_action :set_application_type
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @application_type.update(application_type_params, :category)
+            format.html do
+              redirect_to next_path, notice: t(".success")
+            end
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def application_type_params
+        params.require(:application_type).permit(:category)
+      end
+
+      def set_application_type
+        @application_type = ApplicationType.find(application_type_id)
+      end
+
+      def next_path
+        if @application_type.configured?
+          application_type_path(@application_type)
+        else
+          edit_application_type_reporting_path(@application_type)
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/application_types/reporting_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/reporting_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module ApplicationTypes
+    class ReportingController < ApplicationController
+      before_action :set_application_type
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @application_type.update(application_type_params, :reporting)
+            format.html do
+              redirect_to next_path, notice: t(".success")
+            end
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def application_type_params
+        params.require(:application_type).permit(reporting_types: [])
+      end
+
+      def set_application_type
+        @application_type = ApplicationType.find(application_type_id)
+      end
+
+      def next_path
+        if @application_type.configured?
+          application_type_path(@application_type)
+        else
+          edit_application_type_legislation_path(@application_type)
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
@@ -68,7 +68,7 @@ module BopsConfig
       if @application_type.configured?
         application_type_path(@application_type)
       else
-        edit_application_type_legislation_path(@application_type)
+        edit_application_type_category_path(@application_type)
       end
     end
 

--- a/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types_controller.rb
@@ -49,7 +49,7 @@ module BopsConfig
         if @application_type.save
           format.html { redirect_to next_path, notice: t(".success") }
         else
-          format.html { render :new }
+          format.html { render :edit }
         end
       end
     end

--- a/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  class ReportingTypesController < ApplicationController
+    before_action :build_reporting_type, only: %i[new create]
+    before_action :set_reporting_types, only: %i[index]
+    before_action :set_reporting_type, only: %i[edit update]
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      @reporting_type.attributes = reporting_type_params
+
+      respond_to do |format|
+        if @reporting_type.save
+          format.html { redirect_to reporting_types_path, notice: t(".success") }
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def update
+      @reporting_type.attributes = reporting_type_params
+
+      respond_to do |format|
+        if @reporting_type.save
+          format.html { redirect_to reporting_types_path, notice: t(".success") }
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    private
+
+    def reporting_type_attributes
+      %i[code category description guidance guidance_link legislation]
+    end
+
+    def reporting_type_params
+      params.require(:reporting_type).permit(*reporting_type_attributes)
+    end
+
+    def build_reporting_type
+      @reporting_type = ReportingType.new
+    end
+
+    def set_reporting_types
+      @reporting_types = ReportingType.by_code
+    end
+
+    def reporting_type_id
+      Integer(params[:id])
+    rescue
+      raise ActionController::BadRequest, "Invalid reporting type id: #{params[:id].inspect}"
+    end
+
+    def set_reporting_type
+      @reporting_type = ReportingType.find(reporting_type_id)
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
@@ -4,7 +4,7 @@ module BopsConfig
   class ReportingTypesController < ApplicationController
     before_action :build_reporting_type, only: %i[new create]
     before_action :set_reporting_types, only: %i[index]
-    before_action :set_reporting_type, only: %i[edit update]
+    before_action :set_reporting_type, only: %i[edit update destroy]
 
     def index
       respond_to do |format|
@@ -41,6 +41,16 @@ module BopsConfig
 
       respond_to do |format|
         if @reporting_type.save
+          format.html { redirect_to reporting_types_path, notice: t(".success") }
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        if @reporting_type.destroy
           format.html { redirect_to reporting_types_path, notice: t(".success") }
         else
           format.html { render :edit }

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -29,7 +29,8 @@ module BopsConfig
         "determination_periods" => "application_types",
         "legislation" => "application_types",
         "features" => "application_types",
-        "statuses" => "application_types"
+        "statuses" => "application_types",
+        "reporting_types" => "reporting_types"
       }
 
       page_keys.fetch(controller_name, "dashboard")
@@ -40,7 +41,8 @@ module BopsConfig
         {name: "Dashboard", url: root_path, key: "dashboard"},
         {name: "Users", url: users_path, key: "users"},
         {name: "Application types", url: application_types_path, key: "application_types"},
-        {name: "Legislation", url: legislation_index_path, key: "legislation"}
+        {name: "Legislation", url: legislation_index_path, key: "legislation"},
+        {name: "Reporting types", url: reporting_types_path, key: "reporting_types"}
       ]
     end
   end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -25,6 +25,7 @@ module BopsConfig
         "dashboard" => "dashboard",
         "users" => "users",
         "application_types" => "application_types",
+        "categories" => "application_types",
         "determination_periods" => "application_types",
         "legislation" => "application_types",
         "features" => "application_types",

--- a/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
@@ -22,7 +22,7 @@
         <td class="govuk-table__cell">
           <%= application_type.suffix %>
         </td>
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell govuk-!-text-wrap-balance">
           <%= application_type.description %>
         </td>
         <td class="govuk-table__cell">

--- a/engines/bops_config/app/views/bops_config/application_types/category/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/category/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= t(".choose_category") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".choose_category") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @application_type, url: [@application_type, :category] do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+      <%= form.govuk_collection_radio_buttons :category,
+        ApplicationType.categories, :first, ->((k)) { t(".category_labels.#{k}") },
+          legend: {text: t(".category_legend_html", description: @application_type.description)},
+          hint: {text: t(".category_hint"), size: "l"},
+          small: false, classes: "govuk-!-column-count-2 govuk-!-margin-top-5" %>
+
+      <%= form.govuk_submit(t(".continue")) do %>
+        <%= link_to(t("back"), @application_type, class: "govuk-button govuk-button--secondary") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/application_types/determination_periods/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/determination_periods/edit.html.erb
@@ -13,7 +13,7 @@
       <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
 
       <%= form.govuk_text_field :determination_period_days, width: 5,
-        label: {text: t(".set_determination_period"), tag: "h1", size: "l"},
+        label: {text: t(".set_determination_period_html", description: @application_type.description)},
         hint: {text: t(".hint")},
         suffix_text: t(".days") %>
 

--- a/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
@@ -10,11 +10,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l govuk-!-margin-bottom-2">
+        <%= @application_type.description %>
+      </span>
       <%= t(".manage_document_tags") %>
-    </h1>
-
-    <h2 class="govuk-heading-m">
-      <%= @application_type.description %>
     </h1>
 
     <%= form_with model: @application_type, url: [@application_type, :document_tags] do |form| %>

--- a/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
@@ -36,7 +36,7 @@
             <%= tag.div(class: class_names("govuk-tabs__panel", "govuk-tabs__panel--hidden": index != 0), id: "#{group}-tags") do %>
               <%= fields.govuk_collection_check_boxes group.name, group.tag_list, :first, :last,
                 legend: {text: t(".groups.#{group}")}, hint: {text: t(".hints.#{group}")},
-                small: true, classes: "ga-document-tags" %>
+                small: true, classes: "govuk-!-column-count-2" %>
             <% end %>
           <% end %>
         <% end %>

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -9,10 +9,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l"><%= t(".choose_features") %></h1>
-    <h2 class="govuk-heading-m"><%= @application_type.description %></h2>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l govuk-!-margin-bottom-2">
+        <%= @application_type.description %>
+      </span>
+      <%= t(".choose_features") %>
+    </h1>
 
     <%= form_with model: @application_type, url: [@application_type, :features] do |form| %>
       <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
@@ -28,7 +30,7 @@
 
         <%= ff.govuk_fieldset legend: { text: t("legends.consultation", scope: :application_type_features), size: "s" } do %>
           <%= ff.govuk_collection_check_boxes :consultation_steps,
-              Consultation::STEPS.map { |step| OpenStruct.new(id: step, name: t("labels.consultation_steps.#{step}", scope: :application_type_features)) }, 
+              Consultation::STEPS.map { |step| OpenStruct.new(id: step, name: t("labels.consultation_steps.#{step}", scope: :application_type_features)) },
               :id, :name,
               legend: { text: "Consultation steps", tag: "span", class: "govuk-visually-hidden" } %>
         <% end %>

--- a/engines/bops_config/app/views/bops_config/application_types/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/index.html.erb
@@ -9,10 +9,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      Application Types
+      <%= t(".title") %>
     </h1>
     <p class="govuk-body">
-      <%= link_to "Create new application type", new_application_type_path , class: "govuk-button govuk-button--primary" %>
+      <%= link_to t(".create_new_application_type"), new_application_type_path , class: "govuk-button govuk-button--primary" %>
     </p>
     <%= render "table", application_types: @application_types %>
   </div>

--- a/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
@@ -14,7 +14,7 @@
 
       <%= form.govuk_radio_buttons_fieldset(:legislation_type,
         hint: {text: t(".legislation_hint")},
-        legend: {text: t(".enter_legislation"), size: "l", tag: "h1"}) do %>
+        legend: {text: t(".legislation_legend_html", description: @application_type.description)}) do %>
 
         <h2 class="govuk-heading-m"><%= @application_type.description %></h2>
 

--- a/engines/bops_config/app/views/bops_config/application_types/reporting/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/reporting/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with model: @application_type, url: [@application_type, :reporting] do |form| %>
+      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+      <%= form.govuk_collection_check_boxes :reporting_types,
+        @application_type.all_reporting_types, :code, :full_description,
+          legend: {text: t(".reporting_legend_html", description: @application_type.description)},
+          hint: {text: t(".reporting_hint"), size: "l"},
+          small: false, classes: "govuk-!-column-count-2 govuk-!-margin-top-5" %>
+
+      <%= form.govuk_submit(t(".continue")) do %>
+        <%= link_to(t("back"), @application_type, class: "govuk-button govuk-button--secondary") %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -48,6 +48,22 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          <%= t(".category") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <% if @application_type.category? %>
+            <%= t(".categories.#{@application_type.category}") %>
+          <% end %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to [:edit, @application_type, :category], class: "govuk-link" do %>
+            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".category") %></span>
+          <% end %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           <%= t(".legislation") %>
         </dt>
         <dd class="govuk-summary-list__value">

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -64,6 +64,20 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
+          <%= t(".reporting") %>
+        </dt>
+        <dd class="govuk-summary-list__value">
+          <%= @application_type.reporting_types.join(", ") %>
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to [:edit, @application_type, :reporting], class: "govuk-link" do %>
+            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".reporting") %></span>
+          <% end %>
+        </dd>
+      </div>
+
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
           <%= t(".legislation") %>
         </dt>
         <dd class="govuk-summary-list__value">

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -117,7 +117,7 @@
           <dd class="govuk-summary-list__value">
             <p class="govuk-body max-lines max-lines--clamped" data-controller="max-lines" data-action="click->max-lines#toggle">
               <% group.translated_tags.each do |tag| %>
-                <span class="govuk-tag govuk-tag--grey ga-document-tag"><%= tag %></span>
+                <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-0 govuk-!-margin-right-1 govuk-!-margin-top-1 govuk-!-margin-bottom-1"><%= tag %></span>
               <% end %>
             </p>
           </dd>

--- a/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
@@ -13,8 +13,10 @@
        <%= form.govuk_error_summary(presenter: ApplicationTypeStatusErrorPresenter.new(@application_type.errors.messages, @application_type)) %>
 
       <%= form.govuk_radio_buttons_fieldset :status,
-        legend: {text: t(".update_application_type_status_html", description: @application_type.description)} do %>
-        <% if @application_type.inactive? %>
+        legend: {text: t(".update_application_type_status_html",
+        description: @application_type.description)} do %>
+
+        <% if @application_type.status_was == "inactive" %>
           <%= form.govuk_radio_button :status, "inactive", label: {text: t(".inactive")}, hint: {text: t(".inactive_hint")} %>
         <% end %>
 

--- a/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/statuses/edit.html.erb
@@ -12,7 +12,8 @@
     <%= form_with model: @application_type, url: [@application_type, :status] do |form| %>
        <%= form.govuk_error_summary(presenter: ApplicationTypeStatusErrorPresenter.new(@application_type.errors.messages, @application_type)) %>
 
-      <%= form.govuk_radio_buttons_fieldset :status, legend: {size: "l", tag: "h1", text: t(".update_application_type_status")} do %>
+      <%= form.govuk_radio_buttons_fieldset :status,
+        legend: {text: t(".update_application_type_status_html", description: @application_type.description)} do %>
         <% if @application_type.inactive? %>
           <%= form.govuk_radio_button :status, "inactive", label: {text: t(".inactive")}, hint: {text: t(".inactive_hint")} %>
         <% end %>

--- a/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
@@ -13,7 +13,7 @@
   <tbody class="govuk-table__body">
     <% @legislations.each do |legislation| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell">
+        <td class="govuk-table__cell govuk-!-text-wrap-balance">
           <%= legislation.title %>
         </td>
         <td class="govuk-table__cell">

--- a/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: @reporting_type do |form| %>
+  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+
+  <%= form.govuk_text_field :description, label: {text: t(".description_label")}, hint: {text: t(".description_hint")} %>
+  <%= form.govuk_text_field :code, width: 5, label: {text: t(".code_label")}, hint: {text: t(".code_hint")} %>
+
+  <%= form.govuk_collection_radio_buttons :category,
+    ReportingType.categories, :first, ->((k)) { t(".category_labels.#{k}") },
+      legend: {text: t(".category_legend")}, hint: {text: t(".category_hint")},
+      small: false, classes: "govuk-!-column-count-2" %>
+
+  <%= form.govuk_text_area :guidance, label: {text: t(".guidance_label")}, rows: 5 %>
+  <%= form.govuk_text_field :guidance_link, label: {text: t(".guidance_link_label")} %>
+  <%= form.govuk_text_area :legislation, label: {text: t(".legislation_label")}, hint: {text: t(".legislation_hint")}, rows: 3 %>
+
+  <%= form.govuk_submit(t(".save_reporting_type")) do %>
+    <%= link_to(t("back"), :reporting_types, class: "govuk-button govuk-button--secondary") %>
+  <% end %>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
@@ -13,7 +13,13 @@
   <%= form.govuk_text_field :guidance_link, label: {text: t(".guidance_link_label")} %>
   <%= form.govuk_text_area :legislation, label: {text: t(".legislation_label")}, hint: {text: t(".legislation_hint")}, rows: 3 %>
 
-  <%= form.govuk_submit(t(".save_reporting_type")) do %>
+  <%= form.govuk_submit(t(".save")) do %>
+    <% if @reporting_type.persisted? %>
+      <%= link_to(t(".remove"), reporting_type_path(@reporting_type),
+        class: "govuk-button govuk-button--warning",
+        method: :delete, data: {confirm: "Are you sure?"}) %>
+    <% end %>
+
     <%= link_to(t("back"), :reporting_types, class: "govuk-button govuk-button--secondary") %>
   <% end %>
 <% end %>

--- a/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
@@ -1,0 +1,39 @@
+<% if @reporting_types.any? %>
+  <table class="govuk-table application-types-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          <%= t(".code") %>
+        </th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
+          <%= t(".category") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".description") %>
+        </th>
+        <th scope="col" class="govuk-table__header">
+          <%= t(".action") %>
+        </th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% @reporting_types.each do |reporting_type| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= reporting_type.code %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= t(".categories.#{reporting_type.category}") %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= reporting_type.description %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= link_to t(".edit"), edit_reporting_type_path(reporting_type) , class: "govuk-link" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
@@ -26,7 +26,7 @@
           <td class="govuk-table__cell">
             <%= t(".categories.#{reporting_type.category}") %>
           </td>
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell govuk-!-text-wrap-balance">
             <%= reporting_type.description %>
           </td>
           <td class="govuk-table__cell">

--- a/engines/bops_config/app/views/bops_config/reporting_types/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/edit.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Reporting Types", reporting_types_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/reporting_types/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/edit.html.erb
@@ -8,7 +8,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
       <%= t(".title") %>
     </h1>

--- a/engines/bops_config/app/views/bops_config/reporting_types/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/index.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t('page_title') %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
+    <p class="govuk-body">
+      <%= link_to t(".create_reporting_type"), new_reporting_type_path , class: "govuk-button govuk-button--primary" %>
+    </p>
+    <%= render "table" %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/reporting_types/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Reporting Types", reporting_types_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/reporting_types/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/new.html.erb
@@ -8,7 +8,7 @@
 <% content_for :title, t(".title") %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
       <%= t(".title") %>
     </h1>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -43,6 +43,13 @@ en:
           determination_period: Determination period
           hint: Choose the length of the determination period for this type of application.
           set_determination_period: Set determination period
+          set_determination_period_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Set determination period
+            </h1>
         update:
           success: Determination period successfully updated
       document_tags:
@@ -90,6 +97,13 @@ en:
             or create a new one. The title will appear in consultation letters, decision notices and
             other places that need to specify what the relevant legislation is.
           legislation_id_label: Legislation title
+          legislation_legend_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Enter legislation
+            </h1>
           legislation_link_hint: Enter an optional link to legislation.gov.uk
           legislation_link_label: Link
           legislation_title_hint: Enter a title – this is usually the name of the act and the relevant section
@@ -149,6 +163,13 @@ en:
           retired: Retired
           retired_hint: Application type was previously used to submit planning application but has been retired due to legislation changes, etc.
           update_application_type_status: Update status
+          update_application_type_status_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Update status
+            </h1>
         update:
           success: Status successfully updated
       table:

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -113,6 +113,20 @@ en:
           success: Legislation successfully updated
       new:
         application_profile: Application profile
+      reporting:
+        edit:
+          continue: Continue
+          reporting_hint: Select the possible reporting types for this application type on the planning matters return
+          reporting_legend_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Select reporting types
+            </h1>
+          title: Select reporting types
+        update:
+          success: Reporting successfully updated
       show:
         categories:
           advertisment: Advertisment
@@ -148,6 +162,7 @@ en:
           plans: plan tags
           supporting_documents: supporting document tags
         name: Name
+        reporting: Reporting
         review_application_type: Review the application type
         status: Status
         suffix: Suffix

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -7,7 +7,7 @@ en:
     application_types:
       category:
         edit:
-          category_hint: Select the appropriate category for reporting codes
+          category_hint: Choose the appropriate category for reporting codes
           category_labels:
             advertisment: Advertisment
             certificate_of_lawfulness: Lawful Development Certificate

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -233,6 +233,8 @@ en:
     reporting_types:
       create:
         success: Reporting type successfully created
+      destroy:
+        success: Reporting type successfully removed
       edit:
         title: Edit reporting type
       form:
@@ -261,7 +263,8 @@ en:
         guidance_link_label: Link to the guidance if available
         legislation_hint: Enter the applicable legislation if the category is prior approval
         legislation_label: Legislation
-        save_reporting_type: Save reporting type
+        remove: Remove
+        save: Save
       index:
         create_reporting_type: Create reporting type
         title: Reporting Types

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -215,6 +215,66 @@ en:
         title: Title
       update:
         success: Legislation successfully updated
+    reporting_types:
+      create:
+        success: Reporting type successfully created
+      edit:
+        title: Edit reporting type
+      form:
+        category_hint: Choose what category of application types this option will appear on when selecting the reporting type during validation
+        category_labels:
+          advertisment: Advertisment
+          certificate_of_lawfulness: Lawful Development Certificate
+          change_of_use: Change of Use
+          conservation_area: Conservation Area
+          full: Full Planning Permission
+          hedgerows: Hedgerows
+          householder: Householder
+          listed_building: Listed Building
+          non_material_amendment: Non-material Amendment
+          other: Other
+          outline: Outline Planning Permission
+          prior_approval: Prior Approval
+          reserved_matters: Reserved Matters
+          tree_works: Tree Works
+        category_legend: Category
+        code_hint: Enter the code used to identify this reporting type (e.g. Q26 or PA15)
+        code_label: Code
+        description_hint: Enter the description from the district planning matters return
+        description_label: Description
+        guidance_label: Guidance
+        guidance_link_label: Link to the guidance if available
+        legislation_hint: Enter the applicable legislation if the category is prior approval
+        legislation_label: Legislation
+        save_reporting_type: Save reporting type
+      index:
+        create_reporting_type: Create reporting type
+        title: Reporting Types
+      new:
+        title: Create reporting type
+      table:
+        action: Action
+        categories:
+          advertisment: Advertisment
+          certificate_of_lawfulness: Lawful Development Certificate
+          change_of_use: Change of Use
+          conservation_area: Conservation Area
+          full: Full Planning Permission
+          hedgerows: Hedgerows
+          householder: Householder
+          listed_building: Listed Building
+          non_material_amendment: Non-material Amendment
+          other: Other
+          outline: Outline Planning Permission
+          prior_approval: Prior Approval
+          reserved_matters: Reserved Matters
+          tree_works: Tree Works
+        category: Category
+        code: Code
+        description: Description
+        edit: Edit
+      update:
+        success: Reporting type successfully updated
     users:
       create:
         user_successfully_created: User successfully created

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -5,6 +5,35 @@ en:
       navigation_items:
         users: Users
     application_types:
+      category:
+        edit:
+          category_hint: Select the appropriate category for reporting codes
+          category_labels:
+            advertisment: Advertisment
+            certificate_of_lawfulness: Lawful Development Certificate
+            change_of_use: Change of Use
+            conservation_area: Conservation Area
+            full: Full Planning Permission
+            hedgerows: Hedgerows
+            householder: Householder
+            listed_building: Listed Building
+            non_material_amendment: Non-material Amendment
+            other: Other
+            outline: Outline Planning Permission
+            prior_approval: Prior Approval
+            reserved_matters: Reserved Matters
+            tree_works: Tree Works
+          category_legend_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Choose category
+            </h1>
+          choose_category: Choose category
+          continue: Continue
+        update:
+          success: Category successfully updated
       create:
         success: Application profile successfully created
       determination_periods:
@@ -70,6 +99,22 @@ en:
       new:
         application_profile: Application profile
       show:
+        categories:
+          advertisment: Advertisment
+          certificate_of_lawfulness: Lawful Development Certificate
+          change_of_use: Change of Use
+          conservation_area: Conservation Area
+          full: Full Planning Permission
+          hedgerows: Hedgerows
+          householder: Householder
+          listed_building: Listed Building
+          non_material_amendment: Non-material Amendment
+          other: Other
+          outline: Outline Planning Permission
+          prior_approval: Prior Approval
+          reserved_matters: Reserved Matters
+          tree_works: Tree Works
+        category: Category
         change: Change
         continue: Continue
         determination_period: Determination period

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -75,6 +75,7 @@ en:
         suffix_hint: Set the application suffix, such as 'HAPP' (Householder application) or 'PA' (Prior Approvals). This will be added to all application numbers for this application type.
         suffix_label: Suffix
       index:
+        create_new_application_type: Create new application type
         title: Application Types
       legislation:
         edit:

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -19,6 +19,7 @@ BopsConfig::Engine.routes.draw do
         resource :document_tags
         resource :features
         resource :legislation
+        resource :reporting, controller: "reporting"
         resource :status
       end
     end

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -24,7 +24,10 @@ BopsConfig::Engine.routes.draw do
     end
   end
 
-  resources :legislation, except: %i[show]
+  with_options except: %i[show] do
+    resources :legislation
+    resources :reporting_types
+  end
 
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -14,6 +14,7 @@ BopsConfig::Engine.routes.draw do
   resources :application_types do
     scope module: "application_types" do
       with_options only: %i[edit update] do
+        resource :category, controller: "category"
         resource :determination_period
         resource :document_tags
         resource :features

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -376,6 +376,65 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_selector("dl div:nth-child(11) dd", text: "Active")
   end
 
+  it "allows editing of the category" do
+    application_type = create(:application_type, :configured, :ldc_proposed)
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(3)" do
+      expect(page).to have_selector("dt", text: "Category")
+      expect(page).to have_selector("dd:nth-child(2)", text: "Lawful Development Certificate")
+
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Choose category")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
+
+    choose "Change of Use"
+    click_button "Continue"
+
+    expect(page).to have_content("Category successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(3)" do
+      expect(page).to have_selector("dt", text: "Category")
+      expect(page).to have_selector("dd:nth-child(2)", text: "Change of Use")
+    end
+  end
+
+  it "allows editing of the reporting types" do
+    create(:reporting_type, :prior_approval_1a)
+    create(:reporting_type, :prior_approval_all_others)
+
+    application_type = create(:application_type, :configured, :prior_approval)
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(4)" do
+      expect(page).to have_selector("dt", text: "Reporting")
+      expect(page).to have_selector("dd:nth-child(2)", text: "PA1")
+
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Select reporting types")
+    expect(page).to have_selector("h1 > span", text: "Prior Approval - Larger extension to a house")
+
+    check "All others"
+    click_button "Continue"
+
+    expect(page).to have_content("Reporting successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(4)" do
+      expect(page).to have_selector("dt", text: "Reporting")
+      expect(page).to have_selector("dd:nth-child(2)", text: "PA1, PA99")
+    end
+  end
+
   it "allows editing of the legislation" do
     legislation = create(:legislation, title: "Town and Country Planning Act 1990")
     determination_period_days = 25

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -256,7 +256,57 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_selector("dl div:nth-child(11) dd", text: "Active")
   end
 
-  it "prevents activation of a new application type when legislation has not been set" do
+  it "prevents activation of a new application type when the category has not been set" do
+    application_type = create(:application_type, :without_category, status: "inactive")
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(11)" do
+      expect(page).to have_selector("dd", text: "Inactive")
+      click_link "Change"
+    end
+
+    choose "Active"
+    click_button "Continue"
+
+    expect(page).to have_selector("[role=alert] li", text: "A category must be set when an application type is made active")
+    expect(page).to have_link(
+      "A category must be set when an application type is made active",
+      href: "/application_types/#{application_type.id}/category/edit"
+    )
+
+    click_link "A category must be set when an application type is made active"
+
+    expect(page).to have_selector("h1", text: "Choose category")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Existing use")
+  end
+
+  it "prevents activation of a new application type when a reporting type has not been selected" do
+    application_type = create(:application_type, :without_reporting_types, status: "inactive")
+
+    visit "/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(11)" do
+      expect(page).to have_selector("dd", text: "Inactive")
+      click_link "Change"
+    end
+
+    choose "Active"
+    click_button "Continue"
+
+    expect(page).to have_selector("[role=alert] li", text: "A least one reporting type must be selected when an application type is made active")
+    expect(page).to have_link(
+      "A least one reporting type must be selected when an application type is made active",
+      href: "/application_types/#{application_type.id}/reporting/edit"
+    )
+
+    click_link "A least one reporting type must be selected when an application type is made active"
+
+    expect(page).to have_selector("h1", text: "Select reporting types")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Existing use")
+  end
+
+  it "prevents activation of a new application type when the legislation has not been set" do
     application_type = create(:application_type, :without_legislation, status: "inactive")
 
     visit "/application_types/#{application_type.id}"
@@ -269,13 +319,13 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     choose "Active"
     click_button "Continue"
 
-    expect(page).to have_selector("[role=alert] li", text: "Legislation must be set when application type is made active")
+    expect(page).to have_selector("[role=alert] li", text: "The legislation must be set when an application type is made active")
     expect(page).to have_link(
-      "Legislation must be set when application type is made active",
+      "The legislation must be set when an application type is made active",
       href: "/application_types/#{application_type.id}/legislation/edit"
     )
 
-    click_link "Legislation must be set when application type is made active"
+    click_link "The legislation must be set when an application type is made active"
 
     expect(page).to have_selector("h1", text: "Enter legislation")
     expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Existing use")

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
   it "allows adding a new application type" do
     create(:legislation, title: "Town and Country Planning Act 1990")
 
+    create(:reporting_type, :major_dwellings)
+    create(:reporting_type, :major_offices)
+    create(:reporting_type, :major_industry)
+    create(:reporting_type, :major_retail)
+
     visit "/application_types/new"
     expect(page).to have_selector("h1", text: "Application profile")
 
@@ -26,8 +31,38 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_content("Application profile successfully created")
 
+    # Choose category
+    expect(page).to have_selector("h1", text: "Choose category")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
+    expect(page).to have_selector("div.govuk-hint", text: "Choose the appropriate category for reporting codes")
+
+    click_button "Continue"
+    expect(page).to have_selector("[role=alert] li", text: "Choose a category from the list")
+
+    choose "Full Planning Permission"
+    click_button "Continue"
+
+    expect(page).to have_content("Category successfully updated")
+
+    # Select reporting types
+    expect(page).to have_selector("h1", text: "Select reporting types")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
+    expect(page).to have_selector("div.govuk-hint", text: "Select the possible reporting types for this application type on the planning matters return")
+
+    click_button "Continue"
+    expect(page).to have_selector("[role=alert] li", text: "A least one reporting type must be selected")
+
+    check "Q01 – Dwellings (major)"
+    check "Q02 – Offices, R&D, and light industry (major)"
+    check "Q03 – General Industry, storage and warehousing (major)"
+    check "Q04 – Retail and services (major)"
+    click_button "Continue"
+
+    expect(page).to have_content("Reporting successfully updated")
+
     # Enter legislation
     expect(page).to have_selector("h1", text: "Enter legislation")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
     expect(page).to have_selector("div.govuk-hint", text: "Enter either the name of an existing legislation that relates to this application type or create a new one.")
     expect(page).to have_selector("div.govuk-hint", text: "The title will appear in consultation letters, decision notices and other places that need to specify what the relevant legislation is.")
 
@@ -43,6 +78,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     # Set determination period
     expect(page).to have_selector("h1", text: "Set determination period")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
     expect(page).to have_selector("div.govuk-hint", text: "Choose the length of the determination period for this type of application.")
 
     fill_in "Set determination period", with: ""
@@ -75,7 +111,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     # Choose features
     expect(page).to have_selector("h1", text: "Choose features")
-    expect(page).to have_selector("h2", text: "Planning Permission - Major application")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
 
     check "Check permitted development rights"
     check "Neighbours consultation"
@@ -85,7 +121,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     # Manage document tags
     expect(page).to have_selector("h1", text: "Manage document tags")
-    expect(page).to have_selector("h2", text: "Planning Permission - Major application")
+    expect(page).to have_selector("h1 > span", text: "Planning Permission - Major application")
     expect(page).to have_selector("legend", text: "Plans")
     expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for plans")
 
@@ -113,17 +149,19 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(1) dd", text: "Planning Permission - Major application")
     expect(page).to have_selector("dl div:nth-child(2) dd", text: "MAJR")
-    expect(page).to have_selector("dl div:nth-child(3) dd", text: "Town and Country Planning Act 1990")
-    expect(page).to have_selector("dl div:nth-child(4) dd", text: "25 days - bank holidays included")
-    expect(page).to have_selector("dl div:nth-child(5) dd li", text: "Check permitted development rights")
-    expect(page).to have_selector("dl div:nth-child(5) dd li", text: "Neighbour")
-    expect(page).to have_selector("dl div:nth-child(6) dd span:nth-child(1)", text: "Elevations - existing")
-    expect(page).to have_selector("dl div:nth-child(6) dd span:nth-child(2)", text: "Elevations - proposed")
-    expect(page).to have_selector("dl div:nth-child(7) dd span:nth-child(1)", text: "Bank statement")
-    expect(page).to have_selector("dl div:nth-child(7) dd span:nth-child(2)", text: "Utility bill")
-    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(1)", text: "Environmental Impact Assessment (EIA)")
-    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(2)", text: "Sustainability statement")
-    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Inactive")
+    expect(page).to have_selector("dl div:nth-child(3) dd", text: "Full Planning Permission")
+    expect(page).to have_selector("dl div:nth-child(4) dd", text: "Q01, Q02, Q03, Q04")
+    expect(page).to have_selector("dl div:nth-child(5) dd", text: "Town and Country Planning Act 1990")
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "25 days - bank holidays included")
+    expect(page).to have_selector("dl div:nth-child(7) dd li", text: "Check permitted development rights")
+    expect(page).to have_selector("dl div:nth-child(7) dd li", text: "Neighbour")
+    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(1)", text: "Elevations - existing")
+    expect(page).to have_selector("dl div:nth-child(8) dd span:nth-child(2)", text: "Elevations - proposed")
+    expect(page).to have_selector("dl div:nth-child(9) dd span:nth-child(1)", text: "Bank statement")
+    expect(page).to have_selector("dl div:nth-child(9) dd span:nth-child(2)", text: "Utility bill")
+    expect(page).to have_selector("dl div:nth-child(10) dd span:nth-child(1)", text: "Environmental Impact Assessment (EIA)")
+    expect(page).to have_selector("dl div:nth-child(10) dd span:nth-child(2)", text: "Sustainability statement")
+    expect(page).to have_selector("dl div:nth-child(11) dd", text: "Inactive")
   end
 
   it "allows editing of an inactive application type" do
@@ -203,18 +241,19 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(9)" do
+    within "dl div:nth-child(11)" do
       expect(page).to have_selector("dd", text: "Inactive")
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Update status")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
 
     choose "Active"
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(11) dd", text: "Active")
   end
 
   it "prevents activation of a new application type when legislation has not been set" do
@@ -222,7 +261,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(9)" do
+    within "dl div:nth-child(11)" do
       expect(page).to have_selector("dd", text: "Inactive")
       click_link "Change"
     end
@@ -239,6 +278,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     click_link "Legislation must be set when application type is made active"
 
     expect(page).to have_selector("h1", text: "Enter legislation")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Existing use")
   end
 
   it "allows retirement of an application type" do
@@ -247,40 +287,43 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     visit "/application_types/#{application_type.id}"
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(9)" do
+    within "dl div:nth-child(11)" do
       expect(page).to have_selector("dd", text: "Active")
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Update status")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
     expect(page).to have_no_field("Inactive")
 
     choose "Retired"
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Retired")
+    expect(page).to have_selector("dl div:nth-child(11) dd", text: "Retired")
   end
 
   it "allows an application type to be brought out of retirement" do
     application_type = create(:application_type, :ldc_proposed, status: "retired")
 
     visit "/application_types/#{application_type.id}"
+
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(9)" do
+    within "dl div:nth-child(11)" do
       expect(page).to have_selector("dd", text: "Retired")
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Update status")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
     expect(page).to have_no_field("Inactive")
 
     choose "Active"
     click_button "Continue"
 
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(9) dd", text: "Active")
+    expect(page).to have_selector("dl div:nth-child(11) dd", text: "Active")
   end
 
   it "allows editing of the legislation" do
@@ -290,11 +333,12 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(3)" do
+    within "dl div:nth-child(5)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Enter legislation")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
 
     choose "Enter a new legislation"
     click_button "Continue"
@@ -312,7 +356,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_content("Legislation successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(3) dd", text: "The Town and Country Planning (General Permitted Development) (England) Order 2015")
+    expect(page).to have_selector("dl div:nth-child(5) dd", text: "The Town and Country Planning (General Permitted Development) (England) Order 2015")
   end
 
   it "allows editing of the determination period days" do
@@ -320,18 +364,19 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(4)" do
+    within "dl div:nth-child(6)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Set determination period")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
 
     fill_in "Set determination period", with: "35"
     click_button "Continue"
 
     expect(page).to have_content("Determination period successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(4) dd", text: "35 days - bank holidays included")
+    expect(page).to have_selector("dl div:nth-child(6) dd", text: "35 days - bank holidays included")
   end
 
   it "allows editing of the features" do
@@ -346,7 +391,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
+    within "dl div:nth-child(7) dd.govuk-summary-list__value" do
       expect(page).to have_selector("p strong", text: "Application details")
       expect(page).to have_selector("li", text: "Check planning conditions")
       expect(page).not_to have_selector("li", text: "Check permitted development rights")
@@ -357,12 +402,12 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
       expect(page).not_to have_selector("li", text: "Consultee")
     end
 
-    within "dl div:nth-child(5)" do
+    within "dl div:nth-child(7)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Choose features")
-    expect(page).to have_selector("h2", text: application_type.description)
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
 
     expect(page).to have_selector("fieldset legend", text: "Check application details")
     expect(page).to have_checked_field("Check planning conditions")
@@ -382,7 +427,7 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
     expect(page).to have_content("Features successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
 
-    within "dl div:nth-child(5) dd.govuk-summary-list__value" do
+    within "dl div:nth-child(7) dd.govuk-summary-list__value" do
       expect(page).to have_selector("p strong", text: "Application details")
       expect(page).not_to have_selector("li", text: "Check planning conditions")
       expect(page).to have_selector("li", text: "Check permitted development rights")
@@ -409,17 +454,17 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(6) dd:nth-child(2)" do
+    within "dl div:nth-child(8) dd:nth-child(2)" do
       expect(page).to have_selector("span", text: "Elevations - existing")
       expect(page).not_to have_selector("span", text: "Elevations - proposed")
     end
 
-    within "dl div:nth-child(6) dd:nth-child(3)" do
+    within "dl div:nth-child(8) dd:nth-child(3)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Manage document tags")
-    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
     expect(page).to have_selector("legend", text: "Plans")
     expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for plans")
 
@@ -429,8 +474,8 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_content("Document tags successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(6) dd span", text: "Elevations - proposed")
-    expect(page).not_to have_selector("dl div:nth-child(6) dd span", text: "Elevations - existing")
+    expect(page).to have_selector("dl div:nth-child(8) dd span", text: "Elevations - proposed")
+    expect(page).not_to have_selector("dl div:nth-child(8) dd span", text: "Elevations - existing")
   end
 
   it "allows editing of the tags for evidence" do
@@ -443,17 +488,17 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(7) dd:nth-child(2)" do
+    within "dl div:nth-child(9) dd:nth-child(2)" do
       expect(page).to have_selector("span", text: "Bank statement")
       expect(page).not_to have_selector("span", text: "Utility bill")
     end
 
-    within "dl div:nth-child(7) dd:nth-child(3)" do
+    within "dl div:nth-child(9) dd:nth-child(3)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Manage document tags")
-    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
     expect(page).to have_selector("legend", text: "Evidence")
     expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for evidence documents")
 
@@ -463,8 +508,8 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_content("Document tags successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(7) dd span", text: "Utility bill")
-    expect(page).not_to have_selector("dl div:nth-child(7) dd span", text: "Bank statement")
+    expect(page).to have_selector("dl div:nth-child(9) dd span", text: "Utility bill")
+    expect(page).not_to have_selector("dl div:nth-child(9) dd span", text: "Bank statement")
   end
 
   it "allows editing of the tags for supporting documents" do
@@ -477,17 +522,17 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     visit "/application_types/#{application_type.id}"
 
-    within "dl div:nth-child(8) dd:nth-child(2)" do
+    within "dl div:nth-child(10) dd:nth-child(2)" do
       expect(page).to have_selector("span", text: "Environmental Impact Assessment (EIA)")
       expect(page).not_to have_selector("span", text: "Sustainability statement")
     end
 
-    within "dl div:nth-child(8) dd:nth-child(3)" do
+    within "dl div:nth-child(10) dd:nth-child(3)" do
       click_link "Change"
     end
 
     expect(page).to have_selector("h1", text: "Manage document tags")
-    expect(page).to have_selector("h2", text: "Lawful Development Certificate - Proposed use")
+    expect(page).to have_selector("h1 > span", text: "Lawful Development Certificate - Proposed use")
     expect(page).to have_selector("legend", text: "Supporting documents")
     expect(page).to have_selector("div.govuk-hint", text: "Select the relevant tags for supporting documents")
 
@@ -497,8 +542,8 @@ RSpec.describe "Application Types", type: :system, bops_config: true do
 
     expect(page).to have_content("Document tags successfully updated")
     expect(page).to have_selector("h1", text: "Review the application type")
-    expect(page).to have_selector("dl div:nth-child(8) dd span", text: "Sustainability statement")
-    expect(page).not_to have_selector("dl div:nth-child(8) dd span", text: "Environmental Impact Assessment (EIA)")
+    expect(page).to have_selector("dl div:nth-child(10) dd span", text: "Sustainability statement")
+    expect(page).not_to have_selector("dl div:nth-child(10) dd span", text: "Environmental Impact Assessment (EIA)")
   end
 
   it "displays application types" do

--- a/engines/bops_config/spec/system/reporting_types_spec.rb
+++ b/engines/bops_config/spec/system/reporting_types_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Reporting types", type: :system, bops_config: true do
+  let!(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
+  let!(:reporting_type) { create(:reporting_type, :prior_approval_1a) }
+  let!(:application_type) { create(:application_type, :prior_approval) }
+
+  before do
+    sign_in(user)
+    visit "/"
+  end
+
+  it "allows viewing of reporting types" do
+    click_link "Reporting types"
+
+    expect(page).to have_selector("h1", text: "Reporting Types")
+    expect(page).to have_link("Create reporting type", href: "/reporting_types/new")
+
+    within "table" do
+      within "thead tr" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Code")
+        expect(page).to have_selector("th:nth-child(2)", text: "Category")
+        expect(page).to have_selector("th:nth-child(3)", text: "Description")
+        expect(page).to have_selector("th:nth-child(4)", text: "Action")
+      end
+
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA1")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "Larger householder extensions")
+
+        within "td:nth-child(4)" do
+          expect(page).to have_link("Edit", href: "/reporting_types/#{reporting_type.id}/edit")
+        end
+      end
+    end
+  end
+
+  it "allows creation of reporting types" do
+    click_link "Reporting types"
+    expect(page).to have_selector("h1", text: "Reporting Types")
+
+    click_link "Create reporting type"
+    expect(page).to have_selector("h1", text: "Create reporting type")
+
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "Enter a code for this reporting type")
+    expect(page).to have_selector("[role=alert] li", text: "Choose a category for this reporting type")
+    expect(page).to have_selector("[role=alert] li", text: "Enter a description for this reporting type")
+
+    fill_in "Description", with: "All others"
+    fill_in "Code", with: "PA99"
+    choose "Prior Approval"
+
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "Enter the legislation for prior approval reporting types")
+
+    fill_in "Legislation", with: "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2"
+
+    click_button "Save"
+    expect(page).to have_content("Reporting type successfully created")
+
+    within "table" do
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA99")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+      end
+    end
+  end
+
+  it "allows editing of reporting types" do
+    create(:reporting_type, :prior_approval_all_others)
+
+    click_link "Reporting types"
+    expect(page).to have_selector("h1", text: "Reporting Types")
+
+    within "table" do
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA99")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+
+        click_link "Edit"
+      end
+    end
+
+    expect(page).to have_selector("h1", text: "Edit reporting type")
+
+    fill_in "Description", with: "All other prior approvals"
+    click_button "Save"
+
+    expect(page).to have_content("Reporting type successfully updated")
+
+    within "table" do
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA99")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "All other prior approvals")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+      end
+    end
+  end
+
+  it "allows removal of reporting types" do
+    create(:reporting_type, :prior_approval_all_others)
+
+    click_link "Reporting types"
+    expect(page).to have_selector("h1", text: "Reporting Types")
+
+    within "table" do
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA99")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+
+        click_link "Edit"
+      end
+    end
+
+    expect(page).to have_selector("h1", text: "Edit reporting type")
+
+    accept_confirm do
+      click_link "Remove"
+    end
+
+    expect(page).to have_content("Reporting type successfully removed")
+    expect(page).not_to have_selector("table tbody tr:nth-child(2)")
+  end
+
+  it "doesn't allow removal of reporting types when they're used" do
+    click_link "Reporting types"
+    expect(page).to have_selector("h1", text: "Reporting Types")
+
+    within "table" do
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "PA1")
+        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(3)", text: "Larger householder extensions")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+
+        click_link "Edit"
+      end
+    end
+
+    expect(page).to have_selector("h1", text: "Edit reporting type")
+
+    accept_confirm do
+      click_link "Remove"
+    end
+
+    expect(page).to have_selector("[role=alert] li", text: "You can't remove a reporting type that's being used by an application type")
+  end
+end

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
       code { "ldc.existing" }
       suffix { "LDCE" }
       steps { %w[validation assessment review] }
+      category { "certificate-of-lawfulness" }
+      reporting_types { %w[Q26] }
 
       assessment_details do
         %w[
@@ -106,6 +108,8 @@ FactoryBot.define do
       name { "prior_approval" }
       code { "pa.part1.classA" }
       suffix { "PA" }
+      category { "prior-approval" }
+      reporting_types { %w[PA1] }
       features {
         {
           "site_visits" => true,
@@ -235,6 +239,8 @@ FactoryBot.define do
 
       code { "pa.part14.classJ" }
       suffix { "PA14J" }
+      category { "prior-approval" }
+      reporting_types { [] }
       part { 14 }
       section { "J" }
     end
@@ -243,6 +249,8 @@ FactoryBot.define do
       name { "planning_permission" }
       code { "pp.full.householder" }
       suffix { "HAPP" }
+      category { "householder" }
+      reporting_types { %w[Q21] }
       steps { %w[validation consultation assessment review] }
       features {
         {

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -406,6 +406,15 @@ FactoryBot.define do
       legislation { nil }
     end
 
+    trait :without_category do
+      category { nil }
+      reporting_types { [] }
+    end
+
+    trait :without_reporting_types do
+      reporting_types { [] }
+    end
+
     trait :active do
       status { "active" }
     end

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -240,7 +240,7 @@ FactoryBot.define do
       code { "pa.part14.classJ" }
       suffix { "PA14J" }
       category { "prior-approval" }
-      reporting_types { [] }
+      reporting_types { %w[PA99] }
       part { 14 }
       section { "J" }
     end

--- a/spec/factories/reporting_type.rb
+++ b/spec/factories/reporting_type.rb
@@ -45,5 +45,12 @@ FactoryBot.define do
       description { "Larger householder extensions" }
       legislation { "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A" }
     end
+
+    trait :prior_approval_all_others do
+      code { "PA99" }
+      category { "prior-approval" }
+      description { "All others" }
+      legislation { "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2" }
+    end
   end
 end

--- a/spec/factories/reporting_type.rb
+++ b/spec/factories/reporting_type.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :reporting_type do
+    trait :major_dwellings do
+      code { "Q01" }
+      category { "full" }
+      description { "Dwellings (major)" }
+    end
+
+    trait :major_offices do
+      code { "Q02" }
+      category { "full" }
+      description { "Offices, R&D, and light industry (major)" }
+    end
+
+    trait :major_industry do
+      code { "Q03" }
+      category { "full" }
+      description { "General Industry, storage and warehousing (major)" }
+    end
+
+    trait :major_retail do
+      code { "Q04" }
+      category { "full" }
+      description { "Retail and services (major)" }
+    end
+
+    trait :householder do
+      code { "Q21" }
+      category { "householder" }
+      description { "Householder developments" }
+    end
+
+    trait :ldc do
+      code { "Q26" }
+      category { "certificate-of-lawfulness" }
+      description { "Certificates of lawful development" }
+      guidance { "Includes both existing & proposed applications" }
+    end
+
+    trait :prior_approval_1a do
+      code { "PA1" }
+      category { "prior-approval" }
+      description { "Larger householder extensions" }
+      legislation { "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A" }
+    end
+  end
+end

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe ApplicationType do
         let(:application_type) { build(:application_type, :active, :without_legislation) }
 
         it "validates presence" do
-          expect { application_type.valid? }.to change { application_type.errors[:legislation] }.to ["must be set when application type is made active"]
+          expect { application_type.valid? }.to change { application_type.errors[:legislation] }.to ["The legislation must be set when an application type is made active"]
         end
       end
 

--- a/spec/system/planning_applications/validating/reporting_type_spec.rb
+++ b/spec/system/planning_applications/validating/reporting_type_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Reporting type validation task" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:reporting_type) { create(:reporting_type, :ldc) }
 
   let!(:planning_application) do
     create(:planning_application, :invalidated, local_authority: default_local_authority)
@@ -39,10 +40,9 @@ RSpec.describe "Reporting type validation task" do
 
       expect(page).to have_content("Select development type for reporting")
 
-      choose "Q26 - Certificate of Lawful Development"
+      choose "Q26 – Certificates of lawful development"
 
-      expect(page).to have_content("Guidance")
-      expect(page).to have_content("Includes both Existing & Proposed applications")
+      expect(page).to have_content("Includes both existing & proposed applications")
 
       click_button "Save and mark as complete"
 


### PR DESCRIPTION
### Description of change

* Adds a category for the `ApplicationType` model to group reporting types
* Adds CRUD for a `ReportingType` model
* Adds a screen to select the possible reporting types for an application type
* Updates the 'Select development type for reporting' validation task to use the new feature
* Creates an initial set of reporting types based on the existing data in the locale file

### Story Link

https://trello.com/c/OYbSsK2h

### Screenshots

![Reporting types index page](https://github.com/unboxed/bops/assets/6321/34eb0189-5d67-4685-ba61-f3a37d01d7c5)

![Reporting types edit page](https://github.com/unboxed/bops/assets/6321/562b6221-05f8-4d4a-bbba-2b992fd99b7c)

![Choosing a category for an application type](https://github.com/unboxed/bops/assets/6321/f0f1376b-89c9-472c-95b8-f79b50998fa4)

![Selecting reporting types for an application type](https://github.com/unboxed/bops/assets/6321/5b126b6a-029b-4f8b-9a2c-86a82eb2e900)

![Application type summary page](https://github.com/unboxed/bops/assets/6321/d623b41d-cdb6-4a2e-ab93-999bfe6f8039)




### Decisions

Added a GOV.UK heading caption to better delineate the action and the application type, e.g.

![Selecting reporting types](https://github.com/unboxed/bops/assets/6321/c4613196-8552-43f8-9194-d5cbc6d52679)

Have copied this styling to the other screens when setting up the application type
