### PR TITLE
Get rid of 'save and mark as checked'

### DIFF
--- a/app/views/planning_applications/validation/constraints/index.html.erb
+++ b/app/views/planning_applications/validation/constraints/index.html.erb
@@ -14,7 +14,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Add, remove and save constraints</h2>
     <p class="govuk-body govuk-!-margin-bottom-8">
-      Check the constraints for this application. Add any constraints that are relevant. When all relevant constraints have been added, save and mark as checked.
+      Check the constraints for this application. Add any constraints that are relevant. When all relevant constraints have been added, save and mark as complete.
     </p>
   </div>
 </div>
@@ -62,7 +62,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @planning_application, url: planning_application_validation_constraints_path(@planning_application) do |form| %>
       <div class="govuk-button-group">
-        <%= form.submit "Save and mark as checked", class: "govuk-button", data: {module: "govuk-button"} %>
+        <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -717,7 +717,6 @@ en:
     publish_decision: Publish decision
     review_and_publish_decision: Review and publish decision
     save_and_come_back_later: Save and come back later
-    save_and_mark_as_checked: Save and mark as checked
     save_and_mark_as_complete: Save and mark as complete
   heads_of_terms:
     update:

--- a/spec/system/planning_applications/validating/constraints_spec.rb
+++ b/spec/system/planning_applications/validating/constraints_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Constraints" do
 
       expect(page).to have_link("Back", href: planning_application_validation_tasks_path(planning_application))
 
-      click_button "Save and mark as checked"
+      click_button "Save and mark as complete"
 
       expect(page).to have_text("Constraints was successfully checked")
 
@@ -89,7 +89,7 @@ RSpec.describe "Constraints" do
         expect(page).to have_content "Special area of conservation"
       end
 
-      click_button "Save and mark as checked"
+      click_button "Save and mark as complete"
 
       visit "/planning_applications/#{planning_application.id}/validation/constraints"
 


### PR DESCRIPTION
### Description of change

Change "save and mark as checked" to "save and mark as complete"

### Story Link

https://trello.com/c/b1A1AKI2/2855-pattern-main-navigation-buttons
