### PR TITLE
Key dates in status panel container

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -13,6 +13,7 @@ $govuk-page-width: 1100px;
 @import "components/primary_navigation";
 @import "components/secondary_navigation";
 @import "components/sortable";
+@import "components/status_panel";
 @import "components/table";
 @import "components/task_list";
 @import "consultation";
@@ -362,55 +363,6 @@ $govuk-page-width: 1100px;
 
 .bottom-border-none {
   border-bottom: none;
-}
-
-.status-bar-container {
-  background-color: rgb(202, 222, 237);
-  width: calc(100vw);
-  margin-left: calc(-1 * ((100vw - 100%) / 2));
-
-  h2 {
-    max-width: $govuk-page-width;
-    margin-left: auto;
-    margin-right: auto;
-    padding-top: 1rem;
-  }
-}
-
-.status-bar {
-  max-width: $govuk-page-width;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 2rem;
-  padding-bottom: 2rem;
-
-  display: flex;
-  gap: 3rem;
-}
-
-.status-panel {
-  background-color: govuk-colour("light-grey");
-  margin-top: 1rem;
-  margin-bottom: 1rem;
-
-  h3 {
-    margin: 0;
-  }
-  p {
-    text-decoration: underline;
-    margin-bottom: 0;
-    margin-top: 0.5em;
-  }
-
-  .status-filter-link {
-    display: inline-block;
-    padding: 1rem;
-  }
-}
-
-.status-panel--highlighted {
-  background-color: white;
-  border: 5px solid govuk-colour("yellow");
 }
 
 body {

--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -1,7 +1,10 @@
 .status-bar-container {
-  background-color: rgb(202, 222, 237);
   width: calc(100vw);
   margin-left: calc(-1 * ((100vw - 100%) / 2));
+
+  &--colored {
+    background-color: rgb(202, 222, 237);
+  }
 
   h2 {
     max-width: $govuk-page-width;
@@ -9,40 +12,36 @@
     margin-right: auto;
     padding-top: 1rem;
   }
-}
 
-.status-bar {
-  max-width: $govuk-page-width;
-  margin-left: auto;
-  margin-right: auto;
-  margin-bottom: 2rem;
-  padding-bottom: 2rem;
+  .status-bar {
+    max-width: $govuk-page-width;
+    margin-left: auto;
+    margin-right: auto;
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    display: flex;
+    gap: 3rem;
 
-  display: flex;
-  gap: 3rem;
-}
+    .status-panel {
+      background-color: govuk-colour("light-grey");
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+      display: inline-block;
+      padding: 1rem;
 
-.status-panel {
-  background-color: govuk-colour("light-grey");
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+      &--highlighted {
+        background-color: white;
+        border: 5px solid govuk-colour("yellow");
+      }
 
-  &--highlighted {
-    background-color: white;
-    border: 5px solid govuk-colour("yellow");
-  }
+      h3 {
+        margin: 0;
+      }
 
-  h3 {
-    margin: 0;
-  }
-  p {
-    text-decoration: underline;
-    margin-bottom: 0;
-    margin-top: 0.5em;
-  }
-
-  .status-filter-link {
-    display: inline-block;
-    padding: 1rem;
+      p {
+        margin-bottom: 0;
+        margin-top: 0.5em;
+      }
+    }
   }
 }

--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -17,8 +17,6 @@
     max-width: $govuk-page-width;
     margin-left: auto;
     margin-right: auto;
-    margin-bottom: 2rem;
-    padding-bottom: 2rem;
     display: flex;
     gap: 3rem;
 

--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -27,6 +27,11 @@
   margin-top: 1rem;
   margin-bottom: 1rem;
 
+  &--highlighted {
+    background-color: white;
+    border: 5px solid govuk-colour("yellow");
+  }
+
   h3 {
     margin: 0;
   }
@@ -40,9 +45,4 @@
     display: inline-block;
     padding: 1rem;
   }
-}
-
-.status-panel--highlighted {
-  background-color: white;
-  border: 5px solid govuk-colour("yellow");
 }

