### PR TITLE
Fix PDF thumbnails

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -52,4 +52,14 @@ module DocumentHelper
       rails_blob_url(document.file, disposition: "attachment")
     end
   end
+
+  def document_thumbnail_link(document, thumbnail_args: {}, image_args: {})
+    image = if document.file.previewable?
+      image_tag(document.file.preview(**thumbnail_args), **image_args)
+    else
+      image_tag(document.file, **image_args)
+    end
+
+    link_to_document image, document
+  end
 end

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -1,5 +1,5 @@
 <% if document.representable? %>
-  <%= link_to_document image_tag(document.file, style: "max-width:100%"), document %>
+  <%= document_thumbnail_link document, thumbnail_args: {resize: resize}, image_args: {style: "max-width: 100%"} %>
   <p class="govuk-body">
     <%= link_to_document(t(".view_in_new"), document) %>
   </p>

--- a/app/views/documents/archive.html.erb
+++ b/app/views/documents/archive.html.erb
@@ -19,7 +19,7 @@
       File name: <%= @document.name %>
     </p>
     <p>
-      <%= link_to_document image_tag(@document.file.representation(resize: "300x212")), @document %>
+      <%= document_thumbnail_link @document, thumbnail_args: {resize: "300x212"} %>
     </p>
     <%= render "archive_form" %>
   </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -29,7 +29,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <% if @document.representable? %>
-      <%= link_to_document image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"), @document %>
+      <%= document_thumbnail_link @document, thumbnail_args: {resize: "500x500"}, image_args: {style: "max-width:100%"} %>
       <%= link_to_document t(".view_in_new"), @document, class: "govuk-body" %>
     <% end %>
   </div>

--- a/app/views/documents/index.html.erb
+++ b/app/views/documents/index.html.erb
@@ -88,7 +88,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-quarter">
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
+              <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
             </p>
             <p class="govuk-body">
               <%= document.name %><br>

--- a/app/views/planning_applications/neighbour_responses/_responses.html.erb
+++ b/app/views/planning_applications/neighbour_responses/_responses.html.erb
@@ -47,7 +47,7 @@
                       <tr class="govuk-table__row">
                         <td class="govuk-table__cell govuk-!-width-one-third">
                           <p class="govuk-body govuk-!-margin-bottom-1">
-                            <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
+                            <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
                           </p>
                           <p class="govuk-body">
                             <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/press_notices/_press_notices.html.erb
+++ b/app/views/planning_applications/press_notices/_press_notices.html.erb
@@ -12,7 +12,7 @@
         <td class="govuk-table__cell govuk-!-width-one-third">
           <% press_notice.documents.with_file_attachment.each do |document| %>
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
+              <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/site_notices/show.html.erb
+++ b/app/views/planning_applications/site_notices/show.html.erb
@@ -28,7 +28,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-third">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to_document image_tag(@site_notice.document.file.representation(resize: "300x212")), @site_notice.document %>
+            <%= document_thumbnail_link @site_notice.document, thumbnail_args: {resize: "300x212"} %>
           </p>
           <p class="govuk-body">
             <%= truncate(@site_notice.document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/site_visits/show.html.erb
+++ b/app/views/planning_applications/site_visits/show.html.erb
@@ -39,7 +39,7 @@
         <tr class="govuk-table__row">
           <td class="govuk-table__cell govuk-!-width-one-third">
             <p class="govuk-body govuk-!-margin-bottom-1">
-              <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
+              <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
             </p>
             <p class="govuk-body">
               <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/document/redactions/_form.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_form.html.erb
@@ -17,7 +17,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-padding-top-3 govuk-!-padding-bottom-3">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to_document image_tag(ff.object.file.representation(resize: "150x106")), ff.object %>
+            <%= document_thumbnail_link ff.object, thumbnail_args: {resize: "150x106"} %>
           </p>
           <p class="govuk-body">
             <%= truncate(ff.object.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
+++ b/app/views/planning_applications/validation/document/redactions/_redacted_table.html.erb
@@ -10,7 +10,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to_document image_tag(document.file.representation(resize: "150x106")), document %>
+            <%= document_thumbnail_link document, thumbnail_args: {resize: "150x106"} %>
           </p>
           <p class="govuk-body">
             <%= truncate(document.name.to_s, length: 50) %><br>

--- a/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
+++ b/app/views/planning_applications/validation/fee_change_validation_requests/_supporting_documents.html.erb
@@ -11,7 +11,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell govuk-!-width-one-half">
           <p class="govuk-body govuk-!-margin-bottom-1">
-            <%= link_to_document image_tag(document.file.representation(resize: "300x212")), document %>
+            <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
           </p>
           <p class="govuk-body">
             <%= link_to_document "View in new window", document %>

--- a/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
+++ b/app/views/planning_applications/validation/replacement_document_validation_requests/_document_summary.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-column-one-half">
-  <%= link_to_document image_tag(@document.file.representation(resize: "500x500"), style: "max-width:100%"), @document %>
+  <%= document_thumbnail_link @document, thumbnail_args: {resize: "500x500"}, image_args: {style: "max-width:100%"} %>
   <p class="govuk-body">
     <%= link_to_document "View in new window", @document %>
   </p>


### PR DESCRIPTION
### Description of change

#1858 introduced an error when the file is a PDF, because it would try to serve the PDF as the image directly.

It seems like the behaviour we actually want is: if it's unrepresentable, show an error (that seemingly means failed virus scan?). If it _is_ representable, then if it's previewable it's a PDF (or video potentially), so generate a thumbnail and serve that; otherwise serve the representation.

### Story Link

https://trello.com/c/WFgCUtGQ/3059-documents-table-tries-to-load-pdf-instead-of-thumbnail