### PR TITLE
Post production cases to staging for testing

### DIFF
--- a/app/jobs/post_application_to_staging_job.rb
+++ b/app/jobs/post_application_to_staging_job.rb
@@ -4,6 +4,10 @@ class PostApplicationToStagingJob < ApplicationJob
   queue_as :low_priority
 
   def perform(local_authority, planning_application)
-    Apis::Bops::Query.new.post(local_authority.subdomain, planning_application)
+    if (submission = planning_application.params_v2)
+      Apis::Bops::Query.new.post(local_authority.subdomain, submission)
+    else
+      Appsignal.send_error("Unable to find submission data for planning application with id: #{planning_application.id}")
+    end
   end
 end

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -7,11 +7,13 @@ module Apis
     class Client
       TIMEOUT = 5
 
-      def call(local_authority, planning_application)
+      def call(local_authority, submission)
         faraday(local_authority).post("planning_applications") do |request|
           request.options[:timeout] = TIMEOUT
-          request.body = JSON.parse(planning_application.params_v1).merge("send_email" => "false",
-            "from_production" => "true").to_json
+          request.body = submission.merge(
+            "send_email" => "false",
+            "from_production" => "true"
+          ).to_json
         end
       end
 

--- a/app/services/apis/bops/query.rb
+++ b/app/services/apis/bops/query.rb
@@ -5,8 +5,8 @@ require "faraday"
 module Apis
   module Bops
     class Query
-      def post(local_authority, planning_application)
-        client.call(local_authority, planning_application)
+      def post(local_authority, submission)
+        client.call(local_authority, submission)
       rescue Faraday::ClientError
         []
       rescue Faraday::Error => e

--- a/spec/jobs/post_application_to_staging_job_spec.rb
+++ b/spec/jobs/post_application_to_staging_job_spec.rb
@@ -3,17 +3,31 @@
 require "rails_helper"
 
 RSpec.describe PostApplicationToStagingJob do
-  let!(:planning_application) { create(:planning_application, :from_planx) }
+  let(:planning_application) { create(:planning_application) }
 
   before do
     stub_bops_api_request_for(planning_application.local_authority, planning_application)
   end
 
-  it "calls the query to post to staging" do
-    expect_any_instance_of(Apis::Bops::Query).to receive(:post)
-      .with(planning_application.local_authority.subdomain, planning_application)
-      .and_call_original
+  context "when there is an ODP submission" do
+    before do
+      create(:planx_planning_data, params_v2: api_json_fixture("odp/v0.7.0/validPlanningPermission.json"), planning_application:)
+    end
 
-    described_class.perform_now(planning_application.local_authority, planning_application)
+    it "calls the query to post to staging" do
+      expect_any_instance_of(Apis::Bops::Query).to receive(:post)
+        .with(planning_application.local_authority.subdomain, planning_application.params_v2)
+        .and_call_original
+
+      described_class.perform_now(planning_application.local_authority, planning_application)
+    end
+  end
+
+  context "when there is no ODP submission" do
+    it "sends an error to AppSignal" do
+      expect(Appsignal).to receive(:send_error).with("Unable to find submission data for planning application with id: #{planning_application.id}")
+
+      described_class.perform_now(planning_application.local_authority, planning_application)
+    end
   end
 end

--- a/spec/services/apis/bops/client_spec.rb
+++ b/spec/services/apis/bops/client_spec.rb
@@ -4,13 +4,16 @@ require "rails_helper"
 
 RSpec.describe Apis::Bops::Client do
   let(:client) { described_class.new }
-  let(:planning_application) { create(:planning_application, :from_planx) }
+  let(:planning_application) { create(:planning_application) }
+
+  before do
+    create(:planx_planning_data, params_v2: api_json_fixture("odp/v0.7.0/validPlanningPermission.json"), planning_application:)
+  end
 
   describe "#call" do
     it "is successful" do
       Rails.configuration.staging_api_bearer = "testtesttest"
-
-      expect(client.call(planning_application.local_authority.subdomain, planning_application).status).to eq(200)
+      expect(client.call(planning_application.local_authority.subdomain, planning_application.params_v2).status).to eq(200)
     end
   end
 end

--- a/spec/services/apis/bops/query_spec.rb
+++ b/spec/services/apis/bops/query_spec.rb
@@ -3,16 +3,20 @@
 require "rails_helper"
 
 RSpec.describe Apis::Bops::Query do
-  let(:planning_application) { create(:planning_application, :from_planx) }
+  let(:planning_application) { create(:planning_application) }
+
+  before do
+    create(:planx_planning_data, params_v2: api_json_fixture("odp/v0.7.0/validPlanningPermission.json"), planning_application:)
+  end
 
   describe ".fetch" do
     it "initializes a Client object with planning application audit log and invokes #call" do
       expect_any_instance_of(Apis::Bops::Client).to receive(:call).with(
         planning_application.local_authority.subdomain,
-        planning_application
+        planning_application.params_v2
       ).and_call_original
 
-      described_class.new.post(planning_application.local_authority.subdomain, planning_application)
+      described_class.new.post(planning_application.local_authority.subdomain, planning_application.params_v2)
     end
   end
 end

--- a/spec/support/api/bops_helpers.rb
+++ b/spec/support/api/bops_helpers.rb
@@ -4,7 +4,7 @@ module BopsHelper
   BASE_URL = "bops-staging.services/planning_applications"
 
   def stub_bops_api_request_for(local_authority, planning_application)
-    stub_request(:post, "https://#{local_authority.subdomain}.#{BASE_URL}").with(body: planning_application.params_v1).to_return(bops_api_response(200))
+    stub_request(:post, "https://#{local_authority.subdomain}.#{BASE_URL}").with(body: planning_application.params_v2).to_return(bops_api_response(200))
   end
 
   def stub_any_bops_api_request


### PR DESCRIPTION
### Description of change

- Previously, we were using `params_v1` as the submission data to create the production application in staging. This is no longer used with the new ODP schema
- Switch to using `params_v2` and send an error to AppSignal if this is not present when trying to run the job

- Need to manually call this job for all the applications that failed to submit 

### Story Link

https://trello.com/c/FYWWuQt7/3074-investigate-production-cases-not-being-pulled-through-to-staging
