### PR TITLE
Use govuk summary-list component

### DIFF
--- a/app/components/consultee_summary_component.html.erb
+++ b/app/components/consultee_summary_component.html.erb
@@ -3,72 +3,41 @@
     <%= t(".heading") %>
   </h2>
 
-  <dl class="govuk-summary-list">
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t(".name") %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= name %>
-      </dd>
-    </div>
+<%= govuk_summary_list(actions: false) do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key { t(".name") }
+        row.with_value { name }
+      end
 
-    <% if role? %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".role") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= role %>
-        </dd>
-      </div>
-    <% end %>
+      if role?
+        summary_list.with_row do |row|
+          row.with_key { t(".role") }
+          row.with_value { role }
+        end
+      end
 
-    <% if organisation? %>
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".organisation") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= organisation %>
-        </dd>
-      </div>
-    <% end %>
+      if organisation?
+        summary_list.with_row do |row|
+          row.with_key { t(".organisation") }
+          row.with_value { organisation }
+        end
+      end
 
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t(".email_address") %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= email_address %>
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t(".consulted_on") %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= consulted_on %>
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t(".last_received_on") %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= last_received_on %>
-      </dd>
-    </div>
-
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= t(".status") %>
-      </dt>
-      <dd class="govuk-summary-list__value">
-        <%= consultee_status %>
-      </dd>
-    </div>
-  </dl>
+      summary_list.with_row do |row|
+        row.with_key { t(".email_address") }
+        row.with_value { email_address }
+      end
+      summary_list.with_row do |row|
+        row.with_key { t(".consulted_on") }
+        row.with_value { consulted_on }
+      end
+      summary_list.with_row do |row|
+        row.with_key { t(".last_received_on") }
+        row.with_value { last_received_on }
+      end
+      summary_list.with_row do |row|
+        row.with_key { t(".status") }
+        row.with_value { consultee_status }
+      end
+    end %>
 </div>

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -18,27 +18,21 @@
       </strong>
     </h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-    <dl class="govuk-summary-list govuk-summary-list--no-border">
- <% {
-      "Applicant" => planning_application.applicant_name,
-      "Application number" => planning_application.reference,
-      "Application received" => planning_application.received_at.to_fs,
-      "Decision date" => planning_application.determination_date&.to_fs || "TBD",
-      "Site address" => planning_application.full_address,
-      "Use/development" => planning_application.description
-    }.each do |key, value| %>
-        <div class="govuk-summary-list__column">
-          <dt class="govuk-summary-list__key">
-            <%= key %>
-          </dt>
-        </div>
-        <div class="govuk-summary-list__column">
-          <dt class="govuk-summary-list__value">
-            <%= value %>
-          </dt>
-        </div>
-      <% end %>
-    </dl>
+    <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list|
+          {
+            "Applicant" => planning_application.applicant_name,
+            "Application number" => planning_application.reference,
+            "Application received" => planning_application.received_at.to_fs,
+            "Decision date" => planning_application.determination_date&.to_fs || "TBD",
+            "Site address" => planning_application.full_address,
+            "Use/development" => planning_application.description
+          }.each do |pair|
+            summary_list.with_row do |row|
+              row.with_key { pair[0] }
+              row.with_value { pair[1] }
+            end
+          end
+        end %>
     <% if @planning_application.application_type.name == "lawfulness_certificate" %>
       <p class="govuk-body">
         We certify that on the date of the application, the <%= @planning_application.work_status %> use or operations described in the application and supporting plans were <%= @planning_application.granted? ? "lawful" : "not lawful" %> for the purposes of <%= (@planning_application.work_status == "proposed") ? "S.192" : "S.191" %> of the Town and Country Planning Act 1990.

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -13,182 +13,101 @@
       <%= t(".review_application_type") %>
     </h1>
 
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".name") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_type.description %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% if @application_type.inactive? %>
-            <%= govuk_link_to [:edit, @application_type] do %>
-              <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".name") %></span>
-            <% end %>
-          <% end %>
-        </dd>
-      </div>
+    <%= govuk_summary_list(classes: "govuk-summary-list--no-border") do |summary_list|
+          summary_list.with_row do |row|
+            row.with_key { t(".name") }
+            row.with_value { @application_type.description }
+            if @application_type.inactive?
+              row.with_action(text: t(".change"), href: url_for([:edit, @application_type]), visually_hidden_text: t(".name"))
+            end
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".suffix") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_type.suffix %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <% if @application_type.inactive? %>
-            <%= govuk_link_to [:edit, @application_type] do %>
-              <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".suffix") %></span>
-            <% end %>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".suffix") }
+            row.with_value { @application_type.suffix }
+            if @application_type.inactive?
+              row.with_action(text: t(".change"), href: url_for([:edit, @application_type]), visually_hidden_text: t(".suffix"))
+            end
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".category") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if @application_type.category? %>
-            <%= t(".categories.#{@application_type.category}") %>
-          <% end %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :category] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".category") %></span>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".category") }
+            row.with_value { t(".categories.#{@application_type.category}") if @application_type.category? }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :category]), visually_hidden_text: t(".category"))
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".reporting") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_type.reporting_types.join(", ") %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :reporting] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".reporting") %></span>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".reporting") }
+            row.with_value { @application_type.reporting_types.join(", ")}
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :reporting]), visually_hidden_text: t(".reporting"))
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".legislation") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if @application_type.legislation %>
-            <%= @application_type.legislation.title %>
-          <% end %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :legislation] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".legislation") %></span>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".legislation") }
+            row.with_value { @application_type.legislation.title if @application_type.legislation }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :legislation]), visually_hidden_text: t(".legislation"))
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".determination_period") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <% if @application_type.determination_period_days %>
-            <%= t(".determination_period_including_bank_holidays", count: @application_type.determination_period_days) %>
-          <% end %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :determination_period] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".determination_period") %></span>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".determination_period") }
+            row.with_value { t(".determination_period_including_bank_holidays", count: @application_type.determination_period_days) if @application_type.determination_period_days }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :determination_period]), visually_hidden_text: t(".determination_period"))
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".features") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <p class="govuk-body"><strong>Application details</strong></p>
-          <ul class="govuk-list govuk-list--bullet">
-            <% if @application_type.permitted_development_rights? %>
-              <li>Check permitted development rights</li>
-            <% end %>
-            <% if @application_type.planning_conditions? %>
-              <li>Check planning conditions</li>
-            <% end %>
-          </ul>
+          summary_list.with_row do |row|
+            row.with_key { t(".features") }
+            row.with_value { %>
+              <p class="govuk-body"><strong>Application details</strong></p>
+              <ul class="govuk-list govuk-list--bullet">
+                <% if @application_type.permitted_development_rights? %>
+                  <li>Check permitted development rights</li>
+                <% end %>
+                <% if @application_type.planning_conditions? %>
+                  <li>Check planning conditions</li>
+                <% end %>
+              </ul>
 
-          <% if @application_type.consultation? %>
-            <p class="govuk-body"><strong>Consultation</strong></p>
-            <ul class="govuk-list govuk-list--bullet">
-              <% @application_type.consultation_steps.each do |step| %>
-                <li><%= step.humanize %></li>
+              <% if @application_type.consultation? %>
+                <p class="govuk-body"><strong>Consultation</strong></p>
+                <ul class="govuk-list govuk-list--bullet">
+                  <% @application_type.consultation_steps.each do |step| %>
+                    <li><%= step.humanize %></li>
+                  <% end %>
+                </ul>
               <% end %>
-            </ul>
-          <% end %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :features] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".features") %></span>
-          <% end %>
-        </dd>
-      </div>
+            <% }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :features]), visually_hidden_text: t(".features"))
+          end
 
