### PR TITLE
Create public planning applications controller with search action for API

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    module Public
+      class PlanningApplicationsController < PublicController
+        def search
+          @pagy, @planning_applications = search_service.call
+
+          respond_to do |format|
+            format.json
+          end
+        end
+
+        private
+
+        def planning_applications_scope
+          @local_authority.planning_applications.where(make_public: true)
+        end
+
+        def search_params
+          params.permit(:page, :maxresults, :q)
+        end
+
+        def search_service(scope = planning_applications_scope.by_created_at_desc)
+          @search_service ||= Application::SearchService.new(scope, search_params)
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/controllers/bops_api/v2/public_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    class PublicController < ApplicationController
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/application/query_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/query_service.rb
@@ -3,12 +3,6 @@
 module BopsApi
   module Application
     class QueryService
-      include Pagy::Backend
-
-      DEFAULT_PAGE = 1
-      DEFAULT_MAXRESULTS = 10
-      MAXRESULTS_LIMIT = 20
-
       def initialize(scope, params)
         @scope = scope
         @params = params
@@ -17,7 +11,7 @@ module BopsApi
       attr_reader :scope, :params
 
       def call
-        paginate(filter_by_ids)
+        Pagination.new(scope: filter_by_ids, params:).paginate
       end
 
       private
@@ -26,13 +20,6 @@ module BopsApi
         return scope if params[:ids].blank?
 
         scope.where(id: params[:ids])
-      end
-
-      def paginate(scope)
-        page = (params[:page] || DEFAULT_PAGE).to_i
-        maxresults = [(params[:maxresults] || DEFAULT_MAXRESULTS).to_i, MAXRESULTS_LIMIT].min
-
-        pagy(scope, page:, items: maxresults)
       end
     end
   end

--- a/engines/bops_api/app/services/bops_api/application/search_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/search_service.rb
@@ -3,12 +3,6 @@
 module BopsApi
   module Application
     class SearchService
-      include Pagy::Backend
-
-      DEFAULT_PAGE = 1
-      DEFAULT_MAXRESULTS = 10
-      MAXRESULTS_LIMIT = 20
-
       def initialize(scope, params)
         @scope = scope
         @params = params
@@ -18,7 +12,7 @@ module BopsApi
       attr_reader :scope, :params, :query
 
       def call
-        paginate(search)
+        Pagination.new(scope: search, params:).paginate
       end
 
       private
@@ -60,13 +54,6 @@ module BopsApi
 
       def query_terms
         @query_terms ||= query.split.join(" | ")
-      end
-
-      def paginate(scope)
-        page = (params[:page] || DEFAULT_PAGE).to_i
-        maxresults = [(params[:maxresults] || DEFAULT_MAXRESULTS).to_i, MAXRESULTS_LIMIT].min
-
-        pagy(scope, page:, items: maxresults)
       end
     end
   end

--- a/engines/bops_api/app/services/bops_api/application/search_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/search_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module Application
+    class SearchService
+      include Pagy::Backend
+
+      DEFAULT_PAGE = 1
+      DEFAULT_MAXRESULTS = 10
+      MAXRESULTS_LIMIT = 20
+
+      def initialize(scope, params)
+        @scope = scope
+        @params = params
+        @query = params[:q]
+      end
+
+      attr_reader :scope, :params, :query
+
+      def call
+        paginate(search)
+      end
+
+      private
+
+      def search
+        return scope if query.blank?
+
+        search_reference.presence || search_description
+      end
+
+      def search_reference
+        scope.where(
+          "LOWER(reference) LIKE ?",
+          "%#{query.downcase}%"
+        )
+      end
+
+      def search_description
+        scope.select(sanitized_select_sql)
+          .where(where_sql, query_terms)
+          .order(rank: :desc)
+      end
+
+      def sanitized_select_sql
+        ActiveRecord::Base.sanitize_sql_array([select_sql, query_terms])
+      end
+
+      def select_sql
+        "planning_applications.*,
+          ts_rank(
+            to_tsvector('english', description),
+            to_tsquery('english', ?)
+          ) AS rank"
+      end
+
+      def where_sql
+        "to_tsvector('english', description) @@ to_tsquery('english', ?)"
+      end
+
+      def query_terms
+        @query_terms ||= query.split.join(" | ")
+      end
+
+      def paginate(scope)
+        page = (params[:page] || DEFAULT_PAGE).to_i
+        maxresults = [(params[:maxresults] || DEFAULT_MAXRESULTS).to_i, MAXRESULTS_LIMIT].min
+
+        pagy(scope, page:, items: maxresults)
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/_show.json.jbuilder
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+json.application do
+  json.type do
+    json.value planning_application.application_type.code
+    json.description planning_application.application_type.name
+  end
+  json.reference planning_application.reference
+  json.full_reference planning_application.reference_in_full
+end
+json.property do
+  json.address do
+    json.latitude planning_application.latitude
+    json.longitude planning_application.longitude
+    json.title planning_application.address_1
+    json.singleLine planning_application.full_address
+    json.uprn planning_application.uprn
+    json.town planning_application.town
+    json.postcode planning_application.postcode
+  end
+  json.boundary do
+    json.site planning_application.boundary_geojson
+  end
+end
+json.proposal do
+  json.description planning_application.description
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+json.metadata do
+  json.page @pagy.page
+  json.results @pagy.items
+  json.from @pagy.from
+  json.to @pagy.to
+  json.total_pages @pagy.pages
+  json.total_results @pagy.count
+end
+
+json.data @planning_applications.each do |planning_application|
+  json.partial! "show", planning_application:
+end

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -16,6 +16,12 @@ BopsApi::Engine.routes.draw do
       resources :planning_applications, only: [:index, :show, :create] do
         get :determined, on: :collection
       end
