### PR TITLE
Use job metadata to store the user

### DIFF
--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -936,8 +936,7 @@ RSpec.describe PlanningApplication do
             "UserMailer",
             "update_notification_mail",
             "deliver_now",
-            args: [planning_application, "reviewers@example.com"],
-            current_user: Current.user
+            args: [planning_application, "reviewers@example.com"]
           )
       end
     end


### PR DESCRIPTION
This is cleaner than mutating the job arguments.
