### PR TITLE
Filter out existing neighbours before adding

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -115,7 +115,8 @@ class Consultation < ApplicationRecord
 
   before_save :apply_deadline_extension, if: -> { deadline_extension.present? }
 
-  accepts_nested_attributes_for :consultees, :neighbours
+  accepts_nested_attributes_for :consultees
+  accepts_nested_attributes_for :neighbours, reject_if: :neighbour_exists?
 
   enum status: {
     not_started: "not_started",
@@ -515,5 +516,9 @@ class Consultation < ApplicationRecord
     end
 
     extend_deadline(deadline_extension.days.from_now)
+  end
+
+  def neighbour_exists?(new_neighbour)
+    neighbours.find_by(address: new_neighbour[:address]).present?
   end
 end

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       expect(page).not_to have_content("6, COXSON WAY, LONDON, SE1 2XB")
     end
 
-    it "I cannot add a neighbour address if it already exists" do
+    it "I can add a neighbour address if it already exists" do
       create(:neighbour, consultation:, address: "5, COXSON WAY, LONDON, SE1 2XB")
       # Draw polygon for same addresses
       mock_csrf_token
@@ -359,11 +359,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
       click_button "Continue to sending letters"
 
-      within(".govuk-error-summary") do
-        expect(page).to have_content(
-          "5, COXSON WAY, LONDON, SE1 2XB has already been added."
-        )
-      end
+      expect(page).not_to have_content("5, COXSON WAY, LONDON, SE1 2XB has already been added.")
     end
 
     context "when redrawing the polygon" do


### PR DESCRIPTION
### Description of change

Neighbour records must be unique for a given consultation, but because the map input automatically creates a list of these it's very easy for existing neighbours to be included in the list to be added. Filtering out the existing addresses in the controller means that repeatedly submitting the same area, or overlapping areas, will only add the new neighbours each time, if any, rather than warning of duplicates.

### Story Link

https://trello.com/c/LZLwdKVE/3047-user-cannot-continue-adding-new-neighbour-address-in-boundary-of-neighbours-already-selected

### Decisions

This could probably have been done at a few different levels, e.g. by somehow causing Rails to use a `find_or_create` rather than `create`, but this seemed like the most straightforward.

