### PR TITLE
Use if_not_exists when disabling ddl transaction

### DIFF
--- a/db/migrate/20240416155826_add_unique_validation_on_informative.rb
+++ b/db/migrate/20240416155826_add_unique_validation_on_informative.rb
@@ -4,7 +4,7 @@ class AddUniqueValidationOnInformative < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :informatives, [:title, :informative_set_id], unique: true, algorithm: :concurrently
-    add_index :informatives, [:text, :informative_set_id], unique: true, algorithm: :concurrently
+    add_index :informatives, [:title, :informative_set_id], unique: true, algorithm: :concurrently, if_not_exists: true
+    add_index :informatives, [:text, :informative_set_id], unique: true, algorithm: :concurrently, if_not_exists: true
   end
 end


### PR DESCRIPTION
### Description of change

The migration half ran, then failed, then when trying to run again the column already existed because of `disable_ddl_transaction!`