### PR TITLE
Improve site and press notice

### DIFF
--- a/app/components/task_list_items/confirm_press_notice_component.rb
+++ b/app/components/task_list_items/confirm_press_notice_component.rb
@@ -28,15 +28,9 @@ module TaskListItems
     end
 
     def status
-      if press_notice.nil?
-        "not_started"
-      elsif press_notice.published_at?
-        "complete"
-      elsif press_notice.press_sent_at?
-        "in_progress"
-      else
-        "not_started"
-      end
+      return "complete" if press_notice&.published_at?
+
+      "not_started"
     end
   end
 end

--- a/app/controllers/planning_applications/press_notices/confirmations_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmations_controller.rb
@@ -30,7 +30,7 @@ module PlanningApplications
       private
 
       def press_notice_params
-        params.require(:press_notice).permit(:press_sent_at, :published_at, :comment, documents: [])
+        params.require(:press_notice).permit(:published_at, :comment, documents: [])
       end
 
       def set_press_notice
@@ -41,6 +41,8 @@ module PlanningApplications
         elsif !@press_notice.required?
           redirect_to planning_application_consultation_path(@planning_application), alert: t(".not_required")
         end
+
+        @press_notice.published_at ||= Time.zone.today
       end
     end
   end

--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -74,6 +74,7 @@ module PlanningApplications
 
     def set_site_notice
       @site_notice = @planning_application.site_notices.find(params[:id])
+      @site_notice.displayed_at ||= Time.zone.today
     end
 
     def site_notice_params

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -7,6 +7,8 @@ class PressNotice < ApplicationRecord
   include DateValidateable
   include Consultable
 
+  self.ignored_columns += %w[press_sent_at]
+
   REASONS = %i[
     conservation_area
     listed_building
@@ -30,17 +32,10 @@ class PressNotice < ApplicationRecord
   end
 
   with_options on: :confirmation do
-    validates :press_sent_at,
-      presence: true,
-      date: {
-        on_or_before: :current,
-        on_or_after: :consultation_start_date
-      }
-
     validates :published_at,
       date: {
         on_or_before: :current,
-        on_or_after: :press_sent_at
+        on_or_after: :consultation_start_date
       }
   end
 

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -22,6 +22,10 @@ class SiteNotice < ApplicationRecord
       }
   end
 
+  with_options format: {with: URI::MailTo::EMAIL_REGEXP} do
+    validates :internal_team_email, allow_blank: true
+  end
+
   before_create :ensure_publicity_feature!
 
   after_update :extend_consultation!, if: :saved_change_to_displayed_at?

--- a/app/views/planning_applications/press_notices/confirmations/show.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/show.html.erb
@@ -46,7 +46,6 @@
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">
-      <%= form.govuk_date_field(:press_sent_at, rows: 6, id: "press-sent-at-field", legend: { size: "s", text: t(".press_sent_at") }) %>
       <%= form.govuk_date_field(:published_at, rows: 6, id: "published-at-field", legend: { size: "s", text: t(".published_at") }) %>
 
       <%= render "documents", documents: @press_notice.documents %>

--- a/app/views/planning_applications/site_notices/new.html.erb
+++ b/app/views/planning_applications/site_notices/new.html.erb
@@ -38,7 +38,7 @@
       <%= form.govuk_radio_button :required, false, label: { text: "No" }, data: { action: "change->show-hide-form#handleEvent" } %>
     <% end %>
 
