### PR TITLE
Use rack_test for system tests where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,35 +58,15 @@ jobs:
           - { group: "models" }
           - { group: "requests", want_pdf: true }
           - {
-              group: "system: assessing",
-              directories: "system/planning_applications/assessing",
+              group: "system: rack_test",
+              directories: "system",
+              additional_spec_opts: "--tag '~capybara' --tag '~js'",
+              want_pdf: true,
             }
           - {
-              group: "system: consulting/publicity",
-              directories: "system/planning_applications/{consulting,publicity}",
-            }
-          - { group: "system: documents", directories: "system/documents" }
-          - { group: "system: public", directories: "system/public" }
-          - {
-              group: "system: recommending",
-              directories: "system/planning_applications/recommending",
-            }
-          - {
-              group: "system: review",
-              directories: "system/planning_applications/review",
-            }
-          - {
-              group: "system: validation",
-              directories: "system/planning_applications/validating",
-            }
-          - {
-              group: "system: workflow tasks",
-              directories: "system/workflow_tasks",
-            }
-          - {
-              group: "system: other",
-              directories: "{system,system/planning_applications}",
-              pattern: "*_spec.rb", # n.b. pattern needed here otherwise it'll recurse and duplicate other groups
+              group: "system: capybara",
+              directories: "system",
+              additional_spec_opts: "--tag 'capybara' --tag 'js'",
               want_pdf: true,
             }
           - {
@@ -102,6 +82,7 @@ jobs:
       name: "${{matrix.specs.group}}"
       include: "${{matrix.specs.module || 'spec'}}/${{matrix.specs.directories || matrix.specs.group}}/${{matrix.specs.pattern || '**/*_spec.rb'}}"
       want-pdf: "${{ !!matrix.specs.want_pdf }}"
+      additional_spec_opts: "${{ matrix.specs.additional_spec_opts }}"
     secrets: inherit
 
   cucumber:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,6 +30,10 @@ on:
         type: string
         required: false
         default: "."
+      additional_spec_opts:
+        type: string
+        required: false
+        default: ""
 
     secrets:
       NOTIFY_API_KEY:
@@ -108,7 +112,7 @@ jobs:
           RAILS_ENV: test
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
           OTP_SECRET_ENCRYPTION_KEY: ${{ secrets.OTP_SECRET_ENCRYPTION_KEY }}
-          SPEC_OPTS: '-f doc  --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}"'
+          SPEC_OPTS: '-f doc  --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}" ${{ inputs.additional_spec_opts }}'
         run: |
           bundle exec rake spec
 

--- a/engines/bops_admin/spec/system/consultees_spec.rb
+++ b/engines/bops_admin/spec/system/consultees_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe "Consultees" do
     end
   end
 
-  it "allows deleting a consultee" do
+  it "allows deleting a consultee", :capybara do
     create(:contact, local_authority:, name: "Chris Wood")
 
     visit "/admin/consultees"

--- a/engines/bops_admin/spec/system/informatives_spec.rb
+++ b/engines/bops_admin/spec/system/informatives_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe "Informatives" do
     end
   end
 
-  it "allows deleting an informative" do
+  it "allows deleting an informative", :capybara do
     create(:local_authority_informative, local_authority:, title: "Section 106", text: "Section 106 needs doing")
 
     visit "/admin/informatives"

--- a/engines/bops_admin/spec/system/policy_areas_spec.rb
+++ b/engines/bops_admin/spec/system/policy_areas_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Policy areas" do
+RSpec.describe "Policy areas", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :administrator, local_authority:) }
 

--- a/engines/bops_admin/spec/system/policy_references_spec.rb
+++ b/engines/bops_admin/spec/system/policy_references_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "Policy references" do
     end
   end
 
-  it "allows deleting a policy reference" do
+  it "allows deleting a policy reference", :capybara do
     create(:local_authority_policy_reference, local_authority:, code: "PP-256", description: "Biodiversity")
 
     visit "/admin/policy/references"

--- a/engines/bops_admin/spec/system/users_spec.rb
+++ b/engines/bops_admin/spec/system/users_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe "Users" do
     end
   end
 
