### PR TITLE
Use planning application reference in routes

### DIFF
--- a/app/components/task_list_items/assessment/conditions_component.rb
+++ b/app/components/task_list_items/assessment/conditions_component.rb
@@ -10,7 +10,7 @@ module TaskListItems
       private
 
       attr_reader :condition_set
-      delegate :planning_application_id, to: :condition_set
+      delegate :planning_application, to: :condition_set
 
       def link_text
         pre_commencement? ? "Add pre-commencement conditions" : "Add conditions"
@@ -18,9 +18,9 @@ module TaskListItems
 
       def link_path
         if pre_commencement?
-          planning_application_assessment_pre_commencement_conditions_path(planning_application_id)
+          planning_application_assessment_pre_commencement_conditions_path(planning_application.reference)
         else
-          planning_application_assessment_conditions_path(planning_application_id)
+          planning_application_assessment_conditions_path(planning_application.reference)
         end
       end
 

--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -6,8 +6,8 @@ module Api
       skip_before_action :authenticate
 
       def show
-        document =
-          PlanningApplication.find(params[:planning_application_id]).documents.for_publication.find(params[:id])
+        raise ActiveRecord::RecordNotFound unless planning_application
+        document = planning_application.documents.for_publication.find(params[:id])
         redirect_to rails_public_blob_url(document.file)
       end
 

--- a/app/controllers/api/v1/neighbour_responses_controller.rb
+++ b/app/controllers/api/v1/neighbour_responses_controller.rb
@@ -33,8 +33,7 @@ module Api
       private
 
       def set_application
-        @planning_application =
-          current_local_authority.planning_applications.find_by(id: params[:planning_application_id])
+        @planning_application = planning_application
 
         return if @planning_application
 

--- a/app/controllers/api/v1/planning_applications_controller.rb
+++ b/app/controllers/api/v1/planning_applications_controller.rb
@@ -9,7 +9,7 @@ module Api
       skip_before_action :set_default_format, only: %i[decision_notice]
 
       def show
-        @planning_application = current_local_authority.planning_applications.where(id: params[:id]).first
+        @planning_application = planning_application
         if @planning_application
           respond_to(:json)
         else
@@ -18,7 +18,7 @@ module Api
       end
 
       def decision_notice
-        @planning_application = current_local_authority.planning_applications.where(id: params[:id]).first
+        @planning_application = planning_application
         @blank_layout = true
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -30,15 +30,27 @@ class ApplicationController < ActionController::Base
 
   protected
 
-  def set_planning_application
-    param = params[planning_application_param]
-    application = if param.match?(/[a-z]/i)
+  def get_planning_application(param)
+    if param.match?(/[a-z]/i)
       planning_applications_scope.find_by!(reference: param)
     else
       planning_applications_scope.find(planning_application_id)
     end
+  end
+
+  def set_planning_application
+    param = params[planning_application_param]
+    application = get_planning_application(param)
 
     @planning_application = PlanningApplicationPresenter.new(view_context, application)
+  end
+
+  def redirect_to_reference_url
+    param = params[planning_application_param]
+    return if param.match?(/[a-z]/i)
+    planning_application = get_planning_application(param)
+
+    redirect_to request.env["PATH_INFO"].gsub(%r{/#{planning_application.id}}, "/#{planning_application.reference}")
   end
 
   def planning_applications_scope

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,13 @@ class ApplicationController < ActionController::Base
   protected
 
   def set_planning_application
-    application = planning_applications_scope.find(planning_application_id)
+    param = params[planning_application_param]
+    application = if param.match?(/[a-z]/i)
+      planning_applications_scope.find_by!(reference: param)
+    else
+      planning_applications_scope.find(planning_application_id)
+    end
+
     @planning_application = PlanningApplicationPresenter.new(view_context, application)
   end
 
@@ -40,7 +46,7 @@ class ApplicationController < ActionController::Base
   end
 
   def planning_application_param
-    request.path_parameters.key?(:planning_application_id) ? :planning_application_id : :id
+    request.path_parameters.key?(:planning_application_reference) ? :planning_application_reference : :reference
   end
 
   def planning_application_id

--- a/app/controllers/os_places_api_controller.rb
+++ b/app/controllers/os_places_api_controller.rb
@@ -30,6 +30,11 @@ class OsPlacesApiController < ApplicationController
   end
 
   def set_planning_application
-    @planning_application = current_local_authority.planning_applications.find_by(id: planning_application_id)
+    param = params[:planning_application]
+    @planning_application = if param.match?(/[a-z]/i)
+      current_local_authority.planning_applications.find_by(reference: param)
+    else
+      current_local_authority.planning_applications.find_by(id: planning_application_id)
+    end
   end
 end

--- a/app/controllers/planning_applications/assessment/consistency_checklists_controller.rb
+++ b/app/controllers/planning_applications/assessment/consistency_checklists_controller.rb
@@ -4,6 +4,7 @@ module PlanningApplications
   module Assessment
     class ConsistencyChecklistsController < BaseController
       before_action :set_consistency_checklist, except: %i[new create]
+      before_action :redirect_to_reference_url
 
       def show
       end

--- a/app/controllers/planning_applications/assessment/tasks_controller.rb
+++ b/app/controllers/planning_applications/assessment/tasks_controller.rb
@@ -3,6 +3,8 @@
 module PlanningApplications
   module Assessment
     class TasksController < BaseController
+      before_action :redirect_to_reference_url
+
       def index
         respond_to do |format|
           format.html

--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -96,7 +96,7 @@ module PlanningApplications
 
     def create_audit_log(_neighbour_response, action)
       Audit.create!(
-        planning_application_id:,
+        planning_application_id: @planning_application.id,
         user: Current.user,
         activity_type: "neighbour_response_#{action}",
         audit_comment: "Neighbour response from #{@neighbour_response.neighbour.address} was #{action}"

--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -123,7 +123,7 @@ module PlanningApplications
       end
 
       Audit.create!(
-        planning_application_id:,
+        planning_application_id: @planning_application.id,
         user: Current.user,
         activity_type: "site_notice_created",
         audit_comment: comment

--- a/app/controllers/planning_applications/validation/base_controller.rb
+++ b/app/controllers/planning_applications/validation/base_controller.rb
@@ -4,6 +4,7 @@ module PlanningApplications
   module Validation
     class BaseController < AuthenticationController
       before_action :set_planning_application
+      before_action :redirect_to_reference_url
 
       def index
         redirect_to planning_application_validation_tasks_url(@planning_application)

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -9,6 +9,8 @@ class PlanningApplicationsController < AuthenticationController
   before_action :ensure_site_notice_displayed_at, only: %i[determine]
   before_action :ensure_press_notice_published_at, only: %i[determine]
 
+  before_action :redirect_to_reference_url, only: %i[show edit]
+
   rescue_from PlanningApplication::WithdrawRecommendationError do |_exception|
     redirect_failed_withdraw_recommendation
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -386,7 +386,7 @@ class Consultation < ApplicationRecord
   end
 
   def application_link
-    "#{local_authority.applicants_url}/planning_applications/#{planning_application_id}"
+    "#{local_authority.applicants_url}/planning_applications/#{planning_application.reference}"
   end
 
   def period_days

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -400,7 +400,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def site_notice_link
-    "#{local_authority.applicants_url}/planning_applications/#{id}/site_notices/download"
+    "#{local_authority.applicants_url}/planning_applications/#{reference}/site_notices/download"
   end
 
   def last_site_notice_audit

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -940,6 +940,10 @@ class PlanningApplication < ApplicationRecord
     documents.for_publication + site_notice_documents_for_publication
   end
 
+  def to_param
+    reference
+  end
+
   private
 
   def create_fee_calculation

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -27,7 +27,7 @@
                 <p class="govuk-body govuk-!-margin-right-2 govuk-!-text-align-right">
                   <%= govuk_link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br>
                   <%= govuk_link_to "Archive", planning_application_document_archive_path(document_id: document.id) %><br>
-                  <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: @planning_application.id, document: document, type: "replacement_document") %>
+                  <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: @planning_application.reference, document: document, type: "replacement_document") %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -11,7 +11,7 @@
       <%= govuk_link_to t(".archive"), planning_application_document_archive_path(planning_application, document) %>
     </p>
     <p class="govuk-body">
-      <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_id: planning_application.id, document: document, type: "replacement_document") %>
+      <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: planning_application.reference, document: document, type: "replacement_document") %>
     </p>
   <% end %>
 <% else %>

--- a/app/views/planning_applications/consultee/emails/index.html.erb
+++ b/app/views/planning_applications/consultee/emails/index.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
   <%= content_tag(:div, class: "govuk-grid-column-full", data: {
         controller: "consultees",
-        consultees_planning_application_id: @planning_application.id,
+        consultees_planning_application_id: @planning_application.reference,
         consultees_confirmation_message: t(".send_emails_to_consultees"),
         consultees_prompt_message: t(".please_search_for_a_consultee"),
         consultees_error_message: t(".unable_to_add_consultee")

--- a/app/views/planning_applications/consultees/index.html.erb
+++ b/app/views/planning_applications/consultees/index.html.erb
@@ -15,7 +15,7 @@
 <div class="govuk-grid-row">
   <%= content_tag :div, class: "govuk-grid-column-full", data: {
         controller: "consultees",
-        consultees_planning_application_id: @planning_application.id,
+        consultees_planning_application_id: @planning_application.reference,
         consultees_confirmation_message: "Send emails to consultees",
         consultees_prompt_message: "Select a consultee",
         consultees_error_message: "Unable to add consultee",

--- a/app/views/planning_applications/edit.html.erb
+++ b/app/views/planning_applications/edit.html.erb
@@ -17,7 +17,7 @@
           partial: "form",
           locals: {
             planning_application: @planning_application,
-            return_to: @back_path
+            return_to: (@back_path.gsub(@planning_application.reference, @planning_application.id.to_s) if @back_path)
           }
         ) %>
   </div>

--- a/app/workflows/validation/add_validation_request_task.rb
+++ b/app/workflows/validation/add_validation_request_task.rb
@@ -7,7 +7,7 @@ module Validation
     end
 
     def task_list_link
-      new_planning_application_validation_validation_request_path(planning_application.id, type: :other_change)
+      new_planning_application_validation_validation_request_path(planning_application.reference, type: :other_change)
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,40 +1,6 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "1340c35bdf0fb49e664e917b289d969603dfaf470391628f5fbd6702c3236f27",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/planning_applications/confirm_validation.html.erb",
-      "line": 28,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Unresolved Model).new.message",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PlanningApplicationsController",
-          "method": "confirm_validation",
-          "line": 74,
-          "file": "app/controllers/planning_applications_controller.rb",
-          "rendered": {
-            "name": "planning_applications/confirm_validation",
-            "file": "app/views/planning_applications/confirm_validation.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "planning_applications/confirm_validation"
-      },
-      "user_input": null,
-      "confidence": "High",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "HTTP Verb Confusion",
       "warning_code": 118,
       "fingerprint": "1e9f155cd38f2facbc9e446a4dc8c8dd88fe1b44f97b50e5ca1a6d9e2a23c936",
@@ -58,13 +24,57 @@
       "note": ""
     },
     {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "48d9d34244ff41b9c3894726e080fa9f653d6c28603c765ce0f0a72b0dd8623e",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/planning_applications/site_notices/_status.html.erb",
+      "line": 21,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "PlanningApplicationPresenter.new(view_context, (planning_applications_scope.find_by!(:reference => params[planning_application_param]) or planning_applications_scope.find(planning_application_id))).last_site_notice.preview_content",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "PlanningApplications::SiteNoticesController",
+          "method": "create",
+          "line": 53,
+          "file": "app/controllers/planning_applications/site_notices_controller.rb",
+          "rendered": {
+            "name": "planning_applications/site_notices/new",
+            "file": "app/views/planning_applications/site_notices/new.html.erb"
+          }
+        },
+        {
+          "type": "template",
+          "name": "planning_applications/site_notices/new",
+          "line": 22,
+          "file": "app/views/planning_applications/site_notices/new.html.erb",
+          "rendered": {
+            "name": "planning_applications/site_notices/_status",
+            "file": "app/views/planning_applications/site_notices/_status.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "planning_applications/site_notices/_status"
+      },
+      "user_input": "params[planning_application_param]",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "HTTP Verb Confusion",
       "warning_code": 118,
       "fingerprint": "713f84552953d2a9fdc5b7ca548ef91be96630ff38a470b5fd2dede70a9153ab",
       "check_name": "VerbConfusion",
       "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
       "file": "engines/bops_config/app/controllers/bops_config/application_controller.rb",
-      "line": 22,
+      "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
       "code": "session[:back_path] = request.referer if request.get?",
       "render_path": null,
@@ -81,47 +91,13 @@
       "note": ""
     },
     {
-      "warning_type": "Dynamic Render Path",
-      "warning_code": 15,
-      "fingerprint": "7db818492a354dcc125c250a78a18b6689d8fa8545c3e7c1a015440df0ea2094",
-      "check_name": "Render",
-      "message": "Render path contains parameter value",
-      "file": "app/views/planning_applications/validation/validation_requests/cancel_confirmation.html.erb",
-      "line": 1,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => \"planning_applications/validation/#{PlanningApplicationPresenter.new(view_context, planning_applications_scope.find(planning_application_id)).validation_requests.find(params[:id].to_i).model_name.plural}/cancel_confirmation\", {})",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PlanningApplications::Validation::ValidationRequestsController",
-          "method": "cancel",
-          "line": 124,
-          "file": "app/controllers/planning_applications/validation/validation_requests_controller.rb",
-          "rendered": {
-            "name": "planning_applications/validation/validation_requests/cancel_confirmation",
-            "file": "app/views/planning_applications/validation/validation_requests/cancel_confirmation.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "planning_applications/validation/validation_requests/cancel_confirmation"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "cwe_id": [
-        22
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "HTTP Verb Confusion",
       "warning_code": 118,
       "fingerprint": "9629e1b14cc8c66eb28d151ebd4ca28a458a3add860a62c9130def76133d424c",
       "check_name": "VerbConfusion",
       "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
       "file": "app/controllers/application_controller.rb",
-      "line": 69,
+      "line": 79,
       "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
       "code": "session[:back_path] = request.referer if request.get?",
       "render_path": null,
@@ -136,42 +112,8 @@
         352
       ],
       "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c418e59906d847f7e4233e6bf0c80c90100a4bbfffc83cad09c9ff3d0fba3556",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped model attribute",
-      "file": "app/views/planning_applications/make_public.html.erb",
-      "line": 26,
-      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "(Unresolved Model).new.message",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "PlanningApplicationsController",
-          "method": "make_public",
-          "line": 178,
-          "file": "app/controllers/planning_applications_controller.rb",
-          "rendered": {
-            "name": "planning_applications/make_public",
-            "file": "app/views/planning_applications/make_public.html.erb"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "planning_applications/make_public"
-      },
-      "user_input": null,
-      "confidence": "High",
-      "cwe_id": [
-        79
-      ],
-      "note": ""
     }
   ],
-  "updated": "2024-03-01 12:02:20 +0000",
+  "updated": "2024-08-09 16:13:17 +0100",
   "brakeman_version": "6.0.1"
 }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,15 +24,85 @@
       "note": ""
     },
     {
+      "warning_type": "HTTP Verb Confusion",
+      "warning_code": 118,
+      "fingerprint": "713f84552953d2a9fdc5b7ca548ef91be96630ff38a470b5fd2dede70a9153ab",
+      "check_name": "VerbConfusion",
+      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
+      "file": "engines/bops_config/app/controllers/bops_config/application_controller.rb",
+      "line": 32,
+      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
+      "code": "session[:back_path] = request.referer if request.get?",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "BopsConfig::ApplicationController",
+        "method": "set_back_path"
+      },
+      "user_input": "request.get?",
+      "confidence": "Weak",
+      "cwe_id": [
+        352
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Denial of Service",
+      "warning_code": 76,
+      "fingerprint": "76f55a4f527e1d179af74841ccb067e61a02033a08e86bc7844b843e8a2c1b41",
+      "check_name": "RegexDoS",
+      "message": "Parameter value used in regular expression",
+      "file": "app/controllers/application_controller.rb",
+      "line": 53,
+      "link": "https://brakemanscanner.org/docs/warning_types/denial_of_service/",
+      "code": "/\\/#{get_planning_application(params[planning_application_param]).id}/",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationController",
+        "method": "redirect_to_reference_url"
+      },
+      "user_input": "params[planning_application_param]",
+      "confidence": "Weak",
+      "cwe_id": [
+        20,
+        185
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "HTTP Verb Confusion",
+      "warning_code": 118,
+      "fingerprint": "9629e1b14cc8c66eb28d151ebd4ca28a458a3add860a62c9130def76133d424c",
+      "check_name": "VerbConfusion",
+      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
+      "file": "app/controllers/application_controller.rb",
+      "line": 89,
+      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
+      "code": "session[:back_path] = request.referer if request.get?",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationController",
+        "method": "set_back_path"
+      },
+      "user_input": "request.get?",
+      "confidence": "Weak",
+      "cwe_id": [
+        352
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
-      "fingerprint": "48d9d34244ff41b9c3894726e080fa9f653d6c28603c765ce0f0a72b0dd8623e",
+      "fingerprint": "98a2eb7517c9b0fbbbb711af14b9eb2241ece8b3b375dc85bc30d394a659a0f5",
       "check_name": "CrossSiteScripting",
       "message": "Unescaped parameter value",
       "file": "app/views/planning_applications/site_notices/_status.html.erb",
       "line": 21,
       "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "PlanningApplicationPresenter.new(view_context, (planning_applications_scope.find_by!(:reference => params[planning_application_param]) or planning_applications_scope.find(planning_application_id))).last_site_notice.preview_content",
+      "code": "PlanningApplicationPresenter.new(view_context, get_planning_application(params[planning_application_param])).last_site_notice.preview_content",
       "render_path": [
         {
           "type": "controller",
@@ -66,54 +136,8 @@
         79
       ],
       "note": ""
-    },
-    {
-      "warning_type": "HTTP Verb Confusion",
-      "warning_code": 118,
-      "fingerprint": "713f84552953d2a9fdc5b7ca548ef91be96630ff38a470b5fd2dede70a9153ab",
-      "check_name": "VerbConfusion",
-      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
-      "file": "engines/bops_config/app/controllers/bops_config/application_controller.rb",
-      "line": 32,
-      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
-      "code": "session[:back_path] = request.referer if request.get?",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "BopsConfig::ApplicationController",
-        "method": "set_back_path"
-      },
-      "user_input": "request.get?",
-      "confidence": "Weak",
-      "cwe_id": [
-        352
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "HTTP Verb Confusion",
-      "warning_code": 118,
-      "fingerprint": "9629e1b14cc8c66eb28d151ebd4ca28a458a3add860a62c9130def76133d424c",
-      "check_name": "VerbConfusion",
-      "message": "Potential HTTP verb confusion. `HEAD` is routed like `GET` but `request.get?` will return `false`",
-      "file": "app/controllers/application_controller.rb",
-      "line": 79,
-      "link": "https://brakemanscanner.org/docs/warning_types/http_verb_confusion/",
-      "code": "session[:back_path] = request.referer if request.get?",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "ApplicationController",
-        "method": "set_back_path"
-      },
-      "user_input": "request.get?",
-      "confidence": "Weak",
-      "cwe_id": [
-        352
-      ],
-      "note": ""
     }
   ],
-  "updated": "2024-08-09 16:13:17 +0100",
+  "updated": "2024-08-13 12:28:19 +0100",
   "brakeman_version": "6.0.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,7 @@ Rails.application.routes.draw do
       get "/policy/references", to: "policy_references#index"
     end
 
-    resources :planning_applications, except: %i[destroy] do
+    resources :planning_applications, param: :reference, except: %i[destroy] do
       member do
         get :confirm_validation
         patch :validate
@@ -329,7 +329,7 @@ Rails.application.routes.draw do
     end
 
     namespace :public do
-      resources :planning_applications, only: [] do
+      resources :planning_applications, param: :reference, only: [] do
         member do
           get "decision_notice"
         end

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "BOPS public API" do
           expect(data["application"]["reference"]).to eq(planning_application.reference)
           expect(data["files"]).not_to be_empty
           expect(data["decisionNotice"]["name"]).to eq("decision-notice-PlanX-24-00100-HAPP.pdf")
-          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf")
+          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf")
         end
       end
 

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -25,7 +25,7 @@ Given("I create a description change request with {string}") do |details|
 end
 
 When("I visit the new description change request link") do
-  visit "/planning_applications/#{@planning_application.id}/validation/validation_requests/new?type=description_change"
+  visit "/planning_applications/#{@planning_application.reference}/validation/validation_requests/new?type=description_change"
 end
 
 When("I cancel the existing description change request") do

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -22,7 +22,7 @@ Given("I view the document with reference {string}") do |reference|
 
   document = @planning_application.documents.find_by(numbers: reference)
 
-  visit "/planning_applications/#{@planning_application.id}/documents/#{document.id}/edit"
+  visit "/planning_applications/#{@planning_application.reference}/documents/#{document.id}/edit"
 end
 
 Given("I attach a replacement file with path {string}") do |path|

--- a/features/step_definitions/note_steps.rb
+++ b/features/step_definitions/note_steps.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 When("I view the planning application notes") do
-  visit "/planning_applications/#{@planning_application.id}/notes"
+  visit "/planning_applications/#{@planning_application.reference}/notes"
 end
 
 When("I see the note form actions") do

--- a/features/step_definitions/planning_application_steps.rb
+++ b/features/step_definitions/planning_application_steps.rb
@@ -110,11 +110,11 @@ When("I choose {string} from a fieldset {string}") do |option, fieldset|
 end
 
 When("I view the planning application") do
