### PR TITLE
Add policy areas and references to local authority admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,6 @@ gem "devise"
 gem "devise-two-factor"
 gem "faker", require: false
 gem "faraday", "~> 2", require: false
-gem "govuk-components", "~> 5", ">= 5.3.2"
-gem "govuk_design_system_formbuilder"
 gem "grover"
 gem "i18n", "< 1.9"
 gem "i18n-tasks"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,8 @@ PATH
   remote: engines/bops_core
   specs:
     bops_core (0.1.0)
+      govuk-components (~> 5, >= 5.3.2)
+      govuk_design_system_formbuilder (~> 5, >= 5.3.2)
       pagy
       rails (>= 7.1.3, < 7.2)
 
@@ -274,7 +276,7 @@ GEM
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 8)
       view_component (>= 3.9, < 3.12)
-    govuk_design_system_formbuilder (5.3.1)
+    govuk_design_system_formbuilder (5.3.3)
       actionview (>= 6.1)
       activemodel (>= 6.1)
       activesupport (>= 6.1)
@@ -673,8 +675,6 @@ DEPENDENCIES
   faker
   faraday (~> 2)
   foreman
-  govuk-components (~> 5, >= 5.3.2)
-  govuk_design_system_formbuilder
   grover
   guard
   guard-cucumber

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -11,6 +11,7 @@ $govuk-page-width: 1100px;
 @import "components/inset_text";
 @import "components/loading_spinner";
 @import "components/primary_navigation";
+@import "components/secondary_navigation";
 @import "components/sortable";
 @import "components/table";
 @import "components/task_list";