-  context "when there are a mix of confirmed and unconfirmed users" do
+  context "when there are a mix of confirmed and unconfirmed users", :capybara do
     before do
       create(:user, :reviewer, local_authority:, name: "Dieter Waldbeck")
       create(:user, :assessor, :unconfirmed, local_authority:, name: "Andrea Khan")

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -2,7 +2,7 @@
 
 require "bops_config_helper"
 
-RSpec.describe "Application Types", type: :system do
+RSpec.describe "Application Types", type: :system, capybara: true do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
 
   before do

--- a/engines/bops_config/spec/system/legislation_spec.rb
+++ b/engines/bops_config/spec/system/legislation_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Legislation", type: :system do
     expect(find_field("Link").value).to eq("https://www.legislation.gov.uk/ukpga/1990/8/section/192")
   end
 
-  it "allows deleting the legislation" do
+  it "allows deleting the legislation", :capybara do
     visit "/legislation/#{legislation.id}/edit"
     accept_confirm(text: "Are you sure?") do
       click_link("Remove")

--- a/engines/bops_config/spec/system/reporting_types_spec.rb
+++ b/engines/bops_config/spec/system/reporting_types_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Reporting types", type: :system do
     end
   end
 
-  it "allows removal of reporting types" do
+  it "allows removal of reporting types", :capybara do
     create(:reporting_type, :prior_approval_all_others)
 
     click_link "Reporting types"
@@ -163,7 +163,7 @@ RSpec.describe "Reporting types", type: :system do
     expect(page).not_to have_selector("table tbody tr:nth-child(2)")
   end
 
-  it "doesn't allow removal of reporting types when they're used" do
+  it "doesn't allow removal of reporting types when they're used", :capybara do
     click_link "Reporting types"
     expect(page).to have_selector("h1", text: "Reporting Types")
 

--- a/engines/bops_config/spec/system/users_spec.rb
+++ b/engines/bops_config/spec/system/users_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Users", type: :system do
     end
   end
 
-  context "when there are a mix of confirmed and unconfirmed users" do
+  context "when there are a mix of confirmed and unconfirmed users", :capybara do
     before do
       create(:user, :global_administrator, local_authority: nil, name: "Dieter Waldbeck")
       create(:user, :global_administrator, :unconfirmed, local_authority: nil, name: "Andrea Khan")

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -36,7 +36,14 @@ RSpec.configure do |config|
   end
 
   config.before type: :system do |example|
-    driven_by(ENV.fetch("JS_DRIVER", "chrome_headless").to_sym)
+    driver = if example.metadata[:capybara] || example.metadata[:js]
+      ENV.fetch("JS_DRIVER", "chrome_headless").to_sym
+    else
+      ENV.fetch("TEST_DRIVER", "rack_test").to_sym
+    end
+
+    driven_by driver
+
     Capybara.app_host = "http://planx.example.com"
   end
 end

--- a/spec/system/api_index_spec.rb
+++ b/spec/system/api_index_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Swagger index file" do
+RSpec.describe "Swagger index file", type: :system, capybara: true do
   let!(:local_authority) { create(:local_authority, :default) }
 
   before do

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Edit document" do
+RSpec.describe "Edit document", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
 
   let!(:planning_application) do
@@ -77,7 +77,7 @@ RSpec.describe "Edit document" do
         )
       end
 
-      it "renders an error if user tries to replace the file" do
+      it "renders an error if user tries to replace the file", :capybara do
         visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
 
         attach_file(
@@ -108,7 +108,7 @@ RSpec.describe "Edit document" do
       )
     end
 
-    it "with wrong format document" do
+    it "with wrong format document", :capybara do
       visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
 
       attach_file("Upload a replacement file", "spec/fixtures/images/image.gif")

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Documents index page" do
+RSpec.describe "Documents index page", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -46,7 +46,7 @@ RSpec.describe "Documents index page" do
       expect(page).not_to have_text("Application information")
     end
 
-    it "File image opens in new tab" do
+    it "File image opens in new tab", :capybara do
       window = window_opened_by do
         click_link("View in new window")
         sleep 0.5
@@ -73,7 +73,7 @@ RSpec.describe "Documents index page" do
         )
       end
 
