### PR TITLE
Install govuk-components gem for future use

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "devise"
 gem "devise-two-factor"
 gem "faker", require: false
 gem "faraday", "~> 2", require: false
+gem "govuk-components", "~> 5"
 gem "govuk_design_system_formbuilder"
 gem "grover"
 gem "i18n", "< 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,11 +261,15 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_design_system_formbuilder (3.3.0)
+    govuk-components (5.3.1)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (>= 6, < 8)
+      view_component (>= 3.9, < 3.12)
+    govuk_design_system_formbuilder (5.3.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
-      html-attributes-utils (~> 0.9, >= 0.9.2)
+      html-attributes-utils (~> 1)
     grover (1.1.7)
       combine_pdf (~> 1.0)
       nokogiri (~> 1.0)
@@ -289,7 +293,7 @@ GEM
     hana (1.3.7)
     hashdiff (1.1.0)
     highline (2.0.3)
-    html-attributes-utils (0.9.2)
+    html-attributes-utils (1.0.2)
       activesupport (>= 6.1.4.4)
     htmlentities (4.3.4)
     i18n (1.8.11)
@@ -602,7 +606,7 @@ GEM
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     uri (0.13.0)
-    view_component (3.12.0)
+    view_component (3.11.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
@@ -658,6 +662,7 @@ DEPENDENCIES
   faker
   faraday (~> 2)
   foreman
+  govuk-components (~> 5)
   govuk_design_system_formbuilder
   grover
   guard


### PR DESCRIPTION
### Description of change

This will allow us to use the GOV.UK design system components in ViewComponent form, which will be preferable in some cases.

### Story Link

<https://trello.com/c/emIN8osq/2818-review-how-we-use-components>
