### PR TITLE
Remove use of `type_with_status`

### DIFF
--- a/app/components/accordion_sections/application_information_component.html.erb
+++ b/app/components/accordion_sections/application_information_component.html.erb
@@ -11,7 +11,7 @@
         <%= govuk_link_to description_change_link_text, description_change_link_path, class: "govuk-body" %>
       </td>
     </tr>
-    <% %i[type_and_work_status full_address].each do |attribute| %>
+    <% %i[type_description full_address].each do |attribute| %>
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <strong><%= t(".#{attribute}") %></strong>

--- a/app/components/accordion_sections/application_information_component.rb
+++ b/app/components/accordion_sections/application_information_component.rb
@@ -7,7 +7,7 @@ module AccordionSections
     delegate(
       :closed_or_cancelled?,
       :uprn,
-      :type_and_work_status,
+      :type_description,
       :full_address,
       to: :planning_application
     )

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -53,7 +53,7 @@ module PlanningApplications
     end
 
     def your_application_attributes
-      %i[reference full_address application_type_with_status formatted_expiry_date days_status_tag status_tag]
+      %i[reference full_address formatted_expiry_date days_status_tag status_tag]
     end
 
     def closed_attributes
@@ -70,7 +70,6 @@ module PlanningApplications
       %i[
         reference
         full_address
-        application_type_with_status
         formatted_expiry_date
         days_status_tag
         status_tag

--- a/app/models/concerns/planning_application_decorator.rb
+++ b/app/models/concerns/planning_application_decorator.rb
@@ -35,7 +35,7 @@ module PlanningApplicationDecorator
     I18n.t(application_type.name, scope: "application_types", default: application_type.description)
   end
 
-  def type_and_work_status
-    "#{type} (#{work_status.humanize})"
+  def type_description
+    application_type.description
   end
 end

--- a/app/views/shared/_proposal_header.html.erb
+++ b/app/views/shared/_proposal_header.html.erb
@@ -25,7 +25,8 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= @planning_application.type_and_work_status %>: <%= @planning_application.description %>
+      <%= @planning_application.type_description %>:<br>
+      <%= @planning_application.description %>
     </p>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
       payment_amount: 'Payment amount:'
       payment_reference: 'Payment reference:'
       propose_a_change: Propose a change to the description
-      type_and_work_status: 'Application type:'
+      type_description: 'Application type:'
       uprn: 'UPRN:'
       view_on_mapit: View on mapit
       view_requested_change: View requested change
@@ -378,6 +378,8 @@ en:
   application_types:
     lawfulness_certificate: Lawful Development Certificate
     lawfulness_certificate_abbr: LDC
+    other: Other planning application
+    other_abbr: Other
     planning_permission: Householder Application for Planning Permission
     planning_permission_abbr: PP
     prior_approval: Prior approval

--- a/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Review documents for recommendation" do
       end
       expect(page).to have_content("Application number: #{planning_application.reference}")
       expect(page).to have_content(planning_application.full_address)
-      expect(page).to have_content("#{planning_application.type_and_work_status}: #{planning_application.description}")
+      expect(page).to have_content("#{planning_application.type_description}: #{planning_application.description}")
       expect(page).to have_content("Check document details")
       expect(page).to have_content("All documents need a reference to be on the decision notice and be made public.")
 

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -102,6 +102,9 @@ RSpec.describe "Send letters to neighbours", js: true do
       page.find(:xpath, "//*[@id='main-content']/div[2]/div/form/details/summary/span").click
       fill_in "Neighbour letter", with: "This is some content I'm putting in"
 
+      # Toggle the govuk-details so that the submit button is on-screen
+      page.find(:xpath, "//*[@id='main-content']/div[2]/div/form/details/summary/span").click
+
       click_button "Confirm and send letters"
       expect(page).to have_content("Letters have been sent to neighbours and a copy of the letter has been sent to the applicant.")
 

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Creating a planning application" do
 
       expect(page).to have_text("Site address: Palace Road, Crystal Palace, SE19 2LX")
       expect(page).to have_text("UPRN: 19284783939")
-      expect(page).to have_text("Application type: Lawful Development Certificate (Proposed)")
+      expect(page).to have_text("Application type: Lawful Development Certificate - Proposed")
       expect(page).to have_text("Work already started: No")
       expect(page).to have_text("Description: Backyard bird hotel")
     end

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "editing planning application" do
       "Planning application was successfully updated."
     )
     within("#planning-application-details") do
