### PR TITLE
Extract error summary into a viewcomponent

### DIFF
--- a/app/components/error_summary_component.html.erb
+++ b/app/components/error_summary_component.html.erb
@@ -1,0 +1,14 @@
+<% if errors.any? %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      <%= title %>
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% error_messages.each do |error| %>
+          <li><%= error.html_safe %></li> <%# erblint:disable ErbSafety %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/components/error_summary_component.rb
+++ b/app/components/error_summary_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ErrorSummaryComponent < ViewComponent::Base
+  def initialize(errors:, full_messages: false)
+    @errors = errors
+    @full_messages = full_messages
+  end
+
+  attr_reader :errors
+
+  def title
+    "There is a problem"
+  end
+
+  def error_messages
+    @full_messages ? @errors.full_messages : @errors.map(&:message)
+  end
+end

--- a/app/components/planning_applications/search_component.html.erb
+++ b/app/components/planning_applications/search_component.html.erb
@@ -6,7 +6,7 @@
       url: planning_applications_path(anchor: panel_type, status: selected_status, application_type: selected_application_type),
       data: {controller: "clear-form"}
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <div class="search-form-inputs">
     <%= form.govuk_fieldset(legend: {text: nil}) do %>
       <%= form.govuk_text_field(

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,7 +10,7 @@
       url: password_path(resource_name),
       method: :put
     ) do |f| %>
-  <%= f.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= f.govuk_error_summary %>
   <%= f.hidden_field :reset_password_token %>
   <div class="govuk-form-group govuk-!-margin-top-8">
     <%= f.label :password, "New password", class: "govuk-heading-s govuk-!-margin-bottom-1" %>

--- a/app/views/devise/sessions/setup.html.erb
+++ b/app/views/devise/sessions/setup.html.erb
@@ -15,7 +15,7 @@
             url: user_session_path,
             method: :post
           ) do |form| %>
-        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_error_summary %>
         <%= form.govuk_text_field(:mobile_number) %>
         <div class="govuk-button-group">
           <%= form.govuk_submit(t(".send_code")) %>

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [@planning_application, @document], class: "document" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= render partial: "documents/form_partials/upload", locals: {form: form} unless @validate_document %>
   <div class="govuk-form-group">
     <%= render partial: "documents/form_partials/received_at", locals: {form: form} unless @validate_document %>

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @planning_application do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.hidden_field(
         :return_to,

--- a/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/assessment/assess_immunity_detail_permitted_development_rights/_form.html.erb
@@ -3,7 +3,7 @@
       url: form_url,
       method: form_method
     ) do |form| %>
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.govuk_error_summary %>
 
     <div class="govuk-form-group <%= form.object.errors.any? ? "govuk-form-group--error" : "" %>">
       <%= form.fields_for :review do |review_immunity_detail| %>

--- a/app/views/planning_applications/assessment/assessment_details/additional_evidence/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/additional_evidence/edit.html.erb
@@ -20,7 +20,7 @@
     </p>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/additional_evidence/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/additional_evidence/new.html.erb
@@ -22,7 +22,7 @@
     </p>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10, value: @rejected_assessment_detail&.entry) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/amenity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/amenity/edit.html.erb
@@ -29,7 +29,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/amenity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/amenity/new.html.erb
@@ -30,7 +30,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10, value: @rejected_assessment_detail&.entry) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
@@ -204,7 +204,7 @@
     </div>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.hidden_field(:category, value: @category) %>
 

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
@@ -202,7 +202,7 @@
     </div>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.hidden_field(:category, value: @category) %>
 

--- a/app/views/planning_applications/assessment/assessment_details/neighbour_summary/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/neighbour_summary/edit.html.erb
@@ -16,7 +16,7 @@
           heading: updated_neighbour_responses_summary_text(@neighbour_responses, @assessment_detail) %>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <% NeighbourResponse::TAGS.each_with_index do |tag, index| %>
         <% next if @neighbour_responses.select { |response| response.tags.include? tag.to_s }.none? %>

--- a/app/views/planning_applications/assessment/assessment_details/neighbour_summary/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/neighbour_summary/new.html.erb
@@ -18,7 +18,7 @@
     <%= render(partial: "comment", locals: {comment: @rejected_assessment_detail&.comment}) %>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <% NeighbourResponse::TAGS.each_with_index do |tag, index| %>
         <% next if @neighbour_responses.select { |response| response.tags.include? tag.to_s }.none? %>

--- a/app/views/planning_applications/assessment/assessment_details/site_description/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/site_description/edit.html.erb
@@ -29,7 +29,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/site_description/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/site_description/new.html.erb
@@ -30,7 +30,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10, value: @rejected_assessment_detail&.entry) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_work/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_work/edit.html.erb
@@ -35,7 +35,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_work/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_work/new.html.erb
@@ -35,7 +35,7 @@
     </ul>
 
     <%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(:entry, label: nil, rows: 10, value: @rejected_assessment_detail&.entry) %>
       <%= form.hidden_field(:category, value: @category) %>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -4,7 +4,7 @@
       html: {data: {controller: "conditions reset-text"}},
       method: :patch do |form| %>
 
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <div id="standard-conditions">
     <%= form.govuk_check_boxes_fieldset :conditions, multiple: false, legend: {text: "Suggested conditions"} do %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_form.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_form.html.erb
