### PR TITLE
Validate example json against schema

### DIFF
--- a/engines/bops_api/app/views/bops_api/v2/public/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/_show.json.jbuilder
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# json.key_format! camelize: :lower
+
 json.application do
   json.type do
     json.value planning_application.application_type.code
@@ -7,7 +9,9 @@ json.application do
   end
   json.reference planning_application.reference
   json.full_reference planning_application.reference_in_full
+  json.fullReference planning_application.reference_in_full
   json.received_at planning_application.received_at
+  json.receivedAt planning_application.received_at
   json.status planning_application.status
 end
 json.property do

--- a/engines/bops_api/schemas/odp/v0.6.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/search.json
@@ -92,8 +92,15 @@
                 "full_reference": {
                   "type": "string"
                 },
+                "fullReference": {
+                  "type": "string"
+                },
                 "received_at": {
-                  "format": "date",
+                  "format": "datetime",
+                  "type": "string"
+                },
+                "receivedAt": {
+                  "format": "datetime",
                   "type": "string"
                 },
                 "status": {

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.6.0/search.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.6.0/search.json
@@ -22,7 +22,9 @@
         },
         "reference": "24-00107-HAPP",
         "full_reference": "PlanX-24-00107-HAPP",
+        "fullReference": "PlanX-24-00107-HAPP",
         "received_at": "2024-04-17T00:00:00.000+01:00",
+        "receivedAt": "2024-04-17T00:00:00.000+01:00",
         "status": "in_assessment"
       },
       "property": {
@@ -87,7 +89,9 @@
         },
         "reference": "24-00106-HAPP",
         "full_reference": "PlanX-24-00106-HAPP",
+        "fullReference": "PlanX-24-00106-HAPP",
         "received_at": "2024-04-18T00:00:00.000+01:00",
+        "receivedAt": "2024-04-18T00:00:00.000+01:00",
         "status": "in_assessment"
       },
       "property": {

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "BOPS public API" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:application_type) { create(:application_type, :householder) }
   let!(:planning_applications) { create_list(:planning_application, 6, :with_boundary_geojson, local_authority:, application_type:, make_public: true) }
+  let(:page) { 1 }
   let(:maxresults) { 5 }
   let(:q) { "" }
 
@@ -57,6 +58,13 @@ RSpec.describe "BOPS public API" do
 
           expect(data["data"].first["application"]["full_reference"]).to eq("PlanX-#{planning_applications.first.reference}")
         end
+      end
+
+      it "validates successfully against the example search json" do
+        schema = BopsApi::Schemas.find!("search", version: "odp/v0.6.0").value
+        schemer = JSONSchemer.schema(schema)
+
+        expect(schemer.valid?(example_fixture("search.json"))).to eq(true)
       end
 
       response "200", "returns planning applications when searching by the description" do


### PR DESCRIPTION
### Description of change

Validate example json against schema

- Add camel case for response keys for consistency
- We can remove the duplicate keys once they aren't being used
