### PR TITLE
Add valid_from and published_at dates to API

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -252,11 +252,14 @@ class PlanningApplicationsController < AuthenticationController
       received_at
       town
       uprn
-      make_public
       longitude
       latitude]
     # rubocop:enable Naming/VariableNumber
-    params.require(:planning_application).permit permitted_keys
+    permitted_params = params.require(:planning_application).permit permitted_keys
+
+    permitted_params[:published_at] = (params[:planning_application][:make_public] == "true") ? Time.zone.now : nil
+
+    permitted_params
   end
 
   def determination_date_params

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -102,6 +102,7 @@ class PlanningApplication < ApplicationRecord
   scope :for_user_and_null_users, ->(user_id) { where(user_id: [user_id, nil]) }
   scope :prior_approvals, -> { joins(:application_type).where(application_type: {name: :prior_approval}) }
   scope :accepted, -> { where.not(status: "pending") }
+  scope :published, -> { where.not(published_at: nil) }
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -905,6 +905,15 @@ class PlanningApplication < ApplicationRecord
     press_notices.first
   end
 
+  def make_public?
+    published_at.present?
+  end
+  alias_method :make_public, :make_public?
+
+  def make_public=(value)
+    self[:published_at] = value ? Time.zone.now : nil
+  end
+
   private
 
   def create_fee_calculation

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -15,7 +15,7 @@ class PlanningApplication < ApplicationRecord
 
   include PlanningApplication::Notification
 
-  self.ignored_columns += %i[work_status]
+  self.ignored_columns += %i[work_status make_public]
 
   DAYS_TO_EXPIRE = 56
   DAYS_TO_EXPIRE_EIA = 112

--- a/app/views/api/v1/planning_applications/_show.json.jbuilder
+++ b/app/views/api/v1/planning_applications/_show.json.jbuilder
@@ -81,4 +81,4 @@ if planning_application.consultation.present?
     json.end_date planning_application.consultation.end_date
   end
 end
-json.make_public planning_application.make_public
+json.make_public planning_application.make_public?

--- a/db/migrate/20240605143118_add_published_at_to_planning_applications.rb
+++ b/db/migrate/20240605143118_add_published_at_to_planning_applications.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddPublishedAtToPlanningApplications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :planning_applications, :published_at, :datetime
+
+    up_only do
+      PlanningApplication.find_each(make_public: true) do |application|
+        application.update(published_at: application.validated_at)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_03_145529) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_143118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -716,6 +716,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_03_145529) do
     t.boolean "regulation_3", default: false, null: false
     t.boolean "regulation_4", default: false, null: false
     t.boolean "ownership_certificate_checked", default: false, null: false
+    t.datetime "published_at"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -15,7 +15,7 @@ module BopsApi
         private
 
         def planning_applications_scope
-          @local_authority.planning_applications.where(make_public: true)
+          @local_authority.planning_applications.where.not(published_at: nil)
         end
 
         def search_params

--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -15,7 +15,7 @@ module BopsApi
         private
 
         def planning_applications_scope
-          @local_authority.planning_applications.where.not(published_at: nil)
+          @local_authority.planning_applications.published
         end
 
         def search_params

--- a/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
@@ -78,4 +78,4 @@ if planning_application.consultation.present?
     json.end_date planning_application.consultation.end_date
   end
 end
-json.make_public planning_application.make_public
+json.make_public planning_application.make_public?

--- a/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
@@ -52,6 +52,7 @@ json.site do
 end
 json.received_date planning_application.received_at
 json.validAt planning_application.validated_at
+json.publishedAt planning_application.published_at
 json.decision planning_application.decision if planning_application.determined?
 json.constraints planning_application.planning_application_constraints.map(&:constraint).map(&:type_code) if planning_application.planning_application_constraints.any?
 json.documents planning_application.documents.for_publication do |document|

--- a/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/planning_applications/_show.json.jbuilder
@@ -51,6 +51,7 @@ json.site do
   json.longitude planning_application.longitude
 end
 json.received_date planning_application.received_at
+json.validAt planning_application.validated_at
 json.decision planning_application.decision if planning_application.determined?
 json.constraints planning_application.planning_application_constraints.map(&:constraint).map(&:type_code) if planning_application.planning_application_constraints.any?
 json.documents planning_application.documents.for_publication do |document|

--- a/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
@@ -8,5 +8,6 @@ json.application do
   json.reference planning_application.reference
   json.fullReference planning_application.reference_in_full
   json.receivedAt planning_application.received_at
+  json.validAt planning_application.validated_at
   json.status planning_application.status
 end