@@ -3,7 +3,7 @@
       url: planning_application_assessment_consistency_checklist_path(planning_application),
       class: "consistency-checklist-form"
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <% planning_application.application_type.consistency_checklist.each do |checklist| %>
     <%= render(
           partial: checklist,

--- a/app/views/planning_applications/assessment/consultees/index.html.erb
+++ b/app/views/planning_applications/assessment/consultees/index.html.erb
@@ -16,20 +16,7 @@
 
 <div class="govuk-grid-row">
   <%= content_tag :div, class: "govuk-grid-column-full", data: {} do %>
-    <% if @consultation.errors.any? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @consultation.errors.each do |error| %>
-              <li><%= error.message %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= render ErrorSummaryComponent.new(errors: @consultation.errors) %>
 
     <%= render "shared/consultees_table", planning_application: @planning_application, consultation: @consultation %>
 

--- a/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/_form.html.erb
@@ -2,7 +2,7 @@
       url: planning_application_assessment_heads_of_terms_path(@planning_application),
       html: {data: {controller: "heads-of-terms"}},
       method: :patch do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <div id="standard-terms">
     <%= form.govuk_check_boxes_fieldset :heads_of_term, multiple: false, legend: {text: "Suggested heads of terms"} do %>

--- a/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
+++ b/app/views/planning_applications/assessment/heads_of_terms/edit.html.erb
@@ -24,7 +24,7 @@
               url: planning_application_assessment_heads_of_terms_path(@planning_application),
               html: {data: {controller: "heads-of-terms"}},
               method: :patch do |form| %>
-          <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+          <%= form.govuk_error_summary %>
 
           <div id="other-terms" data-heads-of-terms-target="terms">
             <%= form.fields_for :terms, @term do |fields| %>

--- a/app/views/planning_applications/assessment/informatives/_form.html.erb
+++ b/app/views/planning_applications/assessment/informatives/_form.html.erb
@@ -2,7 +2,7 @@
       url:,
       method: :patch do |form| %>
   <% if !@informative_set.current_review&.complete? || params[:show_form] == "true" || form.object.errors.any? %>
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.govuk_error_summary %>
 
     <div data-informatives-array-value="<%= @planning_application.local_authority.informatives.pluck(:title, :text).to_json %>"></div>
 

--- a/app/views/planning_applications/assessment/informatives/edit.html.erb
+++ b/app/views/planning_applications/assessment/informatives/edit.html.erb
@@ -19,7 +19,7 @@
     <%= form_with model: @informative,
           url: planning_application_assessment_informative_path(@planning_application, @informative),
           method: :patch do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
       <div data-controller="informatives">
         <div data-informatives-array-value="<%= @planning_application.local_authority.informatives.pluck(:title, :text).to_json %>"></div>
 

--- a/app/views/planning_applications/assessment/local_policy_areas/_edit_form.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/_edit_form.html.erb
@@ -1,9 +1,7 @@
 <%= form_with(model: @local_policy_area,
       url: planning_application_assessment_local_policy_area_path(@planning_application, @local_policy_area),
       class: "govuk-!-margin-top-5") do |form| %>
-  <%= form.govuk_error_summary(
-        presenter: ErrorPresenter
-      ) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_text_field :area, label: {text: "Area text", size: "s"}, hint: {text: "Enter a title for your custom local policy topic if it does not appear in the list below"} %>
   <%= form.govuk_text_field :policies, label: {text: "Which policies are relevant", size: "s"}, hint: {text: "Enter the policy reference"} %>
   <%= form.govuk_radio_buttons_fieldset(:policy, legend: {size: "s", text: "Is there relevant guidance?"}) do %>

--- a/app/views/planning_applications/assessment/local_policy_areas/_form.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/_form.html.erb
@@ -4,9 +4,7 @@
   <%= form_with(model: @local_policy_area,
         url: planning_application_assessment_local_policy_areas_path(@planning_application),
         class: "govuk-!-margin-top-5") do |form| %>
-    <%= form.govuk_error_summary(
-          presenter: ErrorPresenter
-        ) %>
+    <%= form.govuk_error_summary %>
     <h3 class="govuk-heading-m">Choose policy area from a list</h3>
     <label class="govuk-label">
       <strong>

--- a/app/views/planning_applications/assessment/permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/assessment/permitted_development_rights/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [@planning_application, :assessment, @permitted_development_right],
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :removed,

--- a/app/views/planning_applications/assessment/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/pre_commencement_conditions/_form.html.erb
@@ -10,7 +10,7 @@
       </h2>
     </legend>
 
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.govuk_error_summary %>
 
     <%= form.govuk_text_field :title, label: {text: "Enter title"} %>
     <%= form.govuk_text_area :text, rows: 5, label: {text: "Enter condition"} %>

--- a/app/views/planning_applications/assessment/recommendations/_form.html.erb
+++ b/app/views/planning_applications/assessment/recommendations/_form.html.erb
@@ -6,7 +6,7 @@
         recommendation
       )
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(
         :challenged,
         legend: {text: t(".do_you_agree"), size: "s"}

--- a/app/views/planning_applications/assessment/recommendations/new.html.erb
+++ b/app/views/planning_applications/assessment/recommendations/new.html.erb
@@ -53,7 +53,7 @@
           model: @recommendation,
           url: planning_application_assessment_recommendations_path(@planning_application)
         ) do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_radio_buttons_fieldset(:recommend, legend: {size: "s", text: "Does this planning application need to be decided by committee?"}) do %>
         <%= form.govuk_radio_button :recommend, true, label: {text: "Yes"}, link_errors: true, checked: @committee_decision&.recommend? do %>

