### PR TITLE
Avoid collisions of name parameter on test matrix run

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: selenium-screenshots
+          name: selenium-screenshots-${{ inputs.name }}
           path: ${{ github.workspace }}/tmp/capybara/*.png
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
If more than one test group in the matrix fails, all but the first will fail to save the screenshots because they all try to upload files to the same location. Distinguish them by name of the test group instead.