--- a/app/assets/stylesheets/components/_primary_navigation.scss
+++ b/app/assets/stylesheets/components/_primary_navigation.scss
@@ -1,4 +1,4 @@
-// https://github.com/x-govuk/govuk-prototype-components/releases/tag/v3.0.4
+// https://github.com/x-govuk/govuk-prototype-components/releases/tag/v3.0.5
 
 .x-govuk-primary-navigation {
   @include govuk-font(19, $weight: bold);

--- a/app/assets/stylesheets/components/_secondary_navigation.scss
+++ b/app/assets/stylesheets/components/_secondary_navigation.scss
@@ -1,0 +1,71 @@
+// https://github.com/x-govuk/govuk-prototype-components/releases/tag/v3.0.5
+
+.x-govuk-secondary-navigation {
+  @include govuk-font(19);
+}
+
+.x-govuk-secondary-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-no-visited-state;
+  @include govuk-link-style-no-underline;
+
+  // Extend the touch area of the link to the list
+  &::after {
+    bottom: 0;
+    content: "";
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+}
+
+.x-govuk-secondary-navigation__list {
+  @include govuk-clearfix;
+
+  // The list uses box-shadow rather than a border to set a 1px
+  // grey line at the bottom, so that border from the current
+  // item appears on top of the grey line.
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.x-govuk-secondary-navigation__list-item {
+  box-sizing: border-box;
+  display: block;
+  float: left;
+  margin-right: govuk-spacing(4);
+  padding-bottom: govuk-spacing(2);
+  padding-top: govuk-spacing(2);
+  position: relative;
+
+  // More generous padding beneath items on wider screens
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: govuk-spacing(3);
+  }
+}
+
+// The last item of the list doesn’t need any spacing to its right.
+// Removing this prevents the item from wrapping to the next line
+// unnecessarily.
+.x-govuk-secondary-navigation__list-item:last-child {
+  margin-right: 0;
+}
+
+.x-govuk-secondary-navigation__list-item--current {
+  border-bottom: $govuk-border-width solid $govuk-brand-colour;
+  padding-bottom: govuk-spacing(1);
+
+  // More generous padding beneath items on wider screens
+  @include govuk-media-query($from: tablet) {
+    padding-bottom: govuk-spacing(2);
+  }
+}
+
+.x-govuk-secondary-navigation__list-item--current .x-govuk-secondary-navigation__link:link,
+.x-govuk-secondary-navigation__list-item--current .x-govuk-secondary-navigation__link:visited {
+  color: $govuk-text-colour;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include BopsCore::ApplicationHelper
+
   attr_reader :back_path
 
   def back_link(classname: "govuk-button govuk-button--secondary")

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -7,6 +7,8 @@ class LocalAuthority < ApplicationRecord
     has_many :constraints
     has_many :contacts
     has_many :informatives
+    has_many :policy_areas
+    has_many :policy_references
     has_many :api_users
   end
 

--- a/app/models/local_authority/policy_area.rb
+++ b/app/models/local_authority/policy_area.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class LocalAuthority < ApplicationRecord
+  class PolicyArea < ApplicationRecord
+    belongs_to :local_authority
+    has_and_belongs_to_many :policy_references # rubocop:disable Rails/HasAndBelongsToMany
+
+    validates :description,
+      uniqueness: {scope: :local_authority},
+      presence: true
+
+    class << self
+      def menu
+        by_description.pluck(:id, :description)
+      end
+
+      def search(query)
+        scope = by_description
+
+        if query.blank?
+          scope
+        else
+          scope.where(search_query, search_param(query))
+        end
+      end
+
+      def by_description
+        order(:description)
+      end
+
+      private
+
+      delegate :quote_column_name, to: :connection
+
+      def search_query
+        "#{quoted_table_name}.#{quote_column_name("search")} @@ to_tsquery('simple', ?)"
+      end
+
+      def search_param(query)
+        query.to_s
+          .scan(/[-\w]{3,}/)
+          .map { |word| word.gsub(/^-/, "!") }
+          .map { |word| word.gsub(/-$/, "") }
+          .map { |word| word.gsub(/.+/, "\\0:*") }
+          .join(" & ")
+      end
+    end
+  end
+end

--- a/app/models/local_authority/policy_reference.rb
+++ b/app/models/local_authority/policy_reference.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class LocalAuthority < ApplicationRecord
+  class PolicyReference < ApplicationRecord
+    belongs_to :local_authority
+    has_and_belongs_to_many :policy_areas # rubocop:disable Rails/HasAndBelongsToMany
+
+    validates :code,
+      uniqueness: {scope: :local_authority},
+      presence: true
+
+    validates :description,
+      uniqueness: {scope: :local_authority},
+      presence: true
+
+    validates :url, url: true
+
+    class << self
+      def default_scope
+        preload(:policy_areas)
+      end
+
+      def search(query)
+        scope = by_code
+
+        if query.blank?
+          scope
+        else
+          scope.where(search_query, search_param(query))
+        end
+      end
+
+      def by_code
+        order(:code)
+      end
+
+      private
+
+      delegate :quote_column_name, to: :connection
+
+      def search_query
+        "#{quoted_table_name}.#{quote_column_name("search")} @@ to_tsquery('simple', ?)"
+      end
+
+      def search_param(query)
+        query.to_s
+          .scan(/[-\w]{3,}/)
+          .map { |word| word.gsub(/^-/, "!") }
+          .map { |word| word.gsub(/-$/, "") }
+          .map { |word| word.gsub(/.+/, "\\0:*") }
+          .join(" & ")
+      end
+    end
+
+    def human_policy_areas
+      policy_areas.map(&:description).join(", ")
+    end
+  end
+end

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -37,17 +37,6 @@
   </div>
 </header>
 
-<% if nav_items.any? %>
-  <nav class="x-govuk-primary-navigation" aria-labelledby="primary-navigation-heading">
-    <div class="govuk-width-container">
-      <h2 class="govuk-visually-hidden" id="primary-navigation-heading">Navigation</h2>
-      <ul class="x-govuk-primary-navigation__list">
-        <% nav_items.each do |item| %>
-          <li class="x-govuk-primary-navigation__item <%= "x-govuk-primary-navigation__item--current" if active_page_key == item[:key] %>">
-            <a class="x-govuk-primary-navigation__link" <%= "aria-current=page" if active_page_key == item[:key] %> href="<%= item[:url] %>"><%= item[:name] %></a>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </nav>
+<%= govuk_primary_navigation do |nav| %>
+  <% nav_items.each { |item| nav.with_item(**item) } %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,10 @@
 
       <%= render_navigation unless @blank_layout == true %>
 
+      <% if content_for?(:secondary_navigation) %>
+        <%= yield :secondary_navigation %>
+      <% end %>
+
       <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing app-main-class" id="main-content" role="main">
         <%= render "application/flash_content" %>
         <%= yield %>

--- a/db/migrate/20240501074351_create_local_authority_policies.rb
+++ b/db/migrate/20240501074351_create_local_authority_policies.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class CreateLocalAuthorityPolicies < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension :btree_gin
+
+    area_sql = <<~SQL.squish
+      to_tsvector('simple', description)
+    SQL
+
+    create_table :local_authority_policy_areas do |t|
+      t.references :local_authority, null: false, index: true, foreign_key: true
+      t.string :description, null: false
+      t.virtual :search, type: :tsvector, as: area_sql, stored: true
+
+      t.timestamps
+
+      t.index [:local_authority_id, :description], unique: true
+      t.index [:local_authority_id, :search], using: :gin
+    end
+
+    reference_sql = <<~SQL.squish
+      to_tsvector('simple', code || ' ' || description)
+    SQL
+
+    create_table :local_authority_policy_references do |t|
+      t.references :local_authority, null: false, index: true, foreign_key: true
+      t.string :code, null: false
+      t.string :description, null: false
+      t.string :url
+      t.virtual :search, type: :tsvector, as: reference_sql, stored: true
+
+      t.timestamps
+
+      t.index [:local_authority_id, :code], unique: true
+      t.index [:local_authority_id, :description], unique: true
+      t.index [:local_authority_id, :search], using: :gin
+    end
+
+    create_table :local_authority_policy_areas_references, id: false do |t|
+      t.references :policy_area, index: true, foreign_key: {to_table: :local_authority_policy_areas}
+      t.references :policy_reference, index: true, foreign_key: {to_table: :local_authority_policy_references}
+      t.index [:policy_area_id, :policy_reference_id], unique: true
+    end
+  end
+end

--- a/engines/bops_admin/app/controllers/bops_admin/policy_areas_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/policy_areas_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  class PolicyAreasController < ApplicationController
+    before_action :set_policy_areas, only: %i[index]
+    before_action :build_policy_area, only: %i[new create]
+    before_action :set_policy_area, only: %i[edit update destroy]
+
+    rescue_from Pagy::OverflowError do
+      redirect_to policy_areas_path
+    end
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      respond_to do |format|
+        if @policy_area.save
+          format.html do
+            redirect_to policy_areas_path, notice: t(".successfully_created")
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @policy_area.update(policy_area_params)
+          format.html do
+            redirect_to policy_areas_path, notice: t(".successfully_updated")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        if @policy_area.destroy
+          format.html do
+            redirect_to policy_areas_path, notice: t(".successfully_destroyed")
+          end
+        else
+          format.html do
+            redirect_to policy_areas_path, alert: t(".not_destroyed")
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_policy_areas
+      @pagy, @policy_areas = pagy(current_local_authority.policy_areas.search(search_param), items: 10)
+    end
+
+    def search_param
+      params.fetch(:q, "")
+    end
+
+    def build_policy_area
+      @policy_area = current_local_authority.policy_areas.build(policy_area_params)
+    end
+
+    def set_policy_area
+      @policy_area = current_local_authority.policy_areas.find(params[:id])
+    end
+
+    def policy_area_params
+      if action_name == "new"
+        {}
+      else
+        params.require(:policy_area).permit(*policy_area_attributes)
+      end
+    end
+
+    def policy_area_attributes
+      %i[description]
+    end
+  end
+end

--- a/engines/bops_admin/app/controllers/bops_admin/policy_references_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/policy_references_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  class PolicyReferencesController < ApplicationController
+    before_action :set_policy_references, only: %i[index]
+    before_action :build_policy_reference, only: %i[new create]
+    before_action :set_policy_reference, only: %i[edit update destroy]
+
+    rescue_from Pagy::OverflowError do
+      redirect_to policy_references_path
+    end
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      respond_to do |format|
+        if @policy_reference.save
+          format.html do
+            redirect_to policy_references_path, notice: t(".successfully_created")
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @policy_reference.update(policy_reference_params)
+          format.html do
+            redirect_to policy_references_path, notice: t(".successfully_updated")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        if @policy_reference.destroy
+          format.html do
+            redirect_to policy_references_path, notice: t(".successfully_destroyed")
+          end
+        else
+          format.html do
+            redirect_to policy_references_path, alert: t(".not_destroyed")
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_policy_references
+      @pagy, @policy_references = pagy(current_local_authority.policy_references.search(search_param), items: 10)
+    end
+
+    def search_param
+      params.fetch(:q, "")
+    end
+
+    def build_policy_reference
+      @policy_reference = current_local_authority.policy_references.build(policy_reference_params)
+    end
+
+    def set_policy_reference
+      @policy_reference = current_local_authority.policy_references.find(params[:id])
+    end
+
+    def policy_reference_params
+      if action_name == "new"
+        {}
+      else
+        params.require(:policy_reference).permit(*policy_reference_attributes, policy_area_ids: [])
+      end
+    end
+
+    def policy_reference_attributes
+      %i[code description url]
+    end
+  end
+end

--- a/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
@@ -2,6 +2,7 @@
 
 module BopsAdmin
   module ApplicationHelper
+    include BopsCore::ApplicationHelper
     include BreadcrumbNavigationHelper
 
     attr_reader :back_path
@@ -37,11 +38,11 @@ module BopsAdmin
 
     def nav_items
       [
-        {name: "Dashboard", url: root_path, key: "dashboard"},
-        {name: "Consultees", url: consultees_path, key: "consultees"},
-        {name: "Informatives", url: informatives_path, key: "informatives"},
-        {name: "Users", url: users_path, key: "users"},
-        {name: "Profile", url: profile_path, key: "profile"}
+        {link: {text: "Dashboard", href: root_path}, current: active_page_key?("dashboard")},
+        {link: {text: "Consultees", href: consultees_path}, current: active_page_key?("consultees")},
+        {link: {text: "Informatives", href: informatives_path}, current: active_page_key?("informatives")},
+        {link: {text: "Users", href: users_path}, current: active_page_key?("users")},
+        {link: {text: "Profile", href: profile_path}, current: active_page_key?("profile")}
       ]
     end
   end

--- a/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
@@ -31,6 +31,8 @@ module BopsAdmin
         "profile"
       when "informatives"
         "informatives"
+      when "policy_areas", "policy_references"
+        "policy"
       else
         "dashboard"
       end
@@ -41,6 +43,7 @@ module BopsAdmin
         {link: {text: "Dashboard", href: root_path}, current: active_page_key?("dashboard")},
         {link: {text: "Consultees", href: consultees_path}, current: active_page_key?("consultees")},
         {link: {text: "Informatives", href: informatives_path}, current: active_page_key?("informatives")},
+        {link: {text: "Policy", href: policy_root_path}, current: active_page_key?("policy")},
         {link: {text: "Users", href: users_path}, current: active_page_key?("users")},
         {link: {text: "Profile", href: profile_path}, current: active_page_key?("profile")}
       ]

--- a/engines/bops_admin/app/views/bops_admin/informatives/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/informatives/_form.html.erb
@@ -4,7 +4,6 @@
   <%= form.govuk_text_area :text, width: "one-half", rows: 10, label: {text: t(".labels.text")} %>
 <% end %>
 
-<div class="govuk-button-group">
-  <%= form.govuk_submit(t(".submit")) %>
+<%= form.govuk_submit(t(".submit")) do %>
   <%= back_link %>
-</div>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/informatives/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/informatives/index.html.erb
@@ -12,38 +12,38 @@
 
 <%= form_with url: informatives_path, class: "govuk-!-margin-bottom-7", method: :get do |form| %>
   <%= form.govuk_text_field :q, value: params[:q], width: "one-half", label: {text: t(".find_informatives"), hidden: true} %>
-  <div class="govuk-button-group">
-    <%= form.govuk_submit t(".find_informatives") %>
-    <%= govuk_link_to t(".add_informative"), new_informative_path, class: "govuk-link--no-visited-state" %>
-  </div>
+  <%= form.govuk_submit t(".find_informatives") do %>
+    <%= govuk_link_to t(".add_informative"), new_informative_path, no_visited_state: true %>
+  <% end %>
 <% end %>
 
-<table class="govuk-table" id="informatives">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header"><%= t(".headings.title") %></th>
-      <th scope="col" class="govuk-table__header"><%= t(".headings.text") %></th>
-      <th scope="col" class="govuk-table__header govuk-!-text-align-right"><%= t(".headings.actions") %></th>
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
+<%= govuk_table(id: "informatives") do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: t(".headings.title")) %>
+      <% row.with_cell(text: t(".headings.text")) %>
+      <% row.with_cell(text: t(".headings.actions"), classes: %w[govuk-!-text-align-right]) %>
+    <% end %>
+  <% end %>
+
+  <% table.with_body do |body| %>
     <% if @informatives.present? %>
       <% @informatives.each do |informative| %>
