### PR TITLE
Allow reporting types to apply to multiple application categories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lint:
 	$(DOCKER-RUN) console rubocop
 
 lint-auto-correct:
-	$(DOCKER-RUN) console rubocop --auto-correct-all
+	$(DOCKER-RUN) console rubocop --autocorrect-all
 
 # this regenerates the Rubocop TODO and ensures that cops aren't
 # turned off over a max number of file offenses. Note: we don't want

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -290,12 +290,13 @@ en:
           attributes:
             base:
               used: You can't remove a reporting type that's being used by an application type
-            category:
-              blank: Choose a category for this reporting type
+            categories:
+              blank: Choose at least one category for this reporting type
             code:
               blank: Enter a code for this reporting type
               invalid_pa_code: The code must be in the form 'PAX' or 'PAXX' where 'X' is a number
               invalid_q_code: The code must be in the form 'QXX' where 'X' is a number
+              taken: Enter a unique code for this reporting type
             description:
               blank: Enter a description for this reporting type
             guidance_link:

--- a/config/locales/odp.yml
+++ b/config/locales/odp.yml
@@ -1,5 +1,21 @@
 en:
   odp:
+    application_categories:
+      advertisment: Advertisment
+      certificate_of_lawfulness: Lawful Development Certificate
+      change_of_use: Change of Use
+      conservation_area: Conservation Area
+      full: Full Planning Permission
+      hedgerows: Hedgerows
+      householder: Householder
+      listed_building: Listed Building
+      non_material_amendment: Non-material Amendment
+      other: Other
+      outline: Outline Planning Permission
+      prior_approval: Prior Approval
+      reserved_matters: Reserved Matters
+      tree_works: Tree Works
+
     application_types:
       - ['advertConsent', 'Consent to display an advertisement']
       - ['hazardousSubstanceConsent', 'Consent to move and dispose of hazardous substances']

--- a/db/migrate/20240410102618_migrate_reporting_type_category_to_categories.rb
+++ b/db/migrate/20240410102618_migrate_reporting_type_category_to_categories.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MigrateReportingTypeCategoryToCategories < ActiveRecord::Migration[7.1]
+  class ReportingType < ActiveRecord::Base; end
+
+  def change
+    add_column :reporting_types, :categories, :string, array: true
+    change_column_null :reporting_types, :category, true
+
+    up_only do
+      ReportingType.reset_column_information
+
+      ReportingType.find_each do |type|
+        type.update!(categories: [type.category])
+      end
+
+      change_column_default :reporting_types, :categories, []
+      change_column_null :reporting_types, :categories, false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_04_113623) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_102618) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -751,7 +751,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_113623) do
 
   create_table "reporting_types", force: :cascade do |t|
     t.string "code", null: false
-    t.string "category", null: false
+    t.string "category"
     t.string "description", null: false
     t.string "guidance"
     t.string "guidance_link"
@@ -760,6 +760,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_04_113623) do
     t.datetime "updated_at", null: false
     t.virtual "code_prefix", type: :text, as: "regexp_replace((code)::text, '[0-9]+$'::text, ''::text)", stored: true
     t.virtual "code_suffix", type: :integer, as: "(regexp_replace((code)::text, '^[A-Z]+'::text, ''::text))::integer", stored: true
+    t.string "categories", default: [], null: false, array: true
     t.index ["code"], name: "ix_reporting_types_on_code", unique: true
     t.index ["code_prefix", "code_suffix"], name: "ix_reporting_types_on_code_prefix__code_suffix"
   end

--- a/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/reporting_types_controller.rb
@@ -61,7 +61,7 @@ module BopsConfig
     private
 
     def reporting_type_attributes
-      %i[code category description guidance guidance_link legislation]
+      [:code, :description, :guidance, :guidance_link, :legislation, categories: []]
     end
 
     def reporting_type_params

--- a/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table application-types-table">
+<table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">

--- a/engines/bops_config/app/views/bops_config/decisions/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/decisions/_table.html.erb
@@ -1,5 +1,5 @@
 <% if @decisions.any? %>
-  <table class="govuk-table application-types-table">
+  <table class="govuk-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header govuk-!-width-one-third">

--- a/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
@@ -4,9 +4,9 @@
   <%= form.govuk_text_field :description, label: {text: t(".description_label")}, hint: {text: t(".description_hint")} %>
   <%= form.govuk_text_field :code, width: 5, label: {text: t(".code_label")}, hint: {text: t(".code_hint")} %>
 
-  <%= form.govuk_collection_radio_buttons :category,
-    ReportingType.categories, :first, ->((k)) { t(".category_labels.#{k}") },
-      legend: {text: t(".category_legend")}, hint: {text: t(".category_hint")},
+  <%= form.govuk_collection_check_boxes :categories,
+    ReportingType.category_menu, :first, :last,
+      legend: {text: t(".categories_legend")}, hint: {text: t(".categories_hint")},
       small: false, classes: "govuk-!-column-count-2" %>
 
   <%= form.govuk_text_area :guidance, label: {text: t(".guidance_label")}, rows: 5 %>

