### PR TITLE
Add --force-color to rspec options so it shows in Github output

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -112,7 +112,7 @@ jobs:
           RAILS_ENV: test
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
           OTP_SECRET_ENCRYPTION_KEY: ${{ secrets.OTP_SECRET_ENCRYPTION_KEY }}
-          SPEC_OPTS: '-f doc  --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}" ${{ inputs.additional_spec_opts }}'
+          SPEC_OPTS: '-f doc --force-color --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}" ${{ inputs.additional_spec_opts }}'
         run: |
           bundle exec rake spec
 


### PR DESCRIPTION
Otherwise rspec's documentation output is useless, since it relies on colour.