--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -1,0 +1,48 @@
+.status-bar-container {
+  background-color: rgb(202, 222, 237);
+  width: calc(100vw);
+  margin-left: calc(-1 * ((100vw - 100%) / 2));
+
+  h2 {
+    max-width: $govuk-page-width;
+    margin-left: auto;
+    margin-right: auto;
+    padding-top: 1rem;
+  }
+}
+
+.status-bar {
+  max-width: $govuk-page-width;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 2rem;
+  padding-bottom: 2rem;
+
+  display: flex;
+  gap: 3rem;
+}
+
+.status-panel {
+  background-color: govuk-colour("light-grey");
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+
+  h3 {
+    margin: 0;
+  }
+  p {
+    text-decoration: underline;
+    margin-bottom: 0;
+    margin-top: 0.5em;
+  }
+
+  .status-filter-link {
+    display: inline-block;
+    padding: 1rem;
+  }
+}
+
+.status-panel--highlighted {
+  background-color: white;
+  border: 5px solid govuk-colour("yellow");
+}

--- a/app/presenters/concerns/status_presenter.rb
+++ b/app/presenters/concerns/status_presenter.rb
@@ -46,11 +46,11 @@ module StatusPresenter
 
     def next_date_label
       if in_progress?
-        "Expiry date: "
+        "Expiry date"
       elsif determined?
-        "#{decision.humanize} at: "
+        "#{decision.humanize} at"
       else
-        "#{status.humanize} at: "
+        "#{status.humanize} at"
       end
     end
 

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -34,7 +34,7 @@
 
 <div class="status-bar-container status-bar-container--colored">
   <h2 class="govuk-heading-m">Status update:</h2>
-  <div class="status-bar">
+  <div class="status-bar govuk-!-margin-bottom-4 govuk-!-padding-bottom-4">
     <div class="status-panel<% if filter_enabled_uniquely?(status: 'to_be_reviewed') %> status-panel--highlighted<% end %>" id="reviewer-requests">
       <a class="status-filter-link" href="<%= planning_applications_path(filter_enabled_uniquely?(status: "to_be_reviewed") ? {} : {status: [:to_be_reviewed]}) %>">
         <h3 class="govuk-heading-s"><%= t ".reviewer_requests.title" %></h3>

--- a/app/views/planning_applications/index.html.erb
+++ b/app/views/planning_applications/index.html.erb
@@ -32,7 +32,7 @@
   </div>
 </div>
 
-<div class="status-bar-container">
+<div class="status-bar-container status-bar-container--colored">
   <h2 class="govuk-heading-m">Status update:</h2>
   <div class="status-bar">
     <div class="status-panel<% if filter_enabled_uniquely?(status: 'to_be_reviewed') %> status-panel--highlighted<% end %>" id="reviewer-requests">

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -3,18 +3,16 @@
     <% if @planning_application.consultation&.end_date %>
       <% if display_or_publish_required?(@planning_application, :site) %>
         <div id="confirm-site-notice-warning">
-          <%= render(
-                partial: "shared/warning_text",
-                locals: {message: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))}
+          <%= govuk_warning_text(
+                text: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))
               ) %>
         </div>
       <% end %>
 
       <% if display_or_publish_required?(@planning_application, :press) %>
         <div id="confirm-press-notice-warning">
-          <%= render(
-                partial: "shared/warning_text",
-                locals: {message: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application))}
+          <%= govuk_warning_text(
+                text: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application))
               ) %>
         </div>
       <% end %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -1,74 +1,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="dates-and-assignment-details">
-    <p class="govuk-body">
-      <strong>Validation date:</strong>
-      <% if @planning_application.valid_from.present? %>
-        <%= time_tag @planning_application.valid_from %>
-      <% else %>
-        Not yet valid
+    <% if @planning_application.consultation&.end_date %>
+      <% if display_or_publish_required?(@planning_application, :site) %>
+        <div id="confirm-site-notice-warning">
+          <%= render(
+                partial: "shared/warning_text",
+                locals: {message: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))}
+              ) %>
+        </div>
       <% end %>
-    </p>
 