-        <tr class="govuk-table__row">
-          <th scope="row" class="govuk-table__header"><%= informative.title %></th>
-          <td class="govuk-table__cell"><%= informative.text %></td>
-          <td class="govuk-table__cell govuk-!-text-align-right">
-            <%= govuk_link_to t(".actions.edit"), edit_informative_path(informative), class: "govuk-link--no-visited-state govuk-link--no-underline" %>
-            <%= govuk_link_to t(".actions.delete"), informative_path(informative), class: "govuk-link--no-visited-state govuk-link--no-underline govuk-!-margin-left-1", method: :delete, data: {confirm: t(".are_you_sure")} %>
-          </td>
-        </tr>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: informative.title, header: true) %>
+          <% row.with_cell(text: informative.text) %>
+          <% row.with_cell(classes: %w[govuk-!-text-align-right]) do |cell| %>
+            <%= govuk_link_to t(".actions.edit"), edit_informative_path(informative), no_visited_state: true, no_underline: true %>
+            <%= govuk_link_to t(".actions.delete"), informative_path(informative), no_visited_state: true, no_underline: true, class: "govuk-!-margin-left-1", method: :delete, data: {confirm: t(".are_you_sure")} %>
+          <% end %>
+        <% end %>
       <% end %>
     <% else %>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell" colspan="5"><%= t(".no_informatives_found") %></td>
-      </tr>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: t(".no_informatives_found"), colspan: 3) %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>
 
 <%= govuk_pagination(pagy: @pagy) if @pagy.pages > 1 %>

--- a/engines/bops_admin/app/views/bops_admin/policy_areas/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_areas/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form.govuk_error_summary %>
+
+<%= form.govuk_fieldset(legend: {text: nil}) do %>
+  <%= form.govuk_text_field :description, width: "one-half", label: {text: t(".labels.description")} %>
+<% end %>
+
+<%= form.govuk_submit(t(".submit")) do %>
+  <%= back_link %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/policy_areas/_secondary_navigation.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_areas/_secondary_navigation.html.erb
@@ -1,0 +1,9 @@
+<%= govuk_secondary_navigation(classes: %w[govuk-!-margin-top-5]) do |nav| %>
+  <% nav.with_item(current: true) do |item| %>
+    <% item.with_link(text: t(".policy_areas"), href: policy_areas_path) %>
+  <% end %>
+
+  <% nav.with_item do |item| %>
+    <% item.with_link(text: t(".policy_references"), href: policy_references_path) %>
+  <% end %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/policy_areas/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_areas/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".edit_policy_area") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link t(".policy_areas"), policy_areas_path %>
+
+<% content_for :title, t(".edit_policy_area") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".edit_policy_area") %>
+    </h1>
+
+    <%= form_with model: @policy_area, url: policy_area_path(@policy_area), scope: :policy_area do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/policy_areas/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_areas/index.html.erb
@@ -1,0 +1,51 @@
+<% content_for :page_title do %>
+  <%= t(".manage_policy_areas") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".manage_policy_areas") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <%= t(".manage_policy_areas") %>
+</h1>
+
+<%= form_with url: policy_areas_path, method: :get do |form| %>
+  <%= form.govuk_text_field :q, value: params[:q], width: "one-half", label: {text: t(".find_policy_areas"), hidden: true} %>
+  <%= form.govuk_submit t(".find_policy_areas") do %>
+    <%= govuk_link_to t(".add_policy_area"), new_policy_area_path, no_visited_state: true %>
+  <% end %>
+<% end %>
+
+<%= govuk_table(id: "policy-areas") do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: t(".headings.description")) %>
+      <% row.with_cell(text: t(".headings.actions"), classes: %w[govuk-!-text-align-right]) %>
+    <% end %>
+  <% end %>
+
+  <% table.with_body do |body| %>
+    <% if @policy_areas.present? %>
+      <% @policy_areas.each do |policy_area| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: policy_area.description) %>
+          <% row.with_cell(classes: %w[govuk-!-text-align-right]) do |cell| %>
+            <%= govuk_link_to t(".actions.edit"), edit_policy_area_path(policy_area), no_visited_state: true, no_underline: true %>
+            <%= govuk_link_to t(".actions.delete"), policy_area_path(policy_area), no_visited_state: true, no_underline: true, class: "govuk-!-margin-left-1", method: :delete, data: {confirm: t(".are_you_sure")} %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: t(".no_policy_areas_found"), colspan: 3) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= govuk_pagination(pagy: @pagy) if @pagy.pages > 1 %>

