### PR TITLE
Do not require comment if site visit not performed

### DIFF
--- a/app/models/site_visit.rb
+++ b/app/models/site_visit.rb
@@ -9,7 +9,8 @@ class SiteVisit < ApplicationRecord
 
   has_many :documents, as: :owner, dependent: :destroy, autosave: true
 
-  validates :status, :comment, presence: true
+  validates :status, :comment, presence: true,
+    if: -> { decision? && consultation_start_date_present? }
   validates :decision, inclusion: {in: [true, false]}
 
   validate :consultation_started?, on: :create

--- a/spec/models/site_visit_spec.rb
+++ b/spec/models/site_visit_spec.rb
@@ -25,8 +25,20 @@ RSpec.describe SiteVisit do
     end
 
     describe "#comment" do
+      before do
+        site_visit.consultation = create(:consultation)
+        site_visit.consultation.start_deadline
+      end
+
       it "validates presence" do
+        site_visit.decision = true
+        expect(site_visit.send(:consultation_start_date_present?)).to be true
         expect { site_visit.valid? }.to change { site_visit.errors[:comment] }.to ["Enter a comment about the site visit"]
+      end
+
+      it "does not require a comment when there is no visit" do
+        site_visit.decision = false
+        expect { site_visit.valid? }.not_to change { site_visit.errors[:comment] }
       end
     end
 

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -137,17 +137,22 @@ RSpec.describe "Site visit" do
       click_button "Save"
 
       within(".govuk-error-summary") do
-        expect(page).to have_content("Enter a comment about the site visit")
         expect(page).to have_content("Choose 'Yes' or 'No'")
       end
       within("#site-visit-decision-error") do
         expect(page).to have_content("Choose 'Yes' or 'No'")
       end
+
+      choose "Yes"
+      click_button("Save")
+
+      within(".govuk-error-summary") do
+        expect(page).to have_content("Enter a comment about the site visit")
+      end
       within("#site-visit-comment-error") do
         expect(page).to have_content("Enter a comment about the site visit")
       end
 
-      choose "Yes"
       attach_file("Upload photo(s)", "spec/fixtures/images/image.gif")
       click_button("Save")
 
@@ -278,6 +283,15 @@ RSpec.describe "Site visit" do
         expect(page).to have_content("Comment: Site visit not needed")
 
         expect(page).not_to have_css(".govuk-table")
+      end
+
+      it "I do not have give a reason why if I choose no" do
+        choose "No"
+        click_button "Save"
+
+        within("#site-visit") do
+          expect(page).to have_content("Completed")
+        end
       end
     end
   end


### PR DESCRIPTION
### Description of change

Skip validation on comment etc if there was no site visit.

### Story Link

https://trello.com/c/YFDb2lpW/2687-forced-to-enter-comment-on-add-site-visit-even-if-no-site-visit

