### PR TITLE
Drop category column from reporting_types table

### DIFF
--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class ReportingType < ApplicationRecord
-  self.ignored_columns += %w[category]
-
   with_options presence: true do
     validates :code, uniqueness: true
     validates :categories, :description

--- a/db/migrate/20240410165750_drop_category_from_reporting_type.rb
+++ b/db/migrate/20240410165750_drop_category_from_reporting_type.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class DropCategoryFromReportingType < ActiveRecord::Migration[7.1]
+  class ReportingType < ActiveRecord::Base; end
+
+  def up
+    safety_assured { remove_column :reporting_types, :category }
+  end
+
+  def down
+    add_column :reporting_types, :category, :string
+
+    ReportingType.reset_column_information
+
+    ReportingType.find_each do |type|
+      type.update!(category: type.categories.first)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_102618) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_165750) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -751,7 +751,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_102618) do
 
   create_table "reporting_types", force: :cascade do |t|
     t.string "code", null: false
-    t.string "category"
     t.string "description", null: false
     t.string "guidance"
     t.string "guidance_link"


### PR DESCRIPTION
IMPORTANT: Not to be merged and deployed until the new categories column has been deployed to production otherwise it will cause an error when running ECS tasks see the column disappear.
