### PR TITLE
Create suggested conditions automatically rather than prefilling form

### DIFF
--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -12,6 +12,8 @@ class Condition < ApplicationRecord
   after_create :create_validation_request!, if: :pre_commencement?
   before_update :create_validation_request!, if: -> { pre_commencement? && should_create_validation_request? }
 
+  scope :sorted, -> { sort_by(&:sort_key) }
+
   def checked?
     persisted? || errors.present?
   end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -32,6 +32,12 @@ class Condition < ApplicationRecord
     (text + "\n\nReason: #{reason}").truncate(100, separator: "Reason")
   end
 
+  class << self
+    def standard_conditions
+      I18n.t(:conditions_list).map { |k, v| Condition.new(v) }
+    end
+  end
+
   private
 
   def titles

--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -3,7 +3,7 @@
 class ConditionSet < ApplicationRecord
   belongs_to :planning_application
   has_many :reviews, as: :owner, dependent: :destroy, class_name: "Review"
-  has_many :conditions, -> { order(position: :asc) }, extend: ConditionsExtension, dependent: :destroy
+  has_many :conditions, -> { order(position: :asc) }, dependent: :destroy
   has_many :validation_requests, through: :conditions
 
   accepts_nested_attributes_for :conditions, allow_destroy: true

--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -9,6 +9,7 @@ class ConditionSet < ApplicationRecord
   accepts_nested_attributes_for :conditions, allow_destroy: true
   accepts_nested_attributes_for :reviews
 
+  after_create :create_standard_conditions, unless: :pre_commencement?
   after_update :create_review, if: :should_create_review?
 
   def current_review
@@ -69,5 +70,9 @@ class ConditionSet < ApplicationRecord
 
   def create_review(status)
     reviews.create!(assessor: Current.user, owner_type: "ConditionSet", owner_id: id, status:)
+  end
+
+  def create_standard_conditions
+    Condition.standard_conditions.each { |condition| condition.update!(condition_set: self) }
   end
 end

--- a/app/models/condition_set/conditions_extension.rb
+++ b/app/models/condition_set/conditions_extension.rb
@@ -5,15 +5,5 @@ class ConditionSet < ApplicationRecord
     def sorted
       sort_by(&:sort_key)
     end
-
-    def standard
-      Condition.standard_conditions.map do |condition|
-        detect { |c| c.title == condition.title } || condition
-      end
-    end
-
-    def other
-      reject(&:standard?)
-    end
   end
 end

--- a/app/models/condition_set/conditions_extension.rb
+++ b/app/models/condition_set/conditions_extension.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class ConditionSet < ApplicationRecord
-  module ConditionsExtension
-    def sorted
-      sort_by(&:sort_key)
-    end
-  end
-end

--- a/app/models/condition_set/conditions_extension.rb
+++ b/app/models/condition_set/conditions_extension.rb
@@ -7,19 +7,13 @@ class ConditionSet < ApplicationRecord
     end
 
     def standard
-      standard_conditions.map do |condition|
+      Condition.standard_conditions.map do |condition|
         detect { |c| c.title == condition.title } || condition
       end
     end
 
     def other
       reject(&:standard?)
-    end
-
-    private
-
-    def standard_conditions
-      I18n.t(:conditions_list).map { |k, v| Condition.new(v) }
     end
   end
 end

--- a/app/presenters/concerns/assessment_tasks_presenter.rb
+++ b/app/presenters/concerns/assessment_tasks_presenter.rb
@@ -11,7 +11,7 @@ module AssessmentTasksPresenter
       recommendation.present? ||
       immunity_validation_in_progress? ||
       pre_commencement_condition_set.conditions.any? ||
-      condition_set.conditions.any? ||
+      condition_set.conditions.any? { |condition| !condition.standard } ||
       consultees_checked? ||
       informative_set.informatives.any? ||
       heads_of_term.terms.any?

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -5,10 +5,11 @@
 <ul id="conditions-list" class="govuk-list">
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <% @conditions.each_with_index do |condition, i| %>
-    <%= next unless condition.persisted? %>
     <%= content_tag(:li, id: dom_id(condition), class: "govuk-!-margin-bottom-7") do %>
