### PR TITLE
Don't limit not_to raise_error expectations to specific errors

### DIFF
--- a/spec/models/press_notice_spec.rb
+++ b/spec/models/press_notice_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PressNotice do
           it "allows a press notice to be created" do
             expect do
               press_notice
-            end.not_to raise_error(described_class::NotCreatableError)
+            end.not_to raise_error
           end
         end
 

--- a/spec/models/replacement_document_validation_request_spec.rb
+++ b/spec/models/replacement_document_validation_request_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe ReplacementDocumentValidationRequest do
         it "allows a replacement_document_validation_request to be created" do
           expect do
             replacement_document_validation_request
-          end.not_to raise_error(ValidationRequest::ValidationRequestNotCreatableError,
-            "Cannot create Replacement Document Validation Request when planning application has been validated")
+          end.not_to raise_error
         end
       end
     end

--- a/spec/models/site_notice_spec.rb
+++ b/spec/models/site_notice_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SiteNotice do
           it "allows a site notice to be created" do
             expect do
               site_notice
-            end.not_to raise_error(described_class::NotCreatableError)
+            end.not_to raise_error
           end
         end
 


### PR DESCRIPTION
### Description of change

Fixing the below warning in tests:

```
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass, message)`
risks false positives, since literally any other error would cause the
expectation to pass, including those raised by Ruby (e.g. `NoMethodError`,
`NameError` and `ArgumentError`), meaning the code you are intending to test
may not even get reached. Instead consider using `expect { }.not_to
raise_error` or `expect { }.to raise_error(DifferentSpecificErrorClass)`.
```
