### PR TITLE
Add multiple press notices

### DIFF
--- a/app/controllers/planning_applications/press_notices/confirmations_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmations_controller.rb
@@ -8,8 +8,17 @@ module PlanningApplications
       before_action :set_planning_application
       before_action :ensure_publicity_is_permitted
       before_action :set_press_notice
+      before_action :set_press_notices, only: :show
 
       def show
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def edit
+        @press_notice.published_at ||= Time.zone.today
+
         respond_to do |format|
           format.html
         end
@@ -22,7 +31,8 @@ module PlanningApplications
               redirect_to planning_application_consultation_path(@planning_application), notice: t(".success")
             end
           else
-            format.html { render :show }
+            set_press_notices
+            format.html { render :edit }
           end
         end
       end
@@ -41,8 +51,10 @@ module PlanningApplications
         elsif !@press_notice.required?
           redirect_to planning_application_consultation_path(@planning_application), alert: t(".not_required")
         end
+      end
 
-        @press_notice.published_at ||= Time.zone.today
+      def set_press_notices
+        @press_notices = @planning_application.press_notices.published.exclude_by_id(@press_notice.id)
       end
     end
   end

--- a/app/controllers/planning_applications/press_notices_controller.rb
+++ b/app/controllers/planning_applications/press_notices_controller.rb
@@ -6,7 +6,14 @@ module PlanningApplications
 
     before_action :set_planning_application
     before_action :ensure_publicity_is_permitted
-    before_action :set_press_notice
+    before_action :build_press_notice, only: [:new, :create]
+    before_action :set_press_notice, only: [:show, :update]
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
 
     def show
       respond_to do |format|
@@ -15,6 +22,22 @@ module PlanningApplications
     end
 
     def create
+      @press_notice.assign_attributes(press_notice_params)
+
+      respond_to do |format|
+        if @press_notice.save
+          enqueue_send_press_notice_email_job
+
+          format.html do
+            redirect_to planning_application_consultation_path(@planning_application), notice: t(".success")
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
       respond_to do |format|
         if @press_notice.update(press_notice_params)
           enqueue_send_press_notice_email_job
@@ -28,16 +51,18 @@ module PlanningApplications
       end
     end
 
-    alias_method :update, :create
-
     private
 
     def press_notice_params
       params.require(:press_notice).permit(:required, :other_reason, reasons: [])
     end
 
+    def build_press_notice
+      @press_notice = @planning_application.press_notices.new
+    end
+
     def set_press_notice
-      @press_notice = @planning_application.press_notice || @planning_application.build_press_notice
+      @press_notice = @planning_application.press_notice || build_press_notice
     end
 
     def enqueue_send_press_notice_email_job

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -47,8 +47,9 @@ class PlanningApplication < ApplicationRecord
     has_many :constraints, through: :planning_application_constraints, source: :constraint
     has_many :site_notices
     has_many :policy_classes, -> { order(:section) }
-    has_one :heads_of_term
+    has_many :press_notices, -> { by_created_at_desc }
 
+    has_one :heads_of_term
     has_one :condition_set, -> { where(pre_commencement: false) }, required: false
     has_one :consistency_checklist
     has_one :consultation, required: false
@@ -61,7 +62,6 @@ class PlanningApplication < ApplicationRecord
     has_one :ownership_certificate, required: false
     has_one :planx_planning_data, required: false
     has_one :pre_commencement_condition_set, -> { where(pre_commencement: true) }, class_name: "ConditionSet", required: false
-    has_one :press_notice, required: false
     has_one :proposal_measurement, required: false
     has_one :committee_decision, required: false
   end
@@ -899,6 +899,10 @@ class PlanningApplication < ApplicationRecord
   def committee_details_filled?
     committee_decision.recommend? &&
       committee_decision.all_details_present?
+  end
+
+  def press_notice
+    press_notices.first
   end
 
   private

--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -49,6 +49,9 @@ class PressNotice < ApplicationRecord
   delegate :press_notice_email, to: :local_authority
 
   scope :required, -> { where(required: true) }
+  scope :published, -> { where.not(published_at: nil) }
+  scope :by_created_at_desc, -> { order(created_at: :desc) }
+  scope :exclude_by_id, ->(id) { where.not(id: id) }
 
   alias_method :consultable_event_at, :published_at
 

