### PR TITLE
Fix up description changes page

### DIFF
--- a/app/views/planning_applications/validation/description_change_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_show.html.erb
@@ -26,12 +26,15 @@
       </p>
     </div>
     <p class="govuk-body">
-      <% if @planning_application.invalidated? %>
-        <% if @validation_request.open? %>
-          Sent on <%= @validation_request.created_at.to_date.to_fs %>. Agent or applicant has not yet responded.
-        <% else %>
-          <%= @validation_request.approved? ? "Approved" : "Rejected" %>
-        <% end %>
+      <% if @validation_request.open? %>
+        Sent on <%= @validation_request.created_at.to_date.to_fs %>. Agent or applicant has not yet responded.
+      <% else %>
+        <%= @validation_request.approved? ? "Approved" : "Rejected" %>
+        <p>
+          <% if @validation_request.rejected? %>
+            <%= govuk_link_to "Request a new description change", new_planning_application_validation_validation_request_path(@planning_application, type: "description_change"), class: "govuk-body" %>
+          <% end %>
+        </p>
       <% end %>
     </p>
 
@@ -54,6 +57,22 @@
                 class: "button-as-link govuk-body"
               ) %>
         </div>
+      <% end %>
+    <% end %>
+    <% if @validation_request.closed? %>
+      <%= form_with(
+            model: @planning_application,
+            url: validate_planning_application_validation_description_changes_path(
+              @planning_application
+            )
+          ) do |form| %>
+          <%= form.hidden_field(:return_to, value: @back_path) %>
+          <%= form.hidden_field(:valid_description, value: true) %>
+          <div class="govuk-button-group">
+            <%= form.govuk_submit("Save and mark as complete") do %>
+              <%= govuk_button_link_to("back", @back_path, secondary: true) %>
+            <% end %>
+          </div>
       <% end %>
     <% end %>
   </div>

--- a/app/views/planning_applications/validation/description_changes/show.html.erb
+++ b/app/views/planning_applications/validation/description_changes/show.html.erb
@@ -19,16 +19,26 @@
         )
       ) %>
 
-    <%= form_with model: @planning_application, url: validate_planning_application_validation_description_changes_path(@planning_application) do |form| %>
-      <%= form.govuk_radio_buttons_fieldset :valid_description, legend: {text: "Does the description match the development or use in the plans?"} do %>
-        <%= form.govuk_radio_button :valid_description, true, label: {text: "Yes"} %>
-        <%= form.govuk_radio_button :valid_description, false, label: {text: "No"} %>
+    <% if @planning_application.valid_description.nil? || params[:edit] == "true" %>
+      <%= form_with model: @planning_application, url: validate_planning_application_validation_description_changes_path(@planning_application) do |form| %>
+        <%= form.govuk_radio_buttons_fieldset :valid_description, legend: {text: "Does the description match the development or use in the plans?"} do %>
+          <%= form.govuk_radio_button :valid_description, true, label: {text: "Yes"} %>
+          <%= form.govuk_radio_button :valid_description, false, label: {text: "No"} %>
+        <% end %>
+
+        <div class="govuk-button-group">
+          <%= form.govuk_submit("Save") do %>
+            <%= govuk_button_link_to("back", planning_application_validation_tasks_path(@planning_application), secondary: true) %>
+          <% end %>
+        </div>
       <% end %>
-
+    <% else %>
+      <p class="govuk-body">
+        Description was marked as <%= @planning_application.valid_description? ? "valid" : "invalid" %>
+      </p>
       <div class="govuk-button-group">
-        <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
-
         <%= link_to "Back", planning_application_validation_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary" %>
+        <%= govuk_link_to "Edit description", planning_application_validation_description_changes_path(@planning_application, edit: true), class: "govuk-body" %>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
### Description of change

- Add back button to description change request page
- When officer has marked as valid, don't show the form again

### Story Link

https://trello.com/c/b1A1AKI2/2855-pattern-main-navigation-buttons
