### PR TITLE
Mark document links as content-disposition: attachment

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -8,7 +8,7 @@ module Api
       def show
         document =
           PlanningApplication.find(params[:planning_application_id]).documents.for_publication.find(params[:id])
-        redirect_to rails_blob_url(document.file)
+        redirect_to rails_blob_url(document.file, disposition: "attachment")
       end
 
       def tags

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -49,7 +49,7 @@ module DocumentHelper
     if document.published?
       api_v1_planning_application_document_url(document.planning_application, document)
     else
-      rails_blob_url(document.file)
+      rails_blob_url(document.file, disposition: "attachment")
     end
   end
 end

--- a/spec/requests/api/document_show_spec.rb
+++ b/spec/requests/api/document_show_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "API request to show document file", show_exceptions: true do
 
     it "redirects to blob url" do
       get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
-      expect(response).to redirect_to(rails_blob_path(document.file))
+      expect(response).to redirect_to(rails_blob_path(document.file, disposition: "attachment"))
     end
   end
 end

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -79,6 +79,9 @@ RSpec.describe "Documents index page", type: :system do
         end
 
         expect(File).to exist(Rails.root.join("tmp/downloads/proposed-roofplan.png"))
+
+        # confirm that we didn't change tab
+        expect(page).to have_selector("h1", text: "Documents")
       end
     end
 


### PR DESCRIPTION
### Description of change

The change in #1839 doesn't seem to be sufficient for all browsers. Setting the content-disposition in the helper should catch more cases.

### Story Link

https://trello.com/c/hpdOAqcc/3030-pdfs-open-in-system-viewer