-    <% if @planning_application.consultation.present? %>
-      <p class="govuk-body govuk-!-margin-bottom-0">
-        <strong>Consultation start date:</strong>
-        <% if @planning_application.consultation.start_date.present? %>
-          <%= time_tag @planning_application.consultation.start_date %>
-        <% else %>
-          <%= t(".consultation_end_date_not_set") %>
-        <% end %>
-      </p>
-
-      <p class="govuk-body">
-        <strong>Consultation end date:</strong>
-        <% if @planning_application.consultation.end_date.present? %>
-          <% unless display_or_publish_required?(@planning_application, :site) || display_or_publish_required?(@planning_application, :press) %>
-            <%= time_tag @planning_application.consultation.end_date %>
-            <span class="govuk-!-margin-left-1">
-              <span class="govuk-tag govuk-tag--#{status_consultation_date_tag_colour}">
-                <% days_left = @planning_application.consultation.days_left %>
-                <%= (days_left > 0) ? t("planning_applications.days_left", count: days_left) : t("planning_applications.overdue", count: days_left.abs) %>
-              </span>
-            </span>
-            <span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span>
-          <% end %>
-
-          <% if display_or_publish_required?(@planning_application, :site) %>
-            <div id="confirm-site-notice-warning">
-              <%= render(
-                    partial: "shared/warning_text",
-                    locals: {message: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))}
-                  ) %>
-            </div>
-          <% end %>
-
-          <% if display_or_publish_required?(@planning_application, :press) %>
-            <div id="confirm-press-notice-warning">
-              <%= render(
-                    partial: "shared/warning_text",
-                    locals: {message: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application))}
-                  ) %>
-            </div>
-          <% end %>
-        <% else %>
-          <%= t(".consultation_end_date_not_set") %>
-        <% end %>
-      </p>
-    <% end %>
-
-    <p class="govuk-body">
-      <%= @planning_application.next_relevant_date_tag %>
-
-      <% if @planning_application.open_time_extension_requests.any? %>
-        <%= govuk_link_to "Extension requested", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request) %>
-      <% else %>
-        <%= govuk_link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension") %>
+      <% if display_or_publish_required?(@planning_application, :press) %>
+        <div id="confirm-press-notice-warning">
+          <%= render(
+                partial: "shared/warning_text",
+                locals: {message: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application))}
+              ) %>
+        </div>
       <% end %>
-    </p>
-
-    <% if @planning_application.environment_impact_assessment_required? %>
-      <p class="govuk-body govuk-!-margin-bottom-0"><strong>Subject to an EIA</strong></p>
-      <p class="govuk-body">The expiry date has been extended to 16 weeks</p>
     <% end %>
 
     <% if @planning_application.in_progress? %>
@@ -94,3 +43,5 @@
     </p>
   </div>
 </div>
+
+<%= render(partial: "shared/dates_panel") %>

--- a/app/views/shared/_dates_panel.html.erb
+++ b/app/views/shared/_dates_panel.html.erb
@@ -1,0 +1,54 @@
+<div class="status-bar-container" id="dates-details">
+  <div class="status-bar">
+    <div class="status-panel" id="validation-date">
+      <p class="govuk-body">Valid from</p>
+      <h3 class="govuk-heading-s">
+        <% if @planning_application.valid_from.present? %>
+          <%= @planning_application.valid_from.to_fs(:day_month_year_slashes) %>
+        <% else %>
+          Not yet valid
+        <% end %>
+      </h3>
+    </div>
+    <div class="status-panel" id="consultation-end-date">
+      <p class="govuk-body">Consultation end</p>
+      <% if @planning_application.consultation.present? && @planning_application.consultation.end_date.present? %>
+        <h3 class="govuk-heading-s"><%= @planning_application.consultation.end_date.to_fs(:day_month_year_slashes) %></h3>
+        <p class="govuk-body"><span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span></p>
+      <% else %>
+        <h3 class="govuk-heading-s">Not yet started</h3>
+      <% end %>
+    </div>
+    <div class="status-panel" id="expiry-date">
+      <p class="govuk-body"><%= @planning_application.next_date_label %></p>
+      <h3 class="govuk-heading-s"><%= @planning_application.next_date.to_fs(:day_month_year_slashes) %></h3>
+      <p class="govuk-body">
+        <% if @planning_application.open_time_extension_requests.any? %>
+          <%= govuk_link_to "Extension requested", planning_application_validation_validation_request_path(@planning_application, @planning_application.time_extension_request) %>
+        <% else %>
+          <%= govuk_link_to "Request extension", new_planning_application_validation_validation_request_path(@planning_application, type: "time_extension") %>
+        <% end %>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      <ul class="govuk-list govuk-list--bullet">
+        <% if @planning_application.environment_impact_assessment_required? %>
+          <li id="view-eia-details">The expiry date has been extended to 16 weeks <%= govuk_link_to "View details", planning_application_validation_environment_impact_assessment_path(@planning_application) %></li>
+        <% end %>
+        <% if @planning_application.consultation&.end_date %>
+          <% unless display_or_publish_required?(@planning_application, :site) || display_or_publish_required?(@planning_application, :press) %>
+            <li id="edit-consultation-change-end-date">
+              <% days_left = @planning_application.consultation.days_left %>
+              The consultation end date is <%= (days_left > 0) ? t("planning_applications.days_left", count: days_left) : t("planning_applications.overdue", count: days_left.abs) %> <%= govuk_link_to "Change end date", edit_planning_application_consultation_path(@planning_application) %>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    </p>
+  </div>
+</div>

