### PR TITLE
Add documents endpoint

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/application_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/application_controller.rb
@@ -15,5 +15,15 @@ module BopsApi
     def set_local_authority
       @local_authority = LocalAuthority.find_by!(subdomain: request.subdomain)
     end
+
+    def find_planning_application param
+      if /\A\d{2}-\d{5}-[A-Za-z0-9]+\z/.match?(param)
+        planning_applications_scope.find_by!(reference: param)
+      else
+        planning_applications_scope.find(Integer(param))
+      end
+    rescue ArgumentError
+      raise ActionController::BadRequest, "Invalid planning application reference or id: #{param.inspect}"
+    end
   end
 end

--- a/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
@@ -27,7 +27,7 @@ module BopsApi
       end
 
       def show
-        @planning_application = find_planning_application
+        @planning_application = find_planning_application params[:id]
 
         respond_to do |format|
           format.json
@@ -43,7 +43,7 @@ module BopsApi
       end
 
       def submission
-        @planning_application = find_planning_application
+        @planning_application = find_planning_application params[:id]
         @submission = Application::SubmissionRedactionService.new(planning_application: @planning_application).call
 
         respond_to do |format|
@@ -52,16 +52,6 @@ module BopsApi
       end
 
       private
-
-      def find_planning_application
-        if /\A\d{2}-\d{5}-[A-Za-z0-9]+\z/.match?(params[:id])
-          planning_applications_scope.find_by!(reference: params[:id])
-        else
-          planning_applications_scope.find(Integer(params[:id]))
-        end
-      rescue ArgumentError
-        raise ActionController::BadRequest, "Invalid planning application reference or id: #{params[:id].inspect}"
-      end
 
       def send_email
         query_parameters[:send_email] == "true"

--- a/engines/bops_api/app/controllers/bops_api/v2/public/documents_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/documents_controller.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    module Public
+      class DocumentsController < PublicController
+        def show
+          @planning_application = find_planning_application params[:planning_application_id]
+
+          respond_to do |format|
+            format.json
+          end
+        end
+
+        private
+
+        def planning_applications_scope
+          @local_authority.planning_applications.published
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+json.partial! "bops_api/v2/shared/application", planning_application: @planning_application
+
+json.files @planning_application.documents.for_publication do |document|
+  json.name document.name
+  json.url main_app.api_v1_planning_application_document_url(@planning_application, document)
+  json.extract! document,
+    :created_at,
+    :applicant_description
+end
+
+json.metadata do
+  json.results @planning_application.documents.for_publication.count
+  json.totalResults @planning_application.documents.for_publication.count
+end

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -21,6 +21,7 @@ BopsApi::Engine.routes.draw do
       namespace :public do
         resources :planning_applications, only: [] do
           get :search, on: :collection
+          resource :documents, only: [:show]
         end
       end
     end

--- a/engines/bops_api/schemas/odp/v0.6.0/documents.json
+++ b/engines/bops_api/schemas/odp/v0.6.0/documents.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "integer"
+        },
+        "totalResults": {
+          "type": "integer"
+        }
+      },
+      "required": ["results", "totalResults"]
+    },
+    "application": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": ["value", "description"]
+        },
+        "reference": {
+          "type": "string"
+        },
+        "fullReference": {
+          "type": "string"
+        },
+        "receivedAt": {
+          "format": "datetime",
+          "type": "string"
+        },
+        "validAt": {
+          "format": "datetime",
+          "type": ["string", "null"]
+        },
+        "publishedAt": {
+          "format": "datetime",
+          "type": ["string", "null"]
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": ["type", "reference", "fullReference", "receivedAt", "status"]
+    },
+    "files": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string",
+              "format": "url"
+            },
+            "createdAt": {
+              "format": "datetime",
+              "type": ["string", "null"]
+            },
+            "applicantDescription": {
+              "type": ["string","null"]
+            }
+          },
+          "required": ["name"]
+        }
+      ]
+    }
+  },
+  "required": ["metadata", "application", "files"]
+}

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.6.0/documents.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.6.0/documents.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "type": {
+      "value": "pp.full.householder",
+      "description": "planning_permission"
+    },
+    "reference": "24-00100-HAPP",
+    "fullReference": "PlanX-24-00100-HAPP",
+    "receivedAt": "2024-06-12T15:56:29.830+01:00",
+    "validAt": "2024-06-12T00:00:00.000+01:00",
+    "publishedAt": "2024-06-12T15:56:29.828+01:00",
+    "status": "in_assessment"
+  },
+  "files": [
+    {
+      "name": "proposed-floorplan.png",
+      "url": "http://planx.example.com/api/v1/planning_applications/1889/documents/111",
+      "createdAt": "2024-06-12T15:56:29.803+01:00",
+      "applicantDescription": null
+    }
+  ],
+  "metadata": {
+    "results": 1,
+    "totalResults": 1
+  }
+}