--- a/app/views/planning_applications/press_notices/_form.html.erb
+++ b/app/views/planning_applications/press_notices/_form.html.erb
@@ -1,0 +1,58 @@
+<%= form_with model: @press_notice, url: planning_application_press_notice_path(@planning_application) do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%= form.govuk_radio_buttons_fieldset(
+        :required,
+        legend: -> {
+          if @press_notice.new_record?
+            content_tag(:h2, "Does this application require a press notice?", class: "govuk-heading-m")
+          else
+            content_tag(:h2, "Press notice details", class: "govuk-heading-m")
+          end
+        }
+      ) do %>
+
+    <%= form.govuk_radio_button(
+          :required, true, disabled: @press_notice.published_at?, label: {text: "Yes"}
+        ) do %>
+
+      <%= form.govuk_check_boxes_fieldset :reasons, legend: -> { "" } do %>
+        <% PressNotice::REASONS.each do |reason| %>
+          <% if reason == :other %>
+            <%= form.govuk_check_box_divider "or" %>
+            <%= form.govuk_check_box :reasons, reason.to_s, disabled: @press_notice.published_at?, label: {text: t(reason, scope: :press_notice_reasons)} do %>
+              <%= form.govuk_text_area :other_reason, disabled: @press_notice.published_at?, label: {text: t("press_notice_reasons.other_reason")} %>
+            <% end %>
+          <% else %>
+            <%= form.govuk_check_box :reasons, reason.to_s, disabled: @press_notice.published_at?, label: {text: t(reason, scope: :press_notice_reasons)} %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% unless @press_notice.published_at? %>
+        <div class="govuk-form-group">
+          <p class="govuk-body">
+            <% if @press_notice.press_notice_email.present? %>
+              An email notification will be sent to <strong><%= @planning_application.local_authority.press_notice_email %></strong> if a press notice is required.
+            <% else %>
+              No press notice email has been set. This can be done by an administrator in the admin dashboard.
+            <% end %>
+          </p>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%= form.govuk_radio_button(
+          :required, false, disabled: @press_notice.published_at?, label: {text: "No"}
+        ) %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <% if @press_notice.published_at %>
+      <%= govuk_link_to "Add a new press notice response", new_planning_application_press_notice_path(@planning_application) %>
+    <% else %>
+      <%= form.submit "Save and mark as complete", class: "govuk-button", data: {module: "govuk-button"} %>
+    <% end %>
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/press_notices/_press_notices.html.erb
+++ b/app/views/planning_applications/press_notices/_press_notices.html.erb
@@ -1,0 +1,36 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-third"></th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-thirds"></th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% press_notices.each do |press_notice| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell govuk-!-width-one-third">
+          <% press_notice.documents.with_file_attachment.each do |document| %>
+            <p class="govuk-body govuk-!-margin-bottom-1">
+              <%= link_to image_tag(document.file.representation(resize: "300x212")),
+                    url_for_document(document), target: :_blank, rel: :noopener %>
+            </p>
+            <p class="govuk-body">
+              <%= truncate(document.name.to_s, length: 50) %><br>
+              <%= govuk_link_to "View in new window", url_for_document(document), new_tab: true %>
+            </p>
+          <% end %>
+        </td>
+
+        <td class="govuk-table__cell govuk-!-width-two-thirds">
+          <p class="govuk-body"><strong class="govuk-tag">Published</strong></p>
+          <p class="govuk-body">Date requested: <strong><%= time_tag(press_notice.requested_at) %></strong></p>
+          <p class="govuk-body">Date published: <strong><%= time_tag(press_notice.published_at) %></strong></p>
+          <% if press_notice.comment.present? %>
+            <p class="govuk-body">Comments: <%= press_notice.comment %></p>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/planning_applications/press_notices/confirmations/edit.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/edit.html.erb
@@ -1,0 +1,73 @@
+<% content_for :page_title do %>
+  Press notice - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Consultation", planning_application_consultation_path(@planning_application) %>
+<% content_for :title, "Confirm press notice" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Confirm press notice"}
+    ) %>
+
+<%= form_with(
+      model: @press_notice,
+      url: planning_application_press_notice_confirmation_path(@planning_application)
+    ) do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <% if @press_notice.requested_at? %>
+    <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">
+      <p class="govuk-body-s govuk-!-margin-bottom-2">
+        <%= time_tag(@press_notice.requested_at, format: t(".requested_on")) %>
+      </p>
+      <p class="govuk-body">
+        <strong class="govuk-tag">Emailed</strong>
+      </p>
+    </div>
+  <% end %>
+
+  <div class="background-light-grey govuk-!-padding-bottom-1 govuk-!-padding-left-5 govuk-!-padding-right-5 govuk-!-padding-top-5 govuk-!-margin-bottom-7">
+    <h2 class="govuk-heading-s">Reasons selected:</h2>
+    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+      <% @press_notice.reasons.each do |reason| %>
+        <li>
+          <% if reason == "other" %>
+            <%= @press_notice.other_reason %>
+          <% else %>
+            <%= t(reason, scope: :press_notice_reasons) %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+
+  <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset">
+      <%= form.govuk_date_field(:published_at, rows: 6, id: "published-at-field", legend: {size: "s", text: t(".published_at")}) %>
+
+      <%= render "documents", documents: @press_notice.documents %>
+
+      <%= form.govuk_file_field :documents,
+            label: {size: "s", text: t(".upload_photos")},
+            hint: {text: t(".photos_hint")},
+            accept: acceptable_file_mime_types,
+            multiple: true %>
+
+      <%= form.govuk_text_area(:comment, rows: 3, label: {text: t(".optional_comment")}) %>
+    </fieldset>
+
+    <div class="govuk-button-group govuk-!-padding-top-7">
+      <%= form.submit t(".save"), class: "govuk-button govuk-button--primary" %>
+      <%= govuk_button_link_to t(".back"), planning_application_consultation_path(@planning_application), secondary: true %>
+    </div>
+
+    <% if @press_notice.published_at %>
+      <p class="govuk-body">
+        <%= govuk_link_to "Add a new press notice response", new_planning_application_press_notice_path(@planning_application) %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/planning_applications/press_notices/confirmations/show.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  Press notice - <%= t("page_title") %>
+  Confirm press notice - <%= t("page_title") %>
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
@@ -12,56 +12,54 @@
       locals: {heading: "Confirm press notice"}
     ) %>
 
