### PR TITLE
Fix assessment statuses

### DIFF
--- a/app/components/status_tags/additional_document_component.rb
+++ b/app/components/status_tags/additional_document_component.rb
@@ -15,7 +15,7 @@ module StatusTags
       if planning_application.additional_document_validation_requests.open_or_pending.any?
         :invalid
       elsif planning_application.documents_missing == false
-        :valid
+        :complete
       else
         :not_started
       end

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -13,15 +13,17 @@ module StatusTags
     delegate :ownership_certificate, to: :planning_application
 
     def status
-      planning_application.in_assessment? ? assessment_status : validation_status
+      (planning_application.in_assessment? || planning_application.to_be_reviewed?) ? assessment_status : validation_status
     end
 
     def assessment_status
       if planning_application.validation_requests.ownership_certificates.open.any?
         :invalid
+      elsif planning_application.valid_ownership_certificate
+        :complete
       elsif ownership_certificate.present?
         if ownership_certificate.current_review.complete?
-          planning_application.valid_ownership_certificate? ? :valid : :invalid
+          planning_application.valid_ownership_certificate? ? :complete : :invalid
         else
           :not_started
         end

--- a/app/components/status_tags/ownership_certificate_component.rb
+++ b/app/components/status_tags/ownership_certificate_component.rb
@@ -19,14 +19,16 @@ module StatusTags
     def assessment_status
       if planning_application.validation_requests.ownership_certificates.open.any?
         :invalid
-      elsif planning_application.valid_ownership_certificate
-        :complete
       elsif ownership_certificate.present?
-        if ownership_certificate.current_review.complete?
-          planning_application.valid_ownership_certificate? ? :complete : :invalid
+        if planning_application.ownership_certificate_updated?
+          :updated
+        elsif ownership_certificate.current_review.complete?
+          marked_as_valid?
         else
           :not_started
         end
+      elsif planning_application.ownership_certificate_checked
+        marked_as_valid?
       else
         :not_started
       end
@@ -35,15 +37,15 @@ module StatusTags
     def validation_status
       if planning_application.valid_ownership_certificate.nil?
         :not_started
-      elsif ownership_certificate.present?
-        if planning_application.ownership_certificate_awaiting_validation?
-          :updated
-        else
-          planning_application.valid_ownership_certificate? ? :valid : :invalid
-        end
+      elsif planning_application.ownership_certificate_updated?
+        :updated
       else
-        :invalid
+        marked_as_valid?
       end
+    end
+
+    def marked_as_valid?
+      planning_application.valid_ownership_certificate? ? :complete : :invalid
     end
   end
 end

--- a/app/components/task_list_items/assessment/conditions_component.rb
+++ b/app/components/task_list_items/assessment/conditions_component.rb
@@ -35,8 +35,10 @@ module TaskListItems
       def status
         if condition_set.current_review.present?
           if condition_set.pre_commencement?
-            if condition_set.validation_requests.any? { |validation_request| !validation_request.approved.nil? } && !condition_set.current_review.complete?
-              "updated"
+            if condition_set.current_review.to_be_reviewed?
+              :to_be_reviewed
+            elsif condition_set.validation_requests.any? { |validation_request| !validation_request.approved.nil? } && !condition_set.current_review.complete?
+              :updated
             else
               condition_set.current_review.status.to_sym
             end

--- a/app/components/task_list_items/check_red_line_boundary_component.rb
+++ b/app/components/task_list_items/check_red_line_boundary_component.rb
@@ -36,7 +36,7 @@ module TaskListItems
 
     def status
       @status = if valid?
-        :valid
+        :complete
       elsif red_line_boundary_change_validation_requests.open_or_pending.any?
         :invalid
       elsif change_request&.approved == false
@@ -48,7 +48,7 @@ module TaskListItems
 
     def render_sitemap_path?
       status == :not_started ||
-        (status == :valid && red_line_boundary_change_validation_requests.closed.none?)
+        (status == :complete && red_line_boundary_change_validation_requests.closed.none?)
     end
 
     def valid?

--- a/app/components/task_list_items/description_change.rb
+++ b/app/components/task_list_items/description_change.rb
@@ -18,7 +18,7 @@ module TaskListItems
 
     def link_path
       case status
