### PR TITLE
Mark document links as downloads

### DIFF
--- a/app/components/consultee_response_component.html.erb
+++ b/app/components/consultee_response_component.html.erb
@@ -16,7 +16,7 @@
     <% if documents.present? %>
       <ul class="govuk-list govuk-body-s">
         <% documents.each do |document| %>
-          <li><%= document_link_tag(document) %></li>
+          <li><%= helpers.link_to_document(document.name, document) %></li>
         <% end %>
       </ul>
     <% end %>

--- a/app/components/consultee_response_component.rb
+++ b/app/components/consultee_response_component.rb
@@ -66,16 +66,4 @@ class ConsulteeResponseComponent < ViewComponent::Base
 
     content_tag(:a, t(".redact_and_publish"), **options)
   end
-
-  def url_for_document(document)
-    if document.published?
-      api_v1_planning_application_document_url(document.planning_application, document)
-    else
-      rails_blob_url(document.file)
-    end
-  end
-
-  def document_link_tag(document)
-    govuk_link_to(document.name, url_for_document(document), new_tab: "")
-  end
 end

--- a/app/components/consultee_responses_component.html.erb
+++ b/app/components/consultee_responses_component.html.erb
@@ -26,7 +26,7 @@
       <% if last_response.documents.present? %>
         <ul class="govuk-list govuk-body-s">
           <% last_response.documents.each do |document| %>
-            <li><%= document_link_tag(document) %></li>
+            <li><%= helpers.link_to_document(document.name, document) %></li>
           <% end %>
         </ul>
       <% end %>

--- a/app/components/consultee_responses_component.rb
+++ b/app/components/consultee_responses_component.rb
@@ -73,18 +73,6 @@ class ConsulteeResponsesComponent < ViewComponent::Base
     end
   end
 
-  def url_for_document(document)
-    if document.published?
-      api_v1_planning_application_document_url(document.planning_application, document)
-    else
-      rails_blob_url(document.file)
-    end
-  end
-
-  def document_link_tag(document)
-    govuk_link_to(document.name, url_for_document(document), new_tab: "")
-  end
-
   def view_responses_link_tag
     options = {
       class: "govuk-link",

--- a/app/components/evidence_groups/documents_component.html.erb
+++ b/app/components/evidence_groups/documents_component.html.erb
@@ -15,7 +15,7 @@
           </p>
         </div>
         <div class="govuk-grid-column-one-third govuk-!-margin-bottom-6">
-          <%= govuk_link_to "View document", url_for_document(document), new_tab: true %><br>
+          <%= helpers.link_to_document "View document", document %><br>
           <%= govuk_link_to "Edit", edit_planning_application_document_path(document.planning_application, document) %><br>
           <%= govuk_link_to "Archive", planning_application_document_archive_path(document_id: document.id) %><br>
           <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: document.planning_application.id, document: document, type: "replacement_document") %>

--- a/app/components/evidence_groups/documents_component.rb
+++ b/app/components/evidence_groups/documents_component.rb
@@ -7,15 +7,5 @@ module EvidenceGroups
     end
 
     attr_reader :documents
-
-    private
-
-    def url_for_document(document)
-      if document.published?
-        api_v1_planning_application_document_url(document.planning_application, document)
-      else
-        rails_blob_url(document.file)
-      end
-    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,14 +9,6 @@ module ApplicationHelper
     link_to(t("back"), back_path, class: classname)
   end
 
-  def url_for_document(document)
-    if document.published?
-      api_v1_planning_application_document_url(document.planning_application, document)
-    else
-      rails_blob_url(document.file)
-    end
-  end
-
   def unsaved_changes_data
     {
       controller: "unsaved-changes",

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -32,4 +32,14 @@ module DocumentHelper
   def reference_or_file_name(document)
     document.numbers.presence || document.name
   end
+
+  def link_to_document(link_text, document, **args)
+    govuk_link_to(
+      link_text,
+      url_for_document(document),
+      new_tab: "",
+      download: reference_or_file_name(document),
+      **args
+    )
+  end
 end

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -34,10 +34,12 @@ module DocumentHelper
   end
 
   def link_to_document(link_text, document, **args)
+    new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
+
     govuk_link_to(
       link_text,
       url_for_document(document),
-      new_tab: "",
+      new_tab:,
       download: reference_or_file_name(document),
       **args
     )

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -44,4 +44,12 @@ module DocumentHelper
       **args
     )
   end