--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -17,20 +17,8 @@
       When all parts of the application have been checked and are correct, mark the application as valid.
     </p>
     <%= form_with model: @planning_application, url: validate_planning_application_path(@planning_application), local: true do |form| %>
-      <% if @planning_application.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @planning_application.errors.each do |error| %>
-                <li><%= error.message.html_safe %></li><%# erblint:disable ErbSafety %>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= render ErrorSummaryComponent.new(errors: @planning_application.errors) %>
+
       <%= form.govuk_date_field :validated_at, legend: {size: "s"}, hint: {text: "Enter valid date, for example, 28 12 2021"} %>
       <%= form.govuk_radio_buttons_fieldset :make_public, legend: {text: "Publish application on BOPS Public Portal?"} do %>
         <%= form.govuk_radio_button :make_public, true, label: {text: "Yes"} %>

--- a/app/views/planning_applications/consultations/edit.html.erb
+++ b/app/views/planning_applications/consultations/edit.html.erb
@@ -15,7 +15,7 @@
       model: @consultation,
       url: planning_application_consultation_path(@planning_application)
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_date_field :end_date, legend: {text: "Set consultation end date", size: "m"} %>
 

--- a/app/views/planning_applications/consultee/emails/index.html.erb
+++ b/app/views/planning_applications/consultee/emails/index.html.erb
@@ -26,7 +26,7 @@
           method: :post,
           data: {consultees_target: "form"}
         ) do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= render ConsulteesComponent.new(consultees: @consultees, form: form) %>
       <%= render ConsulteeEmailComponent.new(form: form) %>

--- a/app/views/planning_applications/consultee/responses/edit.html.erb
+++ b/app/views/planning_applications/consultee/responses/edit.html.erb
@@ -30,7 +30,7 @@
       method: :patch,
       data: {controller: "reset-text"}
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_text_area :response,
         rows: 8,
         label: {size: "l", text: "Full comment"},

--- a/app/views/planning_applications/consultee/responses/new.html.erb
+++ b/app/views/planning_applications/consultee/responses/new.html.erb
@@ -20,7 +20,7 @@
       url: planning_application_consultee_responses_path(@planning_application, @consultee),
       method: :post
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_text_field :name %>
   <%= form.govuk_text_field :email %>
   <%= form.govuk_date_field :received_at, legend: {text: "Response received on", size: "s", tag: "p"} %>

--- a/app/views/planning_applications/consultees/index.html.erb
+++ b/app/views/planning_applications/consultees/index.html.erb
@@ -22,26 +22,13 @@
         consultees_target: "allConsultees"
 
       } do %>
-    <% if @consultation.errors.any? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @consultation.errors.each do |error| %>
-              <li><%= error.message %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
 
   <%= form_with(model: @consultation,
         url: planning_application_consultees_emails_path(@planning_application),
         data: {
           consultees_target: "form"
         }) do |form| %>
+    <%= form.govuk_error_summary %>
     <%= render "shared/consultees_table", planning_application: @planning_application, consultation: @consultation %>
     <%= render AddConsulteeComponent.new(consultees: @consultees, form: form) %>
   <% end %>

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -33,7 +33,7 @@
           url: planning_application_consultees_assign_constraint_path(@planning_application),
           method: "POST",
           class: "govuk-!-margin-top-7" do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.label "Select consultee for #{@constraint.type_code}", class: "govuk-label" %>
       <%= form.hidden_field :constraint, value: @constraint.id %>

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -14,20 +14,8 @@
 
 <div class="govuk-grid-row">
   <%= content_tag :div, class: "govuk-grid-column-full", data: {} do %>
