### PR TITLE
Set the condition position to not-null

### DIFF
--- a/db/migrate/20240617134713_set_condition_position_default_not_null.rb
+++ b/db/migrate/20240617134713_set_condition_position_default_not_null.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class SetConditionPositionDefaultNotNull < ActiveRecord::Migration[7.1]
+  def change
+    up_only do
+      Condition.where(position: nil).update_all(position: 0)
+      change_column_default :conditions, :position, 0
+    end
+
+    add_check_constraint :conditions, "position IS NOT NULL", name: "conditions_position_null", validate: false
+  end
+end

--- a/db/migrate/20240617135942_validate_set_condition_position_default_not_null.rb
+++ b/db/migrate/20240617135942_validate_set_condition_position_default_not_null.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateSetConditionPositionDefaultNotNull < ActiveRecord::Migration[7.1]
+  def up
+    validate_check_constraint :conditions, name: "conditions_position_null"
+    change_column_null :conditions, :position, false
+    remove_check_constraint :conditions, name: "conditions_position_null"
+  end
+
+  def down
+    add_check_constraint :conditions, "position IS NOT NULL", name: "conditions_position_null", validate: false
+    change_column_null :conditions, :position, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_10_102853) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_135942) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -156,7 +156,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_10_102853) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "condition_set_id"
-    t.integer "position"
+    t.integer "position", default: 0, null: false
     t.datetime "cancelled_at"
     t.index ["condition_set_id"], name: "ix_conditions_on_condition_set_id"
   end


### PR DESCRIPTION
### Description of change

Condition position can be null, which breaks if we try to sort by it (null can't be compared with integer). Setting a default of zero seems like the safest option.