+
+  def url_for_document(document)
+    if document.published?
+      api_v1_planning_application_document_url(document.planning_application, document)
+    else
+      rails_blob_url(document.file)
+    end
+  end
 end

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -2,12 +2,7 @@
   <%= link_to image_tag(document.file.representation(resize: resize), style: "max-width:100%"),
         url_for_document(document), target: :_blank, rel: :noopener %>
   <p class="govuk-body">
-    <%= govuk_link_to( # erblint:disable Rubocop
-          t(".view_in_new"),
-          url_for_document(document),
-          # do not use `new_tab:` here, as it adds rel="noreferer" and breaks our referrer checks
-          target: :_blank
-        ) %>
+    <%= link_to_document(t(".view_in_new"), document) %>
   </p>
   <% if edit_and_archive %>
     <p class="govuk-body">

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -1,6 +1,5 @@
 <% if document.representable? %>
-  <%= link_to image_tag(document.file.representation(resize: resize), style: "max-width:100%"),
-        url_for_document(document), target: :_blank, rel: :noopener %>
+  <%= link_to_document image_tag(document.file.representation(resize: resize), style: "max-width:100%"), document %>
   <p class="govuk-body">
     <%= link_to_document(t(".view_in_new"), document) %>
   </p>

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -19,8 +19,7 @@
       File name: <%= @document.name %>
     </p>
     <p>
-      <%= link_to image_tag(@document.file.representation(resize: "300x212")),
-            url_for_document(@document), target: :_blank, rel: :noopener %>
+      <%= link_to_document image_tag(@document.file.representation(resize: "300x212")), @document %>
     </p>
     <%= render "archive_form" %>
   </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -37,13 +37,7 @@
             url_for_document(@document),
             target: "_blank", rel: "noopener"
           ) %>
-      <%= govuk_link_to( # erblint:disable Rubocop
-            t(".view_in_new"),
-            url_for_document(@document),
-            # do not use `new_tab:` here, as it adds rel="noreferer" and breaks our referrer checks
-            target: "_blank",
-            class: "govuk-body"
-          ) %>
+      <%= link_to_document t(".view_in_new"), @document, class: "govuk-body" %>
     <% end %>
   </div>
   <div class="govuk-grid-column-one-half">

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -29,14 +29,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <% if @document.representable? %>
-      <%= link_to(
-            image_tag(
-              @document.file.representation(resize: "500x500"),
-              style: "max-width:100%"
-            ),
-            url_for_document(@document),
-            target: "_blank", rel: "noopener"
-          ) %>
+      <%= link_to_document image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"), @document %>
       <%= link_to_document t(".view_in_new"), @document, class: "govuk-body" %>
     <% end %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -88,8 +88,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-quarter">
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                    url_for_document(document), target: :_blank, rel: :noopener %>
+              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
             </p>
             <p class="govuk-body">
               <%= document.name %><br>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -93,9 +93,7 @@
             </p>
             <p class="govuk-body">
               <%= document.name %><br>
-              <%= link_to "View in new window", url_for_document(document), # erblint:disable Rubocop
-                    # do not use `new_tab:` here, as it adds rel="noreferer" and breaks our referrer checks
-                    target: :_blank, rel: :noopener %>
+              <%= link_to_document "View in new window", document %>
             </p>
             <p class="govuk-body">
               <%= form_for document, url: planning_application_document_unarchive_path(document_id: document.id), class: "restore" do |form| %>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
@@ -86,7 +86,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), no_visited_state: true %></li>
               </ul>
             </div>
@@ -167,7 +167,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %></li>
               </ul>
             </div>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/edit.html.erb
@@ -83,7 +83,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
@@ -164,7 +164,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
@@ -83,7 +83,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
@@ -163,7 +163,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/new.html.erb
@@ -86,7 +86,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), no_visited_state: true %></li>
               </ul>
             </div>
@@ -166,7 +166,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %></li>
               </ul>
             </div>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
@@ -47,7 +47,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
@@ -114,7 +114,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>

--- a/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/check_publicity/show.html.erb
@@ -50,7 +50,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), no_visited_state: true %></li>
               </ul>
             </div>
@@ -117,7 +117,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %></li>
               </ul>
             </div>

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -52,7 +52,7 @@
                           </p>
                           <p class="govuk-body">
                             <%= truncate(document.name.to_s, length: 50) %><br>
-                            <%= govuk_link_to "View in new window", url_for_document(document), new_tab: "" %>
+                            <%= link_to_document "View in new window", document %>
                           </p>
                         </td>
                         <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -47,8 +47,7 @@
                       <tr class="govuk-table__row">
                         <td class="govuk-table__cell govuk-!-width-one-third">
                           <p class="govuk-body govuk-!-margin-bottom-1">
