### PR TITLE
Add Leaflet-based map to review page

### DIFF
--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -10,15 +10,13 @@
   <p class="govuk-body">
     <%= t(".site_map_drawn_by", name: site_map_drawn_by) %>
   </p>
-  <%= render(
-        partial: "shared/location_map",
-        locals: {
-          locals: {
-            in_accordion: false,
-            geojson: planning_application.boundary_geojson
-          }
-        }
-      ) %>
+  <%= tag.div id: :map,
+        style: "height: 733.333px",
+        data: {
+          controller: :map,
+          latLong: [planning_application.latitude, planning_application.longitude].join(","),
+          redline: planning_application.boundary_geojson
+        } %>
 <% else %>
   <p class="govuk-body"><%= t(".no_digital_sitemap") %></p>
 <% end %>

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -46,6 +46,9 @@ application.register("neighbours", NeighboursController)
 import ConsiderationFormController from "./consideration_form_controller.js"
 application.register("consideration-form", ConsiderationFormController)
 
+import MapController from "./map_controller.js"
+application.register("map", MapController)
+
 import PdfController from "./pdf_controller.js"
 application.register("pdf", PdfController)
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+import "leaflet"
+import "leaflet-css"
+
+export default class extends Controller {
+  connect() {
+    const [lat, long, ..._] = this.element.dataset.latlong.split(",")
+    this.map = L.map(this.element.id, {
+      center: [lat, long],
+      zoom: 12,
+    })
+    L.tileLayer("https://tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      maxZoom: 25,
+      attribution:
+        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(this.map)
+
+    const redline = JSON.parse(this.element.dataset.redline)
+    L.geoJson(redline, {
+      style: {
+        color: "#ff0000",
+        weight: 2,
+        opacity: 0.67,
+      },
+    }).addTo(this.map)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "govuk-frontend": "^5.2.0",
     "is-svg": "^5.0.0",
     "jspdf": "^2.5.1",
+    "leaflet": "^1.9.4",
+    "leaflet-css": "^0.1.0",
     "puppeteer": "^21.0.0",
     "sortablejs": "^1.15.2",
     "stimulus": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,16 @@ jspdf@^2.5.1:
     dompurify "^2.2.0"
     html2canvas "^1.0.0-rc.5"
 
+leaflet-css@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/leaflet-css/-/leaflet-css-0.1.0.tgz#c1d07652092897b6321fa5caf634a15472ef152d"
+  integrity sha512-KWbt3jNLkEBYl7S/rcj5CAUgHeVVvniHgv2qmkpRrQnyLy3cV1FkY3c68cbKXuYvQMR4J8NQxiPHrRmKq6t+dA==
+
+leaflet@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
+  integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
+
 lerc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lerc/-/lerc-3.0.0.tgz#36f36fbd4ba46f0abf4833799fff2e7d6865f5cb"


### PR DESCRIPTION
### Description of change

Replacing the openlayers-based map with a more extensible leaflet-based one. Currently only showing the redline as before.

### Story Link

https://trello.com/c/AfTxlO7f/3129-add-new-style-map-to-review-page

### Screenshots

<img width="1195" alt="Screenshot 2024-08-08 at 15 24 12" src="https://github.com/user-attachments/assets/3f3066d7-eda3-4263-a1ca-8faaf93cf2e0">

