### PR TITLE
Fix task list status tags

### DIFF
--- a/app/components/task_list_items/base_component.html.erb
+++ b/app/components/task_list_items/base_component.html.erb
@@ -2,5 +2,7 @@
   <span class="app-task-list__task-name">
     <%= link_to_if(link_active?, link_text, link_path, class: "govuk-link") %>
   </span>
-  <%= render(status_tag_component) %>
+  <div class="govuk-task-list__status app-task-list__task-tag" id="<%= link_text.parameterize %>-status">
+    <%= render(status_tag_component) %>
+  </div>
 </li>

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -7,11 +7,13 @@
       <span class="app-task-list__task-name">
         <%= govuk_link_to t(".description_documents_and"), consistency_checklist_path(consistency_checklist) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::ConsistencyChecklistComponent.new(
               consistency_checklist: consistency_checklist
             )
           ) %>
+      </div>
     </li>
     <% if @planning_application.check_publicity? %>
       <%= render(

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -17,11 +17,13 @@
               class: "govuk-link"
             ) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::AssessRecommendationComponent.new(
               planning_application: @planning_application
             )
           ) %>
+      </div>
     </li>
     <% if @planning_application.application_type.planning_conditions? %>
       <%= render(
@@ -45,11 +47,13 @@
       <span class="app-task-list__task-name">
         <%= govuk_link_to "Add heads of terms", planning_application_assessment_heads_of_terms_path(@planning_application) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::HeadsOfTermsComponent.new(
               heads_of_term: @planning_application.heads_of_term
             )
           ) %>
+      </div>
     </li>
     <li class="app-task-list__item">
       <span class="app-task-list__task-name">
@@ -59,11 +63,13 @@
           Review and submit recommendation
         <% end %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::SubmitRecommendationComponent.new(
               planning_application: @planning_application
             )
           ) %>
+      </div>
     </li>
   </ul>
 </li>

--- a/app/views/planning_applications/review/tasks/_policy_classes.html.erb
+++ b/app/views/planning_applications/review/tasks/_policy_classes.html.erb
@@ -5,6 +5,7 @@
     <% end %>
 
     <% c.with_tag do %>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::BaseComponent.new(
               status: if policy_class.current_review&.status == "updated"
@@ -14,6 +15,7 @@
                       end
             )
           ) %>
+      </div>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -14,11 +14,13 @@
     <span class="app-task-list__task-name">
       <%= govuk_link_to "Check Community Infrastructure Levy (CIL)", planning_application_review_cil_liability_path(@planning_application) %>
     </span>
+    <div class="govuk-task-list__status app-task-list__task-tag">
     <%= render(
           StatusTags::BaseComponent.new(
             status: (@planning_application.audits.review_cil_liability.any? ? :complete : :not_started)
           )
         ) %>
+    </div>
   </li>
   <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.evidence.any? %>
       <%= render(
@@ -109,11 +111,13 @@
               class: "govuk-link"
             ) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::AddCommitteeDecisionComponent.new(
               planning_application: @planning_application
             )
           ) %>
+      </div>
     </li>
   <% end %>
 </ul>

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -8,11 +8,13 @@
               planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation) :
               edit_planning_application_review_consultation_neighbour_responses_path(@planning_application, @planning_application.consultation)) %>
     </span>
+    <div class="govuk-task-list__status app-task-list__task-tag">
     <%= render(
           StatusTags::BaseComponent.new(
             status: (@planning_application.consultation.neighbour_review.present? ? @planning_application.consultation.neighbour_review.review_status : :not_started)
           )
         ) %>
+    </div>
   </li>
 
   <li class="app-task-list__item">
@@ -21,10 +23,12 @@
               planning_application_review_consultation_publicities_path(@planning_application, @planning_application.consultation) :
               edit_planning_application_review_consultation_publicities_path(@planning_application.id, @planning_application.consultation.id)) %>
     </span>
+    <div class="govuk-task-list__status app-task-list__task-tag">
     <%= render(
           StatusTags::BaseComponent.new(
             status: (@planning_application.check_publicity&.review_status.present? ? @planning_application.check_publicity.review_status : :not_started)
           )
         ) %>
+    </div>
   </li>
 </ul>

--- a/app/views/planning_applications/review/tasks/_sign_off_recommendation.html.erb
+++ b/app/views/planning_applications/review/tasks/_sign_off_recommendation.html.erb
@@ -8,9 +8,11 @@
           class: "govuk-link"
         ) %>
   </span>