--- a/engines/bops_admin/app/views/bops_admin/policy_areas/new.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_areas/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".add_policy_area") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link t(".policy_areas"), policy_areas_path %>
+
+<% content_for :title, t(".add_policy_area") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".add_policy_area") %>
+    </h1>
+
+    <%= form_with model: @policy_area, url: policy_areas_path, scope: :policy_area do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/policy_references/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_references/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form.govuk_error_summary %>
+
+<%= form.govuk_fieldset(legend: {text: nil}) do %>
+  <%= form.govuk_text_field :code, width: "one-quarter", label: {text: t(".labels.code")} %>
+  <%= form.govuk_text_field :description, width: "three-quarters", label: {text: t(".labels.description")} %>
+  <%= form.govuk_text_field :url, width: "three-quarters", label: {text: t(".labels.url")} %>
+<% end %>
+
+<%= form.govuk_collection_check_boxes :policy_area_ids,
+      current_local_authority.policy_areas.menu, :first, :last,
+      legend: {text: t(".labels.policy_areas")},
+      hint: {text: t(".hints.policy_areas"), size: "l"},
+      small: false, class: "govuk-!-column-count-2" %>
+
+<%= form.govuk_submit(t(".submit")) do %>
+  <%= back_link %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/policy_references/_secondary_navigation.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_references/_secondary_navigation.html.erb
@@ -1,0 +1,9 @@
+<%= govuk_secondary_navigation(classes: %w[govuk-!-margin-top-5]) do |nav| %>
+  <% nav.with_item do |item| %>
+    <% item.with_link(text: t(".policy_areas"), href: policy_areas_path) %>
+  <% end %>
+
+  <% nav.with_item(current: true) do |item| %>
+    <% item.with_link(text: t(".policy_references"), href: policy_references_path) %>
+  <% end %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/policy_references/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_references/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".edit_policy_reference") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link t(".policy_references"), policy_references_path %>
+
+<% content_for :title, t(".edit_policy_reference") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".edit_policy_reference") %>
+    </h1>
+
+    <%= form_with model: @policy_reference, url: policy_reference_path(@policy_reference), scope: :policy_reference do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/policy_references/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_references/index.html.erb
@@ -1,0 +1,61 @@
+<% content_for :page_title do %>
+  <%= t(".manage_policy_references") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".manage_policy_references") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <%= t(".manage_policy_references") %>
+</h1>
+
+<%= form_with url: policy_references_path, method: :get do |form| %>
+  <%= form.govuk_text_field :q, value: params[:q], width: "one-half", label: {text: t(".find_policy_references"), hidden: true} %>
+  <%= form.govuk_submit t(".find_policy_references") do %>
+    <%= govuk_link_to t(".add_policy_reference"), new_policy_reference_path, no_visited_state: true %>
+  <% end %>
+<% end %>
+
+<%= govuk_table(id: "policy-references") do |table| %>
+  <% table.with_head do |head| %>
+    <% head.with_row do |row| %>
+      <% row.with_cell(text: t(".headings.code")) %>
+      <% row.with_cell(text: t(".headings.description")) %>
+      <% row.with_cell(text: t(".headings.policy_areas")) %>
+      <% row.with_cell(text: t(".headings.actions"), classes: %w[govuk-!-text-align-right]) %>
+    <% end %>
+  <% end %>
+
+  <% table.with_body do |body| %>
+    <% if @policy_references.present? %>
+      <% @policy_references.each do |policy_reference| %>
+        <% body.with_row do |row| %>
+          <% row.with_cell(text: policy_reference.code) %>
+          <% row.with_cell do %>
+            <% if policy_reference.url? %>
+              <%= govuk_link_to(policy_reference.description, policy_reference.url, no_visited_state: true, no_underline: true, target: "_blank") %>
+            <% else %>
+              <%= policy_reference.description %>
+            <% end %>
+          <% end %>
+          <% row.with_cell(text: policy_reference.human_policy_areas) %>
+          <% row.with_cell(classes: %w[govuk-!-text-align-right]) do |cell| %>
+            <%= govuk_link_to t(".actions.edit"), edit_policy_reference_path(policy_reference), no_visited_state: true, no_underline: true %>
+            <%= govuk_link_to t(".actions.delete"), policy_reference_path(policy_reference), no_visited_state: true, no_underline: true, class: "govuk-!-margin-left-1", method: :delete, data: {confirm: t(".are_you_sure")} %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: t(".no_policy_references_found"), colspan: 3) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+
+<%= govuk_pagination(pagy: @pagy) if @pagy.pages > 1 %>

--- a/engines/bops_admin/app/views/bops_admin/policy_references/new.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy_references/new.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".add_policy_reference") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link t(".policy_references"), policy_references_path %>
+
+<% content_for :title, t(".add_policy_reference") %>
+
+<% content_for :secondary_navigation do %>
+  <%= render "secondary_navigation" %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".add_policy_reference") %>
+    </h1>
+
+    <%= form_with model: @policy_reference, url: policy_references_path, scope: :policy_reference do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -79,6 +79,83 @@ en:
         add_informative: Add a new informative
       update:
         informative_successfully_updated: Informative successfully updated
+    policy_areas:
+      create:
+        successfully_created: Policy area successfully created
+      destroy:
+        not_destroyed: Unable to delete policy area - please contact support
+        successfully_destroyed: Policy area successfully deleted
+      edit:
+        edit_policy_area: Edit policy area
+        policy_areas: Policy areas
+      form:
+        labels:
+          description: Description
+        submit: Submit
+      index:
+        actions:
+          delete: Delete
+          edit: Edit
+        add_policy_area: Add policy area
+        are_you_sure: Are you sure you want to delete this policy area?
+        find_policy_areas: Find policy areas
+        headings:
+          actions: Actions
+          description: Description
+        manage_policy_areas: Manage policy areas
+        no_policy_areas_found: No policy areas found
+        policy_areas: Policy areas
+        policy_references: Policy references
+      new:
+        add_policy_area: Add a new policy area
+        policy_areas: Policy areas
+      secondary_navigation:
+        policy_areas: Policy areas
+        policy_references: Policy references
+      update:
+        successfully_updated: Policy area successfully updated
+    policy_references:
+      create:
+        successfully_created: Policy reference successfully created
+      destroy:
+        not_destroyed: Unable to delete policy reference - please contact support
+        successfully_destroyed: Policy reference successfully deleted
+      edit:
+        edit_policy_reference: Edit policy reference
+        policy_references: Policy references
+      form:
+        hints:
+          policy_areas: Select the relevant policy areas for this policy
+        labels:
+          code: Code
+          description: Description
+          policy_areas: Policy areas
+          url: URL
+        submit: Submit
+      index:
+        actions:
+          delete: Delete
+          edit: Edit
+        add_policy_reference: Add policy reference
+        are_you_sure: Are you sure you want to delete this policy reference?
+        find_policy_references: Find policy references
+        headings:
+          actions: Actions
+          code: Code
+          description: Description
+          policy_areas: Policy areas
+        manage_policy_references: Manage policy references
+        no_policy_references_found: No policy references found
+        policy_areas: Policy areas
+        policy_references: Policy references
+      new:
+        add_policy_reference: Add a new policy reference
+        policy_references: Policy references
+      secondary_navigation:
+        policy_areas: Policy areas
+        policy_references: Policy references
+      update:
+        successfully_updated: Policy reference successfully updated
     profiles:
       edit:
         profile: Edit profile

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -10,6 +10,15 @@ BopsAdmin::Engine.routes.draw do
 
   resources :informatives, except: %i[show]
 