--- a/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
@@ -9,5 +9,6 @@ json.application do
   json.fullReference planning_application.reference_in_full
   json.receivedAt planning_application.received_at
   json.validAt planning_application.validated_at
+  json.publishedAt planning_application.published_at
   json.status planning_application.status
 end

--- a/engines/bops_api/schemas/odp/v0.6.0/applicationSubmission.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/applicationSubmission.json
@@ -30,6 +30,10 @@
           "format": "datetime",
           "type": "string"
         },
+        "validAt": {
+          "format": "datetime",
+          "type": ["string", "null"]
+        },
         "status": {
           "type": "string"
         }

--- a/engines/bops_api/schemas/odp/v0.6.0/applicationSubmission.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/applicationSubmission.json
@@ -34,6 +34,10 @@
           "format": "datetime",
           "type": ["string", "null"]
         },
+        "publishedAt": {
+          "format": "datetime",
+          "type": ["string", "null"]
+        },
         "status": {
           "type": "string"
         }

--- a/engines/bops_api/schemas/odp/v0.6.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/search.json
@@ -96,6 +96,10 @@
                   "format": "datetime",
                   "type": "string"
                 },
+                "validAt": {
+                  "format": "datetime",
+                  "type": ["string", "null"]
+                },
                 "status": {
                   "type": "string"
                 }

--- a/engines/bops_api/schemas/odp/v0.6.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/search.json
@@ -100,6 +100,10 @@
                   "format": "datetime",
                   "type": ["string", "null"]
                 },
+                "publishedAt": {
+                  "format": "datetime",
+                  "type": ["string", "null"]
+                },
                 "status": {
                   "type": "string"
                 }

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "BOPS API" do
   let(:planning_application) { example_fixture("validPlanningPermission.json") }
   let(:send_email) { "true" }
 
-  let!(:planning_applications) { create_list(:planning_application, 8, local_authority:, application_type:, make_public: true) }
+  let!(:planning_applications) { create_list(:planning_application, 8, :published, local_authority:, application_type:) }
   let!(:determined_planning_applications) { create_list(:planning_application, 3, :determined, local_authority:, application_type:) }
 
   let(:submission) { create(:planx_planning_data, params_v2: example_fixture("validPlanningPermission.json")) }

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -5,14 +5,14 @@ require "swagger_helper"
 RSpec.describe "BOPS public API" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:application_type) { create(:application_type, :householder) }
-  let!(:planning_applications) { create_list(:planning_application, 6, :with_boundary_geojson, local_authority:, application_type:, make_public: true) }
+  let!(:planning_applications) { create_list(:planning_application, 6, :published, :with_boundary_geojson, local_authority:, application_type:) }
   let(:page) { 1 }
   let(:maxresults) { 5 }
   let(:q) { "" }
 
   before do
-    create_list(:planning_application, 2, :with_boundary_geojson_features, local_authority:, application_type:, make_public: true)
-    create_list(:planning_application, 2, :with_boundary_geojson_features, local_authority:, application_type:, make_public: true, description: "I want to build a roof extension.")
+    create_list(:planning_application, 2, :with_boundary_geojson_features, :published, local_authority:, application_type:)
+    create_list(:planning_application, 2, :with_boundary_geojson_features, :published, local_authority:, application_type:, description: "I want to build a roof extension.")
   end
 
   path "/api/v2/public/planning_applications/search" do

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -16136,6 +16136,9 @@ components:
                   validAt:
                     format: datetime
                     type: string
+                  publishedAt:
+                    format: datetime
+                    type: string
                   status:
                     type: string
                 required:
@@ -16293,6 +16296,11 @@ components:
               format: datetime
               type: string
             validAt:
+              format: datetime
+              type:
+              - string
+              - 'null'
+            publishedAt:
               format: datetime
               type:
               - string

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -16133,6 +16133,9 @@ components:
                   receivedAt:
                     format: datetime
                     type: string
+                  validAt:
+                    format: datetime
+                    type: string
                   status:
                     type: string
                 required:
@@ -16289,6 +16292,11 @@ components:
             receivedAt:
               format: datetime
               type: string
+            validAt:
+              format: datetime
+              type:
+              - string
+              - 'null'
             status:
               type: string
           required:

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -782,5 +782,9 @@ FactoryBot.define do
         planning_application.planx_planning_data = build(:planx_planning_data, params_v2: JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access, planning_application:)
       end
     end
+
+    trait :published do
+      published_at { Time.zone.now }
+    end
   end
 end

