### PR TITLE
Allow mark as complete when no neighbour responses

### DIFF
--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -96,7 +96,7 @@ class AssessmentDetail < ApplicationRecord
     return false if accepted? || rejected?
 
     summary_of_work? ||
-      site_description? || amenity? || neighbour_summary? ||
+      site_description? || amenity? || any_neighbour_responses? ||
       (assessment_complete? && consultation_summary?)
   end
 
@@ -112,5 +112,11 @@ class AssessmentDetail < ApplicationRecord
     entries = tag_array.push(:untagged).map { |tag| entry[/(?<=#{tag.to_s.humanize}:)\s\n/] }
 
     errors.add(:entry, "Fill in all summaries of comments") if entries.any?
+  end
+
+  def any_neighbour_responses?
+    return unless planning_application&.consultation
+
+    planning_application.consultation.neighbour_responses.any?
   end
 end

--- a/app/views/planning_applications/assessment/assessment_details/neighbour_summary/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/neighbour_summary/show.html.erb
@@ -15,11 +15,13 @@
           title: "View neighbour responses",
           heading: updated_neighbour_responses_summary_text(@neighbour_responses, @assessment_detail) %>
 
-    <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
+    <% if @assessment_detail.entry.present? %>
+      <h2 class="govuk-heading-m"><%= t(".heading") %></h2>
 
-    <p class="govuk-body">
-      <%= render(FormattedContentComponent.new(text: @assessment_detail.entry)) %>
-    </p>
+      <p class="govuk-body">
+        <%= render(FormattedContentComponent.new(text: @assessment_detail.entry)) %>
+      </p>
+    <% end %>
 
     <div class="govuk-button-group">
       <%= back_link %>


### PR DESCRIPTION
### Description of change

Ability to mark summary of neighbour responses as complete even when there are no responses

### Story Link

https://trello.com/c/iUnpBg5e/2686-cant-mark-add-summary-of-neighbour-responses-in-consultation-as-complete-if-there-are-no-neighbour-responses
