### PR TITLE
Don't serve documents as attachments in the API

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -8,7 +8,7 @@ module Api
       def show
         document =
           PlanningApplication.find(params[:planning_application_id]).documents.for_publication.find(params[:id])
-        redirect_to rails_blob_url(document.file, disposition: "attachment")
+        redirect_to rails_blob_url(document.file)
       end
 
       def tags

--- a/spec/requests/api/document_show_spec.rb
+++ b/spec/requests/api/document_show_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "API request to show document file", show_exceptions: true do
 
     it "redirects to blob url" do
       get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
-      expect(response).to redirect_to(rails_blob_path(document.file, disposition: "attachment"))
+      expect(response).to redirect_to(rails_blob_path(document.file))
     end
   end
 end


### PR DESCRIPTION
### Description of change

Partially reverting the changes in #1839 and #1843 so that files served over the API are not treated as downloads.

It may be that there's no good way of managing both requirements, and it might be better/easier to solve it on the client side, but hopefully this is the least disruptive option.

### Story Link

https://trello.com/c/geWs1Jpo/3042-dpr-would-like-documents-to-open-in-browser-by-default