### PR TITLE
Move spec setup into the engine

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
+-I engines/bops_admin/spec
 -I engines/bops_api/spec
+-I engines/bops_config/spec
 --require spec_helper

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,9 @@ api-docs:
 api-specs:
 	$(DOCKER-RUN) console rspec engines/bops_api/spec
 
+admin-specs:
+	$(DOCKER-RUN) console rspec engines/bops_admin/spec
+
 config-specs:
 	$(DOCKER-RUN) console rspec engines/bops_config/spec
 

--- a/engines/bops_config/spec/bops_config_helper.rb
+++ b/engines/bops_config/spec/bops_config_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.configure do |config|
+  config.before type: :system do |example|
+    Capybara.app_host = "http://config.bops.services"
+  end
+end

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "bops_config_helper"
 
-RSpec.describe "Application Types", type: :system, bops_config: true do
+RSpec.describe "Application Types", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
 
   before do

--- a/engines/bops_config/spec/system/dashboard_spec.rb
+++ b/engines/bops_config/spec/system/dashboard_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "bops_config_helper"
 
-RSpec.describe "Dashboard", type: :system, bops_config: true do
+RSpec.describe "Dashboard", type: :system do
   let(:local_authority) { create(:local_authority, :default) }
 
   before do

--- a/engines/bops_config/spec/system/legislation_spec.rb
+++ b/engines/bops_config/spec/system/legislation_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "bops_config_helper"
 
-RSpec.describe "Legislation", type: :system, bops_config: true do
+RSpec.describe "Legislation", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
   let!(:legislation) { create(:legislation, title: "Town and Country Planning Act 1990, Section 192") }
 

--- a/engines/bops_config/spec/system/reporting_types_spec.rb
+++ b/engines/bops_config/spec/system/reporting_types_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "bops_config_helper"
 
-RSpec.describe "Reporting types", type: :system, bops_config: true do
+RSpec.describe "Reporting types", type: :system do
   let!(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
   let!(:reporting_type) { create(:reporting_type, :prior_approval_1a) }
   let!(:application_type) { create(:application_type, :prior_approval) }

--- a/engines/bops_config/spec/system/users_spec.rb
+++ b/engines/bops_config/spec/system/users_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "bops_config_helper"
 
-RSpec.describe "Users", type: :system, bops_config: true do
+RSpec.describe "Users", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
   let(:last_email) { ActionMailer::Base.deliveries.last }
   let(:secure_password) { PasswordGenerator.call }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -37,11 +37,6 @@ RSpec.configure do |config|
 
   config.before type: :system do |example|
     driven_by(ENV.fetch("JS_DRIVER", "chrome_headless").to_sym)
-
-    Capybara.app_host = if example.metadata[:bops_config]
-      "http://config.bops.services"
-    else
-      "http://planx.example.com"
-    end
+    Capybara.app_host = "http://planx.example.com"
   end
 end


### PR DESCRIPTION
The main BOPS application should not have to know about how engine specs are configured.
