### PR TITLE
Fix entry validation for check publicity

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -170,6 +170,10 @@ class ApplicationType < ApplicationRecord
     code.include?(".existing")
   end
 
+  def prior_approval?
+    code.start_with?("pa.")
+  end
+
   def retrospective?
     code.include?(".retro")
   end

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -116,6 +116,7 @@ class AssessmentDetail < ApplicationRecord
 
   def any_neighbour_responses?
     return unless planning_application&.consultation
+    return unless neighbour_summary?
 
     planning_application.consultation.neighbour_responses.any?
   end

--- a/app/models/concerns/planning_application_decorator.rb
+++ b/app/models/concerns/planning_application_decorator.rb
@@ -31,10 +31,6 @@ module PlanningApplicationDecorator
     "#{address_1}, #{town}, #{postcode}"
   end
 
-  def type
-    I18n.t(application_type.name, scope: "application_types", default: application_type.description)
-  end
-
   def type_description
     application_type.description
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -71,6 +71,7 @@ class PlanningApplication < ApplicationRecord
     delegate :neighbour_consultation_feature?
     delegate :consultee_consultation_feature?
     delegate :publicity_consultation_feature?
+    delegate :prior_approval?
   end
 
   delegate :reviewer_group_email, to: :local_authority

--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -20,22 +20,6 @@ class PlanningApplicationPresenter
     send(:"#{status}_at")
   end
 
-  def application_type_name
-    I18n.t("application_types.#{application_type.name}")
-  end
-
-  def application_type_abbreviation
-    I18n.t("application_types.#{application_type.name}_abbr", default: application_type_name)
-  end
-
-  def application_type_with_status
-    status_title = work_status.titlecase
-    sanitize(
-      "<abbr title=\"#{application_type_name} #{status_title}\">" \
-      "#{application_type_abbreviation} #{status_title}</abbr>"
-    )
-  end
-
   %i[awaiting_determination_at expiry_date outcome_date].each do |date|
     define_method(:"formatted_#{date}") { send(date).to_date.to_fs(:day_month_only) }
   end

--- a/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
+++ b/app/views/planning_applications/neighbour_letters/_letter_template.html.erb
@@ -26,7 +26,7 @@
     <div class="govuk-inset-text">
       <p class="govuk-body">Text marked with a # (hashtag) will appear as a header in the printed letter.</p>
       <p class="govuk-body">Text marked with a * (asterisk) will appear as a bullet point in the printed letter.</p>
-      <% if @planning_application.type == "Prior approval" %>
+      <% if @planning_application.prior_approval? %>
         <p class="govuk-body">
           Measurements in the letter have been taken from PlanX. If measurements are incorrect, <%= link_to "change the measurements in the consistency checklist", new_planning_application_assessment_consistency_checklist_path(planning_application) %> then return to this template.
         </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -941,6 +941,7 @@ en:
             no_documents_uploaded: No documents uploaded
             press_notice: Press notice
             press_notice_incomplete: Press notice task incomplete.
+            press_notice_not_required: Press notice marked as not required for this application.
             publication_date: Publication date
             reasons_for_press_notice: Reasons for press notice
             site_notice: Site notice

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -377,13 +377,9 @@ en:
       users: Users
   application_types:
     lawfulness_certificate: Lawful Development Certificate
-    lawfulness_certificate_abbr: LDC
     other: Other planning application
-    other_abbr: Other
     planning_permission: Householder Application for Planning Permission
-    planning_permission_abbr: PP
     prior_approval: Prior approval
-    prior_approval_abbr: PA
   archive_reasons:
     design: Revise design
     dimensions: Revise dimensions
@@ -1322,7 +1318,6 @@ en:
     panel_component:
       all: All
       application_type_name: Application type
-      application_type_with_status: Application type
       awaiting_determination: Awaiting determination
       closed: Closed
       days_status_tag: Days

--- a/db/migrate/20240122141420_add_reporting_type_to_planning_applications.rb
+++ b/db/migrate/20240122141420_add_reporting_type_to_planning_applications.rb
@@ -1,17 +1,23 @@
 # frozen_string_literal: true
 
 class AddReportingTypeToPlanningApplications < ActiveRecord::Migration[7.0]
+  class ApplicationType < ActiveRecord::Base; end
+
+  class PlanningApplication < ActiveRecord::Base
+    belongs_to :application_type
+  end
+
   def change
     add_column :planning_applications, :reporting_type, :string
 
     up_only do
       PlanningApplication.find_each do |pa|
-        case pa.application_type_name.to_sym
-        when :lawfulness_certificate
+        case pa.application_type.name
+        when "lawfulness_certificate"
           pa.update_column(:reporting_type, "Q26")