--- a/engines/bops_api/spec/fixtures/examples/planning_applications/documents.json
+++ b/engines/bops_api/spec/fixtures/examples/planning_applications/documents.json
@@ -1,0 +1,26 @@
+{
+  "application": {
+    "type": {
+      "value": "pp.full.householder",
+      "description": "planning_permission"
+    },
+    "reference": "24-00100-HAPP",
+    "fullReference": "PlanX-24-00100-HAPP",
+    "receivedAt": "2024-06-12T15:56:29.830+01:00",
+    "validAt": "2024-06-12T00:00:00.000+01:00",
+    "publishedAt": "2024-06-12T15:56:29.828+01:00",
+    "status": "in_assessment"
+  },
+  "files": [
+    {
+      "name": "proposed-floorplan.png",
+      "url": "http://planx.example.com/api/v1/planning_applications/1889/documents/111",
+      "createdAt": "2024-06-12T15:56:29.803+01:00",
+      "applicantDescription": null
+    }
+  ],
+  "metadata": {
+    "results": 1,
+    "totalResults": 1
+  }
+}

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS public API" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:application_type) { create(:application_type, :householder) }
+  let(:document) { create(:document, validated: true, publishable: true) }
+  let(:planning_application) { create(:planning_application, :published, :with_boundary_geojson, documents: [document], local_authority:, application_type:) }
+
+  path "/api/v2/public/planning_applications/{id}/documents" do
+    get "Retrieves documents for a planning application" do
+      tags "Planning applications"
+      produces "application/json"
+
+      parameter name: :id, in: :path, schema: {
+        oneOf: [
+          {type: :string, pattern: "\d{2}-\d{5}-[A-Za-z0-9]+"},
+          {type: :integer}
+        ],
+        description: "The planning application reference or ID"
+      }
+
+      response "200", "returns a planning application's documents given an ID" do
+        example "application/json", :default, api_json_fixture("planning_applications/documents.json")
+        schema "$ref" => "#/components/schemas/Documents"
+
+        let(:id) { planning_application.id }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["application"]["reference"]).to eq(planning_application.reference)
+          expect(data["files"]).not_to be_empty
+        end
+      end
+
+      response "200", "returns a planning application's documents given a reference" do
+        example "application/json", :default, api_json_fixture("planning_applications/documents.json")
+        schema "$ref" => "#/components/schemas/Documents"
+
+        let(:id) { planning_application.reference }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["application"]["reference"]).to eq(planning_application.reference)
+          expect(data["files"]).not_to be_empty
+        end
+      end
+
+      it "validates successfully against the example documents json" do
+        schema = BopsApi::Schemas.find!("documents", version: "odp/v0.6.0").value
+        schemer = JSONSchemer.schema(schema)
+
+        expect(schemer.valid?(example_fixture("documents.json"))).to eq(true)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   submission_json = BopsApi::Schemas.find!("submission", version: "odp/v0.6.0").value
   search_json = BopsApi::Schemas.find!("search", version: "odp/v0.6.0").value
   application_submission_json = BopsApi::Schemas.find!("applicationSubmission", version: "odp/v0.6.0").value