-      when :valid, :not_started
+      when :complete, :not_started
         planning_application_validation_description_changes_path(
           planning_application
         )
@@ -32,7 +32,7 @@ module TaskListItems
 
     def status
       @status ||= if planning_application.valid_description?
-        :valid
+        :complete
       elsif description_change_validation_requests.open_or_pending.any?
         :invalid
       elsif description_change_validation_requests.closed.any?

--- a/app/components/task_list_items/fee_component.rb
+++ b/app/components/task_list_items/fee_component.rb
@@ -18,7 +18,7 @@ module TaskListItems
 
     def link_path
       case status
-      when :valid, :not_started
+      when :complete, :not_started
         planning_application_validation_fee_items_path(
           planning_application
         )
@@ -32,7 +32,7 @@ module TaskListItems
 
     def status
       @status ||= if planning_application.valid_fee?
-        :valid
+        :complete
       elsif fee_change_validation_requests.open_or_pending.any?
         :invalid
       elsif fee_change_validation_requests.closed.any?

--- a/app/controllers/planning_applications/assessment/ownership_certificates_controller.rb
+++ b/app/controllers/planning_applications/assessment/ownership_certificates_controller.rb
@@ -22,7 +22,7 @@ module PlanningApplications
 
       def update
         ActiveRecord::Base.transaction do
-          @planning_application.update!(valid_ownership_certificate:)
+          @planning_application.update!(valid_ownership_certificate:, ownership_certificate_checked: true)
           @planning_application.ownership_certificate&.current_review&.update!(status:)
         end
 

--- a/app/controllers/planning_applications/assessment/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/assessment/pre_commencement_conditions_controller.rb
@@ -86,7 +86,6 @@ module PlanningApplications
 
       def pre_commencement_condition_params
         params.require(:condition).permit(*pre_commencement_condition_attributes)
-          .to_h.merge(reviews_attributes: [status:, id: (@condition_set&.current_review&.id if !mark_as_complete?)])
       end
 
       def set_condition
@@ -110,14 +109,6 @@ module PlanningApplications
           planning_application_assessment_pre_commencement_conditions_path(@planning_application)
         else
           planning_application_assessment_tasks_path(@planning_application)
-        end
-      end
-
-      def status
-        if mark_as_complete?
-          "complete"
-        else
-          "in_progress"
         end
       end
     end

--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -48,7 +48,11 @@ class ConditionSet < ApplicationRecord
 
   def create_or_update_review!(status)
     if current_review.present?
-      current_review.update!(status:)
+      if current_review.review_complete?
+        create_review(status)
+      else
+        current_review.update!(status:)
+      end
     else
       create_review(status)
     end

--- a/app/models/ownership_certificate_validation_request.rb
+++ b/app/models/ownership_certificate_validation_request.rb
@@ -20,10 +20,6 @@ class OwnershipCertificateValidationRequest < ValidationRequest
     ).call
   end
 
-  def not_yet_validated?
-    post_validation == false
-  end
-
   private
 
   def audit_api_comment

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -445,11 +445,10 @@ class PlanningApplication < ApplicationRecord
     raise SubmitRecommendationError, e.message
   end
 
-  def ownership_certificate_awaiting_validation?
-    has_requests = ownership_certificate_validation_requests.open.any?
-    not_yet_validated = ownership_certificate_validation_requests&.last&.not_yet_validated?
+  def ownership_certificate_updated?
+    has_requests = ownership_certificate_validation_requests.order(:created_at).last&.state == "closed"
 
-    has_requests && not_yet_validated
+    has_requests && !valid_ownership_certificate
   end
 
   def withdraw_last_recommendation!

--- a/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
+++ b/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
@@ -126,16 +126,20 @@
       </details>
     </div>
 
+    <% if @condition_set.validation_requests.any?(&:open?) %>
+      <p class="govuk-body">Waiting for the applicant to respond to the requests.</p>
+    <% end %>
+
     <div class="govuk-button-group">