-      expect(page).to have_content("Prior approval")
+      expect(page).to have_content("Prior Approval - Larger extension to a house")
     end
 
     expect(page).to have_current_path(

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -478,7 +478,6 @@ RSpec.describe "Planning Application index page" do
               within(all(".govuk-table__row").first) do
                 expect(page).to have_content("Application number")
                 expect(page).to have_content("Site address")
-                expect(page).to have_content("Application type")
                 expect(page).to have_content("Expiry date")
                 expect(page).to have_content("Days")
                 expect(page).to have_content("Status")
@@ -491,10 +490,10 @@ RSpec.describe "Planning Application index page" do
               within(rows[0]) do
                 cells = page.all(".govuk-table__cell")
 
-                within(cells[2]) do
-                  expect(page).to have_content("PA Proposed")
+                within(cells[0]) do
+                  expect(page).to have_content(/^\d{2}-\d{5}-PA1A$/)
                 end
-                within(cells[5]) do
+                within(cells[4]) do
                   expect(page).to have_content("Not started")
                 end
               end
@@ -502,10 +501,10 @@ RSpec.describe "Planning Application index page" do
               within(rows[1]) do
                 cells = page.all(".govuk-table__cell")
 
-                within(cells[2]) do
-                  expect(page).to have_content("LDC Proposed")
+                within(cells[0]) do
+                  expect(page).to have_content(/^\d{2}-\d{5}-LDCP$/)
                 end
-                within(cells[5]) do
+                within(cells[4]) do
                   expect(page).to have_content("Not started")
                 end
               end
@@ -513,10 +512,10 @@ RSpec.describe "Planning Application index page" do
               within(rows[2]) do
                 cells = page.all(".govuk-table__cell")
 
-                within(cells[2]) do
-                  expect(page).to have_content("LDC Proposed")
+                within(cells[0]) do
+                  expect(page).to have_content(/^\d{2}-\d{5}-LDCP$/)
                 end
-                within(cells[5]) do
+                within(cells[4]) do
                   expect(page).to have_content("In assessment")
                 end
               end
@@ -524,10 +523,10 @@ RSpec.describe "Planning Application index page" do
               within(rows[3]) do
                 cells = page.all(".govuk-table__cell")
 
-                within(cells[2]) do
-                  expect(page).to have_content("LDC Proposed")
+                within(cells[0]) do
+                  expect(page).to have_content(/^\d{2}-\d{5}-LDCP$/)
                 end
-                within(cells[5]) do
+                within(cells[4]) do
                   expect(page).to have_content("In assessment")
                 end
               end
@@ -535,10 +534,10 @@ RSpec.describe "Planning Application index page" do
               within(rows[4]) do
                 cells = page.all(".govuk-table__cell")
 
-                within(cells[2]) do
-                  expect(page).to have_content("LDC Proposed")
+                within(cells[0]) do
+                  expect(page).to have_content(/^\d{2}-\d{5}-LDCP$/)
                 end
-                within(cells[5]) do
+                within(cells[4]) do
                   expect(page).to have_content("Awaiting determination")
                 end
               end

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Planning Application show page" do
 
       it "I can view the correct application type name and the planning application code" do
         expect(page).to have_content("#{planning_application.created_at.year % 100}-00100-HAPP")
-        expect(page).to have_content("Householder Application for Planning Permission")
+        expect(page).to have_content("Planning Permission - Full householder")
       end
     end
   end


### PR DESCRIPTION
The application type description is more useful and it won't fit on the dashboard.

## Dashboard

![image](https://github.com/unboxed/bops/assets/6321/a8864cf5-d043-4c4b-a5b6-9a68c014e481)

## Planning application header

![image](https://github.com/unboxed/bops/assets/6321/b7b89a59-f732-4c2d-9cdf-385319b9931e)

