### PR TITLE
Use upstream tag component helper

### DIFF
--- a/app/components/status_tags/base_component.html.erb
+++ b/app/components/status_tags/base_component.html.erb
@@ -1,9 +1,0 @@
-<% if %i[review_complete complete awaiting_response awaiting_responses checked granted valid posted supportive approved auto_approved granted_legal_agreement].include?(status.to_sym) %>
-  <div class="app-task-list__task-tag">
-    <div class="govuk-task-list__status" id="<%= t("status_tag_component.#{status}") %>">
-      <%= t("status_tag_component.#{status}") %>
-    </div>
-  </div>
-<% else %>
-  <%= tag.strong(t("status_tag_component.#{status}"), class: html_classes) %>
-<% end %>

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -2,9 +2,8 @@
 
 module StatusTags
   class BaseComponent < ViewComponent::Base
-    def initialize(status:, task_list: true)
+    def initialize(status:)
       @status = status
-      @task_list = task_list
     end
 
     def render?
@@ -17,7 +16,7 @@ module StatusTags
 
     private
 
-    attr_reader :status, :task_list
+    attr_reader :status
 
     def colour
       case status.to_sym
@@ -32,10 +31,6 @@ module StatusTags
       when :printing
         "purple"
       end
-    end
-
-    def task_list?
-      task_list
     end
   end
 end

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -11,30 +11,26 @@ module StatusTags
       status.present?
     end
 
+    def call
+      govuk_tag(text: t("status_tag_component.#{status}"), colour:)
+    end
+
     private
 
     attr_reader :status, :task_list
 
-    def html_classes
-      [
-        "govuk-tag",
-        colour_class,
-        ("app-task-list__task-tag" if task_list?)
-      ].compact.join(" ")
-    end
-
-    def colour_class
+    def colour
       case status.to_sym
       when :not_started, :new, :review_not_started, :not_consulted
-        "govuk-tag--blue"
+        "blue"
       when :in_progress, :sending
-        "govuk-tag--light-blue"
+        "light-blue"
       when :updated, :to_be_reviewed, :submitted, :neutral, :amendments_needed
-        "govuk-tag--yellow"
+        "yellow"
       when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection, :failed, :refused_legal_agreement
-        "govuk-tag--red"
+        "red"
       when :printing
-        "govuk-tag--purple"
+        "purple"
       end
     end
 

--- a/app/components/status_tags/decision_component.rb
+++ b/app/components/status_tags/decision_component.rb
@@ -4,7 +4,7 @@ module StatusTags
   class DecisionComponent < StatusTags::BaseComponent
     def initialize(planning_application:)
       @planning_application = planning_application
-      super(status:, task_list: false)
+      super(status:)
     end
 
     private

--- a/app/components/status_tags/letter_component.rb
+++ b/app/components/status_tags/letter_component.rb
@@ -4,7 +4,7 @@ module StatusTags
   class LetterComponent < StatusTags::BaseComponent
     def initialize(status:)
       @status = status
-      super(status:, task_list: false)
+      super(status:)
     end
   end
 end

--- a/app/components/status_tags/reviewing/assessment_detail_component.rb
+++ b/app/components/status_tags/reviewing/assessment_detail_component.rb
@@ -9,7 +9,7 @@ module StatusTags
       def initialize(assessment_detail:, planning_application:)
         @planning_application = planning_application
         @assessment_detail = assessment_detail
-        super(status:, task_list: false)
+        super(status:)
       end
 
       private

--- a/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
+++ b/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
@@ -46,7 +46,7 @@
           <h2 class="govuk-heading-m"><%= condition.title %></h2>
 
           <p style="float: none">
-            <%= render(StatusTags::BaseComponent.new(status: status(condition), task_list: false)) %>
+            <%= render(StatusTags::BaseComponent.new(status: status(condition))) %>
           </p>
 
           <% if current_request = condition.current_validation_request %>

