### PR TITLE
Ensure there is always a current review when saving in order to update it

### DIFF
--- a/app/controllers/planning_applications/assessment/conditions_controller.rb
+++ b/app/controllers/planning_applications/assessment/conditions_controller.rb
@@ -63,7 +63,7 @@ module PlanningApplications
       end
 
       def mark_as_complete
-        current_review = @condition_set.current_review
+        current_review = @condition_set.current_review || @condition_set.reviews.new
         if current_review.status == "to_be_reviewed"
           @condition_set.reviews.create!(status: "updated")
           redirect_to planning_application_assessment_tasks_path(@planning_application),

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -173,6 +173,22 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       expect(page).to have_content "The development hereby permitted shall be commenced within three years of the date of this permission."
       expect(page).to have_content "To comply with the provisions of Section 91 of the Town and Country Planning Act 1990 (as amended)."
     end
+
+    context "when there is no current review" do
+      let(:condition_set) { planning_application.condition_set }
+
+      before do
+        condition_set.reviews = []
+      end
+
+      it "doesn't break" do
+        visit "/planning_applications/#{planning_application.id}"
+        click_link "Check and assess"
+
+        click_link "Add conditions"
+        click_button "Save and mark as complete"
+      end
+    end
   end
 
   context "when changing the list position" do


### PR DESCRIPTION
### Description of change

If a review doesn't currently exist, `mark_as_complete` will fail because it tries to check the status. Create one if it doesn't exist.

### Story Link

https://trello.com/c/CwMi48w7/3052-conditionset-currentreview-is-nil-when-marking-conditions-as-complete
