### PR TITLE
Add autocorrect tasks for linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ db-prompt:
 	$(DOCKER-RUN) console psql postgres://postgres:postgres@db
 
 lint:
-	$(DOCKER-RUN) console rubocop
+	$(DOCKER-RUN) console rake rubocop biome erblint
 
 lint-auto-correct:
-	$(DOCKER-RUN) console rubocop --autocorrect-all
+	$(DOCKER-RUN) console rake rubocop:fix biome:fix erblint:fix
 
 # this regenerates the Rubocop TODO and ensures that cops aren't
 # turned off over a max number of file offenses. Note: we don't want

--- a/lib/tasks/biome.rake
+++ b/lib/tasks/biome.rake
@@ -4,3 +4,11 @@ desc "Run biome linter"
 task biome: :environment do
   exit 1 unless system "git ls-files -z '*.js' '*.ts' | xargs -0 node_modules/.bin/biome ci"
 end
+
+namespace :biome do
+  desc "Run biome linter and apply fixes"
+  task fix: :environment do
+    exit 1 unless system "git ls-files -z '*.js' '*.ts' | xargs -0 node_modules/.bin/biome format --write"
+    exit 1 unless system "git ls-files -z '*.js' '*.ts' | xargs -0 node_modules/.bin/biome check --apply-unsafe"
+  end
+end

--- a/lib/tasks/erblint.rake
+++ b/lib/tasks/erblint.rake
@@ -4,3 +4,10 @@ desc "Run erblint linter"
 task erblint: :environment do
   exit 1 unless system "git ls-files -z '*.erb'| xargs -0 erblint"
 end
+
+namespace :erblint do
+  desc "Run erblint linter and apply fixes"
+  task fix: :environment do
+    exit 1 unless system "git ls-files -z '*.erb'| xargs -0 erblint -a"
+  end
+end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -4,3 +4,10 @@ desc "Run the rubocop static code analyzer"
 task rubocop: :environment do
   exit 1 unless system "rubocop"
 end
+
+namespace :rubocop do
+  desc "Run the rubocop static code analyzer and apply fixes"
+  task fix: :environment do
+    exit 1 unless system "rubocop --autocorrect-all"
+  end
+end


### PR DESCRIPTION
Simplify automatically applying linter corrections. Adds rake tasks `rubocop:fix`, `biome:fix`, and `erblint:fix`.