### PR TITLE
Fix test failure caused by mismatched time mocking

### DIFF
--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Requesting time extension to a planning application" do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
-  let!(:planning_application) do
+  let(:planning_application) do
     create(:planning_application, :in_assessment, local_authority: default_local_authority)
   end
 


### PR DESCRIPTION
Timecop in `before` did not always get activated.