### PR TITLE
Tidy up status texts

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -190,6 +190,10 @@ $govuk-page-width: 1100px;
   max-width: none;
 }
 
+.govuk-tag--colourless {
+  background-color: transparent;
+}
+
 .header-session-info {
   display: flex;
   align-items: center;

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -11,7 +11,7 @@ module StatusTags
     end
 
     def call
-      govuk_tag(text: link_text, colour:)
+      govuk_tag(text: link_text, colour:, html_attributes: colour ? {} : {class: "govuk-tag--colourless"})
     end
 
     private

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -11,25 +11,27 @@ module StatusTags
     end
 
     def call
-      govuk_tag(text: t("status_tag_component.#{status}"), colour:)
+      govuk_tag(text: link_text, colour:)
     end
 
     private
 
     attr_reader :status
 
+    def link_text
+      t("status_tag_component.#{status}")
+    end
+
     def colour
       case status.to_sym
       when :not_started, :new, :review_not_started, :not_consulted
         "blue"
-      when :in_progress, :sending
+      when :in_progress
         "light-blue"
       when :updated, :to_be_reviewed, :submitted, :neutral, :amendments_needed
         "yellow"
-      when :refused, :removed, :invalid, :technical_failure, :permanent_failure, :rejected, :objection, :failed, :refused_legal_agreement
+      when :refused, :removed, :invalid, :rejected, :objection, :failed, :refused_legal_agreement
         "red"
-      when :printing
-        "purple"
       end
     end
   end

--- a/app/components/status_tags/cil_liability_component.rb
+++ b/app/components/status_tags/cil_liability_component.rb
@@ -15,10 +15,8 @@ module StatusTags
 
     def status
       case cil_liable
-      when TrueClass
-        :cil_liable
-      when FalseClass
-        :not_cil_liable
+      when TrueClass, FalseClass
+        :complete
       when NilClass
         :not_started
       else

--- a/app/components/status_tags/constraints_component.rb
+++ b/app/components/status_tags/constraints_component.rb
@@ -12,7 +12,7 @@ module StatusTags
     attr_reader :planning_application
 
     def status
-      planning_application.constraints_checked? ? :checked : :not_started
+      planning_application.constraints_checked? ? :complete : :not_started
     end
   end
 end

--- a/app/components/status_tags/draw_red_line_boundary_component.rb
+++ b/app/components/status_tags/draw_red_line_boundary_component.rb
@@ -12,7 +12,7 @@ module StatusTags
     attr_reader :boundary_geojson
 
     def status
-      boundary_geojson.present? ? :checked : :not_started
+      boundary_geojson.present? ? :complete : :not_started
     end
   end
 end

--- a/app/components/status_tags/letter_component.rb
+++ b/app/components/status_tags/letter_component.rb
@@ -3,8 +3,29 @@
 module StatusTags
   class LetterComponent < StatusTags::BaseComponent
     def initialize(status:)
-      @status = status
+      @status = status.to_sym
+      raise "Invalid status `#{@status.inspect}'" unless NeighbourLetter::STATUSES.values.map(&:to_sym).include?(@status) || @status == :new
+
       super(status:)
+    end
+
+    def link_text
+      t("status_tag_component.letter_status.#{status}")
+    end
+
+    def colour
+      return "red" if NeighbourLetter::FAILURE_STATUSES.include? status
+
+      case status.to_sym
+      when :new
+        "blue"
+      when :posted
+        "light-blue"
+      when :submitted
+        "yellow"
+      when :printing
+        "purple"
+      end
     end
   end
 end

--- a/app/components/status_tags/reviewing/assessment_details_component.rb
+++ b/app/components/status_tags/reviewing/assessment_details_component.rb
@@ -19,7 +19,7 @@ module StatusTags
         if updated?
           :updated
         elsif review_assessment_details_complete?
-          :checked
+          :complete
         elsif assessment_details.any?(&:reviewer_verdict)
           :in_progress
         else

--- a/app/components/task_list_items/assessment/permitted_development_right_component.rb
+++ b/app/components/task_list_items/assessment/permitted_development_right_component.rb
@@ -28,7 +28,7 @@ module TaskListItems
             planning_application,
             permitted_development_right
           )