-      it "opens each file in a new tab" do
+      it "opens each file in a new tab", :capybara do
         visit "/planning_applications/#{planning_application.id}/documents"
         expect(page).to have_selector("h1", text: "Documents")
 

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "filtering planning applications" do
+RSpec.describe "filtering planning applications", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :assessor, local_authority:) }
 

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Requesting a new document for a planning application" do
+RSpec.describe "Requesting a new document for a planning application", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -104,7 +104,7 @@ RSpec.describe "Requesting a new document for a planning application" do
     let!(:document_evidence_and_plan_tags) { create(:document, tags: %w[photographs.proposed floorPlan.proposed], planning_application:) }
     let!(:document_plan_and_supporting_tags) { create(:document, tags: %w[floorPlan.proposed otherDocument], planning_application:) }
 
-    it "I can view the documents separated by their tag category" do
+    it "I can view the documents separated by their tag category", :capybara do
       visit "/planning_applications/#{planning_application.id}/validation/tasks"
       click_link "Check and request documents"
 
@@ -164,7 +164,7 @@ RSpec.describe "Requesting a new document for a planning application" do
       create(:document, :archived, :with_file, planning_application:)
     end
 
-    it "I can see the list of active documents when I go to validate" do
+    it "I can see the list of active documents when I go to validate", :capybara do
       visit "/planning_applications/#{planning_application.id}/validation/tasks"
 
       within("#check-missing-documents-task") do
@@ -352,7 +352,7 @@ RSpec.describe "Requesting a new document for a planning application" do
         end
       end
 
-      it "I can delete the additional document validation request" do
+      it "I can delete the additional document validation request", :capybara do
         visit "/planning_applications/#{planning_application.id}/validation/tasks"
         expect(page).to have_selector("h1", text: "Check the application")
 

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add conditions" do
+RSpec.describe "Add conditions", type: :system, capybara: true do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add heads of terms" do
+RSpec.describe "Add heads of terms", type: :system, capybara: true do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/assessing/adding_informatives_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_informatives_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add informatives" do
+RSpec.describe "Add informatives", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
@@ -68,7 +68,7 @@ RSpec.describe "Add informatives" do
     end
   end
 
-  it "I can save and come back later" do
+  it "I can save and come back later", :capybara do
     within("#add-informatives") do
       expect(page).to have_content "Not started"
       click_link "Add informatives"
@@ -162,7 +162,7 @@ RSpec.describe "Add informatives" do
     let!(:informative_two) { create(:informative, informative_set:, title: "Title 2", text: "Text 2", position: 2) }
     let!(:informative_three) { create(:informative, informative_set:, title: "Title 3", text: "Text 3", position: 3) }
 
-    it "I can drag and drop to sort the informatives" do
+    it "I can drag and drop to sort the informatives", :capybara do
       click_link "Add informatives"
       expect(page).to have_selector("p", text: "Drag and drop informatives to change the order that they appear in the decision notice.")
 

--- a/spec/system/planning_applications/assessing/adding_neighbour_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_neighbour_summary_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "neighbour responses" do
+RSpec.describe "neighbour responses", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -29,7 +29,7 @@ RSpec.describe "neighbour responses" do
       let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive", tags: ["access"]) }
       let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
 
-      it "I can view the information on the neighbour responses page" do
+      it "I can view the information on the neighbour responses page", :capybara do
         click_link "Check and assess"
 
         within("#assessment-information-tasks") do

--- a/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Add pre-commencement conditions" do
+RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/assessing/assess_against_polices_and_guidance_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_against_polices_and_guidance_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "assess against policies and guidance" do
+RSpec.describe "assess against policies and guidance", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: local_authority) }
 

--- a/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Assess immunity detail permitted development right" do
+RSpec.describe "Assess immunity detail permitted development right", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -69,7 +69,7 @@ RSpec.describe "Assess immunity detail permitted development right" do
       end
     end
 
-    context "when viewing the content" do
+    context "when viewing the content", :capybara do
       before do
         Capybara.ignore_hidden_elements = true
       end
@@ -242,7 +242,7 @@ RSpec.describe "Assess immunity detail permitted development right" do
         )
       end
 
