### PR TITLE
Update tests for Rails 7.1 readonly attribute behaviour

### DIFF
--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -40,7 +40,7 @@ module PlanningApplications
 
     def update
       ActiveRecord::Base.transaction do
-        @neighbour_response.update!(neighbour_response_params.except(:address, :files))
+        @neighbour_response.update!(neighbour_response_params.except(:address, :files, :response))
         @neighbour_response.neighbour.update!(address: neighbour_response_params[:address]) if address_param_present?
         create_files(@neighbour_response) if files_present?
         create_audit_log(@neighbour_response, "edited")

--- a/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
@@ -16,7 +16,7 @@ module PlanningApplications
       @neighbour_response.redacted_by = current_user
 
       respond_to do |format|
-        if @neighbour_response.update(redact_neighbour_response_params)
+        if @neighbour_response.update(redact_neighbour_response_params.except(:response))
           format.html do
             redirect_to neighbour_responses_path, notice: t(".success")
           end

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,9 +54,6 @@ module Bops
 
     config.active_storage.variant_processor = :mini_magick
 
-    # don't fail tests in this case
-    config.active_record.raise_on_assign_to_attr_readonly = false
-
     # use rails 7.0 encryption method
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
 

--- a/engines/bops_config/app/controllers/bops_config/legislation_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/legislation_controller.rb
@@ -38,7 +38,7 @@ module BopsConfig
 
     def update
       respond_to do |format|
-        if @legislation.update(legislation_params)
+        if @legislation.update(legislation_params.except(:title))
           format.html do
             redirect_to legislation_index_path, notice: t(".success")
           end

--- a/spec/models/legislation_spec.rb
+++ b/spec/models/legislation_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe Legislation do
 
       it "is readonly" do
         legislation = create(:legislation, title: "Legislation title")
-        legislation.update!(title: "A new legislation title")
+
+        expect {
+          legislation.update!(title: "A new legislation title")
+        }.to raise_error(ActiveRecord::ReadonlyAttributeError)
 
         expect(legislation.reload.title).to eq("Legislation title")
       end

--- a/spec/models/neighbour_response_spec.rb
+++ b/spec/models/neighbour_response_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe NeighbourResponse do
     let!(:neighbour_response) { create(:neighbour_response, response: "A response") }
 
     it "response is a readonly attribute" do
-      neighbour_response.update(response: "A new response")
+      expect {
+        neighbour_response.update(response: "A new response")
+      }.to raise_error(ActiveRecord::ReadonlyAttributeError)
 
       expect(neighbour_response.reload.response).to eq("A response")
     end


### PR DESCRIPTION
### Description of change

Rails 7.1 changed the default so that writes to readonly attributes would raise exceptions rather than failing silently. We overrode this behaviour to avoid having to fix it, but in practice it looks like we're only actually running into this behaviour in specific tests that check that the attributes are readonly. Setting aside the question of the value of testing framework behaviour, this is straightforward enough to update and rely on the default behaviour.

### Story Link

https://trello.com/c/7psibLse/2611-tidy-up-writes-to-readonly-attributes
