### PR TITLE
Validate applicant and agent email address format

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -2,6 +2,7 @@
 
 class PlanningApplicationsController < AuthenticationController
   before_action :set_planning_application, except: %i[new create index]
+  before_action :build_planning_application, only: %i[new create]
   before_action :ensure_user_is_reviewer_checking_assessment, only: %i[edit_public_comment]
   before_action :ensure_no_open_post_validation_requests, only: %i[submit]
   before_action :ensure_draft_recommendation_complete, only: :update
@@ -18,29 +19,42 @@ class PlanningApplicationsController < AuthenticationController
 
   def index
     @planning_applications = search.call
+
+    respond_to do |format|
+      format.html
+    end
   end
 
   def show
+    respond_to do |format|
+      format.html
+    end
   end
 
   def new
-    @planning_application = PlanningApplication.new
+    respond_to do |format|
+      format.html
+    end
   end
 
   def edit
+    respond_to do |format|
+      format.html
+    end
   end
 
   def create
-    @planning_application = PlanningApplication.new(planning_application_params)
-    @planning_application.assign_attributes(local_authority: current_local_authority)
+    @planning_application.attributes = planning_application_params
 
-    if @planning_application.save
-      @planning_application.mark_accepted!
-      @planning_application.send_receipt_notice_mail
+    respond_to do |format|
+      if @planning_application.save
+        @planning_application.mark_accepted!
+        @planning_application.send_receipt_notice_mail
 
-      redirect_to planning_application_documents_path(@planning_application), notice: t(".success")
-    else
-      render :new
+        format.html { redirect_to planning_application_documents_path(@planning_application), notice: t(".success") }
+      else
+        format.html { render :new }
+      end
     end
   end
 
@@ -203,6 +217,10 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   private
+
+  def build_planning_application
+    @planning_application = current_local_authority.planning_applications.new
+  end
 
   def search
     @search ||= PlanningApplicationSearch.new(params)

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -97,16 +97,10 @@
         </h2>
       </legend>
 
-      <div class="govuk-form-group">
-        <%= form.label "#{role}_first_name", "First name", class: "govuk-label" %>
-        <%= form.text_field "#{role}_first_name", class: "govuk-textarea govuk-input" %>
-        <%= form.label "#{role}_last_name", "Last name", class: "govuk-label" %>
-        <%= form.text_field "#{role}_last_name", class: "govuk-textarea govuk-input" %>
-        <%= form.label "#{role}_email", "Email address", class: "govuk-label" %>
-        <%= form.text_field "#{role}_email", class: "govuk-textarea govuk-input" %>
-        <%= form.label "#{role}_phone", "UK telephone number", class: "govuk-label" %>
-        <%= form.text_field "#{role}_phone", class: "govuk-textarea govuk-input" %>
-      </div>
+      <%= form.govuk_text_field :"#{role}_first_name", label: {text: "First name"}, width: "one-half" %>
+      <%= form.govuk_text_field :"#{role}_last_name", label: {text: "Last name"}, width: "one-half" %>
+      <%= form.govuk_text_field :"#{role}_email", label: {text: "Email address"}, width: "one-half" %>
+      <%= form.govuk_text_field :"#{role}_phone", label: {text: "UK telephone number"}, width: "one-half" %>
     </fieldset>
   <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,8 @@ en:
               blank: Fill in the policies you consulted
         planning_application:
           attributes:
+            application_type_id:
+              blank: An application type must be chosen
             base:
               no_boundary_geojson: This application does not have a digital sitemap and cannot be validated. Please <a href='%{path}'>create a digital site map</a> before validating this application.
             decision:

--- a/spec/requests/api/planning_applications_post_spec.rb
+++ b/spec/requests/api/planning_applications_post_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
       it "renders failure message" do
         post "/api/v1/planning_applications", params: json,
           headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
-        expect(response.body).to eq("{\"message\":\"Validation failed: Application type must exist, An applicant or agent email is required.\"}")
+        expect(response.body).to eq("{\"message\":\"Validation failed: Application type must exist, Application type An application type must be chosen, An applicant or agent email is required.\"}")
       end
     end
 

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Creating a planning application" do
     fill_in "Description", with: "Bad bad application"
 
     click_button "Save"
-    expect(page).to have_text("An applicant or agent email is required.")
+    expect(page).to have_selector("[role=alert] li", text: "An applicant or agent email is required.")
 
     within_fieldset "Agent information" do
       fill_in "Email address", with: "agentina@agentino.com"
@@ -61,11 +61,25 @@ RSpec.describe "Creating a planning application" do
     expect(page).to have_text("Description: Bad bad application")
   end
 
+  it "displays an error with an invalid email address" do
+    click_link "Add new application"
+    within_fieldset "Agent information" do
+      fill_in "Email address", with: "invalid-agent-email"
+    end
+    within_fieldset "Applicant information" do
+      fill_in "Email address", with: "invalid-applicant-email"
+    end
+
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "Agent email is invalid")
+    expect(page).to have_selector("[role=alert] li", text: "Applicant email is invalid")
+  end
+
   it "displays an error when application type is not selected" do
     click_link "Add new application"
 
     click_button "Save"
-    expect(page).to have_text("Application type must exist")
+    expect(page).to have_selector("[role=alert] li", text: "An application type must be chosen")
   end
 
   it "allows for an application to be created by a reviewer, using minimum details" do


### PR DESCRIPTION
### Description of change

- Validate applicant and agent email address format
- Display errors inline

### Story Link

https://trello.com/c/72sCyM2w/3012-validate-emails-on-manual-application-form