-      it "I can view and edit my response" do
+      it "I can view and edit my response", :capybara do
         within("#assess-immunity-detail-section") do
           choose "No"
 

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "assessment against legislation" do
+RSpec.describe "assessment against legislation", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: local_authority) }
 

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Assessment tasks" do
+RSpec.describe "Assessment tasks", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -113,7 +113,7 @@ RSpec.describe "Assessment tasks" do
     end
   end
 
-  context "when there are proposal details" do
+  context "when there are proposal details", :capybara do
     let(:planning_application) do
       create(
         :planning_application,

--- a/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Evidence of immunity" do
+RSpec.describe "Evidence of immunity", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
@@ -11,7 +11,7 @@ RSpec.describe "Evidence of immunity" do
     create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
   end
 
-  context "when signed in as an assessor" do
+  context "when signed in as an assessor", :capybara do
     before do
       create(:evidence_group, :with_document, tag: "utilityBill", immunity_detail: planning_application.immunity_detail)
       create(:evidence_group, :with_document, tag: "buildingControlCertificate", end_date: nil, immunity_detail: planning_application.immunity_detail)

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Immunity" do
+RSpec.describe "Immunity", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
@@ -63,7 +63,7 @@ RSpec.describe "Immunity" do
       visit "/planning_applications/#{planning_application.id}"
     end
 
-    it "shows the assessment and review stages for immunity" do
+    it "shows the assessment and review stages for immunity", :capybara do
       click_link("Check and assess")
       expect(page).to have_content("Note: application may be immune from enforcement")
 

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "viewing assessment report" do
+RSpec.describe "viewing assessment report", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: local_authority) }
 

--- a/spec/system/planning_applications/consulting/add_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/add_consultees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Consultation", js: true do
+RSpec.describe "Consultation", type: :system, js: true do
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }
   let(:application_type) { create(:application_type, :planning_permission) }

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "View neighbour responses", js: true do
+RSpec.describe "View neighbour responses", type: :system, js: true do
   include ActionDispatch::TestProcess::FixtureFile
 
   let(:default_local_authority) { create(:local_authority, :default) }

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Consultation", js: true do
+RSpec.describe "Consultation", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Consultation", js: true do
+RSpec.describe "Consultation", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "faraday"
 
-RSpec.describe "Send letters to neighbours", js: true do
+RSpec.describe "Send letters to neighbours", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Consultation", js: true do
+RSpec.describe "Consultation", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "faraday"
 
-RSpec.describe "Send letters to neighbours", js: true do
+RSpec.describe "Send letters to neighbours", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Consultation", js: true do
+RSpec.describe "Consultation", type: :system, js: true do
   let(:api_user) { create(:api_user, name: "PlanX") }
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 require "faraday"
 
-RSpec.describe "Creating a planning application" do
+RSpec.describe "Creating a planning application", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor1) { create(:user, :assessor, local_authority: default_local_authority, name: "Assessor 1") }
   let!(:reviewer1) { create(:user, :reviewer, local_authority: default_local_authority, name: "Reviewer 1") }

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Planning Application index page" do
+RSpec.describe "Planning Application index page", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:application_type_ldc_proposed) { create(:application_type, :ldc_proposed) }
   let!(:application_type_prior_approval) { create(:application_type, :prior_approval) }
@@ -116,7 +116,7 @@ RSpec.describe "Planning Application index page" do
       end
     end
 
-    context "when viewing tabs" do
+    context "when viewing tabs", :capybara do
       let!(:prior_approval_not_started) do
         create(
           :planning_application,

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Planning Application Assessment" do
+RSpec.describe "Planning Application Assessment", type: :system do
   let!(:default_local_authority) do
     create(
       :local_authority,
@@ -570,7 +570,7 @@ RSpec.describe "Planning Application Assessment" do
       end
     end
 
-    context "when withdrawing a recommendation" do
+    context "when withdrawing a recommendation", :capybara do
       let!(:planning_application) do
         create(:planning_application, :with_recommendation, :awaiting_determination, local_authority: default_local_authority, decision: "granted")
       end

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Requesting document changes to a planning application" do
+RSpec.describe "Requesting document changes to a planning application", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -46,7 +46,7 @@ RSpec.describe "Requesting document changes to a planning application" do
       )
     end
 
-    it "I can mark documents as invalid and edit/delete the validation request" do
+    it "I can mark documents as invalid and edit/delete the validation request", :capybara do
       click_link "Check and validate"
       click_link "Tag and validate supplied documents"
 

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Check neighbour notifications" do
+RSpec.describe "Check neighbour notifications", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
@@ -73,7 +73,7 @@ RSpec.describe "Check neighbour notifications" do
         )
       end
 