-      <% @application_type.document_tags.tag_groups.each do |group| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= t(".tags") %> – <%= t(".groups.#{group}") %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <p class="govuk-body max-lines max-lines--clamped" data-controller="max-lines" data-action="click->max-lines#toggle">
-              <% group.translated_tags.each do |tag| %>
-                <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-0 govuk-!-margin-right-1 govuk-!-margin-top-1 govuk-!-margin-bottom-1"><%= tag %></span>
-              <% end %>
-            </p>
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to [:edit, @application_type, :document_tags, anchor: "#{group}-tags"] do %>
-              <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".links.#{group}") %></span>
-            <% end %>
-          </dd>
-        </div>
-      <% end %>
+          @application_type.document_tags.tag_groups.each do |group|
+            summary_list.with_row do |row|
+              row.with_key { t(".groups.#{group}") }
+              row.with_value { %>
+                <p class="govuk-body max-lines max-lines--clamped" data-controller="max-lines" data-action="click->max-lines#toggle">
+                  <% group.translated_tags.each do |tag| %>
+                    <span class="govuk-tag govuk-tag--grey govuk-!-margin-left-0 govuk-!-margin-right-1 govuk-!-margin-top-1 govuk-!-margin-bottom-1"><%= tag %></span>
+                  <% end %>
+                </p>
+              <% }
+              row.with_action(
+              text: t(".change"),
+              href: url_for([:edit, @application_type, :document_tags, anchor: "#{group}-tags"]),
+              visually_hidden_text: t(".links.#{group}"))
+            end
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".decisions") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_type.decisions.map(&:humanize).join(", ") %>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :decisions] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".decisions") %></span>
-          <% end %>
-        </dd>
-      </div>
+          summary_list.with_row do |row|
+            row.with_key { t(".decisions") }
+            row.with_value { @application_type.decisions.map(&:humanize).join(", ") }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :decisions]), visually_hidden_text: t(".decisions"))
+          end
 
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          <%= t(".status") %>
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <span class="govuk-tag <%= "govuk-tag--#{tag_colour(@application_type.status)}" %>">
-            <%= @application_type.status.humanize %>
-          </span>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <%= govuk_link_to [:edit, @application_type, :status] do %>
-            <%= t(".change") %><span class="govuk-visually-hidden"> <%= t(".status") %></span>
-          <% end %>
-        </dd>
-      </div>
-    </dl>
+          summary_list.with_row do |row|
+            row.with_key { t(".status") }
+            row.with_value { govuk_tag(text: @application_type.status.humanize, colour: tag_colour(@application_type.status)) }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :status]), visually_hidden_text: t(".status"))
+          end
+        end %>
 
     <div class="govuk-button-group">
       <%= link_to t(".continue"), :application_types, class: "govuk-button" %>


### PR DESCRIPTION
### Description of change

More concise and maintainable to use the upstream component.


### Decisions

The component can also take an array of hashes as a `rows:` parameter which might allow us to move even more logic out of the views, but this would be a more invasive change so I've left it for a future improvement.
