### PR TITLE
Correct status tag alignment in constraint/consultee table

### DIFF
--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -18,7 +18,7 @@
           <%= govuk_link_to "Assign consultee", new_planning_application_consultee_path(@planning_application, constraint: constraint) %>
         <% end %>
       </td>
-      <td class="govuk-table__cell">
+      <td class="govuk-table__cell govuk-!-text-align-right">
         <% if constraint.consultee.present? %>
           <%= render StatusTags::BaseComponent.new(status: constraint.consultee.status) %>
         <% else %>
@@ -36,7 +36,7 @@
       <td class="govuk-table__cell">
         <%= consultee.name %>
       </td>
-      <td class="govuk-table__cell govuk-table__cell--centred">
+      <td class="govuk-table__cell govuk-!-text-align-right">
         <%= render StatusTags::BaseComponent.new(status: consultee.status) %>
       </td>
     </tr>


### PR DESCRIPTION
Missing CSS alignment in some table cells. https://trello.com/c/8SZFU7wI/2978-status-tags-and-header-arent-aligned-in-select-and-add-consultees-page