-      it "you can send it back for assessment" do
+      it "you can send it back for assessment", :capybara do
         visit "/planning_applications/#{planning_application.id}/review/tasks"
 
         expect(page).to have_list_item_for(

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Reviewing evidence of immunity" do
+RSpec.describe "Reviewing evidence of immunity", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
 
   let(:reviewer) do
@@ -48,7 +48,7 @@ RSpec.describe "Reviewing evidence of immunity" do
       visit "/planning_applications/#{planning_application.id}/review/tasks"
     end
 
-    context "when planning application is awaiting determination" do
+    context "when planning application is awaiting determination", :capybara do
       it "I can view the information on the review evidence of immunity page" do
         expect(page).to have_list_item_for(
           "Review evidence of immunity",

--- a/spec/system/planning_applications/review/heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/review/heads_of_terms_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Reviewing heads of terms" do
+RSpec.describe "Reviewing heads of terms", type: :system, capybara: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/review/permitted_development_rights_spec.rb
+++ b/spec/system/planning_applications/review/permitted_development_rights_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Permitted development right" do
+RSpec.describe "Permitted development right", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
@@ -140,7 +140,7 @@ RSpec.describe "Permitted development right" do
         expect(page).to have_content("Permitted development rights response was successfully updated")
       end
 
-      it "I can save and mark as complete when adding my review to accept the permitted development right response" do
+      it "I can save and mark as complete when adding my review to accept the permitted development right response", capybara: true do
         click_link "Review and sign-off"
         click_link "Review permitted development rights"
 
@@ -159,7 +159,7 @@ RSpec.describe "Permitted development right" do
         expect(find_by_id("permitted-development-right-accepted-field").selected?).to be(false)
       end
 
-      it "I can save and mark as complete when adding my review to reject the permitted development right response" do
+      it "I can save and mark as complete when adding my review to reject the permitted development right response", capybara: true do
         click_link "Review and sign-off"
         click_link "Review permitted development rights"
 

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Reviewing Policy Class" do
+RSpec.describe "Reviewing Policy Class", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
 
   let(:reviewer) do
@@ -190,7 +190,7 @@ RSpec.describe "Reviewing Policy Class" do
         expect(page).to have_text("policy comment")
       end
 
-      it "allows the reviewer to edit comments" do
+      it "allows the reviewer to edit comments", capybara: true do
         travel_to(Time.zone.local(2020, 10, 16)) do
           click_button("Edit comment")
 

--- a/spec/system/planning_applications/review/sign_off_spec.rb
+++ b/spec/system/planning_applications/review/sign_off_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Reviewing sign-off" do
+RSpec.describe "Reviewing sign-off", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:reviewer) do
     create(:user,
@@ -233,7 +233,7 @@ RSpec.describe "Reviewing sign-off" do
   end
 
   context "when editing the public comment that appears on the decision notice" do
-    it "as a reviewer I am able to edit" do
+    it "as a reviewer I am able to edit", capybara: true do
       create(:recommendation,
         planning_application:,
         assessor_comment: "New assessor comment",

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Drawing a sitemap on a planning application" do
+RSpec.describe "Drawing a sitemap on a planning application", type: :system, capybara: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority, name: "Assessor 1") }
 

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Planning Application show page" do
+RSpec.describe "Planning Application show page", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
@@ -94,7 +94,7 @@ RSpec.describe "Planning Application show page" do
       end
     end
 
-    it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
+    it "makes valid task list for when it is awaiting determination and recommendation has been reviewed", :capybara do
       planning_application = create(:planning_application, :awaiting_determination,
         local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)

--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Requesting time extension to a planning application" do
+RSpec.describe "Requesting time extension to a planning application", type: :system, capybara: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 

--- a/spec/system/planning_applications/updated_tab_spec.rb
+++ b/spec/system/planning_applications/updated_tab_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Planning application updated tab spec" do
+RSpec.describe "Planning application updated tab spec", type: :system do
   let!(:local_authority) { create(:local_authority, :default) }
 
   let!(:user) { create(:user, name: "Assigned Officer") }
@@ -37,7 +37,7 @@ RSpec.describe "Planning application updated tab spec" do
     click_link "Updated"
   end
 
-  it "lists the applications with the latest audit log entry" do
+  it "lists the applications with the latest audit log entry", :capybara do
     expect(page).to have_content("This list shows applications which have been recently updated by a user other than the assigned officer.")
 
     within("#updated") do

--- a/spec/system/planning_applications/validating/cil_liability_spec.rb
+++ b/spec/system/planning_applications/validating/cil_liability_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Community Infrastructure Levy (CIL)" do
+RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: true do
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }

--- a/spec/system/planning_applications/validating/cil_liability_spec.rb
+++ b/spec/system/planning_applications/validating/cil_liability_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: true do
+RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
@@ -60,8 +60,8 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: t
 
       click_link "Confirm Community Infrastructure Levy (CIL)"
 
-      expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
-      expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+      expect(page).to have_checked_field("planning-application-cil-liable-true-field")
+      expect(page).not_to have_checked_field("planning-application-cil-liable-field")
     end
 
     it "is marked as false when not liable" do
@@ -72,8 +72,8 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: t
 
       click_link "Confirm Community Infrastructure Levy (CIL)"
 
-      expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-      expect(find_by_id("planning-application-cil-liable-field")).to be_selected
+      expect(page).not_to have_checked_field("planning-application-cil-liable-true-field")
+      expect(page).to have_checked_field("planning-application-cil-liable-field")
     end
   end
 
@@ -116,8 +116,8 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: t
         visit "/planning_applications/#{planning_application.id}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
-        expect(find_by_id("planning-application-cil-liable-true-field")).to be_selected
-        expect(find_by_id("planning-application-cil-liable-field")).not_to be_selected
+        expect(page).to have_checked_field("planning-application-cil-liable-true-field")
+        expect(page).not_to have_checked_field("planning-application-cil-liable-field")
       end
     end
 
@@ -136,8 +136,8 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system, capybara: t
         visit "/planning_applications/#{planning_application.id}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
-        expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
-        expect(find_by_id("planning-application-cil-liable-field")).to be_selected
+        expect(page).not_to have_checked_field("planning-application-cil-liable-true-field")
+        expect(page).to have_checked_field("planning-application-cil-liable-field")
       end
     end
   end

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "FeeItemsValidation" do
+RSpec.describe "FeeItemsValidation", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -300,7 +300,7 @@ RSpec.describe "FeeItemsValidation" do
         end
       end
 
-      it "I can delete the fee validation request" do
+      it "I can delete the fee validation request", :capybara do
         visit "/planning_applications/#{planning_application.id}/validation/tasks"
         click_link "Check fee"
 
@@ -449,7 +449,7 @@ RSpec.describe "FeeItemsValidation" do
         )
       end
 
-      it "I can see the updated state of the fee request" do
+      it "I can see the updated state of the fee request", :capybara do
         visit "/planning_applications/#{planning_application.id}/validation/tasks"
 
         within("#fee-validation-task") do

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Planning Application Assessment" do
+RSpec.describe "Planning Application Assessment", type: :system do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
@@ -107,7 +107,7 @@ RSpec.describe "Planning Application Assessment" do
         }.to_json
       end
 
-      it "blocks validation until boundary geojson has been added" do
+      it "blocks validation until boundary geojson has been added", :capybara do
         visit "/planning_applications/#{application.id}/confirm_validation"
         click_button("Mark the application as valid")
 

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "searching planning applications" do
+RSpec.describe "searching planning applications", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :assessor, local_authority:) }
 


### PR DESCRIPTION
rack_test is noticeably faster on tests where we don't need javascript or other interactivity, so use capybara only where necessary.

In practice I think even more of these tests could be rewritten without capybara but I'm not sure. This is just a quick fix.