### PR TITLE
Use application description as default type

### DIFF
--- a/app/models/concerns/planning_application_decorator.rb
+++ b/app/models/concerns/planning_application_decorator.rb
@@ -32,7 +32,7 @@ module PlanningApplicationDecorator
   end
 
   def type
-    I18n.t(application_type.name, scope: "application_types")
+    I18n.t(application_type.name, scope: "application_types", default: application_type.description)
   end
 
   def type_and_work_status

--- a/spec/components/accordion_sections/application_information_component_spec.rb
+++ b/spec/components/accordion_sections/application_information_component_spec.rb
@@ -42,13 +42,28 @@ RSpec.describe AccordionSections::ApplicationInformationComponent, type: :compon
     )
   end
 
-  it "renders type and work status" do
-    render_inline(component)
+  context "when ldc proposed application" do
+    it "renders correct type and work status" do
+      render_inline(component)
 
-    expect(page).to have_row_for(
-      "Application type:",
-      with: "Lawful Development Certificate"
-    )
+      expect(page).to have_row_for(
+        "Application type:",
+        with: "Lawful Development Certificate"
+      )
+    end
+  end
+
+  context "when listed building application" do
+    let(:application_type) { create(:application_type, :listed) }
+
+    it "renders correct type and work status" do
+      render_inline(component)
+
+      expect(page).to have_row_for(
+        "Application type:",
+        with: "Consent to do works to a Listed Building"
+      )
+    end
   end
 
   it "renders address" do

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -393,6 +393,11 @@ FactoryBot.define do
       legislation { association :legislation, :pp_full_householder_retro }
     end
 
+    trait :listed do
+      code { "listed" }
+      suffix { "LBC" }
+    end
+
     trait :without_consultation do
       features {
         {


### PR DESCRIPTION
### Description of change

If the mapping does not exist for translation `I18n.t(application_type.name, scope: "application_types"` then default back to the application description which is mapped in `odp.yml`

### Story Link

https://trello.com/c/XbI6XNdf/2930-squiffy-text-in-application-header