### PR TITLE
Colour completed tags differently in task lists

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -190,8 +190,11 @@ $govuk-page-width: 1100px;
   max-width: none;
 }
 
-.govuk-tag--colourless {
-  background-color: transparent;
+.govuk-task-list,
+.app-task-list {
+  .govuk-tag--status-complete {
+    background-color: transparent;
+  }
 }
 
 .header-session-info {

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -11,7 +11,7 @@ module StatusTags
     end
 
     def call
-      govuk_tag(text: link_text, colour:, html_attributes: colour ? {} : {class: "govuk-tag--colourless"})
+      govuk_tag(text: link_text, colour:, html_attributes: {class: "govuk-tag--status-#{status}"})
     end
 
     private


### PR DESCRIPTION
We want status tags coloured by default but not in task lists when the status is 'complete'. The easiest way to do this is to expose the status as a CSS class and then treat the complete class differently in task lists, rather than adding some complex logic in the Rails component about which colours should be used when.