--- a/app/views/shared/_proposal_header.html.erb
+++ b/app/views/shared/_proposal_header.html.erb
@@ -17,6 +17,7 @@
       <h1 class="govuk-heading-l"><%= @planning_application.full_address %></h1>
     <% end %>
 
+  <div id="planning-application-statuses-tags">
     <p class="govuk-body">
       <%= @planning_application.status_tag %>
       <% if @planning_application.in_progress? %>
@@ -31,6 +32,7 @@
         </span>
       <% end %>
     </p>
+  </div>
 
     <% if @planning_application.closed? %>
       <p class="govuk-body">

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -124,11 +124,11 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
 
   describe "#next_relevant_date_tag" do
     [
-      [:not_started, "Expiry date: ", :expiry_date],
-      [:determined, "Granted at: ", :determination_date],
-      [:returned, "Returned at: ", :returned_at],
-      [:withdrawn, "Withdrawn at: ", :withdrawn_at],
-      [:closed, "Closed at: ", :closed_at]
+      [:not_started, "Expiry date", :expiry_date],
+      [:determined, "Granted at", :determination_date],
+      [:returned, "Returned at", :returned_at],
+      [:withdrawn, "Withdrawn at", :withdrawn_at],
+      [:closed, "Closed at", :closed_at]
     ].each do |state, label, date|
       context "when the application is #{state.to_s.humanize}" do
         let(:planning_application) { create("#{state}_planning_application") }

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -91,7 +91,10 @@ RSpec.describe "Planning Application Assessment" do
 
         expect(page).to have_content("Decision Notice sent to applicant")
 
