### PR TITLE
Avoid collisions of name parameter in logs on test matrix run

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -128,7 +128,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: rails-logs
+          name: rails-logs-${{ inputs.name }}
           path: ${{ github.workspace }}/log/test.log
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
If more than one test group in the matrix fails, all but the first will fail to save the logs because they all try to upload files to the same location. Distinguish them by name of the test group instead.

This was missed in #1789.