### PR TITLE
Remove press_sent_at from press notice

### DIFF
--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -7,8 +7,6 @@ class PressNotice < ApplicationRecord
   include DateValidateable
   include Consultable
 
-  self.ignored_columns += %w[press_sent_at]
-
   REASONS = %i[
     conservation_area
     listed_building

--- a/db/migrate/20240411120100_remove_press_sent_at_from_press_notices.rb
+++ b/db/migrate/20240411120100_remove_press_sent_at_from_press_notices.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePressSentAtFromPressNotices < ActiveRecord::Migration[7.1]
+  def change
+    safety_assured { remove_column :press_notices, :press_sent_at, :datetime }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_165750) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_11_120100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -712,7 +712,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_165750) do
     t.boolean "required", null: false
     t.jsonb "reasons"
     t.datetime "requested_at"
-    t.datetime "press_sent_at"
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
### Description of change

- References removed in https://github.com/unboxed/bops/pull/1693. Must be deployed after this

