### PR TITLE
Allow for numbers in application type suffix

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
@@ -45,7 +45,7 @@ module BopsApi
       private
 
       def find_planning_application
-        if /\A\d{2}-\d{5}-[A-Za-z]+\z/.match?(params[:id])
+        if /\A\d{2}-\d{5}-[A-Za-z0-9]+\z/.match?(params[:id])
           planning_applications_scope.find_by!(reference: params[:id])
         else
           planning_applications_scope.find(Integer(params[:id]))

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe "BOPS API" do
 
       parameter name: :id, in: :path, schema: {
         oneOf: [
-          {type: :string, pattern: "\d{2}-\d{5}-[A-Za-z]+"},
+          {type: :string, pattern: "\d{2}-\d{5}-[A-Za-z0-9]+"},
           {type: :integer}
         ],
         description: "The planning application reference or ID"

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -16130,8 +16130,13 @@ components:
                     type: string
                   full_reference:
                     type: string
+                  fullReference:
+                    type: string
                   received_at:
-                    format: date
+                    format: datetime
+                    type: string
+                  receivedAt:
+                    format: datetime
                     type: string
                   status:
                     type: string
@@ -22127,7 +22132,7 @@ paths:
         schema:
           oneOf:
           - type: string
-            pattern: d{2}-d{5}-[A-Za-z]+
+            pattern: d{2}-d{5}-[A-Za-z0-9]+
           - type: integer
           description: The planning application reference or ID
         required: true
@@ -22273,7 +22278,9 @@ paths:
                           description: planning_permission
                         reference: 24-00107-HAPP
                         full_reference: PlanX-24-00107-HAPP
+                        fullReference: PlanX-24-00107-HAPP
                         received_at: '2024-04-17T00:00:00.000+01:00'
+                        receivedAt: '2024-04-17T00:00:00.000+01:00'
                         status: in_assessment
                       property:
                         address:
@@ -22323,7 +22330,9 @@ paths:
                           description: planning_permission
                         reference: 24-00106-HAPP
                         full_reference: PlanX-24-00106-HAPP
+                        fullReference: PlanX-24-00106-HAPP
                         received_at: '2024-04-18T00:00:00.000+01:00'
+                        receivedAt: '2024-04-18T00:00:00.000+01:00'
                         status: in_assessment
                       property:
                         address:


### PR DESCRIPTION
An application type suffix can include numbers such as PA1A. This change will match on these cases too.