-        when :prior_approval
+        when "prior_approval"
           pa.update_column(:reporting_type, "PA1")
-        when :planning_permission
+        when "planning_permission"
           pa.update_column(:reporting_type, "Q21")
         end
       end

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -252,26 +252,4 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       end
     end
   end
-
-  describe "#application_type_with_status" do
-    let(:presenter) { described_class.new(view, planning_application) }
-
-    context "when the status is proposed" do
-      let(:planning_application) { create(:planning_application, :ldc_proposed) }
-
-      it "is reflected in the type" do
-        expect(presenter.application_type_with_status).to include("LDC Proposed")
-        expect(presenter.application_type_with_status).to include("Lawful Development Certificate Proposed")
-      end
-    end
-
-    context "when the work status is existing" do
-      let(:planning_application) { create(:planning_application, :ldc_existing) }
-
-      it "is reflected in the type" do
-        expect(presenter.application_type_with_status).to include("LDC Existing")
-        expect(presenter.application_type_with_status).to include("Lawful Development Certificate Existing")
-      end
-    end
-  end
 end

--- a/spec/system/planning_applications/assessing/checking_publicity_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_publicity_spec.rb
@@ -300,16 +300,6 @@ RSpec.describe "checking publicity" do
         internal_team_email: "pressteam@example.com")
     end
 
-    let!(:press_notice) do
-      create(:press_notice,
-        planning_application: planning_application,
-        required: true,
-        reasons: ["major_development"],
-        requested_at: "2024-01-08T09:00:00Z",
-        published_at: "2024-01-11T09:00:00Z",
-        expiry_date: "2024-02-01")
-    end
-
     let!(:site_notice_evidence) do
       create(:document,
         planning_application: planning_application,
@@ -317,15 +307,6 @@ RSpec.describe "checking publicity" do
         user: uploader,
         file: fixture_file_upload("site-notice.jpg", "image/jpeg", true),
         tags: ["internal.siteNotice"])
-    end
-
-    let!(:press_notice_evidence) do
-      create(:document,
-        planning_application: planning_application,
-        owner: press_notice,
-        user: uploader,
-        file: fixture_file_upload("press-notice.jpg", "image/jpeg", true),
-        tags: ["internal.pressNotice"])
     end
 
     let!(:assessment_detail) do
@@ -336,59 +317,134 @@ RSpec.describe "checking publicity" do
         category: "check_publicity")
     end
 
-    it "allows editing of the publicity check" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
-
-      expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
-
-      click_link "Check site notice and press notice"
-      expect(page).to have_selector("h1", text: "Site notice and press notice")
-
-      within("#site-notice") do
-        expect(page).to have_selector("h2", text: "Site notice")
-
-        within "tbody tr:nth-child(1)" do
-          expect(page).to have_selector("td:nth-child(1)", text: "08/01/2024")
-          expect(page).to have_selector("td:nth-child(2)", text: "Bob Jones")
-          expect(page).to have_selector("td:nth-child(3)", text: "30/01/2024")
-        end
-
-        expect(page).to have_selector("a", text: "View in new window")
-        expect(page).to have_selector("a", text: "View more documents")
-
-        expect(page).to have_content("File name: site-notice.jpg")
-        expect(page).to have_content("Date uploaded: 29 February 2024")
+    context "and the press notice was marked as required" do
+      let!(:press_notice) do
+        create(:press_notice,
+          planning_application: planning_application,
+          required: true,
+          reasons: ["major_development"],
+          requested_at: "2024-01-08T09:00:00Z",
+          published_at: "2024-01-11T09:00:00Z",
+          expiry_date: "2024-02-01")
       end
 
-      within("#press-notice") do
-        expect(page).to have_selector("h2", text: "Press notice")
-
-        within "tbody tr:nth-child(1)" do
-          expect(page).to have_selector("td:nth-child(1)", text: "Major development")
-          expect(page).to have_selector("td:nth-child(2)", text: "11/01/2024")
-          expect(page).to have_selector("td:nth-child(3)", text: "Bob Jones")
-          expect(page).to have_selector("td:nth-child(4)", text: "01/02/2024")
-        end
-
-        expect(page).to have_selector("a", text: "View in new window")
-        expect(page).to have_selector("a", text: "View more documents")
-
-        expect(page).to have_content("File name: press-notice.jpg")
-        expect(page).to have_content("Date uploaded: 29 February 2024")
+      let!(:press_notice_evidence) do
+        create(:document,
+          planning_application: planning_application,
+          owner: press_notice,
+          user: uploader,
+          file: fixture_file_upload("press-notice.jpg", "image/jpeg", true),
+          tags: ["internal.pressNotice"])
       end
 