+  scope "/policy" do
+    get "/", to: redirect("policy/areas"), as: "policy_root"
+
+    with_options except: %i[show] do
+      resources :policy_areas, path: "areas"
+      resources :policy_references, path: "references"
+    end
+  end
+
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member
   end

--- a/engines/bops_admin/spec/system/informatives_spec.rb
+++ b/engines/bops_admin/spec/system/informatives_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Informatives" do
     end
   end
 
-  it "allows searching for a informative" do
+  it "allows searching for an informative" do
     25.times { create(:local_authority_informative, local_authority:) }
     informative = create(:local_authority_informative, local_authority:, title: "Section 106", text: "Section 106 needs doing")
 
@@ -68,7 +68,7 @@ RSpec.describe "Informatives" do
     end
   end
 
-  it "allows adding a informative" do
+  it "allows adding an informative" do
     visit "/admin/informatives"
     expect(page).to have_selector("h1", text: "Manage informatives")
 
@@ -88,7 +88,7 @@ RSpec.describe "Informatives" do
     expect(page).to have_content("Informative successfully created")
   end
 
-  it "allows editing a informative" do
+  it "allows editing an informative" do
     create(:local_authority_informative, local_authority:, title: "Section 106", text: "Section 106 needs doing")
 
     visit "/admin/informatives"
@@ -115,7 +115,7 @@ RSpec.describe "Informatives" do
     end
   end
 
-  it "allows deleting a informative" do
+  it "allows deleting an informative" do
     create(:local_authority_informative, local_authority:, title: "Section 106", text: "Section 106 needs doing")
 
     visit "/admin/informatives"
@@ -134,7 +134,11 @@ RSpec.describe "Informatives" do
   end
 
   it "redirects to the first page if the page parameter overflows" do
-    25.times { create(:contact, local_authority:) }
+    25.times { create(:local_authority_informative, local_authority:) }
+
+    visit "/admin/informatives?page=2"
+    expect(page).to have_selector("h1", text: "Manage informatives")
+    expect(page).to have_current_path("/admin/informatives?page=2")
 
     visit "/admin/informatives?page=4"
     expect(page).to have_selector("h1", text: "Manage informatives")

--- a/engines/bops_admin/spec/system/informatives_spec.rb
+++ b/engines/bops_admin/spec/system/informatives_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe "Informatives" do
     click_button("Submit")
     expect(page).to have_current_path("/admin/informatives")
     expect(page).to have_content("Informative successfully created")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Section 106")
+      expect(page).to have_selector("td:nth-child(2)", text: "Section 106 needs doing")
+    end
   end
 
   it "allows editing an informative" do

--- a/engines/bops_admin/spec/system/policy_areas_spec.rb
+++ b/engines/bops_admin/spec/system/policy_areas_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Policy areas" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :administrator, local_authority:) }
+
+  before do
+    sign_in(user)
+  end
+
+  it "paginates the policy area list" do
+    25.times { create(:local_authority_policy_area, local_authority:) }
+
+    visit "/admin/policy/areas"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+    expect(page).to have_selector("tbody tr", count: 10)
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "1")
+      expect(page).to have_no_link("Previous")
+      expect(page).to have_link("Next", href: "/admin/policy/areas?page=2")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/policy/areas?page=2")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "2")
+      expect(page).to have_link("Previous", href: "/admin/policy/areas?page=1")
+      expect(page).to have_link("Next", href: "/admin/policy/areas?page=3")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/policy/areas?page=3")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "3")
+      expect(page).to have_link("Previous", href: "/admin/policy/areas?page=2")
+      expect(page).to have_no_link("Next")
+    end
+  end
+
+  it "allows searching for a policy area" do
+    25.times { create(:local_authority_policy_area, local_authority:) }
+    policy_area = create(:local_authority_policy_area, local_authority:, description: "Design")
+
+    visit "/admin/policy/areas"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+
+    fill_in "Find policy areas", with: "Design"
+
+    click_button("Find policy areas")
+    expect(page).to have_selector("tbody tr", count: 1)
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "Design")
+
+      within "td:nth-child(2)" do
+        expect(page).to have_link("Edit", href: "/admin/policy/areas/#{policy_area.to_param}/edit")
+        expect(page).to have_link("Delete", href: "/admin/policy/areas/#{policy_area.to_param}")
+      end
+    end
+  end
+
+  it "allows adding a policy area" do
+    create(:local_authority_policy_area, local_authority:, description: "Biodiversity")
+
+    visit "/admin/policy/areas"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+
+    click_link("Add policy area")
+    expect(page).to have_selector("h1", text: "Add a new policy area")
+
+    click_button("Submit")
+    expect(page).to have_selector("h2", text: "There is a problem")
+    expect(page).to have_link("Description can't be blank", href: "#policy-area-description-field-error")
+
+    fill_in "Description", with: "Biodiversity"
+
+    click_button("Submit")
+    expect(page).to have_selector("h2", text: "There is a problem")
+    expect(page).to have_link("Description has already been taken", href: "#policy-area-description-field-error")
+
+    fill_in "Description", with: "Design"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/policy/areas")
+    expect(page).to have_content("Policy area successfully created")
+
+    within "tbody tr:nth-child(2)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "Design")
+    end
+  end
+
+  it "allows editing an policy area" do
+    create(:local_authority_policy_area, local_authority:, description: "Design")
+
+    visit "/admin/policy/areas"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "Design")
+
+      click_link("Edit")
+    end
+
+    expect(page).to have_selector("h1", text: "Edit policy area")
+
+    fill_in "Description", with: "Design and access"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/policy/areas")
+    expect(page).to have_content("Policy area successfully updated")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "Design and access")
+    end
+  end
+
+  it "allows deleting a policy area" do
+    create(:local_authority_policy_area, local_authority:, description: "Design")
+
+    visit "/admin/policy/areas"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "Design")
+
+      accept_confirm do
+        click_link("Delete")
+      end
+    end
+
+    expect(page).to have_content("Policy area successfully deleted")
+    expect(page).to have_selector("tbody tr:nth-child(1)", text: "No policy areas found")
+  end
+
+  it "redirects to the first page if the page parameter overflows" do
+    25.times { create(:local_authority_policy_area, local_authority:) }
+
+    visit "/admin/policy/areas?page=2"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+    expect(page).to have_current_path("/admin/policy/areas?page=2")
+
+    visit "/admin/policy/areas?page=4"
+    expect(page).to have_selector("h1", text: "Manage policy areas")
+    expect(page).to have_current_path("/admin/policy/areas")
+  end
+end