-<%= form_with(
-      model: @press_notice,
-      url: planning_application_press_notice_confirmation_path(@planning_application)
-    ) do |form| %>
-  <%= form.govuk_error_summary %>
+<h2 class="govuk-heading-m">Confirm press notice publication</h2>
 
-  <% if @press_notice.requested_at? %>
-    <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">
-      <p class="govuk-body-s govuk-!-margin-bottom-2">
-        <%= time_tag(@press_notice.requested_at, format: t(".requested_on")) %>
-      </p>
-      <p class="govuk-body">
-        <strong class="govuk-tag">Emailed</strong>
-      </p>
-    </div>
+<div class="background-light-grey govuk-!-padding-bottom-1 govuk-!-padding-left-5 govuk-!-padding-right-5 govuk-!-padding-top-5 govuk-!-margin-bottom-2">
+  <h2 class="govuk-heading-s">Reasons selected:</h2>
+  <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+    <% @press_notice.reasons.each do |reason| %>
+      <li>
+        <% if reason == "other" %>
+          <%= @press_notice.other_reason %>
+        <% else %>
+          <%= t(reason, scope: :press_notice_reasons) %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>
+
+<p class="govuk-body">Date requested: <strong><%= time_tag(@press_notice.requested_at) %></strong></p>
+
+<% if @press_notice.published_at %>
+  <p class="govuk-body">Date published: <strong><%= time_tag(@press_notice.published_at) %></strong></p>
+
+  <% if @press_notice.comment.present? %>
+    <p class="govuk-body govuk-!-margin-bottom-2">
+      Comments: <%= @press_notice.comment %>
+    </p>
   <% end %>
 