-  visit "/planning_applications/#{@planning_application.id}"
+  visit "/planning_applications/#{@planning_application.reference}"
 end
 
 When("I view the planning application audit") do
-  visit "/planning_applications/#{@planning_application.id}/audits"
+  visit "/planning_applications/#{@planning_application.reference}/audits"
 end
 
 And("the planning application has a description of {string}") do |description|

--- a/features/step_definitions/validation_requests_steps.rb
+++ b/features/step_definitions/validation_requests_steps.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 When("I view the application's validations requests") do
-  visit "/planning_applications/#{@planning_application.id}/validation/validation_requests"
+  visit "/planning_applications/#{@planning_application.reference}/validation/validation_requests"
 end
 
 When("I start the validation wizard") do
-  visit "/planning_applications/#{@planning_application.id}/validation/tasks"
+  visit "/planning_applications/#{@planning_application.reference}/validation/tasks"
 end
 
 When("I create a new document validation request for a(n) {string} because {string}") do |type, reason|

--- a/spec/components/accordion_sections/audit_log_component_spec.rb
+++ b/spec/components/accordion_sections/audit_log_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AccordionSections::AuditLogComponent, type: :component do
 
     expect(page).to have_link(
       "View all audits",
-      href: "/planning_applications/#{planning_application.id}/audits"
+      href: "/planning_applications/#{planning_application.reference}/audits"
     )
   end
 

--- a/spec/components/accordion_sections/documents_component_spec.rb
+++ b/spec/components/accordion_sections/documents_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AccordionSections::DocumentsComponent, type: :component do
 
     expect(page).to have_link(
       "Manage documents",
-      href: "/planning_applications/#{planning_application.id}/documents"
+      href: "/planning_applications/#{planning_application.reference}/documents"
     )
   end
 

--- a/spec/components/accordion_sections/notes_component_spec.rb
+++ b/spec/components/accordion_sections/notes_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AccordionSections::NotesComponent, type: :component do
 
     expect(page).to have_link(
       "Add a note",
-      href: "/planning_applications/#{planning_application.id}/notes"
+      href: "/planning_applications/#{planning_application.reference}/notes"
     )
   end
 
@@ -47,7 +47,7 @@ RSpec.describe AccordionSections::NotesComponent, type: :component do
     it "renders link to add and view notes" do
       expect(page).to have_link(
         "Add and view all notes",
-        href: "/planning_applications/#{planning_application.id}/notes"
+        href: "/planning_applications/#{planning_application.reference}/notes"
       )
     end
   end

--- a/spec/components/accordion_sections/site_map_component_spec.rb
+++ b/spec/components/accordion_sections/site_map_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
       expect(page).to have_link(
         "Request approval for a change to red line boundary",
-        href: "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=red_line_boundary_change"
+        href: "/planning_applications/#{planning_application.reference}/validation/validation_requests/new?type=red_line_boundary_change"
       )
     end
 
@@ -34,7 +34,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
         expect(page).to have_link(
           "View requested red line boundary change",
-          href: "/planning_applications/#{planning_application.id}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
+          href: "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
         )
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe AccordionSections::SiteMapComponent, type: :component do
 
         expect(page).to have_link(
           "View applicants response to requested red line boundary change",
-          href: "/planning_applications/#{planning_application.id}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
+          href: "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{red_line_boundary_change_validation_request.id}"
         )
       end
     end

--- a/spec/components/task_list_items/assessment/assessment_detail_component_spec.rb
+++ b/spec/components/task_list_items/assessment/assessment_detail_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TaskListItems::Assessment::AssessmentDetailComponent, type: :comp
     it "renders link to new assessment detail page" do
       expect(page).to have_link(
         "Summary of works",
-        href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=summary_of_work"
+        href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=summary_of_work"
       )
     end
 
@@ -56,7 +56,7 @@ RSpec.describe TaskListItems::Assessment::AssessmentDetailComponent, type: :comp
     it "renders link to new assessment detail page" do
       expect(page).to have_link(
         "Summary of works",
-        href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=summary_of_work"
+        href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=summary_of_work"
       )
     end
 
@@ -87,7 +87,7 @@ RSpec.describe TaskListItems::Assessment::AssessmentDetailComponent, type: :comp
     it "renders link to edit assessment detail page" do
       expect(page).to have_link(
         "Summary of works",
-        href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=summary_of_work"
+        href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}/edit?category=summary_of_work"
       )
     end
 
@@ -118,7 +118,7 @@ RSpec.describe TaskListItems::Assessment::AssessmentDetailComponent, type: :comp
     it "renders link to show assessment detail page" do
       expect(page).to have_link(
         "Summary of works",
-        href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=summary_of_work"
+        href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}?category=summary_of_work"
       )
     end
 

--- a/spec/components/task_list_items/assessment/conditions_component_spec.rb
+++ b/spec/components/task_list_items/assessment/conditions_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to new assessment detail page" do
         expect(page).to have_link(
           "Add conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/conditions"
         )
       end
 
@@ -51,7 +51,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to permitted development right review page" do
         expect(page).to have_link(
           "Add conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/conditions"
         )
       end
 
@@ -74,7 +74,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to edit permitted development right review page" do
         expect(page).to have_link(
           "Add conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/conditions"
         )
       end
 
@@ -99,7 +99,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to new assessment detail page" do
         expect(page).to have_link(
           "Add pre-commencement conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions"
         )
       end
 
@@ -122,7 +122,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to permitted development right review page" do
         expect(page).to have_link(
           "Add pre-commencement conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions"
         )
       end
 
@@ -145,7 +145,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to edit permitted development right review page" do
         expect(page).to have_link(
           "Add pre-commencement conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions"
         )
       end
 
@@ -173,7 +173,7 @@ RSpec.describe TaskListItems::Assessment::ConditionsComponent, type: :component 
       it "renders link to edit permitted development right review page" do
         expect(page).to have_link(
           "Add pre-commencement conditions",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions"
         )
       end
 

--- a/spec/components/task_list_items/assessment/immunity_details_component_spec.rb
+++ b/spec/components/task_list_items/assessment/immunity_details_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe TaskListItems::Assessment::ImmunityDetailsComponent, type: :compo
     it "renders link to new assessment detail page" do
       expect(page).to have_link(
         "Evidence of immunity",
-        href: "/planning_applications/#{planning_application.id}/assessment/immunity_details/new"
+        href: "/planning_applications/#{planning_application.reference}/assessment/immunity_details/new"
       )
     end
 
@@ -40,7 +40,7 @@ RSpec.describe TaskListItems::Assessment::ImmunityDetailsComponent, type: :compo
     it "renders link to permitted development right review page" do
       expect(page).to have_link(
         "Evidence of immunity",
-        href: "/planning_applications/#{planning_application.id}/assessment/immunity_details/#{planning_application.immunity_detail.id}"
+        href: "/planning_applications/#{planning_application.reference}/assessment/immunity_details/#{planning_application.immunity_detail.id}"
       )
     end
 
@@ -63,7 +63,7 @@ RSpec.describe TaskListItems::Assessment::ImmunityDetailsComponent, type: :compo
     it "renders link to edit permitted development right review page" do
       expect(page).to have_link(
         "Evidence of immunity",
-        href: "/planning_applications/#{planning_application.id}/assessment/immunity_details/#{planning_application.immunity_detail.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/assessment/immunity_details/#{planning_application.immunity_detail.id}/edit"
       )
     end
 

--- a/spec/components/task_list_items/assessment/permitted_development_right_component_spec.rb
+++ b/spec/components/task_list_items/assessment/permitted_development_right_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
     it "renders link to new permitted development right" do
       expect(page).to have_link(
         "Permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+        href: "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
       )
     end
 
@@ -50,7 +50,7 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
     it "renders link to new permitted development right" do
       expect(page).to have_link(
         "Permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+        href: "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
       )
     end
 
@@ -77,7 +77,7 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
     it "renders link to edit permitted development right" do
       expect(page).to have_link(
         "Permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/#{permitted_development_right.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/#{permitted_development_right.id}/edit"
       )
     end
 
@@ -104,7 +104,7 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
     it "renders link to permitted development right" do
       expect(page).to have_link(
         "Permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/#{permitted_development_right.id}"
+        href: "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/#{permitted_development_right.id}"
       )
     end
 
@@ -131,7 +131,7 @@ RSpec.describe TaskListItems::Assessment::PermittedDevelopmentRightComponent, ty
     it "renders link to permitted development right" do
       expect(page).to have_link(
         "Permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/#{permitted_development_right.id}"
+        href: "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/#{permitted_development_right.id}"
       )
     end
 

--- a/spec/components/task_list_items/assessment/policy_class_component_spec.rb
+++ b/spec/components/task_list_items/assessment/policy_class_component_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TaskListItems::Assessment::PolicyClassComponent, type: :component
     it "renders link to policy_class" do
       expect(page).to have_link(
         "Part 1, Class A",
-        href: "/planning_applications/#{planning_application.id}/assessment/policy_classes/#{policy_class.id}"
+        href: "/planning_applications/#{planning_application.reference}/assessment/policy_classes/#{policy_class.id}"
       )
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe TaskListItems::Assessment::PolicyClassComponent, type: :component
     it "renders link edit to policy_class" do
       expect(page).to have_link(
         "Part 1, Class A",
-        href: "/planning_applications/#{planning_application.id}/assessment/policy_classes/#{policy_class.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/assessment/policy_classes/#{policy_class.id}/edit"
       )
     end
   end

--- a/spec/components/task_list_items/document_component_spec.rb
+++ b/spec/components/task_list_items/document_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe TaskListItems::DocumentComponent, type: :component do
     it "renders link" do
       expect(page).to have_link(
         "proposed-floorplan.png",
-        href: "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit?validate=yes"
+        href: "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit?validate=yes"
       )
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe TaskListItems::DocumentComponent, type: :component do
     it "renders link" do
       expect(page).to have_link(
         "proposed-floorplan.png",
-        href: "/planning_applications/#{planning_application.id}/validation/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
+        href: "/planning_applications/#{planning_application.reference}/validation/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
       )
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe TaskListItems::DocumentComponent, type: :component do
     it "renders link" do
       expect(page).to have_link(
         "proposed-floorplan.png",
-        href: "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit?validate=yes"
+        href: "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit?validate=yes"
       )
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe TaskListItems::DocumentComponent, type: :component do
     it "renders link" do
       expect(page).to have_link(
         "proposed-floorplan.png",
-        href: "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit?validate=yes"
+        href: "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit?validate=yes"
       )
     end
   end

--- a/spec/components/task_list_items/reviewing/assessment_details_component_spec.rb
+++ b/spec/components/task_list_items/reviewing/assessment_details_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TaskListItems::Reviewing::AssessmentDetailsComponent, type: :comp
     it "renders link to show assessment details review page" do
       expect(page).to have_link(
         "Review assessment summaries",
-        href: "/planning_applications/#{planning_application.id}/review/assessment_details"
+        href: "/planning_applications/#{planning_application.reference}/review/assessment_details"
       )
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe TaskListItems::Reviewing::AssessmentDetailsComponent, type: :comp
     it "renders link to edit assessment details review page" do
       expect(page).to have_link(
         "Review assessment summaries",
-        href: "/planning_applications/#{planning_application.id}/review/assessment_details/edit"
+        href: "/planning_applications/#{planning_application.reference}/review/assessment_details/edit"
       )
     end
   end

--- a/spec/components/task_list_items/reviewing/documents_component_spec.rb
+++ b/spec/components/task_list_items/reviewing/documents_component_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TaskListItems::Reviewing::DocumentsComponent, type: :component do
   it "renders link" do
     expect(page).to have_link(
       "Review documents for recommendation",
-      href: "/planning_applications/#{planning_application.id}/review/documents"
+      href: "/planning_applications/#{planning_application.reference}/review/documents"
     )
   end
 

--- a/spec/components/task_list_items/reviewing/immunity_details_component_spec.rb
+++ b/spec/components/task_list_items/reviewing/immunity_details_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TaskListItems::Reviewing::ImmunityDetailsComponent, type: :compon
     it "renders link to permitted development right review page" do
       expect(page).to have_link(
         "Review evidence of immunity",
-        href: "/planning_applications/#{planning_application.id}/review/immunity_details/#{review_immunity_detail.id}"
+        href: "/planning_applications/#{planning_application.reference}/review/immunity_details/#{review_immunity_detail.id}"
       )
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe TaskListItems::Reviewing::ImmunityDetailsComponent, type: :compon
     it "renders link to edit permitted development right review page" do
       expect(page).to have_link(
         "Review evidence of immunity",
-        href: "/planning_applications/#{planning_application.id}/review/immunity_details/#{review_immunity_detail.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/review/immunity_details/#{review_immunity_detail.id}/edit"
       )
     end
   end

--- a/spec/components/task_list_items/reviewing/immunity_enforcement_component_spec.rb
+++ b/spec/components/task_list_items/reviewing/immunity_enforcement_component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TaskListItems::Reviewing::ImmunityEnforcementComponent, type: :co
     it "renders link to permitted development right review page" do
       expect(page).to have_link(
         "Review assessment of immunity",
-        href: "/planning_applications/#{planning_application.id}/review/immunity_enforcements/#{review_immunity_detail.id}"
+        href: "/planning_applications/#{planning_application.reference}/review/immunity_enforcements/#{review_immunity_detail.id}"
       )
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe TaskListItems::Reviewing::ImmunityEnforcementComponent, type: :co
     it "renders link to edit permitted development right review page" do
       expect(page).to have_link(
         "Review assessment of immunity",
-        href: "/planning_applications/#{planning_application.id}/review/immunity_enforcements/#{review_immunity_detail.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/review/immunity_enforcements/#{review_immunity_detail.id}/edit"
       )
     end
   end

--- a/spec/components/task_list_items/reviewing/permitted_development_right_component_spec.rb
+++ b/spec/components/task_list_items/reviewing/permitted_development_right_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TaskListItems::Reviewing::PermittedDevelopmentRightComponent, typ
     it "renders link to permitted development right review page" do
       expect(page).to have_link(
         "Review permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/review/permitted_development_rights/#{permitted_development_right.id}"
+        href: "/planning_applications/#{planning_application.reference}/review/permitted_development_rights/#{permitted_development_right.id}"
       )
     end
   end
@@ -36,7 +36,7 @@ RSpec.describe TaskListItems::Reviewing::PermittedDevelopmentRightComponent, typ
     it "renders link to edit permitted development right review page" do
       expect(page).to have_link(
         "Review permitted development rights",
-        href: "/planning_applications/#{planning_application.id}/review/permitted_development_rights/#{permitted_development_right.id}/edit"
+        href: "/planning_applications/#{planning_application.reference}/review/permitted_development_rights/#{permitted_development_right.id}/edit"
       )
     end
   end

--- a/spec/components/task_list_items/site_notice_component_spec.rb
+++ b/spec/components/task_list_items/site_notice_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TaskListItems::SiteNoticeComponent, type: :component do
     it "renders link to new site notice" do
       expect(page).to have_link(
         "Send site notice",
-        href: "/planning_applications/#{planning_application.id}/site_notices/new"
+        href: "/planning_applications/#{planning_application.reference}/site_notices/new"
       )
     end
   end
@@ -43,7 +43,7 @@ RSpec.describe TaskListItems::SiteNoticeComponent, type: :component do
     it "renders link to new site notice" do
       expect(page).to have_link(
         "Send site notice",
-        href: "/planning_applications/#{planning_application.id}/site_notices/new"
+        href: "/planning_applications/#{planning_application.reference}/site_notices/new"
       )
     end
   end

--- a/spec/helpers/validation_request_helper_spec.rb
+++ b/spec/helpers/validation_request_helper_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ValidationRequestHelper do
         expect(
           helper.show_validation_request_link(planning_application, request)
         ).to eq(
-          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/validation/validation_requests/#{request.id}\">View and update</a>"
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.reference}/validation/validation_requests/#{request.id}\">View and update</a>"
         )
       end
 
@@ -40,7 +40,7 @@ RSpec.describe ValidationRequestHelper do
           expect(
             helper.show_validation_request_link(planning_application, request)
           ).to eq(
-            "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/validation/documents/edit\">View and update</a>"
+            "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.reference}/validation/documents/edit\">View and update</a>"
           )
         end
       end
@@ -55,7 +55,7 @@ RSpec.describe ValidationRequestHelper do
         expect(
           helper.show_validation_request_link(planning_application, request)
         ).to eq(
-          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/validation/validation_requests/#{request.id}\">View</a>"
+          "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.reference}/validation/validation_requests/#{request.id}\">View</a>"
         )
       end
 
@@ -71,7 +71,7 @@ RSpec.describe ValidationRequestHelper do
           expect(
             helper.show_validation_request_link(planning_application, request)
           ).to eq(
-            "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.id}/documents\">View</a>"
+            "<a class=\"govuk-link\" href=\"/planning_applications/#{planning_application.reference}/documents\">View</a>"
           )
         end
       end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes a link to the decision notice" do
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
+        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
       )
     end
 
@@ -130,7 +130,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "includes a link to the decision notice" do
         expect(mail_body).to include(
-          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
+          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
         )
       end
 
@@ -900,7 +900,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "A prior approval application has been made for the development described below:"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}"
       )
     end
 
@@ -988,7 +988,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "As part of the application process"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
       )
     end
   end
@@ -1058,7 +1058,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "The site notice for this application is ready for display"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
       )
     end
   end
@@ -1386,7 +1386,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the bops request url" do
       expect(mail_body).to include(
-        "You can view the application at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.id}/press_notice/confirmation."
+        "You can view the application at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/press_notice/confirmation."
       )
     end
 
@@ -1403,7 +1403,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
           "This application is subject to an Environmental Impact Assessment (EIA)."
         )
         expect(mail_body).to include(
-          "You can view the application and Environmental Statement at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.id}/press_notice/confirmation."
+          "You can view the application and Environmental Statement at http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/press_notice/confirmation."
         )
       end
     end

--- a/spec/mailer/user_mailer_spec.rb
+++ b/spec/mailer/user_mailer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "includes plannng application url" do
       expect(mail_body).to include(
-        "http://buckinghamshire.bops.services/planning_applications/#{planning_application.id}"
+        "http://buckinghamshire.bops.services/planning_applications/#{planning_application.reference}"
       )
     end
   end
@@ -104,7 +104,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     it "includes plannng application url" do
       expect(mail_body).to include(
-        "http://buckinghamshire.bops.services/planning_applications/#{planning_application.id}"
+        "http://buckinghamshire.bops.services/planning_applications/#{planning_application.reference}"
       )
     end
   end

--- a/spec/presenters/policy_class_presenter_spec.rb
+++ b/spec/presenters/policy_class_presenter_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe PolicyClassPresenter, type: :presenter do
         expect(
           presenter.default_path
         ).to eq(
-          "/planning_applications/#{planning_application.id}/assessment/policy_classes/#{policy_class.id}"
+          "/planning_applications/#{planning_application.reference}/assessment/policy_classes/#{policy_class.id}"
         )
       end
     end
@@ -46,7 +46,7 @@ RSpec.describe PolicyClassPresenter, type: :presenter do
         expect(
           presenter.default_path
         ).to eq(
-          "/planning_applications/#{planning_application.id}/assessment/policy_classes/#{policy_class.id}/edit"
+          "/planning_applications/#{planning_application.reference}/assessment/policy_classes/#{policy_class.id}/edit"
         )
       end
     end

--- a/spec/requests/api/additional_document_validation_request_patch_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_patch_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
   end
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id}"
   end
 
   let(:file) do
@@ -78,7 +78,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
   end
 
   it "rejects wrong document types" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: {files: [fixture_file_upload("../images/proposed-floorplan.png", "application/octet-stream")]},
       headers: {Authorization: "Bearer #{api_user.token}"}
 
@@ -89,7 +89,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
   end
 
   it "returns a 400 if the new document is missing" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: {files: ""},
       headers: {Authorization: "Bearer #{api_user.token}"}
 
@@ -101,7 +101,7 @@ RSpec.describe "API request to patch document create requests", show_exceptions:
     # Return byte size greater than limit of 30mb (31457280 bytes)
     allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
 