-    <% if @consultation.errors.any? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @consultation.errors.each do |error| %>
-              <li><%= error.message %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+
+    <%= render ErrorSummaryComponent.new(errors: @consultation.errors) %>
 
     <%= form_with model: @constraint,
           url: planning_application_consultees_assign_constraint_path(@planning_application),

--- a/app/views/planning_applications/make_public.html.erb
+++ b/app/views/planning_applications/make_public.html.erb
@@ -15,20 +15,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @planning_application,
           url: planning_application_path(@planning_application) do |form| %>
-      <% if @planning_application.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @planning_application.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
+
       <%= form.govuk_radio_buttons_fieldset :make_public, legend: {text: "Publish application on BOPS Public Portal?"} do %>
         <%= form.govuk_radio_button :make_public, true, label: {text: "Yes"} %>
         <%= form.govuk_radio_button :make_public, false, label: {text: "No"} %>

--- a/app/views/planning_applications/neighbour_letters/index.html.erb
+++ b/app/views/planning_applications/neighbour_letters/index.html.erb
@@ -50,20 +50,7 @@
           method: :post,
           url: send_letters_planning_application_consultation_neighbour_letters_path(@planning_application)
         ) do |form| %>
-      <% if @consultation.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @consultation.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
 
       <%= render "list", planning_application: @planning_application, consultation: @consultation, form: form %>
 

--- a/app/views/planning_applications/neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/neighbour_responses/edit.html.erb
@@ -19,7 +19,7 @@
       url: planning_application_consultation_neighbour_response_path(@planning_application, @neighbour_response),
       method: :patch
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_field :name %>
   <%= form.govuk_text_field :email %>

--- a/app/views/planning_applications/neighbour_responses/new.html.erb
+++ b/app/views/planning_applications/neighbour_responses/new.html.erb
@@ -19,7 +19,7 @@
       url: planning_application_consultation_neighbour_responses_path(@planning_application, @neighbour_response),
       method: :post
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_text_field :name %>
   <%= form.govuk_text_field :email %>
   <%= form.govuk_select :address, @consultation.selected_neighbour_addresses, options: {include_blank: true}, label: {text: "Select an existing neighbour address"} %>

--- a/app/views/planning_applications/neighbours/_selected_list.html.erb
+++ b/app/views/planning_applications/neighbours/_selected_list.html.erb
@@ -25,7 +25,7 @@
                   url: planning_application_consultation_neighbour_path(planning_application, neighbour),
                   class: "govuk-!-display-none"
                 ) do |form| %>
-              <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+              <%= form.govuk_error_summary %>
               <%= form.govuk_text_field :address %>
               <br>
               <%= form.submit(

--- a/app/views/planning_applications/neighbours/index.html.erb
+++ b/app/views/planning_applications/neighbours/index.html.erb
@@ -22,20 +22,8 @@
         polygon_search_id: "neighbour-addresses",
         polygon_search_name: "consultation[neighbours_attributes][][address]"
       } do %>
-    <% if @consultation.errors.any? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @consultation.errors.each do |error| %>
-              <li><%= error.message %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= render ErrorSummaryComponent.new(errors: @consultation.errors) %>
+
     <%= render "select_neighbours", planning_application: @planning_application, consultation: @consultation %>
 
     <%= render "form", planning_application: @planning_application, consultation: @consultation %>

--- a/app/views/planning_applications/notes/_form.html.erb
+++ b/app/views/planning_applications/notes/_form.html.erb
@@ -1,18 +1,5 @@
 <%= form_with model: [@planning_application, @note], url: planning_application_notes_path(@planning_application) do |form| %>
-  <% if @note.errors.any? %>
-    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-      <h2 class="govuk-error-summary__title" id="error-summary-title">
-        There is a problem
-      </h2>
-      <div class="govuk-error-summary__body">
-        <ul class="govuk-list govuk-error-summary__list">
-          <% @note.errors.full_messages.each do |error| %>
-            <li><%= error %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-  <% end %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_area :entry, rows: 5, required: true %>
 

--- a/app/views/planning_applications/press_notices/confirmations/show.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/show.html.erb
@@ -16,7 +16,7 @@
       model: @press_notice,
       url: planning_application_press_notice_confirmation_path(@planning_application)
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <% if @press_notice.requested_at? %>
     <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">

--- a/app/views/planning_applications/press_notices/show.html.erb
+++ b/app/views/planning_applications/press_notices/show.html.erb
@@ -24,7 +24,7 @@
 <% end %>
 
 <%= form_with model: @press_notice, url: planning_application_press_notice_path(@planning_application) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :required,

--- a/app/views/planning_applications/publish.html.erb
+++ b/app/views/planning_applications/publish.html.erb
@@ -23,20 +23,8 @@
     <%= form_with model: @planning_application,
           url: determine_planning_application_path(@planning_application) do |form| %>
 