--- a/engines/bops_admin/spec/system/policy_references_spec.rb
+++ b/engines/bops_admin/spec/system/policy_references_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Policy references" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :administrator, local_authority:) }
+
+  let!(:building_control) { create(:local_authority_policy_area, local_authority:, description: "Building Control") }
+  let!(:environment) { create(:local_authority_policy_area, local_authority:, description: "Environment") }
+
+  before do
+    sign_in(user)
+  end
+
+  it "paginates the policy reference list" do
+    25.times { create(:local_authority_policy_reference, local_authority:) }
+
+    visit "/admin/policy/references"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+    expect(page).to have_selector("tbody tr", count: 10)
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "1")
+      expect(page).to have_no_link("Previous")
+      expect(page).to have_link("Next", href: "/admin/policy/references?page=2")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/policy/references?page=2")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "2")
+      expect(page).to have_link("Previous", href: "/admin/policy/references?page=1")
+      expect(page).to have_link("Next", href: "/admin/policy/references?page=3")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/policy/references?page=3")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "3")
+      expect(page).to have_link("Previous", href: "/admin/policy/references?page=2")
+      expect(page).to have_no_link("Next")
+    end
+  end
+
+  it "allows searching for a policy reference" do
+    25.times { create(:local_authority_policy_reference, local_authority:) }
+
+    policy_reference = create(
+      :local_authority_policy_reference,
+      local_authority:,
+      code: "PP-256",
+      description: "Biodiversity",
+      url: "https://planx.example.com/planning-guidance",
+      policy_areas: [environment]
+    )
+
+    visit "/admin/policy/references"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+
+    # Find by description
+    fill_in "Find policy references", with: "Biodiversity"
+
+    click_button("Find policy references")
+    expect(page).to have_selector("tbody tr", count: 1)
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "PP-256")
+
+      within "td:nth-child(2)" do
+        expect(page).to have_link("Biodiversity", href: "https://planx.example.com/planning-guidance")
+      end
+
+      expect(page).to have_selector("td:nth-child(3)", text: "Environment")
+
+      within "td:nth-child(4)" do
+        expect(page).to have_link("Edit", href: "/admin/policy/references/#{policy_reference.to_param}/edit")
+        expect(page).to have_link("Delete", href: "/admin/policy/references/#{policy_reference.to_param}")
+      end
+    end
+
+    # Find by code
+    fill_in "Find policy references", with: "PP-256"
+
+    click_button("Find policy references")
+    expect(page).to have_selector("tbody tr", count: 1)
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "PP-256")
+
+      within "td:nth-child(2)" do
+        expect(page).to have_link("Biodiversity", href: "https://planx.example.com/planning-guidance")
+      end
+
+      expect(page).to have_selector("td:nth-child(3)", text: "Environment")
+
+      within "td:nth-child(4)" do
+        expect(page).to have_link("Edit", href: "/admin/policy/references/#{policy_reference.to_param}/edit")
+        expect(page).to have_link("Delete", href: "/admin/policy/references/#{policy_reference.to_param}")
+      end
+    end
+  end
+
+  it "allows adding a policy reference" do
+    create(:local_authority_policy_reference, local_authority:, code: "PP-256", description: "Biodiversity")
+
+    visit "/admin/policy/references"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+
+    click_link("Add policy reference")
+    expect(page).to have_selector("h1", text: "Add a new policy reference")
+
+    click_button("Submit")
+    expect(page).to have_selector("h2", text: "There is a problem")
+    expect(page).to have_link("Code can't be blank", href: "#policy-reference-code-field-error")
+    expect(page).to have_link("Description can't be blank", href: "#policy-reference-description-field-error")
+
+    fill_in "Code", with: "PP-256"
+    fill_in "Description", with: "Biodiversity"
+
+    click_button("Submit")
+    expect(page).to have_selector("h2", text: "There is a problem")
+    expect(page).to have_link("Code has already been taken", href: "#policy-reference-code-field-error")
+    expect(page).to have_link("Description has already been taken", href: "#policy-reference-description-field-error")
+
+    fill_in "Code", with: "PP-999"
+    fill_in "Description", with: "Design"
+    check "Building Control"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/policy/references")
+    expect(page).to have_content("Policy reference successfully created")
+
+    within "tbody tr:nth-child(2)" do
+      expect(page).to have_selector("td:nth-child(1)", text: "PP-999")
+      expect(page).to have_selector("td:nth-child(2)", text: "Design")
+      expect(page).to have_selector("td:nth-child(3)", text: "Building Control")
+    end
+  end
+
+  it "allows editing an policy reference" do
+    create(:local_authority_policy_reference, local_authority:, code: "PP-256", description: "Biodiversity")
+
+    visit "/admin/policy/references"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(2)", text: "Biodiversity")
+
+      click_link("Edit")
+    end
+
+    expect(page).to have_selector("h1", text: "Edit policy reference")
+
+    fill_in "Description", with: "Biodiversity net gain"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/policy/references")
+    expect(page).to have_content("Policy reference successfully updated")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(2)", text: "Biodiversity net gain")
+    end
+  end
+
+  it "allows deleting a policy reference" do
+    create(:local_authority_policy_reference, local_authority:, code: "PP-256", description: "Biodiversity")
+
+    visit "/admin/policy/references"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(2)", text: "Biodiversity")
+
+      accept_confirm do
+        click_link("Delete")
+      end
+    end
+
+    expect(page).to have_content("Policy reference successfully deleted")
+    expect(page).to have_selector("tbody tr:nth-child(1)", text: "No policy references found")
+  end
+
+  it "redirects to the first page if the page parameter overflows" do
+    25.times { create(:local_authority_policy_reference, local_authority:) }
+
+    visit "/admin/policy/references?page=2"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+    expect(page).to have_current_path("/admin/policy/references?page=2")
+
+    visit "/admin/policy/references?page=4"
+    expect(page).to have_selector("h1", text: "Manage policy references")
+    expect(page).to have_current_path("/admin/policy/references")
+  end
+end

--- a/engines/bops_admin/spec/system/policy_spec.rb
+++ b/engines/bops_admin/spec/system/policy_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Policies" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :administrator, local_authority:) }
+
+  before do
+    sign_in(user)
+  end
+
+  context "when clicking 'Policy' in the primary navigation" do
+    it "redirects to 'Policy areas'" do
+      visit "/"
+      expect(page).to have_link("Policy", href: "/admin/policy")
+
+      click_link "Policy"
+      expect(page).to have_current_path("/admin/policy/areas")
+      expect(page).to have_selector("h1", text: "Manage policy areas")
+    end
+  end
+end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -2,6 +2,7 @@
 
 module BopsConfig
   module ApplicationHelper