-    patch "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: {files: [file]},
       headers: {Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/additional_document_validation_request_spec.rb
+++ b/spec/requests/api/additional_document_validation_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
-    let(:path) { "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests" }
+    let(:path) { "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests" }
     let!(:additional_document_validation_request2) do
       travel_to(DateTime.new(2023, 12, 15)) { create(:additional_document_validation_request, :closed, :with_documents, planning_application:) }
     end
@@ -93,7 +93,7 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
 
   describe "#show" do
     let(:path) do
-      "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id}"
+      "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id}"
     end
 
     context "when the request is successful" do
@@ -138,7 +138,7 @@ RSpec.describe "Additional document validation requests API", show_exceptions: t
 
       describe "when the additional document request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/additional_document_validation_requests/#{additional_document_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/additional_document_validation_requests/#{additional_document_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "additional_document_validation_request"

--- a/spec/requests/api/description_change_validation_request_put_spec.rb
+++ b/spec/requests/api/description_change_validation_request_put_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   let!(:api_user) { create(:api_user, local_authority: default_local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}"
   end
 
   let(:params) do
@@ -94,7 +94,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "successfully accepts a rejection" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -110,7 +110,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 400 if the rejection is missing a rejection reason" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json_missing_reason,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -118,7 +118,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 401 if API key is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: approved_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
@@ -126,7 +126,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 401 if change_access_id is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=CHANGEISGOOD",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=CHANGEISGOOD",
       params: approved_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/description_change_validation_request_spec.rb
+++ b/spec/requests/api/description_change_validation_request_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe "Description change validation requests API", show_exceptions: tr
 
       describe "when the description change validation request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "description_change_validation_request"

--- a/spec/requests/api/document_show_spec.rb
+++ b/spec/requests/api/document_show_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "API request to show document file", show_exceptions: true do
 
     it "returns a 404 if no document" do
       expect do
-        get "/api/v1/planning_applications/#{planning_application.id}/documents/xxx"
+        get "/api/v1/planning_applications/#{planning_application.reference}/documents/xxx"
       end.to raise_error(ActiveRecord::RecordNotFound)
     end
 
@@ -26,7 +26,7 @@ RSpec.describe "API request to show document file", show_exceptions: true do
 
       it "returns a 404" do
         expect do
-          get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+          get "/api/v1/planning_applications/#{planning_application.reference}/documents/#{document.id}"
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
@@ -38,13 +38,13 @@ RSpec.describe "API request to show document file", show_exceptions: true do
 
       it "returns a 404" do
         expect do
-          get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+          get "/api/v1/planning_applications/#{planning_application.reference}/documents/#{document.id}"
         end.to raise_error(ActiveRecord::RecordNotFound)
       end
     end
 
     it "redirects to blob url" do
-      get "/api/v1/planning_applications/#{planning_application.id}/documents/#{document.id}"
+      get "/api/v1/planning_applications/#{planning_application.reference}/documents/#{document.id}"
       expect(response).to redirect_to(rails_blob_path(document.file))
     end
   end

--- a/spec/requests/api/fee_change_validation_request_put_spec.rb
+++ b/spec/requests/api/fee_change_validation_request_put_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   let!(:api_user) { create(:api_user, local_authority: default_local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/fee_change_validation_requests/#{fee_change_validation_request.id}"
   end
 
   let(:params) do
@@ -78,7 +78,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   end
 
   it "returns a 401 if API key is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: valid_response,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
@@ -86,7 +86,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   end
 
   it "returns a 401 if change_access_id is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=CHANGEISGOOD",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/fee_change_validation_requests/#{fee_change_validation_request.id}?change_access_id=CHANGEISGOOD",
       params: valid_response,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Creating a planning application via the API", show_exceptions: t
   let!(:planning_application) { create(:planning_application, :planning_permission, local_authority: default_local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/neighbour_responses"
+    "/api/v1/planning_applications/#{planning_application.reference}/neighbour_responses"
   end
 
   let(:headers) do

--- a/spec/requests/api/other_change_validation_request_put_spec.rb
+++ b/spec/requests/api/other_change_validation_request_put_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   let!(:api_user) { create(:api_user, local_authority: local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id}"
   end
 
   let(:params) do
@@ -83,7 +83,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   end
 
   it "returns a 400 if the update is missing a response" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: missing_response,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -91,7 +91,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   end
 
   it "returns a 401 if API key is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: valid_response,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
@@ -99,7 +99,7 @@ RSpec.describe "API request to list change requests", show_exceptions: true do
   end
 
   it "returns a 401 if change_access_id is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=CHANGEISGOOD",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id}?change_access_id=CHANGEISGOOD",
       params: valid_response,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/other_change_validation_request_spec.rb
+++ b/spec/requests/api/other_change_validation_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
   end
 
   describe "#index" do
-    let(:path) { "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests" }
+    let(:path) { "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests" }
     let!(:other_change_validation_request2) do
       travel_to(DateTime.new(2023, 12, 15)) { create(:other_change_validation_request, :closed, planning_application:) }
     end
@@ -85,7 +85,7 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
 
   describe "#show" do
     let(:path) do
-      "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id}"
+      "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id}"
     end
 
     context "when the request is successful" do
@@ -125,7 +125,7 @@ RSpec.describe "Other change validation requests API", show_exceptions: true do
 
       describe "when the other change validation request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/other_change_validation_requests/#{other_change_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/other_change_validation_requests/#{other_change_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "other_change_validation_request"

--- a/spec/requests/api/planning_application_show_spec.rb
+++ b/spec/requests/api/planning_application_show_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
     let(:access_control_allow_headers) { response.headers["Access-Control-Allow-Headers"] }
 
     it "responds to JSON" do
-      get("/api/v1/planning_applications/#{planning_application.id}", headers: headers)
+      get("/api/v1/planning_applications/#{planning_application.reference}", headers: headers)
       expect(response).to be_successful
     end
 
     it "sets CORS headers" do
-      get("/api/v1/planning_applications/#{planning_application.id}", headers: headers)
+      get("/api/v1/planning_applications/#{planning_application.reference}", headers: headers)
 
       expect(response).to be_successful
       expect(access_control_allow_origin).to eq("*")
@@ -55,7 +55,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
 
     context "with a new planning application" do
       it "returns the accurate data" do
-        get("/api/v1/planning_applications/#{planning_application.id}", headers: headers)
+        get("/api/v1/planning_applications/#{planning_application.reference}", headers: headers)
         expect(planning_application_json["status"]).to eq("in_assessment")
         expect(planning_application_json["id"]).to eq(planning_application.id)
         expect(planning_application_json["reference"]).to eq(planning_application.reference)
@@ -104,7 +104,7 @@ RSpec.describe "API request to list planning applications", show_exceptions: tru
         let!(:neighbour_response) { create(:neighbour_response, neighbour:, redacted_response: "It's fine", received_at: 1.day.ago, summary_tag: "supportive") }
 
         it "returns the accurate data" do
-          get("/api/v1/planning_applications/#{planning_application.id}", headers: headers)
+          get("/api/v1/planning_applications/#{planning_application.reference}", headers: headers)
           expect(planning_application_json["status"]).to eq("determined")
           expect(planning_application_json["id"]).to eq(planning_application.id)
           expect(planning_application_json["reference"]).to eq(planning_application.reference)

--- a/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_put_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   let!(:api_user) { create(:api_user, local_authority: default_local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
   end
 
   let(:params) do
@@ -89,7 +89,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   it "successfully accepts a rejection" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -105,7 +105,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   it "returns a 400 if params are missing" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json_missing_reason,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/requests/api/red_line_boundary_change_validation_request_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
   let(:token) { "Bearer #{api_user.token}" }
 
   describe "#index" do
-    let(:path) { "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests" }
+    let(:path) { "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests" }
     let!(:red_line_boundary_change_validation_request2) do
       travel_to(DateTime.new(2023, 12, 15)) { create(:red_line_boundary_change_validation_request, :closed, planning_application:) }
     end
@@ -75,7 +75,7 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
 
   describe "#show" do
     let(:path) do
-      "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+      "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
     end
 
     context "when the request is successful" do
@@ -121,7 +121,7 @@ RSpec.describe "Red line boundary change validation requests API", show_exceptio
 
       describe "when the red line boundary change validation request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "red_line_boundary_change_validation_request"

--- a/spec/requests/api/replacement_document_validation_request_put_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_put_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
   end
 
   let(:file) do
@@ -124,7 +124,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   it "rejects wrong document types" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: {new_file: fixture_file_upload("../images/proposed-floorplan.png", "image/gif")},
       headers: {Authorization: "Bearer #{api_user.token}"}
 
@@ -134,7 +134,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
   end
 
   it "returns a 400 if the new document is missing" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: "{}",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -145,7 +145,7 @@ RSpec.describe "API request to patch document validation requests", show_excepti
     # Return byte size greater than limit of 30mb (31457280 bytes)
     allow_any_instance_of(ActionDispatch::Http::UploadedFile).to receive(:size).and_return(31_457_281)
 
-    patch "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/replacement_document_validation_requests/#{replacement_document_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: {new_file: file},
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/replacement_document_validation_request_spec.rb
+++ b/spec/requests/api/replacement_document_validation_request_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "Replacement document validation requests API", show_exceptions: 
 
       describe "when the replacement document request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/replacement_document_validation_requests/#{replacement_document_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/replacement_document_validation_requests/#{replacement_document_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "replacement_document_validation_request"

--- a/spec/requests/api/time_extension_validation_request_put_spec.rb
+++ b/spec/requests/api/time_extension_validation_request_put_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   let!(:api_user) { create(:api_user, local_authority: default_local_authority) }
 
   let(:path) do
-    "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}"
+    "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}"
   end
 
   let(:params) do
@@ -94,7 +94,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "successfully accepts a rejection" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -110,7 +110,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 400 if the rejection is missing a rejection reason" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: rejected_json_missing_reason,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 
@@ -118,7 +118,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 401 if API key is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=#{planning_application.change_access_id}",
       params: approved_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer BEAR_THE_BEARER"}
 
@@ -126,7 +126,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 401 if change_access_id is wrong" do
-    patch "/api/v1/planning_applications/#{planning_application.id}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=CHANGEISGOOD",
+    patch "/api/v1/planning_applications/#{planning_application.reference}/description_change_validation_requests/#{description_change_validation_request.id}?change_access_id=CHANGEISGOOD",
       params: approved_json,
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
 

--- a/spec/requests/api/time_extension_validation_request_spec.rb
+++ b/spec/requests/api/time_extension_validation_request_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe "Time extension validation requests API", show_exceptions: true d
 
       describe "when the time extension validation request is not found" do
         let(:path) do
-          "/api/v1/planning_applications/#{planning_application.id}/time_extension_validation_requests/#{time_extension_validation_request.id + 1}"
+          "/api/v1/planning_applications/#{planning_application.reference}/time_extension_validation_requests/#{time_extension_validation_request.id + 1}"
         end
 
         it_behaves_like "ApiRequest::NotFound", "time_extension_validation_request"

--- a/spec/requests/api/validation_request_list_spec.rb
+++ b/spec/requests/api/validation_request_list_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "lists the all description validation requests that exist on the planning application" do
-    get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
+    get "/api/v1/planning_applications/#{planning_application.reference}/validation_requests?change_access_id=#{planning_application.change_access_id}",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["description_change_validation_requests"]).to eq([{
@@ -36,7 +36,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "lists the all document validation requests that exist on the planning application" do
-    get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
+    get "/api/v1/planning_applications/#{planning_application.reference}/validation_requests?change_access_id=#{planning_application.change_access_id}",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["replacement_document_validation_requests"].first).to include({
@@ -55,7 +55,7 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "lists the all document create requests that exist on the planning application" do
-    get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
+    get "/api/v1/planning_applications/#{planning_application.reference}/validation_requests?change_access_id=#{planning_application.change_access_id}",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to be_successful
     expect(json["data"]["additional_document_validation_requests"].first).to include({
@@ -73,13 +73,13 @@ RSpec.describe "API request to list validation requests", show_exceptions: true 
   end
 
   it "returns a 401 if API key is wrong" do
-    get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=#{planning_application.change_access_id}",
+    get "/api/v1/planning_applications/#{planning_application.reference}/validation_requests?change_access_id=#{planning_application.change_access_id}",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer bipbopboop"}
     expect(response).to have_http_status(:unauthorized)
   end
 
   it "returns a 401 if change_access_id is wrong" do
-    get "/api/v1/planning_applications/#{planning_application.id}/validation_requests?change_access_id=fffffff",
+    get "/api/v1/planning_applications/#{planning_application.reference}/validation_requests?change_access_id=fffffff",
       headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"}
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/support/validation_requests_shared_examples.rb
+++ b/spec/support/validation_requests_shared_examples.rb
@@ -20,7 +20,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
       it "responds with a 200" do
         params = {
           id: request.id,
-          planning_application_id: request.planning_application.id
+          planning_application_reference: request.planning_application.reference
         }
 
         get(:cancel_confirmation, params:)
@@ -35,7 +35,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
       it "responds with a 404" do
         params = {
           id: request.id,
-          planning_application_id: request.planning_application.id
+          planning_application_reference: request.planning_application.reference
         }
 
         get(:cancel_confirmation, params:)
@@ -50,7 +50,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
       it "successfully redirects to the validation requests index page" do
         params = {
           id: request.id,
-          planning_application_id: request.planning_application.id,
+          planning_application_reference: request.planning_application.reference,
           "#{request_type}": {cancel_reason: "my mistake"}
         }
 
@@ -64,7 +64,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
       it "with no cancel reason it redirects back to the cancel_confirmation page" do
         params = {
           id: request.id,
-          planning_application_id: request.planning_application.id,
+          planning_application_reference: request.planning_application.reference,
           "#{request_type}": {cancel_reason: ""}
         }
 
@@ -79,7 +79,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
 
         params = {
           id: request.id,
-          planning_application_id: request.planning_application.id,
+          planning_application_reference: request.planning_application.reference,
           "#{request_type}": {cancel_reason: request.cancel_reason}
         }
 
@@ -100,7 +100,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
 
       it "responds with a 403" do
         params = {
-          planning_application_id: request.planning_application.id
+          planning_application_reference: request.planning_application.reference
         }
 
         get(:new, params:)
@@ -112,7 +112,7 @@ RSpec.shared_examples "ValidationRequests" do |_klass, request_type|
     context "when planning application is not closed or cancelled" do
       it "responds with a 200" do
         params = {
-          planning_application_id: planning_application.id
+          planning_application_reference: planning_application.reference
         }
 
         if request_type == "replacement_document_validation_request"

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Documents index page" do
 
   context "as a user who is not logged in" do
     it "User cannot see archive page" do
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       expect(page).to have_current_path(/sign_in/)
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
@@ -58,7 +58,7 @@ RSpec.describe "Documents index page" do
   context "as an assessor" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
     end
 
     it "Assessor can see Archive document links when application is in assessment" do
@@ -80,7 +80,7 @@ RSpec.describe "Documents index page" do
   context "when archiving journey" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link "Archive"
     end
 
@@ -137,7 +137,7 @@ RSpec.describe "Documents index page" do
   context "when restoring from archive" do
     it "Archived document can be restored" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link "Archive"
 
       fill_in "Why do you want to archive this document?", with: "Scale was wrong"
@@ -168,7 +168,7 @@ RSpec.describe "Documents index page" do
   context "as a reviewer" do
     before do
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link "Archive"
     end
 
@@ -183,7 +183,7 @@ RSpec.describe "Documents index page" do
   context "with an application that has not been started" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link "Archive"
     end
 
@@ -243,7 +243,7 @@ RSpec.describe "Documents index page" do
     end
 
     it "cannot archive" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
       expect(page).to have_content("forbidden")
     end

--- a/spec/system/documents/display_and_publish_documents_spec.rb
+++ b/spec/system/documents/display_and_publish_documents_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Edit document numbers page" do
       end
 
       before do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
       end
 
       it "displays the planning application address and reference" do
@@ -168,7 +168,7 @@ RSpec.describe "Edit document numbers page" do
       before do
         allow_any_instance_of(Document).to receive(:representable?).and_return(false)
 
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
       end
 
       it "displays a placeholder image with error information" do

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Edit document", type: :system do
 
   context "as a user who is not logged in" do
     it "User cannot see edit_numbers page" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
       expect(page).to have_current_path(/sign_in/)
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
@@ -30,7 +30,7 @@ RSpec.describe "Edit document", type: :system do
   context "as an assessor" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
     end
 
     it "displays the planning application address and reference" do
@@ -39,7 +39,7 @@ RSpec.describe "Edit document", type: :system do
     end
 
     it "archives and replaces existing document when new file is uploaded" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
       check("Roof plan - proposed")
       fill_in("Document reference(s)", with: "DOC123")
@@ -78,7 +78,7 @@ RSpec.describe "Edit document", type: :system do
       end
 
       it "renders an error if user tries to replace the file", :capybara do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
         attach_file(
           "Upload a replacement file",
@@ -94,7 +94,7 @@ RSpec.describe "Edit document", type: :system do
     end
 
     it "renders error when document is in unrepresentable format" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
       attach_file(
         "Upload a replacement file",
@@ -109,7 +109,7 @@ RSpec.describe "Edit document", type: :system do
     end
 
     it "with wrong format document", :capybara do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
       attach_file("Upload a replacement file", "spec/fixtures/images/image.gif")
 
@@ -119,7 +119,7 @@ RSpec.describe "Edit document", type: :system do
     end
 
     it "cannot validate document via manage documents screen" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
       expect(page).not_to have_content("Is the document valid?")
       expect(page).not_to have_css("#validate-document")
@@ -135,7 +135,7 @@ RSpec.describe "Edit document", type: :system do
       end
 
       it "cannot edit" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
         expect(page).to have_content("forbidden")
       end
@@ -143,7 +143,7 @@ RSpec.describe "Edit document", type: :system do
 
     context "when editing/archiving document from the documents accordian section" do
       it "can edit document and return back to the planning applications index page" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
         fill_in("Document reference(s)", with: "DOCREF123")
 
@@ -151,11 +151,11 @@ RSpec.describe "Edit document", type: :system do
 
         expect(page).to have_content("Document has been updated")
 
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
 
       it "can archive document and return back to the planning applications index page" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/archive"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/archive"
 
         fill_in "archive_reason", with: "an archive reason"
 
@@ -163,7 +163,7 @@ RSpec.describe "Edit document", type: :system do
 
         expect(page).to have_content("#{document.name} has been archived")
 
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
     end
 
@@ -178,7 +178,7 @@ RSpec.describe "Edit document", type: :system do
         click_button "Save"
 
         expect(page).to have_content("Document has been updated")
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
 
       it "can archive document and return back to the documents index page" do
@@ -191,7 +191,7 @@ RSpec.describe "Edit document", type: :system do
         click_button "Archive"
 
         expect(page).to have_content("#{document.name} has been archived")
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
 
       it "the back button returns to the documents index page" do
@@ -200,23 +200,23 @@ RSpec.describe "Edit document", type: :system do
         end
 
         click_link "Back"
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
     end
 
     context "when visiting the edit/archive url directly" do
       it "edit returns to the documents index page" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 
         click_button "Save"
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
 
       it "archive returns to the documents index page" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/archive"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/archive"
 
         click_button "Archive"
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
     end
 
@@ -232,19 +232,19 @@ RSpec.describe "Edit document", type: :system do
       end
 
       it "edit returns to the documents index page" do
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/edit"
-        visit "/planning_applications/#{other_planning_application.id}/documents/#{other_document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
+        visit "/planning_applications/#{other_planning_application.reference}/documents/#{other_document.id}/edit"
 
         click_button "Save"
-        expect(page).to have_current_path("/planning_applications/#{other_planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{other_planning_application.reference}/documents")
       end
 
       it "archive returns to the documents index page" do
-        visit "/planning_applications/#{other_planning_application.id}/documents/#{other_document.id}/edit"
-        visit "/planning_applications/#{planning_application.id}/documents/#{document.id}/archive"
+        visit "/planning_applications/#{other_planning_application.reference}/documents/#{other_document.id}/edit"
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/archive"
 
         click_button "Archive"
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents")
       end
     end
   end

--- a/spec/system/documents/index_spec.rb
+++ b/spec/system/documents/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Documents index page", type: :system do
 
   context "as a user who is not logged in" do
     it "User is redirected to login page" do
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       expect(page).to have_current_path(/sign_in/)
       expect(page).to have_content("You need to sign in or sign up before continuing.")
     end
@@ -27,7 +27,7 @@ RSpec.describe "Documents index page", type: :system do
   context "as an assessor" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
     end
 
     it "Application reference is displayed on page" do
@@ -63,7 +63,7 @@ RSpec.describe "Documents index page", type: :system do
       end
 
       it "downloads each file", :capybara do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         expect(page).to have_selector("h1", text: "Documents")
 
         within("tr", text: "File name: proposed-floorplan.png") do
@@ -92,14 +92,14 @@ RSpec.describe "Documents index page", type: :system do
       click_button "Documents"
       click_link "Manage documents"
       click_link "Back"
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}")
 
       # Navigate via archive document page
       click_button "Documents"
       click_link "Archive"
       click_link "Cancel"
       click_link "Back"
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/documents/#{document.id}/archive")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents/#{document.id}/archive")
     end
   end
 
@@ -118,7 +118,7 @@ RSpec.describe "Documents index page", type: :system do
 
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
     end
 
     it "displays the number of invalid documents at the top of the page" do

--- a/spec/system/documents/upload_spec.rb
+++ b/spec/system/documents/upload_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Document uploads" do
 
     context "when the application is under assessment" do
       it "cannot upload a document in the wrong format" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
 
         click_link("Upload document")
         attach_file("Upload a file", "spec/fixtures/images/image.gif")
@@ -31,7 +31,7 @@ RSpec.describe "Document uploads" do
       end
 
       it "cannot save without a document being attached" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
 
         click_link("Upload document")
         check("Floor plan - existing")

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
   end
 
   it "allows for a document creation request to be created and sent to the applicant" do
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link "Check and validate"
     click_link "Check and request documents"
@@ -54,7 +54,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       activity_type: "additional_document_validation_request_received", activity_information: 1, audit_comment: "roof_plan.pdf", api_user:)
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
 
     click_button "Audit log"
     click_link "View all audits"
@@ -105,7 +105,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     let!(:document_plan_and_supporting_tags) { create(:document, tags: %w[floorPlan.proposed otherDocument], planning_application:) }
 
     it "I can view the documents separated by their tag category", :capybara do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
 
       within(".govuk-tabs") do
@@ -165,7 +165,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I can see the list of active documents when I go to validate", :capybara do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#check-missing-documents-task") do
         expect(page).to have_content("Check and request documents")
@@ -229,7 +229,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I can validate that there are no missing documents" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
       click_button "Save"
 
@@ -244,7 +244,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I get validation errors when I omit required information" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
       click_link "Add a request for a missing document"
       click_button "Save request"
@@ -259,7 +259,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I can request missing documents meaning the required documents are invalid" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
       click_link "Add a request for a missing document"
       click_button "Save request"
@@ -315,7 +315,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       end
 
       it "I can edit the additional document validation request" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         within("#check-missing-documents-task") do
           expect(page).to have_content("Awaiting response")
         end
@@ -324,7 +324,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
         click_link "Edit request"
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/validation/validation_requests/#{additional_document_validation_request.id}/edit"
+          "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{additional_document_validation_request.id}/edit"
         )
 
         fill_in "Please specify the new document type:", with: "Floor plans"
@@ -337,7 +337,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
 
         expect(page).to have_content("Additional document request successfully updated")
 
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
         within("#check-missing-documents-task") do
           expect(page).to have_content("Awaiting response")
@@ -354,7 +354,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       end
 
       it "I can delete the additional document validation request", :capybara do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         expect(page).to have_selector("h1", text: "Check the application")
 
         click_link "Check and request documents"
@@ -364,7 +364,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
           click_link("Delete request")
         end
 
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/validation/tasks")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/validation/tasks")
         expect(page).to have_content("Additional document request was successfully deleted.")
 
         within("#check-missing-documents-task") do
@@ -390,7 +390,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I can view the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
 
       expect(page).to have_content("Check and request documents")
@@ -418,7 +418,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I can cancel the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
       click_link "Cancel request"
 
@@ -463,7 +463,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "I cannot edit the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/#{additional_document_validation_request.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{additional_document_validation_request.id}/edit"
 
       expect(page).to have_content("forbidden")
       expect(page).not_to have_link("Edit request")
@@ -476,7 +476,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       end
 
       it "I can see an overdue request" do
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
 
         expect(page).to have_content("overdue")
       end
@@ -498,7 +498,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       end
 
       it "I can see the new document in the validate documents list" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
         within("#check-missing-documents-task") do
           expect(page).to have_content("Not started")
@@ -534,7 +534,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     end
 
     it "does not allow you to validate for missing documents" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#check-missing-documents-task") do
         expect(page).to have_content("Planning application has already been validated")
@@ -550,7 +550,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     before do
       allow_any_instance_of(Document).to receive(:representable?).and_return(false)
 
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check and request documents"
     end
 

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Check and assess"
   end
 
@@ -68,7 +68,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
     it "you can edit conditions" do
       create(:condition, condition_set: planning_application.condition_set, standard: false, title: "", text: "You must do this", reason: "For this reason")
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
 
       click_link "Add conditions"
@@ -97,7 +97,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
     end
 
     it "you can delete conditions" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
 
       click_link "Add conditions"
@@ -165,7 +165,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       create(:recommendation, :assessment_in_progress, planning_application:)
       create(:condition, condition_set: planning_application.condition_set, standard: true)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Review and submit recommendation"
 
@@ -182,7 +182,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       end
 
       it "doesn't break" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Check and assess"
 
         click_link "Add conditions"
@@ -210,7 +210,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       type = create(:application_type)
       planning_application.update(application_type: type)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
 
       expect(page).not_to have_content("Add conditions")

--- a/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_consultation_summary_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "adding consultation summary" do
 
   before do
     sign_in(assessor)
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link("Check and assess")
   end
 

--- a/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
     Current.user = assessor
     travel_to(Time.zone.local(2024, 4, 17, 12, 30))
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Check and assess"
   end
 
@@ -100,7 +100,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
       create(:review, owner: term2.heads_of_term)
 
       travel_to(Time.zone.local(2024, 4, 17, 14, 30))
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Add heads of terms"
 
@@ -110,7 +110,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
         expect(page).to have_selector("p", text: "Sent on: 17 April 2024 13:30")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.id}/assessment/terms/#{term1.id}/edit"
+          href: "/planning_applications/#{planning_application.reference}/assessment/terms/#{term1.id}/edit"
         )
       end
 
@@ -118,7 +118,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
         expect(page).to have_selector(".govuk-tag", text: "Accepted")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.id}/assessment/terms/#{term2.id}/edit"
+          href: "/planning_applications/#{planning_application.reference}/assessment/terms/#{term2.id}/edit"
         )
       end
 
@@ -149,7 +149,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
       end
       create(:review, owner: planning_application.heads_of_term)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
 
       click_link "Add heads of terms"

--- a/spec/system/planning_applications/assessing/adding_informatives_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_informatives_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Add informatives", type: :system do
       allow(Current).to receive(:user).and_return assessor
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
     end
 
@@ -376,7 +376,7 @@ RSpec.describe "Add informatives", type: :system do
       create(:recommendation, :assessment_in_progress, planning_application:)
       informative = create(:informative, informative_set: planning_application.informative_set)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Review and submit recommendation"
 

--- a/spec/system/planning_applications/assessing/adding_neighbour_summary_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_neighbour_summary_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "neighbour responses", type: :system do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when planning application is in assessment" do
@@ -46,7 +46,7 @@ RSpec.describe "neighbour responses", type: :system do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=neighbour_summary"
+          "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=neighbour_summary"
         )
 
         within(".govuk-breadcrumbs__list") do
@@ -184,7 +184,7 @@ RSpec.describe "neighbour responses", type: :system do
     it "does not allow me to visit the page" do
       expect(page).not_to have_link("neighbour responses")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/assessment_details/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/assessing/adding_past_application_references_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_past_application_references_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "adding past application references" do
 
   it "lets user save draft, mark as complete, and edit" do
     sign_in(assessor)
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link("Check and assess")
 
     expect(list_item("History (manual)")).to have_content("Not started")

--- a/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
     Current.user = assessor
     travel_to(Time.zone.local(2024, 4, 17, 12, 30))
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Check and assess"
   end
 
@@ -193,7 +193,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       create(:review, owner: condition2.condition_set)
 
       travel_to(Time.zone.local(2024, 4, 17, 14, 30))
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Add pre-commencement conditions"
 
@@ -203,7 +203,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
         expect(page).to have_selector("p", text: "Sent on: 17 April 2024 13:30")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions/#{condition1.id}/edit"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions/#{condition1.id}/edit"
         )
       end
 
@@ -211,7 +211,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
         expect(page).to have_selector(".govuk-tag", text: "Accepted")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.id}/assessment/pre_commencement_conditions/#{condition2.id}/edit"
+          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions/#{condition2.id}/edit"
         )
       end
 
@@ -244,7 +244,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       end
       create(:review, owner: condition1.condition_set)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Add pre-commencement conditions"
 
@@ -306,7 +306,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       condition = create(:condition, :other, condition_set: planning_application.pre_commencement_condition_set, title: "title 1")
       create(:pre_commencement_condition_validation_request, owner: condition, approved: true, state: "closed")
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
       click_link "Review and submit recommendation"
 
@@ -335,7 +335,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       type = create(:application_type)
       planning_application.update(application_type: type)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and assess"
 
       expect(page).not_to have_content("Add conditions")

--- a/spec/system/planning_applications/assessing/additional_evidence_spec.rb
+++ b/spec/system/planning_applications/assessing/additional_evidence_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Additional evidence" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when planning application is in assessment" do
@@ -25,7 +25,7 @@ RSpec.describe "Additional evidence" do
       end
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=additional_evidence"
+        "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=additional_evidence"
       )
 
       within(".govuk-breadcrumbs__list") do
@@ -110,7 +110,7 @@ RSpec.describe "Additional evidence" do
     it "does not allow me to visit the page" do
       expect(page).not_to have_link("Additional evidence")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/assessment_details/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/assessing/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_against_policies_and_guidance_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Assessing against policies and guidance", type: :system, js: tru
 
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Check and assess"
   end
 
@@ -393,7 +393,7 @@ RSpec.describe "Assessing against policies and guidance", type: :system, js: tru
       expect(page).to have_selector("h3", text: "Policies and guidance")
       expect(page).to have_selector("h4", text: "Design")
       expect(page).to have_selector("h4", text: "Environment")
-      expect(page).to have_link("Edit assessment", href: "/planning_applications/#{planning_application.id}/assessment/considerations/edit")
+      expect(page).to have_link("Edit assessment", href: "/planning_applications/#{planning_application.reference}/assessment/considerations/edit")
     end
 
     within_fieldset "Does this planning application need to be decided by committee?" do
@@ -424,7 +424,7 @@ RSpec.describe "Assessing against policies and guidance", type: :system, js: tru
       expect(page).to have_selector("h3", text: "Policies and guidance")
       expect(page).to have_selector("h4", text: "Design")
       expect(page).to have_selector("h4", text: "Environment")
-      expect(page).to have_link("Edit assessment", href: "/planning_applications/#{planning_application.id}/assessment/considerations/edit")
+      expect(page).to have_link("Edit assessment", href: "/planning_applications/#{planning_application.reference}/assessment/considerations/edit")
     end
 
     click_button "Submit recommendation"

--- a/spec/system/planning_applications/assessing/assess_amenity_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_amenity_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "assessing amenity" do
 
   it "lets user save draft, mark as complete, and edit" do
     sign_in(assessor)
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link("Check and assess")
 
     expect(list_item("Amenity")).to have_content("Not started")

--- a/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
   context "when assessing whether an application is immune" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link("Check and assess")
       click_link("Immunity/permitted development rights")
     end
@@ -345,7 +345,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
     end
 
     it "I cannot create a new permitted development right request when there is an open response" do
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       within("#assess-immunity-detail-section") do
         choose "Yes"
@@ -367,11 +367,11 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(page).not_to have_link("Immunity/permitted development rights")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end
@@ -382,12 +382,12 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link "Check and assess"
       expect(page).not_to have_link("Immunity/permitted development rights")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       expect(page).to have_content("forbidden")
     end
@@ -397,7 +397,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
     it "I can view the information on the permitted development rights page" do
       create(:immunity_detail, planning_application:)
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       expect(page).to have_content("Evidence cover: Unknown")
       expect(page).to have_content("Missing evidence (gap in time): No")
@@ -416,7 +416,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
     it "lists the evidence in a single group for a single document" do
       document = create(:document, tags: %w[councilTaxBill])
       immunity_detail.add_document(document)
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       expect(page).to have_content("Council tax bills (1)")
     end
@@ -426,7 +426,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
       document2 = create(:document, tags: %w[councilTaxBill])
       immunity_detail.add_document(document1)
       immunity_detail.add_document(document2)
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       expect(page).to have_content("Council tax bills (2)")
     end
@@ -436,7 +436,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
       document2 = create(:document, tags: %w[photographs.existing])
       immunity_detail.add_document(document1)
       immunity_detail.add_document(document2)
-      visit "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
 
       expect(page).to have_content("Council tax bills (1)")
       expect(page).to have_content("Photographs - existings (1)")

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
 
       before do
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
       end
 
       it "warns the user about unsaved changes", pending: "flaky" do
@@ -170,7 +170,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
         click_link("Log out")
         travel_to(Time.zone.local(2022, 9, 2))
         sign_in(assessor2)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link("Check and assess")
         click_link("Part 1, Class D")
 
@@ -428,7 +428,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
 
       before do
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
       end
 
       it "displays the constraints without edit" do
@@ -470,7 +470,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
         )
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "doesn't show policy classes" do

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessment tasks", type: :system do
   before do
     sign_in assessor
     Rails.configuration.planning_history_enabled = true
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
   end
 
   context "when the planning application is in_assessment, I can assess the planning application" do