-      <span class="govuk-caption-m">Condition <%= i + 1 %></span>
-      <h2 class="govuk-heading-m"><%= condition.title %></h2>
+      <span class="govuk-caption-m"><%= "#{condition.standard? ? "Suggested condition" : "Condition"}  #{i + 1}" %></span>
+      <% unless condition.title.blank? %>
+        <h2 class="govuk-heading-m"><%= condition.title %></h2>
+      <% end %>
 
       <p class="govuk-body">
         <strong>Condition</strong><%= render(FormattedContentComponent.new(text: condition.text)) %>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -6,40 +6,23 @@
 
   <%= form.govuk_error_summary %>
 
-  <div id="standard-conditions">
-    <%= form.govuk_check_boxes_fieldset :conditions, multiple: false, legend: {text: "Suggested conditions"} do %>
-      <%= form.fields_for :conditions, @conditions.standard do |fields| %>
-        <div class="condition">
-          <%= fields.hidden_field :_destroy, value: true %>
-          <%= fields.govuk_check_box :_destroy, false, multiple: false, label: {text: fields.object.title}, checked: fields.object.checked? do %>
-            <%= fields.hidden_field :id %>
-            <%= fields.hidden_field :standard, value: true %>
-            <%= fields.hidden_field :title, label: {text: "Enter a title"} %>
-            <%= fields.govuk_text_area :text, label: {text: "Enter condition"} %>
-            <%= fields.govuk_text_area :reason, label: {text: "Enter a reason for this condition"} %>
-          <% end %>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
-
   <div class="govuk-!-margin-bottom-7">
     <h2 class="govuk-heading-m">
       Other conditions
     </h2>
-    <div id="other-conditions" data-conditions-target="conditions">
-      <%= form.fields_for :conditions, (@conditions.other unless @pre_commencement) do |fields| %>
-        <%= content_tag :div, class: "condition govuk-!-margin-bottom-5", data: {index: fields.index} do %>
+    <div id="conditions" data-conditions-target="conditions">
+      <%= form.fields_for :conditions, @conditions do |fields| %>
+        <%= content_tag :div, id: "condition-#{fields.object.title.present? ? fields.object.title.parameterize : fields.object.id}", class: "condition govuk-!-margin-bottom-5", data: {index: fields.index} do %>
           <%= fields.hidden_field :_destroy, value: false %>
           <%= fields.hidden_field :id %>
           <%= fields.hidden_field :standard, value: false %>
-          <%= fields.hidden_field :title, value: "" %>
+          <%= fields.hidden_field :title, value: fields.object.title if fields.object.standard %>
           <%= fields.hidden_field :text_source, value: fields.object.text, data: {reset_text_target: "source"} %>
           <%= fields.govuk_text_area :text, label: {text: "Enter condition"}, data: {reset_text_target: "destination"} %>
-          <%= button_tag "Reset condition", type: "button", class: "button-as-link govuk-!-margin-bottom-6", value: "text", data: {action: "click->reset-text#reset"} %>
+          <%= button_tag "Reset condition", type: "button", class: "govuk-body button-as-link govuk-!-margin-bottom-6", value: "text", data: {action: "click->reset-text#reset"} %>
           <%= fields.hidden_field :reason_source, value: fields.object.reason, data: {reset_text_target: "source"} %>
           <%= fields.govuk_text_area :reason, label: {text: "Enter a reason for this condition"}, data: {reset_text_target: "destination"} %>
-          <%= button_tag "Reset reason", type: "button", class: "button-as-link govuk-!-margin-bottom-6", value: "reason", data: {action: "click->reset-text#reset"} %><br>
+          <%= button_tag "Reset reason", type: "button", class: "govuk-body button-as-link govuk-!-margin-bottom-6", value: "reason", data: {action: "click->reset-text#reset"} %><br>
           <%= govuk_link_to "Remove condition", "#", class: "govuk-body", data: {action: "click->conditions#removeCondition"} %>
         <% end %>
       <% end %>

