### PR TITLE
Track whether a constraint requires consultation

### DIFF
--- a/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
+++ b/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
@@ -8,7 +8,8 @@ module PlanningApplications
 
       def create
         respond_to do |format|
-          if planning_application_constraint.update(consultee_id: consultee_id)
+          if planning_application_constraint.update(consultee_id: consultee_id,
+            consultation_required: consultation_required)
             format.html do
               redirect_to planning_application_consultees_url(@planning_application)
             end
@@ -31,13 +32,19 @@ module PlanningApplications
       end
 
       def consultee_id
+        return if permitted_params[:consultee].blank?
+
         Integer(permitted_params[:consultee])
       rescue ArgumentError
         raise ActionController::BadRequest, "Invalid consultee id: #{permitted_params[:consultee].inspect}"
       end
 
+      def consultation_required
+        permitted_params[:consultation_required] == ["true"]
+      end
+
       def permitted_params
-        params.require(:planning_application_constraint).permit([:constraint, :consultee])
+        params.require(:planning_application_constraint).permit([:constraint, :consultee, consultation_required: []])
       end
     end
   end

--- a/app/controllers/planning_applications/consultees_controller.rb
+++ b/app/controllers/planning_applications/consultees_controller.rb
@@ -5,7 +5,6 @@ module PlanningApplications
     before_action :set_planning_application
     before_action :set_consultation
     before_action :set_consultees
-    before_action :set_consultee, only: %i[show]
 
     def create
       @consultee = @consultees.create!(consultee_params)
@@ -16,6 +15,8 @@ module PlanningApplications
     end
 
     def show
+      @consultee = @consultees.find(consultee_id)
+
       respond_to do |format|
         format.html
       end
@@ -39,10 +40,6 @@ module PlanningApplications
 
     def set_consultees
       @consultees = @consultation.consultees
-    end
-
-    def set_consultee
-      @consultee = @consultees.find(consultee_id)
     end
 
     def constraint_id

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -37,7 +37,9 @@
 
       <%= form.label "Select consultee for #{@constraint.type_code}", class: "govuk-label" %>
       <%= form.hidden_field :constraint, value: @constraint.id %>
-      <%= form.govuk_select :consultee, options_for_select(@consultation.consultees.map { |c| [c.name, c.id] }) %>
+      <%= form.govuk_select :consultee, options_for_select([nil, nil] + @consultation.consultees.map { |c| [c.name, c.id] }) %>
+
+      <%= form.govuk_check_box :consultation_required, true, false, label: {text: "Consultation required?"}, selected: true %>
 
       <div class="govuk-button-group">
         <%= form.submit "Assign consultee", class: "govuk-button", data: {module: "govuk-button"} %>

--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -24,6 +24,9 @@
         <% else %>
           <%= render StatusTags::BaseComponent.new(status: "not_assigned") %>
         <% end %>
+        <% unless constraint.consultation_required? %>
+          <%= render StatusTags::BaseComponent.new(status: "not_required") %>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/db/migrate/20240405154811_add_consultation_required_to_planning_application_constraint.rb
+++ b/db/migrate/20240405154811_add_consultation_required_to_planning_application_constraint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class AddConsultationRequiredToPlanningApplicationConstraint < ActiveRecord::Migration[7.1]
+  def change
+    add_column :planning_application_constraints, :consultation_required, :boolean
+
+    up_only do
+      PlanningApplicationConstraint.find_each do |constraint|
+        constraint.update!(consultation_required: true)
+      end
+
+      change_column_default :planning_application_constraints, :consultation_required, true
+      change_column_null :planning_application_constraints, :consultation_required, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -561,6 +561,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_102618) do
     t.boolean "identified", default: false, null: false
     t.string "identified_by", null: false
     t.bigint "consultee_id"
+    t.boolean "consultation_required", default: true, null: false
     t.index ["constraint_id"], name: "ix_planning_application_constraints_on_constraint_id"
     t.index ["consultee_id"], name: "ix_planning_application_constraints_on_consultee_id"
     t.index ["planning_application_constraints_query_id"], name: "ix_planning_application_constraints_on_planning_application_con"

--- a/spec/system/planning_applications/consulting/add_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/add_consultees_spec.rb
@@ -82,4 +82,55 @@ RSpec.describe "Consultation", js: true do
 
     expect(page).to have_selector(".govuk-table__row", text: "Conservation area Chris Wood")
   end
+
+  it "allows marking a constraint as requiring consultation" do
+    click_link "Select and add consultees"
+
+    fill_in "Search for consultees", with: "Tree Officer"
+    pick "Chris Wood (Tree Officer, PlanX Council)", from: "#add-consultee"
+    click_button "Add consultee"
+
+    within "tbody tr:first-child" do
+      click_link "Assign consultee"
+    end
+
+    check "Consultation required"
+    click_button "Assign consultee"
+
+    expect(page).not_to have_selector(".govuk-table__row", text: "Not required")
+  end
+
+  it "allows marking a constraint as not requiring consultation" do
+    click_link "Select and add consultees"
+
+    fill_in "Search for consultees", with: "Tree Officer"
+    pick "Chris Wood (Tree Officer, PlanX Council)", from: "#add-consultee"
+    click_button "Add consultee"
+
+    within "tbody tr:first-child" do
+      click_link "Assign consultee"
+    end
+
+    uncheck "Consultation required"
+    click_button "Assign consultee"
+
+    expect(page).to have_selector(".govuk-table__row", text: "Conservation area Assign consultee Not assigned Not required")
+  end
+
+  it "allows marking a constraint as not requiring consultation even with a consultee associated" do
+    click_link "Select and add consultees"
+
+    fill_in "Search for consultees", with: "Tree Officer"
+    pick "Chris Wood (Tree Officer, PlanX Council)", from: "#add-consultee"
+    click_button "Add consultee"
+
+    within "tbody tr:first-child" do
+      click_link "Assign consultee"
+    end
+    select "Chris Wood", from: "Consultee"
+    uncheck "Consultation required"
+    click_button "Assign consultee"
+
+    expect(page).to have_selector(".govuk-table__row", text: "Conservation area Chris Wood Not consulted Not required")
+  end
 end


### PR DESCRIPTION
### Description of change

We need to track the difference between a constraint that doesn't need consultation, and a constraint that simply hasn't had a consultee assigned to it yet.

### Story Link

https://trello.com/c/zKNjrVNd/2709-allow-marking-constraints-as-not-requiring-a-consultee

### Screenshots

<img width="425" alt="Screenshot 2024-04-08 at 11 36 08" src="https://github.com/unboxed/bops/assets/3986/bf6ae3b8-16ed-4809-963c-8b0996a276f5">

<img width="1135" alt="Screenshot 2024-04-08 at 11 37 26" src="https://github.com/unboxed/bops/assets/3986/2561a3fb-9234-42fc-838a-61cf71640e33">