--- a/spec/system/planning_applications/assessing/check_consultees_spec.rb
+++ b/spec/system/planning_applications/assessing/check_consultees_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "checking consultees", js: true do
       :from_planx_prior_approval,
       :with_boundary_geojson,
       :with_constraints_and_consultees,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 

--- a/spec/system/planning_applications/consulting/add_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/add_consultees_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Consultation", type: :system, js: true do
       :from_planx_prior_approval,
       :with_boundary_geojson,
       :with_constraints,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Consultation", type: :system, js: true do
       :planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Consultation", type: :system, js: true do
       :planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     create(:planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority: default_local_authority,
       api_user:,
       agent_email: "agent@example.com",
       applicant_email: "applicant@example.com",
-      make_public: true,
       uprn: uprn)
   end
   let(:uprn) { "20000111111" }

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Consultation", type: :system, js: true do
       :planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 
@@ -436,12 +436,12 @@ RSpec.describe "Consultation", type: :system, js: true do
         :not_started,
         :from_planx_prior_approval,
         :with_boundary_geojson,
+        :published,
         application_type:,
         local_authority:,
         api_user:,
         agent_email: "agent@example.com",
-        applicant_email: "applicant@example.com",
-        make_public: true
+        applicant_email: "applicant@example.com"
       )
     end
 
@@ -489,8 +489,7 @@ RSpec.describe "Consultation", type: :system, js: true do
         local_authority:,
         api_user:,
         agent_email: "agent@example.com",
-        applicant_email: "applicant@example.com",
-        make_public: false
+        applicant_email: "applicant@example.com"
       )
     end
 
@@ -539,8 +538,7 @@ RSpec.describe "Consultation", type: :system, js: true do
         local_authority:,
         api_user:,
         agent_email: "agent@example.com",
-        applicant_email: "applicant@example.com",
-        make_public: false
+        applicant_email: "applicant@example.com"
       )
     end
 

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     create(:planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority: default_local_authority,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true)
+      applicant_email: "applicant@example.com")
   end
 
   let(:consultation) do
@@ -147,8 +147,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
         create(:planning_application,
           :from_planx_prior_approval,
           application_type:,
-          local_authority: default_local_authority,
-          make_public: false)
+          local_authority: default_local_authority)
       end
 
       it "prevents me sending letters and displays an alert" do

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Consultation", type: :system, js: true do
       :planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority:,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true
+      applicant_email: "applicant@example.com"
     )
   end
 

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "making planning application public" do
 
     expect(page).to have_content("Public on BOPS Public Portal: Yes")
 
+    expect(planning_application.reload.published_at).to eq(Time.zone.local(2022, 1, 1))
+
     visit "/planning_applications/#{planning_application.id}/make_public"
 
     choose "No"
@@ -46,5 +48,7 @@ RSpec.describe "making planning application public" do
     click_button "Update application"
 
     expect(page).to have_content("Public on BOPS Public Portal: No")
+
+    expect(planning_application.reload.published_at).to be_nil
   end
 end

--- a/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe "Confirm site notice", js: true do
     create(:planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority: default_local_authority,
       api_user:,
       agent_email: "agent@example.com",
-      applicant_email: "applicant@example.com",
-      make_public: true)
+      applicant_email: "applicant@example.com")
   end
 
   let!(:consultation) { planning_application.consultation }

--- a/spec/system/planning_applications/publicity/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/create_site_notice_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe "Create a site notice", js: true do
     create(:planning_application,
       :from_planx_prior_approval,
       :with_boundary_geojson,
+      :published,
       application_type:,
       local_authority: default_local_authority,
       api_user:,
       agent_email: "agent@example.com",
       applicant_email: "applicant@example.com",
-      user: assessor,
-      make_public: true)
+      user: assessor)
   end
 
   around do |example|

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
   let!(:planning_application) do
-    create(:planning_application, :planning_permission, :awaiting_determination, local_authority: default_local_authority, user: assessor, make_public: true)
+    create(:planning_application, :planning_permission, :awaiting_determination, :published, local_authority: default_local_authority, user: assessor)
   end
   let!(:recommendation) { create(:recommendation, planning_application:) }
   let!(:consultation) { planning_application.consultation }


### PR DESCRIPTION
### Description of change

- **Add valid_from date to API responses**
- **Add a published_at date to be set when an application is made public**
- **Add published_at date to API responses**
- **Add make_public to ignored_columns in advance of removing it entirely**

### Story Link

https://trello.com/c/wEnTHZQf/3011-add-validatedat-and-published-to-register-date-to-api-output
