### PR TITLE
Use govuk_link helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Style/VisitLiteral:
 Style/NoFetchWithLiteralNilDefault:
   Enabled: true
 
+Style/UseGovukLinkHelper:
+  Enable: true
+
 # past migrations are ignored; we don't expect to go back and edit them ever,
 # we'll fix them in future migrations if at all.
 Rails/BulkChangeTable:

--- a/app/components/accordion_sections/application_information_component.html.erb
+++ b/app/components/accordion_sections/application_information_component.html.erb
@@ -1,8 +1,4 @@
-<%= link_to(
-  t(".edit_details"),
-  edit_planning_application_path(planning_application),
-  class: "govuk-link govuk-body"
-) %>
+<%= govuk_link_to t(".edit_details"), edit_planning_application_path(planning_application), class: "govuk-body" %>
 <hr>
 <table class="govuk-table">
   <tbody class="govuk-table__body">
@@ -12,11 +8,7 @@
       </td>
       <td class="govuk-table__cell">
         <%= render(FormattedContentComponent.new(text: planning_application.description)) %>
-        <%= link_to(
-          description_change_link_text,
-          description_change_link_path,
-          class: "govuk-link govuk-body"
-        ) %>
+        <%= govuk_link_to description_change_link_text, description_change_link_path, class: "govuk-body" %>
       </td>
     </tr>
     <% %i[type_and_work_status full_address].each do |attribute| %>
@@ -32,12 +24,10 @@
         <strong><%= t(".location") %></strong>
       </td>
       <td class="govuk-table__cell">
-        <%= link_to(
+        <%= govuk_link_to(
           t(".view_site_on"),
           map_link,
-          target: "_blank",
-          class: "govuk-link"
-        ) %>
+          target: "_blank") %>
       </td>
     </tr>
     <% if planning_application.parish_name.present? %>
@@ -55,12 +45,10 @@
       <td class="govuk-table__cell">
         <% if planning_application.postcode.present? %>
           <p class="govuk-body"><%= planning_application.ward %></p>
-          <%= link_to(
+          <%= govuk_link_to(
             t(".view_on_mapit"),
             mapit_link,
-            target: "_blank",
-            class: "govuk-link"
-          ) %>
+            target: "_blank") %>
         <% else %>
           <%= t(".a_postcode_is") %>
         <% end %>

--- a/app/components/accordion_sections/audit_log_component.html.erb
+++ b/app/components/accordion_sections/audit_log_component.html.erb
@@ -11,8 +11,4 @@
     ) %>
   </p>
 <% end %>
-<%= link_to(
-  t(".view_all_audits"),
-  planning_application_audits_path(planning_application),
-  class: "govuk-link govuk-body"
-) %>
+<%= govuk_link_to t(".view_all_audits"), planning_application_audits_path(planning_application), class: "govuk-body" %>

--- a/app/components/accordion_sections/notes_component.html.erb
+++ b/app/components/accordion_sections/notes_component.html.erb
@@ -2,8 +2,4 @@
   <%= render(FormattedContentComponent.new(text: first_note_entry)) %>
   <p class="govuk-body"><%= first_note.created_at.to_fs %></p>
 <% end %>
-<%= link_to(
-  link_text,
-  planning_application_notes_path(planning_application),
-  class: "govuk-link govuk-body"
-) %>
+<%= govuk_link_to link_text, planning_application_notes_path(planning_application), class: "govuk-body" %>

--- a/app/components/accordion_sections/site_map_component.html.erb
+++ b/app/components/accordion_sections/site_map_component.html.erb
@@ -1,10 +1,6 @@
 <% if planning_application.validated? %>
   <p class="govuk-body">
-    <%= link_to(
-      change_request_link_text,
-      change_request_link_path,
-      class: "govuk-link"
-    ) %>
+    <%= govuk_link_to change_request_link_text, change_request_link_path %>
   </p>
 <% end %>
 <% if planning_application.boundary_geojson.present? %>

--- a/app/components/evidence_groups/accordion_component.html.erb
+++ b/app/components/evidence_groups/accordion_component.html.erb
@@ -55,11 +55,11 @@
                     label: { text: "List all the gap(s) in time" },
                     disabled: !editable
                   ) %>
-                  <%= link_to(
+                  <%= govuk_link_to(
                     "Request a new document",
                     new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"),
                     role: "button",
-                    class: "govuk-link govuk-!-margin-top-",
+                    class: "govuk-!-margin-top-",
                     data: { module: "govuk-button" },
                     disabled: !editable
                   ) %>
@@ -112,7 +112,7 @@
 </div>
 
 <div class="govuk-button-group">
-  <% if editable  %>
+  <% if editable %>
     <%= form_with model: [@planning_application, :assessment, @planning_application.immunity_detail] do |form| %>
       <div class="govuk-button-group">
         <%= form.submit(
@@ -134,6 +134,6 @@
   <%= back_link %>
 
   <% if !editable %>
-    <%= link_to "Edit evidence of immunity", edit_planning_application_assessment_immunity_detail_path(@planning_application, @planning_application.immunity_detail), class: "govuk-link" %>
+    <%= govuk_link_to "Edit evidence of immunity", edit_planning_application_assessment_immunity_detail_path(@planning_application, @planning_application.immunity_detail) %>
   <% end %>
 </div>

--- a/app/components/evidence_groups/documents_component.html.erb
+++ b/app/components/evidence_groups/documents_component.html.erb
@@ -16,9 +16,9 @@
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-bottom-6">
           <%= link_to "View document", url_for_document(document), target: :_new %><br>
-          <%= link_to "Edit", edit_planning_application_document_path(document.planning_application, document), class: "govuk-link" %><br>
-          <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
-          <%= link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: document.planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
+          <%= govuk_link_to "Edit", edit_planning_application_document_path(document.planning_application, document) %><br>
+          <%= govuk_link_to "Archive", planning_application_document_archive_path(document_id: document.id) %><br>
+          <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: document.planning_application.id, document: document, type: "replacement_document") %>
         </div>
       </div>
     <% end %>

--- a/app/components/planning_applications/assessment/policy_classes/summary_component.html.erb
+++ b/app/components/planning_applications/assessment/policy_classes/summary_component.html.erb
@@ -1,9 +1,5 @@
 <h4 class="govuk-body policy-class-title">
-  <%= link_to(
-        t(".policy_class_name", part: part, class: section, name: name),
-        default_path,
-        class: "govuk-link"
-      ) %>
+  <%= govuk_link_to t(".policy_class_name", part: part, class: section, name: name), default_path %>
 </h4>
 <p class="govuk-body"><strong><%= policies_summary %></strong></p>
 <% if policies.to_be_determined.none? %>

--- a/app/components/planning_applications/immunity_details_assessment_component.html.erb
+++ b/app/components/planning_applications/immunity_details_assessment_component.html.erb
@@ -25,9 +25,7 @@
     <% for evidence_group in evidence_groups %>
     <div class="display-flex align-items-center">
       <h3 class="govuk-heading-s">
-        <%= link_to sanitize("#{evidence_group.name} (#{evidence_group.documents.count})<br>#{evidence_group.date_range}"),
-                    new_planning_application_assessment_immunity_detail_path(planning_application) + "#accordion-default-heading-#{evidence_group.id}",
-                    class: "govuk-link govuk-link--no-underline" %>
+        <%= govuk_link_to sanitize("#{evidence_group.name} (#{evidence_group.documents.count})<br>#{evidence_group.date_range}"), new_planning_application_assessment_immunity_detail_path(planning_application) + "#accordion-default-heading-#{evidence_group.id}", class: "govuk-link--no-underline" %>
       </h3>
       <% if evidence_group.missing_evidence? %>
         <div class="govuk-warning-text govuk-!-margin-left-6 govuk-!-margin-top-2">

--- a/app/components/proposal_details/link_component.html.erb
+++ b/app/components/proposal_details/link_component.html.erb
@@ -2,5 +2,5 @@
   "li",
   data: { show_hide_target: ("toggleable" if auto_answered?) }
 ) do %>
-  <%= link_to(title, "##{id}", class: "govuk-link") %>
+  <%= govuk_link_to title, "##{id}" %>
 <% end %>

--- a/app/components/reviewing/policy_class/link_component.html.erb
+++ b/app/components/reviewing/policy_class/link_component.html.erb
@@ -1,5 +1,4 @@
-<%= link_to(
+<%= govuk_link_to(
       link_text,
       link_path,
-      aria: { describedby: link_text },
-      class: "govuk-link") %>
+      aria: { describedby: link_text }) %>

--- a/app/components/reviewing/policy_class/navigation_component.html.erb
+++ b/app/components/reviewing/policy_class/navigation_component.html.erb
@@ -1,18 +1,10 @@
 <% if multiple_policy_classes? %>
   <div class="policy-class-scroll-links">
     <% if @policy_class.previous.present? %>
-      <%= link_to(
-            t(".view_previous_class"),
-            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.previous),
-            class: "govuk-link"
-          ) %>
+      <%= govuk_link_to t(".view_previous_class"), edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.previous) %>
     <% end %>
     <% if @policy_class.next.present? %>
-      <%= link_to(
-            t(".view_next_class"),
-            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.next),
-            class: "govuk-link next-policy-class-link"
-          ) %>
+      <%= govuk_link_to t(".view_next_class"), edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class.next), class: "next-policy-class-link" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/devise/sessions/two_factor.html.erb
+++ b/app/views/devise/sessions/two_factor.html.erb
@@ -17,7 +17,7 @@
         <%= form.label :otp_attempt, class: "govuk-label" %>
         <%= form.text_field :otp_attempt, class: "govuk-textarea govuk-input" %>
 
-        <%= link_to "Resend code", resend_code_path, class: "govuk-link" %>
+        <%= govuk_link_to "Resend code", resend_code_path %>
 
         <% if @user.local_authority %>
           <p class="govuk-phase-banner__content govuk-!-padding-top-3 govuk-!-padding-bottom-3">

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,15 +3,15 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "govuk-link" %><br />
+  <%= govuk_link_to "Forgot your password?", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "govuk-link" %><br />
+  <%= govuk_link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), class: "govuk-link" %><br />
+    <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
   <% end %>
 <% end %>

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -25,9 +25,9 @@
             <% if @planning_application.can_validate? %>
               <% if document.representable? %>
                 <p class="govuk-body govuk-!-margin-right-2" style="text-align:right">
-                  <%= link_to "Edit", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %><br>
-                  <%= link_to "Archive", planning_application_document_archive_path(document_id: document.id), class: "govuk-link" %><br>
-                  <%= link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: @planning_application.id, document: document, type: "replacement_document"), class: "govuk-link" %>
+                  <%= govuk_link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br>
+                  <%= govuk_link_to "Archive", planning_application_document_archive_path(document_id: document.id) %><br>
+                  <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: @planning_application.id, document: document, type: "replacement_document") %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -2,34 +2,20 @@
   <%= link_to image_tag(document.file.representation(resize: resize), style: "max-width:100%"),
       url_for_document(document), target: :_blank %>
   <p class="govuk-body">
-    <%= link_to(
+    <%= govuk_link_to(
       t(".view_in_new"),
       url_for_document(document),
-      target: :_blank,
-      class: "govuk-link"
-    ) %>
+      target: :_blank) %>
   </p>
   <% if edit_and_archive %>
     <p class="govuk-body">
-      <%= link_to(
-        t(".edit"),
-        edit_planning_application_document_path(planning_application, document),
-        class: "govuk-link"
-      ) %>
+      <%= govuk_link_to t(".edit"), edit_planning_application_document_path(planning_application, document) %>
     </p>
     <p class="govuk-body">
-      <%= link_to(
-        t(".archive"),
-        planning_application_document_archive_path(planning_application, document),
-        class: "govuk-link"
-      ) %>
+      <%= govuk_link_to t(".archive"), planning_application_document_archive_path(planning_application, document) %>
     </p>
     <p class="govuk-body">
-      <%= link_to(
-        "Request replacement",
-        new_planning_application_validation_validation_request_path(planning_application_id: planning_application.id, document: document, type: "replacement_document"),
-        class: "govuk-link"
-      ) %>
+      <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: planning_application.id, document: document, type: "replacement_document") %>
     </p>
   <% end %>
 <% else %>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -37,11 +37,11 @@
         url_for_document(@document),
         target: "_blank"
       ) %>