--- a/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
@@ -5,13 +5,13 @@
         <th scope="col" class="govuk-table__header">
           <%= t(".code") %>
         </th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">
+          <%= t(".description") %>
+        </th>
         <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           <%= t(".category") %>
         </th>
-        <th scope="col" class="govuk-table__header">
-          <%= t(".description") %>
-        </th>
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-text-align-right">
           <%= t(".action") %>
         </th>
       </tr>
@@ -23,14 +23,18 @@
           <td class="govuk-table__cell">
             <%= reporting_type.code %>
           </td>
-          <td class="govuk-table__cell">
-            <%= t(".categories.#{reporting_type.category}") %>
-          </td>
           <td class="govuk-table__cell govuk-!-text-wrap-balance">
             <%= reporting_type.description %>
           </td>
           <td class="govuk-table__cell">
-            <%= link_to t(".edit"), edit_reporting_type_path(reporting_type) , class: "govuk-link" %>
+            <ul class="govuk-list govuk-!-margin-bottom-0">
+              <% reporting_type.human_categories.each do |category| %>
+                <li class="govuk-!-margin-bottom-0"><%= category %></li>
+              <% end %>
+            </ul>
+          </td>
+          <td class="govuk-table__cell govuk-!-text-align-right">
+            <%= link_to t(".edit"), edit_reporting_type_path(reporting_type), class: "govuk-link" %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -310,8 +310,8 @@ en:
       edit:
         title: Edit reporting type
       form:
-        category_hint: Choose what category of application types this option will appear on when selecting the reporting type during validation
-        category_labels:
+        categories_hint: Choose what category of application types this option will appear on when selecting the reporting type during validation
+        categories_labels:
           advertisment: Advertisment
           certificate_of_lawfulness: Lawful Development Certificate
           change_of_use: Change of Use
@@ -326,7 +326,7 @@ en:
           prior_approval: Prior Approval
           reserved_matters: Reserved Matters
           tree_works: Tree Works
-        category_legend: Category
+        categories_legend: Category
         code_hint: Enter the code used to identify this reporting type (e.g. Q26 or PA15)
         code_label: Code
         description_hint: Enter the description from the district planning matters return
@@ -344,21 +344,6 @@ en:
         title: Create reporting type
       table:
         action: Action
-        categories:
-          advertisment: Advertisment
-          certificate_of_lawfulness: Lawful Development Certificate
-          change_of_use: Change of Use
-          conservation_area: Conservation Area
-          full: Full Planning Permission
-          hedgerows: Hedgerows
-          householder: Householder
-          listed_building: Listed Building
-          non_material_amendment: Non-material Amendment
-          other: Other
-          outline: Outline Planning Permission
-          prior_approval: Prior Approval
-          reserved_matters: Reserved Matters
-          tree_works: Tree Works
         category: Category
         code: Code
         description: Description

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -715,7 +715,7 @@ RSpec.describe "Application Types", type: :system do
       href: "/application_types/new"
     )
 
-    within(".govuk-table.application-types-table") do
+    within("table") do
       within "thead > tr:first-child" do
         expect(page).to have_selector("th:nth-child(1)", text: "Suffix")
         expect(page).to have_selector("th:nth-child(2)", text: "Name")

--- a/engines/bops_config/spec/system/legislation_spec.rb
+++ b/engines/bops_config/spec/system/legislation_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Legislation", type: :system do
     expect(page).to have_selector("h2", text: "Application types with this legislation")
     expect(page).not_to have_link("Remove")
 
-    within(".govuk-table.application-types-table") do
+    within("table") do
       within "thead > tr:first-child" do
         expect(page).to have_selector("th:nth-child(1)", text: "Suffix")
         expect(page).to have_selector("th:nth-child(2)", text: "Name")

--- a/engines/bops_config/spec/system/reporting_types_spec.rb
+++ b/engines/bops_config/spec/system/reporting_types_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "thead tr" do
         expect(page).to have_selector("th:nth-child(1)", text: "Code")
-        expect(page).to have_selector("th:nth-child(2)", text: "Category")
-        expect(page).to have_selector("th:nth-child(3)", text: "Description")
+        expect(page).to have_selector("th:nth-child(2)", text: "Description")
+        expect(page).to have_selector("th:nth-child(3)", text: "Category")
         expect(page).to have_selector("th:nth-child(4)", text: "Action")
       end
 
       within "tbody tr:nth-child(1)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA1")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "Larger householder extensions")
+        expect(page).to have_selector("td:nth-child(2)", text: "Larger householder extensions")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
 
         within "td:nth-child(4)" do
           expect(page).to have_link("Edit", href: "/reporting_types/#{reporting_type.id}/edit")
@@ -47,12 +47,12 @@ RSpec.describe "Reporting types", type: :system do
 
     click_button "Save"
     expect(page).to have_selector("[role=alert] li", text: "Enter a code for this reporting type")