+    include BopsCore::ApplicationHelper
     include BreadcrumbNavigationHelper
 
     attr_reader :back_path
@@ -39,12 +40,12 @@ module BopsConfig
 
     def nav_items
       [
-        {name: "Dashboard", url: root_path, key: "dashboard"},
-        {name: "Users", url: users_path, key: "users"},
-        {name: "Application types", url: application_types_path, key: "application_types"},
-        {name: "Legislation", url: legislation_index_path, key: "legislation"},
-        {name: "Reporting types", url: reporting_types_path, key: "reporting_types"},
-        {name: "Decisions", url: decisions_path, key: "decisions"}
+        {link: {text: "Dashboard", href: root_path}, current: active_page_key?("dashboard")},
+        {link: {text: "Users", href: users_path}, current: active_page_key?("users")},
+        {link: {text: "Application types", href: application_types_path}, current: active_page_key?("application_types")},
+        {link: {text: "Legislation", href: legislation_index_path}, current: active_page_key?("legislation")},
+        {link: {text: "Reporting types", href: reporting_types_path}, current: active_page_key?("reporting_types")},
+        {link: {text: "Decisions", href: decisions_path}, current: active_page_key?("decisions")}
       ]
     end
   end

--- a/engines/bops_core/app/components/govuk_component/primary_navigation_component.rb
+++ b/engines/bops_core/app/components/govuk_component/primary_navigation_component.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module GovukComponent
+  class PrimaryNavigationComponent < GovukComponent::Base
+    using HTMLAttributesUtils
+
+    class HeadingComponent < GovukComponent::Base
+      attr_reader :id, :text
+
+      def initialize(
+        id: "primary-navigation-heading",
+        text: "Navigation",
+        classes: [],
+        html_attributes: {}
+      )
+        @id = id
+        @text = text
+
+        super(classes:, html_attributes:)
+      end
+
+      def call
+        tag.h2(text, id:, **html_attributes)
+      end
+
+      private
+
+      def default_attributes
+        {class: "govuk-visually-hidden"}
+      end
+    end
+
+    class ItemComponent < GovukComponent::Base
+      attr_reader :link, :current
+
+      def initialize(link:, current: false, classes: [], html_attributes: {})
+        @link = link
+        @current = current
+
+        super(classes:, html_attributes:)
+      end
+
+      def call
+        tag.li(**html_attributes) do
+          LinkComponent.new(current:, **link).call
+        end
+      end
+
+      private
+
+      def default_attributes
+        {
+          class: class_names(
+            "x-#{brand}-primary-navigation__item",
+            "x-#{brand}-primary-navigation__item--current": current
+          )
+        }
+      end
+    end
+
+    class LinkComponent < GovukComponent::Base
+      attr_reader :text, :href, :current
+
+      def initialize(text:, href:, current:, classes: [], html_attributes: {})
+        @text = text
+        @href = href
+        @current = current
+
+        super(classes:, html_attributes:)
+      end
+
+      def call
+        tag.a(text, href:, **html_attributes)
+      end
+
+      private
+
+      def default_attributes
+        {
+          class: "x-#{brand}-primary-navigation__link",
+          aria: {current: (current ? "page" : nil)}
+        }
+      end
+    end
+
+    renders_one :heading, "HeadingComponent"
+    renders_many :items, "ItemComponent"
+
+    attr_reader :labelled_by
+
+    def initialize(
+      heading: {},
+      items: [],
+      labelled_by: nil,
+      classes: [],
+      html_attributes: {}
+    )
+      @labelled_by = labelled_by
+
+      if heading.present?
+        with_heading(**heading)
+      end
+
+      items.each do |item|
+        with_item(**item)
+      end
+
+      super(classes:, html_attributes:)
+    end
+
+    def before_render
+      with_heading unless labelled_by.present? || heading?
+    end
+
+    def call
+      return unless items?
+
+      tag.nav(**nav_attributes) do
+        tag.div(class: "#{brand}-width-container") do
+          safe_join([
+            heading,
+            tag.ul(class: "x-#{brand}-primary-navigation__list") do
+              safe_join(items)
+            end
+          ])
+        end
+      end
+    end
+
+    private
+
+    def default_attributes
+      {class: "x-#{brand}-primary-navigation"}
+    end
+
+    def aria_attributes
+      if labelled_by.present? || heading?
+        {aria: {labelledby: labelled_by || heading.id}}
+      else
+        {}
+      end
+    end
+
+    def nav_attributes
+      aria_attributes.deep_merge_html_attributes(html_attributes)
+    end
+  end
+end

--- a/engines/bops_core/app/components/govuk_component/secondary_navigation_component.rb
+++ b/engines/bops_core/app/components/govuk_component/secondary_navigation_component.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module GovukComponent
+  class SecondaryNavigationComponent < GovukComponent::Base
+    class ItemComponent < GovukComponent::Base
+      class LinkComponent < GovukComponent::Base
+        attr_reader :text, :href, :current
+
+        def initialize(text:, href:, current:, classes: [], html_attributes: {})
+          @text = text
+          @href = href
+          @current = current
+
+          super(classes:, html_attributes:)
+        end
+
+        def call
+          tag.a(text, href:, **html_attributes)
+        end
+
+        private
+
+        def default_attributes
+          {
+            class: "x-#{brand}-secondary-navigation__link",
+            aria: {current: (current ? "page" : nil)}
+          }
+        end
+      end
+
+      renders_one :link, ->(text:, href:, classes: [], html_attributes: {}, &block) do
+        LinkComponent.new(text:, href:, classes:, html_attributes:, current: @current, &block)
+      end
+
+      attr_reader :current
+
+      def initialize(link: nil, current: false, classes: [], html_attributes: {})
+        @current = current
+
+        if link.present?
+          with_link(**link)
+        end
+
+        super(classes:, html_attributes:)
+      end
+
+      def call
+        tag.li(link, **html_attributes)
+      end
+
+      private
+
+      def default_attributes
+        {
+          class: class_names(
+            "x-#{brand}-secondary-navigation__list-item",
+            "x-#{brand}-secondary-navigation__list-item--current": current
+          )
+        }
+      end
+    end
+
+    renders_many :items, "ItemComponent"
+
+    attr_reader :label
+
+    def initialize(label: nil, items: [], classes: [], html_attributes: {})
+      items.each do |item|
+        with_item(**item)
+      end
+
+      @label = label
+
+      super(classes:, html_attributes:)
+    end
+
+    def call
+      return unless items?
+
+      tag.nav(**html_attributes) do
+        tag.ul(class: "x-#{brand}-secondary-navigation__list") do
+          safe_join(items)
+        end
+      end
+    end
+
+    private
+
+    def default_attributes
+      {
+        class: "x-#{brand}-secondary-navigation",
+        aria: {label: label || "Secondary Navigation"}
+      }
+    end
+  end
+end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module ApplicationHelper
+    {
+      govuk_primary_navigation: "GovukComponent::PrimaryNavigationComponent"
+    }.each do |name, klass|
+      define_method(name) do |*args, **kwargs, &block|
+        capture do
+          render(klass.constantize.new(*args, **kwargs)) do |com|
+            block.call(com) if block.present?
+          end
+        end
+      end
+    end
+
+    def active_page_key?(page_key)
+      active_page_key == page_key
+    end
+  end
+end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -3,7 +3,8 @@
 module BopsCore
   module ApplicationHelper
     {
-      govuk_primary_navigation: "GovukComponent::PrimaryNavigationComponent"
+      govuk_primary_navigation: "GovukComponent::PrimaryNavigationComponent",
+      govuk_secondary_navigation: "GovukComponent::SecondaryNavigationComponent"
     }.each do |name, klass|
       define_method(name) do |*args, **kwargs, &block|
         capture do

