### PR TITLE
Show constraint layers and entities on planning data

### DIFF
--- a/app/controllers/planning_applications/validation/constraints_controller.rb
+++ b/app/controllers/planning_applications/validation/constraints_controller.rb
@@ -8,6 +8,9 @@ module PlanningApplications
       before_action :set_other_constraints, only: %i[index]
 
       def index
+        respond_to do |format|
+          format.html
+        end
       end
 
       def create

--- a/app/helpers/planning_data_helper.rb
+++ b/app/helpers/planning_data_helper.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module PlanningDataHelper
+  PLANNING_DATA_BASE_URL = "https://www.planning.data.gov.uk/"
+
+  def planning_data_entity_url(entity_id)
+    "#{PLANNING_DATA_BASE_URL}entity/#{entity_id}"
+  end
+
+  def planning_data_map_url(datasets, planning_application)
+    uri = URI.join(PLANNING_DATA_BASE_URL, "map/")
+    uri.query = URI.encode_www_form({dataset: datasets}) if datasets.any?
+    uri.fragment = lat_lon_zoom(planning_application)
+    uri.to_s
+  end
+
+  private
+
+  def lat_lon_zoom(planning_application)
+    "#{planning_application.latitude},#{planning_application.longitude},17"
+  end
+end

--- a/app/models/planning_application_constraint.rb
+++ b/app/models/planning_application_constraint.rb
@@ -36,8 +36,16 @@ class PlanningApplicationConstraint < ApplicationRecord
     metadata["description"] if metadata
   end
 
+  def dataset
+    data&.pluck("dataset")
+  end
+
   def checked?
     (identified? && !removed_at?) || !identified?
+  end
+
+  def entities
+    data&.pluck("name", "entity")
   end
 
   private

--- a/app/views/planning_applications/validation/constraints/_row.html.erb
+++ b/app/views/planning_applications/validation/constraints/_row.html.erb
@@ -6,6 +6,15 @@
   </td>
   <td class="govuk-table__cell">
     <%= planning_application_constraint.type_code %>
+
+    <% if show_entity && planning_application_constraint.entities.present? %>
+        <ul class="govuk-list">
+          <% planning_application_constraint.entities.each do |name, entity| %>
+            <% entity_name = name.present? ? name.titleize : "Entity ##{entity}" %>
+            <li><%= govuk_link_to entity_name, planning_data_entity_url(entity), new_tab: true %></li>
+          <% end %>
+        </ul>
+    <% end %>
   </td>
   <% if show_source %>
     <td class="govuk-table__cell">

--- a/app/views/planning_applications/validation/constraints/_table.html.erb
+++ b/app/views/planning_applications/validation/constraints/_table.html.erb
@@ -2,7 +2,7 @@
   <%= tag.table(class: ["govuk-table", "#{identifier}-constraints-table"]) do %>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-third">
           Category
         </th>
         <th scope="col" class="govuk-table__header">
@@ -25,7 +25,8 @@
                 partial: "row",
                 locals: {
                   planning_application_constraint: planning_application_constraint,
-                  show_source: show_source
+                  show_source: show_source,
+                  show_entity: show_entity
                 }
               ) %>
         <% end %>

--- a/app/views/planning_applications/validation/constraints/index.html.erb
+++ b/app/views/planning_applications/validation/constraints/index.html.erb
@@ -22,18 +22,22 @@
 <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">Identified constraints</h2>
+    <p class="govuk-body">
+      <%= govuk_link_to "View map on Planning Data", planning_data_map_url(@planning_application_constraints.flat_map(&:dataset).compact, @planning_application), new_tab: true %>
+    </p>
     <%= render(
           partial: "table",
           locals: {
             title: "Identified constraints",
             identifier: "identified",
             planning_application_constraints: @planning_application_constraints,
-            show_source: true
+            show_source: true,
+            show_entity: true
           }
         ) %>
 
 <div class="govuk-grid-row govuk-!-margin-top-6 govuk-!-margin-bottom-6">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-full">
     <details class="govuk-details" <%= "open" if params[:q].present? %>>
       <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
@@ -54,7 +58,8 @@
                 title: "",
                 identifier: "other",
                 planning_application_constraints: @other_constraints,
