### PR TITLE
Exclude open time extension requests when submitting recommendation

### DIFF
--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -123,9 +123,7 @@ module PlanningApplications
       end
 
       def post_validation_requests
-        validation_requests = @planning_application.validation_requests.where(
-          post_validation: true
-        ).where.not(type: "TimeExtensionValidationRequest")
+        validation_requests = @planning_application.validation_requests.post_validation.excluding_time_extension
 
         @cancelled_validation_requests = validation_requests.cancelled
         @active_validation_requests = validation_requests.active

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -309,7 +309,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def ensure_no_open_post_validation_requests
-    return unless @planning_application.validation_requests.open.post_validation.any?
+    return if @planning_application.no_open_post_validation_requests_excluding_time_extension?
 
     flash.now[:alert] = t(".has_open_non_validation_requests_html", href: post_validation_requests_planning_application_validation_validation_requests_path(@planning_application))
     render :submit_recommendation and return

--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -131,7 +131,7 @@ module PlanningApplicationStatus
 
       event :submit do
         transitions from: %i[in_assessment in_committee], to: :awaiting_determination,
-          guards: %i[decision_present? no_open_post_validation_requests?] do
+          guards: %i[decision_present? no_open_post_validation_requests_excluding_time_extension?] do
           after { recommendation.update!(submitted: true) }
         end
       end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -703,12 +703,8 @@ class PlanningApplication < ApplicationRecord
     validation_requests.closed.max_by(&:updated_at).updated_at
   end
 
-  def all_open_post_validation_requests
-    validation_requests.open.post_validation
-  end
-
-  def no_open_post_validation_requests?
-    validation_requests.open.post_validation.none?
+  def no_open_post_validation_requests_excluding_time_extension?
+    open_post_validation_requests.excluding_time_extension.none?
   end
 
   def open_post_validation_requests
@@ -720,7 +716,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def open_post_validation_requests?
-    validation_requests.open.post_validation.any?
+    open_post_validation_requests.any?
   end
 
   def other_change_validation_request

--- a/app/views/planning_applications/assessment/recommendations/new.html.erb
+++ b/app/views/planning_applications/assessment/recommendations/new.html.erb
@@ -29,13 +29,13 @@
          recommendations: @planning_application.recommendations.reviewed
        }
     ) %>
-    <% if @planning_application.all_open_post_validation_requests.any? %>
+    <% if @planning_application.open_post_validation_requests.any? %>
       <%= render(
         partial: "shared/alert_banner",
         locals: {
           message: t(
             ".there_are_outstanding_change_requests_html",
-            last_request: @planning_application.all_open_post_validation_requests.last.created_at.to_fs,
+            last_request: @planning_application.open_post_validation_requests.last.created_at.to_fs,
             href: post_validation_requests_planning_application_validation_validation_requests_path(@planning_application)
           )
         }

--- a/app/views/planning_applications/review/recommendations/new.html.erb
+++ b/app/views/planning_applications/review/recommendations/new.html.erb
@@ -20,13 +20,13 @@
          recommendations: @planning_application.recommendations.reviewed
        }
     ) %>
-    <% if @planning_application.all_open_post_validation_requests.any? %>
+    <% if @planning_application.open_post_validation_requests.any? %>
       <%= render(
         partial: "shared/alert_banner",
         locals: {
           message: t(
             ".there_are_outstanding_change_requests_html",
-            last_request: @planning_application.all_open_post_validation_requests.last.created_at.to_fs,
+            last_request: @planning_application.open_post_validation_requests.last.created_at.to_fs,
             href: post_validation_requests_planning_application_validation_validation_requests_path(@planning_application)
           )
         }

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -963,7 +963,7 @@ RSpec.describe PlanningApplication do
 
         it "raises PlanningApplication::SubmitRecommendationError" do
           expect { planning_application.submit_recommendation! }
-            .to raise_error(PlanningApplication::SubmitRecommendationError, "Event 'submit' cannot transition from 'in_assessment'. Failed callback(s): [:no_open_post_validation_requests?].")
+            .to raise_error(PlanningApplication::SubmitRecommendationError, "Event 'submit' cannot transition from 'in_assessment'. Failed callback(s): [:no_open_post_validation_requests_excluding_time_extension?].")
             .and not_change(Audit, :count)
 
           expect(planning_application).to be_in_assessment

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -456,6 +456,32 @@ RSpec.describe "Planning Application Assessment" do
           expect(planning_application).to be_in_assessment
         end
       end
+
+      context "when there is an open time extension request" do
+        let(:planning_application) { create(:in_assessment_planning_application, local_authority: default_local_authority) }
+        let!(:time_extension_request) { create(:time_extension_validation_request, :open, planning_application:, post_validation: true) }
+
+        it "allows me to submit the planning application" do
+          within(selected_govuk_tab) do
+            click_link(planning_application.reference)
+          end
+
+          click_link("Check and assess")
+          click_link("Make draft recommendation")
+          within_fieldset("What is your recommendation?") do
+            choose("Granted")
+          end
+          fill_in("State the reasons for your recommendation.", with: "This is a public comment")
+          fill_in("Provide supporting information for your manager.", with: "This is a private assessor comment")
+          click_button("Save and mark as complete")
+
+          click_link("Review and submit recommendation")
+          click_button("Submit recommendation")
+
+          expect(page).to have_content("Recommendation was successfully submitted.")
+          expect(page).to have_content("Awaiting determination")
+        end
+      end
     end
 
     context "when it needs to go to committee" do


### PR DESCRIPTION
### Description of change

Exclude open time extension requests when submitting recommendation

### Story Link

https://trello.com/c/ApNz2tnQ/2711-closed-pre-commencement-condition-request-blocking-submission-to-manager-for-review