@@ -60,7 +60,7 @@ RSpec.describe "Assessment tasks", type: :system do
       before do
         application_type = create(:application_type, :prior_approval)
         planning_application.update(application_type:)
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       end
 
       it "displays the assessment tasks list" do

--- a/spec/system/planning_applications/assessing/check_consultees_spec.rb
+++ b/spec/system/planning_applications/assessing/check_consultees_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "checking consultees", js: true do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
   end
 
   it "allows the assessor to see the list of constraints and consultees" do

--- a/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/assessing/check_ownership_certificate_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Check ownership certificate" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
   end
 
   context "when there is an ownership certificate" do
@@ -48,7 +48,7 @@ RSpec.describe "Check ownership certificate" do
 
       click_link "Check ownership certificate"
 
-      expect(page).to have_link("Edit ownership certificate", href: "/planning_applications/#{planning_application.id}/assessment/ownership_certificate/edit")
+      expect(page).to have_link("Edit ownership certificate", href: "/planning_applications/#{planning_application.reference}/assessment/ownership_certificate/edit")
     end
 
     it "I can request a new certificate" do
@@ -72,7 +72,7 @@ RSpec.describe "Check ownership certificate" do
       # # Applicant responds
       ValidationRequest.last.update(state: "closed", approved: "true")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(list_item("Check ownership certificate")).to have_content("Not started")
 
@@ -112,7 +112,7 @@ RSpec.describe "Check ownership certificate" do
       ValidationRequest.last.update(state: "closed", approved: "true")
       OwnershipCertificate.create(planning_application:, certificate_type: "a")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(list_item("Check ownership certificate")).to have_content("Not started")
 

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "checking consistency" do
 
   before do
     sign_in(user)
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when the application is an LDC" do
@@ -310,7 +310,7 @@ RSpec.describe "checking consistency" do
       .last
       .auto_close_request!
 
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_link("Check description, documents and proposal details")
 
     expect(page).to have_content("Accepted 15 September 2022 13:00")
@@ -352,7 +352,7 @@ RSpec.describe "checking consistency" do
 
     request.close!
     request.update!(approved: true)
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_link("Check description, documents and proposal details")
 
     expect(page).to have_content("Accepted 15 September 2022 14:00")
@@ -409,7 +409,7 @@ RSpec.describe "checking consistency" do
     )
 
     click_button("Confirm cancellation")
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_link("Check description, documents and proposal details")
 
     expect(page).to have_content("Cancelled 15 September 2022 12:00")

--- a/spec/system/planning_applications/assessing/checking_publicity_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_publicity_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe "checking publicity" do
     end
 
     it "allows an assessor to mark the publicity check as complete" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=check_publicity")
+      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=check_publicity")
 
       click_link "Check site notice and press notice"
 
@@ -121,32 +121,32 @@ RSpec.describe "checking publicity" do
 
   context "when the publicity has not been started" do
     it "shows an alert to create a site notice" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=check_publicity")
+      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=check_publicity")
 
       click_link "Check site notice and press notice"
       expect(page).to have_selector("h1", text: "Check site notice and press notice")
 
       within "[role=alert]" do
         expect(page).to have_selector("p", text: "Site notice task incomplete.")
-        expect(page).to have_link("Create site notice", href: "/planning_applications/#{planning_application.id}/site_notices/new")
+        expect(page).to have_link("Create site notice", href: "/planning_applications/#{planning_application.reference}/site_notices/new")
       end
     end
 
     it "shows an alert to create a press notice" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=check_publicity")
+      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=check_publicity")
 
       click_link "Check site notice and press notice"
       expect(page).to have_selector("h1", text: "Check site notice and press notice")
 
       within "[role=alert]" do
         expect(page).to have_selector("p", text: "Press notice task incomplete.")
-        expect(page).to have_link("Create press notice", href: "/planning_applications/#{planning_application.id}/press_notice")
+        expect(page).to have_link("Create press notice", href: "/planning_applications/#{planning_application.reference}/press_notice")
       end
     end
   end
@@ -172,10 +172,10 @@ RSpec.describe "checking publicity" do
     end
 
     before do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=check_publicity")
+      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=check_publicity")
 
       click_link "Check site notice and press notice"
       expect(page).to have_selector("h1", text: "Check site notice and press notice")
@@ -184,14 +184,14 @@ RSpec.describe "checking publicity" do
     it "shows an alert to confirm the site notice" do
       within "[role=alert]" do
         expect(page).to have_selector("p", text: "Site notice task incomplete.")
-        expect(page).to have_link("Confirm site notice", href: "/planning_applications/#{planning_application.id}/site_notices/#{site_notice.id}/edit")
+        expect(page).to have_link("Confirm site notice", href: "/planning_applications/#{planning_application.reference}/site_notices/#{site_notice.id}/edit")
       end
     end
 
     it "shows an alert to confirm the press notice" do
       within "[role=alert]" do
         expect(page).to have_selector("p", text: "Press notice task incomplete.")
-        expect(page).to have_link("Confirm press notice", href: "/planning_applications/#{planning_application.id}/press_notice/confirmation")
+        expect(page).to have_link("Confirm press notice", href: "/planning_applications/#{planning_application.reference}/press_notice/confirmation")
       end
     end
 
@@ -268,10 +268,10 @@ RSpec.describe "checking publicity" do
     end
 
     before do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(page).to have_selector("h1", text: "Assess the application")
-      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=check_publicity")
+      expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=check_publicity")
 
       click_link "Check site notice and press notice"
       expect(page).to have_selector("h1", text: "Check site notice and press notice")
@@ -339,10 +339,10 @@ RSpec.describe "checking publicity" do
       end
 
       it "allows editing of the publicity check" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_selector("h1", text: "Assess the application")
-        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
+        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
 
         click_link "Check site notice and press notice"
         expect(page).to have_selector("h1", text: "Site notice and press notice")
@@ -389,7 +389,7 @@ RSpec.describe "checking publicity" do
 
         within("#check-consistency-assessment-tasks") do
           within("li:nth-child(2)") do
-            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
+            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
             expect(page).to have_selector("strong", text: "In progress")
           end
         end
@@ -405,10 +405,10 @@ RSpec.describe "checking publicity" do
       end
 
       it "allows editing of the publicity check" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_selector("h1", text: "Assess the application")
-        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
+        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
 
         click_link "Check site notice and press notice"
         expect(page).to have_selector("h1", text: "Site notice and press notice")
@@ -443,7 +443,7 @@ RSpec.describe "checking publicity" do
 
         within("#check-consistency-assessment-tasks") do
           within("li:nth-child(2)") do
-            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
+            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
             expect(page).to have_selector("strong", text: "In progress")
           end
         end
@@ -462,10 +462,10 @@ RSpec.describe "checking publicity" do
       end
 
       it "allows editing of the publicity check" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_selector("h1", text: "Assess the application")
-        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
+        expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}?category=check_publicity")
 
         click_link "Check site notice and press notice"
         expect(page).to have_selector("h1", text: "Site notice and press notice")
@@ -500,7 +500,7 @@ RSpec.describe "checking publicity" do
 
         within("#check-consistency-assessment-tasks") do
           within("li:nth-child(2)") do
-            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.id}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
+            expect(page).to have_link("Check site notice and press notice", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{assessment_detail.id}/edit?category=check_publicity")
             expect(page).to have_selector("strong", text: "In progress")
           end
         end

--- a/spec/system/planning_applications/assessing/determine_application_spec.rb
+++ b/spec/system/planning_applications/assessing/determine_application_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Planning Application Assessment" do
 
         travel_to review_date
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
       end
 
       it "I can determine the application" do
@@ -110,7 +110,7 @@ RSpec.describe "Planning Application Assessment" do
 
         expect(page).to have_content("Jane Smith, Director")
 
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         # Check latest audit
         click_button "Audit log"
@@ -241,7 +241,7 @@ RSpec.describe "Planning Application Assessment" do
           within(".govuk-notification-banner--alert") do
             expect(page).to have_content("Confirm the press notice published at date before determining the application")
             expect(page).to have_link(
-              "Confirm the press notice published at date", href: "/planning_applications/#{planning_application.id}/press_notice/confirmation"
+              "Confirm the press notice published at date", href: "/planning_applications/#{planning_application.reference}/press_notice/confirmation"
             )
           end
         end
@@ -282,7 +282,7 @@ RSpec.describe "Planning Application Assessment" do
 
       before do
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
       end
 
       it "I cannot determine the application" do

--- a/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Evidence of immunity", type: :system do
       create(:evidence_group, :with_document, tag: "buildingControlCertificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     context "when planning application is in assessment" do
@@ -36,7 +36,7 @@ RSpec.describe "Evidence of immunity", type: :system do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/assessment/immunity_details/new"
+          "/planning_applications/#{planning_application.reference}/assessment/immunity_details/new"
         )
 
         within(".govuk-heading-l") do
@@ -182,11 +182,11 @@ RSpec.describe "Evidence of immunity", type: :system do
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(page).not_to have_link("Evidence of immunity")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/immunity_details/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/immunity_details/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Immunity", type: :system do
   context "when not immune" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     let(:planning_application) do
@@ -35,7 +35,7 @@ RSpec.describe "Immunity", type: :system do
     before do
       allow_any_instance_of(PlanningApplication).to receive(:possibly_immune?).and_return(true)
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "returns true from possibly_immune?" do
@@ -60,7 +60,7 @@ RSpec.describe "Immunity", type: :system do
       create(:decision, :ldc_refused)
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "shows the assessment and review stages for immunity", :capybara do
@@ -106,7 +106,7 @@ RSpec.describe "Immunity", type: :system do
       click_on("Submit recommendation")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Review and sign-off"
 
       click_link "Review evidence of immunity"
@@ -133,7 +133,7 @@ RSpec.describe "Immunity", type: :system do
       expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link("Check and assess")
       click_link("Evidence of immunity")
 
@@ -181,7 +181,7 @@ RSpec.describe "Immunity", type: :system do
       expect(page).to have_content("Immunity/permitted development rights response was successfully created")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Review and sign-off"
 
       click_link "Review evidence of immunity"

--- a/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Permitted development right" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when signed in as an assessor" do
@@ -22,7 +22,7 @@ RSpec.describe "Permitted development right" do
       create(:decision, :ldc_refused)
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     context "when planning application is in assessment" do
@@ -41,7 +41,7 @@ RSpec.describe "Permitted development right" do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+          "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
         )
 
         within(".govuk-heading-l") do
@@ -197,7 +197,7 @@ RSpec.describe "Permitted development right" do
           click_button("Submit recommendation")
           click_link("Log out")
           sign_in(reviewer)
