### PR TITLE
Add save progress to heads of terms

### DIFF
--- a/app/controllers/planning_applications/assessment/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/assessment/heads_of_terms_controller.rb
@@ -29,7 +29,7 @@ module PlanningApplications
           format.html do
             if @heads_of_term.update(heads_of_terms_params)
               redirect_to planning_application_assessment_tasks_path(@planning_application),
-                notice: I18n.t("heads_of_terms.update.success")
+                notice: I18n.t("heads_of_terms.update.#{@heads_of_term.public? ? "public" : "saved"}.success")
             else
               render :index
             end
@@ -57,7 +57,11 @@ module PlanningApplications
         params.require(:heads_of_term)
           .permit(
             terms_attributes: %i[_destroy id title text]
-          ).to_h.merge(reviews_attributes: [status:, id: (@heads_of_term&.current_review&.id if !mark_as_complete?)])
+          ).to_h.merge(public:, reviews_attributes: [status:, id: (@heads_of_term&.current_review&.id if !mark_as_complete?)])
+      end
+
+      def public
+        params[:commit] == "Confirm and send to applicant"
       end
 
       def status

--- a/app/models/heads_of_term.rb
+++ b/app/models/heads_of_term.rb
@@ -10,6 +10,7 @@ class HeadsOfTerm < ApplicationRecord
   accepts_nested_attributes_for :reviews
 
   after_update :create_heads_of_terms_review!, if: :should_create_review?
+  after_commit :update_validation_requests, if: :public?
 
   def current_review
     reviews.order(:created_at).last
@@ -38,6 +39,10 @@ class HeadsOfTerm < ApplicationRecord
 
   def create_heads_of_terms_review!
     reviews.create!(reviewer: Current.user, owner_id: id, specific_attributes: {"review_type" => "heads_of_term"}, status: "complete")
+  end
+
+  def update_validation_requests
+    validation_requests.pending.each { |request| request.email_and_timestamp }
   end
 
   private

--- a/app/models/heads_of_terms_validation_request.rb
+++ b/app/models/heads_of_terms_validation_request.rb
@@ -7,6 +7,8 @@ class HeadsOfTermsValidationRequest < ValidationRequest
   belongs_to :owner, polymorphic: true
 
   def email_and_timestamp
+    return unless owner.heads_of_term.public?
+
     send_post_validation_request_email if owner.heads_of_term.send_notification?
 
     mark_as_sent!

--- a/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
@@ -7,7 +7,6 @@
   <div id="standard-terms">
     <%= form.govuk_check_boxes_fieldset :heads_of_term, multiple: false, legend: { text: "Suggested heads of terms" } do %>
       <%= form.fields_for :terms, @heads_of_term.terms.standard do |fields| %>
-        <% next if fields.object.persisted? %>
         <%= fields.hidden_field :_destroy, value: true %>
         <%= fields.govuk_check_box :_destroy, false, multiple: false, label: { text: fields.object.title }, checked: fields.object.checked?, class: "term", link_errors: true do %>
           <%= fields.hidden_field :id %>
@@ -56,5 +55,13 @@
     </div>
   </template>
 
-  <%= form.submit "Submit", class: "govuk-button", data: { module: "govuk-button" } %>
+  <div class="govuk-button-group">
+    <%= form.submit "Confirm and send to applicant", class: "govuk-button", data: { module: "govuk-button" } %>
+
+    <% if @planning_application.heads_of_term.terms.none?(&:persisted?) %>
+      <%= form.submit "Save and come back later", class: "govuk-button govuk-button--secondary", data: { module: "govuk-button" } %>
+    <% end %>
+
+    <%= link_to "Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+  </div>
 <% end %>

--- a/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
@@ -37,8 +37,11 @@
               <% end %>
             <% end %>
           </div>
-        <%= form.submit "Submit", class: "govuk-button", data: { module: "govuk-button" } %>
-
+        
+        <div class="govuk-button-group">
+          <%= form.submit "Confirm and send to applicant", class: "govuk-button", data: { module: "govuk-button" } %>
+          <%= link_to "Back", planning_application_assessment_heads_of_terms_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        </div>
         <% end %>
       </div>
     </div>

--- a/app/views/planning_applications/assessment/heads_of_terms/index.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/index.html.erb
@@ -20,7 +20,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <% if @planning_application.heads_of_term.terms.any?(&:persisted?) && @planning_application.heads_of_term.errors.none? %>
+    <% if @planning_application.heads_of_term.public? && @planning_application.heads_of_term.terms.any?(&:persisted?) && @planning_application.heads_of_term.errors.none? %>
       <%= render "heads_of_terms" %>
     <% else %>
       <%= render "form" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -721,7 +721,10 @@ en:
     save_and_mark_as_complete: Save and mark as complete
   heads_of_terms:
     update:
-      success: Heads of terms successfully updated and sent to applicant
+      public:
+        success: Heads of terms successfully updated and sent to applicant
+      saved:
+        success: Heads of terms successfully saved
   helpers:
     hint:
       neighbour_response:

--- a/db/migrate/20240425100305_add_public_to_heads_of_terms.rb
+++ b/db/migrate/20240425100305_add_public_to_heads_of_terms.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddPublicToHeadsOfTerms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :heads_of_terms, :public, :boolean, default: false, null: false
+
+    HeadsOfTerm.find_each do |term|
+      term.update(public: true)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_24_142947) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_25_100305) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -376,6 +376,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_24_142947) do
     t.bigint "planning_application_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "public", default: false, null: false
     t.index ["planning_application_id"], name: "ix_heads_of_terms_on_planning_application_id"
   end
 

--- a/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add pre-commencement conditions" do
+RSpec.describe "Add heads of terms" do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
@@ -42,9 +42,67 @@ RSpec.describe "Add pre-commencement conditions" do
         fill_in "Enter detail", with: "Detail 3"
       end
 
-      click_button "Submit"
+      click_button "Confirm and send to applicant"
 
-      expect(page).to have_content "Heads of terms successfully updated"
+      expect(page).to have_content "Heads of terms successfully updated and sent to applicant"
+
+      within("#add-heads-of-terms") do
+        expect(page).to have_content "In progress"
+        click_link "Add heads of terms"
+      end
+
+      within("tr", text: "Car free development") do
+        expect(page).to have_content "Awaiting response"
+      end
+
+      within("tr", text: "Highway and public transport") do
+        expect(page).to have_content "Awaiting response"
+      end
+
+      within("tr", text: "Term 3") do
+        expect(page).to have_content "Awaiting response"
+      end
+    end
+
+    it "you can save and come back" do
+      within("#add-heads-of-terms") do
+        expect(page).to have_content "Not started"
+        click_link "Add heads of terms"
+      end
+
+      check "Car free development"
+      within("#heads-of-term-terms-attributes-0--destroy-conditional") do
+        fill_in "Enter detail", with: "No cars"
+      end
+
+      check "Highway and public transport"
+      within("#heads-of-term-terms-attributes-2--destroy-conditional") do
+        fill_in "Enter detail", with: "Wider roads"
+      end
+
+      click_button "Save and come back later"
+
+      expect(page).to have_content "Heads of terms successfully saved"
+
+      within("#add-heads-of-terms") do
+        expect(page).to have_content "In progress"
+        click_link "Add heads of terms"
+      end
+
+      within("#heads-of-term-terms-attributes-2--destroy-conditional") do
+        fill_in "Enter detail", with: "Even wider roads"
+      end
+
+      click_link "Add term"
+
+      within("#other-terms") do
+        fill_in "Enter a title", with: "Term 3"
+        fill_in "Enter detail", with: "Detail 3"
+      end
+
+      click_button "Confirm and send to applicant"
+
+      expect(page).to have_content "Heads of terms successfully updated and sent to applicant"
 
       within("#add-heads-of-terms") do
         expect(page).to have_content "In progress"
@@ -65,6 +123,7 @@ RSpec.describe "Add pre-commencement conditions" do
     end
 
     it "you can edit terms once they've been rejected" do
+      planning_application.heads_of_term.update(public: true)
       term1 = create(:term, title: "Title 1", heads_of_term: planning_application.heads_of_term)
       term1.current_validation_request.update(state: "closed", approved: false, rejection_reason: "Typo", notified_at: 1.day.ago, closed_at: Time.zone.now)
       create(:review, owner: planning_application.heads_of_term)
@@ -99,7 +158,7 @@ RSpec.describe "Add pre-commencement conditions" do
         fill_in "Enter detail", with: "Custom detail 1"
       end
 
-      click_button "Submit"
+      click_button "Confirm and send to applicant"
 
       click_link "Add heads of terms"
 
@@ -119,6 +178,7 @@ RSpec.describe "Add pre-commencement conditions" do
     end
 
     it "you can cancel terms" do
+      planning_application.heads_of_term.update(public: true)
       term1 = create(:term, title: "Title 1", heads_of_term: planning_application.heads_of_term)
       create(:review, owner: planning_application.heads_of_term)
 
@@ -157,7 +217,7 @@ RSpec.describe "Add pre-commencement conditions" do
         fill_in "Enter detail", with: ""
       end
 
-      click_button "Submit"
+      click_button "Confirm and send to applicant"
 
       expect(page).to have_content "Enter the title of this term"
       expect(page).to have_content "Enter the detail of this term"
@@ -170,7 +230,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
       click_link "+ Add term"
 
-      click_button "Submit"
+      click_button "Confirm and send to applicant"
 
       expect(page).to have_content "Enter the title of this term"
       expect(page).to have_content "Enter the detail of this term"
@@ -178,6 +238,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
     context "when marking the task as complete" do
       it "you can do it if all requests are approved" do
+        planning_application.heads_of_term.update(public: true)
         term1 = create(:term, title: "Title 1", heads_of_term: planning_application.heads_of_term)
         term1.current_validation_request.update(state: "closed", approved: false, rejection_reason: "Typo", notified_at: 1.day.ago, closed_at: Time.zone.now)
         create(:review, owner: planning_application.heads_of_term)


### PR DESCRIPTION
### Description of change

Allow officer to save and come back later when adding heads of terms

For now, they can only do this on initial creation of terms, for simplicity's sake

### Story Link

part of https://trello.com/c/b1A1AKI2/2855-pattern-main-navigation-buttons