-       <% if @planning_application.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @planning_application.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
+
       <% if @planning_application.open_description_change_request.present? %>
         <%= render(
               partial: "shared/alert_banner",

--- a/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
+++ b/app/views/planning_applications/redact_neighbour_responses/edit.html.erb
@@ -43,7 +43,7 @@
       method: :patch,
       data: {controller: "reset-text"}
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_text_area :response,
         rows: 8,
         label: {size: "l", text: "Full comment"},

--- a/app/views/planning_applications/review/assessment_details/_form.html.erb
+++ b/app/views/planning_applications/review/assessment_details/_form.html.erb
@@ -3,7 +3,7 @@
       url: planning_application_review_assessment_details_path(planning_application),
       method: :put
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <% planning_application.application_type.assessment_details.each_with_index do |assessment_detail, index| %>
     <% next if assessment_detail == "check_publicity" %>
     <% unless index == 0 %>

--- a/app/views/planning_applications/review/cil_liability/_form.html.erb
+++ b/app/views/planning_applications/review/cil_liability/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application],
       url: planning_application_review_cil_liability_url(@planning_application),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :cil_liability,

--- a/app/views/planning_applications/review/conditions/_form.html.erb
+++ b/app/views/planning_applications/review/conditions/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @condition_set,
       url: planning_application_review_conditions_path(@planning_application),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.fields_for :reviews_attributes, @condition_set.current_review do |review_form| %>
     <%= review_form.govuk_radio_buttons_fieldset :action, legend: {text: "Actions"} do %>

--- a/app/views/planning_applications/review/heads_of_terms/_form.html.erb
+++ b/app/views/planning_applications/review/heads_of_terms/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @planning_application.heads_of_term,
       url: planning_application_review_heads_of_term_path(@planning_application),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <% if current_review = heads_of_term.current_review %>
     <%= form.fields_for :reviews_attributes, current_review do |review_form| %>

--- a/app/views/planning_applications/review/immunity_details/_comment.html.erb
+++ b/app/views/planning_applications/review/immunity_details/_comment.html.erb
@@ -20,7 +20,7 @@
             model: [planning_application, :assessment, planning_application.immunity_detail, evidence_group, new_comment],
             data: {action: "submit->submit-form#handleSubmit"}
           ) do |form| %>
-        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_error_summary %>
         <%= form.govuk_text_area(
               :text,
               value: comment.text,

--- a/app/views/planning_applications/review/immunity_details/_form.html.erb
+++ b/app/views/planning_applications/review/immunity_details/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application, @immunity_detail, @review_immunity_detail],
       url: planning_application_review_immunity_detail_path(@planning_application, @review_immunity_detail),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <div class="govuk-form-group <%= form.object.errors.any? ? "govuk-form-group--error" : "" %>">
     <fieldset class="govuk-fieldset">

--- a/app/views/planning_applications/review/immunity_enforcements/_form.html.erb
+++ b/app/views/planning_applications/review/immunity_enforcements/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application, @review_immunity_detail],
       url: planning_application_review_immunity_enforcement_path(@planning_application, @review_immunity_detail),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :action, legend: {text: "Is the application immune from enforcement?"}

--- a/app/views/planning_applications/review/local_policies/_form.html.erb
+++ b/app/views/planning_applications/review/local_policies/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application, @review_local_policy],
       url: planning_application_review_local_policy_path(@planning_application, @review_local_policy),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset :action, legend: {text: "Actions"} do %>
     <%= form.govuk_radio_button(

--- a/app/views/planning_applications/review/notifications/edit.html.erb
+++ b/app/views/planning_applications/review/notifications/edit.html.erb
@@ -51,7 +51,7 @@
         <span class="govuk-hint">These details will be included in the notification.</span>
       </div>
 
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
       <%= form.govuk_date_field :date_of_committee, legend: {text: "Enter date of meeting", size: "s"} %>
       <%= form.govuk_text_field :location, label: {text: "Enter location"}, hint: {text: "Enter the address where the meeting will be held. Include the name of the room, building number or hame, street, town and postcode."} %>
       <%= form.govuk_text_field :link, label: {text: "Enter link"}, hint: {text: "Add a URL where neighbours can view agendas and more information about committee meetings, such as a link to join online."} %>

--- a/app/views/planning_applications/review/permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/review/permitted_development_rights/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application, @permitted_development_right],
       url: planning_application_review_permitted_development_right_path(@planning_application, @permitted_development_right),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :accepted

--- a/app/views/planning_applications/review/policy_classes/_comment.html.erb
+++ b/app/views/planning_applications/review/policy_classes/_comment.html.erb
@@ -20,7 +20,7 @@
             model: [planning_application, :assessment, policy_class, policy, new_comment],
             data: {action: "submit->submit-form#handleSubmit"}
           ) do |form| %>