-          visit "/planning_applications/#{planning_application.id}"
+          visit "/planning_applications/#{planning_application.reference}"
 
           expect(page).to have_list_item_for(
             "Review and sign-off",
@@ -241,7 +241,7 @@ RSpec.describe "Permitted development right" do
 
           expect(page).to have_text("#{permitted_development_right.reviewer.name} accepted this response on #{permitted_development_right.reviewed_at}")
 
-          visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/#{permitted_development_right.id}/edit"
+          visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/#{permitted_development_right.id}/edit"
           expect(page).to have_text("forbidden")
         end
       end
@@ -276,7 +276,7 @@ RSpec.describe "Permitted development right" do
         end
 
         it "I cannot create a new permitted development right request when there is an open response" do
-          visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
           choose "No"
           click_button "Save and mark as complete"
           expect(page).to have_text("Cannot create a permitted development right response when there is already an open response")
@@ -306,7 +306,7 @@ RSpec.describe "Permitted development right" do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/assessment/assess_immunity_detail_permitted_development_rights/new"
+          "/planning_applications/#{planning_application.reference}/assessment/assess_immunity_detail_permitted_development_rights/new"
         )
 
         within(".govuk-heading-l") do
@@ -334,11 +334,11 @@ RSpec.describe "Permitted development right" do
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(page).not_to have_link("Permitted development rights")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end
@@ -351,12 +351,12 @@ RSpec.describe "Permitted development right" do
 
     it "returns 404" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(page).not_to have_link("Permitted development rights")
 
       expect do
-        visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
         expect(page).to have_selector("h1", text: "Does not exist")
       end.to raise_error(ActionController::RoutingError, "Not found")
     end

--- a/spec/system/planning_applications/assessing/planning_history_show_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_history_show_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Planning History" do
     end
 
     before do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       click_link "History search (in testing)"
     end
 
@@ -107,7 +107,7 @@ RSpec.describe "Planning History" do
     end
 
     before do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       click_link "History search (in testing)"
     end
 

--- a/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Review documents for recommendation" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when planning application is in assessment" do
@@ -41,7 +41,7 @@ RSpec.describe "Review documents for recommendation" do
       end
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/review/documents"
+        "/planning_applications/#{planning_application.reference}/review/documents"
       )
 
       within(".govuk-heading-l") do
@@ -240,7 +240,7 @@ RSpec.describe "Review documents for recommendation" do
     end
 
     it "does not allow me to visit the page" do
-      visit "/planning_applications/#{planning_application.id}/review/documents"
+      visit "/planning_applications/#{planning_application.reference}/review/documents"
 
       expect(page).to have_content("The planning application must be validated before reviewing can begin")
     end

--- a/spec/system/planning_applications/assessing/site_description_spec.rb
+++ b/spec/system/planning_applications/assessing/site_description_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Site description" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when planning application is in assessment" do
@@ -31,7 +31,7 @@ RSpec.describe "Site description" do
       end
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=site_description"
+        "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=site_description"
       )
 
       expect(page).to have_link(
@@ -122,7 +122,7 @@ RSpec.describe "Site description" do
     it "does not allow me to visit the page" do
       expect(page).not_to have_link("Site description")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/assessment_details/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/assessing/summary_of_works_spec.rb
+++ b/spec/system/planning_applications/assessing/summary_of_works_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Summary of works" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when planning application is in assessment" do
@@ -29,7 +29,7 @@ RSpec.describe "Summary of works" do
       end
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/assessment/assessment_details/new?category=summary_of_work"
+        "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new?category=summary_of_work"
       )
 
       expect(page).to have_content(planning_application.reference)
@@ -122,7 +122,7 @@ RSpec.describe "Summary of works" do
     it "does not allow me to visit the page" do
       expect(page).not_to have_link("Summary of works")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/assessment_details/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/assessment_details/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
 
   it "lets the user view and download the report" do
     sign_in(assessor)
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_link("Review and submit recommendation")
     click_button("Assessment report details")
 

--- a/spec/system/planning_applications/assigning_spec.rb
+++ b/spec/system/planning_applications/assigning_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "assigning planning application" do
     it "lets a planning application be assigned to a user" do
       travel_to("2022-01-01")
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/assign_users"
+      visit "/planning_applications/#{planning_application.reference}/assign_users"
       select("Jane Smith")
       click_button("Confirm")
 
@@ -65,7 +65,7 @@ RSpec.describe "assigning planning application" do
     it "lets a planning application be assigned to a user" do
       travel_to("2022-01-01")
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/assign_users"
+      visit "/planning_applications/#{planning_application.reference}/assign_users"
       select("Jane Smith")
       click_button("Confirm")
 
@@ -102,7 +102,7 @@ RSpec.describe "assigning planning application" do
 
     it "can be unnassigned" do
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/assign_users"
+      visit "/planning_applications/#{planning_application.reference}/assign_users"
       select("Unassigned")
       click_button("Confirm")
 
@@ -118,7 +118,7 @@ RSpec.describe "assigning planning application" do
     it "there is an error message and no update is persisted" do
       sign_in(reviewer)
 
-      visit "/planning_applications/#{planning_application.id}/assign_users"
+      visit "/planning_applications/#{planning_application.reference}/assign_users"
       select("Jane Smith")
       click_button("Confirm")
 

--- a/spec/system/planning_applications/audit_spec.rb
+++ b/spec/system/planning_applications/audit_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Auditing changes to a planning application" do
       activity_type: "replacement_document_validation_request_received", activity_information: 1, audit_comment: "floor_plan.pdf", api_user:)
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_button "Audit log"
     click_link "View all audits"
   end
@@ -65,7 +65,7 @@ RSpec.describe "Auditing changes to a planning application" do
     before { validation_request.auto_close_request! }
 
     it "shows correct information with link to request" do
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
 
       expect(page).to have_row_for(
         "Auto-closed: validation request (red line boundary#1)",
@@ -75,7 +75,7 @@ RSpec.describe "Auditing changes to a planning application" do
       click_link("Auto-closed: validation request (red line boundary#1)")
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{validation_request.id}"
+        "/planning_applications/#{planning_application.reference}/validation/red_line_boundary_change_validation_requests/#{validation_request.id}"
       )
     end
   end
@@ -95,7 +95,7 @@ RSpec.describe "Auditing changes to a planning application" do
     before { validation_request.auto_close_request! }
 
     it "shows correct information with link to request" do
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
 
       expect(page).to have_row_for(
         "Auto-closed: validation request (description#1)",
@@ -105,13 +105,13 @@ RSpec.describe "Auditing changes to a planning application" do
       click_link("Auto-closed: validation request (description#1)")
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/description_change_validation_requests/#{validation_request.id}"
+        "/planning_applications/#{planning_application.reference}/validation/description_change_validation_requests/#{validation_request.id}"
       )
     end
   end
 
   it "navigates back to the previous page I was on" do
     click_link "Back"
-    expect(page).to have_current_path("/planning_applications/#{planning_application.id}")
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}")
   end
 end

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Consultation" do
     sign_in assessor
 
     planning_application.consultation.update(start_date: Time.zone.local(2023, 8, 15, 12), end_date: Time.zone.local(2023, 9, 15, 12))
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when there is a consultation end date" do
@@ -88,7 +88,7 @@ RSpec.describe "Consultation" do
       within("#confirm-press-notice-warning .govuk-warning-text") do
         expect(page).to have_link(
           "Confirm press notice publication date",
-          href: "/planning_applications/#{planning_application.id}/press_notice/confirmation"
+          href: "/planning_applications/#{planning_application.reference}/press_notice/confirmation"
         )
       end
     end
@@ -111,19 +111,19 @@ RSpec.describe "Consultation" do
 
     it "returns 404 when navigating to the site notice urls directly" do
       expect do
-        visit "/planning_applications/#{planning_application.id}/site_notices/new"
+        visit "/planning_applications/#{planning_application.reference}/site_notices/new"
         expect(page).to have_selector("h1", text: "Does not exist")
       end.to raise_error(ActionController::RoutingError, "Not found")
     end
 
     it "returns 404 when navigating to the press notice urls directly" do
       expect do
-        visit "/planning_applications/#{planning_application.id}/press_notice"
+        visit "/planning_applications/#{planning_application.reference}/press_notice"
         expect(page).to have_selector("h1", text: "Does not exist")
       end.to raise_error(ActionController::RoutingError, "Not found")
 
       expect do
-        visit "/planning_applications/#{planning_application.id}/press_notice/confirmation"
+        visit "/planning_applications/#{planning_application.reference}/press_notice/confirmation"
         expect(page).to have_selector("h1", text: "Does not exist")
       end.to raise_error(ActionController::RoutingError, "Not found")
     end

--- a/spec/system/planning_applications/consulting/add_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/add_consultees_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Consultation", type: :system, js: true do
       email_address: "chris.wood@#{local_authority.subdomain}.gov.uk"
     )
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/consultation"
+    visit "/planning_applications/#{planning_application.reference}/consultation"
   end
 
   it "lists constraints on the selection page" do

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     consultation.update(end_date: "2023-07-08 16:17:35 +0100")
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Consultees, neighbours and publicity"
   end
 
@@ -63,7 +63,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     expect(page).to have_content("I think this proposal looks great and I would like to make a really long comment about how great it is and please let this person build this thing.")
 
     # Check audit log
-    visit "/planning_applications/#{planning_application.id}/audits"
+    visit "/planning_applications/#{planning_application.reference}/audits"
     within("#audit_#{Audit.last.id}") do
       expect(page).to have_content("Neighbour response uploaded")
       expect(page).to have_content(assessor.name)
@@ -102,7 +102,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     expect(page).to have_content("Objection")
 
     # Check audit log
-    visit "/planning_applications/#{planning_application.id}/audits"
+    visit "/planning_applications/#{planning_application.reference}/audits"
     within("#audit_#{Audit.last.id}") do
       expect(page).to have_content("Neighbour response uploaded")
       expect(page).to have_content(assessor.name)
@@ -110,7 +110,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     end
 
     # Check neighbour is not added to the selected neighbours page
-    visit "/planning_applications/#{planning_application.id}/consultation"
+    visit "/planning_applications/#{planning_application.reference}/consultation"
     expect(page).not_to have_content("123 Street, AAA111")
   end
 
@@ -234,7 +234,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     expect(page).to have_link("Back", href: planning_application_consultation_path(planning_application))
 
     # Check audit log
-    visit "/planning_applications/#{planning_application.id}/audits"
+    visit "/planning_applications/#{planning_application.reference}/audits"
     within("#audit_#{Audit.last.id}") do
       expect(page).to have_content("Neighbour response edited")
       expect(page).to have_content(assessor.name)
@@ -292,7 +292,7 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     end
 
     it "is marked as not started" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       expect(page).to have_content("View neighbour responses Not started")
     end

--- a/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/reconsults_existing_consultees_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Consultation", type: :system, js: true do
   it "reconsults existing consultees" do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     expect(page).to have_selector("h1", text: "Application")
 
     within "#consultation-section" do

--- a/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/resends_emails_to_consultees_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Consultation", type: :system, js: true do
   it "resends emails to existing consultees" do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     expect(page).to have_selector("h1", text: "Application")
 
     within "#consultation-section" do

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     stub_any_os_places_api_request
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "displays the planning application address, reference, and addresses submitted by applicant" do
@@ -547,7 +547,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     context "when there are no neigbhours" do
       it "shows 'not started'" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         expect(page).to have_content "Select and add neighbours Not started"
       end
@@ -559,7 +559,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       end
 
       it "shows 'completed'" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         expect(page).to have_content "Select and add neighbours Completed"
       end

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Consultation", type: :system, js: true do
   it "sends emails to consultees" do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     expect(page).to have_selector("h1", text: "Application")
 
     within "#consultation-section" do
@@ -448,7 +448,7 @@ RSpec.describe "Consultation", type: :system, js: true do
     it "doesn't send emails to consultees" do
       sign_in assessor
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_selector("h1", text: "Application")
 
       within "#consultation-section" do
@@ -496,7 +496,7 @@ RSpec.describe "Consultation", type: :system, js: true do
     it "doesn't send emails to consultees" do
       sign_in assessor
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_selector("h1", text: "Application")
 
       within "#consultation-section" do
@@ -545,7 +545,7 @@ RSpec.describe "Consultation", type: :system, js: true do
     it "doesn't send emails to consultees" do
       sign_in assessor
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_selector("h1", text: "Application")
 
       within "#consultation-section" do

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("production")
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when sending letters" do
     before do
       travel_to(Time.zone.local(2023, 9, 1, 10))
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       neighbour = create(:neighbour, consultation:)
       neighbour_letter = create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
@@ -70,7 +70,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       expect(NeighbourLetter.last.text).to include("A prior approval application has been made for the development described below:")
 
       # View audit log
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
       within("#audit_#{Audit.last.id}") do
         expect(page).to have_content("Neighbour letters sent")
         expect(page).to have_content(assessor.name)
@@ -89,7 +89,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       expect(PlanningApplicationMailer).to receive(:neighbour_consultation_letter_copy_mail).with(planning_application, "applicant@example.com").and_call_original
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
@@ -118,7 +118,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     it "allows overriding the response period" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
@@ -131,7 +131,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     it "fails if no response period is set" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
@@ -154,7 +154,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
         expect(LetterSendingService).not_to receive(:new)
 
         sign_in assessor
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         click_link "Send letters to neighbours"
 
@@ -162,7 +162,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
         within(".govuk-notification-banner--alert") do
           expect(page).to have_content("The planning application must be made public on the BOPS Public Portal before you can send letters to neighbours.")
-          expect(page).to have_link("made public on the BOPS Public Portal", href: "/planning_applications/#{planning_application.id}/make_public")
+          expect(page).to have_link("made public on the BOPS Public Portal", href: "/planning_applications/#{planning_application.reference}/make_public")
         end
       end
     end
@@ -173,7 +173,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
     end
@@ -190,7 +190,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     it "I can not send letters with an invalid address" do
       neighbour.save(validate: false)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
@@ -238,7 +238,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     context "when there are no letters" do
       it "shows 'not started'" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         expect(page).to have_content "Send letters to neighbours Not started"
       end
@@ -251,7 +251,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       end
 
       it "shows 'completed'" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         expect(page).to have_content "Send letters to neighbours Completed"
       end
@@ -266,7 +266,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       end
 
       it "shows 'failed'" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         expect(page).to have_content "Send letters to neighbours Failed"
       end
@@ -289,7 +289,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     end
 
     it "shows that letters have been sent" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
 
       expect(page).not_to have_content "Send letters to neighbours Not started"
@@ -302,7 +302,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     end
 
     it "allows resending of letters" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
@@ -318,7 +318,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     end
 
     it "does not resend letters unless selected" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
@@ -327,7 +327,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     end
 
     it "requires a reason to resend letters" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
@@ -339,7 +339,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     end
 
     it "includes a reason in the letter when resending letters" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Send letters to neighbours"
 
@@ -358,7 +358,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       end
 
       it "allows setting a reason when resend letters" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
         click_link "Send letters to neighbours"
 

--- a/spec/system/planning_applications/consulting/site_visit_spec.rb
+++ b/spec/system/planning_applications/consulting/site_visit_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Site visit" do
       let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:) }
 
       it "shows the site visit item in the tasklist" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
 
         expect(page).to have_css("#site-visit")
@@ -40,7 +40,7 @@ RSpec.describe "Site visit" do
       let!(:site_visit) { create(:site_visit, consultation:) }
 
       it "shows the site visit item in the tasklist" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
 
         expect(page).to have_css("#site-visit")
@@ -52,7 +52,7 @@ RSpec.describe "Site visit" do
       let!(:neighbour_response2) { create(:neighbour_response, summary_tag: "supportive", neighbour:) }
 
       it "does not show the site visit item in the tasklist" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
 
         expect(page).not_to have_css("#site-visit")
@@ -64,7 +64,7 @@ RSpec.describe "Site visit" do
       let!(:consultation) { planning_application.consultation }
 
       it "allows officers to upload site visits any time" do
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
         click_link "Consultees, neighbours and publicity"
 
         expect(page).to have_css("#site-visit")
@@ -78,7 +78,7 @@ RSpec.describe "Site visit" do
     let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:, received_at: Time.zone.now) }
 
     before do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       click_link "Site visit"
     end
@@ -126,7 +126,7 @@ RSpec.describe "Site visit" do
     let!(:neighbour_response) { create(:neighbour_response, summary_tag: "objection", neighbour:, received_at: Time.zone.now) }
 
     before do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       within("#site-visit") do
         click_link "Site visit"
@@ -175,7 +175,7 @@ RSpec.describe "Site visit" do
     it "I can't add a site visit before the consultation has started" do
       planning_application = create(:planning_application, :planning_permission, local_authority:)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Consultees, neighbours and publicity"
       within("#site-visit") do
         click_link "Site visit"
@@ -209,7 +209,7 @@ RSpec.describe "Site visit" do
 
         expect(page).to have_link(
           "Site visit",
-          href: "/planning_applications/#{planning_application.id}/consultation/site_visits"
+          href: "/planning_applications/#{planning_application.reference}/consultation/site_visits"
         )
         expect(page).to have_content("Completed")
 
@@ -247,7 +247,7 @@ RSpec.describe "Site visit" do
 
         click_link "Back"
         expect(current_url).to include(
-          "/planning_applications/#{planning_application.id}/consultation/site_visits"
+          "/planning_applications/#{planning_application.reference}/consultation/site_visits"
         )
       end
     end

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Consultation", type: :system, js: true do
   it "views consultee responses" do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     expect(page).to have_selector("h1", text: "Application")
 
     within "#consultation-section" do

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "editing planning application" do
     end
 
     click_button("Save")
+    planning_application.reload
 
     expect(page).to have_content(
       "Planning application was successfully updated."
@@ -61,7 +62,7 @@ RSpec.describe "editing planning application" do
     end
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/assessment/tasks"
+      "/planning_applications/#{planning_application.reference}/assessment/tasks"
     )
 
     click_link("Check description, documents and proposal details")
@@ -72,17 +73,18 @@ RSpec.describe "editing planning application" do
     expect(page).to have_select("planning-application-application-type-id-field", selected: "Prior Approval - Larger extension to a house")
     fill_in("Address 1", with: "125 High Street")
     click_button("Save")
+    planning_application.reload
 
     expect(page).to have_content(
       "Planning application was successfully updated."
     )
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/assessment/consistency_checklist/new"
+      "/planning_applications/#{planning_application.reference}/assessment/consistency_checklist/new"
     )
 
     # Check audit
-    visit "/planning_applications/#{planning_application.reload.reference}/audits"
+    visit "/planning_applications/#{planning_application.reference}/audits"
     within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "editing planning application" do
     end
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.reference}/assessment/tasks"
+      "/planning_applications/#{planning_application.id}/assessment/tasks"
     )
 
     click_link("Check description, documents and proposal details")
@@ -78,11 +78,11 @@ RSpec.describe "editing planning application" do
     )
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.reference}/assessment/consistency_checklist/new"
+      "/planning_applications/#{planning_application.id}/assessment/consistency_checklist/new"
     )
 
     # Check audit
-    visit "/planning_applications/#{planning_application.reference}/audits"
+    visit "/planning_applications/#{planning_application.reload.reference}/audits"
     within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "editing planning application" do
     travel_to(DateTime.new(2023, 1, 1))
     sign_in(assessor)
     create(:application_type, :prior_approval)
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "returns the user to the previous page after updating" do
@@ -61,7 +61,7 @@ RSpec.describe "editing planning application" do
     end
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/assessment/tasks"
+      "/planning_applications/#{planning_application.reference}/assessment/tasks"
     )
 
     click_link("Check description, documents and proposal details")
@@ -78,11 +78,11 @@ RSpec.describe "editing planning application" do
     )
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/assessment/consistency_checklist/new"
+      "/planning_applications/#{planning_application.reference}/assessment/consistency_checklist/new"
     )
 
     # Check audit
-    visit "/planning_applications/#{planning_application.id}/audits"
+    visit "/planning_applications/#{planning_application.reference}/audits"
     within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(

--- a/spec/system/planning_applications/fee_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/fee_change_validation_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Requesting other changes to a planning application" do
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when there are fee item validation requests" do
@@ -27,7 +27,7 @@ RSpec.describe "Requesting other changes to a planning application" do
     end
 
     it "does not show in the other validation issues task list" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       within("#other-change-validation-tasks") do
         expect(page).to have_link(
           "View other validation request ##{other_change_validation_request.sequence}",

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe "making planning application public" do
     travel_to("2022-01-01")
     sign_in(assessor)
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
 
     expect(page).to have_content("Public on BOPS Public Portal: No")
 
-    visit "/planning_applications/#{planning_application.id}/make_public"
+    visit "/planning_applications/#{planning_application.reference}/make_public"
 
     expect(page).to have_content("Make application public")
 
@@ -41,7 +41,7 @@ RSpec.describe "making planning application public" do
 
     expect(planning_application.reload.published_at).to eq(Time.zone.local(2022, 1, 1))
 
-    visit "/planning_applications/#{planning_application.id}/make_public"
+    visit "/planning_applications/#{planning_application.reference}/make_public"
 
     choose "No"
 

--- a/spec/system/planning_applications/other_change_validation_request_spec.rb
+++ b/spec/system/planning_applications/other_change_validation_request_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Requesting other changes to a planning application" do
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "displays the planning application address and reference" do
@@ -96,7 +96,7 @@ RSpec.describe "Requesting other changes to a planning application" do
     click_link("Back")
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/validation/tasks"
+      "/planning_applications/#{planning_application.reference}/validation/tasks"
     )
   end
 
@@ -167,7 +167,7 @@ RSpec.describe "Requesting other changes to a planning application" do
     end
 
     it "does not show in the other validation issues task list" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#other-change-validation-tasks") do
         expect(page).to have_link(

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "post validation requests" do
   before do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "when application has been validated" do
@@ -18,7 +18,7 @@ RSpec.describe "post validation requests" do
     end
 
     it "lets the assessor create an additional document request" do
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link("Request a new document")
       fill_in("Please specify the new document type:", with: "Floor plan")
 
@@ -33,7 +33,7 @@ RSpec.describe "post validation requests" do
         "Additional document request successfully created."
       )
 
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
 
       expect(page).to have_content(planning_application.full_address)
       expect(page).to have_content(planning_application.reference)
@@ -42,7 +42,7 @@ RSpec.describe "post validation requests" do
         expect(page).to have_content("Floor plan")
       end
 
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
 
       within("#additional-document-validation-requests-table") do
         expect(page).to have_content("Document requested: Floor plan")
@@ -90,7 +90,7 @@ RSpec.describe "post validation requests" do
       end
 
       it "lets the assessor cancel the request" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         document_row = row_with_content("Document requested: Floor plan")
 
         within(document_row) do
@@ -112,13 +112,13 @@ RSpec.describe "post validation requests" do
           expect(page).to have_content("Requested in error")
         end
 
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
 
         expect(page).not_to have_content("Document requested: Floor plan")
       end
 
       it "does not show request on validation documents page" do
-        visit "/planning_applications/#{planning_application.id}/validation/documents/edit"
+        visit "/planning_applications/#{planning_application.reference}/validation/documents/edit"
         expect(page).not_to have_content("Document requested: Floor plan")
       end
     end
@@ -134,7 +134,7 @@ RSpec.describe "post validation requests" do
 
         planning_application.start!
 
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
       end
 
       it "does not display any pre validation requests" do
@@ -143,7 +143,7 @@ RSpec.describe "post validation requests" do
         expect(page).not_to have_content("Cancelled requests")
 
         # check pre valiation requests table
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
         within(".validation-requests-table") do
           expect(page).to have_content("Red line boundary changes")
           expect(page).to have_link("View")
@@ -177,7 +177,7 @@ RSpec.describe "post validation requests" do
           proposed_description: "New description 2"
         )
 
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
       end
 
       it "does not display any post validation requests" do