+  documents_json = BopsApi::Schemas.find!("documents", version: "odp/v0.6.0").value
 
   keys = %w[
     additionalProperties
@@ -34,6 +35,8 @@ RSpec.configure do |config|
   search = search_json.slice(*keys).deep_transform_values(&transformer)
 
   application_submission = application_submission_json.slice(*keys).deep_transform_values(&transformer)
+
+  documents = documents_json.slice(*keys).deep_transform_values(&transformer)
 
   config.openapi_specs = {
     "v2/swagger_doc.yaml" => {
@@ -71,6 +74,8 @@ RSpec.configure do |config|
           Search: search,
 
           ApplicationSubmission: application_submission,
+
+          Documents: documents,
 
           Healthcheck: {
             type: "object",

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -16135,10 +16135,14 @@ components:
                     type: string
                   validAt:
                     format: datetime
-                    type: string
+                    type:
+                    - string
+                    - 'null'
                   publishedAt:
                     format: datetime
-                    type: string
+                    type:
+                    - string
+                    - 'null'
                   status:
                     type: string
                 required:
@@ -16334,6 +16338,82 @@ components:
       required:
       - application
       - submission
+      type: object
+    Documents:
+      properties:
+        metadata:
+          type: object
+          properties:
+            results:
+              type: integer
+            totalResults:
+              type: integer
+          required:
+          - results
+          - totalResults
+        application:
+          type: object
+          properties:
+            type:
+              type: object
+              properties:
+                value:
+                  type: string
+                description:
+                  type: string
+              required:
+              - value
+              - description
+            reference:
+              type: string
+            fullReference:
+              type: string
+            receivedAt:
+              format: datetime
+              type: string
+            validAt:
+              format: datetime
+              type:
+              - string
+              - 'null'
+            publishedAt:
+              format: datetime
+              type:
+              - string
+              - 'null'
+            status:
+              type: string
+          required:
+          - type
+          - reference
+          - fullReference
+          - receivedAt
+          - status
+        files:
+          type: array
+          items:
+          - type: object
+            properties:
+              name:
+                type: string
+              url:
+                type: string
+                format: url
+              createdAt:
+                format: datetime
+                type:
+                - string
+                - 'null'
+              applicantDescription:
+                type:
+                - string
+                - 'null'
+            required:
+            - name
+      required:
+      - metadata
+      - application
+      - files
       type: object
     Healthcheck:
       type: object
@@ -22689,6 +22769,51 @@ paths:
                       message: Unauthorized
               schema:
                 "$ref": "#/components/schemas/UnauthorizedError"
+  "/api/v2/public/planning_applications/{id}/documents":
+    get:
+      summary: Retrieves documents for a planning application
+      tags:
+      - Planning applications
+      parameters:
+      - name: id
+        in: path
+        schema:
+          oneOf:
+          - type: string
+            pattern: d{2}-d{5}-[A-Za-z0-9]+
+          - type: integer
+          description: The planning application reference or ID
+        required: true
+      responses:
+        '200':
+          description: returns a planning application's documents given a reference
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    application:
+                      type:
+                        value: pp.full.householder
+                        description: planning_permission
+                      reference: 24-00100-HAPP
+                      fullReference: PlanX-24-00100-HAPP
+                      receivedAt: '2024-06-12T15:56:29.830+01:00'
+                      validAt: '2024-06-12T00:00:00.000+01:00'
+                      publishedAt: '2024-06-12T15:56:29.828+01:00'
+                      status: in_assessment
+                    files:
+                    - name: proposed-floorplan.png
+                      url: http://planx.example.com/api/v1/planning_applications/1889/documents/111
+                      createdAt: '2024-06-12T15:56:29.803+01:00'
+                      tags: []
+                      numbers: ''
+                      applicantDescription:
+                    metadata:
+                      results: 1
+                      totalResults: 1
+              schema:
+                "$ref": "#/components/schemas/Documents"
   "/api/v2/public/planning_applications/search":
     get:
       summary: Retrieves planning applications based on a search criteria


### PR DESCRIPTION
### Description of change

Add a public endpoint to return all public documents for an application.

### Story Link

https://trello.com/c/jBGKKOOM/3029-add-documents-to-new-api-endpoint

### Decisions [OPTIONAL]

Moved `find_planning_application` (which finds by reference or ID) into the parent class so that we can use it elsewhere. It isn't a strict requirement (yet?) but if we want to start moving in that direction it seems like a good idea to have any new controllers making use of that, especially since it's backwards-compatible anyway so there's no loss.