-    <div class="govuk-!-display-none" id="site-notice-options">
+    <%= tag.div(id: "site-notice-options", class: class_names("govuk-!-display-none": @site_notice.errors.blank?)) do %>
       <div class="grey-box" id="email-site-notice">
         <%= form.govuk_radio_buttons_fieldset(
           :method,
@@ -64,7 +64,7 @@
       <div class="govuk-button-group govuk-!-padding-top-7">
         <%= back_link %>
       </div>
-    </div>
+    <% end %>
 
     <div class="govuk-button-group govuk-!-padding-top-7 govuk-!-display-none" id="site-notice-form-actions">
       <%= form.submit "Save and mark as complete", class: "govuk-button govuk-button--primary" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -276,15 +276,10 @@ en:
               blank: Provide documentary evidence that the press notice was published
             other_reason:
               blank: Provide the other reason for the press notice
-            press_sent_at:
-              date_blank: Provide the date when the press notice was sent
-              date_invalid: The date the press notice was sent must be a valid date
-              date_not_on_or_after: The date the press notice was sent must be on or after the consultation start date
-              date_not_on_or_before: The date the press notice was sent must be on or before today
             published_at:
               date_blank: Provide the date when the press notice was published
               date_invalid: The date the press notice was published must be a valid date
-              date_not_on_or_after: The date the press notice was published must be on or after the press sent date
+              date_not_on_or_after: The date the press notice was published must be on or after the consultation start date
               date_not_on_or_before: The date the press notice was published must be on or before today
             reasons:
               blank: Provide a reason for the press notice
@@ -1332,7 +1327,6 @@ en:
           not_required: The press notice is not required so there is no need to confirm it
           optional_comment: Optional comment
           photos_hint: Provide documentary evidence of the press notice being published
-          press_sent_at: What date was the press notice sent?
           published_at: What date was the press notice published?
           requested_on: Press notice requested on %-d %B %Y
           save: Save

--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -163,11 +163,11 @@ RSpec.describe PressNotice do
           end
 
           it "there is no update to the consultation end date" do
-            expect { press_notice.update(press_sent_at: Time.zone.local(2023, 3, 15)) }.not_to change(consultation, :end_date)
+            expect { press_notice.update(requested_at: Time.zone.local(2023, 3, 15)) }.not_to change(consultation, :end_date)
           end
 
           it "does not update the expiry date" do
-            expect { press_notice.update(press_sent_at: Time.zone.local(2023, 3, 15)) }.not_to change(press_notice, :expiry_date).from(nil)
+            expect { press_notice.update(requested_at: Time.zone.local(2023, 3, 15)) }.not_to change(press_notice, :expiry_date).from(nil)
           end
         end
 

--- a/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe "Confirm site notice", js: true do
     expect(page).to have_content "Site notice was emailed to the applicant"
     expect(page).to have_content audit.created_at.to_fs(:day_month_year_slashes).to_s
 
+    # Defaults to Time.zone.today if this is not set
+    expect(page).to have_field("Day", with: "1")
+    expect(page).to have_field("Month", with: "2")
+    expect(page).to have_field("Year", with: "2023")
+
+    fill_in "Day", with: ""
+    fill_in "Month", with: ""
+    fill_in "Year", with: ""
     click_button "Save and mark as complete"
     expect(page).to have_content "Provide the date when the site notice was displayed"
 

--- a/spec/system/planning_applications/publicity/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/create_site_notice_spec.rb
@@ -106,9 +106,13 @@ RSpec.describe "Create a site notice", js: true do
     expect(page).to have_content("Email the site notice")
 
     choose "Send it by email to internal team to post"
+    fill_in "Internal team email", with: "invalidemail.com"
+    click_button "Email site notice and mark as complete"
 
+    expect(page).to have_selector("[role=alert] li", text: "Internal team email is invalid")
+
+    choose "Send it by email to internal team to post"
     fill_in "Internal team email", with: "internal@email.com"
-
     click_button "Email site notice and mark as complete"
 
     perform_enqueued_jobs

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -469,57 +469,25 @@ RSpec.describe "Press notice" do
         expect(consultation.end_date.to_date).to eq("Thu, 12 Oct 2023".to_date)
 
         click_link "Consultees, neighbours and publicity"
-        click_link "Confirm press notice"
-
-        click_button "Save"
-        expect(page).to have_content("Provide the date when the press notice was sent")
-
-        within("#press-sent-at-field") do
-          expect(page).to have_content("What date was the press notice sent?")
-          fill_in "Day", with: "1"
-          fill_in "Month", with: "1"
-          fill_in "Year", with: "2023"
-        end
-
-        click_button "Save"
-        expect(page).to have_content("The date the press notice was sent must be on or after the consultation start date")
-
-        within("#press-sent-at-field") do
-          expect(page).to have_content("What date was the press notice sent?")
-          fill_in "Day", with: "31"
-          fill_in "Month", with: "12"
-          fill_in "Year", with: "2023"
-        end
-
-        click_button "Save"
-        expect(page).to have_content("The date the press notice was sent must be on or before today")
-
-        within("#press-sent-at-field") do
-          expect(page).to have_content("What date was the press notice sent?")
-          fill_in "Day", with: "25"
-          fill_in "Month", with: "9"
-          fill_in "Year", with: "2023"
-        end
-
-        fill_in "Optional comment", with: "Press notice comment"
-        click_button "Save"
-
-        expect(page).to have_content("Press notice response has been successfully updated")
-
         within("#confirm-press-notice") do
-          expect(page).to have_content("In progress")
           click_link("Confirm press notice")
         end
 
         within("#published-at-field") do
           expect(page).to have_content("What date was the press notice published?")
+
+          # Defaults to Time.zone.today if this is not set
+          expect(page).to have_field("Day", with: "31")
+          expect(page).to have_field("Month", with: "10")
+          expect(page).to have_field("Year", with: "2023")
+
           fill_in "Day", with: "1"
           fill_in "Month", with: "1"
           fill_in "Year", with: "2023"
         end
 
         click_button "Save"
-        expect(page).to have_content("The date the press notice was published must be on or after the press sent date")
+        expect(page).to have_content("The date the press notice was published must be on or after the consultation start date")
 
         within("#published-at-field") do
           expect(page).to have_content("What date was the press notice published?")
@@ -532,15 +500,16 @@ RSpec.describe "Press notice" do
         expect(page).to have_content("The date the press notice was published must be on or before today")
 
         within("#published-at-field") do
-          expect(page).to have_content("What date was the press notice published?")
           fill_in "Day", with: "29"
           fill_in "Month", with: "9"
           fill_in "Year", with: "2023"
         end
 
         attach_file("Upload photo(s)", "spec/fixtures/images/proposed-floorplan.png")
+        fill_in "Optional comment", with: "Press notice comment"
 
         click_button "Save"
+        expect(page).to have_content("Press notice response has been successfully updated")
 
         within("#confirm-press-notice") do
           expect(page).to have_content("Complete")
@@ -556,7 +525,6 @@ RSpec.describe "Press notice" do
         end
 
         expect(PressNotice.last).to have_attributes(
-          press_sent_at: Time.zone.local(2023, 9, 25),
           published_at: Time.zone.local(2023, 9, 29),
           comment: "Press notice comment"
         )
@@ -570,12 +538,6 @@ RSpec.describe "Press notice" do
         it "I can confirm the press notice details and consultation period is extended by 30 days" do
           click_link "Consultees, neighbours and publicity"
           click_link "Confirm press notice"
-
-          within("#press-sent-at-field") do
-            fill_in "Day", with: "25"
-            fill_in "Month", with: "9"
-            fill_in "Year", with: "2023"
-          end
 
           within("#published-at-field") do
             fill_in "Day", with: "29"


### PR DESCRIPTION
### Description of change

Improve site and press notice

- Remove press sent at as there was no value in having this
- Prepopulate site notice displayed at and press notice published at with today's date if there is no saved value

### Story Link

https://trello.com/c/9H9vJbp2/2801-fill-the-frequent-tasks-more-quickly
https://trello.com/c/kFvahrcO/2735-clear-instruction-of-the-required-dates

