### PR TITLE
Use service name class to fix navbar spacing

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -9,10 +9,14 @@
           <span class="govuk-header__service-name">
             <%= current_local_authority.short_name %>
           </span>
+          <span class="govuk-header__product-name">
+            <%= t(".back_office_planning") %>
+          </span>
+        <% else %>
+          <span class="govuk-header__service-name">
+            <%= t(".back_office_planning") %>
+          </span>
         <% end %>
-        <span class="govuk-header__product-name">
-          <%= t(".back_office_planning") %>
-        </span>
       <% end %>
       <% if current_user.present? %>
         <div class="header-session-info">


### PR DESCRIPTION
### Description of change

On login page the header bottom padding is wrong because there's no service name element to set it. Once logged in it appears fine because of the name and 'log out' menu items. By using the service name instead of the product name it adds the correct bottom padding.

### Before

![image](https://github.com/unboxed/bops/assets/6321/826b75c6-22e6-494b-b818-98d95409409d)

### After

![image](https://github.com/unboxed/bops/assets/6321/d207b2bd-8262-463c-9150-aa61c035363c)