### PR TITLE
Add link to draft decision notice on considerations pages

### DIFF
--- a/app/views/planning_applications/assessment/local_policies/_informational_links.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/_informational_links.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+  <%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank" %>
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to "View draft decision notice (in a new tab)", decision_notice_planning_application_path(@planning_application), target: "_blank" %>
+</p>

--- a/app/views/planning_applications/assessment/local_policies/new.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/new.html.erb
@@ -14,7 +14,7 @@
       locals: {heading: "Assess against policies and guidance"}
     ) %>
 
-<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body govuk-!-margin-top-6" %>
+<%= render partial: "informational_links" %>
 
 <%= render "table" %>
 

--- a/app/views/planning_applications/assessment/local_policies/show.html.erb
+++ b/app/views/planning_applications/assessment/local_policies/show.html.erb
@@ -14,7 +14,7 @@
       locals: {heading: "Assess against policies and guidance"}
     ) %>
 
-<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
+<%= render partial: "informational_links" %>
 
 <%= render(ReviewerCommentComponent.new(comment: @reviewer_comment)) %>
 

--- a/app/views/planning_applications/assessment/local_policy_areas/edit.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/edit.html.erb
@@ -14,6 +14,6 @@
       locals: {heading: "Update consideration: #{@local_policy_area.area}"}
     ) %>
 
-<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
+<%= render partial: "planning_applications/assessment/local_policies/informational_links" %>
 
 <%= render "edit_form" %>

--- a/app/views/planning_applications/assessment/local_policy_areas/new.html.erb
+++ b/app/views/planning_applications/assessment/local_policy_areas/new.html.erb
@@ -14,6 +14,6 @@
       locals: {heading: "Add new consideration"}
     ) %>
 
-<%= govuk_link_to "Check your local policies and guidance in a new tab", I18n.t("council_documents.#{@planning_application.local_authority.subdomain}.planning_policy_and_guidance"), target: "_blank", class: "govuk-body" %>
+<%= render partial: "planning_applications/assessment/local_policies/informational_links" %>
 
 <%= render "form" %>

--- a/spec/system/planning_applications/assessing/assess_against_polices_and_guidance_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_against_polices_and_guidance_spec.rb
@@ -41,7 +41,11 @@ RSpec.describe "assess against policies and guidance" do
 
     expect(page).to have_content "You have not added any considerations"
 
+    expect(page).to have_content("View draft decision notice")
+
     click_link "Add new consideration"
+
+    expect(page).to have_content("View draft decision notice")
 
     expect(page).to have_content("Add new consideration")
 
@@ -96,9 +100,11 @@ RSpec.describe "assess against policies and guidance" do
     end
 
     expect(page).to have_content "You have not added any considerations"
+    expect(page).to have_content("View draft decision notice")
 
     click_link "Add new consideration"
 
+    expect(page).to have_content("View draft decision notice")
     expect(page).to have_content("Add a custom policy area if it does not appear in the list above")
 
     fill_in "manual-policy-input", with: "Consistency with local architecture"


### PR DESCRIPTION
### Description of change

'Add new' and summary screen for considerations should include a link to the draft decision notice.

### Story Link

<https://trello.com/c/8SICjYfw/2994-improve-add-considerations-add-link-to-draft-decision-notice-in-add-new-screen-and-summary-screen>

### Screenshots

<img width="531" alt="Screenshot 2024-05-14 at 16 15 46" src="https://github.com/unboxed/bops/assets/3986/74f90c37-5460-4d54-aab3-aeca7ab8a365">