+
+      namespace :public do
+        resources :planning_applications, only: [] do
+          get :search, on: :collection
+        end
+      end
     end
   end
 end

--- a/engines/bops_api/lib/bops_api.rb
+++ b/engines/bops_api/lib/bops_api.rb
@@ -2,6 +2,7 @@
 
 require "bops_api/engine"
 require "bops_api/errors"
+require "bops_api/pagination"
 require "bops_api/schemas"
 
 module BopsApi

--- a/engines/bops_api/lib/bops_api/pagination.rb
+++ b/engines/bops_api/lib/bops_api/pagination.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BopsApi
+  class Pagination
+    include Pagy::Backend
+
+    DEFAULT_PAGE = 1
+    DEFAULT_MAXRESULTS = 10
+    MAXRESULTS_LIMIT = 20
+
+    def initialize(scope:, params:)
+      @scope = scope
+      @params = params
+    end
+
+    attr_reader :scope, :params
+
+    def paginate
+      page = (params[:page] || DEFAULT_PAGE).to_i
+      maxresults = [(params[:maxresults] || DEFAULT_MAXRESULTS).to_i, MAXRESULTS_LIMIT].min
+
+      pagy(scope, page:, items: maxresults)
+    end
+  end
+end

--- a/engines/bops_api/spec/fixtures/examples/public/planning_applications/search.json
+++ b/engines/bops_api/spec/fixtures/examples/public/planning_applications/search.json
@@ -1,0 +1,69 @@
+{
+  "metadata": {
+    "page": 1,
+    "results": 10,
+    "from": 1,
+    "to": 1,
+    "total_pages": 1,
+    "total_results": 1
+  },
+  "data": [
+    {
+      "application": {
+        "type": {
+          "value": "pp.full.householder",
+          "description": "planning_permission"
+        },
+        "reference": "24-00620-HAPP",
+        "full_reference": "SWK-24-00620-HAPP"
+      },
+      "property": {
+        "address": {
+          "latitude": 51.4656522,
+          "longitude": -0.1185926,
+          "title": "40, STANSFIELD ROAD",
+          "singleLine": "40, STANSFIELD ROAD, LONDON, SW9 9RZ",
+          "uprn": "100021892955",
+          "town": "LONDON",
+          "postcode": "SW9 9RZ"
+        },
+        "boundary": {
+          "site": {
+            "type": "Feature",
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ],
+                  [
+                    -0.1185938715934822,
+                    51.465724418998775
+                  ],
+                  [
+                    -0.1184195280075143,
+                    51.46552473766957
+                  ],
+                  [
+                    -0.11848390102387167,
+                    51.4655038504508
+                  ],
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ]
+                ]
+              ]
+            },
+            "properties": null
+          }
+        }
+      },
+      "proposal": {
+        "description": "Roof extension to the rear of the property, incorporating starship launchpad."
+      }
+    }
+  ]
+}

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "BOPS API" do
   let(:planning_application) { example_fixture("validPlanningPermission.json") }
   let(:send_email) { "true" }
 
