### PR TITLE
Don't try to show sent letter date when there are none

### DIFF
--- a/app/views/planning_applications/review/neighbour_responses/_form.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/_form.html.erb
@@ -3,7 +3,11 @@
     <% if @consultation.start_date && @consultation.end_date %>
       <ul class="govuk-list govuk-list--bullet">
         <li>the consultation period for this application is <%= (@consultation.end_date - @consultation.start_date).to_i %> days</li>
-        <li>the last letter was sent <%= (Date.current - @consultation.neighbour_letters.sent.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
+        <% if (sent_letters = @consultation.neighbour_letters.sent) && sent_letters.present? %>
+          <li>the last letter was sent <%= (Date.current - sent_letters.max_by(&:sent_at).sent_at.to_date).to_i %> days ago</li>
+        <% else %>
+          <li>no letters have been sent yet</li>
+        <% end %>
         <li>the consultation expiry date for this application is <%= @consultation.end_date.to_date.to_fs %></li>
       </ul>
     <% else %>


### PR DESCRIPTION
### Description of change

Bug caused by querying for all sent letters and assuming there would always be at least one result. Fix by checking for empty responses

### Story Link

https://trello.com/c/Y98lhJPY/2816-undefined-method-sentat-for-neighbour-responses
