### PR TITLE
Remove check on referer for file requests

### DIFF
--- a/app/controllers/concerns/active_storage/authorize.rb
+++ b/app/controllers/concerns/active_storage/authorize.rb
@@ -9,15 +9,15 @@ module ActiveStorage
     end
 
     def public?
-      return unless request.referer.include?("bops-care") || request.referer.include?("bops-applicants")
+      return if @blob.nil?
 
-      if @blob.attachments.count == 1 && @blob.attachments.any? { |a| a.record_type == "ActiveStorage::VariantRecord" }
-        @blob.attachments.first.record.blob.attachments.first.record.attachments.includes(:record).any? do |a|
-          a.record.published?
-        end
+      attachments = if @blob.attachments.count == 1 && @blob.attachments.any? { |a| a.record_type == "ActiveStorage::VariantRecord" }
+        @blob.attachments.first.record.blob.attachments.first.record.attachments
       else
-        @blob.attachments.includes(:record).any? { |a| a.record.published? }
+        @blob.attachments
       end
+
+      attachments.includes(:record).any? { |a| a.record&.published? }
     end
   end
 end


### PR DESCRIPTION
This doesn't work locally, or for API requests, or any case when the referer is suppressed.

This is used to bypass the authentication requirement for public files when the referer matches. But it seems unlikely that accessing public files without a referer is a risk, and anyway this would have been simple to bypass by forging a referer.