@@ -188,7 +188,7 @@ RSpec.describe "post validation requests" do
         expect(page).not_to have_content("New description 2")
 
         # check post valiation requests table
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
         within(".validation-requests-table") do
           expect(page).to have_content("Red line boundary changes")
           expect(page).to have_link("View")
@@ -210,7 +210,7 @@ RSpec.describe "post validation requests" do
 
     it "does not allow you to view post validation requests" do
       # visit url directly
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
       expect(page).to have_content("forbidden")
     end
   end
@@ -222,7 +222,7 @@ RSpec.describe "post validation requests" do
 
     it "does not allow you to view post validation requests" do
       # visit url directly
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
       expect(page).to have_content("forbidden")
     end
   end
@@ -237,7 +237,7 @@ RSpec.describe "post validation requests" do
     end
 
     it "lets the assessor create an additional document request" do
-      visit "/planning_applications/#{planning_application.id}/documents"
+      visit "/planning_applications/#{planning_application.reference}/documents"
       click_link("Request a new document")
       fill_in("Please specify the new document type:", with: "Floor plan")
 

--- a/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Confirm site notice", js: true do
     travel_to("2023-02-01")
     sign_in(assessor)
 
-    visit "/planning_applications/#{planning_application.id}/consultation"
+    visit "/planning_applications/#{planning_application.reference}/consultation"
   end
 
   it "allows planning officer to update displayed at date" do

--- a/spec/system/planning_applications/publicity/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/create_site_notice_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Create a site notice", js: true do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("test")
     sign_in(assessor)
-    visit "/planning_applications/#{planning_application.id}/consultation"
+    visit "/planning_applications/#{planning_application.reference}/consultation"
   end
 
   it "allows officers to create a site notice and print it" do

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Press notice" do
   before do
     sign_in assessor
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   describe "responding to whether a press notice is required" do
@@ -105,7 +105,7 @@ RSpec.describe "Press notice" do
           user: assessor
         )
 
-        visit "/planning_applications/#{planning_application.id}/audits"
+        visit "/planning_applications/#{planning_application.reference}/audits"
         within("#audit_#{audits.first.id}") do
           expect(page).to have_content("Press notice response added")
           expect(page).to have_content(assessor.name)
@@ -611,8 +611,8 @@ RSpec.describe "Press notice" do
         click_link "Consultees, neighbours and publicity"
         expect(page).not_to have_content("Confirm press notice")
 
-        visit "/planning_applications/#{planning_application.id}/press_notice/confirmation"
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/consultation")
+        visit "/planning_applications/#{planning_application.reference}/press_notice/confirmation"
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/consultation")
         expect(page).to have_content("The press notice is not required so there is no need to confirm it")
       end
     end

--- a/spec/system/planning_applications/recommending/legislation_spec.rb
+++ b/spec/system/planning_applications/recommending/legislation_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Planning Application Assessment Legislation" do
   end
 
   it "shows assessed legislation on recommendation page" do
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link("Check and assess")
     click_link("Add assessment area")
     choose("Part 1 - Development within the curtilage of a dwellinghouse")
@@ -95,7 +95,7 @@ RSpec.describe "Planning Application Assessment Legislation" do
         section: "1A",
         policy_class:)
 
-      visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
       expect(page).to have_selector "h1", text: "Make draft recommendation"
       expect(page).not_to have_content("View commented legislation for class T")
@@ -111,7 +111,7 @@ RSpec.describe "Planning Application Assessment Legislation" do
         section: "1A",
         policy_class:)
 
-      visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
       expect(page).to have_selector "h1", text: "Make draft recommendation"
       expect(page).to have_content("View commented legislation for class T")
@@ -131,7 +131,7 @@ RSpec.describe "Planning Application Assessment Legislation" do
 
       create(:comment, commentable: policy)
 
-      visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
       expect(page).to have_content("Complies")
       expect(page).to have_content("View commented legislation for class T")

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
 
     it "shows the correct status tags at each stage" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(list_item("Make draft recommendation")).to have_content("Not started")
 
@@ -83,7 +83,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       expect(list_item("Make draft recommendation")).to have_content("Completed")
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       ["Not started", "In progress", "Completed"].each do |status|
         expect(list_item("View recommendation")).not_to have_content(status)
       end
@@ -93,12 +93,12 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(page).to have_content "Draft"
       click_button("Submit recommendation")
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(list_item("View recommendation")).to have_content("Awaiting determination")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(list_item("Review and sign-off")).to have_content("Not started")
 
@@ -136,7 +136,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link("Check and assess")
       click_link("Make draft recommendation")
@@ -156,7 +156,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(list_item("View recommendation")).to have_content("Awaiting determination")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(list_item("Review and sign-off")).to have_content("Not started")
 
@@ -173,7 +173,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       expect(list_item("Make draft recommendation")).to have_content("Completed")
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(list_item("View recommendation")).to have_content("Completed")
     end
@@ -251,7 +251,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           planning_application.reload
           expect(planning_application.status).to eq("awaiting_determination")
 
-          visit "/planning_applications/#{planning_application.id}"
+          visit "/planning_applications/#{planning_application.reference}"
           click_link "View recommendation"
           expect(page).to have_text("Recommendations submitted by #{planning_application.recommendations.first.assessor.name}")
 
@@ -268,7 +268,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       it "shows errors if decision and public comment are blank" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
         click_button("Save and mark as complete")
 
         expect(page).to have_content("Please select an option to record your recommendation")
@@ -354,7 +354,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_button("Submit recommendation")
 
         expect(page).to have_content("Recommendation was successfully submitted.")
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}")
         click_link("View recommendation")
         within(".govuk-button-group") do
           expect(page).to have_button("Withdraw recommendation")
@@ -362,9 +362,9 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
         expect(planning_application.reload.status).to eq("awaiting_determination")
 
-        visit "/planning_applications/#{planning_application.id}/submit_recommendation"
+        visit "/planning_applications/#{planning_application.reference}/submit_recommendation"
         expect(page).to have_content("Not Found")
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         # Check latest audit
         click_button "Audit log"
@@ -591,7 +591,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
 
         expect(page).to have_content("Recommendation was successfully withdrawn.")
-        expect(page).to have_current_path("/planning_applications/#{planning_application.id}/submit_recommendation")
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/submit_recommendation")
         expect(page).to have_button("Submit recommendation")
         expect(page).not_to have_button("Withdraw recommendation")
         expect(planning_application.reload.status).to eq("in_assessment")
@@ -660,7 +660,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         it "displays recommendation events" do
           travel_to(Time.zone.local(2022, 8, 23, 9))
 
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           within_fieldset("What is your recommendation?") do
             choose("Granted")
@@ -680,7 +680,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link("Review and submit recommendation")
           click_button("Submit recommendation")
           sign_in(reviewer)
-          visit "/planning_applications/#{planning_application.id}/review/recommendations/#{planning_application.recommendation.id}/edit"
+          visit "/planning_applications/#{planning_application.reference}/review/recommendations/#{planning_application.recommendation.id}/edit"
           choose("No (return the case for assessment)")
 
           expect(page).to have_text "Case currently assigned to: Alice Aplin"
@@ -731,7 +731,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
 
         it "displays the documents to be referenced in the decision notice" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           within("#decision-notice-documents") do
             expect(page).to have_content("Documents included in the decision notice")
@@ -752,7 +752,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       context "when there are no documents" do
         it "displays there are no documents text" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           within("#decision-notice-documents") do
             expect(page).to have_content("Documents included in the decision notice")
@@ -790,7 +790,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       let!(:evidence_group2) { create(:evidence_group, start_date: "2009-05-02 12:13:41.501488206 +0000", end_date: nil, immunity_detail:) }
 
       it "shows the relevant assessment details when assessing the recommendation" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
         within("#constraints-section") do
           expect(page).to have_selector("h3", text: "Constraints including Article 4 direction(s)")
@@ -841,7 +841,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       it "does not show additional evidence when reviewing and submitting the recommendation" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
         within_fieldset("What is your recommendation?") do
           choose("Granted")
         end
@@ -850,7 +850,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         fill_in "Provide supporting information for your manager.", with: "This is a private assessor comment"
         click_button "Save and mark as complete"
 
-        visit "/planning_applications/#{planning_application.id}/submit_recommendation"
+        visit "/planning_applications/#{planning_application.reference}/submit_recommendation"
         expect(page).to have_css("#constraints-section")
         expect(page).to have_css("#past-applications-section")
         expect(page).to have_css("#summary-of-works-section")
@@ -871,7 +871,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
 
         it "displays a warning message with a link to the post validation requests table" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           within(".moj-banner__message") do
             expect(page).to have_content("There are outstanding change requests (last request #{Time.current.to_fs}")
@@ -888,7 +888,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
 
         it "displays a warning message with a link to the post validation requests table" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           within(".moj-banner__message") do
             expect(page).to have_content("There are outstanding change requests (last request #{Time.current.to_fs}")
@@ -905,7 +905,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
 
         it "does not display any warning message" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           expect(page).not_to have_css(".moj-banner__message")
         end
@@ -913,7 +913,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
       context "with no request" do
         it "does not display any warning message" do
-          visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+          visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
           expect(page).not_to have_css(".moj-banner__message")
         end
@@ -1053,7 +1053,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           planning_application.reload
           expect(planning_application.status).to eq("awaiting_determination")
 
-          visit "/planning_applications/#{planning_application.id}"
+          visit "/planning_applications/#{planning_application.reference}"
           click_link "View recommendation"
           expect(page).to have_text("Recommendations submitted by #{planning_application.recommendations.first.assessor.name}")
 
@@ -1076,7 +1076,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       it "displays a warning message with the consultation end date" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
         within(".moj-banner__message") do
           expect(page).to have_content("The consultation is still ongoing. It will end on the #{consultation.end_date.to_fs(:day_month_year_slashes)}. Are you sure you still want to make the recommendation?")
@@ -1090,7 +1090,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       it "does not display a warning message" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
         expect(page).not_to have_css(".moj-banner__message")
       end

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
   before do
     travel_to Time.zone.local(2021, 1, 1)
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   context "before an application has been invalidated" do
@@ -37,12 +37,12 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
     end
 
     it "returns to task list if document is not marked as valid or invalid" do
-      visit "/planning_applications/#{planning_application.id}/documents/#{document1.id}/edit?validate=yes"
+      visit "/planning_applications/#{planning_application.reference}/documents/#{document1.id}/edit?validate=yes"
 
       click_button("Save")
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/supply_documents"
+        "/planning_applications/#{planning_application.reference}/supply_documents"
       )
     end
 
@@ -325,7 +325,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
 
       # Cancel request
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       click_link "Tag and validate supplied documents"
       within("#check-tag-documents-tasks") do
@@ -360,7 +360,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       end
       expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 2)
 
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       within("#invalid-items-count") do
         expect(page).to have_content("Invalid items 0")
       end
@@ -402,7 +402,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
 
       it "can only view response and original document is archived" do
         # Can only view request
-        visit "/planning_applications/#{planning_application.id}/validation/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
+        visit "/planning_applications/#{planning_application.reference}/validation/replacement_document_validation_requests/#{replacement_document_validation_request.id}"
         expect(page).not_to have_link("Cancel request")
         expect(page).not_to have_link("Delete request")
         expect(page).not_to have_link("Edit request")
@@ -410,10 +410,10 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
         expect(page).to have_content("A replacement document has been provided for this request:")
         expect(page).to have_link(
           replacement_document_validation_request.reload.new_document.name.to_s,
-          href: "/planning_applications/#{planning_application.id}/documents/#{replacement_document_validation_request.new_document.id}/edit?validate=yes"
+          href: "/planning_applications/#{planning_application.reference}/documents/#{replacement_document_validation_request.new_document.id}/edit?validate=yes"
         )
 
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
         within("#invalid-items-count") do
           expect(page).to have_content("Invalid items 0")
@@ -534,7 +534,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       fill_in "List all issues with the document", with: "This is very invalid"
       click_button "Send request"
 
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
 
       within ".validation-requests-table" do
         expect(page).to have_content(document1.name)
@@ -622,7 +622,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       end
 
       it "does show a invalid documents warning" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         expect(page).to have_content("Invalid documents: 1")
       end
     end
@@ -633,14 +633,14 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       end
 
       it "does not show a warning" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         expect(page).not_to have_content("Invalid documents")
       end
     end
 
     context "when there is no replacement document validation request" do
       it "does not show a warning" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         expect(page).not_to have_content("Invalid documents")
       end
     end
@@ -652,7 +652,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       end
 
       it "does not show a warning" do
-        visit "/planning_applications/#{planning_application.id}/documents"
+        visit "/planning_applications/#{planning_application.reference}/documents"
         expect(page).not_to have_content("Invalid documents")
       end
     end

--- a/spec/system/planning_applications/review/add_committee_decision_spec.rb
+++ b/spec/system/planning_applications/review/add_committee_decision_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Update decision notice after committee" do
     end
 
     it "does not show the option to Update decision notice after committee" do
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_content("Review and sign-off")
 
@@ -45,7 +45,7 @@ RSpec.describe "Update decision notice after committee" do
   context "when the assessor has recommended the application go to committee" do
     context "when the committee agrees with the assessor" do
       it "can add what the committee decided" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Update decision notice after committee",
@@ -72,7 +72,7 @@ RSpec.describe "Update decision notice after committee" do
 
     context "when the committee agrees with the assessor but needs amendments" do
       it "can add what the committee decided" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Update decision notice after committee",
@@ -99,7 +99,7 @@ RSpec.describe "Update decision notice after committee" do
       end
 
       it "shows errors" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         click_link "Update decision notice after committee"
 
@@ -120,7 +120,7 @@ RSpec.describe "Update decision notice after committee" do
       end
 
       it "can add what the committee decided" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Update decision notice after committee",
@@ -153,7 +153,7 @@ RSpec.describe "Update decision notice after committee" do
         sign_out reviewer
         sign_in assessor
 
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         click_link "View recommendation"
 
@@ -161,7 +161,7 @@ RSpec.describe "Update decision notice after committee" do
       end
 
       it "shows errors" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Update decision notice after committee",

--- a/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       travel_to Time.zone.local(2024, 7, 23, 11)
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       click_link "Assess against policies and guidance"
       expect(page).to have_selector("h1", text: "Assess against policies and guidance")
@@ -60,7 +60,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       expect(page).to have_content("Assessment against local policies was successfully saved")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     it "I can accept the planning officer's decision" do
@@ -151,7 +151,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       travel_to Time.zone.local(2024, 7, 23, 12)
       sign_in(assessor)
 
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       expect(page).to have_list_item_for("Assess against policies and guidance", with: "To be reviewed")
 
       click_link "Assess against policies and guidance"
@@ -175,7 +175,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       travel_to Time.zone.local(2024, 7, 23, 13)
       sign_in(reviewer)
 
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
       expect(page).to have_list_item_for("Review assessment against policies and guidance", with: "Updated")
 
       click_link "Review assessment against policies and guidance"

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
       it "allows reviewer to submit correctly filled out form" do
         travel_to(Time.zone.local(2022, 11, 28, 12, 30))
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"
@@ -229,7 +229,7 @@ RSpec.describe "Reviewing assessment summaries" do
         within(find("fieldset", text: "Summary of neighbour responses")) do
           expect(page).to have_link(
             "View neighbour responses",
-            href: "/planning_applications/#{planning_application.id}/consultation/neighbour_responses"
+            href: "/planning_applications/#{planning_application.reference}/consultation/neighbour_responses"
           )
 
           expect(page).to have_content("View neighbour responses: There is 1 neutral, 1 objection, 2 supportive.")
@@ -260,7 +260,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
         click_link("Log out")
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
           "Check and assess", with: "To be reviewed"
@@ -274,7 +274,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Submit recommendation")
         click_link("Log out")
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         click_link("Review and sign-off")
         click_link("Sign off recommendation")
@@ -286,7 +286,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
     context "when assessor didn't fill out summaries" do
       it "allows reviewer to submit correctly filled out form" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"
@@ -367,7 +367,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
         click_button("Save and mark as complete")
 
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
         within("#planning-application-details") do
           expect(page).to have_selector("h1", text: "Review and sign-off")
         end
@@ -454,7 +454,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
       it "allows reviewer to submit correctly filled out form" do
         travel_to(Time.zone.local(2022, 11, 28, 12, 30))
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"
@@ -599,7 +599,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
         click_link("Log out")
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
           "Check and assess", with: "To be reviewed"
@@ -645,7 +645,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Submit recommendation")
         click_link("Log out")
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
           "Review and sign-off", with: "Updated"
@@ -738,7 +738,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
     context "when assessor didn't fill out summaries" do
       it "allows reviewer to submit correctly filled out form" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"
@@ -932,7 +932,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
       it "allows reviewer to submit correctly filled out form" do
         travel_to(Time.zone.local(2022, 11, 28, 12, 30))
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"
@@ -1056,7 +1056,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
         click_link("Log out")
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
           "Check and assess", with: "To be reviewed"
@@ -1070,7 +1070,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Submit recommendation")
         click_link("Log out")
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         click_link("Review and sign-off")
         click_link("Sign off recommendation")
@@ -1082,7 +1082,7 @@ RSpec.describe "Reviewing assessment summaries" do
 
     context "when assessor didn't fill out summaries" do
       it "allows reviewer to submit correctly filled out form" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review assessment summaries", with: "Not started"

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
     end
 
     it "does not show the option to check neighbour notifications" do
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_content("Review and sign-off")
 
@@ -42,7 +42,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can accept that the assessor has notified the correct people" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check neighbour notifications",
@@ -74,7 +74,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can send it back for assessment", :capybara do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check neighbour notifications",
@@ -141,7 +141,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "shows errors" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         click_link "Check neighbour notifications"
 
@@ -161,7 +161,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
     context "when the consultation has not been started" do
       it "you can accept that the assessor has notified the correct people" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check neighbour notifications",
@@ -201,7 +201,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can't accept or reject the officer's work" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check neighbour notifications",

--- a/spec/system/planning_applications/review/check_publicity_spec.rb
+++ b/spec/system/planning_applications/review/check_publicity_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "checking publicity" do
 
     context "when the assessor hasn't assessed the publicity" do
       it "allows a reviewer to mark the publicity check as complete" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check publicity",
@@ -129,7 +129,7 @@ RSpec.describe "checking publicity" do
       end
 
       it "allows a reviewer to return the application to the assessor" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check publicity",
@@ -204,7 +204,7 @@ RSpec.describe "checking publicity" do
       end
 
       it "shows errors" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Check publicity",
