### PR TITLE
Fix no assessor on recommendation

### DIFF
--- a/app/controllers/planning_applications/review/recommendations_controller.rb
+++ b/app/controllers/planning_applications/review/recommendations_controller.rb
@@ -26,6 +26,7 @@ module PlanningApplications
       def create
         @recommendation = @planning_application.recommendations.new(
           status: "review_complete",
+          assessor: Current.user,
           reviewer: Current.user
         )
 

--- a/spec/system/planning_applications/review/add_committee_decision_spec.rb
+++ b/spec/system/planning_applications/review/add_committee_decision_spec.rb
@@ -149,6 +149,15 @@ RSpec.describe "Update decision notice after committee" do
           "Update decision notice after committee",
           with: "Completed"
         )
+
+        sign_out reviewer
+        sign_in assessor
+
+        visit "/planning_applications/#{planning_application.id}"
+
+        click_link "View recommendation"
+
+        expect(page).to have_content "Recommendations submitted by #{reviewer.name}"
       end
 
       it "shows errors" do


### PR DESCRIPTION
### Description of change

When a new recommendation was submitted via committee, the assessor id was blank, causing the page to error.

### Story Link

https://trello.com/c/BWnGSjsG/2902-unable-to-view-recommendation-as-assessor-when-the-recommendation-has-been-made