--- a/engines/bops_core/bops_core.gemspec
+++ b/engines/bops_core/bops_core.gemspec
@@ -13,5 +13,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.1.3", "< 7.2"
+  spec.add_dependency "govuk-components", "~> 5", ">= 5.3.2"
+  spec.add_dependency "govuk_design_system_formbuilder", "~> 5", ">= 5.3.2"
   spec.add_dependency "pagy"
 end

--- a/engines/bops_core/lib/bops_core/engine.rb
+++ b/engines/bops_core/lib/bops_core/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "govuk/components"
+
 module BopsCore
   class Engine < ::Rails::Engine
     isolate_namespace BopsCore

--- a/engines/bops_core/spec/components/govuk_component/primary_navigation_component_spec.rb
+++ b/engines/bops_core/spec/components/govuk_component/primary_navigation_component_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe(GovukComponent::PrimaryNavigationComponent, type: :component) do
+  let(:items) do
+    [
+      {link: {text: "Dashboard", href: "/dashboard"}, current: true},
+      {link: {text: "Users", href: "/users"}, current: false},
+      {link: {text: "Profile", href: "/profile"}, current: false}
+    ]
+  end
+
+  let(:kwargs) { {items: items} }
+
+  subject! { render_inline(described_class.new(**kwargs)) }
+
+  it "renders the primary navigation component" do
+    within "nav" do
+      expect(element["aria-labelledby"]).to eq("primary-navigation-heading")
+      expect(element["class"]).to eq("x-govuk-primary-navigation")
+
+      within "div" do
+        expect(element["class"]).to eq("govuk-width-container")
+
+        within "h2" do
+          expect(element["id"]).to eq("primary-navigation-heading")
+          expect(element["class"]).to eq("govuk-visually-hidden")
+          expect(element.text).to eq("Navigation")
+        end
+
+        within "ul" do
+          expect(element["class"]).to eq("x-govuk-primary-navigation__list")
+
+          within "li:nth-child(1)" do
+            expect(element["class"]).to eq("x-govuk-primary-navigation__item x-govuk-primary-navigation__item--current")
+
+            within "a" do
+              expect(element["href"]).to eq("/dashboard")
+              expect(element["class"]).to eq("x-govuk-primary-navigation__link")
+              expect(element["aria-current"]).to eq("page")
+              expect(element.text).to eq("Dashboard")
+            end
+          end
+
+          within "li:nth-child(2)" do
+            expect(element["class"]).to eq("x-govuk-primary-navigation__item")
+
+            within "a" do
+              expect(element["href"]).to eq("/users")
+              expect(element["class"]).to eq("x-govuk-primary-navigation__link")
+              expect(element["aria-current"]).to be_nil
+              expect(element.text).to eq("Users")
+            end
+          end
+
+          within "li:nth-child(3)" do
+            expect(element["class"]).to eq("x-govuk-primary-navigation__item")
+
+            within "a" do
+              expect(element["href"]).to eq("/profile")
+              expect(element["class"]).to eq("x-govuk-primary-navigation__link")
+              expect(element["aria-current"]).to be_nil
+              expect(element.text).to eq("Profile")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/components/govuk_component/secondary_navigation_component_spec.rb
+++ b/engines/bops_core/spec/components/govuk_component/secondary_navigation_component_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe(GovukComponent::SecondaryNavigationComponent, type: :component) do
+  let(:items) do
+    [
+      {link: {text: "Policy areas", href: "/policy/areas"}, current: true},
+      {link: {text: "Policy references", href: "/policy/references"}, current: false}
+    ]
+  end
+
+  let(:kwargs) { {items: items} }
+
+  subject! { render_inline(described_class.new(**kwargs)) }
+
+  it "renders the secondary navigation component" do
+    within "nav" do
+      expect(element["aria-label"]).to eq("Secondary Navigation")
+      expect(element["class"]).to eq("x-govuk-secondary-navigation")
+
+      within "ul" do
+        expect(element["class"]).to eq("x-govuk-secondary-navigation__list")
+
+        within "li:nth-child(1)" do
+          expect(element["class"]).to eq("x-govuk-secondary-navigation__list-item x-govuk-secondary-navigation__list-item--current")
+
+          within "a" do
+            expect(element["href"]).to eq("/policy/areas")
+            expect(element["class"]).to eq("x-govuk-secondary-navigation__link")
+            expect(element["aria-current"]).to eq("page")
+            expect(element.text).to eq("Policy areas")
+          end
+        end
+
+        within "li:nth-child(2)" do
+          expect(element["class"]).to eq("x-govuk-secondary-navigation__list-item")
+
+          within "a" do
+            expect(element["href"]).to eq("/policy/references")
+            expect(element["class"]).to eq("x-govuk-secondary-navigation__link")
+            expect(element["aria-current"]).to be_nil
+            expect(element.text).to eq("Policy references")
+          end
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/support/components.rb
+++ b/engines/bops_core/spec/support/components.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "view_component/test_helpers"
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def scopes
+      @scopes ||= [Capybara::Node::Simple.new(rendered_content)]
+    end
+
+    def page
+      scopes.last
+    end
+    alias_method :element, :page
+
+    def within(*args, **kw_args)
+      new_scope = element.find(*args, **kw_args)
+
+      begin
+        scopes.push(new_scope)
+        yield new_scope if block_given?
+      ensure
+        scopes.pop
+      end
+    end
+  end
+
+  config.include ViewComponent::TestHelpers, type: :component
+  config.include helpers, type: :component
+end

--- a/spec/factories/local_authority_policy_area.rb
+++ b/spec/factories/local_authority_policy_area.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :local_authority_policy_area, class: LocalAuthority::PolicyArea do
+    local_authority
+    description { Faker::Lorem.unique.sentence }
+  end
+end

--- a/spec/factories/local_authority_policy_reference.rb
+++ b/spec/factories/local_authority_policy_reference.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :local_authority_policy_reference, class: LocalAuthority::PolicyReference do
+    local_authority
+    code { Faker::IDNumber.unique.ssn_valid }
+    description { Faker::Lorem.unique.sentence }
+  end
+end


### PR DESCRIPTION
### Description of change

Add policy areas and references to local authority admin so that when an officer is adding considerations they can easily look them up.

### Story Link

https://trello.com/c/O4wocZls
