### PR TITLE
Improve redis docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,13 +107,13 @@ services:
 
   redis:
     image: redis:7.0
-    command: redis-server
+    command: ["redis-server", "--save '60 1'", "--loglevel warning"]
     ports:
       - "127.0.0.1:6379:6379"
     volumes:
       - type: volume
         source: redis
-        target: /var/lib/redis/data
+        target: /data
 
   web:
     <<: *bops


### PR DESCRIPTION
* Save every 60 seconds if there's been at least one write operation

* Save to a named volume instead of a generated name that changes every time the container is created

* Set log level to 'warning' so logs aren't flooded with save info