--- a/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Add pre-commencement conditions" do
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
       within("#condition_#{Condition.first.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
         expect(page).to have_link("Cancel")
 
@@ -81,7 +81,7 @@ RSpec.describe "Add pre-commencement conditions" do
       end
 
       within("#condition_#{Condition.second.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
       end
 
@@ -136,7 +136,7 @@ RSpec.describe "Add pre-commencement conditions" do
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
       within("#condition_#{Condition.first.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
         expect(page).to have_link("Cancel")
 
@@ -159,7 +159,7 @@ RSpec.describe "Add pre-commencement conditions" do
       end
 
       within("#condition_#{Condition.first.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
       end
 
       within("#condition_#{Condition.second.id}") do
@@ -171,7 +171,7 @@ RSpec.describe "Add pre-commencement conditions" do
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
       within("#condition_#{Condition.second.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
       end
     end
 
@@ -204,7 +204,7 @@ RSpec.describe "Add pre-commencement conditions" do
       end
 
       within("#condition_#{condition2.id}") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Accepted")
+        expect(page).to have_selector(".govuk-tag", text: "Accepted")
         expect(page).to have_link(
           "Update condition",
           href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions/#{condition2.id}/edit"
@@ -246,7 +246,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
       within("#condition_#{condition1.id}") do
         expect(page).to have_selector("h2", text: "Title 1")
-        expect(page).to have_selector(".govuk-task-list__status", text: "Awaiting response")
+        expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         click_link "Cancel"
       end
 

--- a/spec/system/planning_applications/assessing/check_consultees_spec.rb
+++ b/spec/system/planning_applications/assessing/check_consultees_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "checking consultees", js: true do
 
     click_button "Confirm as checked"
 
-    expect(page).to have_selector("#check-consultees-consulted .govuk-task-list__status", text: "Completed")
+    expect(page).to have_selector("#check-consultees-consulted .govuk-tag", text: "Completed")
   end
 
   it "allows assessor to add consultees from the summary page" do

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Consultation", js: true do
 
     within "#consultee-tasks" do
       expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"
@@ -234,7 +234,7 @@ RSpec.describe "Consultation", js: true do
 
       within "#consultee-tasks" do
         expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 
@@ -309,7 +309,7 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Consultation", js: true do
 
     within "#consultee-tasks" do
       expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"
@@ -217,7 +217,7 @@ RSpec.describe "Consultation", js: true do
 
       within "#consultee-tasks" do
         expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 
@@ -295,7 +295,7 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -346,7 +346,7 @@ RSpec.describe "Consultation", js: true do
 
       within "#consultee-tasks" do
         expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       end
     end.to have_enqueued_job(SendConsulteeEmailJob).exactly(:once)
 
@@ -414,7 +414,7 @@ RSpec.describe "Consultation", js: true do
     end
 
     within "#consultee-tasks" do
-      expect(page).to have_selector("li:first-child .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:first-child .govuk-tag", text: "Awaiting responses")
     end
 
     click_link "Send emails to consultees"

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Consultation", js: true do
 
     within "#consultee-tasks" do
       expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-      expect(page).to have_selector("li:nth-child(2) .govuk-task-list__status", text: "Awaiting responses")
+      expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Awaiting responses")
       expect(page).to have_selector("li:last-child a", text: "View consultee responses")
       expect(page).to have_selector("li:last-child .govuk-tag", text: "Not started")
     end

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_link("Review assessment summaries")
 
         within(find("fieldset", text: "Summary of works")) do
-          expect(find(".govuk-task-list__status")).to have_content("Completed")
+          expect(find(".govuk-tag")).to have_content("Completed")
 
           choose("Accept")
         end
@@ -470,7 +470,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_link("Review assessment summaries")
 
         within(find("fieldset", text: "Summary of works")) do
-          expect(find(".govuk-task-list__status")).to have_content("Completed")
+          expect(find(".govuk-tag")).to have_content("Completed")
 
           choose("Accept")
         end
@@ -682,7 +682,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_link("Review assessment summaries")
 
         within(find("fieldset", text: "Consultation")) do
-          expect(find(".govuk-task-list__status")).to have_content("Completed")
+          expect(find(".govuk-tag")).to have_content("Completed")
         end
 
         click_link("Review")
@@ -948,7 +948,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_link("Review assessment summaries")
 
         within(find("fieldset", text: "Summary of works")) do
-          expect(find(".govuk-task-list__status")).to have_content("Completed")
+          expect(find(".govuk-tag")).to have_content("Completed")
 
           choose("Accept")
         end

--- a/spec/system/planning_applications/validating/constraints_spec.rb
+++ b/spec/system/planning_applications/validating/constraints_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Constraints" do
         "Check constraints",
         href: planning_application_validation_constraints_path(planning_application)
       )
-      within("#constraints-validation-tasks .govuk-task-list__status") do
+      within("#constraints-validation-tasks .govuk-tag") do
         expect(page).to have_content("Checked")
       end
 

--- a/spec/system/planning_applications/validating/redact_documents_spec.rb
+++ b/spec/system/planning_applications/validating/redact_documents_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Redact documents" do
 
     within("#confirm-documents-tasks") do
       expect(page).to have_selector("li:nth-of-type(3) > span", text: "Upload redacted documents")
-      expect(page).to have_selector("li:nth-of-type(3) .govuk-task-list__status", text: "Completed")
+      expect(page).to have_selector("li:nth-of-type(3) .govuk-tag", text: "Completed")
     end
   end
 

--- a/spec/system/planning_applications/validating/reporting_type_spec.rb
+++ b/spec/system/planning_applications/validating/reporting_type_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Reporting type validation task" do
       end
 
       within("#development-type-for-reporting-task") do
-        expect(page).to have_selector(".govuk-task-list__status", text: "Completed")
+        expect(page).to have_selector(".govuk-tag", text: "Completed")
       end
 
       expect(page).to have_link(

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -225,7 +225,7 @@ RSpec.describe "Validation tasks" do
               "Draw red line boundary",
               href: planning_application_validation_sitemap_path(planning_application)
             )
-            within(".govuk-task-list__status") do
+            within(".govuk-tag") do
               expect(page).to have_content("Checked")
             end
           end
@@ -242,7 +242,7 @@ RSpec.describe "Validation tasks" do
               "Check constraints",
               href: planning_application_validation_constraints_path(planning_application)
             )
-            within(".govuk-task-list__status") do
+            within(".govuk-tag") do
               expect(page).to have_content("Checked")
             end
           end


### PR DESCRIPTION
### Description of change

As a step towards using only the upstream components, if that's ever possible, we can rely on the upstream helper to generate the component as much as possible.

### Story Link

https://trello.com/c/IUfOWTmb
