### PR TITLE
Avoid null file representation in documents when returning a url

### DIFF
--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -1,5 +1,5 @@
 <% if document.representable? %>
-  <%= link_to_document image_tag(document.file.representation(resize: resize), style: "max-width:100%"), document %>
+  <%= link_to_document image_tag(document.file, style: "max-width:100%"), document %>
   <p class="govuk-body">
     <%= link_to_document(t(".view_in_new"), document) %>
   </p>

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -187,6 +187,9 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
 
           expect(rows.size).to eq(2)
 
+          expect(page).to have_content("File name: proposed-floorplan.png")
+          expect(page).to have_content("File name: proposed-first-floor-plan.pdf")
+
           within(rows[0]) do
             cells = page.all(".govuk-table__cell")
 
@@ -195,7 +198,6 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
             end
 
             within(cells[1]) do
-              expect(page).to have_content("File name: proposed-floorplan.png")
               expect(page).to have_content("Date received: 1 January 2021")
               expect(page).to have_content("Included in decision notice: No")
               expect(page).to have_content("Public: No")
@@ -210,7 +212,6 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
             end
 
             within(cells[1]) do
-              expect(page).to have_content("File name: proposed-first-floor-plan.pdf")
               expect(page).to have_content("Date received: 1 January 2021")
               expect(page).to have_content("Included in decision notice: No")
               expect(page).to have_content("Public: No")


### PR DESCRIPTION
### Description of change

We're getting a flaky test when sometimes a `file.representation` returns nil and thus can't have a `processed.url` attribute. It seems like this happens in one specific place where the image tag is behaving oddly.