--- a/spec/support/assessment_tasks_presenter_shared_examples.rb
+++ b/spec/support/assessment_tasks_presenter_shared_examples.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples "AssessmentTasksPresenter" do
           planning_application:
         )
 
-        create(:condition, condition_set:)
+        create(:condition, condition_set:, standard: false)
       end
 
       it "returns true" do

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -23,26 +23,26 @@ RSpec.describe "Add conditions" do
 
       expect(page).to have_content("Add conditions")
 
-      check "Time limit"
-      within(:css, "#standard-conditions .condition:nth-of-type(1)") do
+      click_link "Edit conditions"
+
+      within(:css, "#conditions .condition:nth-of-type(2)") do
         fill_in "Enter condition", with: "New condition"
       end
-      check "Materials to match"
 
       click_link "+ Add condition"
-      within(:css, "#other-conditions .condition:nth-of-type(1)") do
+      within(:css, "#conditions .condition:nth-of-type(4)") do
         fill_in "Enter condition", with: "Custom condition 1"
         fill_in "Enter a reason for this condition", with: "Custom reason 1"
       end
 
       click_link "+ Add condition"
-      within(:css, "#other-conditions .condition:nth-of-type(2)") do
+      within(:css, "#conditions .condition:nth-of-type(5)") do
         fill_in "Enter condition", with: "Custom condition 2"
         fill_in "Enter a reason for this condition", with: "Custom reason 2"
       end
 
       click_link "+ Add condition"
-      within(:css, "#other-conditions .condition:nth-of-type(3)") do
+      within(:css, "#conditions .condition:nth-of-type(6)") do
         fill_in "Enter condition", with: "Custom condition 3"
         fill_in "Enter a reason for this condition", with: "Custom reason 3"
         click_link "Remove condition"
@@ -71,8 +71,7 @@ RSpec.describe "Add conditions" do
     end
 
     it "you can edit conditions" do
-      create(:condition, condition_set: planning_application.condition_set, standard: true)
-      create(:condition, condition_set: planning_application.condition_set, standard: false, text: "You must do this", reason: "For this reason")
+      create(:condition, condition_set: planning_application.condition_set, standard: false, title: "", text: "You must do this", reason: "For this reason")
 
       visit "/planning_applications/#{planning_application.id}"
       click_link "Check and assess"
@@ -87,10 +86,8 @@ RSpec.describe "Add conditions" do
 
       click_link "Edit conditions"
 
-      check "In accordance with approved plans"
-
       click_link "+ Add condition"
-      within(:css, "#other-conditions .condition:nth-of-type(2)") do
+      within(:css, "#conditions .condition:last-of-type") do
         fill_in "Enter condition", with: "Custom condition 1"
         fill_in "Enter a reason for this condition", with: "Custom reason 1"
       end
@@ -112,9 +109,11 @@ RSpec.describe "Add conditions" do
 
       click_link "Edit conditions"
 
-      uncheck "Time limit"
+      within(:css, "#conditions .condition:nth-of-type(1)") do
+        click_link "Remove condition"
+      end
 
-      within(:css, "#other-conditions .condition:nth-of-type(1)") do
+      within(:css, "#conditions .condition:nth-of-type(4)") do
         click_link "Remove condition"
       end
 
@@ -137,14 +136,14 @@ RSpec.describe "Add conditions" do
 
     it "shows errors" do
       click_link "Add conditions"
+      click_link "Edit conditions"
 
-      check "Time limit"
-      within(:css, "#standard-conditions .condition:nth-of-type(1)") do
+      within(:css, "#condition-time-limit") do
         fill_in "Enter condition", with: ""
       end
 
       click_link "+ Add condition"
-      within(:css, "#other-conditions .condition:nth-of-type(1)") do
+      within(:css, "#conditions .condition:last-of-type") do
         fill_in "Enter condition", with: "Custom condition 1"
       end
 

--- a/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe "Add pre-commencement conditions" do
     create(:planning_application, :planning_permission, :in_assessment, :with_condition_set, local_authority: default_local_authority, api_user:, decision: "granted")
   end
 