-                            <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                                  url_for_document(document), target: :_blank, rel: :noopener %>
+                            <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
                           </p>
                           <p class="govuk-body">
                             <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/press_notices/_press_notices.html.erb
+++ b/app/views/planning_applications/press_notices/_press_notices.html.erb
@@ -17,7 +17,7 @@
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>
-              <%= govuk_link_to "View in new window", url_for_document(document), new_tab: true %>
+              <%= link_to_document "View in new window", document %>
             </p>
           <% end %>
         </td>

--- a/app/views/planning_applications/press_notices/_press_notices.html.erb
+++ b/app/views/planning_applications/press_notices/_press_notices.html.erb
@@ -12,8 +12,7 @@
         <td class="govuk-table__cell govuk-!-width-one-third">
           <% press_notice.documents.with_file_attachment.each do |document| %>
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                    url_for_document(document), target: :_blank, rel: :noopener %>
+              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
@@ -13,8 +13,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                    url_for_document(document), target: :_blank, rel: :noopener %>
+              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
+++ b/app/views/planning_applications/press_notices/confirmations/_documents.html.erb
@@ -18,7 +18,7 @@
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>
-              <%= govuk_link_to "View in new window", url_for_document(document), new_tab: "" %>
+              <%= link_to_document "View in new window", document %>
             </p>
           </td>
           <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/review/publicities/edit.html.erb
+++ b/app/views/planning_applications/review/publicities/edit.html.erb
@@ -47,7 +47,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
@@ -114,7 +114,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>

--- a/app/views/planning_applications/review/publicities/edit.html.erb
+++ b/app/views/planning_applications/review/publicities/edit.html.erb
@@ -50,7 +50,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), no_visited_state: true %></li>
               </ul>
             </div>
@@ -117,7 +117,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %></li>
               </ul>
             </div>

--- a/app/views/planning_applications/review/publicities/show.html.erb
+++ b/app/views/planning_applications/review/publicities/show.html.erb
@@ -47,7 +47,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
@@ -114,7 +114,7 @@
           <div class="govuk-grid-row">
             <div class="govuk-grid-column-one-third">
               <p class="govuk-body govuk-!-margin-bottom-1">
-                <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
+                <%= link_to_document(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), document) %>
               </p>
               <ul class="govuk-list">
                 <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>

--- a/app/views/planning_applications/review/publicities/show.html.erb
+++ b/app/views/planning_applications/review/publicities/show.html.erb
@@ -50,7 +50,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @site_notice), no_visited_state: true %></li>
               </ul>
             </div>
@@ -117,7 +117,7 @@
                 <%= link_to(image_tag(document.file.representation(resize_to_fill: [360, 240]), style: "width:100%"), url_for_document(document), target: :_blank, rel: :noopener) %>
               </p>
               <ul class="govuk-list">
-                <li><%= govuk_link_to(t(".view_in_new_window"), url_for_document(document), new_tab: "", no_visited_state: true) %></li>
+                <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
                 <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %></li>
               </ul>
             </div>