-        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_error_summary %>
         <%= form.govuk_text_area(
               :text,
               value: new_comment.text || comment.text,

--- a/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
+++ b/app/views/planning_applications/review/pre_commencement_conditions/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @planning_application.pre_commencement_condition_set,
       url: planning_application_review_pre_commencement_conditions_path(@planning_application),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.fields_for :reviews_attributes, condition_set.current_review do |review_form| %>
     <%= review_form.govuk_radio_buttons_fieldset :action, legend: {text: "Actions"} do %>

--- a/app/views/planning_applications/review/publicities/_form.html.erb
+++ b/app/views/planning_applications/review/publicities/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [@planning_application, @assessment_detail], url: planning_application_review_consultation_publicities_path(@planning_application, @consultation) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(:action, legend: {size: "m", text: "Do you accept that publicity has been completed?"}) do %>
     <% if @consultation.start_date && @consultation.end_date %>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/planning_applications/review/recommendations/_committee_form.html.erb
+++ b/app/views/planning_applications/review/recommendations/_committee_form.html.erb
@@ -6,7 +6,7 @@
         recommendation
       )
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(
         :challenged,
         legend: {text: t(".do_you_agree"), size: "s"}

--- a/app/views/planning_applications/review/recommendations/_form.html.erb
+++ b/app/views/planning_applications/review/recommendations/_form.html.erb
@@ -6,7 +6,7 @@
         recommendation
       )
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(
         :challenged,
         legend: {text: t(".do_you_agree"), size: "s"}

--- a/app/views/planning_applications/review/recommendations/new.html.erb
+++ b/app/views/planning_applications/review/recommendations/new.html.erb
@@ -44,19 +44,8 @@
           model: @recommendation,
           url: planning_application_review_recommendations_path(@planning_application)
         ) do |form| %>
-      <% if form.object.planning_application.present? && form.object.planning_application.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% form.object.planning_application.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
+      <% if form.object.planning_application.present? %>
+        <%= render ErrorSummaryComponent.new(errors: form.object.planning_application.errors) %>
       <% end %>
 
       <h2 class="govuk-heading-m">Add Committee recommendation</h2>

--- a/app/views/planning_applications/site_notices/edit.html.erb
+++ b/app/views/planning_applications/site_notices/edit.html.erb
@@ -17,7 +17,7 @@
       class: "govuk-!-margin-top-5",
       method: :patch
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= render "status", planning_application: @planning_application %>
 

--- a/app/views/planning_applications/site_notices/new.html.erb
+++ b/app/views/planning_applications/site_notices/new.html.erb
@@ -28,7 +28,7 @@
       method: :post
     ) do |form| %>
   <div data-controller="show-hide-form">
-    <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+    <%= form.govuk_error_summary %>
 
     <%= form.govuk_radio_buttons_fieldset(
           :required,

--- a/app/views/planning_applications/site_visits/_form.html.erb
+++ b/app/views/planning_applications/site_visits/_form.html.erb
@@ -5,7 +5,7 @@
       method: :post
     ) do |form| %>
 
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset">

--- a/app/views/planning_applications/submit_recommendation.html.erb
+++ b/app/views/planning_applications/submit_recommendation.html.erb
@@ -29,7 +29,7 @@
             model: @planning_application,
             url: submit_planning_application_path(@planning_application)
           ) do |form| %>