-        expect(page).to have_content("Granted at: 2 April 2025")
+        within "#expiry-date" do
+          expect(page).to have_content("Granted at 02/04/2025")
+        end
+
         expect(page).to have_link(
           "View decision notice",
           href: decision_notice_planning_application_path(planning_application)

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe "Consultation" do
     it "displays the consultation end date" do
       click_link "Consultees, neighbours and publicity"
 
-      expect(page).to have_content("Consultation end date: 15 September 2023")
+      within("#consultation-end-date") do
+        expect(page).to have_content("Consultation end 15/09/2023")
+      end
     end
 
     it "I can edit the consultation end date" do
@@ -53,7 +55,10 @@ RSpec.describe "Consultation" do
       fill_in "Year", with: "2023"
       click_button "Save"
       expect(page).to have_content("Consultation was successfully updated.")
-      expect(page).to have_content("Consultation end date: 20 September 2023")
+
+      within("#consultation-end-date") do
+        expect(page).to have_content("Consultation end 20/09/2023")
+      end
     end
   end
 

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -130,10 +130,8 @@ RSpec.describe "Consultation", js: true do
     click_link "Consultees, neighbours and publicity"
     expect(page).to have_selector("h1", text: "Consultation")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start.to_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{end_date.to_fs}")
-      expect(page).to have_text("7 days to determination date")
+    within "#consultation-end-date" do
+      expect(page).to have_text("Consultation end #{end_date.to_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do
@@ -300,12 +298,9 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Back"
     expect(page).to have_selector("h1", text: "Consultation")
-    expect(page).to have_text("Consultation end date: #{future_date}")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start.to_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{future.to_date.to_fs}")
-      expect(page).to have_text("14 days to determination date")
+    within "#consultation-end-date" do
+      expect(page).to have_text("Consultation end #{future.to_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -130,10 +130,8 @@ RSpec.describe "Consultation", js: true do
     click_link "Consultees, neighbours and publicity"
     expect(page).to have_selector("h1", text: "Consultation")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start.to_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{end_date.to_fs}")
-      expect(page).to have_text("7 days to determination date")
+    within("#consultation-end-date") do
+      expect(page).to have_text("Consultation end #{end_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do
@@ -286,12 +284,9 @@ RSpec.describe "Consultation", js: true do
 
     click_link "Back"
     expect(page).to have_selector("h1", text: "Consultation")
-    expect(page).to have_text("Consultation end date: #{existing_date}")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start.to_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{end_date.to_fs}")
-      expect(page).to have_text("7 days to determination date")
+    within("#consultation-end-date") do
+      expect(page).to have_text("Consultation end #{end_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -83,9 +83,8 @@ RSpec.describe "Consultation", js: true do
     click_link "Consultees, neighbours and publicity"
     expect(page).to have_selector("h1", text: "Consultation")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: Not yet started")
-      expect(page).to have_text("Consultation end date: Not yet started")
+    within "#consultation-end-date" do
+      expect(page).to have_text("Consultation end Not yet started")
     end
 
     within "#consultee-tasks" do
@@ -407,10 +406,8 @@ RSpec.describe "Consultation", js: true do
     click_link "Back"
     expect(page).to have_selector("h1", text: "Consultation")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start_date.to_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{end_date.to_date.to_fs}")
-      expect(page).to have_text("#{period} days to determination date")
+    within "#consultation-end-date" do
+      expect(page).to have_text("Consultation end #{end_date.to_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do
@@ -462,9 +459,8 @@ RSpec.describe "Consultation", js: true do
       click_link "Consultees, neighbours and publicity"
       expect(page).to have_selector("h1", text: "Consultation")
 
-      within "#dates-and-assignment-details" do
-        expect(page).to have_text("Consultation start date: Not yet started")
-        expect(page).to have_text("Consultation end date: Not yet started")
+      within "#consultation-end-date" do
+        expect(page).to have_text("Consultation end Not yet started")
       end
 
       within "#consultee-tasks" do
@@ -512,9 +508,8 @@ RSpec.describe "Consultation", js: true do
       click_link "Consultees, neighbours and publicity"
       expect(page).to have_selector("h1", text: "Consultation")
 
-      within "#dates-and-assignment-details" do
-        expect(page).to have_text("Consultation start date: Not yet started")
-        expect(page).to have_text("Consultation end date: Not yet started")
+      within "#consultation-end-date" do
+        expect(page).to have_text("Consultation end Not yet started")
       end
 
       within "#consultee-tasks" do
@@ -563,9 +558,8 @@ RSpec.describe "Consultation", js: true do
       click_link "Consultees, neighbours and publicity"
       expect(page).to have_selector("h1", text: "Consultation")
 
-      within "#dates-and-assignment-details" do
-        expect(page).to have_text("Consultation start date: Not yet started")
-        expect(page).to have_text("Consultation end date: Not yet started")
+      within "#consultation-end-date" do
+        expect(page).to have_text("Consultation end Not yet started")
       end
 
       within "#consultee-tasks" do

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -102,10 +102,8 @@ RSpec.describe "Consultation", js: true do
     click_link "Consultees, neighbours and publicity"
     expect(page).to have_selector("h1", text: "Consultation")
 
-    within "#dates-and-assignment-details" do
-      expect(page).to have_text("Consultation start date: #{start_date.to_fs}")
-      expect(page).to have_text("Consultation end date: #{end_date.to_fs}")
-      expect(page).to have_text("7 days to determination date")
+    within "#consultation-end-date" do
+      expect(page).to have_text("Consultation end #{end_date.to_date.to_fs(:day_month_year_slashes)}")
     end
 
     within "#consultee-tasks" do

--- a/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
+++ b/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe "Validation tasks" do
 
   context "when application is not started or invalidated" do
     it "displays the content when checking for the environment impact assessment" do
-      expect(page).to have_content("Expiry date: 11 March 2024")
+      within("#expiry-date") do
+        expect(page).to have_content("Expiry date 11/03/2024")
+      end
       click_link "Check Environment Impact Assessment"
 
       expect(page).to have_content("Environment Impact Assessment (EIA)")
@@ -44,9 +46,13 @@ RSpec.describe "Validation tasks" do
       within(".govuk-notification-banner--notice") do
         expect(page).to have_content("Application marked as requiring an EIA. The determination period is extended to 16 weeks.")
       end
-      within("#dates-and-assignment-details") do
-        expect(page).to have_content("Expiry date: 6 May 2024")
-        expect(page).to have_content("Subject to an EIA")
+      within("#planning-application-statuses-tags") do
+        expect(page).to have_selector("span.govuk-tag.govuk-tag--yellow", text: "EIA")
+      end
+      within("#expiry-date") do
+        expect(page).to have_content("Expiry date 06/05/2024")
+      end
+      within("#view-eia-details") do
         expect(page).to have_content("The expiry date has been extended to 16 weeks")
       end
       within("#environmental-impact-assessment-task") do
@@ -79,9 +85,13 @@ RSpec.describe "Validation tasks" do
       within(".govuk-notification-banner--notice") do
         expect(page).to have_content("Application marked as requiring an EIA. The determination period is extended to 16 weeks.")
       end
-      within("#dates-and-assignment-details") do
-        expect(page).to have_content("Expiry date: 6 May 2024")
-        expect(page).to have_content("Subject to an EIA")
+      within("#planning-application-statuses-tags") do
+        expect(page).to have_selector("span.govuk-tag.govuk-tag--yellow", text: "EIA")
+      end
+      within("#expiry-date") do
+        expect(page).to have_content("Expiry date 06/05/2024")
+      end
+      within("#view-eia-details") do
         expect(page).to have_content("The expiry date has been extended to 16 weeks")
       end
       within("#environmental-impact-assessment-task") do
@@ -155,7 +165,9 @@ RSpec.describe "Validation tasks" do
         click_link "Check Environment Impact Assessment"
         choose "Yes"
         click_button "Save and mark as complete"
-        expect(page).to have_content("Expiry date: 6 May 2024")
+        within("#expiry-date") do
+          expect(page).to have_content("Expiry date 06/05/2024")
+        end
 
         click_link "Check Environment Impact Assessment"
         click_link "Edit information"
@@ -168,8 +180,10 @@ RSpec.describe "Validation tasks" do
           end
         end
 
-        expect(page).to have_content("Expiry date: 11 March 2024")
-        expect(page).not_to have_content("Subject to an EIA")
+        within("#expiry-date") do
+          expect(page).to have_content("Expiry date 11/03/2024")
+        end
+        expect(page).not_to have_content("The expiry date has been extended to 16 weeks")
 
         visit "/planning_applications/#{planning_application.id}/audits"
         within("#audit_#{Audit.last.id}") do

--- a/spec/system/planning_applications/withdraw_or_cancel_spec.rb
+++ b/spec/system/planning_applications/withdraw_or_cancel_spec.rb
@@ -60,7 +60,9 @@ RSpec.describe "Withdraw or cancel" do
         expect(page).to have_content("Closed")
       end
       expect(page).to have_content("Reason for being closed: Closed reason")
-      expect(page).to have_content("Closed at: #{planning_application.closed_at}")
+      within("#expiry-date") do
+        expect(page).to have_content("Closed at #{planning_application.closed_at}")
+      end
       planning_application.reload
       expect(planning_application.status).to eq("closed")
       expect(planning_application.closed_or_cancellation_comment).to eq("Closed reason")


### PR DESCRIPTION
### Description of change

- Extract `status-panel` to its own component styling file
- Use sass ampersand
- Reuse status panel to show key dates 
- Use `govuk` classes for margin & padding bottom

### Story Link

https://trello.com/c/fa2bTFRA

### Screenshots

![Screenshot 2024-05-15 at 16 18 27](https://github.com/unboxed/bops/assets/7561969/c33c9258-bd54-4007-9903-00f1f546b0eb)
