### PR TITLE
Override applicants_url in staging/dev

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -62,6 +62,14 @@ class LocalAuthority < ApplicationRecord
     end
   end
 
+  def applicants_url
+    if Bops.env.production?
+      super
+    else
+      "https://#{subdomain}.#{Rails.configuration.applicants_base_url}"
+    end
+  end
+
   private
 
   def council_code_exists

--- a/app/services/local_authority_creation_service.rb
+++ b/app/services/local_authority_creation_service.rb
@@ -6,12 +6,19 @@ class LocalAuthorityCreationService
     @council_code = params[:council_code]
     @short_name = params[:short_name]
     @council_name = params[:council_name]
-    @applicants_url = params[:applicants_url]
     @admin_email = params[:admin_email]
+
+    @applicants_url = if Bops.env.production?
+      params[:applicants_url]
+    else
+      "https://#{@subdomain}.#{Rails.configuration.applicants_base_url}"
+    end
   end
 
   def call
     setup
+
+    local_authority
   end
 
   private

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -101,4 +101,6 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "notasecret")
   config.active_record.encryption.deterministic_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "notasecret")
   config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT", "notasecret")
+
+  config.applicants_base_url = "bops-applicants.localhost:3001"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -140,4 +140,7 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = ENV["ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY"]
   config.active_record.encryption.deterministic_key = ENV["ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY"]
   config.active_record.encryption.key_derivation_salt = ENV["ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT"]
+
+  # nb. only used in staging: production will override
+  config.applicants_base_url = "bops-applicants-staging.services"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -75,4 +75,6 @@ Rails.application.configure do
   config.active_record.encryption.primary_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY", "notasecret")
   config.active_record.encryption.deterministic_key = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY", "notasecret")
   config.active_record.encryption.key_derivation_salt = ENV.fetch("ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT", "notasecret")
+
+  config.applicants_base_url = "bops-applicants.services"
 end

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -86,4 +86,49 @@ RSpec.describe LocalAuthority do
       end
     end
   end
+
+  describe "#applicants_url" do
+    let(:local_authority) { build(:local_authority, :lambeth) }
+    before do
+      allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return(bops_env)
+      allow(Rails).to receive(:env).and_return(ActiveSupport::StringInquirer.new(rails_env))
+    end
+
+    context "when in production" do
+      let(:bops_env) { "production" }
+      let(:rails_env) { bops_env }
+
+      it "returns the database value" do
+        expect(local_authority.applicants_url).to eq(local_authority[:applicants_url])
+      end
+    end
+
+    context "when in staging" do
+      let(:bops_env) { "staging" }
+      let(:rails_env) { "production" }
+
+      it "does not return the database value" do
+        expect(local_authority.applicants_url).not_to eq(local_authority[:applicants_url])
+      end
+
+      it "returns the configured value" do
+        # nb. because this is set at startup time, it won't get the staging version from the production
+        # config; instead it gets the test version.
+        expect(local_authority.applicants_url).to eq("https://#{local_authority.subdomain}.bops-applicants.services")
+      end
+    end
+
+    context "when in development" do
+      let(:bops_env) { "development" }
+      let(:rails_env) { bops_env }
+
+      it "does not return the database value" do
+        expect(local_authority.applicants_url).not_to eq(local_authority[:applicants_url])
+      end
+
+      it "returns the configured value" do
+        expect(local_authority.applicants_url).to eq("https://#{local_authority.subdomain}.bops-applicants.services")
+      end
+    end
+  end
 end

--- a/spec/services/local_authority_creation_service_spec.rb
+++ b/spec/services/local_authority_creation_service_spec.rb
@@ -72,4 +72,34 @@ RSpec.describe LocalAuthorityCreationService do
       end
     end
   end
+  context "when in staging" do
+    let(:options) do
+      {
+        subdomain: "lambeth",
+        council_code: "LBH",
+        short_name: "Lambeth",
+        council_name: "Lambeth Council",
+        applicants_url: "https://planningapplications.lambeth.gov.uk",
+        signatory_name: "Christina Thompson",
+        signatory_job_title: "Director of Finance & Property",
+        enquiries_paragraph: "Planning, London Borough of Lambeth, PO Box 734, Winchester SO23 5DG",
+        email_address: "planning@lambeth.gov.uk",
+        feedback_email: "feedback_email@lambeth.gov.uk",
+        admin_email: "admin_email@lambeth.gov.uk"
+      }
+    end
+
+    let(:service) do
+      described_class.new(options)
+    end
+
+    before do
+      allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("staging")
+    end
+
+    it "overrides the applicants url" do
+      local_authority = service.call
+      expect(local_authority.applicants_url).not_to eq(options[:applicants_url])
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

While we want to allow councils to configure their instance URLs in production, on a staging instance only our URLs are supported, so we should override this so that it can't be accidentally mis-set.

### Story Link

https://trello.com/c/shQ0VCNg/3066-ensure-staging-instances-use-consistent-urls