-      <%= link_to(
+      <%= govuk_link_to(
         t(".view_in_new"),
         url_for_document(@document),
         target: "_new",
-        class: "govuk-link govuk-body"
+        class: "govuk-body"
       ) %>
     <% end %>
   </div>
@@ -57,7 +57,7 @@
     <% if @replacement_document_validation_request %>
       <p class="govuk-body govuk-!-margin-bottom-0">
         <strong>This document replaced:</strong>
-        <%= link_to @replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, @replacement_document_validation_request.old_document), target: :_new, class: "govuk-link" %>
+        <%= govuk_link_to @replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, @replacement_document_validation_request.old_document), target: :_new %>
       </p>
 
       <p class="govuk-body govuk-!-margin-bottom-0">
@@ -80,7 +80,7 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= created_by(@document)  %>
+      <%= created_by(@document) %>
     </p>
   </div>
   <div class="govuk-grid-column-full">

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -195,5 +195,5 @@
   <% end %>
 </div>
 <p class="govuk-body">
-  <%= link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf'), class: "govuk-link" %>
+  <%= govuk_link_to "Download as PDF", decision_notice_api_v1_planning_application_path(@planning_application, format: 'pdf') %>
 </p>

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -18,9 +18,9 @@
     <% else %>
       <p class="govuk-body">
         <% if @planning_application.description_change_validation_requests.open.any? %>
-          <%= link_to "View requested change", planning_application_validation_validation_request_path(@planning_application, @planning_application.description_change_validation_request.id), class: "govuk-link" %>
+          <%= govuk_link_to "View requested change", planning_application_validation_validation_request_path(@planning_application, @planning_application.description_change_validation_request.id) %>
         <% elsif !@planning_application.closed_or_cancelled? %>
-          <%= link_to "Propose a change to the description", new_planning_application_validation_validation_request_path(@planning_application, type: "description_change"), class: "govuk-link" %>
+          <%= govuk_link_to "Propose a change to the description", new_planning_application_validation_validation_request_path(@planning_application, type: "description_change") %>
         <% end %>
       </p>
 

--- a/app/views/planning_applications/_submit_recommendation_accordion.html.erb
+++ b/app/views/planning_applications/_submit_recommendation_accordion.html.erb
@@ -13,14 +13,14 @@
           planning_application: planning_application
         )
       ) %>