-      click_link "Edit site notice and press notice check"
-      expect(page).to have_selector("h1", text: "Check site notice and press notice")
+      it "allows editing of the publicity check" do
+        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
 
-      click_button "Save and come back later"
-      expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_selector("[role=alert] p", text: "Publicity check was successfully updated.")
+        expect(page).to have_selector("h1", text: "Assess the application")
+        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
 
-      within("#check-consistency-assessment-tasks") do
-        within("li:nth-child(2)") do
-          expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
-          expect(page).to have_selector("strong", text: "In progress")
+        click_link "Check site notice and press notice"
+        expect(page).to have_selector("h1", text: "Site notice and press notice")
+
+        within("#site-notice") do
+          expect(page).to have_selector("h2", text: "Site notice")
+
+          within "tbody tr:nth-child(1)" do
+            expect(page).to have_selector("td:nth-child(1)", text: "08/01/2024")
+            expect(page).to have_selector("td:nth-child(2)", text: "Bob Jones")
+            expect(page).to have_selector("td:nth-child(3)", text: "30/01/2024")
+          end
+
+          expect(page).to have_selector("a", text: "View in new window")
+          expect(page).to have_selector("a", text: "View more documents")
+
+          expect(page).to have_content("File name: site-notice.jpg")
+          expect(page).to have_content("Date uploaded: 29 February 2024")
+        end
+
+        within("#press-notice") do
+          expect(page).to have_selector("h2", text: "Press notice")
+
+          within "tbody tr:nth-child(1)" do
+            expect(page).to have_selector("td:nth-child(1)", text: "Major development")
+            expect(page).to have_selector("td:nth-child(2)", text: "11/01/2024")
+            expect(page).to have_selector("td:nth-child(3)", text: "Bob Jones")
+            expect(page).to have_selector("td:nth-child(4)", text: "01/02/2024")
+          end
+
+          expect(page).to have_selector("a", text: "View in new window")
+          expect(page).to have_selector("a", text: "View more documents")
+
+          expect(page).to have_content("File name: press-notice.jpg")
+          expect(page).to have_content("Date uploaded: 29 February 2024")
+        end
+
+        click_link "Edit site notice and press notice check"
+        expect(page).to have_selector("h1", text: "Check site notice and press notice")
+
+        click_button "Save and come back later"
+        expect(page).to have_selector("h1", text: "Assess the application")
+        expect(page).to have_selector("[role=alert] p", text: "Publicity check was successfully updated.")
+
+        within("#check-consistency-assessment-tasks") do
+          within("li:nth-child(2)") do
+            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
+            expect(page).to have_selector("strong", text: "In progress")
+          end
+        end
+      end
+    end
+
+    context "and the press notice was marked as not required" do
+      let!(:press_notice) do
+        create(:press_notice,
+          planning_application: planning_application,
+          required: false,
+          reasons: [])
+      end
+
+      it "allows editing of the publicity check" do
+        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+
+        expect(page).to have_selector("h1", text: "Assess the application")
+        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
+
+        click_link "Check site notice and press notice"
+        expect(page).to have_selector("h1", text: "Site notice and press notice")
+
+        within("#site-notice") do
+          expect(page).to have_selector("h2", text: "Site notice")
+
+          within "tbody tr:nth-child(1)" do
+            expect(page).to have_selector("td:nth-child(1)", text: "08/01/2024")
+            expect(page).to have_selector("td:nth-child(2)", text: "Bob Jones")
+            expect(page).to have_selector("td:nth-child(3)", text: "30/01/2024")
+          end
+
+          expect(page).to have_selector("a", text: "View in new window")
+          expect(page).to have_selector("a", text: "View more documents")
+
+          expect(page).to have_content("File name: site-notice.jpg")
+          expect(page).to have_content("Date uploaded: 29 February 2024")
+        end
+
+        within("#press-notice") do
+          expect(page).to have_selector("h2", text: "Press notice")
+          expect(page).to have_selector("p", text: "Press notice marked as not required for this application.")
+        end
+
+        click_link "Edit site notice and press notice check"
+        expect(page).to have_selector("h1", text: "Check site notice and press notice")
+
+        click_button "Save and come back later"
+        expect(page).to have_selector("h1", text: "Assess the application")
+        expect(page).to have_selector("[role=alert] p", text: "Publicity check was successfully updated.")
+
+        within("#check-consistency-assessment-tasks") do
+          within("li:nth-child(2)") do
+            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
+            expect(page).to have_selector("strong", text: "In progress")
+          end
         end
       end
     end


### PR DESCRIPTION
## Description

The entry validation for when there are neighbour responses should only apply to `neighbour_summary` assessment details.


## Story Link

https://trello.com/c/EdnM9pkS