-        <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+        <%= form.govuk_error_summary %>
         <%= form.govuk_submit(t(".submit_recommendation")) %>
         <%= link_to(
               t(".edit_recommendation"),

--- a/app/views/planning_applications/validation/additional_document_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/additional_document_validation_requests/_form.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.hidden_field(
             :return_to,

--- a/app/views/planning_applications/validation/cil_liability/_form.html.erb
+++ b/app/views/planning_applications/validation/cil_liability/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: [@planning_application],
       url: planning_application_validation_cil_liability_url(@planning_application),
       class: "govuk-!-margin-top-7" do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(
         :cil_liability,

--- a/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
@@ -27,20 +27,8 @@
         <%= render(FormattedContentComponent.new(text: @planning_application.description)) %>
       </p>
       <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
-        <% if @validation_request.errors.any? %>
-          <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
-              There is a problem
-            </h2>
-            <div class="govuk-error-summary__body">
-              <ul class="govuk-list govuk-error-summary__list">
-                <% @validation_request.errors.full_messages.each do |error| %>
-                  <li><%= error %></li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
-        <% end %>
+        <%= form.govuk_error_summary %>
+
         <% if @planning_application.latest_rejected_description_change.present? %>
           <p class="govuk-body">
             <strong>

--- a/app/views/planning_applications/validation/document/redactions/_form.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_form.html.erb
@@ -4,7 +4,7 @@
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
       method: :post
     ) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <table class="govuk-table redacted-document-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
+++ b/app/views/planning_applications/validation/environment_impact_assessments/_form.html.erb
@@ -7,7 +7,7 @@
           )
         ) %>
     <%= form_with model: [@environment_impact_assessment], url: planning_application_validation_environment_impact_assessment_url(@planning_application) do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_radio_buttons_fieldset(
             :title,

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_form.html.erb
@@ -18,20 +18,7 @@
       <%= form.hidden_field :fee_item, value: @validate_fee %>
       <%= hidden_field_tag(:validate_fee, "yes") %>
 
-      <% if @validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @validation_request.errors.full_messages.each do |error| %>
-                <li><%= error %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(
             :reason,

--- a/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/other_change_validation_requests/_form.html.erb
@@ -6,21 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
-
-      <% if @validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @validation_request.errors.full_messages.each do |error| %>
-                <li><%= error %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(
             :reason,

--- a/app/views/planning_applications/validation/ownership_certificate_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/ownership_certificate_validation_requests/_form.html.erb
@@ -11,20 +11,7 @@
 
     <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
 
-      <% if @validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @validation_request.errors.full_messages.each do |error| %>
-                <li><%= error %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_area(
             :reason,

--- a/app/views/planning_applications/validation/red_line_boundary_change_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/red_line_boundary_change_validation_requests/_form.html.erb
@@ -6,20 +6,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
-      <% if @validation_request.errors.any? %>
-        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-          <h2 class="govuk-error-summary__title" id="error-summary-title">
-            There is a problem
-          </h2>
-          <div class="govuk-error-summary__body">
-            <ul class="govuk-list govuk-error-summary__list">
-              <% @validation_request.errors.each do |error| %>
-                <li><%= error.message %></li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      <% end %>
+      <%= form.govuk_error_summary %>
+
       <%= form.govuk_text_area :new_geojson,
             label: {text: @planning_application.boundary_geojson ? "Applicant's existing red line boundary" : "No digital red line boundary has been previously set",
                     size: "s",

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_form.html.erb
@@ -3,20 +3,8 @@
 
     <%= form.hidden_field :old_document_id, value: @document.id %>
 
-    <% if @validation_request.errors.any? %>
-      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-        <h2 class="govuk-error-summary__title" id="error-summary-title">
-          There is a problem
-        </h2>
-        <div class="govuk-error-summary__body">
-          <ul class="govuk-list govuk-error-summary__list">
-            <% @validation_request.errors.full_messages.each do |error| %>
-              <li><%= error %></li>
-            <% end %>
-          </ul>
-        </div>
-      </div>
-    <% end %>
+    <%= form.govuk_error_summary %>
+
     <%= form.hidden_field :type, value: "ReplacementDocumentValidationRequest" %>
     <%= form.govuk_text_area :reason, label: {size: "m", text: "List all issues with the document"}, required: true %>
 

--- a/app/views/planning_applications/validation/reporting_types/_form.html.erb
+++ b/app/views/planning_applications/validation/reporting_types/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @planning_application, local: true, url: planning_application_validation_reporting_type_url(@planning_application) do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_radio_buttons_fieldset(:reporting_type, legend: {size: "m"}) do %>
     <% if @planning_application.application_type.selected_reporting_types? %>

--- a/app/views/planning_applications/validation/time_extension_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_new.html.erb
@@ -15,20 +15,8 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-form-group">
       <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request do |form| %>
-        <% if @validation_request.errors.any? %>
-          <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-            <h2 class="govuk-error-summary__title" id="error-summary-title">
-              There is a problem
-            </h2>
-            <div class="govuk-error-summary__body">
-              <ul class="govuk-list govuk-error-summary__list">
-                <% @validation_request.errors.full_messages.each do |error| %>
-                  <li><%= error %></li>
-                <% end %>
-              </ul>
-            </div>
-          </div>
-        <% end %>
+        <%= form.govuk_error_summary %>
+
         <%= form.hidden_field(:type, value: "TimeExtensionValidationRequest") %>
 
         <%= form.govuk_date_field :proposed_expiry_date, legend: {text: "Enter the proposed expiry date"}, hint: {text: "The proposed date must be after the planning application's current expiry date"} %>

--- a/app/views/planning_applications/validation/validation_requests/_cancel_confirmation_form.html.erb
+++ b/app/views/planning_applications/validation/validation_requests/_cancel_confirmation_form.html.erb
@@ -3,7 +3,7 @@
       scope: :validation_request,
       url: cancel_planning_application_validation_validation_request_path(@planning_application, validation_request) do |form| %>
 
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_area :cancel_reason, label: {text: "Explain to the applicant why this request is being cancelled"}, rows: 5 %>
 

--- a/config/initializers/govuk_design_system_formbuilder.rb
+++ b/config/initializers/govuk_design_system_formbuilder.rb
@@ -4,4 +4,8 @@ require "govuk_design_system_formbuilder"
 
 GOVUKDesignSystemFormBuilder.configure do |conf|
   conf.default_submit_button_text = "Save"
+
+  Rails.application.config.to_prepare do
+    conf.default_error_summary_presenter = ErrorPresenter
+  end
 end

--- a/engines/bops_admin/app/views/bops_admin/consultees/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/consultees/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+<%= form.govuk_error_summary %>
 <%= form.govuk_fieldset(legend: {text: nil}) do %>
   <%= form.govuk_text_field :name, width: "one-half", label: {text: t(".labels.name")} %>
   <%= form.govuk_email_field :email_address, width: "one-half", label: {text: t(".labels.email_address")} %>

--- a/engines/bops_admin/app/views/bops_admin/informatives/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/informatives/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+<%= form.govuk_error_summary %>
 <%= form.govuk_fieldset(legend: {text: nil}) do %>
   <%= form.govuk_text_field :title, width: "one-half", label: {text: t(".labels.title")} %>
   <%= form.govuk_text_area :text, width: "one-half", rows: 10, label: {text: t(".labels.text")} %>

--- a/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with(model: @local_authority, url: profile_path, id: "profile-form") do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_fieldset(legend: {text: nil}) do %>
 
   <%= form.govuk_text_field(

--- a/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @user do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_fieldset(legend: {text: nil}) do %>
     <%= form.govuk_text_field :name, class: "govuk-input--width-30" %>
     <%= form.govuk_text_field :email, class: "govuk-input--width-30" %>

--- a/engines/bops_config/app/views/bops_config/application_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @application_type do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <div data-controller="autocomplete-select">
     <%= form.govuk_select :code, ApplicationType.code_menu,

--- a/engines/bops_config/app/views/bops_config/application_types/category/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/category/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: @application_type, url: [@application_type, :category] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_radio_buttons :category,
             ApplicationType.categories, :first, ->((k)) { t(".category_labels.#{k}") },

--- a/engines/bops_config/app/views/bops_config/application_types/decisions/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/decisions/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: @application_type, url: [@application_type, :decisions] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_check_boxes :decisions, @application_type.all_decisions, :code, :description,
             legend: {size: "l", tag: "h1", text: t(".choose_decisions")} %>

--- a/engines/bops_config/app/views/bops_config/application_types/determination_periods/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/determination_periods/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: @application_type, url: [@application_type, :determination_period] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_field :determination_period_days, width: 5,
             label: {text: t(".set_determination_period_html", description: @application_type.description)},

--- a/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/document_tags/edit.html.erb
@@ -17,7 +17,7 @@
     </h1>
 
     <%= form_with model: @application_type, url: [@application_type, :document_tags] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <div class="govuk-tabs govuk-!-margin-top-7" data-module="govuk-tabs">
         <ul class="govuk-tabs__list">

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -17,7 +17,7 @@
     </h1>
 
     <%= form_with model: @application_type, url: [@application_type, :features] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.fields_for :features, @application_type.features do |ff| %>
         <%= ff.govuk_fieldset legend: {text: t("application_type_features.legends.check_application_details"), size: "s"} do %>

--- a/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/legislation/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_type, url: [@application_type, :legislation] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_radio_buttons_fieldset(:legislation_type,
             hint: {text: t(".legislation_hint")},

--- a/engines/bops_config/app/views/bops_config/application_types/reporting/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/reporting/edit.html.erb
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= form_with model: @application_type, url: [@application_type, :reporting] do |form| %>
-      <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+      <%= form.govuk_error_summary %>
 
       <%= form.govuk_collection_check_boxes :reporting_types,
             @application_type.all_reporting_types, :code, :full_description,

--- a/engines/bops_config/app/views/bops_config/decisions/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/decisions/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @decision do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_field :description, label: {text: t(".description_label")}, hint: {text: t(".description_hint")} %>
 

--- a/engines/bops_config/app/views/bops_config/legislation/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/legislation/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @legislation do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_field :title,
         label: {text: t(".legislation_title_label")},

--- a/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/reporting_types/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @reporting_type do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_field :description, label: {text: t(".description_label")}, hint: {text: t(".description_hint")} %>
   <%= form.govuk_text_field :code, width: 5, label: {text: t(".code_label")}, hint: {text: t(".code_hint")} %>

--- a/engines/bops_config/app/views/bops_config/users/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/users/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: @user do |form| %>
-  <%= form.govuk_error_summary(presenter: ErrorPresenter) %>
+  <%= form.govuk_error_summary %>
   <%= form.govuk_fieldset(legend: {text: nil}) do %>
     <%= form.govuk_text_field :name, class: "govuk-input--width-30" %>
     <%= form.govuk_text_field :email, class: "govuk-input--width-30" %>


### PR DESCRIPTION
### Description of change

Spotted during #1731 that we have a lot of pages all using the same govuk-frontend component for errors, but duplicating the code. In many cases we can use `form.govuk_error_summary`, but this won't work for every case since there are times we want to show errors from an object that isn't the form's model.

There isn't a pre-made viewcomponent of it, but it's simple enough to build our own.

### Story Link

https://trello.com/c/emIN8osq/2818-review-how-we-use-components