-                show_source: false
+                show_source: false,
+                show_entity: false
               }
             ) %>
       </div>

--- a/spec/factories/planning_application_constraint.rb
+++ b/spec/factories/planning_application_constraint.rb
@@ -7,5 +7,61 @@ FactoryBot.define do
     planning_application_constraints_query
 
     identified_by { "BOPS" }
+
+    trait :with_tree_preservation_zone do
+      data {
+        [
+          {
+            "name" => "School Nature Area, Cobourg Road",
+            "entity" => 19109825,
+            "prefix" => "tree-preservation-zone",
+            "dataset" => "tree-preservation-zone",
+            "end-date" => "",
+            "typology" => "geography",
+            "reference" => "",
+            "entry-date" => "2021-12-02",
+            "start-date" => "1993-01-13",
+            "organisation-entity" => "329",
+            "tree-preservation-type" => "Woodland",
+            "tree-preservation-order" => "228"
+          }
+        ]
+      }
+    end
+
+    trait :with_listed_building_and_outline do
+      data {
+        [
+          {
+            "name" => "47, COBOURG ROAD",
+            "entity" => 31834148,
+            "prefix" => "listed-building",
+            "dataset" => "listed-building",
+            "end-date" => "",
+            "typology" => "geography",
+            "reference" => "1378486",
+            "entry-date" => "2023-05-25",
+            "start-date" => "1986-01-24",
+            "documentation-url" => "https://historicengland.org.uk/listing/the-list/list-entry/1378486",
+            "organisation-entity" => "16",
+            "listed-building-grade" => "II"
+          },
+          {
+            "name" => "",
+            "entity" => 42102419,
+            "prefix" => "listed-building-outline",
+            "dataset" => "listed-building-outline",
+            "end-date" => "",
+            "typology" => "geography",
+            "reference" => "470787",
+            "entry-date" => "2021-12-08",
+            "start-date" => "1986-01-24",
+            "documentation-url" => "https://geo.southwark.gov.uk/connect/analyst/Includes/ListedBuildings/SwarkLB201.pdf",
+            "organisation-entity" => "329",
+            "listed-building-grade" => "II"
+          }
+        ]
+      }
+    end
   end
 end

--- a/spec/helpers/planning_data_helper_spec.rb
+++ b/spec/helpers/planning_data_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningDataHelper do
+  describe ".planning_data_map_url" do
+    let(:planning_application) { create(:planning_application) }
+    let(:url) { planning_data_map_url(datasets, planning_application) }
+
+    context "when there are datasets" do
+      let(:datasets) { ["tree-preservation-zone", "listed-building", "listed-building-outline"] }
+
+      it "generates the map url with query parameters and centers on the planning application" do
+        expect(url).to eq(
+          "https://www.planning.data.gov.uk/map/?dataset=tree-preservation-zone&dataset=listed-building&dataset=listed-building-outline##{"#{planning_application.latitude},#{planning_application.longitude},17"}"
+        )
+      end
+    end
+
+    context "when there are no datasets" do
+      let(:datasets) { [] }
+
+      it "generates the map url and centers on the planning application" do
+        expect(url).to eq("https://www.planning.data.gov.uk/map/##{"#{planning_application.latitude},#{planning_application.longitude},17"}")
+      end
+    end
+  end
+
+  describe ".planning_data_entity_url" do
+    let(:url) { planning_data_entity_url(entity) }
+    let(:entity) { 12345 }
+
+    it "generates the entity url" do
+      expect(url).to eq("https://www.planning.data.gov.uk/entity/12345")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Add link to planning data map with constraint layers pre-selected
- Add link to planning data individual entities

### Story Link

https://trello.com/c/ionh9LKS/3096-link-to-pre-selected-constraint-layers-on-planning-data-map-and-add-link-to-entities-in-check-constraints-table

### Screenshots

<img width="842" alt="Screenshot 2024-07-31 at 11 18 25" src="https://github.com/user-attachments/assets/f53bf992-ec90-46c7-8aaa-a4b7e479cdab">


<img width="1225" alt="Screenshot 2024-07-30 at 15 12 30" src="https://github.com/user-attachments/assets/358a2380-6eaf-470c-95dc-5a28d0079eb8">