-      <%= link_to(
+      <%= govuk_link_to(
         t(".download_assessment_report"),
         planning_application_assessment_report_download_path(
           planning_application,
           format: "pdf"
         ),
         target: "_blank",
-        class: "govuk-body govuk-link"
+        class: "govuk-body"
       ) %>
     </div>
   </div>

--- a/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/show.html.erb
+++ b/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/show.html.erb
@@ -22,11 +22,7 @@
 
       <% if @review_immunity_detail.reviewed_at.nil? %>
         <div class="govuk-button-group govuk-!-padding-top-5">
-          <%= link_to(
-            "Edit immunity/permitted development rights",
-            edit_planning_application_assessment_assess_immunity_detail_permitted_development_right_path(@planning_application),
-            class: "govuk-link"
-          ) %>
+          <%= govuk_link_to "Edit immunity/permitted development rights", edit_planning_application_assessment_assess_immunity_detail_permitted_development_right_path(@planning_application) %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/planning_applications/assessment/assessment_details/additional_evidence/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/additional_evidence/show.html.erb
@@ -21,7 +21,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/amenity/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/amenity/show.html.erb
@@ -19,7 +19,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
@@ -17,23 +17,23 @@
       <% if @site_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @site_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".confirm_site_notice"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".confirm_site_notice"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %>
         </p>
       <% end %>
       <% if @press_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @press_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".confirm_press_notice"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".confirm_press_notice"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% end %>
     </div>
@@ -51,7 +51,7 @@
       <% if @site_notice.nil? %>
         <p class="govuk-body">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @site_notice.required? %>
         <table class="govuk-table">
@@ -86,8 +86,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -100,7 +100,7 @@
         <% else %>
           <p class="govuk-body">
             <%= t(".no_documents_uploaded") %><br>
-            <%= link_to(t(".upload_evidence"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+            <%= govuk_link_to t(".upload_evidence"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state govuk-body-s" %>
           </p>
         <% end %>
 
@@ -117,7 +117,7 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".site_notice_not_required") %><br>
-          <%= link_to(t(".mark_site_notice_as_required"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+          <%= govuk_link_to t(".mark_site_notice_as_required"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
         </p>
       <% end %>
     </div>
@@ -130,7 +130,7 @@
       <% if @press_notice.nil? %>
         <p class="govuk-body">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @press_notice.required? %>
         <table class="govuk-table">
@@ -167,8 +167,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"),planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -181,7 +181,7 @@
         <% else %>
           <p class="govuk-body">
             <%= t(".no_documents_uploaded") %><br>
-            <%= link_to(t(".upload_evidence"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+            <%= govuk_link_to t(".upload_evidence"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
           </p>
         <% end %>
 
@@ -198,7 +198,7 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".press_notice_not_required") %><br>
-          <%= link_to(t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+          <%= govuk_link_to t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
         </p>
       <% end %>
     </div>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
@@ -17,23 +17,23 @@
       <% if @site_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @site_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".confirm_site_notice"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".confirm_site_notice"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %>
         </p>
       <% end %>
       <% if @press_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @press_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".confirm_press_notice"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".confirm_press_notice"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% end %>
     </div>
@@ -51,7 +51,7 @@
       <% if @site_notice.nil? %>
         <p class="govuk-body">
           <%= t(".site_notice_incomplete") %>
-          <%= link_to(t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @site_notice.required? %>
         <table class="govuk-table">
@@ -86,8 +86,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -100,7 +100,7 @@
         <% else %>
           <p class="govuk-body">
             <%= t(".no_documents_uploaded") %><br>
-            <%= link_to(t(".upload_evidence"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+            <%= govuk_link_to t(".upload_evidence"), edit_planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state govuk-body-s" %>
           </p>
         <% end %>
 
@@ -116,7 +116,7 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".site_notice_not_required") %><br>
-          <%= link_to(t(".mark_site_notice_as_required"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+          <%= govuk_link_to t(".mark_site_notice_as_required"), new_planning_application_site_notice_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
         </p>
       <% end %>
     </div>
@@ -129,7 +129,7 @@
       <% if @press_notice.nil? %>
         <p class="govuk-body">
           <%= t(".press_notice_incomplete") %>
-          <%= link_to(t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %>
+          <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state" %>
         </p>
       <% elsif @press_notice.required? %>
         <table class="govuk-table">
@@ -166,8 +166,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"),planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -180,7 +180,7 @@
         <% else %>
           <p class="govuk-body">
             <%= t(".no_documents_uploaded") %><br>
-            <%= link_to(t(".upload_evidence"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+            <%= govuk_link_to t(".upload_evidence"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
           </p>
         <% end %>
 
@@ -196,7 +196,7 @@
       <% else %>
         <p class="govuk-body">
           <%= t(".press_notice_not_required") %><br>
-          <%= link_to(t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link govuk-link--no-visited-state govuk-body-s") %>
+          <%= govuk_link_to t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), class: "govuk-link--no-visited-state govuk-body-s" %>
         </p>
       <% end %>
     </div>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
@@ -50,8 +50,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -117,8 +117,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"),planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -142,7 +142,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/consultation_summary/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/consultation_summary/show.html.erb
@@ -44,7 +44,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/neighbour_summary/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/neighbour_summary/show.html.erb
@@ -23,7 +23,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/past_applications/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/past_applications/show.html.erb
@@ -23,7 +23,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/site_description/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/site_description/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      <%= link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank", class: "govuk-link" %>
+      <%= govuk_link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank" %>
     </p>
 
     <h2 class="govuk-heading-m"><%= t(".heading") %></h2>

--- a/app/views/planning_applications/assessment/assessment_details/site_description/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/site_description/new.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      <%= link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank", class: "govuk-link" %>
+      <%= govuk_link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank" %>
     </p>
 
     <h2 class="govuk-heading-m"><%= t(".heading") %></h2>

--- a/app/views/planning_applications/assessment/assessment_details/site_description/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/site_description/show.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">
-      <%= link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank", class: "govuk-link" %>
+      <%= govuk_link_to t(".view_site_on_map"), map_link(@planning_application.full_address), target: "_blank" %>
     </p>
 
     <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
@@ -23,7 +23,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_work/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_work/show.html.erb
@@ -19,7 +19,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category], class: "govuk-link") %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -40,14 +40,13 @@
           <%= fields.hidden_field :reason_source, value: fields.object.reason, data: {reset_text_target: "source"} %>
           <%= fields.govuk_text_area :reason, label: { text: "Enter a reason for this condition" }, data: {reset_text_target: "destination"} %>
           <%= button_tag "Reset reason", type: "button", class: "button-as-link govuk-!-margin-bottom-6", value: "reason", data: {action: "click->reset-text#reset"} %><br>
-          <%= link_to "Remove condition", "#", class: "govuk-body govuk-link", data: { action: "click->conditions#removeCondition" } %>
+          <%= govuk_link_to "Remove condition", "#", class: "govuk-body", data: { action: "click->conditions#removeCondition" } %>
         <% end %>
       <% end %>
     </div>
 
-    <%= link_to "+ Add condition", "#", class: "govuk-body govuk-link", data: { action: "click->conditions#addCondition" } %>
+    <%= govuk_link_to "+ Add condition", "#", class: "govuk-body", data: { action: "click->conditions#addCondition" } %>
   </div>
-
 
   <template id="condition-template" data-conditions-target="template">
     <div class="condition govuk-!-margin-bottom-5">

--- a/app/views/planning_applications/assessment/consistency_checklists/_additional_document_validation_request.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_additional_document_validation_request.html.erb
@@ -8,23 +8,15 @@
   <% elsif request.additional_documents.any? %>
     <% document = request.additional_documents.last %>
     <%= t(".responded", time: document.created_at.to_fs) %><br>
-    <%= link_to(
-      t(".view_new_document"),
-      planning_application_documents_path(
+    <%= govuk_link_to t(".view_new_document"), planning_application_documents_path(
         planning_application,
         anchor: dom_id(document)
-      ),
-      class: "govuk-link"
-    ) %>
+      ) %>
   <% end %>
 </p>
 <% if request.open? %>
-  <%= link_to(
-    t(".view_and_edit"),
-    planning_application_documents_path(
+  <%= govuk_link_to t(".view_and_edit"), planning_application_documents_path(
       planning_application,
       anchor: dom_id(request)
-    ),
-    class: "govuk-link"
-  ) %>
+    ) %>
 <% end %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_description_change_validation_request.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_description_change_validation_request.html.erb
@@ -12,14 +12,10 @@
     <% end %>
   </p>
   <% if request.open? %>
-    <%= link_to(
-      t(".view_and_edit"),
-      planning_application_validation_description_change_validation_request_path(
+    <%= govuk_link_to t(".view_and_edit"), planning_application_validation_description_change_validation_request_path(
         planning_application,
         request,
         consistency_checklist: true
-      ),
-      class: "govuk-link"
-    ) %>
+      ) %>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_description_matches_documents.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_description_matches_documents.html.erb
@@ -17,14 +17,10 @@
       checked: form.object.default_description_matches_documents_to_no?
     ) do %>
       <% unless form.object.open_description_change_requests? %>
-        <%= link_to(
-          t(".request_description_change"),
-          new_planning_application_validation_validation_request_path(
+        <%= govuk_link_to t(".request_description_change"), new_planning_application_validation_validation_request_path(
             planning_application,
             type: "description_change"
-          ),
-          class: "govuk-link"
-        ) %>
+          ) %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_documents_consistent.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_documents_consistent.html.erb
@@ -16,14 +16,10 @@
       label: { text: t(".no") },
       checked: form.object.default_documents_consistent_to_no?
     ) do %>
-      <%= link_to(
-        t(".request_additional_document"),
-        new_planning_application_validation_validation_request_path(
+      <%= govuk_link_to t(".request_additional_document"), new_planning_application_validation_validation_request_path(
           planning_application,
           type: "additional_document"
-        ),
-        class: "govuk-link"
-      ) %>
+        ) %>
     <% end %>
   <% else %>
     <%= form.govuk_radio_button(

--- a/app/views/planning_applications/assessment/consistency_checklists/_form.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_form.html.erb
@@ -20,11 +20,7 @@
   <% else %>
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(
-        t(".edit_check_description"),
-        edit_planning_application_assessment_consistency_checklist_path(planning_application),
-        class: "govuk-link"
-      ) %>
+      <%= govuk_link_to t(".edit_check_description"), edit_planning_application_assessment_consistency_checklist_path(planning_application) %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_red_line_boundary_change_validation_request.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_red_line_boundary_change_validation_request.html.erb
@@ -12,13 +12,9 @@
     <% end %>
   </p>
   <% if request.open? %>
-    <%= link_to(
-      t(".view_and_edit"),
-      planning_application_validation_red_line_boundary_change_validation_request_path(
+    <%= govuk_link_to t(".view_and_edit"), planning_application_validation_red_line_boundary_change_validation_request_path(
         planning_application,
         request
-      ),
-      class: "govuk-link"
-    ) %>
+      ) %>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
@@ -17,14 +17,10 @@
       checked: form.object.default_site_map_correct_to_no?
     ) do %>
       <% unless form.object.open_red_line_boundary_change_requests? %>
-        <%= link_to(
-          t(".request_red_line_boundary_change"),
-          new_planning_application_validation_validation_request_path(
+        <%= govuk_link_to t(".request_red_line_boundary_change"), new_planning_application_validation_validation_request_path(
             planning_application,
             type: "red_line_boundary_change"
-          ),
-          class: "govuk-link"
-        ) %>
+          ) %>
       <% end %>
     <% end %>
   <% else %>

--- a/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
@@ -30,12 +30,12 @@
           <%= fields.hidden_field :id %>
           <%= fields.govuk_text_field :title, label: { text: "Enter a title" }, data: {reset_text_target: "destination"}, disabled: fields.object&.current_validation_request&.open? %>
           <%= fields.govuk_text_area :text, label: { text: "Enter detail" }, data: {reset_text_target: "destination"}, disabled: fields.object&.current_validation_request&.open? %>
-          <%= link_to "Remove term", "#", class: "govuk-body govuk-link", data: { action: "click->heads-of-terms#removeTerm" } %>
+          <%= govuk_link_to "Remove term", "#", class: "govuk-body", data: { action: "click->heads-of-terms#removeTerm" } %>
         <% end %>
       <% end %>
     </div>
 
-    <%= link_to "+ Add term", "#", class: "govuk-body govuk-link", data: { action: "click->heads-of-terms#addTerm" } %>
+    <%= govuk_link_to "+ Add term", "#", class: "govuk-body", data: { action: "click->heads-of-terms#addTerm" } %>
   </div>
 
   <template id="heads-of-term-template" data-heads-of-terms-target="template">

--- a/app/views/planning_applications/assessment/heads_of_terms/_heads_of_terms.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/_heads_of_terms.html.erb
@@ -73,7 +73,7 @@
       <% end %>
     </tbody>
   </table>
-  <%= link_to "+ Add heads of terms", new_planning_application_assessment_heads_of_term_path(@planning_application.id), class: "govuk-body govuk-link" %>
+  <%= govuk_link_to "+ Add heads of terms", new_planning_application_assessment_heads_of_term_path(@planning_application.id), class: "govuk-body" %>
 
   <p class="govuk-body govuk-!-margin-top-5">
     Updated heads of terms will be sent to the applicant immediately

--- a/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
@@ -33,7 +33,7 @@
                 <%= fields.hidden_field :id %>
                 <%= fields.govuk_text_field :title, label: { text: "Enter a title" } %>
                 <%= fields.govuk_text_area :text, label: { text: "Enter detail" } %>
-                <%= link_to "Remove term", "#", class: "govuk-body govuk-link" %>
+                <%= govuk_link_to "Remove term", "#", class: "govuk-body" %>
               <% end %>
             <% end %>
           </div>

--- a/app/views/planning_applications/assessment/informatives/index.html.erb
+++ b/app/views/planning_applications/assessment/informatives/index.html.erb
@@ -26,8 +26,8 @@
           <%= informative.title %>
         </h2>
         <%= render(FormattedContentComponent.new(text: informative.text)) %>
-        <%= link_to "Edit", edit_planning_application_assessment_informative_path(@planning_application, informative), class: "govuk-link" %>
-        <%= link_to "Remove", planning_application_assessment_informative_path(@planning_application, informative), method: :delete, class: "govuk-link" %>
+        <%= govuk_link_to "Edit", edit_planning_application_assessment_informative_path(@planning_application, informative) %>
+        <%= govuk_link_to "Remove", planning_application_assessment_informative_path(@planning_application, informative), method: :delete %>
       <% end %>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
     <% else %>
@@ -35,7 +35,7 @@
     <% end %>
 
     <% if @informative_set.current_review&.complete? && params[:show_form] != "true" %>
-      <%= link_to "+ Add informative", planning_application_assessment_informatives_path(@planning_application, show_form: true), class: "govuk-link govuk-body" %>
+      <%= govuk_link_to "+ Add informative", planning_application_assessment_informatives_path(@planning_application, show_form: true), class: "govuk-body" %>
     <% end %>
 
     <div class="govuk-!-margin-top-8">

--- a/app/views/planning_applications/assessment/local_policies/edit.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/edit.html.erb
@@ -18,7 +18,7 @@
 
 <%= render "table" %>
 
-<%= link_to "+ Add new consideration", new_planning_application_assessment_local_policy_area_path(@planning_application), class: "govuk-link govuk-body" %>
+<%= govuk_link_to "+ Add new consideration", new_planning_application_assessment_local_policy_area_path(@planning_application), class: "govuk-body" %>
 
 <div class="govuk-button-group govuk-!-margin-top-6">
   <%= form_with(

--- a/app/views/planning_applications/assessment/local_policies/new.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/new.html.erb
@@ -14,11 +14,11 @@
       locals: { heading: "Assess against policies and guidance" }
     ) %>
 
-<%= link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-link govuk-body govuk-!-margin-top-6" %>
+<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body govuk-!-margin-top-6" %>
 
 <%= render "table" %>
 
 <div class="govuk-button-group">
   <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-  <%= link_to "Add new consideration", new_planning_application_assessment_local_policy_area_path(@planning_application, @local_policy), class: "govuk-link govuk-body", class: "govuk-button govuk-button--primary" %>
+  <%= link_to "Add new consideration", new_planning_application_assessment_local_policy_area_path(@planning_application, @local_policy), class: "govuk-button govuk-button--primary" %>
 </div>

--- a/app/views/planning_applications/assessment/local_policies/show.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/show.html.erb
@@ -14,7 +14,7 @@
       locals: { heading: "Assess against policies and guidance" }
     ) %>
 
-<%= link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-link govuk-body" %>
+<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
 
 <%= render "comment" %>
 
@@ -31,6 +31,5 @@
 
 <div class="govuk-button-group">
   <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-  <%= link_to "Edit considerations", edit_planning_application_assessment_local_policy_path(@planning_application, @local_policy), class: "govuk-link govuk-body" %>
+  <%= govuk_link_to "Edit considerations", edit_planning_application_assessment_local_policy_path(@planning_application, @local_policy), class: "govuk-body" %>
 </div>
-

--- a/app/views/planning_applications/assessment/local_policy_areas/edit.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/edit.html.erb
@@ -14,6 +14,6 @@
       locals: { heading: "Update consideration: #{@local_policy_area.area}" }
     ) %>
 
-<%= link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-link govuk-body" %>
+<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
 
 <%= render "edit_form" %>

--- a/app/views/planning_applications/assessment/local_policy_areas/new.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/new.html.erb
@@ -14,6 +14,6 @@
       locals: { heading: "Add new consideration" }
     ) %>
 
-<%= link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-link govuk-body" %>
+<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
 
 <%= render "form" %>

--- a/app/views/planning_applications/assessment/local_policy_areas/show.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/show.html.erb
@@ -25,6 +25,6 @@
 
 <div class="govuk-button-group">
   <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-  <%= link_to "Edit consideration", edit_planning_application_assessment_local_policy_area_path(@planning_application, @local_policy_area), class: "govuk-link govuk-body" %>
+  <%= govuk_link_to "Edit consideration", edit_planning_application_assessment_local_policy_area_path(@planning_application, @local_policy_area), class: "govuk-body" %>
 </div>
 

--- a/app/views/planning_applications/assessment/ownership_certificates/show.html.erb
+++ b/app/views/planning_applications/assessment/ownership_certificates/show.html.erb
@@ -32,7 +32,7 @@
 
     <div class="govuk-button-group">
       <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-      <%= link_to "Edit ownership certificate", edit_planning_application_assessment_ownership_certificate_path(@planning_application), class: "govuk-body govuk-link" %>
+      <%= govuk_link_to "Edit ownership certificate", edit_planning_application_assessment_ownership_certificate_path(@planning_application), class: "govuk-body" %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/assessment/permitted_development_rights/_planning_history.html.erb
+++ b/app/views/planning_applications/assessment/permitted_development_rights/_planning_history.html.erb
@@ -8,13 +8,13 @@
       <ul class="govuk-list">
         <li><p><strong><%= past_application.additional_information %></strong></p></li>
         <li><p><%= past_application.entry %><p></li>
-        <%= link_to "Edit history", edit_planning_application_assessment_assessment_detail_path(@planning_application, past_application), class: "govuk-link govuk-body" %>
+        <%= govuk_link_to "Edit history", edit_planning_application_assessment_assessment_detail_path(@planning_application, past_application), class: "govuk-body" %>
       </ul>
     <% else %>
       <p class="govuk-body">
         There is no relevant planning history
       </p>
-      <%= link_to "Edit history", new_planning_application_assessment_assessment_detail_path(@planning_application, category: "past_applications"), class: "govuk-link govuk-body" %>
+      <%= govuk_link_to "Edit history", new_planning_application_assessment_assessment_detail_path(@planning_application, category: "past_applications"), class: "govuk-body" %>
     <% end %>
   </div>
 </section>

--- a/app/views/planning_applications/assessment/permitted_development_rights/show.html.erb
+++ b/app/views/planning_applications/assessment/permitted_development_rights/show.html.erb
@@ -34,11 +34,7 @@
       <%= back_link %>
 
       <% unless @permitted_development_right.accepted %>
-        <%= link_to(
-          "Edit permitted development rights",
-          edit_planning_application_assessment_permitted_development_right_path(@planning_application),
-          class: "govuk-link"
-        ) %>
+        <%= govuk_link_to "Edit permitted development rights", edit_planning_application_assessment_permitted_development_right_path(@planning_application) %>
       <% end %>
     </div>
   </div>

--- a/app/views/planning_applications/assessment/planning_histories/_table.html.erb
+++ b/app/views/planning_applications/assessment/planning_histories/_table.html.erb
@@ -35,7 +35,7 @@
           <%= planning_application["decision"] %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to "View", planning_application["view_documents"] , class: "govuk-link" %>
+          <%= govuk_link_to "View", planning_application["view_documents"] %>
         </td>
       </tr>
     <% end %>

--- a/app/views/planning_applications/assessment/policy_classes/_controls.html.erb
+++ b/app/views/planning_applications/assessment/policy_classes/_controls.html.erb
@@ -1,29 +1,17 @@
 <% if planning_application.multiple_policy_classes? %>
   <div class="policy-class-scroll-links">
     <% if policy_class.previous.present? %>
-      <%= link_to(
-        t(".view_previous_class"),
-        policy_class.previous.default_path,
-        class: "govuk-link"
-      ) %>
+      <%= govuk_link_to t(".view_previous_class"), policy_class.previous.default_path %>
     <% end %>
     <% if policy_class.next.present? %>
-      <%= link_to(
-        t(".view_next_class"),
-        policy_class.next.default_path,
-        class: "govuk-link next-policy-class-link"
-      ) %>
+      <%= govuk_link_to t(".view_next_class"), policy_class.next.default_path, class: "next-policy-class-link" %>
     <% end %>
   </div>
 <% end %>
 <div class="govuk-button-group">
   <%= back_link %>
-  <%= link_to(
-    t(".edit_assessment"),
-    edit_planning_application_assessment_policy_class_path(
+  <%= govuk_link_to t(".edit_assessment"), edit_planning_application_assessment_policy_class_path(
       planning_application,
       policy_class
-    ),
-    class: "govuk-link"
-  ) %>
+    ) %>
 </div>

--- a/app/views/planning_applications/assessment/policy_classes/_form_controls.html.erb
+++ b/app/views/planning_applications/assessment/policy_classes/_form_controls.html.erb
@@ -2,11 +2,7 @@
   <div class="policy-class-scroll-links">
     <% if policy_class.previous.present? %>
       <% if planning_application.assessment_complete? %>
-        <%= link_to(
-          t(".view_previous_class"),
-          policy_class.previous.default_path,
-          class: "govuk-link"
-        ) %>
+        <%= govuk_link_to t(".view_previous_class"), policy_class.previous.default_path %>
       <% else %>
         <%= form.submit(
           t(".save_changes_and_view_previous"),
@@ -16,11 +12,7 @@
     <% end %>
     <% if policy_class.next.present? %>
       <% if planning_application.assessment_complete? %>
-        <%= link_to(
-          t(".view_next_class"),
-          policy_class.next.default_path,
-          class: "govuk-link next-policy-class-link"
-        ) %>
+        <%= govuk_link_to t(".view_next_class"), policy_class.next.default_path, class: "next-policy-class-link" %>
       <% else %>
         <%= form.submit(
           t(".save_changes_and_view_next"),

--- a/app/views/planning_applications/assessment/policy_classes/_summary.html.erb
+++ b/app/views/planning_applications/assessment/policy_classes/_summary.html.erb
@@ -47,10 +47,9 @@
         class: policy_class.section
       ) %>
     <p class="govuk-body">
-      <%= link_to(
+      <%= govuk_link_to(
         t(".open_legislation_in"),
         policy_class.url,
-        class: "govuk-link",
         target: "_blank"
       ) %>
     </p>

--- a/app/views/planning_applications/assessment/policy_classes/new.html.erb
+++ b/app/views/planning_applications/assessment/policy_classes/new.html.erb
@@ -31,11 +31,10 @@
             </p>
 
             <p class="govuk-body">
-              <%= 
-                link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
-                "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made", 
-                class: "govuk-link", 
-                target: "_blank" 
+              <%=
+                govuk_link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
+                "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made",
+                target: "_blank"
               %>
             </p>
           </div>

--- a/app/views/planning_applications/assessment/policy_classes/part.html.erb
+++ b/app/views/planning_applications/assessment/policy_classes/part.html.erb
@@ -26,16 +26,15 @@
           <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
             <p class="govuk-body">
               Select the relevant part of the legislation for your assessment.
-              Parts are defined in The Town and Country Planning 
+              Parts are defined in The Town and Country Planning
               (General Permitted Development) (England) Order 2015
               (GPDO), Schedule 2.
             </p>
             <p class="govuk-body">
-              <%= 
-                link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
-                "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made", 
-                class: "govuk-link", 
-                target: "_blank" 
+              <%=
+                govuk_link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
+                "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made",
+                target: "_blank"
               %>
             </p>
           </legend>

--- a/app/views/planning_applications/assessment/tasks/_assess_against_legislation.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_assess_against_legislation.html.erb
@@ -30,11 +30,7 @@
       <% if @planning_application.can_assess? %>
         <li class="app-task-list__item">
           <span class="app-task-list__task-name">
-            <%= link_to(
-              "Add assessment area",
-              part_new_planning_application_assessment_policy_class_path(@planning_application),
-              class: "govuk-link"
-            ) %>
+            <%= govuk_link_to "Add assessment area", part_new_planning_application_assessment_policy_class_path(@planning_application) %>
           </span>
         </li>
       <% end %>

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -5,11 +5,7 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to(
-        t(".description_documents_and"),
-        consistency_checklist_path(consistency_checklist),
-        class: "govuk-link"
-        ) %>
+        <%= govuk_link_to t(".description_documents_and"), consistency_checklist_path(consistency_checklist) %>
       </span>
       <%= render(
         StatusTags::ConsistencyChecklistComponent.new(
@@ -46,11 +42,7 @@
     <% if @planning_application.planning_history_enabled? %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <%= link_to(
-            t(".history"),
-            planning_application_assessment_planning_history_path(@planning_application),
-            class: "govuk-link"
-          ) %>
+          <%= govuk_link_to t(".history"), planning_application_assessment_planning_history_path(@planning_application) %>
         </span>
       </li>
     <% end %>

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -43,11 +43,7 @@
     <!-- >Only show if it's a minor application<!-->
     <li class="app-task-list__item" id="add-heads-of-terms">
       <span class="app-task-list__task-name">
-        <%= link_to(
-          "Add heads of terms",
-          planning_application_assessment_heads_of_terms_path(@planning_application),
-          class: "govuk-link"
-        ) %>
+        <%= govuk_link_to "Add heads of terms", planning_application_assessment_heads_of_terms_path(@planning_application) %>
       </span>
       <%= render(
       StatusTags::HeadsOfTermsComponent.new(
@@ -58,7 +54,7 @@
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
         <% if @planning_application.can_submit_recommendation? %>
-          <%= link_to "Review and submit recommendation", submit_recommendation_planning_application_path(@planning_application), aria: { describedby: "submit_recommendation-completed" }, class: "govuk-link" %>
+          <%= govuk_link_to "Review and submit recommendation", submit_recommendation_planning_application_path(@planning_application), aria: { describedby: "submit_recommendation-completed" } %>
         <% else %>
           Review and submit recommendation
         <% end %>

--- a/app/views/planning_applications/consultee/emails/index.html.erb
+++ b/app/views/planning_applications/consultee/emails/index.html.erb
@@ -33,7 +33,7 @@
       <% if @consultees.consulted? %>
         <%= render ReconsultConsulteesComponent.new(form: form) %>
         <h3 class="govuk-heading-s">Do you want to ask the applicant to extend the planning application expiry date?</h3>
-        <%= link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension"), class: "govuk-link" %>
+        <%= govuk_link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension") %>
        <% end %>
       <div class="govuk-form-group" id="response-period">
         <h2 class="govuk-heading-m">

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -12,7 +12,7 @@
         <strong><%= current_user.name %>,</strong> <%= role_name %>
       </p>
       <p class="govuk-body">
-        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
+        <%= govuk_link_to "Add new application", new_planning_application_path %>
       </p>
       <p class="govuk-body"><%= link_to "View all applications", planning_applications_path(view: 'all'), class: "govuk-button" %></p>
     <% else %>
@@ -23,7 +23,7 @@
         <strong><%= current_user.name %>,</strong> <%= role_name %>
       </p>
       <p class="govuk-body">
-        <%= link_to "Add new application", new_planning_application_path, class: "govuk-link" %>
+        <%= govuk_link_to "Add new application", new_planning_application_path %>
       </p>
       <p class="govuk-body">
         <%= link_to "View my applications", planning_applications_path, class: "govuk-button" %>

--- a/app/views/planning_applications/neighbour_letters/_list.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_list.html.erb
@@ -1,5 +1,5 @@
 <div id="selected-neighbours-list" data-controller="neighbours">
-  <%= link_to "< Back to add neighbours", planning_application_consultation_neighbours_path(@planning_application), class: "govuk-link govuk-body" %>
+  <%= govuk_link_to "< Back to add neighbours", planning_application_consultation_neighbours_path(@planning_application), class: "govuk-body" %>
 
   <div class="govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-4">Step 2</div>
   <h2 class="govuk-heading-m govuk-!-margin-top-1">Review neighbours to send letters to</h2>

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -82,7 +82,7 @@
                 <% end %>
                 <br>
                 <p class="govuk-body">
-                  <%= link_to "Redact and publish", edit_planning_application_consultation_redact_neighbour_response_path(@planning_application, response), class: "govuk-link" %>
+                  <%= govuk_link_to "Redact and publish", edit_planning_application_consultation_redact_neighbour_response_path(@planning_application, response) %>
                   <% if response.redacted_by.try(:name) %>
                     (Redacted by: <%= response.redacted_by.name %>)
                   <% end %>

--- a/app/views/planning_applications/neighbour_responses/index.html.erb
+++ b/app/views/planning_applications/neighbour_responses/index.html.erb
@@ -23,7 +23,7 @@
 <% end %>
 
 <p class="govuk-body">
-  <%= link_to "Add a new neighbour response", new_planning_application_consultation_neighbour_response_path(@planning_application), class: "govuk-link" %>
+  <%= govuk_link_to "Add a new neighbour response", new_planning_application_consultation_neighbour_response_path(@planning_application) %>
 </p>
 
 <div class="govuk-button-group">

--- a/app/views/planning_applications/neighbours/_selected_list.html.erb
+++ b/app/views/planning_applications/neighbours/_selected_list.html.erb
@@ -10,7 +10,7 @@
           </h2>
         </div>
         <div id="accordion-default-content-1" class="govuk-accordion__section-content govuk-!-padding-bottom-0" aria-labelledby="accordion-default-heading-1">
-          <% @consultation.neighbours.select(&:persisted?).sort_by(&:id).each do |neighbour| %> 
+          <% @consultation.neighbours.select(&:persisted?).sort_by(&:id).each do |neighbour| %>
           <hr>
           <div class="proposal-details-sub-heading" data-controller="edit-form">
             <div class="govuk-!-width-three-quarters govuk-!-margin-top-1">
@@ -35,22 +35,19 @@
             <% end %>
 
             <div class="neighbour-action-links">
-              <%= link_to(
+              <%= govuk_link_to(
                   "Edit",
                   "#",
-                  class: "govuk-link",
                   data: { action: "click->edit-form#handleClick" }
-                )
-              %>
+                ) %>
 
-              <%= link_to(
+              <%= govuk_link_to(
                     "Remove",
                     planning_application_consultation_neighbour_path(
                         @planning_application,
                         neighbour
                     ),
-                    method: :delete,
-                    class: "govuk-link"
+                    method: :delete
               ) %>
             </div>
           </div>

--- a/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
@@ -18,7 +18,7 @@
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>
-              <%= link_to "View in new window", url_for_document(document), class: "govuk-link", target: "_blank" %>
+              <%= govuk_link_to "View in new window", url_for_document(document), target: "_blank" %>
             </p>
           </td>
           <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/review/assessment_details/_form.html.erb
+++ b/app/views/planning_applications/review/assessment_details/_form.html.erb
@@ -20,7 +20,7 @@
         )
       ) %>
       <% if assessment_detail == "site_description" %>
-        <p class="govuk-body govuk-!-margin-top-2"><%= link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank', class: "govuk-link" %></p>
+        <p class="govuk-body govuk-!-margin-top-2"><%= govuk_link_to 'View site on Google Maps', map_link(@planning_application.full_address), target: '_blank' %></p>
       <% end %>
       <% if assessment_detail == "consultation_summary" && @consultation&.consultees&.any? %>
         <%= render(
@@ -32,7 +32,7 @@
       <% if assessment_detail == "amenity" || assessment_detail == "neighbour_summary" %>
         <% if consultation = @planning_application.consultation %>
           <p class="govuk-body govuk-!-margin-top-2">View neighbour responses: <%= neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %></p>
-          <p class="govuk-body govuk-!-margin-top-2"><%= link_to "View neighbour responses", planning_application_consultation_neighbour_responses_path(@planning_application), class: "govuk-link" %></p>
+          <p class="govuk-body govuk-!-margin-top-2"><%= govuk_link_to "View neighbour responses", planning_application_consultation_neighbour_responses_path(@planning_application) %></p>
         <% else %>
           <p class="govuk-body govuk-!-margin-top-2">There is no existing consultation for this planning application.</p>
         <% end %>
@@ -89,13 +89,9 @@
   <% if disabled %>
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(
-        t(".edit_review"),
-        edit_planning_application_review_assessment_details_path(
+      <%= govuk_link_to t(".edit_review"), edit_planning_application_review_assessment_details_path(
           planning_application
-        ),
-        class: "govuk-link"
-      ) %>
+        ) %>
     </div>
   <% else %>
     <%= render(partial: "shared/submit_buttons", locals: { form: form }) %>

--- a/app/views/planning_applications/review/cil_liability/show.html.erb
+++ b/app/views/planning_applications/review/cil_liability/show.html.erb
@@ -46,7 +46,7 @@
       ) %>
     <% end %>
     <%= link_to "Back", planning_application_review_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-    <%= link_to "Change CIL liability", edit_planning_application_review_cil_liability_path(@planning_application), class: "govuk-link govuk-body" %>
+    <%= govuk_link_to "Change CIL liability", edit_planning_application_review_cil_liability_path(@planning_application), class: "govuk-body" %>
   </div>
 <% end %>
 

--- a/app/views/planning_applications/review/committee_decisions/show.html.erb
+++ b/app/views/planning_applications/review/committee_decisions/show.html.erb
@@ -64,5 +64,5 @@
 
 <div class="govuk-button-group">
   <%= link_to "Back", planning_application_review_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-  <%= link_to "Edit recommendation", edit_planning_application_review_committee_decision_path(@planning_application, @planning_application.committee_decision), class: "govuk-link govuk-body" %>
+  <%= govuk_link_to "Edit recommendation", edit_planning_application_review_committee_decision_path(@planning_application, @planning_application.committee_decision), class: "govuk-body" %>
 </div>

--- a/app/views/planning_applications/review/documents/index.html.erb
+++ b/app/views/planning_applications/review/documents/index.html.erb
@@ -64,7 +64,7 @@
                   </td>
                 <% else %>
                   <td class="govuk-table__cell text-align-centre" colspan="2">
-                    <%= link_to "Add document reference", edit_planning_application_document_path(@planning_application, document), class: "govuk-link" %>
+                    <%= govuk_link_to "Add document reference", edit_planning_application_document_path(@planning_application, document) %>
                   </td>
                 <% end %>
               <% end %>

--- a/app/views/planning_applications/review/heads_of_terms/_form.html.erb
+++ b/app/views/planning_applications/review/heads_of_terms/_form.html.erb
@@ -63,7 +63,7 @@
       <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
       <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: {module: "govuk-button"} %>
     <% else %>
-      <%= link_to "Edit recommendation", edit_planning_application_review_heads_of_term_path(@planning_application), class: "govuk-link govuk-body" %>
+      <%= govuk_link_to "Edit recommendation", edit_planning_application_review_heads_of_term_path(@planning_application), class: "govuk-body" %>
     <% end %>
     <%= back_link %>
   </div>

--- a/app/views/planning_applications/review/immunity_details/_form.html.erb
+++ b/app/views/planning_applications/review/immunity_details/_form.html.erb
@@ -52,7 +52,7 @@
     <%= back_link %>
 
     <% if !editable %>
-      <%= link_to "Edit review immunity details", edit_planning_application_review_immunity_detail_path(@planning_application, @immunity_detail), class: "govuk-link" %>
+      <%= govuk_link_to "Edit review immunity details", edit_planning_application_review_immunity_detail_path(@planning_application, @immunity_detail) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/immunity_enforcements/_form.html.erb
+++ b/app/views/planning_applications/review/immunity_enforcements/_form.html.erb
@@ -43,7 +43,7 @@
     <%= back_link %>
 
     <% if !editable %>
-      <%= link_to "Edit review immune from enforcement", edit_planning_application_review_immunity_enforcement_path(@planning_application, @review_immunity_detail), class: "govuk-link" %>
+      <%= govuk_link_to "Edit review immune from enforcement", edit_planning_application_review_immunity_enforcement_path(@planning_application, @review_immunity_detail) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/local_policies/_form.html.erb
+++ b/app/views/planning_applications/review/local_policies/_form.html.erb
@@ -47,7 +47,7 @@
     <%= back_link %>
 
     <% if !editable %>
-      <%= link_to "Edit review policy guidance", edit_planning_application_review_local_policy_path(@planning_application, @review_local_policy), class: "govuk-link" %>
+      <%= govuk_link_to "Edit review policy guidance", edit_planning_application_review_local_policy_path(@planning_application, @review_local_policy) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/neighbour_responses/_form.html.erb
+++ b/app/views/planning_applications/review/neighbour_responses/_form.html.erb
@@ -26,7 +26,7 @@
     <%= back_link %>
 
     <% if disabled %>
-      <%= link_to "Edit review neighbour responses", edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-body govuk-link" %>
+      <%= govuk_link_to "Edit review neighbour responses", edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @consultation), class: "govuk-body" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/review/permitted_development_rights/_form.html.erb
@@ -48,7 +48,7 @@
     <%= back_link %>
 
     <% if !editable %>
-      <%= link_to "Edit check permitted development rights", edit_planning_application_review_permitted_development_right_path(@planning_application, @permitted_development_right), class: "govuk-link" %>
+      <%= govuk_link_to "Edit check permitted development rights", edit_planning_application_review_permitted_development_right_path(@planning_application, @permitted_development_right) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_classes/edit.html.erb
@@ -26,10 +26,9 @@
           ) %>
     </p>
     <p class="govuk-body">
-      <%= link_to(
+      <%= govuk_link_to(
             t(".open_legislation_in"),
             @policy_class.url,
-            class: "govuk-link",
             target: "_blank"
           ) %>
     </p>

--- a/app/views/planning_applications/review/policy_classes/show.html.erb
+++ b/app/views/planning_applications/review/policy_classes/show.html.erb
@@ -26,10 +26,9 @@
           ) %>
     </p>
     <p class="govuk-body">
-      <%= link_to(
+      <%= govuk_link_to(
             t(".open_legislation_in"),
             @policy_class.url,
-            class: "govuk-link",
             target: "_blank"
           ) %>
     </p>
@@ -62,11 +61,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to(
-            "Edit review of Part #{@policy_class.part}, Class #{@policy_class.section}",
-            edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class),
-            class: "govuk-link"
-          ) %>
+      <%= govuk_link_to "Edit review of Part #{@policy_class.part}, Class #{@policy_class.section}", edit_planning_application_review_policy_class_path(@policy_class.planning_application, @policy_class) %>
     </div>
   </div>
 </div>

--- a/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
@@ -47,7 +47,7 @@
     <%= back_link %>
 
     <% if disabled %>
-     <%= link_to "Edit recommendation", edit_planning_application_review_pre_commencement_conditions_path(@planning_application, @planning_application.pre_commencement_condition_set), class: "govuk-link govuk-body" %>
+     <%= govuk_link_to "Edit recommendation", edit_planning_application_review_pre_commencement_conditions_path(@planning_application, @planning_application.pre_commencement_condition_set), class: "govuk-body" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/publicities/_form.html.erb
+++ b/app/views/planning_applications/review/publicities/_form.html.erb
@@ -23,7 +23,7 @@
     <% end %>
     <%= back_link %>
     <% if disabled %>
-      <%= link_to "Edit review of publicity", edit_planning_application_review_consultation_publicities_path(@planning_application, @consultation), class: "govuk-link govuk-body" %>
+      <%= govuk_link_to "Edit review of publicity", edit_planning_application_review_consultation_publicities_path(@planning_application, @consultation), class: "govuk-body" %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/planning_applications/review/publicities/edit.html.erb
+++ b/app/views/planning_applications/review/publicities/edit.html.erb
@@ -50,8 +50,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -117,8 +117,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"),planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">

--- a/app/views/planning_applications/review/publicities/show.html.erb
+++ b/app/views/planning_applications/review/publicities/show.html.erb
@@ -50,8 +50,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">
@@ -117,8 +117,8 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: 'width:100%'), url_for_document(document), target: :_blank) %>
               </p>
               <ul class="govuk-list">
-                <li><%= link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link govuk-link--no-visited-state") %></li>
-                <li><%= link_to(t(".view_more_documents"),planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), target: :_blank, class: "govuk-link--no-visited-state") %></li>
+                <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link--no-visited-state" %></li>
               </ul>
             </div>
             <div class="govuk-grid-column-two-thirds">

--- a/app/views/planning_applications/review/recommendations/edit.html.erb
+++ b/app/views/planning_applications/review/recommendations/edit.html.erb
@@ -25,11 +25,7 @@
       <%= render("shared/warning_text", message: t(".this_information_will")) %>
     </p>
     <%= render(FormattedContentComponent.new(text: @planning_application.public_comment)) %>
-    <%= link_to(
-      t(".edit_information_on"),
-      edit_public_comment_planning_application_path(@planning_application),
-      class: "govuk-link govuk-body"
-    ) %>
+    <%= govuk_link_to t(".edit_information_on"), edit_public_comment_planning_application_path(@planning_application), class: "govuk-body" %>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <%= render(
       partial: "documents_table",
@@ -47,11 +43,7 @@
         <%= t(".you_have_suggested") %>
       </p>
       <p>
-        <%= link_to(
-          t(".review_changes"),
-          planning_application_review_tasks_path(@planning_application),
-          class: "govuk-link govuk-body"
-        ) %>
+        <%= govuk_link_to t(".review_changes"), planning_application_review_tasks_path(@planning_application), class: "govuk-body" %>
       </p>
     <% else %>
       <p class= "govuk-body">

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -12,10 +12,7 @@
 <ul class="app-task-list__items" id="review-assessment-section">
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
-      <%= link_to(
-        "Check Community Infrastructure Levy (CIL)",
-        planning_application_review_cil_liability_path(@planning_application),
-        class: "govuk-link") %>
+      <%= govuk_link_to "Check Community Infrastructure Levy (CIL)", planning_application_review_cil_liability_path(@planning_application) %>
     </span>
     <%= render(
       StatusTags::BaseComponent.new(

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -4,12 +4,9 @@
 <ul class="app-task-list__items" id="review-consultation-section">
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
-      <%= link_to(
-            "Check neighbour notifications",
-            (@planning_application.consultation&.neighbour_review&.review_complete? ?
+      <%= govuk_link_to "Check neighbour notifications", (@planning_application.consultation&.neighbour_review&.review_complete? ?
               planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation) :
-              edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation)),
-            class: "govuk-link") %>
+              edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation)) %>
     </span>
     <%= render(
           StatusTags::BaseComponent.new(
@@ -20,12 +17,9 @@
 
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
-      <%= link_to(
-            "Check publicity",
-            (@planning_application.check_publicity&.review_complete? ?
+      <%= govuk_link_to "Check publicity", (@planning_application.check_publicity&.review_complete? ?
               planning_application_review_consultation_publicities_path(@planning_application, @planning_application.consultation) :
-              edit_planning_application_review_consultation_publicities_path(@planning_application.id, @planning_application.consultation.id)),
-            class: "govuk-link") %>
+              edit_planning_application_review_consultation_publicities_path(@planning_application.id, @planning_application.consultation.id)) %>
     </span>
     <%= render(
           StatusTags::BaseComponent.new(

--- a/app/views/planning_applications/site_notices/_status.html.erb
+++ b/app/views/planning_applications/site_notices/_status.html.erb
@@ -2,7 +2,7 @@
 <div class="proposal-details-sub-heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-controller="pdf">
   <p class="govuk-body govuk-!-margin-top-1">
     <%= @planning_application.last_site_notice_audit&.audit_comment %><br>
-    <%= link_to "Download site notice PDF", "#", "data-action": "click->pdf#handleClick", class: "govuk-link" %>
+    <%= govuk_link_to "Download site notice PDF", "#", "data-action": "click->pdf#handleClick" %>
   </p>
   <div class="consultation-letter-status">
     <div>

--- a/app/views/planning_applications/site_notices/show.html.erb
+++ b/app/views/planning_applications/site_notices/show.html.erb
@@ -33,7 +33,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(@site_notice.document.name.to_s, length: 50) %><br>
-            <%= link_to "View in new window", url_for_document(@site_notice.document), target: :_new, class: "govuk-link" %>
+            <%= govuk_link_to "View in new window", url_for_document(@site_notice.document), target: :_new %>
           </p>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/site_visits/index.html.erb
+++ b/app/views/planning_applications/site_visits/index.html.erb
@@ -40,7 +40,7 @@
         <p class="govuk-body">Comment: <%= site_visit.comment %></p>
         <p class="govuk-body"><%= site_visit.documents.count %> document<%= site_visit.documents.count == 1 ? "" : "s" %> added</p>
 
-        <p><%= link_to "View", planning_application_consultation_site_visit_path(@planning_application, site_visit), class: "govuk-link" %></p>
+        <p><%= govuk_link_to "View", planning_application_consultation_site_visit_path(@planning_application, site_visit) %></p>
         <hr>
       <% end %>
     </div>
@@ -51,7 +51,7 @@
   </p>
 <% end %>
 
-<%= link_to "Add site visit response", new_planning_application_consultation_site_visit_path(@planning_application), class: "govuk-link" %>
+<%= govuk_link_to "Add site visit response", new_planning_application_consultation_site_visit_path(@planning_application) %>
 
 <div class="govuk-button-group govuk-!-padding-top-7">
   <%= back_link %>

--- a/app/views/planning_applications/steps/_consultation.html.erb
+++ b/app/views/planning_applications/steps/_consultation.html.erb
@@ -2,7 +2,7 @@
 <ul class="app-task-list__items" id="consultation-section">
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
-      <%= link_to "Consultees, neighbours and publicity", planning_application_consultation_path(@planning_application), class: "govuk-link" %>
+      <%= govuk_link_to "Consultees, neighbours and publicity", planning_application_consultation_path(@planning_application) %>
     </span>
     <div class="app-task-list__task-tag">
       <%= render(StatusTags::BaseComponent.new(status: @planning_application.consultation.status)) %>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -5,13 +5,13 @@
       <span class="app-task-list__task-name">
         <% if current_user.reviewer? %>
           <% if @planning_application.awaiting_determination? || @planning_application.in_committee? %>
-            <%= link_to "Review and sign-off", planning_application_review_tasks_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
+            <%= govuk_link_to "Review and sign-off", planning_application_review_tasks_path(@planning_application), aria: { describedby: "review_assessment-completed" } %>
           <% else %>
             Review and sign-off
           <% end %>
         <% else %>
           <% if @planning_application.awaiting_determination? %>
-            <%= link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" }, class: "govuk-link" %>
+            <%= govuk_link_to "View recommendation", view_recommendation_planning_application_path(@planning_application), aria: { describedby: "review_assessment-completed" } %>
           <% else %>
             View recommendation
           <% end %>
@@ -27,7 +27,7 @@
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
         <% if @planning_application.can_publish? && current_user.reviewer? %>
-          <%= link_to "Publish determination", publish_planning_application_path(@planning_application), aria: { describedby: "publish-completed" }, class: "govuk-link" %>
+          <%= govuk_link_to "Publish determination", publish_planning_application_path(@planning_application), aria: { describedby: "publish-completed" } %>
         <% else %>
           Publish determination
         <% end %>

--- a/app/views/planning_applications/steps/_validation.html.erb
+++ b/app/views/planning_applications/steps/_validation.html.erb
@@ -3,11 +3,10 @@
   <li class="app-task-list__item">
     <span class="app-task-list__task-name">
       <% if @planning_application.can_validate? %>
-        <%= link_to(
+        <%= govuk_link_to(
            t(".check_and_validate"),
            planning_application_validation_tasks_path(@planning_application),
-           aria: { describedby: "validation-completed" },
-           class: "govuk-link"
+           aria: { describedby: "validation-completed" }
         ) %>
       <% else %>
         Validate application

--- a/app/views/planning_applications/validation/additional_document_validation_requests/_additional_document_validation_requests_table.html.erb
+++ b/app/views/planning_applications/validation/additional_document_validation_requests/_additional_document_validation_requests_table.html.erb
@@ -22,7 +22,7 @@
         <td class="govuk-table__cell govuk-!-width-one-sixth">
           <% if validation_request.open_or_pending? %>
             <% if validation_request.can_cancel? %>
-              <%= link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, validation_request), class: "govuk-link govuk-!-display-block" %>
+              <%= govuk_link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, validation_request), class: "govuk-!-display-block" %>
             <% end %>
 
             <% if @planning_application.not_started? %>

--- a/app/views/planning_applications/validation/constraints/_info.html.erb
+++ b/app/views/planning_applications/validation/constraints/_info.html.erb
@@ -13,10 +13,6 @@
 <% end %>
 <% if planning_application.can_validate? && show_update_button %>
   <p class="govuk-body">
-    <%= link_to(
-          t(".update_constraints"),
-          planning_application_validation_constraints_path(planning_application),
-          class: "govuk-link"
-        ) %>
+    <%= govuk_link_to t(".update_constraints"), planning_application_validation_constraints_path(planning_application) %>
   </p>
 <% end %>

--- a/app/views/planning_applications/validation/document/redactions/_form.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_form.html.erb
@@ -22,7 +22,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(ff.object.name.to_s, length: 50) %><br>
-            <%= link_to "Download", url_for_document(ff.object), download: true, class: "govuk-body-s govuk-link" %>
+            <%= govuk_link_to "Download", url_for_document(ff.object), download: true, class: "govuk-body-s" %>
           </p>
         </td>
         <td class="govuk-table__cell">

--- a/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
@@ -15,7 +15,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(document.name.to_s, length: 50) %><br>
-            <%= link_to "View in new window", url_for_document(document), target: :_blank, class: "govuk-link" %>
+            <%= govuk_link_to "View in new window", url_for_document(document), target: :_blank %>
           </p>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-half">

--- a/app/views/planning_applications/validation/documents/edit.html.erb
+++ b/app/views/planning_applications/validation/documents/edit.html.erb
@@ -49,8 +49,7 @@
     <% end %>
 
     <p class="govuk-!-margin-bottom-6 govuk-!-margin-top-0">
-      <%= link_to "Add a request for a missing document",
-        new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"), class: "govuk-link govuk-body-m" %>
+      <%= govuk_link_to "Add a request for a missing document", new_planning_application_validation_validation_request_path(@planning_application, type: "additional_document"), class: "govuk-body-m" %>
     </p>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
+++ b/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
@@ -8,10 +8,9 @@
           legend: { size: "m" }
         ) do %>
         <p class="govuk-body">
-          <%= link_to(
+          <%= govuk_link_to(
             "Check EIA guidance",
             t("environment_impact_assessment.guidance_link"),
-            class: "govuk-link",
             target: "_blank"
           ) %>
         </p>
@@ -91,7 +90,7 @@
         <% end %>
         <%= back_link %>
         <% if !editable %>
-          <%= link_to "Edit information", edit_planning_application_validation_environment_impact_assessment_path(@planning_application), class: "govuk-body govuk-link" %>
+          <%= govuk_link_to "Edit information", edit_planning_application_validation_environment_impact_assessment_path(@planning_application), class: "govuk-body" %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
+++ b/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
@@ -31,5 +31,5 @@
 </table>
 
 <div class="govuk-!-margin-bottom-8">
-  <%= link_to "Check application documents", planning_application_documents_path(@planning_application), class: "govuk-body govuk-link" %>
+  <%= govuk_link_to "Check application documents", planning_application_documents_path(@planning_application), class: "govuk-body" %>
 </div>

--- a/app/views/planning_applications/validation/ownership_certificates/show.html.erb
+++ b/app/views/planning_applications/validation/ownership_certificates/show.html.erb
@@ -73,12 +73,12 @@
     <% elsif @planning_application.ownership_certificate_validation_requests.closed.any? %>
       <div class="govuk-button-group">
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-        <%= link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-link govuk-body" %>
+        <%= govuk_link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-body" %>
       </div>
     <% else %>
       <div class="govuk-button-group">
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
-        <%= link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-link govuk-body" %>
+        <%= govuk_link_to "Edit ownership certificate", edit_planning_application_validation_ownership_certificate_path(@planning_application), class: "govuk-body" %>
       </div>
     <% end %>
   </div>

--- a/app/views/planning_applications/validation/red_line_boundary_change_validation_requests/_red_line_boundary_change_validation_request.html.erb
+++ b/app/views/planning_applications/validation/red_line_boundary_change_validation_requests/_red_line_boundary_change_validation_request.html.erb
@@ -7,6 +7,6 @@
   </td>
 <% else %>
   <td class="govuk-table__cell change-request-list">
-    <%= link_to "View request red line boundary", planning_application_validation_validation_request_path(@planning_application, red_line_boundary_change_validation_request), class: "govuk-link" %>
+    <%= govuk_link_to "View request red line boundary", planning_application_validation_validation_request_path(@planning_application, red_line_boundary_change_validation_request) %>
   </td>
 <% end %>

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_cancel_confirmation.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_cancel_confirmation.html.erb
@@ -23,7 +23,7 @@
     <div class="govuk-inset-text">
       <p class="govuk-body">
         <strong>Replacement for:
-        <%= link_to @validation_request.old_document.name, url_for_document(@validation_request.old_document), target: :_new, class: "govuk-link" %>
+        <%= govuk_link_to @validation_request.old_document.name, url_for_document(@validation_request.old_document), target: :_new %>
         </strong>
       </p>
       <p class="govuk-body">

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
@@ -2,7 +2,7 @@
   <%= link_to image_tag(@document.file.representation(resize: "500x500"), style: 'max-width:100%'),
               url_for_document(@document), target: :_blank %>
   <p class="govuk-body">
-    <%= link_to "View in new window", url_for_document(@document), target: :_new, class: "govuk-link" %>
+    <%= govuk_link_to "View in new window", url_for_document(@document), target: :_new %>
   </p>
 </div>
 <div class="govuk-grid-column-one-half" id="document-summary">

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_replacement_document_validation_request.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_replacement_document_validation_request.html.erb
@@ -7,7 +7,6 @@
   </td>
 <% else %>
   <td class="govuk-table__cell change-request-list limit-column-width">
-    <%= link_to replacement_document_validation_request.old_document.name,
-        edit_planning_application_document_path(@planning_application, replacement_document_validation_request.old_document), class: "govuk-link" %>
+    <%= govuk_link_to replacement_document_validation_request.old_document.name, edit_planning_application_document_path(@planning_application, replacement_document_validation_request.old_document) %>
   </td>
 <% end %>

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_show.html.erb
@@ -34,8 +34,7 @@
         A replacement document has been provided for this request:
       </p>
       <p class="govuk-body">
-        <%= link_to "#{new_document.name.to_s}",
-          edit_planning_application_document_path(@planning_application, new_document, validate: "yes"), class: "govuk-link" %>
+        <%= govuk_link_to "#{new_document.name.to_s}", edit_planning_application_document_path(@planning_application, new_document, validate: "yes") %>
       </p>
     <% end %>
 

--- a/app/views/planning_applications/validation/reporting_types/_form.html.erb
+++ b/app/views/planning_applications/validation/reporting_types/_form.html.erb
@@ -8,7 +8,7 @@
           <% if reporting_type.guidance? %>
             <%= render FormattedContentComponent.new(text: reporting_type.guidance, classname: "govuk-hint") %>
             <% if reporting_type.guidance_link? %>
-              <p class="govuk-hint"><%= link_to(t(".read_more"), reporting_type.guidance_link, target: "_blank", class: "govuk-link") %></p>
+              <p class="govuk-hint"><%= govuk_link_to(t(".read_more"), reporting_type.guidance_link, target: "_blank") %></p>
             <% end %>
           <% end %>
           <% if reporting_type.legislation? %>

--- a/app/views/planning_applications/validation/sitemaps/_draw_red_line_boundary.html.erb
+++ b/app/views/planning_applications/validation/sitemaps/_draw_red_line_boundary.html.erb
@@ -8,15 +8,15 @@
 <%- sitemap_documents = @planning_application.documents.with_siteplan_tags %>
 <% if sitemap_documents.none? %>
   <p class="govuk-body">No document has been tagged as a sitemap for this application</p>
-  <p class="govuk-body"><%= link_to "View all documents", planning_application_documents_path(@planning_application), class: "govuk-link" %></p>
+  <p class="govuk-body"><%= govuk_link_to "View all documents", planning_application_documents_path(@planning_application) %></p>
 <% else sitemap_documents.any? %>
   <p class="govuk-body">This digital red line boundary was submitted by the applicant on PlanX.</p>
 
   <% if sitemap_documents.one? %>
-    <p class="govuk-body"><%= link_to "View sitemap document", edit_planning_application_document_path(@planning_application, sitemap_documents.first), class: "govuk-link" %></p>
+    <p class="govuk-body"><%= govuk_link_to "View sitemap document", edit_planning_application_document_path(@planning_application, sitemap_documents.first) %></p>
   <% else %>
     <p class="govuk-body">Multiple documents have been tagged as a sitemap for this application</p>
-    <p class="govuk-body"><%= link_to "View all documents", planning_application_documents_path(@planning_application), class: "govuk-link" %></p>
+    <p class="govuk-body"><%= govuk_link_to "View all documents", planning_application_documents_path(@planning_application) %></p>
   <% end %>
 <% end %>
 

--- a/app/views/planning_applications/validation/tasks/_application_details.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_details.html.erb
@@ -20,7 +20,7 @@
     ) %>
     <li id="constraints-validation-tasks" class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to "Check constraints", planning_application_validation_constraints_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "Check constraints", planning_application_validation_constraints_path(@planning_application) %>
       </span>
       <%= render(
         StatusTags::ConstraintsComponent.new(
@@ -43,7 +43,7 @@
     <% end %>
     <li id="development-type-for-reporting-task" class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to "Select development type for reporting", edit_planning_application_validation_reporting_type_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "Select development type for reporting", edit_planning_application_validation_reporting_type_path(@planning_application) %>
       </span>
 
       <%= render(

--- a/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
@@ -18,7 +18,7 @@
     <% end %>
     <li id="cil-liability-validation-tasks" class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to "Confirm Community Infrastructure Levy (CIL)", edit_planning_application_validation_cil_liability_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "Confirm Community Infrastructure Levy (CIL)", edit_planning_application_validation_cil_liability_path(@planning_application) %>
       </span>
       <%= render(
             StatusTags::CilLiabilityComponent.new(
@@ -28,9 +28,7 @@
     </li>
     <li id="environment-impact-assessment-task" class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to "Check Environment Impact Assessment",
-         @planning_application.environment_impact_assessment.nil? ? new_planning_application_validation_environment_impact_assessment_path(@planning_application) : planning_application_validation_environment_impact_assessment_path(@planning_application),
-         class: "govuk-link" %>
+        <%= govuk_link_to "Check Environment Impact Assessment", @planning_application.environment_impact_assessment.nil? ? new_planning_application_validation_environment_impact_assessment_path(@planning_application) : planning_application_validation_environment_impact_assessment_path(@planning_application) %>
       </span>
 
       <%= render(

--- a/app/views/planning_applications/validation/tasks/_documents.html.erb
+++ b/app/views/planning_applications/validation/tasks/_documents.html.erb
@@ -12,7 +12,7 @@
     <% else %>
       <li id="check-supplied-document" class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <%= link_to "Check supplied documents", supply_documents_planning_application_path(@planning_application), class: "govuk-link" %>
+          <%= govuk_link_to "Check supplied documents", supply_documents_planning_application_path(@planning_application) %>
         </span>
       </li>
     <% end %>

--- a/app/views/planning_applications/validation/tasks/_other_validation_request.html.erb
+++ b/app/views/planning_applications/validation/tasks/_other_validation_request.html.erb
@@ -6,7 +6,7 @@
     <% unless @planning_application.validated? %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
-          <%= link_to "Add another validation request", new_planning_application_validation_validation_request_path(type: "other_change"), class: "govuk-link" %>
+          <%= govuk_link_to "Add another validation request", new_planning_application_validation_validation_request_path(type: "other_change") %>
         </span>
       </li>
     <% end %>

--- a/app/views/planning_applications/validation/tasks/_review.html.erb
+++ b/app/views/planning_applications/validation/tasks/_review.html.erb
@@ -5,7 +5,7 @@
   <ul class="app-task-list__items">
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
-        <%= link_to "Review validation requests", planning_application_validation_validation_requests_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "Review validation requests", planning_application_validation_validation_requests_path(@planning_application) %>
       </span>
     </li>
     <%= render(

--- a/app/views/planning_applications/validation_decision.html.erb
+++ b/app/views/planning_applications/validation_decision.html.erb
@@ -49,7 +49,7 @@
         <%= validation_request_summary(@planning_application.validation_requests, @planning_application) %>
       </p>
       <p class="govuk-body">
-        <%= link_to "View existing requests", planning_application_validation_validation_requests_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "View existing requests", planning_application_validation_validation_requests_path(@planning_application) %>
       </p>
       <p class="govuk-body">
         Once the application has been checked and all validation requests resolved, mark the application as valid.
@@ -66,7 +66,7 @@
         </strong>
       </p>
       <p class="govuk-body">
-        <%= link_to "View notification", validation_notice_planning_application_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "View notification", validation_notice_planning_application_path(@planning_application) %>
       </p>
       <h2 class="govuk-heading-m">
         Validation requests

--- a/app/views/public/planning_guides/index.html.erb
+++ b/app/views/public/planning_guides/index.html.erb
@@ -16,43 +16,43 @@
           <h3 class="govuk-heading-s">All drawings</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "All drawings and plans", "/planning_guides/drawings", class: "govuk-link" %>
+              <%= govuk_link_to "All drawings and plans", "/planning_guides/drawings" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Floor plans</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing floor plans", "/planning_guides/floor_plans/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing floor plans", "/planning_guides/floor_plans/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed floor plans", "/planning_guides/floor_plans/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed floor plans", "/planning_guides/floor_plans/proposed" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Site plans</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing site plans", "/planning_guides/site_plans/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing site plans", "/planning_guides/site_plans/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed site plans", "/planning_guides/site_plans/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed site plans", "/planning_guides/site_plans/proposed" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Elevations</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing elevations", "/planning_guides/elevations/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing elevations", "/planning_guides/elevations/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed elevations", "/planning_guides/elevations/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed elevations", "/planning_guides/elevations/proposed" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Sections</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing sections", "/planning_guides/sections/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing sections", "/planning_guides/sections/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed sections", "/planning_guides/sections/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed sections", "/planning_guides/sections/proposed" %>
             </li>
           </ul>
         </div>
@@ -60,28 +60,28 @@
           <h3 class="govuk-heading-s">Roof plans</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing roof plans", "/planning_guides/roof_plans/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing roof plans", "/planning_guides/roof_plans/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed roof plans", "/planning_guides/roof_plans/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed roof plans", "/planning_guides/roof_plans/proposed" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Unit plans</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing unit plans", "/planning_guides/unit_plans/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing unit plans", "/planning_guides/unit_plans/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed unit plans", "/planning_guides/unit_plans/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed unit plans", "/planning_guides/unit_plans/proposed" %>
             </li>
           </ul>
           <h3 class="govuk-heading-s">Use plans</h3>
           <ul class="govuk-list">
             <li>
-              <%= link_to "Existing use plans", "/planning_guides/use_plans/existing", class: "govuk-link" %>
+              <%= govuk_link_to "Existing use plans", "/planning_guides/use_plans/existing" %>
             </li>
             <li>
-              <%= link_to "Proposed use plans", "/planning_guides/use_plans/proposed", class: "govuk-link" %>
+              <%= govuk_link_to "Proposed use plans", "/planning_guides/use_plans/proposed" %>
             </li>
           </ul>
         </div>

--- a/app/views/shared/_back_to_top_link.html.erb
+++ b/app/views/shared/_back_to_top_link.html.erb
@@ -1,6 +1,6 @@
-<%= link_to(
+<%= govuk_link_to(
   target_id,
-  class: "govuk-link govuk-link--no-visited-state back-to-top-link"
+  class: "govuk-link--no-visited-state back-to-top-link"
 ) do %>
   <svg role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
     <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z">

--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -15,7 +15,7 @@
         <% if constraint.consultee.present? %>
           <%= constraint.consultee.name %>
         <% else %>
-          <%= link_to "Assign consultee", new_planning_application_consultee_path(@planning_application, constraint: constraint), class: "govuk-link" %>
+          <%= govuk_link_to "Assign consultee", new_planning_application_consultee_path(@planning_application, constraint: constraint) %>
         <% end %>
       </td>
       <td class="govuk-table__cell">

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -30,7 +30,7 @@
                 <%= days_left > 0 ? t("planning_applications.days_left", count: days_left) : t("planning_applications.overdue", count: days_left.abs) %>
               </span>
             </span>
-            <span id="edit-consultation-end-date"><%= link_to "Change", edit_planning_application_consultation_path(@planning_application), class: "govuk-link" %></span>
+            <span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span>
           <% end %>
 
           <% if display_or_publish_required?(@planning_application, :site) %>
@@ -46,7 +46,7 @@
             <div id="confirm-press-notice-warning">
               <%= render(
                 partial: "shared/warning_text",
-                locals: { message: link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application), class: "govuk-link") }
+                locals: { message: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application)) }
               ) %>
             </div>
           <% end %>
@@ -66,9 +66,9 @@
       <% end %>
 
       <% if @planning_application.open_time_extension_requests.any? %>
-        <%= link_to "Extension requested", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request), class: "govuk-link" %>
+        <%= govuk_link_to "Extension requested", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request) %>
       <% else %>
-        <%= link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension"), class: "govuk-link" %>
+        <%= govuk_link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension") %>
       <% end %>
     </p>
 
@@ -81,11 +81,11 @@
       <p class="govuk-body">
         Assigned to: <strong><%= @planning_application.user&.name || "Unassigned" %></strong>
         <!-- FIXME: make the link explicit and remove the span (i.e "Assign application"/"Change assignee") -->
-        <span class="assignment_cta"><%= link_to "Change", planning_application_assign_users_path(@planning_application), class: "govuk-link" %></span>
+        <span class="assignment_cta"><%= govuk_link_to "Change", planning_application_assign_users_path(@planning_application) %></span>
       </p>
     <% elsif @planning_application.determined? %>
       <p class="govuk-body">
-        <%= link_to "View decision notice", decision_notice_planning_application_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "View decision notice", decision_notice_planning_application_path(@planning_application) %>
       </p>
     <% end %>
 
@@ -96,7 +96,7 @@
     <% end %>
 
     <p class="govuk-body">
-      Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= link_to "Change", make_public_planning_application_path(@planning_application), class: "govuk-link" %></span>
+      Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
     </p>
   </div>
 </div>

--- a/app/views/shared/_description_change_auto_closed_banner.html.erb
+++ b/app/views/shared/_description_change_auto_closed_banner.html.erb
@@ -6,7 +6,7 @@
         C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
       <div class="moj-banner__message">
         <strong> Description change request has been automatically accepted </strong> after 5 days.<br/>
-        <%= link_to "View description change request", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request), class: "govuk-link" %>
+        <%= govuk_link_to "View description change request", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request) %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_overdue_banner.html.erb
+++ b/app/views/shared/_overdue_banner.html.erb
@@ -7,7 +7,7 @@
         <span class="moj-banner__assistive">
           Warning
         </span><strong><%= pluralize(@planning_application.overdue_validation_requests.count, "validation request") %></strong> now overdue.<br/>
-        <%= link_to "View all validation requests", planning_application_validation_validation_requests_path(@planning_application), class: "govuk-link" %>
+        <%= govuk_link_to "View all validation requests", planning_application_validation_validation_requests_path(@planning_application) %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_planning_guides_link.html.erb
+++ b/app/views/shared/_planning_guides_link.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
-  <%= link_to "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
-    public_planning_guides_path, class: "govuk-link", target: "_blank" %>
+  <%= govuk_link_to "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
+    public_planning_guides_path, target: "_blank" %>
 </p>

--- a/app/views/shared/_response_banner.html.erb
+++ b/app/views/shared/_response_banner.html.erb
@@ -8,7 +8,7 @@
         <span class="moj-banner__assistive">
           Warning
         </span><strong><%= pluralize(@planning_application.closed_pre_validation_requests.count, "new response") %></strong> to a validation request.<br/>
-          <%= link_to "View all validation requests", planning_application_validation_validation_requests_path(@planning_application), class: "govuk-link" %>
+          <%= govuk_link_to "View all validation requests", planning_application_validation_validation_requests_path(@planning_application) %>
       </div>
     </div>
   </div>

--- a/app/views/shared/_time_extension_response_banner.html.erb
+++ b/app/views/shared/_time_extension_response_banner.html.erb
@@ -8,7 +8,7 @@
         <span class="moj-banner__assistive">
           Warning
         </span><strong> 1 new response </strong> to a time extension request.<br/>
-          <%= link_to "View time extension requests", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request), class: "govuk-link" %>
+          <%= govuk_link_to "View time extension requests", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request) %>
       </div>
     </div>
   </div>

--- a/engines/bops_admin/app/views/bops_admin/consultees/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/consultees/index.html.erb
@@ -14,7 +14,7 @@
   <%= form.govuk_text_field :q, value: params[:q], width: "one-half", label: { text: t(".find_consultees"), hidden: true } %>
   <div class="govuk-button-group">
     <%= form.govuk_submit t(".find_consultees") %>
-    <%= link_to t(".add_consultee"), new_consultee_path, class: "govuk-link govuk-link--no-visited-state" %>
+    <%= govuk_link_to t(".add_consultee"), new_consultee_path, class: "govuk-link--no-visited-state" %>
   </div>
 <% end %>
 
@@ -37,8 +37,8 @@
           <td class="govuk-table__cell"><%= consultee.organisation.presence || "–" %></td>
           <td class="govuk-table__cell"><%= consultee.origin.titleize %></td>
           <td class="govuk-table__cell govuk-!-text-align-right">
-            <%= link_to t(".actions.edit"), edit_consultee_path(consultee), class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline" %>
-            <%= link_to t(".actions.delete"), consultee_path(consultee), class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-left-1", method: :delete, data: { confirm: t(".are_you_sure") } %>
+            <%= govuk_link_to t(".actions.edit"), edit_consultee_path(consultee), class: "govuk-link--no-visited-state govuk-link--no-underline" %>
+            <%= govuk_link_to t(".actions.delete"), consultee_path(consultee), class: "govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-left-1", method: :delete, data: { confirm: t(".are_you_sure") } %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_admin/app/views/bops_admin/informatives/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/informatives/index.html.erb
@@ -14,7 +14,7 @@
   <%= form.govuk_text_field :q, value: params[:q], width: "one-half", label: { text: t(".find_informatives"), hidden: true } %>
   <div class="govuk-button-group">
     <%= form.govuk_submit t(".find_informatives") %>
-    <%= link_to t(".add_informative"), new_informative_path, class: "govuk-link govuk-link--no-visited-state" %>
+    <%= govuk_link_to t(".add_informative"), new_informative_path, class: "govuk-link--no-visited-state" %>
   </div>
 <% end %>
 
@@ -33,8 +33,8 @@
           <th scope="row" class="govuk-table__header"><%= informative.title %></th>
           <td class="govuk-table__cell"><%= informative.text %></td>
           <td class="govuk-table__cell govuk-!-text-align-right">
-            <%= link_to t(".actions.edit"), edit_informative_path(informative), class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline" %>
-            <%= link_to t(".actions.delete"), informative_path(informative), class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-left-1", method: :delete, data: { confirm: t(".are_you_sure") } %>
+            <%= govuk_link_to t(".actions.edit"), edit_informative_path(informative), class: "govuk-link--no-visited-state govuk-link--no-underline" %>
+            <%= govuk_link_to t(".actions.delete"), informative_path(informative), class: "govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-left-1", method: :delete, data: { confirm: t(".are_you_sure") } %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
@@ -61,7 +61,7 @@
   <%= form.govuk_text_field(
      :notify_api_key,
      label: { text: t(".notify_api_key"), class: "govuk-label govuk-label--m" },
-     hint: { text: t(".notify_api_key_hint_html", notify_notion_link: link_to("Read our guide to Notify set up.", t('.notify_notion_link'), target: '_blank', class: "govuk-link")) },
+     hint: { text: t(".notify_api_key_hint_html", notify_notion_link: govuk_link_to("Read our guide to Notify set up.", t('.notify_notion_link'), target: '_blank')) },
      class: "govuk-input--width-30",
      type: "password"
   ) %>

--- a/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
@@ -19,7 +19,7 @@
       <ol class="govuk-list">
         <li>
           <h2 class="govuk-heading-m"><%= t(".api_key") %></h2>
-          <span class="govuk-hint"><%= t(".api_key_hint_html", swagger_link: link_to("swagger", bops_api.v2_docs_path, target: '_blank', class: "govuk-link")) %></span>
+          <span class="govuk-hint"><%= t(".api_key_hint_html", swagger_link: govuk_link_to("swagger", bops_api.v2_docs_path, target: '_blank')) %></span>
           <p class="govuk-body">
             <%= current_local_authority.api_users.find_by(name: current_local_authority.subdomain).token %>
           </p>
@@ -82,7 +82,7 @@
         </li>
         <li>
           <h2 class="govuk-heading-m"><%= t(".notify_api_key") %></h2>
-          <span class="govuk-hint"><%= t(".notify_api_key_hint_html", notify_notion_link: link_to("Read our guide to Notify set up.", t('.notify_notion_link'), target: '_blank', class: "govuk-link")) %></span>
+          <span class="govuk-hint"><%= t(".notify_api_key_hint_html", notify_notion_link: govuk_link_to("Read our guide to Notify set up.", t('.notify_notion_link'), target: '_blank')) %></span>
           <p class="govuk-body">
             Redacted for security
           </p>
@@ -106,7 +106,7 @@
 
     <div class="govuk-button-group">
       <%= back_link %>
-      <%= link_to "Edit profile", edit_profile_path, class: "govuk-link govuk-body" %>
+      <%= govuk_link_to "Edit profile", edit_profile_path, class: "govuk-body" %>
     </div>
   </div>
 </div>

--- a/engines/bops_admin/app/views/bops_admin/users/_table.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_table.html.erb
@@ -15,9 +15,9 @@
         <%= user.role.capitalize %><br>
         <%= user.email %><br>
         <%= number_to_phone(user.mobile_number, delimiter: " ", pattern: /(\d{5})(\d{3})(\d{3})$/) %><br>
-        <%= link_to("Edit user", edit_user_path(user), class: "govuk-link") %>
+        <%= govuk_link_to "Edit user", edit_user_path(user) %>
         <% if user.unconfirmed? %>
-          <%= link_to("Resend invite", resend_invite_user_path(user), class: "govuk-link") %>
+          <%= govuk_link_to "Resend invite", resend_invite_user_path(user) %>
         <% end %>
       </td>
       <td class="govuk-table__cell">

--- a/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_table.html.erb
@@ -31,7 +31,7 @@
           <% end %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to t(".view_and_or_edit"), application_type_path(application_type) , class: "govuk-link" %>
+          <%= govuk_link_to t(".view_and_or_edit"), application_type_path(application_type) %>
         </td>
       </tr>
     <% end %>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -23,7 +23,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @application_type.inactive? %>
-            <%= link_to [:edit, @application_type], class: "govuk-link" do %>
+            <%= govuk_link_to [:edit, @application_type] do %>
               <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".name") %></span>
             <% end %>
           <% end %>
@@ -39,7 +39,7 @@
         </dd>
         <dd class="govuk-summary-list__actions">
           <% if @application_type.inactive? %>
-            <%= link_to [:edit, @application_type], class: "govuk-link" do %>
+            <%= govuk_link_to [:edit, @application_type] do %>
               <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".suffix") %></span>
             <% end %>
           <% end %>
@@ -56,7 +56,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :category], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :category] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".category") %></span>
           <% end %>
         </dd>
@@ -70,7 +70,7 @@
           <%= @application_type.reporting_types.join(", ") %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :reporting], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :reporting] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".reporting") %></span>
           <% end %>
         </dd>
@@ -86,7 +86,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :legislation], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :legislation] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".legislation") %></span>
           <% end %>
         </dd>