--- a/app/views/planning_applications/site_notices/show.html.erb
+++ b/app/views/planning_applications/site_notices/show.html.erb
@@ -28,8 +28,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-third">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to image_tag(@site_notice.document.file.representation(resize: "300x212")),
-                  url_for_document(@site_notice.document), target: :_blank, rel: :noopener %>
+            <%= link_to_document image_tag(@site_notice.document.file.representation(resize: "300x212")), @site_notice.document %>
           </p>
           <p class="govuk-body">
             <%= truncate(@site_notice.document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/site_notices/show.html.erb
+++ b/app/views/planning_applications/site_notices/show.html.erb
@@ -33,7 +33,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(@site_notice.document.name.to_s, length: 50) %><br>
-            <%= govuk_link_to "View in new window", url_for_document(@site_notice.document), new_tab: "" %>
+            <%= link_to_document "View in new window", @site_notice.document %>
           </p>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/site_visits/show.html.erb
+++ b/app/views/planning_applications/site_visits/show.html.erb
@@ -44,7 +44,7 @@
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>
-              <%= govuk_link_to "View in new window", url_for_document(document), new_tab: "" %>
+              <%= link_to_document "View in new window", document %>
             </p>
           </td>
           <td class="govuk-table__cell govuk-!-width-one-third">

--- a/app/views/planning_applications/site_visits/show.html.erb
+++ b/app/views/planning_applications/site_visits/show.html.erb
@@ -39,8 +39,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                    url_for_document(document), target: :_blank, rel: :noopener %>
+              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/document/redactions/_form.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_form.html.erb
@@ -17,8 +17,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-padding-top-3 govuk-!-padding-bottom-3">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to image_tag(ff.object.file.representation(resize: "150x106")),
-                  url_for_document(ff.object), target: :_blank, rel: :noopener %>
+            <%= link_to_document image_tag(ff.object.file.representation(resize: "150x106")), ff.object %>
           </p>
           <p class="govuk-body">
             <%= truncate(ff.object.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/document/redactions/_form.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_form.html.erb
@@ -22,7 +22,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(ff.object.name.to_s, length: 50) %><br>
-            <%= govuk_link_to "Download", url_for_document(ff.object), download: true, class: "govuk-body-s" %>
+            <%= link_to_document "Download", ff.object, class: "govuk-body-s" %>
           </p>
         </td>
         <td class="govuk-table__cell">

--- a/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
@@ -15,7 +15,7 @@
           </p>
           <p class="govuk-body">
             <%= truncate(document.name.to_s, length: 50) %><br>
-            <%= govuk_link_to "View in new window", url_for_document(document), new_tab: "" %>
+            <%= link_to_document "View in new window", document %>
           </p>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-half">

--- a/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
@@ -10,8 +10,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to image_tag(document.file.representation(resize: "150x106")),
-                  url_for_document(document), target: :_blank, rel: :noopener %>
+            <%= link_to_document image_tag(document.file.representation(resize: "150x106")), document %>
           </p>
           <p class="govuk-body">
             <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
@@ -15,7 +15,7 @@
                   url_for_document(document), target: :_blank, rel: :noopener %>
           </p>
           <p class="govuk-body">
-            <%= govuk_link_to "View in new window", url_for_document(document), new_tab: "" %>
+            <%= link_to_document "View in new window", document %>
           </p>
         </td>
         <td class="govuk-table__cell govuk-!-width-one-half">

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
@@ -11,8 +11,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to image_tag(document.file.representation(resize: "300x212")),
-                  url_for_document(document), target: :_blank, rel: :noopener %>
+            <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
           </p>
           <p class="govuk-body">
             <%= link_to_document "View in new window", document %>

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_cancel_confirmation.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_cancel_confirmation.html.erb
@@ -23,7 +23,7 @@
     <div class="govuk-inset-text">
       <p class="govuk-body">
         <strong>Replacement for:
-        <%= govuk_link_to @validation_request.old_document.name, url_for_document(@validation_request.old_document), new_tab: true %>
+        <%= link_to_document @validation_request.old_document.name, @validation_request.old_document %>
         </strong>
       </p>
       <p class="govuk-body">

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
@@ -1,6 +1,5 @@
 <div class="govuk-grid-column-one-half">
-  <%= link_to image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"),
-        url_for_document(@document), target: :_blank, rel: :noopener %>
+  <%= link_to_document image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"), @document %>
   <p class="govuk-body">
     <%= link_to_document "View in new window", @document %>
   </p>

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
@@ -2,7 +2,7 @@
   <%= link_to image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"),
         url_for_document(@document), target: :_blank, rel: :noopener %>
   <p class="govuk-body">
-    <%= govuk_link_to "View in new window", url_for_document(@document), new_tab: "" %>
+    <%= link_to_document "View in new window", @document %>
   </p>
 </div>
 <div class="govuk-grid-column-one-half" id="document-summary">

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe DocumentHelper do
   end
 
   describe "#link_to_document" do
-    include ApplicationHelper
     include GovukVisuallyHiddenHelper
     include GovukLinkHelper
 

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -17,4 +17,23 @@ RSpec.describe DocumentHelper do
       expect(reference_or_file_name(document)).to eq "proposed-floorplan.png"
     end
   end
+
+  describe "#link_to_document" do
+    include ApplicationHelper
+    include GovukVisuallyHiddenHelper
+    include GovukLinkHelper
+
+    let(:document) { create(:document) }
+
+    it "adds view in new tab text" do
+      link = link_to_document("hello world", document)
+      expect(link).to match(/hello world \(opens in new tab\)/)
+    end
+
+    it "does not repeat view in new tab text" do
+      link = link_to_document("View document in new window", document)
+      expect(link).to match(/View document in new window/)
+      expect(link).not_to match(/\(opens in new tab\)/)
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Add `download="<filename>"` to document links to indicate to the browser that it should be downloaded rather than displayed inline.

Extract the links to a helper to ensure this is applied consistently.

### Story Link

https://trello.com/c/hpdOAqcc/3030-pdfs-open-in-system-viewer