### PR TITLE
Select only distinct conditions for the decision notice

### DIFF
--- a/app/models/condition_set.rb
+++ b/app/models/condition_set.rb
@@ -30,7 +30,7 @@ class ConditionSet < ApplicationRecord
   end
 
   def approved_conditions
-    conditions.joins(:validation_requests).where(validation_requests: {approved: true})
+    conditions.joins(:validation_requests).where(validation_requests: {approved: true}).distinct
   end
 
   def not_cancelled_conditions


### PR DESCRIPTION
### Description of change

Avoid repeating conditions on the decision notice; I think this happens when one has more than one validation request and so shows up multiple times in the query.

### Story Link

https://trello.com/c/cMrZGuiy/2974-pre-commencement-conditions-showing-twice-on-decision-notice