@@ -102,7 +102,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :determination_period], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :determination_period] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".determination_period") %></span>
           <% end %>
         </dd>
@@ -133,7 +133,7 @@
           <% end %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :features], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :features] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".features") %></span>
           <% end %>
         </dd>
@@ -152,7 +152,7 @@
             </p>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <%= link_to [:edit, @application_type, :document_tags, anchor: "#{group}-tags"], class: "govuk-link" do %>
+            <%= govuk_link_to [:edit, @application_type, :document_tags, anchor: "#{group}-tags"] do %>
               <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".links.#{group}") %></span>
             <% end %>
           </dd>
@@ -167,7 +167,7 @@
           <%= @application_type.decisions.map(&:humanize).join(", ") %>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :decisions], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :decisions] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".decisions") %></span>
           <% end %>
         </dd>
@@ -183,7 +183,7 @@
           </span>
         </dd>
         <dd class="govuk-summary-list__actions">
-          <%= link_to [:edit, @application_type, :status], class: "govuk-link" do %>
+          <%= govuk_link_to [:edit, @application_type, :status] do %>
             <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".status") %></span>
           <% end %>
         </dd>

--- a/engines/bops_config/app/views/bops_config/decisions/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/decisions/_table.html.erb
@@ -30,7 +30,7 @@
             <%= decision.description %>
           </td>
           <td class="govuk-table__cell">