-        <%= form_with model: @condition, url: confirm_planning_application_assessment_pre_commencement_conditions_path(@planning_application) do |form| %>
-          <% if @condition_set.conditions.all(&:accepted?) %>
-            <% unless @condition_set.current_review.complete? %>
-              <%= form.submit "Save and mark as complete", class: "govuk-button" %>
-            <% end %>
-          <% else %>
-            <%= form.submit t("form_actions.pre_commencement_condition.confirm"), class: "govuk-button" %>
-            <%= form.govuk_submit("Save and come back later", secondary: true) %>
+      <%= form_with model: @condition, url: confirm_planning_application_assessment_pre_commencement_conditions_path(@planning_application) do |form| %>
+        <% if @condition_set.validation_requests.all?(&:approved?) %>
+          <% unless @condition_set.current_review&.complete? %>
+            <%= form.submit "Save and mark as complete", class: "govuk-button" %>
           <% end %>
+        <% elsif @condition_set.validation_requests.any?(&:pending?) %>
+          <%= form.submit t("form_actions.pre_commencement_condition.confirm"), class: "govuk-button" %>
+          <%= form.govuk_submit("Save and come back later", secondary: true) %>
+        <% end %>
         <%= govuk_button_link_to("Back", planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
       <% end %>
     </div>

--- a/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
+++ b/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
@@ -127,9 +127,15 @@
     </div>
 
     <div class="govuk-button-group">
-      <%= form_with model: @condition, url: confirm_planning_application_assessment_pre_commencement_conditions_path(@planning_application) do |form| %>
-        <%= form.submit t("form_actions.pre_commencement_condition.confirm"), class: "govuk-button" %>
-        <%= form.govuk_submit("Save and come back later", secondary: true) %>
+        <%= form_with model: @condition, url: confirm_planning_application_assessment_pre_commencement_conditions_path(@planning_application) do |form| %>
+          <% if @condition_set.conditions.all(&:accepted?) %>
+            <% unless @condition_set.current_review.complete? %>
+              <%= form.submit "Save and mark as complete", class: "govuk-button" %>
+            <% end %>
+          <% else %>
+            <%= form.submit t("form_actions.pre_commencement_condition.confirm"), class: "govuk-button" %>
+            <%= form.govuk_submit("Save and come back later", secondary: true) %>
+          <% end %>
         <%= govuk_button_link_to("Back", planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
       <% end %>
     </div>

--- a/app/views/planning_applications/review/assessment_details/_consultees.html.erb
+++ b/app/views/planning_applications/review/assessment_details/_consultees.html.erb
@@ -1,4 +1,4 @@
-<h3 class="govuk-heading-s"><%= t(".list_of_who") %></h3>
+<h3 class="govuk-heading-s govuk-!-margin-top-2"><%= t(".list_of_who") %></h3>
 <table class="govuk-table">
   <tbody class="govuk-table__body">
     <% consultees.each do |consultee| %>

--- a/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
+++ b/app/views/planning_applications/validation/time_extension_validation_requests/_show.html.erb
@@ -41,11 +41,11 @@
       <% end %>
     </p>
 
-    <% if @validation_request.open? %>
       <div class="govuk-button-group">
         <%= govuk_link_to("Back", @back_path, class: "govuk-button govuk-button--secondary") %>
-        <%= govuk_link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, @validation_request), class: "govuk-body" %>
+        <% if @validation_request.open? %>
+          <%= govuk_link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, @validation_request), class: "govuk-body" %>
+        <% end %>
       </div>
-    <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1848,6 +1848,7 @@ en:
         user_created_amenity: "%{user} created amenity assessment"
         user_created_consultation_summary: "%{user} created consultation summary"
         user_created_neighbour_summary: "%{user} created neighbour summary"
+        user_created_past_applications: "%{user} created history"
         user_created_site_description: "%{user} created site description"
         user_created_summary_of_work: "%{user} created summary of works"
         user_marked_this: "%{user} marked this for review"

--- a/db/migrate/20240509124429_add_ownership_certificate_checked_to_planning_application.rb
+++ b/db/migrate/20240509124429_add_ownership_certificate_checked_to_planning_application.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddOwnershipCertificateCheckedToPlanningApplication < ActiveRecord::Migration[7.1]
+  def change
+    add_column :planning_applications, :ownership_certificate_checked, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_104253) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_124429) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -714,6 +714,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_104253) do
     t.datetime "in_committee_at"
     t.boolean "regulation_3", default: false, null: false
     t.boolean "regulation_4", default: false, null: false
