### PR TITLE
Upgrade to released version of govuk-components

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "devise"
 gem "devise-two-factor"
 gem "faker", require: false
 gem "faraday", "~> 2", require: false
-gem "govuk-components", git: "https://github.com/x-govuk/govuk-components.git", ref: "fa37301"
+gem "govuk-components", "~> 5", ">= 5.3.2"
 gem "govuk_design_system_formbuilder"
 gem "grover"
 gem "i18n", "< 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/x-govuk/govuk-components.git
-  revision: fa37301f2352c06dae6c6cd713baf77bd877767e
-  ref: fa37301
-  specs:
-    govuk-components (5.3.1)
-      html-attributes-utils (~> 1.0.0, >= 1.0.0)
-      pagy (>= 6, < 8)
-      view_component (>= 3.9, < 3.12)
-
 PATH
   remote: engines/bops_admin
   specs:
@@ -271,6 +261,10 @@ GEM
       raabro (~> 1.4)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    govuk-components (5.3.2)
+      html-attributes-utils (~> 1.0.0, >= 1.0.0)
+      pagy (>= 6, < 8)
+      view_component (>= 3.9, < 3.12)
     govuk_design_system_formbuilder (5.3.1)
       actionview (>= 6.1)
       activemodel (>= 6.1)
@@ -668,7 +662,7 @@ DEPENDENCIES
   faker
   faraday (~> 2)
   foreman
-  govuk-components!
+  govuk-components (~> 5, >= 5.3.2)
   govuk_design_system_formbuilder
   grover
   guard


### PR DESCRIPTION
This was pinned to a git version in #1715 for an unreleased required feature.