### PR TITLE
No longer need to rescue a Pagy::OverflowError

### DIFF
--- a/engines/bops_api/lib/bops_api/pagination.rb
+++ b/engines/bops_api/lib/bops_api/pagination.rb
@@ -20,9 +20,6 @@ module BopsApi
       maxresults = [(params[:maxresults] || DEFAULT_MAXRESULTS).to_i, MAXRESULTS_LIMIT].min.clamp(1, 1000)
 
       pagy(scope, page:, items: maxresults, overflow: :last_page)
-    rescue Pagy::OverflowError
-      last_page = (scope.count.to_f / maxresults).ceil
-      pagy(scope, page: last_page, items: maxresults, overflow: :last_page)
     end
   end
 end


### PR DESCRIPTION
Missed out from #1812 (even though I actually updated the pagy call in the rescue block)