-            <%= link_to t(".edit"), edit_decision_path(decision) , class: "govuk-link" %>
+            <%= govuk_link_to t(".edit"), edit_decision_path(decision) %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/_table.html.erb
@@ -17,7 +17,7 @@
           <%= legislation.title %>
         </td>
         <td class="govuk-table__cell">
-          <%= link_to t(".edit"), edit_legislation_path(legislation), class: "govuk-link" %>
+          <%= govuk_link_to t(".edit"), edit_legislation_path(legislation) %>
         </td>
       </tr>
     <% end %>

--- a/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_table.html.erb
@@ -34,7 +34,7 @@
             </ul>
           </td>
           <td class="govuk-table__cell govuk-!-text-align-right">
-            <%= link_to t(".edit"), edit_reporting_type_path(reporting_type), class: "govuk-link" %>
+            <%= govuk_link_to t(".edit"), edit_reporting_type_path(reporting_type) %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_config/app/views/bops_config/users/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/_table.html.erb
@@ -14,9 +14,9 @@
         <%= user.name %><br>
         <%= user.email %><br>
         <%= number_to_phone(user.mobile_number, delimiter: " ", pattern: /(\d{5})(\d{3})(\d{3})$/) %><br>
-        <%= link_to("Edit user", edit_user_path(user), class: "govuk-link") %>
+        <%= govuk_link_to "Edit user", edit_user_path(user) %>
         <% if user.unconfirmed? %>