+    t.boolean "ownership_certificate_checked", default: false, null: false
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/spec/components/status_tags/additional_document_components_spec.rb
+++ b/spec/components/status_tags/additional_document_components_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe StatusTags::AdditionalDocumentComponent, type: :component do
     it "renders 'Valid' status" do
       render_inline(component)
 
-      expect(page).to have_content("Valid")
+      expect(page).to have_content("Completed")
     end
   end
 end

--- a/spec/components/status_tags/ownership_certificate_component_spec.rb
+++ b/spec/components/status_tags/ownership_certificate_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
       end
 
       it "renders 'Valid' status" do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
     end
 
@@ -75,7 +75,7 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
 
       before do
         create(:ownership_certificate, planning_application:)
-        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid")
+        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid", state: "closed")
 
         render_inline(
           described_class.new(planning_application:)
@@ -113,12 +113,12 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
         ownership_certificate.current_review.update(status: "complete")
       end
 
-      it "renders 'Valid' status" do
+      it "renders 'Completed' status" do
         render_inline(
           described_class.new(planning_application:)
         )
 
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
     end
 
@@ -131,12 +131,12 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
           ownership_certificate.current_review.update(status: "complete")
         end
 
-        it "renders 'Invalid' status" do
+        it "renders 'Completed' status" do
           render_inline(
             described_class.new(planning_application:)
           )
 
-          expect(page).to have_content("Valid")
+          expect(page).to have_content("Completed")
         end
       end
 
@@ -155,23 +155,6 @@ RSpec.describe StatusTags::OwnershipCertificateComponent, type: :component do
 
           expect(page).to have_content("Invalid")
         end
-      end
-    end
-
-    context "when ownership certificate has open validation requests" do
-      let(:valid_ownership_certificate) { false }
-
-      before do
-        create(:ownership_certificate, planning_application:)
-        create(:ownership_certificate_validation_request, planning_application:, reason: "invalid")
-      end
-
-      it "renders 'Updated' status" do
-        render_inline(
-          described_class.new(planning_application:)
-        )
-
-        expect(page).to have_content("Invalid")
       end
     end
   end

--- a/spec/components/task_list_items/check_red_line_boundary_component_spec.rb
+++ b/spec/components/task_list_items/check_red_line_boundary_component_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe TaskListItems::CheckRedLineBoundaryComponent, type: :component do
     it "renders 'Valid' status tag" do
       render_inline(component)
 
-      expect(page).to have_content("Valid")
+      expect(page).to have_content("Completed")
     end
 
     it "renders sitemap link" do
@@ -83,7 +83,7 @@ RSpec.describe TaskListItems::CheckRedLineBoundaryComponent, type: :component do
       before { render_inline(component) }
 
       it "renders 'Valid' status tag" do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       it "renders change request link" do
@@ -115,7 +115,7 @@ RSpec.describe TaskListItems::CheckRedLineBoundaryComponent, type: :component do
     it "renders 'Valid' status tag" do
       render_inline(component)
 
-      expect(page).to have_content("Valid")
+      expect(page).to have_content("Completed")
     end
 
     it "renders sitemap link" do
@@ -140,7 +140,7 @@ RSpec.describe TaskListItems::CheckRedLineBoundaryComponent, type: :component do
       end
 
       it "renders 'Valid' status tag" do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       it "renders change request link" do

--- a/spec/components/task_list_items/fee_component_spec.rb
+++ b/spec/components/task_list_items/fee_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TaskListItems::FeeComponent, type: :component do
     before { render_inline(component) }
 
     it "renders 'Valid' status" do
-      expect(page).to have_content("Valid")
+      expect(page).to have_content("Completed")
     end
 
     it "renders link to fee items path" do

--- a/spec/models/ownership_certificate_validation_request_spec.rb
+++ b/spec/models/ownership_certificate_validation_request_spec.rb
@@ -45,21 +45,4 @@ RSpec.describe OwnershipCertificateValidationRequest do
       end
     end
   end
-
-  describe "#not_yet_validated?" do
-    let(:planning_application) { create(:planning_application, :not_started) }
-    let!(:ownership_certificate_validation_request) do
-      create(:ownership_certificate_validation_request, planning_application:, state: "open")
-    end
-
-    it "returns true when post_validation is false" do
-      expect(ownership_certificate_validation_request.not_yet_validated?).to eq(true)
-    end
-
-    it "returns false when post_validation is true" do
-      ownership_certificate_validation_request.update!(post_validation: true)
-
-      expect(ownership_certificate_validation_request.not_yet_validated?).to eq(false)
-    end
-  end
 end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -208,16 +208,6 @@ RSpec.describe PlanningApplication do
         end
       end
 
-      describe "#ownership_certificate_awaiting_validation?" do
-        it "sets planning application status to updated when certificate is added" do
-          certificate_request = create(:ownership_certificate_validation_request)
-          planning_application = certificate_request.planning_application
-
-          planning_application.update!(valid_ownership_certificate: true)
-          expect(planning_application.ownership_certificate_awaiting_validation?).to be(true)
-        end
-      end
-
       describe "#reference" do
         let(:planning_application) do
           build(:planning_application, :ldc_proposed)

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe "Requesting a new document for a planning application" do
       expect(page).to have_content("Documents required are marked as valid")
 
       within("#check-missing-documents") do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       expect(planning_application.reload.documents_missing).to be(false)

--- a/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Check ownership certificate" do
 
       expect(page).to have_content("Ownership certificate was checked")
 
-      expect(list_item("Check ownership certificate")).to have_content("Valid")
+      expect(list_item("Check ownership certificate")).to have_content("Completed")
 
       click_link "Check ownership certificate"
 
@@ -73,7 +73,7 @@ RSpec.describe "Check ownership certificate" do
 
       click_button "Save and mark as complete"
 
-      expect(list_item("Check ownership certificate")).to have_content("Valid")
+      expect(list_item("Check ownership certificate")).to have_content("Completed")
     end
   end
 
@@ -114,7 +114,7 @@ RSpec.describe "Check ownership certificate" do
 
       click_button "Save and mark as complete"
 
-      expect(list_item("Check ownership certificate")).to have_content("Valid")
+      expect(list_item("Check ownership certificate")).to have_content("Completed")
     end
   end
 end

--- a/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Reviewing pre-commencement conditions" do
 
         expect(page).to have_list_item_for(
           "Add pre-commencement conditions",
-          with: "Updated"
+          with: "To be reviewed"
         )
 
         click_link "Add pre-commencement conditions"

--- a/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "Check ownership certificate type" do
         expect(page).to have_content "Ownership certificate successfully updated"
 
         within("#check-ownership-certificate") do
-          expect(page).to have_content("Valid")
+          expect(page).to have_content("Completed")
         end
 
         click_link "Check ownership certificate"

--- a/spec/system/planning_applications/validating/description_changes_validation_spec.rb
+++ b/spec/system/planning_applications/validating/description_changes_validation_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "DescriptionChangesValidation" do
       expect(page).to have_content("Description was marked as valid")
 
       within("#check-description") do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       expect(planning_application.reload.valid_description).to be_truthy
@@ -133,7 +133,7 @@ RSpec.describe "DescriptionChangesValidation" do
       expect(page).to have_content("Description was marked as valid")
 
       within("#check-description") do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       click_link "Check description"

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "FeeItemsValidation" do
       expect(page).to have_content("Fee item was marked as valid.")
 
       within("#fee-validation-task") do
-        expect(page).to have_content("Valid")
+        expect(page).to have_content("Completed")
       end
 
       expect(planning_application.reload.valid_fee).to be_truthy
@@ -495,7 +495,7 @@ RSpec.describe "FeeItemsValidation" do
         expect(page).to have_content "Planning application payment amount was successfully updated."
 
         within("#fee-validation-task") do
-          expect(page).to have_content("Valid")
+          expect(page).to have_content("Completed")
         end
 
         visit "/planning_applications/#{planning_application.id}/audits"


### PR DESCRIPTION
### Description of change

Further tidy up
- Fix up of some of the assessment task statuses/ get rid of "Valid" status
- Use correct statuses on checking ownership certificates in assessment
- Add a missing back button
- Show correct buttons on pre-commencement conditions (e.g. the "send to applicant" button doesn't show if there's nothing to send to the applicant)

### Story Link

part of https://trello.com/c/izFLUu53/2772-patterns-for-showing-when-review-tasks-have-been-completed