-  <div class="background-light-grey govuk-!-padding-bottom-1 govuk-!-padding-left-5 govuk-!-padding-right-5 govuk-!-padding-top-5 govuk-!-margin-bottom-7">
-    <h2 class="govuk-heading-s">Reasons selected:</h2>
-    <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
-      <% @press_notice.reasons.each do |reason| %>
-        <li>
-          <% if reason == "other" %>
-            <%= @press_notice.other_reason %>
-          <% else %>
-            <%= t(reason, scope: :press_notice_reasons) %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <%= render "documents", documents: @press_notice.documents %>
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      <%= form.govuk_date_field(:published_at, rows: 6, id: "published-at-field", legend: {size: "s", text: t(".published_at")}) %>
+  <p class="govuk-body">
+    <%= govuk_link_to "Edit publication", edit_planning_application_press_notice_confirmation_path(@planning_application) %>
+  </p>
+  <p class="govuk-body">
+    <%= govuk_link_to "Add a new press notice response", new_planning_application_press_notice_path(@planning_application) %>
+  </p>
+<% else %>
+  <p class="govuk-body">Upload evidence of the press notice publication.</p>
 
-      <%= render "documents", documents: @press_notice.documents %>
-
-      <%= form.govuk_file_field :documents,
-            label: {size: "s", text: t(".upload_photos")},
-            hint: {text: t(".photos_hint")},
-            accept: acceptable_file_mime_types,
-            multiple: true %>
-
-      <%= form.govuk_text_area(:comment, rows: 3, label: {text: t(".optional_comment")}) %>
-    </fieldset>
-
-    <div class="govuk-button-group govuk-!-padding-top-7">
-      <%= form.submit t(".save"), class: "govuk-button govuk-button--primary" %>
-      <%= govuk_button_link_to t(".back"), planning_application_consultation_path(@planning_application), secondary: true %>
-    </div>
-  </div>
+  <%= govuk_button_link_to "Confirm publication", edit_planning_application_press_notice_confirmation_path(@planning_application) %>
 <% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<% if @press_notices.any? %>
+  <%= govuk_details(summary_text: "View past press notices") do %>
+    <%= render "planning_applications/press_notices/press_notices", press_notices: @press_notices %>
+  <% end %>
+<% end %>
+
+<%= back_link %>

--- a/app/views/planning_applications/press_notices/new.html.erb
+++ b/app/views/planning_applications/press_notices/new.html.erb
@@ -12,15 +12,4 @@
       locals: {heading: "Press notice"}
     ) %>
 
-<% if @press_notice.published_at %>
-  <div class="govuk-inset-text govuk-!-margin-top-0 govuk-!-padding-top-2 govuk-!-padding-bottom-2">
-    <p class="govuk-body-s govuk-!-margin-bottom-2">
-      <%= time_tag(@press_notice.published_at, format: t(".published_on")) %>
-    </p>
-    <p class="govuk-body">
-      <strong class="govuk-tag">Published</strong>
-    </p>
-  </div>
-<% end %>
-
 <%= render "form" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1370,20 +1370,26 @@ en:
         create:
           success: Request for confirmation of the press notice sent to the press team
       confirmations:
-        show:
+        edit:
           back: Back
-          not_found: Please create the press notice first before confirming
-          not_required: The press notice is not required so there is no need to confirm it
           optional_comment: Optional comment
           photos_hint: Provide documentary evidence of the press notice being published
           published_at: What date was the press notice published?
           requested_on: Press notice requested on %-d %B %Y
           save: Save
           upload_photos: Upload photo(s)
+        show:
+          back: Back
+          not_found: Please create the press notice first before confirming
+          not_required: The press notice is not required so there is no need to confirm it
+          save: Save
         update:
           success: Press notice response has been successfully updated
       create:
         success: Press notice response has been successfully added
+      press_notices:
+        published_on: Press notice published on %-d %B %Y
+        requested_on: Press notice requested on %-d %B %Y
       show:
         published_on: Press notice published on %-d %B %Y
       update:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,8 +80,8 @@ Rails.application.routes.draw do
           patch :update, on: :collection
         end
 
-        resource :press_notice, only: %i[show create update] do
-          resource :confirmation, only: %i[show update], controller: "press_notices/confirmations"
+        resource :press_notice, only: %i[new show create update] do
+          resource :confirmation, only: %i[show edit update], controller: "press_notices/confirmations"
           resources :confirmation_requests, only: %i[create], controller: "press_notices/confirmation_requests"
         end
 


### PR DESCRIPTION
### Description of change

- Allow for multiple press notices
- Show previous press notices 
- Add show and edit pages when confirming the publication

### Story Link

https://trello.com/c/W2W8RmGJ/2793-history-of-previous-dates-entered-press-notice

