### PR TITLE
Improvements to Conditions form

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -435,3 +435,10 @@ body {
   border-left: 10px solid $govuk-link-colour;
   background-color: #F2F9FF;
 }
+
+.govuk-details--borderless {
+  .govuk-details__text {
+    border-left: none;
+    padding-left: 0;
+  }
+}

--- a/app/controllers/planning_applications/assessment/conditions_controller.rb
+++ b/app/controllers/planning_applications/assessment/conditions_controller.rb
@@ -87,7 +87,7 @@ module PlanningApplications
       end
 
       def condition_params
-        params.require(:condition).permit(%i[id standard title text reason])
+        params.require(:condition).permit(%i[id title text reason]).to_h.merge(standard: false)
       end
 
       def status

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -59,7 +59,7 @@
 </ul>
 
 <%= govuk_details(summary_text: "Add condition") do %>
-  <%= render("form") %>
+  <%= render partial: "form", locals: {submit_button_is_secondary: true} %>
 <% end %>
 
 <%= form_with model: @condition_set, url: mark_as_complete_planning_application_assessment_conditions_path(@planning_application) do |form| %>

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -58,7 +58,10 @@
   <% end %>
 </ul>
 
-<%= govuk_details(summary_text: "Add condition", open: @conditions.count(&:persisted?).zero?) do %>
+<%= govuk_details(summary_text: "Add condition",
+      open: @conditions.count(&:persisted?).zero?,
+      classes: "govuk-details--borderless") do %>
+  <h3 class="govuk-heading-s">Add a new condition</h3>
   <%= render partial: "form", locals: {submit_button_is_secondary: true} %>
 <% end %>
 

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -64,5 +64,6 @@
 
 <%= form_with model: @condition_set, url: mark_as_complete_planning_application_assessment_conditions_path(@planning_application) do |form| %>
   <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
