### PR TITLE
Add hint text to choosing policy information

### DIFF
--- a/app/javascript/controllers/consideration_form_controller.js
+++ b/app/javascript/controllers/consideration_form_controller.js
@@ -32,7 +32,7 @@ export default class extends Controller {
       defaultValue: "",
       displayMenu: "overlay",
       showNoOptionsFound: false,
-      minLength: 3,
+      minLength: 1,
       confirmOnBlur: false,
       source: (query, populateResults) => {
         this.findPolicyReference(query, populateResults)
@@ -68,7 +68,7 @@ export default class extends Controller {
       defaultValue: "",
       displayMenu: "overlay",
       showNoOptionsFound: false,
-      minLength: 3,
+      minLength: 1,
       confirmOnBlur: false,
       source: (query, populateResults) => {
         this.findPolicyGuidance(query, populateResults)

--- a/app/models/local_authority/policy_guidance.rb
+++ b/app/models/local_authority/policy_guidance.rb
@@ -35,7 +35,7 @@ class LocalAuthority < ApplicationRecord
 
       def search_param(query)
         query.to_s
-          .scan(/[-\w]{3,}/)
+          .scan(/[-\w]{1,}/)
           .map { |word| word.gsub(/^-/, "!") }
           .map { |word| word.gsub(/-$/, "") }
           .map { |word| word.gsub(/.+/, "\\0:*") }

--- a/app/models/local_authority/policy_reference.rb
+++ b/app/models/local_authority/policy_reference.rb
@@ -44,7 +44,7 @@ class LocalAuthority < ApplicationRecord
 
       def search_param(query)
         query.to_s
-          .scan(/[-\w]{3,}/)
+          .scan(/[-\w]{1,}/)
           .map { |word| word.gsub(/^-/, "!") }
           .map { |word| word.gsub(/-$/, "") }
           .map { |word| word.gsub(/.+/, "\\0:*") }

--- a/app/views/planning_applications/assessment/considerations/edit.html.erb
+++ b/app/views/planning_applications/assessment/considerations/edit.html.erb
@@ -59,6 +59,7 @@
           <div class="govuk-form-group">
             <%= form.govuk_text_field :policy_references,
                   label: {text: "Enter policy references"},
+                  hint: {text: "Start typing to find an existing policy reference"},
                   form_group: {class: "govuk-!-margin-bottom-0", data: {consideration_form_target: "policyReferencesContainer"}},
                   data: {consideration_form_target: "policyReferencesInput"} %>
 
@@ -88,6 +89,7 @@
           <div class="govuk-form-group">
             <%= form.govuk_text_field :policy_guidance,
                   label: {text: "Enter policy guidance (optional)"},
+                  hint: {text: "Start typing to find existing policy guidance"},
                   form_group: {class: "govuk-!-margin-bottom-0", data: {consideration_form_target: "policyGuidanceContainer"}},
                   data: {consideration_form_target: "policyGuidanceInput"} %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -179,7 +179,7 @@ en:
             policy_area:
               blank: Enter the policy area of this consideration
             policy_references:
-              blank: Enter at least one policy reference for this consideration
+              blank: Enter at least one existing policy reference for this consideration
         consistency_checklist:
           attributes:
             description_matches_documents:

--- a/spec/system/planning_applications/assessing/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_against_policies_and_guidance_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Assessing against policies and guidance", type: :system, js: tru
 
     within "div[role=alert]" do
       expect(page).to have_content("Enter the policy area of this consideration")
-      expect(page).to have_content("Enter at least one policy reference for this consideration")
+      expect(page).to have_content("Enter at least one existing policy reference for this consideration")
       expect(page).to have_content("Enter the assessment of this consideration")
       expect(page).to have_content("Enter the conclusion for this consideration")
     end
@@ -62,12 +62,14 @@ RSpec.describe "Assessing against policies and guidance", type: :system, js: tru
     fill_in "Enter policy area", with: "Design"
     pick "Design", from: "#consideration-policy-area-field"
 
+    expect(page).to have_selector("div.govuk-hint", text: "Start typing to find an existing policy reference")
     fill_in "Enter policy references", with: "Wall"
     pick "PP100 - Wall materials", from: "#policyReferencesAutoComplete"
 
     fill_in "Enter policy references", with: "Roofing"
     pick "PP101 - Roofing materials", from: "#policyReferencesAutoComplete"
 
+    expect(page).to have_selector("div.govuk-hint", text: "Start typing to find existing policy guidance")
     fill_in "Enter policy guidance", with: "Design"
     pick "Design Guidance", from: "#policyGuidanceAutoComplete"
 


### PR DESCRIPTION
### Description of change

Add hint text to choosing policy information
- Reduce input word count from 3 to 1 for easier searching. Obviously this will perform the first query earlier but matching 3 characters to see results adds too much friction

### Story Link

https://trello.com/c/PLJ9Ghjr/3120-enter-at-least-one-policy-reference-for-this-consideration-even-when-field-is-completed-in-assessment

