### PR TITLE
Ignore the category column for future removal

### DIFF
--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReportingType < ApplicationRecord
+  self.ignored_columns += %w[category]
+
   with_options presence: true do
     validates :code, uniqueness: true
     validates :categories, :description


### PR DESCRIPTION
When the category column is dropped it will cause an error in Active Record for cached prepared statements. Where the query is outside a transaction it will automatically recover but inside the transaction it's in an state that can't be recovered so ignore the column ahead of removal to avoid a possible scenario where the reporting type is being created/updated at the same time as the database is migrated.