-    expect(page).to have_selector("[role=alert] li", text: "Choose a category for this reporting type")
+    expect(page).to have_selector("[role=alert] li", text: "Choose at least one category for this reporting type")
     expect(page).to have_selector("[role=alert] li", text: "Enter a description for this reporting type")
 
     fill_in "Description", with: "All others"
     fill_in "Code", with: "PA99"
-    choose "Prior Approval"
+    check "Prior Approval"
 
     click_button "Save"
     expect(page).to have_selector("[role=alert] li", text: "Enter the legislation for prior approval reporting types")
@@ -65,8 +65,38 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "tbody tr:nth-child(2)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA99")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(2)", text: "All others")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
+        expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
+      end
+    end
+  end
+
+  it "allows creation of reporting types that apply to multiple categories" do
+    click_link "Reporting types"
+    expect(page).to have_selector("h1", text: "Reporting Types")
+
+    click_link "Create reporting type"
+    expect(page).to have_selector("h1", text: "Create reporting type")
+
+    fill_in "Description", with: "Dwellings (major)"
+    fill_in "Code", with: "Q01"
+    check "Full Planning Permission"
+    check "Outline Planning Permission"
+
+    click_button "Save"
+    expect(page).to have_content("Reporting type successfully created")
+
+    within "table" do
+      within "tbody tr:nth-child(2)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "Q01")
+        expect(page).to have_selector("td:nth-child(2)", text: "Dwellings (major)")
+
+        within "td:nth-child(3)" do
+          expect(page).to have_selector("li:nth-child(1)", text: "Full Planning Permission")
+          expect(page).to have_selector("li:nth-child(2)", text: "Outline Planning Permission")
+        end
+
         expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
       end
     end
@@ -81,8 +111,8 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "tbody tr:nth-child(2)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA99")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(2)", text: "All others")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
         expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
 
         click_link "Edit"
@@ -99,8 +129,8 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "tbody tr:nth-child(2)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA99")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "All other prior approvals")
+        expect(page).to have_selector("td:nth-child(2)", text: "All other prior approvals")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
         expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
       end
     end
@@ -115,8 +145,8 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "tbody tr:nth-child(2)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA99")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "All others")
+        expect(page).to have_selector("td:nth-child(2)", text: "All others")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
         expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
 
         click_link "Edit"
@@ -140,8 +170,8 @@ RSpec.describe "Reporting types", type: :system do
     within "table" do
       within "tbody tr:nth-child(1)" do
         expect(page).to have_selector("td:nth-child(1)", text: "PA1")
-        expect(page).to have_selector("td:nth-child(2)", text: "Prior Approval")
-        expect(page).to have_selector("td:nth-child(3)", text: "Larger householder extensions")
+        expect(page).to have_selector("td:nth-child(2)", text: "Larger householder extensions")
+        expect(page).to have_selector("td:nth-child(3)", text: "Prior Approval")
         expect(page).to have_selector("td:nth-child(4) a", text: "Edit")
 
         click_link "Edit"

--- a/spec/factories/reporting_type.rb
+++ b/spec/factories/reporting_type.rb
@@ -4,51 +4,51 @@ FactoryBot.define do
   factory :reporting_type do
     trait :major_dwellings do
       code { "Q01" }
-      category { "full" }
+      categories { %w[full] }
       description { "Dwellings (major)" }
     end
 
     trait :major_offices do
       code { "Q02" }
-      category { "full" }
+      categories { %w[full] }
       description { "Offices, R&D, and light industry (major)" }
     end
 
     trait :major_industry do
       code { "Q03" }
-      category { "full" }
+      categories { %w[full] }
       description { "General Industry, storage and warehousing (major)" }
     end
 
     trait :major_retail do
       code { "Q04" }
-      category { "full" }
+      categories { %w[full] }
       description { "Retail and services (major)" }
     end
 
     trait :householder do
       code { "Q21" }
-      category { "householder" }
+      categories { %w[householder] }
       description { "Householder developments" }
     end
 
     trait :ldc do
       code { "Q26" }
-      category { "certificate-of-lawfulness" }
+      categories { %w[certificate-of-lawfulness] }
       description { "Certificates of lawful development" }
       guidance { "Includes both existing & proposed applications" }
     end
 
     trait :prior_approval_1a do
       code { "PA1" }
-      category { "prior-approval" }
+      categories { %w[prior-approval] }
       description { "Larger householder extensions" }
       legislation { "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2, Part 1, Class A" }
     end
 
     trait :prior_approval_all_others do
       code { "PA99" }
-      category { "prior-approval" }
+      categories { %w[prior-approval] }
       description { "All others" }
       legislation { "Town and Country Planning (General Permitted Development) (England) Order 2015, Schedule 2" }
     end


### PR DESCRIPTION
### Description of change

For codes like `Q01` they can apply to full and outline planning applications so we need to allow multiple categories

### Screenshots

![image](https://github.com/unboxed/bops/assets/6321/da1663b6-b665-43ff-a736-90efdea7535b)

![image](https://github.com/unboxed/bops/assets/6321/7b00d348-e283-43f8-86bd-6e839f6aa690)
