### PR TITLE
Improve check fee page

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -250,6 +250,7 @@ class PlanningApplicationsController < AuthenticationController
       proposal_details
       payment_reference
       payment_amount
+      valid_fee
       postcode
       public_comment
       received_at
@@ -294,7 +295,7 @@ class PlanningApplicationsController < AuthenticationController
   def redirect_update_url
     case params[:edit_action]&.to_sym
     when :edit_payment_amount
-      redirect_to planning_application_validation_fee_items_path(@planning_application),
+      redirect_to planning_application_validation_tasks_path(@planning_application),
         notice: t(".edit_payment_amount")
     when :edit_public_comment
       redirect_to planning_application_review_tasks_path(@planning_application),

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_show.html.erb
@@ -60,23 +60,22 @@
           <h2 class="govuk-heading-m">
             Confirm total fee paid
           </h2>
-          <p class="govuk-body">
-            Check any extra fee has been received and update the total fee now paid.
-          </p>
           <ul class="govuk-list govuk-list--bullet">
             <li>check that the correct fee has been received</li>
             <li>update the total fee paid</li>
+            <li>if the fee has been refunded, enter 0</li>
           </ul>
           <div class="govuk-input__wrapper">
             <div class="govuk-input__prefix" aria-hidden="true">£</div>
             <%= form.text_field :payment_amount, value: number_to_currency(@planning_application.payment_amount, unit: ""), class: "govuk-textarea govuk-input" %>
             <%= hidden_field_tag(:edit_action, "edit_payment_amount") %>
             <%= hidden_field_tag(:validation_request_id, @validation_request.id) %>
+            <%= form.hidden_field :valid_fee, value: true %>
           </div>
-        </div>
 
-        <%= render "shared/validation_request_show_actions",
-          planning_application: @planning_application, validation_request: @validation_request, form: form %>
+          <%= render "shared/validation_request_show_actions",
+            planning_application: @planning_application, validation_request: @validation_request, form: form, button_text: "Mark as valid" %>
+      </div>
       <% end %>
     <% else %>
       <% if @planning_application.invalidated? %>

--- a/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
+++ b/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table fee-table">
+<table class="govuk-table fee-table govuk-!-margin-bottom-2">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header"><%= t(".item") %></th>
@@ -29,3 +29,7 @@
     </tr>
   </tbody>
 </table>
+
+<div class="govuk-!-margin-bottom-8">
+  <%= link_to "Check application documents", planning_application_documents_path(@planning_application), class: "govuk-body govuk-link" %>
+</div>

--- a/app/views/shared/_validation_request_show_actions.html.erb
+++ b/app/views/shared/_validation_request_show_actions.html.erb
@@ -1,7 +1,7 @@
-<div class="govuk-button-group govuk-!-padding-top-8">
+<div class="govuk-button-group govuk-!-padding-top-2">
   <% if show_continue_link = validation_request.active_closed_fee_item? %>
     <% if form %>
-      <%= form.govuk_submit "Continue", class: "govuk-button" %>
+      <%= form.govuk_submit (button_text ? button_text : "Continue"), class: "govuk-button" %>
     <% else %>
       <%= link_to "Continue", planning_application_validation_fee_items_path(planning_application), class: "govuk-button" %>
     <% end %>

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -485,24 +485,17 @@ RSpec.describe "FeeItemsValidation" do
         end
 
         expect(page).to have_content("Confirm total fee paid")
-        expect(page).to have_content("Check any extra fee has been received and update the total fee now paid.")
         expect(page).to have_content("check that the correct fee has been received")
         expect(page).to have_content("update the total fee paid")
         expect(page).to have_field("planning_application[payment_amount]", with: "100.00")
 
         fill_in "planning_application[payment_amount]", with: "350.22"
-        click_button("Continue")
+        click_button("Mark as valid")
 
-        # Display fee item table
-        within(".fee-table") do
-          within(".govuk-table__head") do
-            expect(page).to have_content("Item")
-            expect(page).to have_content("Detail")
-          end
-          expect(page).to have_content("£350.22")
-        end
-        within(".govuk-fieldset") do
-          expect(page).to have_content("Is the fee valid?")
+        expect(page).to have_content "Planning application payment amount was successfully updated."
+
+        within("#fee-validation-task") do
+          expect(page).to have_content("Valid")
         end
 
         visit "/planning_applications/#{planning_application.id}/audits"


### PR DESCRIPTION
### Description of change

- improve content and links to make process of checking fee clearer to planning officer
- allow officer to make fee valid from applicant response page rather than having to click twice

### Story Link

https://trello.com/c/NsnrLgNn/2771-validate-fee-calculation-from-checking-applicant-response-page
https://trello.com/c/gMdJV9Sl/2761-reference-of-supporting-documents