@@ -274,7 +274,7 @@ RSpec.describe "checking publicity" do
     end
 
     it "the reviewer can accept" do
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_list_item_for(
         "Check publicity",
@@ -327,7 +327,7 @@ RSpec.describe "checking publicity" do
     end
 
     it "allows a reviewer to return the application to the assessor" do
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_list_item_for(
         "Check publicity",
@@ -402,7 +402,7 @@ RSpec.describe "checking publicity" do
     end
 
     it "shows errors" do
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_list_item_for(
         "Check publicity",

--- a/spec/system/planning_applications/review/conditions_spec.rb
+++ b/spec/system/planning_applications/review/conditions_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Reviewing conditions" do
       create(:recommendation, status: "assessment_complete", planning_application:)
       create(:review, owner: condition_set, status: "complete")
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination" do
@@ -115,7 +115,7 @@ RSpec.describe "Reviewing conditions" do
         sign_out(reviewer)
         sign_in(assessor)
 
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_list_item_for(
           "Add conditions",
@@ -137,7 +137,7 @@ RSpec.describe "Reviewing conditions" do
         sign_out(assessor)
         sign_in(reviewer)
 
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
         expect(page).to have_list_item_for(
           "Review conditions",

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
   context "when there's not an evidence of immunity" do
     before do
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     it "I cannot view the link of Review evidence of immunity page" do
@@ -45,7 +45,7 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
       create(:evidence_group, :with_document, tag: "buildingControlCertificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
 
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination", :capybara do
@@ -63,7 +63,7 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/review/immunity_details/#{Review.where(owner_type: "ImmunityDetail").last.id}/edit"
+          "/planning_applications/#{planning_application.reference}/review/immunity_details/#{Review.where(owner_type: "ImmunityDetail").last.id}/edit"
         )
 
         expect(page).to have_content("Review evidence of immunity")

--- a/spec/system/planning_applications/review/heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/review/heads_of_terms_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Reviewing heads of terms", type: :system, capybara: true do
       create(:review, owner: planning_application.heads_of_term)
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination" do
@@ -119,7 +119,7 @@ RSpec.describe "Reviewing heads of terms", type: :system, capybara: true do
         sign_out(reviewer)
         sign_in(assessor)
 
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_list_item_for(
           "Add heads of terms",

--- a/spec/system/planning_applications/review/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/review/immunity_enforcement_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Reviewing immunity enforcement" do
   context "when there's not an immunity enforcement" do
     before do
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     it "I cannot view the link of Review assessment of immunity page" do
@@ -43,7 +43,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       create(:review, :enforcement, owner: planning_application.immunity_detail, assessor:)
 
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination" do
@@ -61,7 +61,7 @@ RSpec.describe "Reviewing immunity enforcement" do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/review/immunity_enforcements/#{Review.where(owner_type: "ImmunityDetail").last.id}/edit"
+          "/planning_applications/#{planning_application.reference}/review/immunity_enforcements/#{Review.where(owner_type: "ImmunityDetail").last.id}/edit"
         )
 
         expect(page).to have_content("Review assessment of immunity")

--- a/spec/system/planning_applications/review/informatives_spec.rb
+++ b/spec/system/planning_applications/review/informatives_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Reviewing informatives" do
         travel_to Time.zone.local(2024, 5, 20, 11)
 
         sign_in(assessor)
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         click_link "Add informatives"
         expect(page).to have_selector("h1", text: "Add informatives")
@@ -30,7 +30,7 @@ RSpec.describe "Reviewing informatives" do
         expect(page).to have_content("Informatives were successfully saved")
 
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
       end
 
       context "when planning application is awaiting determination" do
@@ -123,7 +123,7 @@ RSpec.describe "Reviewing informatives" do
           travel_to Time.zone.local(2024, 5, 20, 12)
           sign_in(assessor)
 
-          visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+          visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
           expect(page).to have_list_item_for("Add informatives", with: "To be reviewed")
 
           click_link "Add informatives"
@@ -148,7 +148,7 @@ RSpec.describe "Reviewing informatives" do
           travel_to Time.zone.local(2024, 5, 20, 13)
           sign_in(reviewer)
 
-          visit "/planning_applications/#{planning_application.id}/review/tasks"
+          visit "/planning_applications/#{planning_application.reference}/review/tasks"
           expect(page).to have_list_item_for("Review informatives", with: "Updated")
 
           click_link "Review informatives"

--- a/spec/system/planning_applications/review/permitted_development_rights_spec.rb
+++ b/spec/system/planning_applications/review/permitted_development_rights_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Permitted development right", type: :system do
       sign_in reviewer
       Current.user = reviewer
       create(:permitted_development_right, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     context "when planning application is awaiting determination" do
@@ -41,7 +41,7 @@ RSpec.describe "Permitted development right", type: :system do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/review/permitted_development_rights/#{PermittedDevelopmentRight.last.id}/edit"
+          "/planning_applications/#{planning_application.reference}/review/permitted_development_rights/#{PermittedDevelopmentRight.last.id}/edit"
         )
 
         expect(page).to have_content("Review permitted development rights")
@@ -255,7 +255,7 @@ RSpec.describe "Permitted development right", type: :system do
         end
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/review/permitted_development_rights/#{PermittedDevelopmentRight.last.id}/edit"
+          "/planning_applications/#{planning_application.reference}/review/permitted_development_rights/#{PermittedDevelopmentRight.last.id}/edit"
         )
 
         expect(page).to have_content("Review permitted development rights")
@@ -282,11 +282,11 @@ RSpec.describe "Permitted development right", type: :system do
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       expect(page).not_to have_link("Review permitted development rights")
 
-      visit "/planning_applications/#{planning_application.id}/assessment/permitted_development_rights/new"
+      visit "/planning_applications/#{planning_application.reference}/assessment/permitted_development_rights/new"
 
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
       policy_class = create(:policy_class, section: "A", planning_application:)
       create(:policy, :complies, policy_class:)
       create(:review, owner: policy_class)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       click_on "Review assessment of Part 1, Class A"
@@ -71,7 +71,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
         section: "A",
         planning_application:)
       create(:review, owner: policy_class)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       click_on "Review assessment of Part 1, Class A"
@@ -102,7 +102,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
 
       sign_in assessor
 
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
       expect(list_item("Part 1, Class A")).to have_content("To be reviewed")
 
@@ -124,7 +124,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
       click_on("Submit recommendation")
 
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(list_item("Review assessment of Part 1, Class A")).to have_content("Updated")
 
@@ -167,12 +167,12 @@ RSpec.describe "Reviewing Policy Class", type: :system do
         create(:review, owner: policy_class)
 
         sign_in(reviewer)
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
         click_on("Review assessment of Part 1, Class A")
       end
 
       it "displays policy_class with comments" do
-        visit "/planning_applications/#{planning_application.id}/review/tasks"
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
         click_on "Review assessment of Part 1, Class A"
 
         within("#planning-application-details") do
@@ -237,7 +237,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
       policy_class = create(:policy_class, section: "B", planning_application:)
       nxt = create(:policy_class, section: "C", planning_application:)
       create(:policy, policy_class:)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       click_on "Review assessment of Part 1, Class B"
@@ -253,7 +253,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
       create(:policy, policy_class:)
       create(:review, owner: policy_class, status: "complete")
 
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       click_on "Review assessment of Part 1, Class A"

--- a/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/review/pre_commencement_conditions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Reviewing pre-commencement conditions" do
       create(:recommendation, status: "assessment_complete", planning_application:)
       create(:review, owner: condition_set, status: "complete")
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination" do
@@ -132,7 +132,7 @@ RSpec.describe "Reviewing pre-commencement conditions" do
         sign_out(reviewer)
         sign_in(assessor)
 
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
 
         expect(page).to have_list_item_for(
           "Add pre-commencement conditions",

--- a/spec/system/planning_applications/review/sign_off_spec.rb
+++ b/spec/system/planning_applications/review/sign_off_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       assessor_comment: "New assessor comment",
       submitted: true)
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
 
     delivered_emails = ActionMailer::Base.deliveries.count
     click_link "Review and sign-off"
@@ -102,7 +102,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       assessor_comment: "New assessor comment",
       submitted: true)
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Review and sign-off"
 
     expect(list_item("Sign off recommendation")).to have_content("Not started")
@@ -160,7 +160,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       assessor_comment: "New assessor comment",
       submitted: true)
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Review and sign-off"
     click_link "Sign off recommendation"
 
@@ -180,7 +180,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       assessor_comment: "New assessor comment",
       submitted: true)
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Review and sign-off"
     click_link "Sign off recommendation"
 
@@ -203,7 +203,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
     recommendation = create(:recommendation, :reviewed, planning_application:,
       reviewer_comment: "Reviewer private comment")
 
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
     click_link "Review and sign-off"
     click_link "Sign off recommendation"
 
@@ -239,7 +239,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
         assessor_comment: "New assessor comment",
         submitted: true)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Review and sign-off"
       click_link "Sign off recommendation"
 
@@ -251,7 +251,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       expect(page).to have_content(planning_application.public_comment)
 
       click_link "Edit information on the decision notice"
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/edit_public_comment")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/edit_public_comment")
 
       expect(page).to have_content("Edit the information appearing on the decision notice")
       expect(page).to have_content("The planning officer recommends that the application is granted")
@@ -268,14 +268,14 @@ RSpec.describe "Reviewing sign-off", type: :system do
       fill_in "This information will appear on the decision notice.", with: "This text will appear on the decision notice."
       click_button "Save"
       expect(page).to have_content("The information appearing on the decision notice was successfully updated.")
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/review/tasks")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/tasks")
 
       click_link "Sign off recommendation"
 
       expect(page).to have_content("This text will appear on the decision notice.")
 
       # Check audit log
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_button "Audit log"
       click_link "View all audits"
 
@@ -289,11 +289,11 @@ RSpec.describe "Reviewing sign-off", type: :system do
 
     it "as an assessor I am unable to edit" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/edit_public_comment"
+      visit "/planning_applications/#{planning_application.reference}/edit_public_comment"
 
       expect(page).to have_content("forbidden")
 
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_content("forbidden")
     end
@@ -310,7 +310,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
     end
 
     it "raises an error if the reviewer accepts the recommendation" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link("Review and sign-off")
       click_link("Review permitted development rights")
       choose("Return to officer with comment")
@@ -365,7 +365,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       end
 
       it "displays a warning message with the consultation end date" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
         within(".moj-banner__message") do
           expect(page).to have_content("The consultation is still ongoing. It will end on the #{consultation.end_date.to_fs(:day_month_year_slashes)}. Are you sure you still want to make the recommendation?")
@@ -379,7 +379,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
       end
 
       it "does not display a warning message" do
-        visit "/planning_applications/#{planning_application.id}/assessment/recommendations/new"
+        visit "/planning_applications/#{planning_application.reference}/assessment/recommendations/new"
 
         expect(page).not_to have_css(".moj-banner__message")
       end
@@ -392,7 +392,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
 
       create(:committee_decision, planning_application:, recommend: true)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_link "Review and sign-off"
       expect(list_item("Sign off recommendation")).to have_content("Not started")
@@ -419,7 +419,7 @@ RSpec.describe "Reviewing sign-off", type: :system do
 
       create(:committee_decision, planning_application:, recommend: true)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Review and sign-off"
 
       expect(list_item("Sign off recommendation")).to have_content("Not started")

--- a/spec/system/planning_applications/review/tasks_index_spec.rb
+++ b/spec/system/planning_applications/review/tasks_index_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Reviewing Tasks Index" do
 
     it "while awaiting determination it can navigate around review tasks" do
       create(:recommendation, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       click_on "Review and sign-off"
 
@@ -49,7 +49,7 @@ RSpec.describe "Reviewing Tasks Index" do
 
     it "displays chosen policy class in a list" do
       policy_classes = create_list(:policy_class, 3, planning_application:)
-      visit "/planning_applications/#{planning_application.id}/review/tasks"
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
       expect(page).to have_selector("h1", text: "Review and sign-off")
       policy_classes.each do |policy_class|

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Planning Application show page" do
   context "as an assessor" do
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "Site address is present" do
@@ -108,7 +108,7 @@ RSpec.describe "Planning Application show page" do
 
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "Breadcrumbs contain reference to Application overview which is not linked" do

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "displays the planning application address and reference" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Draw red line boundary"
 
         expect(page).to have_content(planning_application.full_address)
@@ -35,7 +35,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "is possible to create a sitemap" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Draw red line boundary"
 
         # When no boundary set, map should be displayed zoomed in at latitiude/longitude if fields present
@@ -61,10 +61,10 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "is not possible to edit the sitemap" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         expect(page).not_to have_link("Draw red line boundary")
 
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
         expect(page).to have_content("The planning application must be validated before assessment can begin")
       end
     end
@@ -76,7 +76,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
     end
 
     it "is not possible to create a sitemap" do
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       click_button "Site map"
       expect(page).to have_content("No digital site map provided")
       expect(page).not_to have_link("Draw digital sitemap")
@@ -91,7 +91,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
 
     context "with 0 documents tagged with sitemap" do
       it "links to all documents" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Draw red line boundary"
 
         expect(page).to have_content("No document has been tagged as a sitemap for this application")
@@ -103,7 +103,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       let!(:document1) { create(:document, tags: %w[sitePlan.existing], planning_application:) }
 
       it "links to that documents" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Draw red line boundary"
 
         expect(page).to have_content("This digital red line boundary was submitted by the applicant on PlanX")
@@ -116,7 +116,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       let!(:document2) { create(:document, tags: %w[sitePlan.proposed], planning_application:) }
 
       it "links to all documents" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Draw red line boundary"
 
         expect(page).to have_content("This digital red line boundary was submitted by the applicant on PlanX")
@@ -134,7 +134,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
     let!(:api_user) { create(:api_user, name: "Api Wizard") }
 
     before do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check red line boundary"
 
       within("fieldset", text: "Is this red line boundary valid?") do
@@ -292,7 +292,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
     it "as an officer I can request approval for a change to the red line boundary" do
       delivered_emails = ActionMailer::Base.deliveries.count
 
-      visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
       click_button "Site map"
       click_link "Request approval for a change to red line boundary"
       map = find("my-map")
@@ -306,7 +306,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       expect(page).to have_content("Validation request for red line boundary successfully created.")
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/assessment/tasks"
+        "/planning_applications/#{planning_application.reference}/assessment/tasks"
       )
 
       expect(ActionMailer::Base.deliveries.count).to eql(delivered_emails + 1)
@@ -322,7 +322,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
         expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
       end
 
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/post_validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/post_validation_requests"
       within(".validation-requests-table") do
         expect(page).to have_content("Red line boundary changes")
       end
@@ -368,7 +368,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "I can view the accepted response" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
         click_button "Site map"
         click_link "View applicants response to requested red line boundary change"
 
@@ -385,7 +385,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "I can view the rejected response" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
         click_button "Site map"
         click_link "View applicants response to requested red line boundary change"
 
@@ -406,7 +406,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       it "I can view the accepted response" do
-        visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
         click_button "Site map"
         click_link "View applicants response to requested red line boundary change"
 
@@ -414,7 +414,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
         map = find("my-map")
         expect(map["showCentreMarker"]).to eq("false")
 
-        visit "/planning_applications/#{planning_application.id}/audits"
+        visit "/planning_applications/#{planning_application.reference}/audits"
 
         within("#audit_#{Audit.last.id}") do
           expect(page).to have_content("Auto-closed: validation request (red line boundary#1)")

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Planning Application show page", type: :system do
 
     it "makes valid task list for not_started" do
       planning_application = create(:planning_application, :not_started, local_authority: default_local_authority)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#validation-section" do
         expect(page).to have_link("Check and validate")
@@ -28,7 +28,7 @@ RSpec.describe "Planning Application show page", type: :system do
 
     it "makes valid task list for when it has been validated but no proposal has been made" do
       planning_application = create(:planning_application, local_authority: default_local_authority)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
         expect(page).to have_link("Check and validate")
         expect(page).to have_content("Completed")
@@ -48,7 +48,7 @@ RSpec.describe "Planning Application show page", type: :system do
     it "makes valid task list for when it in assessment and a proposal has been created" do
       planning_application = create(:planning_application, local_authority: default_local_authority)
       create(:recommendation, planning_application:, submitted: true)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#assess-section" do
         click_link "Check and assess"
@@ -65,7 +65,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_determination,
         local_authority: default_local_authority)
       create(:recommendation, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
         expect(page).not_to have_link("Check and validate")
         expect(page).to have_content("Completed")
@@ -83,7 +83,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_content("Completed")
       end
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#review-section" do
         expect(page).to have_link("Review and sign-off")
@@ -98,7 +98,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_determination,
         local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#review-section" do
         expect(page).to have_link("Review and sign-off")
@@ -121,7 +121,7 @@ RSpec.describe "Planning Application show page", type: :system do
         challenged: true
       )
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#validation-section" do
         expect(page).to have_link("Check and validate")
@@ -143,7 +143,7 @@ RSpec.describe "Planning Application show page", type: :system do
         local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
       create(:recommendation, planning_application:, submitted: true)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#validation-section" do
         expect(page).to have_link("Check and validate")
@@ -161,7 +161,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_link("Review and submit recommendation")
       end
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#assess-section" do
         expect(list_item("Check and assess")).to have_content("Completed")
@@ -178,7 +178,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_determination,
         local_authority: default_local_authority)
       create(:recommendation, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
         expect(page).not_to have_link("Check and validate")
         expect(page).to have_content("Completed")
@@ -193,7 +193,7 @@ RSpec.describe "Planning Application show page", type: :system do
         expect(page).to have_content("Completed")
       end
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#review-section" do
         expect(page).not_to have_link("Review and sign-off")
@@ -209,7 +209,7 @@ RSpec.describe "Planning Application show page", type: :system do
       planning_application = create(:planning_application, :awaiting_determination,
         local_authority: default_local_authority)
       create(:recommendation, :reviewed, planning_application:)
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
 
       within "#validation-section" do
         expect(page).to have_content("Completed")

--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   before do
     travel_to Time.zone.local(2024, 1, 1)
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "displays the planning application address and reference" do
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -28,7 +28,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   end
 
   it "lets user create and cancel request" do
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -45,7 +45,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
     expect(page).to have_text("Time extension request successfully sent.")
 
     expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.id}/assessment/tasks"
+      "/planning_applications/#{planning_application.reference}/assessment/tasks"
     )
 
     click_link("Extension requested")
@@ -63,7 +63,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   end
 
   it "displays the expected error message when there is a time extension request already open" do
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -78,7 +78,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   end
 
   it "displays the expected error message when the time extension is earlier than the current expiry" do
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -95,7 +95,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   it "displays the previously created time extension request on the edit page" do
     create(:time_extension_validation_request, :closed, planning_application: planning_application, reason: "Took too long")
 
-    visit "/planning_applications/#{planning_application.id}/assessment/tasks"
+    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -106,7 +106,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   it "displays the rejection reason when applicant rejects the request" do
     rejected_request = create(:time_extension_validation_request, :closed, approved: false, planning_application: planning_application, reason: "Took too long", rejection_reason: "I can't wait any longer")
 
-    visit "/planning_applications/#{planning_application.id}/validation/validation_requests/#{rejected_request.id}"
+    visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{rejected_request.id}"
 
     expect(page).to have_content("Rejected")
     expect(page).to have_content("I can't wait any longer")

--- a/spec/system/planning_applications/validating/check_legislation_spec.rb
+++ b/spec/system/planning_applications/validating/check_legislation_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Check legislation" do
       planning_application.application_type.update(part: 1, section: "A")
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link("Check legislative requirements")
     end
 
@@ -89,7 +89,7 @@ RSpec.describe "Check legislation" do
 
     before do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
     end
 
     it "does not show the check legislation tasklist" do
@@ -97,7 +97,7 @@ RSpec.describe "Check legislation" do
     end
 
     it "shows forbidden when navigating to the page directly" do
-      visit "/planning_applications/#{planning_application.id}/validation/legislation"
+      visit "/planning_applications/#{planning_application.reference}/validation/legislation"
       expect(page).to have_content("Not found")
     end
   end

--- a/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
+++ b/spec/system/planning_applications/validating/check_ownership_certificate_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Check ownership certificate type" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
   end
 
   context "when application is not started" do
@@ -84,7 +84,7 @@ RSpec.describe "Check ownership certificate type" do
     let!(:request) { create(:ownership_certificate_validation_request, planning_application:, state: "open") }
 
     it "I can view it" do
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
 
       expect(page).to have_content("Ownership certificate")
       expect(page).to have_content(request.reason)
@@ -96,7 +96,7 @@ RSpec.describe "Check ownership certificate type" do
     end
 
     it "I can cancel my request" do
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
 
       expect(page).to have_content("Ownership certificate")
       expect(page).to have_content(request.reason)
@@ -121,7 +121,7 @@ RSpec.describe "Check ownership certificate type" do
       end
 
       it "I can view their response" do
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
 
         click_link "View and update"
 
@@ -140,7 +140,7 @@ RSpec.describe "Check ownership certificate type" do
       end
 
       it "I can view their response" do
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests"
 
         click_link "View and update"
 

--- a/spec/system/planning_applications/validating/cil_liability_spec.rb
+++ b/spec/system/planning_applications/validating/cil_liability_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "is listed as incomplete by default" do
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
     within "#cil-liability-task" do
       expect(page).to have_content "Confirm Community Infrastructure Levy (CIL)"
@@ -26,7 +26,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
   end
 
   it "can be marked as liable" do
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
     click_link "Confirm Community Infrastructure Levy (CIL)"
     choose "Yes"
     click_button "Save and mark as complete"
@@ -39,7 +39,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
   end
 
   it "can be marked as not liable" do
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
     click_link "Confirm Community Infrastructure Levy (CIL)"
     choose "No"
     click_button "Save and mark as complete"
@@ -53,7 +53,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
 
   context "when revisiting the edit page" do
     it "is marked as true when liable" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Confirm Community Infrastructure Levy (CIL)"
       choose "Yes"
       click_button "Save and mark as complete"
@@ -65,7 +65,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
     end
 
     it "is marked as false when not liable" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Confirm Community Infrastructure Levy (CIL)"
       choose "No"
       click_button "Save and mark as complete"
@@ -79,14 +79,14 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
 
   context "when there is no liability information from planx" do
     it "explains that there is no liability information" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Confirm Community Infrastructure Levy (CIL)"
 
       expect(page).to have_content("No information on potential CIL liability from PlanX.")
     end
 
     it "does not preselect any radio button" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Confirm Community Infrastructure Levy (CIL)"
 
       expect(find_by_id("planning-application-cil-liable-true-field")).not_to be_selected
@@ -105,7 +105,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
       let(:planx_response) { "More than 100m²" }
 
       it "shows relevant liability information" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
         expect(page).to have_content(planx_response)
@@ -113,7 +113,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
       end
 
       it "selects yes by default" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
         expect(page).to have_checked_field("planning-application-cil-liable-true-field")
@@ -125,7 +125,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
       let(:planx_response) { "Less than 100m²" }
 
       it "shows relevant liability information" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
         expect(page).to have_content(planx_response)
