### PR TITLE
Use strong_migrations to check safety of migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ gem "sidekiq-scheduler"
 gem "sprockets-rails"
 gem "stimulus-rails"
 gem "store_model"
+gem "strong_migrations"
 gem "strong_password", "~> 0.0.9"
 gem "view_component"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -578,6 +578,8 @@ GEM
     store_model (2.1.2)
       activerecord (>= 5.2)
     stringio (3.1.0)
+    strong_migrations (1.8.0)
+      activerecord (>= 5.2)
     strong_password (0.0.10)
     sys-uname (1.2.2)
       ffi (~> 1.1)
@@ -690,6 +692,7 @@ DEPENDENCIES
   standard-rails
   stimulus-rails
   store_model
+  strong_migrations
   strong_password (~> 0.0.9)
   view_component
   web-console

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Mark existing migrations as safe
+StrongMigrations.start_after = 20240410145215
+
+# Set timeouts for migrations
+# If you use PgBouncer in transaction mode, delete these lines and set timeouts on the database user
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour
+
+# Analyze tables after indexes are added
+# Outdated statistics can sometimes hurt performance
+StrongMigrations.auto_analyze = true
+
+# Set the version of the production database
+# so the right checks are run in development
+# StrongMigrations.target_version = 10
+
+# Add custom checks
+# StrongMigrations.add_check do |method, args|
+#   if method == :add_index && args[0].to_s == "users"
+#     stop! "No more indexes on the users table"
+#   end
+# end
+
+# Make some operations safe by default
+# See https://github.com/ankane/strong_migrations#safe-by-default
+# StrongMigrations.safe_by_default = true


### PR DESCRIPTION
### Description of change

Check that we're not introducing changes that might cause performance issues if applied in production (once the service becomes busier).

As recommended in #1682.

### Story Link

https://trello.com/c/3RjI1w3j/2869-add-strongmigrations-gem-to-enforce-good-database-practices