-        when :checked, :removed
+        when :complete, :removed
           planning_application_assessment_permitted_development_right_path(
             planning_application,
             permitted_development_right
@@ -41,6 +41,8 @@ module TaskListItems
           :not_started
         elsif to_be_reviewed?
           :to_be_reviewed
+        elsif permitted_development_right.status.to_sym == :checked
+          :complete
         else
           permitted_development_right.status.to_sym
         end

--- a/app/components/task_list_items/validating/legislation_component.rb
+++ b/app/components/task_list_items/validating/legislation_component.rb
@@ -21,7 +21,7 @@ module TaskListItems
 
       def status
         if planning_application.legislation_checked?
-          :checked
+          :complete
         else
           :not_started
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1907,7 +1907,6 @@ en:
     awaiting_response: Awaiting response
     awaiting_responses: Awaiting responses
     cancelled: Cancelled
-    checked: Checked
     complete: Completed
     emailed: Emailed
     failed: Failed

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1909,7 +1909,6 @@ en:
     awaiting_responses: Awaiting responses
     cancelled: Cancelled
     checked: Checked
-    cil_liable: Liable
     complete: Completed
     emailed: Emailed
     failed: Failed
@@ -1921,7 +1920,6 @@ en:
     neutral: Neutral
     new: New
     not_assigned: Not assigned
-    not_cil_liable: Not liable
     not_consulted: Not consulted
     not_required: Not required
     not_required_legal_agreement: Not required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1627,7 +1627,7 @@ en:
           update_constraints: Update constraints
         update:
           failure: Couldn't check constraints — please contact support.
-          success: Constraints was successfully checked
+          success: Constraints were successfully checked
       description_change_validation_requests:
         description_change_validation_request:
           change_description: Change description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1900,7 +1900,6 @@ en:
       home: Home
       review_application: Review
   status_tag_component:
-    accepted: Printing
     amendments_needed: Amendments needed
     approved: Accepted
     auto_approved: Auto accepted
@@ -1917,6 +1916,15 @@ en:
     granted_not_required_legal_agreement: Prior approval not required with Legal agreement
     in_progress: In progress
     invalid: Invalid
+    letter_status:
+      cancelled: Cancelled
+      new: New
+      permanent_failure: Permanent failure
+      posted: Posted
+      printing: Printing
+      rejected: Rejected
+      submitted: Submitted
+      technical_failure: Technical failure
     neutral: Neutral
     new: New
     not_assigned: Not assigned
@@ -1927,9 +1935,6 @@ en:
     not_started: Not started
     objection: Objection
     pending: Pending
-    permanent_failure: Permanent failure
-    posted: Posted
-    printing: Printing
     refused: To refuse
     refused_legal_agreement: To refuse with Legal agreement
     rejected: Rejected
@@ -1941,7 +1946,6 @@ en:
     sending: Sending
     submitted: Submitted
     supportive: Supportive
-    technical_failure: Technical failure
     to_be_reviewed: To be reviewed
     updated: Updated
     valid: Valid

--- a/spec/components/status_tags/reviewing/assessment_details_component_spec.rb
+++ b/spec/components/status_tags/reviewing/assessment_details_component_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe StatusTags::Reviewing::AssessmentDetailsComponent, type: :compone
       )
     end
 
-    it "renders 'Checked' status" do
-      expect(page).to have_content("Checked")
+    it "renders 'Completed' status" do
+      expect(page).to have_content("Completed")
     end
   end
 

--- a/spec/components/task_list_items/assessment/permitted_development_right_component_spec.rb
+++ b/spec/components/task_list_items/assessment/permitted_development_right_component_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
       )
     end
 
-    it "renders 'Checked' status" do
-      expect(page).to have_content("Checked")
+    it "renders 'Completed' status" do
+      expect(page).to have_content("Completed")
     end
   end
 

--- a/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Permitted development right" do
 
         expect(page).to have_list_item_for(
           "Permitted development rights",
-          with: "Checked"
+          with: "Completed"
         )
 
         click_link "Permitted development rights"
