### PR TITLE
Toggle ownership details feature for application type

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -83,6 +83,7 @@ class ApplicationType < ApplicationRecord
 
   with_options to: :features do
     delegate :informatives?
+    delegate :ownership_details?
     delegate :planning_conditions?
     delegate :permitted_development_rights?
     delegate :site_visits?

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -4,6 +4,7 @@ class ApplicationTypeFeature
   include StoreModel::Model
 
   attribute :informatives, :boolean, default: false
+  attribute :ownership_details, :boolean, default: true
   attribute :planning_conditions, :boolean, default: false
   attribute :permitted_development_rights, :boolean, default: true
   attribute :site_visits, :boolean, default: false

--- a/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_check_consistency.html.erb
@@ -29,11 +29,13 @@
             category: :past_applications
           )
         ) %>
-    <%= render(
-          TaskListItems::Assessment::OwnershipCertificateComponent.new(
-            planning_application: @planning_application
-          )
-        ) %>
+    <% if @planning_application.application_type.ownership_details? %>
+      <%= render(
+            TaskListItems::Assessment::OwnershipCertificateComponent.new(
+              planning_application: @planning_application
+            )
+          ) %>
+    <% end %>
     <% if @planning_application.planning_application_constraints&.any? %>
       <%= render(
             TaskListItems::Assessment::ConsulteesConsultedComponent.new(

--- a/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
+++ b/app/views/planning_applications/validation/tasks/_application_requirements.html.erb
@@ -9,5 +9,7 @@
 
       render Validation::EnvironmentalImpactAssessmentTask.new(@planning_application, task_list:)
 
-      render Validation::OwnershipCertificateTask.new(@planning_application, task_list:)
+      if @planning_application.application_type.ownership_details?
+        render Validation::OwnershipCertificateTask.new(@planning_application, task_list:)
+      end
     end %>

--- a/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
@@ -32,6 +32,7 @@ module BopsConfig
       def features_attributes
         [
           :informatives,
+          :ownership_details,
           :planning_conditions,
           :permitted_development_rights,
           {consultation_steps: []}

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -22,6 +22,7 @@
       <%= form.fields_for :features, @application_type.features do |ff| %>
         <%= ff.govuk_fieldset legend: {text: t("application_type_features.legends.check_application_details"), size: "s"} do %>
           <%= ff.govuk_check_box :informatives, 1, 0, multiple: false, label: {text: t("application_type_features.labels.informatives")} %>
+          <%= ff.govuk_check_box :ownership_details, 1, 0, multiple: false, label: {text: t("application_type_features.labels.ownership_details")} %>
           <%= ff.govuk_check_box :planning_conditions, 1, 0, multiple: false, label: {text: t("application_type_features.labels.planning_conditions")} %>
           <%= ff.govuk_check_box :permitted_development_rights, 1, 0, multiple: false, label: {text: t("application_type_features.labels.permitted_development_rights")} %>
         <% end %>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -62,6 +62,9 @@
                 <% if @application_type.informatives? %>
                   <li><%= t("application_type_features.labels.informatives") %></li>
                 <% end %>
+                <% if @application_type.ownership_details? %>
+                  <li><%= t("application_type_features.labels.ownership_details") %></li>
+                <% end %>
                 <% if @application_type.permitted_development_rights? %>
                   <li><%= t("application_type_features.labels.permitted_development_rights") %></li>
                 <% end %>

--- a/engines/bops_config/config/locales/application_type_features.yml
+++ b/engines/bops_config/config/locales/application_type_features.yml
@@ -2,6 +2,7 @@ en:
   application_type_features:
     labels:
       informatives: "Add informatives"
+      ownership_details: "Ownership details"
       planning_conditions: "Check planning conditions"
       permitted_development_rights: "Check permitted development rights"
       consultation_steps:

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -519,6 +519,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
     within "dl div:nth-child(7) dd.govuk-summary-list__value" do
       expect(page).to have_selector("p strong", text: "Application details")
       expect(page).to have_selector("li", text: "Add informatives")
+      expect(page).to have_selector("li", text: "Ownership details")
       expect(page).to have_selector("li", text: "Check planning conditions")
       expect(page).not_to have_selector("li", text: "Check permitted development rights")
 
@@ -537,6 +538,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
 
     expect(page).to have_selector("fieldset legend", text: "Check application details")
     expect(page).to have_checked_field("Add informatives")
+    expect(page).to have_checked_field("Ownership details")
     expect(page).to have_checked_field("Check planning conditions")
     expect(page).to have_unchecked_field("Check permitted development rights")
 
@@ -545,6 +547,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
     expect(page).to have_checked_field("Publicity (site notice and press notice)")
     expect(page).to have_unchecked_field("Consultees")
 
+    uncheck("Ownership details")
     uncheck("Check planning conditions")
     check("Check permitted development rights")
     check("Consultees")
@@ -557,6 +560,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
     within "dl div:nth-child(7) dd.govuk-summary-list__value" do
       expect(page).to have_selector("p strong", text: "Application details")
       expect(page).to have_selector("li", text: "Add informatives")
+      expect(page).not_to have_selector("li", text: "Ownership details")
       expect(page).not_to have_selector("li", text: "Check planning conditions")
       expect(page).to have_selector("li", text: "Check permitted development rights")
 
@@ -568,6 +572,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
 
     application_type.reload
     expect(application_type.informatives?).to eq(true)
+    expect(application_type.ownership_details?).to eq(false)
     expect(application_type.planning_conditions?).to eq(false)
     expect(application_type.permitted_development_rights?).to eq(true)
     expect(application_type.consultation_steps).to eq(["neighbour", "consultee", "publicity"])

--- a/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
@@ -10,8 +10,16 @@ RSpec.describe "Check ownership certificate" do
     create(
       :planning_application,
       :in_assessment,
-      local_authority: default_local_authority
+      local_authority: default_local_authority,
+      application_type:
     )
+  end
+
+  let(:application_type) do
+    create(:application_type, features:
+      {
+        "ownership_details" => true
+      })
   end
 
   before do
@@ -115,6 +123,19 @@ RSpec.describe "Check ownership certificate" do
       click_button "Save and mark as complete"
 
       expect(list_item("Check ownership certificate")).to have_content("Completed")
+    end
+  end
+
+  context "when application type does not process ownership details" do
+    let(:application_type) do
+      create(:application_type, features:
+        {
+          "ownership_details" => false
+        })
+    end
+
+    it "does not provide a section for checking ownership details in assessment" do
+      expect(page).not_to have_content("Check ownership certificate")
     end
   end
 end

--- a/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
@@ -154,4 +154,18 @@ RSpec.describe "Check ownership certificate type" do
       end
     end
   end
+
+  context "when application type does not process ownership details" do
+    let!(:planning_application) { create(:planning_application, local_authority: default_local_authority, application_type:) }
+    let(:application_type) do
+      create(:application_type, features:
+        {
+          "ownership_details" => false
+        })
+    end
+
+    it "does not provide a section for checking ownership details in assessment" do
+      expect(page).not_to have_content("Check ownership certificate")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Allow global admin to configure whether an application type needs to process ownership details or not

### Story Link

https://trello.com/c/shxRKHvG/2710-choose-whether-application-type-will-process-ownership-details

