### PR TITLE
Creating a release needs a separate token to avoid recursion

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -37,3 +37,4 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
           prerelease: true
           makeLatest: false
+          token: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
See <https://stackoverflow.com/a/69063453>