@@ -164,7 +164,7 @@ RSpec.describe "Permitted development right" do
 
           expect(page).to have_list_item_for(
             "Permitted development rights",
-            with: "Checked"
+            with: "Completed"
           )
 
           click_link "Permitted development rights"
@@ -260,7 +260,7 @@ RSpec.describe "Permitted development right" do
 
           expect(page).to have_list_item_for(
             "Permitted development rights",
-            with: "Checked"
+            with: "Completed"
           )
 
           click_link "Permitted development rights"

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
 
         click_link("Sign off recommendation")
@@ -373,7 +373,7 @@ RSpec.describe "Reviewing assessment summaries" do
         end
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
       end
     end
@@ -579,7 +579,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
 
         click_link("Sign off recommendation")
@@ -676,7 +676,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
 
         click_link("Review assessment summaries")
@@ -841,7 +841,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
       end
     end
@@ -1040,7 +1040,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
 
         click_link("Sign off recommendation")
@@ -1172,7 +1172,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Save and mark as complete")
 
         expect(page).to have_list_item_for(
-          "Review assessment summaries", with: "Checked"
+          "Review assessment summaries", with: "Completed"
         )
       end
     end

--- a/spec/system/planning_applications/validating/check_legislation_spec.rb
+++ b/spec/system/planning_applications/validating/check_legislation_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Check legislation" do
       expect(page).to have_content("Legislative requirements have been marked as checked.")
 
       within("#check-legislative-requirements") do
-        expect(page).to have_content("Checked")
+        expect(page).to have_content("Completed")
       end
 
       click_link "Application"

--- a/spec/system/planning_applications/validating/cil_liability_spec.rb
+++ b/spec/system/planning_applications/validating/cil_liability_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)" do
 
     expect(page).to have_content "CIL liability updated"
     within "#cil-liability-validation-tasks" do
-      expect(page).to have_content "Confirm Community Infrastructure Levy (CIL) Liable"
+      expect(page).to have_content "Confirm Community Infrastructure Levy (CIL) Completed"
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)" do
 
     expect(page).to have_content "CIL liability updated"
     within "#cil-liability-validation-tasks" do
-      expect(page).to have_content "Confirm Community Infrastructure Levy (CIL) Not liable"
+      expect(page).to have_content "Confirm Community Infrastructure Levy (CIL) Completed"
     end
   end
 

--- a/spec/system/planning_applications/validating/constraints_spec.rb
+++ b/spec/system/planning_applications/validating/constraints_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Constraints" do
         href: planning_application_validation_constraints_path(planning_application)
       )
       within("#constraints-validation-tasks .govuk-tag") do
-        expect(page).to have_content("Checked")
+        expect(page).to have_content("Completed")
       end
 
       visit "/planning_applications/#{planning_application.id}/audits"

--- a/spec/system/planning_applications/validating/constraints_spec.rb
+++ b/spec/system/planning_applications/validating/constraints_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Constraints" do
 
       click_button "Save and mark as complete"
 
-      expect(page).to have_text("Constraints was successfully checked")
+      expect(page).to have_text("Constraints were successfully checked")
 
       expect(page).to have_link(
         "Check constraints",

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "Validation tasks" do
               href: planning_application_validation_sitemap_path(planning_application)
             )
             within(".govuk-tag") do
-              expect(page).to have_content("Checked")
+              expect(page).to have_content("Completed")
             end
           end
 

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe "Validation tasks" do
               href: planning_application_validation_constraints_path(planning_application)
             )
             within(".govuk-tag") do
-              expect(page).to have_content("Checked")
+              expect(page).to have_content("Completed")
             end
           end
 


### PR DESCRIPTION
### Description of change

- Show statuses as 'completed' rather than 'checked', 'valid/invalid', etc.
- Treat letter-sending statuses separately, to simplify the conditional for normal statuses.
- Allow tags to have no coloured background.

### Story Link

https://trello.com/c/DlnflNGL/2957-update-text-of-status-tag-labels

### Screenshots

<img width="758" alt="Screenshot 2024-05-07 at 13 57 11" src="https://github.com/unboxed/bops/assets/3986/f1de31fe-ec06-4645-8874-cf52908f4315">