-  let!(:planning_applications) { create_list(:planning_application, 8, local_authority:, application_type:) }
+  let!(:planning_applications) { create_list(:planning_application, 8, local_authority:, application_type:, make_public: true) }
   let!(:determined_planning_applications) { create_list(:planning_application, 3, :determined, local_authority:, application_type:) }
   let(:page) { 2 }
   let(:maxresults) { 5 }

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS public API" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:application_type) { create(:application_type, :householder) }
+  let!(:planning_applications) { create_list(:planning_application, 8, local_authority:, application_type:, make_public: true) }
+  let(:maxresults) { 5 }
+
+  path "/api/v2/public/planning_applications/search" do
+    get "Retrieves planning applications based on a search criteria" do
+      tags "Planning applications"
+      produces "application/json"
+
+      parameter name: :page, in: :query, schema: {
+        type: :integer,
+        default: 1
+      }
+
+      parameter name: :maxresults, in: :query, schema: {
+        type: :integer,
+        default: 10
+      }
+
+      parameter name: "q", in: :query, schema: {
+        type: :string,
+        description: "Search by reference or description"
+      }
+
+      response "200", "returns planning applications when searching by the reference" do
+        example "application/json", :default, api_json_fixture("public/planning_applications/search.json")
+
+        let(:page) { 1 }
+        let(:q) { planning_applications.first.reference }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          metadata = data["metadata"]
+
+          expect(metadata).to eq(
+            {
+              "page" => 1,
+              "results" => 5,
+              "from" => 1,
+              "to" => 1,
+              "total_pages" => 1,
+              "total_results" => 1
+            }
+          )
+
+          expect(data["data"].first["application"]["full_reference"]).to eq("PlanX-#{planning_applications.first.reference}")
+        end
+      end
+
+      response "200", "returns empty array when no results from search" do
+        example "application/json", :default, api_json_fixture("public/planning_applications/search.json")
+
+        let(:page) { 1 }
+        let(:q) { "no results found" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          metadata = data["metadata"]
+
+          expect(metadata).to eq(
+            {
+              "page" => 1,
+              "results" => 5,
+              "from" => 0,
+              "to" => 0,
+              "total_pages" => 1,
+              "total_results" => 0
+            }
+          )
+
+          expect(data["data"]).to eq([])
+        end
+      end
+
+      response "200", "returns planning applications when searching by a reference or description" do
+        example "application/json", :default, api_json_fixture("public/planning_applications/search.json")
+
+        let(:page) { 1 }
+        let(:q) { "HAPP" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          metadata = data["metadata"]
+
+          expect(metadata).to eq(
+            {
+              "page" => 1,
+              "results" => 5,
+              "from" => 1,
+              "to" => 5,
+              "total_pages" => 2,
+              "total_results" => 8
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/services/application/query_service_spec.rb
+++ b/engines/bops_api/spec/services/application/query_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe BopsApi::Application::QueryService do
 
         it "limits the results to MAXRESULTS_LIMIT" do
           pagy, _ = service.call
-          expect(pagy.items).to eq(described_class::MAXRESULTS_LIMIT)
+          expect(pagy.items).to eq(BopsApi::Pagination::MAXRESULTS_LIMIT)
         end
       end
     end

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -20796,3 +20796,76 @@ paths:
                       detail: Couldn't find PlanningApplication with 'id'=734837
               schema:
                 "$ref": "#/components/schemas/NotFoundError"
+  "/api/v2/public/planning_applications/search":
+    get:
+      summary: Retrieves planning applications based on a search criteria
+      tags:
+      - Planning applications
+      parameters:
+      - name: page
+        in: query
+        schema:
+          type: integer
+          default: 1
+      - name: maxresults
+        in: query
+        schema:
+          type: integer
+          default: 10
+      - name: q
+        in: query
+        schema:
+          type: string
+          description: Search by reference or description
+      responses:
+        '200':
+          description: returns planning applications when searching by a reference
+            or description
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    metadata:
+                      page: 1
+                      results: 10
+                      from: 1
+                      to: 1
+                      total_pages: 1
+                      total_results: 1
+                    data:
+                    - application:
+                        type:
+                          value: pp.full.householder
+                          description: planning_permission
+                        reference: 24-00620-HAPP
+                        full_reference: SWK-24-00620-HAPP
+                      property:
+                        address:
+                          latitude: 51.4656522
+                          longitude: -0.1185926
+                          title: 40, STANSFIELD ROAD
+                          singleLine: 40, STANSFIELD ROAD, LONDON, SW9 9RZ
+                          uprn: '100021892955'
+                          town: LONDON
+                          postcode: SW9 9RZ
+                        boundary:
+                          site:
+                            type: Feature
+                            geometry:
+                              type: Polygon
+                              coordinates:
+                              - - - -0.1186569035053321
+                                  - 51.465703531871384
+                                - - -0.1185938715934822
+                                  - 51.465724418998775
+                                - - -0.1184195280075143
+                                  - 51.46552473766957
+                                - - -0.11848390102387167
+                                  - 51.4655038504508
+                                - - -0.1186569035053321
+                                  - 51.465703531871384
+                            properties: 
+                      proposal:
+                        description: Roof extension to the rear of the property, incorporating
+                          starship launchpad.


### PR DESCRIPTION
### Description of change

Creating an unauthenticated endpoint for public search. Search is by complete or partial reference (`LIKE`), falling back to full-text search of description.

### Story Link

https://trello.com/c/wBhBhcQ1/2932-priority-1-the-ability-to-search-based-on-complete-or-partial-application-reference-referenceinfull

### Known issues

Future work:
 
1. more fields in output
2. more fields in full text search
3. refactor search methods to avoid duplication with frontend search.