+  <%= govuk_link_to("Save and come back later", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary") %>
   <%= govuk_link_to("Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary") %>
 <% end %>

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -67,6 +67,6 @@
 
 <%= form_with model: @condition_set, url: mark_as_complete_planning_application_assessment_conditions_path(@planning_application) do |form| %>
   <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
-  <%= govuk_link_to("Save and come back later", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary") %>
-  <%= govuk_link_to("Back", planning_application_assessment_tasks_path(@planning_application), class: "govuk-button govuk-button--secondary") %>
+  <%= govuk_button_link_to("Save and come back later", planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
+  <%= govuk_button_link_to("Back", planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
 <% end %>

--- a/app/views/planning_applications/assessment/conditions/_conditions.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_conditions.html.erb
@@ -58,7 +58,7 @@
   <% end %>
 </ul>
 
-<%= govuk_details(summary_text: "Add condition") do %>
+<%= govuk_details(summary_text: "Add condition", open: @conditions.count(&:persisted?).zero?) do %>
   <%= render partial: "form", locals: {submit_button_is_secondary: true} %>
 <% end %>
 

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -7,7 +7,6 @@
 
   <%= content_tag :div, class: "govuk-!-margin-bottom-5" do %>
     <%= form.hidden_field :id %>
-    <%= form.hidden_field :standard, value: false %>
     <%= form.govuk_text_field :title, value: @condition&.title, label: {text: "Enter title"} %>
     <%= form.govuk_text_area :text, label: {text: "Enter condition"}, data: {reset_text_target: "destination"} %>
     <%= form.govuk_text_area :reason, label: {text: "Enter a reason for this condition"}, data: {reset_text_target: "destination"} %>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -8,7 +8,7 @@
   <%= content_tag :div, class: "govuk-!-margin-bottom-5" do %>
     <%= form.hidden_field :id %>
     <%= form.hidden_field :standard, value: false %>
-    <%= form.hidden_field :title, value: @condition&.title if @condition&.standard %>
+    <%= form.govuk_text_field :title, value: @condition&.title, label: {text: "Enter title"} %>
     <%= form.hidden_field :text_source, value: @condition&.text, data: {reset_text_target: "source"} %>
     <%= form.govuk_text_area :text, label: {text: "Enter condition"}, data: {reset_text_target: "destination"} %>
     <%= button_tag "Reset condition", type: "button", class: "govuk-body button-as-link govuk-!-margin-bottom-6", value: "text", data: {action: "click->reset-text#reset"} %>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -19,8 +19,8 @@
 
   <div class="govuk-button-group">
     <%= form.submit(
-          "Save condition",
-          class: "govuk-button",
+          "Add condition to list",
+          class: "govuk-button #{"govuk-button--secondary" if local_assigns[:submit_button_is_secondary]}",
           data: {module: "govuk-button"}
         ) %>
     <%= back_link if @condition.present? && @condition.persisted? %>

--- a/app/views/planning_applications/assessment/conditions/_form.html.erb
+++ b/app/views/planning_applications/assessment/conditions/_form.html.erb
@@ -9,12 +9,8 @@
     <%= form.hidden_field :id %>
     <%= form.hidden_field :standard, value: false %>
     <%= form.govuk_text_field :title, value: @condition&.title, label: {text: "Enter title"} %>
-    <%= form.hidden_field :text_source, value: @condition&.text, data: {reset_text_target: "source"} %>
     <%= form.govuk_text_area :text, label: {text: "Enter condition"}, data: {reset_text_target: "destination"} %>
-    <%= button_tag "Reset condition", type: "button", class: "govuk-body button-as-link govuk-!-margin-bottom-6", value: "text", data: {action: "click->reset-text#reset"} %>
-    <%= form.hidden_field :reason_source, value: @condition&.reason, data: {reset_text_target: "source"} %>
     <%= form.govuk_text_area :reason, label: {text: "Enter a reason for this condition"}, data: {reset_text_target: "destination"} %>
-    <%= button_tag "Reset reason", type: "button", class: "govuk-body button-as-link govuk-!-margin-bottom-6", value: "reason", data: {action: "click->reset-text#reset"} %><br>
   <% end %>
 
   <div class="govuk-button-group">

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe "Add conditions" do
 
       fill_in "Enter condition", with: "New condition"
       fill_in "Enter a reason for this condition", with: "No reason"
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 1"
       fill_in "Enter a reason for this condition", with: "Custom reason 1"
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 2"
       fill_in "Enter a reason for this condition", with: "Custom reason 2"
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 3"
@@ -83,7 +83,7 @@ RSpec.describe "Add conditions" do
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 1"
       fill_in "Enter a reason for this condition", with: "Custom reason 1"
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       expect(page).to have_content "Time limit"
       expect(page).to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
@@ -140,7 +140,7 @@ RSpec.describe "Add conditions" do
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 1"
 
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       within ".govuk-error-summary" do
         expect(page).to have_content "Enter the reason for this condition"
@@ -155,7 +155,7 @@ RSpec.describe "Add conditions" do
       end
 
       fill_in "Enter condition", with: ""
-      click_button "Save condition"
+      click_button "Add condition to list"
 
       within ".govuk-error-summary" do
         expect(page).to have_content "Enter the text of this condition"

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe "Add conditions" do
       toggle "Add condition"
       fill_in "Enter condition", with: "Custom condition 3"
       fill_in "Enter a reason for this condition", with: "Custom reason 3"
-      click_button "Reset condition"
-      click_button "Reset reason"
+      # n.b. form not submitted here
       toggle "Add condition"
 
       click_button "Save and mark as complete"

--- a/spec/system/planning_applications/review/conditions_spec.rb
+++ b/spec/system/planning_applications/review/conditions_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "Reviewing conditions" do
         end
         fill_in "Enter a reason for this condition", with: "A better response"
 
-        click_button "Save condition"
+        click_button "Add condition to list"
         click_button "Save and mark as complete"
 
         sign_out(assessor)


### PR DESCRIPTION
### Description of change

Small corrections to the conditions forms:

- **Save condition button should be secondary not primary**
- **Open the conditions form by default if there are none**
- **Make condition title a visible form field**
- **Add a no-op save-and-come-back-later button to conditions page**
- **Remove "reset" buttons from conditions form**
- **Don't indent govuk-details body**

### Story Link

https://trello.com/c/XACvAuS9/3017-add-conditions-improvement-conditions-should-have-a-title-field

https://trello.com/c/oFK58Hnp/3000-design-improvements-for-add-conditions

### Screenshots

<img width="664" alt="Screenshot 2024-05-29 at 10 30 04" src="https://github.com/unboxed/bops/assets/3986/1c70b74d-9c80-4435-8f3d-ce7c53ce79f0">