+  def pre_commencement_conditions
+    Condition.joins(:condition_set).where(condition_set: {pre_commencement: true})
+  end
+
   before do
     Current.user = assessor
     travel_to(Time.zone.local(2024, 4, 17, 12, 30))
@@ -49,7 +53,7 @@ RSpec.describe "Add pre-commencement conditions" do
       fill_in "Enter reason", with: "Custom reason 2"
       click_button "Add pre-commencement condition"
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector("span", text: "Condition 1")
         expect(page).to have_selector("h2", text: "Title 1")
         expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
@@ -60,7 +64,7 @@ RSpec.describe "Add pre-commencement conditions" do
         expect(page).to have_link("Update condition")
       end
 
-      within("#condition_#{Condition.second.id}") do
+      within("#condition_#{pre_commencement_conditions.second.id}") do
         expect(page).to have_selector("span", text: "Condition 2")
         expect(page).to have_selector("h2", text: "Title 2")
         expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
@@ -71,7 +75,7 @@ RSpec.describe "Add pre-commencement conditions" do
       click_button "Confirm and send to applicant"
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
         expect(page).to have_link("Cancel")
@@ -80,7 +84,7 @@ RSpec.describe "Add pre-commencement conditions" do
         expect(page).not_to have_link("Remove")
       end
 
-      within("#condition_#{Condition.second.id}") do
+      within("#condition_#{pre_commencement_conditions.second.id}") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
       end
@@ -111,7 +115,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement condition has been successfully added")
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector("span", text: "Condition 1")
         expect(page).to have_selector("h2", text: "Title 1")
         expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
@@ -127,7 +131,7 @@ RSpec.describe "Add pre-commencement conditions" do
         click_link "Add pre-commencement conditions"
       end
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
       end
 
@@ -135,7 +139,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
         expect(page).to have_selector("p", text: "Sent on 17 April 2024 12:30")
         expect(page).to have_link("Cancel")
@@ -158,11 +162,11 @@ RSpec.describe "Add pre-commencement conditions" do
         click_link "Add pre-commencement conditions"
       end
 
-      within("#condition_#{Condition.first.id}") do
+      within("#condition_#{pre_commencement_conditions.first.id}") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
       end
 
-      within("#condition_#{Condition.second.id}") do
+      within("#condition_#{pre_commencement_conditions.second.id}") do
         expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
       end
 
@@ -170,7 +174,7 @@ RSpec.describe "Add pre-commencement conditions" do
 
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement conditions have been confirmed and sent to the applicant")
 
-      within("#condition_#{Condition.second.id}") do
+      within("#condition_#{pre_commencement_conditions.second.id}") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting response")
       end
     end

--- a/spec/system/planning_applications/review/conditions_spec.rb
+++ b/spec/system/planning_applications/review/conditions_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Reviewing conditions" do
 
         choose "Edit to accept"
 
-        within("#condition-set-conditions-attributes-1--destroy-conditional") do
+        within("#condition-set-conditions-attributes-4--destroy-conditional") do
           fill_in "Reason", with: "This is different reason"
         end
 
@@ -128,7 +128,7 @@ RSpec.describe "Reviewing conditions" do
 
         click_link "Edit conditions"
 
-        within("#condition-set-conditions-attributes-0--destroy-conditional") do
+        within("#conditions .condition:last-of-type") do
           fill_in "Enter a reason for this condition", with: "A better response"
         end
 


### PR DESCRIPTION
### Description of change

In the new design the conditions will be created by default and able to be removed by the user, rather than being a prefilled form that they can optionally add.

This creates them in the controller action if none exist.

### Story Link

https://trello.com/c/oFK58Hnp/3000-design-improvements-for-add-conditions

### Screenshots

<img width="414" alt="Screenshot 2024-05-21 at 16 32 16" src="https://github.com/unboxed/bops/assets/3986/b3432b3f-0449-49f1-8b93-bd4c2cf2ed5f">