@@ -133,7 +133,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
       end
 
       it "selects no by default" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Confirm Community Infrastructure Levy (CIL)"
 
         expect(page).not_to have_checked_field("planning-application-cil-liable-true-field")

--- a/spec/system/planning_applications/validating/constraints_spec.rb
+++ b/spec/system/planning_applications/validating/constraints_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Constraints" do
   before do
     Rails.application.load_seed
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/constraints"
+    visit "/planning_applications/#{planning_application.reference}/validation/constraints"
   end
 
   it "displays the planning application address and reference" do
@@ -58,7 +58,7 @@ RSpec.describe "Constraints" do
         expect(page).to have_content("Completed")
       end
 
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
 
       expect(page).to have_text("Constraints Checked")
     end
@@ -73,7 +73,7 @@ RSpec.describe "Constraints" do
     end
 
     it "I can view a link to the individual entities and planning data map with layers pre-selected" do
-      visit "/planning_applications/#{planning_application.id}/validation/constraints"
+      visit "/planning_applications/#{planning_application.reference}/validation/constraints"
       lat_lon_zoom = "#{planning_application.latitude},#{planning_application.longitude},17"
       expect(page).to have_link(
         "View map on Planning Data (opens in new tab)",
@@ -116,7 +116,7 @@ RSpec.describe "Constraints" do
 
       click_button "Save and mark as complete"
 
-      visit "/planning_applications/#{planning_application.id}/validation/constraints"
+      visit "/planning_applications/#{planning_application.reference}/validation/constraints"
 
       within(".identified-constraints-table") do
         expect(page).to have_text("Conservation area")
@@ -150,7 +150,7 @@ RSpec.describe "Constraints" do
         expect(page).to have_text("Special area of conservation")
       end
 
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
 
       within("#audit_#{Audit.last.id - 1}") do
         expect(page).to have_content("Constraints Checked")

--- a/spec/system/planning_applications/validating/description_changes_validation_spec.rb
+++ b/spec/system/planning_applications/validating/description_changes_validation_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "DescriptionChangesValidation" do
     end
 
     it "I can validate the description" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       within("#check-description-task") do
         expect(page).to have_content("Not started")
       end
@@ -51,7 +51,7 @@ RSpec.describe "DescriptionChangesValidation" do
     end
 
     it "I get validation errors when I omit required information" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check description"
       click_button "Save and mark as complete"
 
@@ -72,7 +72,7 @@ RSpec.describe "DescriptionChangesValidation" do
     it "I can invalidate the description" do
       expect(PlanningApplicationMailer).to receive(:description_change_mail).and_call_original
 
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check description"
 
       within(".govuk-fieldset") do
@@ -82,7 +82,7 @@ RSpec.describe "DescriptionChangesValidation" do
       click_button "Save and mark as complete"
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=description_change"
+        "/planning_applications/#{planning_application.reference}/validation/validation_requests/new?type=description_change"
       )
       expect(page).to have_content("Description change")
       expect(page).to have_content("Application number: #{planning_application.reference}")
@@ -108,18 +108,18 @@ RSpec.describe "DescriptionChangesValidation" do
       description_change_validation_request = DescriptionChangeValidationRequest.last
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/description_change_validation_requests/#{description_change_validation_request.id}"
+        "/planning_applications/#{planning_application.reference}/validation/description_change_validation_requests/#{description_change_validation_request.id}"
       )
 
       expect(page).to have_content("My better description")
 
       click_link "Back"
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/validation/tasks")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/validation/tasks")
     end
 
     it "I can mark the task as completed when the description change request has been approved" do
       create(:description_change_validation_request, planning_application:, approved: true, state: "closed")
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#check-description-task") do
         expect(page).to have_content("Updated")
@@ -145,7 +145,7 @@ RSpec.describe "DescriptionChangesValidation" do
 
     it "I can request another change when the description change request has been rejected" do
       create(:description_change_validation_request, planning_application:, approved: false, state: "closed", rejection_reason: "no")
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#check-description-task") do
         expect(page).to have_content("Updated")
@@ -180,7 +180,7 @@ RSpec.describe "DescriptionChangesValidation" do
     end
 
     it "does not allow you to validate description" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#check-description-task") do
         expect(page).to have_content("Planning application has already been validated")

--- a/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
+++ b/spec/system/planning_applications/validating/environment_impact_assessment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Validation tasks" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
   end
 
   context "when application is not started or invalidated" do
@@ -61,7 +61,7 @@ RSpec.describe "Validation tasks" do
         end
       end
 
-      visit "/planning_applications/#{planning_application.id}/audits"
+      visit "/planning_applications/#{planning_application.reference}/audits"
       within("#audit_#{Audit.last.id}") do
         expect(page).to have_content("Changed to: true")
         expect(page).to have_content("Environment impact assessment updated")
@@ -185,7 +185,7 @@ RSpec.describe "Validation tasks" do
         end
         expect(page).not_to have_content("The expiry date has been extended to 16 weeks")
 
-        visit "/planning_applications/#{planning_application.id}/audits"
+        visit "/planning_applications/#{planning_application.reference}/audits"
         within("#audit_#{Audit.last.id}") do
           expect(page).to have_content("Changed from: true Changed to: false")
           expect(page).to have_content("Environment impact assessment updated")

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "displays the planning application address and reference" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
 
       expect(page).to have_content(planning_application.full_address)
@@ -55,7 +55,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I can see a summary breakdown of the fee when I go to validate" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
 
       expect(page).to have_content("Check fee")
@@ -90,7 +90,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "renders fee related proposal details" do
-      visit "/planning_applications/#{planning_application.id}/validation/fee_items"
+      visit "/planning_applications/#{planning_application.reference}/validation/fee_items"
 
       expect(page).to have_content("Related questions and answers from PlanX")
 
@@ -121,7 +121,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I can validate the fee item" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       within("#fee-validation-task") do
         expect(page).to have_content("Not started")
       end
@@ -147,7 +147,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I get validation errors when I omit required information" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
       click_button "Save and mark as complete"
 
@@ -167,7 +167,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I can invalidate the fee item" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
 
       within(".govuk-fieldset") do
@@ -177,7 +177,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       click_button "Save and mark as complete"
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/validation_requests/new?type=fee_change"
+        "/planning_applications/#{planning_application.reference}/validation/validation_requests/new?type=fee_change"
       )
       expect(page).to have_content("Request other validation change (fee)")
       expect(page).to have_content("Application number: #{planning_application.reference}")
@@ -229,7 +229,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       other_change_validation_request = FeeChangeValidationRequest.last
 
       expect(page).to have_current_path(
-        "/planning_applications/#{planning_application.id}/validation/fee_change_validation_requests/#{other_change_validation_request.id}"
+        "/planning_applications/#{planning_application.reference}/validation/fee_change_validation_requests/#{other_change_validation_request.id}"
       )
       expect(page).to have_content("View fee change request")
       expect(page).to have_content("Officer request")
@@ -241,7 +241,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       click_link "Back"
-      expect(page).to have_current_path("/planning_applications/#{planning_application.id}/validation/tasks")
+      expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/validation/tasks")
     end
 
     context "when fee item is invalid" do
@@ -257,12 +257,12 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       it "I can edit the fee validation request" do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Check fee"
         click_link "Edit request"
 
         expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.id}/validation/validation_requests/#{other_change_validation_request.id}/edit"
+          "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{other_change_validation_request.id}/edit"
         )
 
         expect(page).to have_content("Request other validation change (fee)")
@@ -301,7 +301,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       it "I can delete the fee validation request", :capybara do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
         click_link "Check fee"
 
         accept_confirm(text: "Are you sure?") do
@@ -334,7 +334,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       it "shows the fee as £0.00" do
-        visit "/planning_applications/#{planning_application.id}/validation/fee_items"
+        visit "/planning_applications/#{planning_application.reference}/validation/fee_items"
 
         expect(page).to have_row_for("Fee Paid", with: "£0.00")
         expect(page).to have_row_for("Payment Reference", with: "Exempt")
@@ -361,7 +361,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I can view the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
 
       expect(page).to have_content("View fee change request")
@@ -391,7 +391,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I can cancel the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       click_link "Check fee"
       click_link "Cancel request"
 
@@ -424,7 +424,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "I cannot edit the request" do
-      visit "/planning_applications/#{planning_application.id}/validation/validation_requests/#{other_change_validation_request.id}/edit"
+      visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{other_change_validation_request.id}/edit"
 
       expect(page).to have_content("forbidden")
       expect(page).not_to have_link("Edit request")
@@ -450,7 +450,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       it "I can see the updated state of the fee request", :capybara do
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
         within("#fee-validation-task") do
           expect(page).to have_content("Updated")
@@ -498,7 +498,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
           expect(page).to have_content("Completed")
         end
 
-        visit "/planning_applications/#{planning_application.id}/audits"
+        visit "/planning_applications/#{planning_application.reference}/audits"
 
         # Check audit log
         within("#audit_#{Audit.last.id}") do
@@ -508,7 +508,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
       end
 
       it "I do not see a continue link for non active fee requests" do
-        visit "/planning_applications/#{planning_application.id}/validation/validation_requests/#{other_change_validation_request.id}"
+        visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{other_change_validation_request.id}"
 
         expect(page).not_to have_link("Continue")
       end
@@ -521,7 +521,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
     end
 
     it "does not allow you to validate documents" do
-      visit "/planning_applications/#{planning_application.id}/validation/tasks"
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
 
       within("#fee-validation-task") do
         expect(page).to have_content("Planning application has already been validated")

--- a/spec/system/planning_applications/validating/redact_documents_spec.rb
+++ b/spec/system/planning_applications/validating/redact_documents_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Redact documents" do
     create(:document, :archived, file: file3, planning_application:)
 
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
   end
 
   it "allows an assessor to upload redacted documents" do

--- a/spec/system/planning_applications/validating/reporting_spec.rb
+++ b/spec/system/planning_applications/validating/reporting_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Reporting validation task" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
   end
 
   context "when application is not started" do
     it "I can see that reporting type is not started" do
       expect(page).to have_link(
         "Add reporting details",
-        href: "/planning_applications/#{planning_application.id}/validation/reporting_type/edit"
+        href: "/planning_applications/#{planning_application.reference}/validation/reporting_type/edit"
       )
       click_link "Add reporting details"
 
@@ -53,7 +53,7 @@ RSpec.describe "Reporting validation task" do
 
       expect(page).to have_link(
         "Add reporting details",
-        href: "/planning_applications/#{planning_application.id}/validation/reporting_type"
+        href: "/planning_applications/#{planning_application.reference}/validation/reporting_type"
       )
     end
 

--- a/spec/system/planning_applications/validating/validate_spec.rb
+++ b/spec/system/planning_applications/validating/validate_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Validating the application" do
           # 04/01/2023 12:00
           travel_to(DateTime.new(2023, 1, 4, 12)) do
             validation_request.close!
-            visit "/planning_applications/#{planning_application.id}/confirm_validation"
+            visit "/planning_applications/#{planning_application.reference}/confirm_validation"
           end
         end
 
@@ -40,7 +40,7 @@ RSpec.describe "Validating the application" do
           # 04/01/2023 18:00
           travel_to(DateTime.new(2023, 1, 4, 18)) do
             validation_request.close!
-            visit "/planning_applications/#{planning_application.id}/confirm_validation"
+            visit "/planning_applications/#{planning_application.reference}/confirm_validation"
           end
         end
 
@@ -54,7 +54,7 @@ RSpec.describe "Validating the application" do
           # 01/01/2023 12:00
           travel_to(DateTime.new(2023, 1, 1, 12)) do
             validation_request.close!
-            visit "/planning_applications/#{planning_application.id}/confirm_validation"
+            visit "/planning_applications/#{planning_application.reference}/confirm_validation"
           end
         end
 
@@ -65,7 +65,7 @@ RSpec.describe "Validating the application" do
     end
 
     context "when there is no closed validation request" do
-      before { visit "/planning_applications/#{planning_application.id}/confirm_validation" }
+      before { visit "/planning_applications/#{planning_application.reference}/confirm_validation" }
 
       context "when the planning application was created during work hours" do
         let(:planning_application) do

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
   context "when application not started" do
     it "shows text and links when application has not been started" do
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       click_link "Check and validate"
       click_link "Review validation requests"
 
@@ -167,7 +167,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       it "allows validation of the planning application" do
         planning_application = create(:planning_application, :with_boundary_geojson, :not_started, local_authority: default_local_authority)
         create(:description_change_validation_request, planning_application:, state: "open")
-        visit "/planning_applications/#{planning_application.id}"
+        visit "/planning_applications/#{planning_application.reference}"
 
         click_link "Check and validate"
         click_link "Send validation decision"
@@ -223,7 +223,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
     before do
       planning_application = create(:planning_application, :in_assessment, local_authority: default_local_authority)
 
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "does not allow you to add requests if application has been validated" do

--- a/spec/system/planning_applications/validating/validation_banner_display_spec.rb
+++ b/spec/system/planning_applications/validating/validation_banner_display_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Validation banners" do
 
     it "shows the correct count for 1 overdue request validation" do
       travel 2.months
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_content("1 validation request now overdue")
     end
 
@@ -28,7 +28,7 @@ RSpec.describe "Validation banners" do
         state: "open")
 
       travel 2.months
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_content("2 validation requests now overdue")
     end
   end
@@ -45,7 +45,7 @@ RSpec.describe "Validation banners" do
     before do
       travel 2.months
       sign_in assessor
-      visit "/planning_applications/#{planning_application.id}"
+      visit "/planning_applications/#{planning_application.reference}"
     end
 
     it "does not display the overdue validation request banner" do

--- a/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
+++ b/spec/system/planning_applications/validating/validation_tasks_index_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Validation tasks" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}/validation/tasks"
+    visit "/planning_applications/#{planning_application.reference}/validation/tasks"
   end
 
   context "when application is not started or invalidated" do
@@ -193,7 +193,7 @@ RSpec.describe "Validation tasks" do
         planning_application.application_type.update(part: 1, section: "A")
 
         sign_in assessor
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       end
 
       it "shows the check legislation task" do
@@ -346,7 +346,7 @@ RSpec.describe "Validation tasks" do
         planning_application.application_type.update(part: 1, section: "A")
 
         sign_in assessor
-        visit "/planning_applications/#{planning_application.id}/validation/tasks"
+        visit "/planning_applications/#{planning_application.reference}/validation/tasks"
       end
 
       it "shows the check legislation task" do

--- a/spec/system/planning_applications/withdraw_or_cancel_spec.rb
+++ b/spec/system/planning_applications/withdraw_or_cancel_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Withdraw or cancel" do
 
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.id}"
+    visit "/planning_applications/#{planning_application.reference}"
   end
 
   it "displays the planning application address and reference" do
@@ -86,7 +86,7 @@ RSpec.describe "Withdraw or cancel" do
 
     it "prevents closing or cancelling" do
       expect(page).not_to have_link "Withdraw or cancel application"
-      visit "/planning_applications/#{planning_application.id}/withdraw_or_cancel"
+      visit "/planning_applications/#{planning_application.reference}/withdraw_or_cancel"
       expect(page).to have_content("This application has been determined and cannot be withdrawn or cancelled")
     end
   end
@@ -98,7 +98,7 @@ RSpec.describe "Withdraw or cancel" do
 
     it "prevents closing or cancelling" do
       expect(page).not_to have_link "Withdraw or cancel application"
-      visit "/planning_applications/#{planning_application.id}/withdraw_or_cancel"
+      visit "/planning_applications/#{planning_application.reference}/withdraw_or_cancel"
       expect(page).to have_content("This application has already been withdrawn or cancelled.")
     end
   end
@@ -106,7 +106,7 @@ RSpec.describe "Withdraw or cancel" do
   context "when uploading a supporting document" do
     context "when providing a file with a permitted extension" do
       it "withdraws or cancels the planning application with a redacted document" do
-        visit "/planning_applications/#{planning_application.id}/withdraw_or_cancel"
+        visit "/planning_applications/#{planning_application.reference}/withdraw_or_cancel"
         expect(page).to have_content("Upload a supporting document")
         expect(page).to have_content("Optionally add a redacted document to support the decision")
 
@@ -141,7 +141,7 @@ RSpec.describe "Withdraw or cancel" do
 
     context "when providing a file with an unpermitted extension" do
       it "presents an error" do
-        visit "/planning_applications/#{planning_application.id}/withdraw_or_cancel"
+        visit "/planning_applications/#{planning_application.reference}/withdraw_or_cancel"
         choose "Cancelled for other reason"
 
         attach_file(

--- a/spec/system/public/planning_applications/decision_notice_spec.rb
+++ b/spec/system/public/planning_applications/decision_notice_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Decision notice" do
 
   context "when not logged in" do
     before do
-      visit "/public/planning_applications/#{planning_application.id}/decision_notice"
+      visit "/public/planning_applications/#{planning_application.reference}/decision_notice"
     end
 
     context "when planning application has been determined" do
@@ -43,7 +43,7 @@ RSpec.describe "Decision notice" do
     before do
       sign_in(user)
 
-      visit "/public/planning_applications/#{planning_application.id}/decision_notice"
+      visit "/public/planning_applications/#{planning_application.reference}/decision_notice"
     end
 
     it "is accessible" do

--- a/spec/system/workflow_tasks/validation/check_missing_documents_task_spec.rb
+++ b/spec/system/workflow_tasks/validation/check_missing_documents_task_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Validation::CheckMissingDocumentsTask, type: :component do
 
   it "renders link" do
     expect(task.task_list_link_text).to eq "Check and request documents"
-    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/documents/edit"
+    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/documents/edit"
   end
 
   it "renders 'Not started' status" do

--- a/spec/system/workflow_tasks/validation/check_red_line_boundary_component_spec.rb
+++ b/spec/system/workflow_tasks/validation/check_red_line_boundary_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
     end
 
     it "renders sitemap link" do
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/sitemap"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/sitemap"
       expect(task.task_list_link_text).to eq "Check red line boundary"
     end
   end
@@ -55,7 +55,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
     end
 
     it "renders sitemap link" do
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/sitemap"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/sitemap"
       expect(task.task_list_link_text).to eq "Check red line boundary"
     end
 
@@ -73,7 +73,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
       end
 
       it "renders change request link" do
-        expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+        expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
         expect(task.task_list_link_text).to eq "Check red line boundary"
       end
     end
@@ -101,7 +101,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
     end
 
     it "renders sitemap link" do
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/sitemap"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/sitemap"
       expect(task.task_list_link_text).to eq "Check red line boundary"
     end
 
@@ -120,7 +120,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
       end
 
       it "renders change request link" do
-        expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+        expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
         expect(task.task_list_link_text).to eq "Check red line boundary"
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
     end
 
     it "renders change request link" do
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
       expect(task.task_list_link_text).to eq "Check red line boundary"
     end
   end
@@ -175,7 +175,7 @@ RSpec.describe Validation::CheckRedLineBoundaryTask, type: :component do
     end
 
     it "renders change request link" do
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/red_line_boundary_change_validation_requests/#{red_line_boundary_change_validation_request.id}"
 
       expect(task.task_list_link_text).to eq "Check red line boundary"
     end

--- a/spec/system/workflow_tasks/validation/fee_validation_task_spec.rb
+++ b/spec/system/workflow_tasks/validation/fee_validation_task_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Validation::FeeValidationTask, type: :component do
 
     it "renders link to fee items path" do
       expect(task.task_list_link_text).to eq "Check fee"
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/fee_items"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/fee_items"
     end
   end
 
@@ -29,7 +29,7 @@ RSpec.describe Validation::FeeValidationTask, type: :component do
 
     it "renders link to fee items path" do
       expect(task.task_list_link_text).to eq "Check fee"
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/fee_items"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/fee_items"
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Validation::FeeValidationTask, type: :component do
 
     it "renders link to fee items path" do
       expect(task.task_list_link_text).to eq "Check fee"
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/fee_change_validation_requests/#{fee_change_validation_request.id}"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/fee_change_validation_requests/#{fee_change_validation_request.id}"
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe Validation::FeeValidationTask, type: :component do
 
     it "renders link to fee items path" do
       expect(task.task_list_link_text).to eq "Check fee"
-      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/fee_change_validation_requests/#{fee_change_validation_request.id}"
+      expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/fee_change_validation_requests/#{fee_change_validation_request.id}"
     end
   end
 end

--- a/spec/system/workflow_tasks/validation/other_change_validation_task_spec.rb
+++ b/spec/system/workflow_tasks/validation/other_change_validation_task_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Validation::OtherChangeValidationTask, type: :component do
 
   it "renders link" do
     expect(task.task_list_link_text).to eq "View other validation request #1"
-    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation/other_change_validation_requests/#{other_change_validation_request.id}"
+    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation/other_change_validation_requests/#{other_change_validation_request.id}"
   end
 
   context "when request is closed" do

--- a/spec/system/workflow_tasks/validation/validation_decision_task_spec.rb
+++ b/spec/system/workflow_tasks/validation/validation_decision_task_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Validation::ValidationDecisionTask, type: :component do
   end
 
   it "renders link" do
-    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.id}/validation_decision"
+    expect(task.task_list_link).to eq "/planning_applications/#{planning_application.reference}/validation_decision"
     expect(task.task_list_link_text).to eq "Send validation decision"
   end
 


### PR DESCRIPTION
### Description of change

Accept and generate routes for planning applications that use the user-visible reference as the parameter, not the internal database ID.

Accept database IDs still for backwards compatibility.

### Known issues

References can change. In one specific case therefore (the edit form) I've had to specifically use a URL with the ID in it, not the reference, as the page to return to, since changing the application type will otherwise break the form submission success (it'll try to go back to a url containing the old reference).

It might be nice to redirect ID-based routes to the reference-based ones. This would help the above scenario and be slightly nicer in general, including for any old-style URLs around, at the expense of being a little more complicated.