+  <div class="govuk-task-list__status app-task-list__task-tag">
   <%= render(
         StatusTags::SignoffRecommendationComponent.new(
           planning_application: @planning_application
         )
       ) %>
+  </div>
 </li>

--- a/app/views/planning_applications/validation/tasks/_application_details.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_details.html.erb
@@ -7,11 +7,13 @@
       <span class="app-task-list__task-name">
         <%= link_to_unless(@planning_application.boundary_geojson.present? && @planning_application.officer_can_draw_boundary?, "Draw red line boundary", planning_application_validation_sitemap_path(@planning_application), class: "govuk-link") %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::DrawRedLineBoundaryComponent.new(
               boundary_geojson: @planning_application.boundary_geojson
             )
           ) %>
+      </div>
     </li>
     <%= render(
           TaskListItems::CheckRedLineBoundaryComponent.new(
@@ -22,11 +24,13 @@
       <span class="app-task-list__task-name">
         <%= govuk_link_to "Check constraints", planning_application_validation_constraints_path(@planning_application) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::ConstraintsComponent.new(
               planning_application: @planning_application
             )
           ) %>
+      </div>
     </li>
     <% if @planning_application.validated? %>
       <li id="check-description" class="app-task-list__item">
@@ -46,11 +50,13 @@
         <%= govuk_link_to "Select development type for reporting", edit_planning_application_validation_reporting_type_path(@planning_application) %>
       </span>
 
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::BaseComponent.new(
               status: @planning_application.reporting_type_status
             )
           ) %>
+      </div>
     </li>
     <% if @planning_application.application_type.legislation_description %>
       <% if @planning_application.validated? %>

--- a/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
@@ -20,22 +20,26 @@
       <span class="app-task-list__task-name">
         <%= govuk_link_to "Confirm Community Infrastructure Levy (CIL)", edit_planning_application_validation_cil_liability_path(@planning_application) %>
       </span>
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::CilLiabilityComponent.new(
               planning_application: @planning_application
             )
           ) %>
+      </div>
     </li>
     <li id="environment-impact-assessment-task" class="app-task-list__item">
       <span class="app-task-list__task-name">
         <%= govuk_link_to "Check Environment Impact Assessment", @planning_application.environment_impact_assessment.nil? ? new_planning_application_validation_environment_impact_assessment_path(@planning_application) : planning_application_validation_environment_impact_assessment_path(@planning_application) %>
       </span>
 
+      <div class="govuk-task-list__status app-task-list__task-tag">
       <%= render(
             StatusTags::BaseComponent.new(
               status: @planning_application.environment_impact_assessment_status
             )
           ) %>
+      </div>
     </li>
     <%= render(
           TaskListItems::Validating::OwnershipCertificateComponent.new(

--- a/spec/system/planning_applications/assessing/check_consultees_spec.rb
+++ b/spec/system/planning_applications/assessing/check_consultees_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "checking consultees", js: true do
 
   it "allows the assessor to see the list of constraints and consultees" do
     expect(page).to have_link("Check consultees consulted")
-    expect(page).to have_selector("#check-consultees-consulted > strong", text: "Not started")
+    expect(page).to have_selector("#check-consultees-consulted .govuk-tag", text: "Not started")
 
     click_link("Check consultees consulted")
 
@@ -48,7 +48,7 @@ RSpec.describe "checking consultees", js: true do
 
   it "allows assessor to mark as checked" do
     expect(page).to have_link("Check consultees consulted")
-    expect(page).to have_selector("#check-consultees-consulted > strong", text: "Not started")
+    expect(page).to have_selector("#check-consultees-consulted .govuk-tag", text: "Not started")
     click_link "Check consultees consulted"
 
     within ".govuk-table" do

--- a/spec/system/planning_applications/validating/redact_documents_spec.rb
+++ b/spec/system/planning_applications/validating/redact_documents_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Redact documents" do
 
     within("#confirm-documents-tasks") do
       expect(page).to have_selector("li:nth-of-type(3) > span", text: "Upload redacted documents")
-      expect(page).to have_selector("li:nth-of-type(3) > span + strong", text: "In progress")
+      expect(page).to have_selector("li:nth-of-type(3) .govuk-tag", text: "In progress")
     end
 
     click_button "Documents"


### PR DESCRIPTION
### Description of change

Removing the `task_list` parameter in #1763 caused a rendering error, but strictly speaking the classes it added aren't part of the status tag, they're part of the task list. Added them to the base TaskListItem and then additionally to any uses of StatusTag components in a hardcoded task list.