-          <%= link_to("Resend invite", resend_invite_user_path(user), class: "govuk-link") %>
+          <%= govuk_link_to "Resend invite", resend_invite_user_path(user) %>
         <% end %>
       </td>
       <td class="govuk-table__cell">

--- a/lib/bops/cop.rb
+++ b/lib/bops/cop.rb
@@ -8,3 +8,4 @@ end
 require_relative "cop/style/have_current_path_literal"
 require_relative "cop/style/visit_literal"
 require_relative "cop/style/fetch_literal_nil"
+require_relative "cop/style/govuk_link_helper"

--- a/lib/bops/cop/style/govuk_link_helper.rb
+++ b/lib/bops/cop/style/govuk_link_helper.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Bops
+  module Cop
+    module Style
+      class UseGovukLinkHelper < RuboCop::Cop::Base
+        extend ::RuboCop::Cop::AutoCorrector
+
+        MSG = "Prefer `%<good_action>s` over `%<bad_action>s`."
+        RESTRICT_ON_SEND = %i[link_to].freeze
+
+        def on_send(node)
+          return unless node.method_name == :link_to
+
+          hash_arg = node.arguments.select { _1.type == :hash }.first
+          return if hash_arg.nil? || hash_arg.empty? # rubocop:disable Rails/Blank
+
+          hash_arg.each_pair do |k, v|
+            next unless k.value == :class
+
+            classes = v.source
+            next unless /\bgovuk-link\b/.match?(classes)
+
+            add_offense(node.loc.selector, message: message) do |corrector|
+              if node.arguments.length == 3 && hash_arg.pairs.length == 1
+                replacement = "govuk_link_to #{node.arguments[0].source}, #{node.arguments[1].source}"
+                replacement_classes = classes.sub(/\bgovuk-link\b/, "").strip
+                replacement_classes.gsub!(/^('|") /, '\1')
+                replacement_classes.gsub!(/ ('|")$/, '\1')
+                replacement << ", class: #{replacement_classes}" unless replacement_classes == '""'
+
+                corrector.replace(node, replacement)
+              end
+            end
+          end
+        end
+
+        private
+
+        def message
+          format(MSG, good_action: good_action, bad_action: bad_action)
+        end
+
+        def good_action
+          %(govuk_link_to foo_path)
+        end
+
+        def bad_action
+          %(link_to foo_path, class: "govuk-link")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

govuk-components includes a helper `govuk_link` to apply the right classes. Apply this where appropriate and use a rubocop check to catch places where it's missing.

### Further improvements

- This doesn't catch use of things like `govuk-link--no-underline`, which the helper has a special parameter for. We use it rarely enough that it doesn't seem worth the effort of writing a check/fix.
- Currently I'm only looking for links that have `govuk-link`. This means that there might be links which don't have any class, and should be styled as `govuk-link` but are just left with the browser default styles. It's possible, and quite simple, to fix this, but I'm concerned about false positives. Perhaps any `link_to` with no class should be assumed to be replaceable with `govuk_link_to`?
- This warns for all links with `govuk-link`, but doesn't autocorrect links that have additional parameters like `target:` — I'm playing it safe in terms of messing around with the AST.