### PR TITLE
Add gpdo schedule

### DIFF
--- a/app/models/policy_schedule.rb
+++ b/app/models/policy_schedule.rb
@@ -4,4 +4,12 @@ class PolicySchedule < ApplicationRecord
   has_many :policy_parts, dependent: :restrict_with_error
 
   validates :number, presence: true, uniqueness: true
+
+  def full_name
+    if name.present?
+      "Schedule #{number} - #{name}"
+    else
+      "Schedule #{number}"
+    end
+  end
 end

--- a/app/models/policy_schedule.rb
+++ b/app/models/policy_schedule.rb
@@ -3,7 +3,9 @@
 class PolicySchedule < ApplicationRecord
   has_many :policy_parts, dependent: :restrict_with_error
 
-  validates :number, presence: true, uniqueness: true
+  validates :number, presence: true, uniqueness: true, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 4}
+
+  attr_readonly :number
 
   def full_name
     if name.present?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -277,6 +277,13 @@ en:
           attributes:
             base:
               policies_to_be_determined: All policies must be assessed
+        policy_schedule:
+          attributes:
+            number:
+              blank: Enter a number for the schedule
+              greater_than_or_equal_to: The schedule number must be greater than or equal to 1
+              less_than_or_equal_to: The schedule number must be less than or equal to 4
+              not_a_number: The schedule number must be a number
         press_notice:
           attributes:
             documents:

--- a/engines/bops_config/app/controllers/bops_config/gpdo/policy_schedules_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/gpdo/policy_schedules_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module Gpdo
+    class PolicySchedulesController < ApplicationController
+      before_action :build_policy_schedule, only: %i[new]
+      before_action :set_policy_schedules, only: %i[index]
+      before_action :set_policy_schedule, only: %i[edit update]
+
+      def index
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def new
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @application_type.update(policy_schedule_params)
+            format.html do
+              redirect_to policy_schedules_path, notice: t(".success")
+            end
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def policy_schedule_params
+        params.require(:policy_schedule).permit(:number, :name)
+      end
+
+      def set_policy_schedule
+        @schedule = PolicySchedule.find(policy_schedule_id)
+      end
+
+      def set_policy_schedules
+        @schedules = PolicySchedule.all
+      end
+
+      def policy_schedule_id
+        Integer(params[:id])
+      rescue
+        raise ActionController::BadRequest, "Invalid policy schedule id: #{params[:id].inspect}"
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -32,7 +32,8 @@ module BopsConfig
         "features" => "application_types",
         "decisions" => "decisions",
         "statuses" => "application_types",
-        "reporting_types" => "reporting_types"
+        "reporting_types" => "reporting_types",
+        "policy_schedules" => "policy_schedules"
       }
 
       page_keys.fetch(controller_name, "dashboard")
@@ -45,7 +46,8 @@ module BopsConfig
         {link: {text: "Application types", href: application_types_path}, current: active_page_key?("application_types")},
         {link: {text: "Legislation", href: legislation_index_path}, current: active_page_key?("legislation")},
         {link: {text: "Reporting types", href: reporting_types_path}, current: active_page_key?("reporting_types")},
-        {link: {text: "Decisions", href: decisions_path}, current: active_page_key?("decisions")}
+        {link: {text: "Decisions", href: decisions_path}, current: active_page_key?("decisions")},
+        {link: {text: "GPDO", href: gpdo_policy_schedules_path}, current: active_page_key?("policy_schedules")}
       ]
     end
   end

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_form.html.erb
@@ -1,0 +1,18 @@
+<%= form_with model: [:gpdo, @schedule], url: url do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%= form.govuk_text_field :number, label: {text: t(".number_label")}, hint: {text: t(".number_hint")}, readonly: @schedule.persisted? %>
+  <%= form.govuk_text_field :name, label: {text: t(".name_label")}, hint: {text: t(".name_hint")} %>
+
+  <%= form.govuk_submit(t(".save")) do %>
+    <% if action_name == "edit" && @schedule.policy_parts.none? %>
+      <%= govuk_button_link_to(t(".remove"),
+            gpdo_policy_schedule_path(@schedule.number),
+            warning: true,
+            method: :delete,
+            data: {confirm: "Are you sure?"}) %>
+    <% end %>
+
+    <%= govuk_button_link_to t("back"), gpdo_policy_schedules_path, secondary: true %>
+  <% end %>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_table.html.erb
@@ -18,7 +18,7 @@
             <%= schedule.full_name %>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to t(".edit"), edit_gpdo_policy_schedule_path(schedule) %>
+            <%= govuk_link_to t(".edit"), edit_gpdo_policy_schedule_path(schedule.number) %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/_table.html.erb
@@ -1,0 +1,27 @@
+<% if @schedules.any? %>
+  <table class="govuk-table application-types-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">
+          Name
+        </th>
+        <th scope="col" class="govuk-table__header">
+          Action
+        </th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% @schedules.each do |schedule| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= schedule.full_name %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= govuk_link_to t(".edit"), edit_gpdo_policy_schedule_path(schedule) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "GPDO", application_types_path %>
+<% add_parent_breadcrumb_link "Policy schedules", schedules_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
+
+    <%= render "form" %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/edit.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
-<% add_parent_breadcrumb_link "GPDO", application_types_path %>
-<% add_parent_breadcrumb_link "Policy schedules", schedules_path %>
+<% add_parent_breadcrumb_link "GPDO", gpdo_policy_schedules_path %>
+<% add_parent_breadcrumb_link "Schedules", gpdo_policy_schedules_path %>
 
 <% content_for :title, t(".title") %>
 
@@ -14,6 +14,6 @@
       <%= t(".title") %>
     </h1>
 
-    <%= render "form" %>
+    <%= render "form", url: gpdo_policy_schedule_path(@schedule.number) %>
   </div>
 </div>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "GPDO", application_types_path %>
+
+<% content_for :title, t(".title") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".title") %>
+    </h1>
+    <p class="govuk-body">
+     
+    </p>
+    <%= render "table" %>
+  </div>
+</div>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/new.html.erb
@@ -4,6 +4,7 @@
 
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "GPDO", gpdo_policy_schedules_path %>
+<% add_parent_breadcrumb_link "Schedules", gpdo_policy_schedules_path %>
 
 <% content_for :title, t(".title") %>
 
@@ -12,9 +13,7 @@
     <h1 class="govuk-heading-l">
       <%= t(".title") %>
     </h1>
-    <p class="govuk-body">
-      <%= govuk_button_link_to t(".create_new_schedule"), new_gpdo_policy_schedule_path %>
-    </p>
-    <%= render "table" %>
+
+    <%= render "form", url: nil %>
   </div>
 </div>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -275,6 +275,12 @@ en:
         edit: Edit
       update:
         success: Decision successfully updated
+    gpdo:
+      policy_schedules:
+        index:
+          title: Schedules
+        table:
+          edit: Edit
     legislation:
       create:
         success: Legislation successfully created

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -277,10 +277,28 @@ en:
         success: Decision successfully updated
     gpdo:
       policy_schedules:
+        create:
+          success: GPDO schedule successfully created
+        destroy:
+          success: GPDO schedule successfully removed
+        edit:
+          title: Edit schedule
+        form:
+          name_hint: Enter the schedule name
+          name_label: Name
+          number_hint: Enter the schedule number
+          number_label: Number
+          remove: Remove
+          save: Save
         index:
+          create_new_schedule: Create new schedule
           title: Schedules
+        new:
+          title: Create new schedule
         table:
           edit: Edit
+        update:
+          success: GPDO schedule successfully updated
     legislation:
       create:
         success: Legislation successfully created

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -32,6 +32,10 @@ BopsConfig::Engine.routes.draw do
     resources :reporting_types
   end
 
+  namespace :gpdo do
+    resources :policy_schedules, path: "schedules"
+  end
+
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member
   end

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -30,10 +30,10 @@ BopsConfig::Engine.routes.draw do
     resources :legislation
     resources :decisions
     resources :reporting_types
-  end
 
-  namespace :gpdo do
-    resources :policy_schedules, path: "schedules"
+    namespace :gpdo do
+      resources :policy_schedules, param: :number, path: "schedules"
+    end
   end
 
   resources :users, except: %i[show destroy] do

--- a/engines/bops_config/spec/system/gpdo_spec.rb
+++ b/engines/bops_config/spec/system/gpdo_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "bops_config_helper"
+
+RSpec.describe "GPDO", type: :system do
+  let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
+  let!(:schedule) { create(:policy_schedule, number: 2, name: "Permitted development rights") }
+
+  before do
+    sign_in(user)
+    visit "/"
+  end
+
+  it "allows viewing and creating the policy schedules" do
+    click_link "GPDO"
+    expect(page).to have_selector("h1", text: "Schedules")
+
+    within(".govuk-table") do
+      within "thead > tr:first-child" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Name")
+        expect(page).to have_selector("th:nth-child(2)", text: "Action")
+      end
+
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Schedule 2 - Permitted development rights")
+          within "td:nth-child(2)" do
+            expect(page).to have_link(
+              "Edit",
+              href: "/gpdo/schedules/#{schedule.number}/edit"
+            )
+          end
+        end
+      end
+    end
+
+    click_link "Create new schedule"
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "Enter a number for the schedule")
+    fill_in "Number", with: "0"
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "The schedule number must be greater than or equal to 1")
+    fill_in "Number", with: "5"
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "The schedule number must be less than or equal to 4")
+    fill_in "Number", with: "NaN"
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "The schedule number must be a number")
+    fill_in "Number", with: "2"
+    click_button "Save"
+    expect(page).to have_selector("[role=alert] li", text: "Number has already been taken")
+
+    fill_in "Number", with: "3"
+    fill_in "Name", with: "Procedures for Article 4 directions"
+    click_button "Save"
+
+    expect(page).to have_content("GPDO schedule successfully created")
+
+    within(".govuk-table") do
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Schedule 2 - Permitted development rights")
+        end
+        within "tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Schedule 3 - Procedures for Article 4 directions")
+        end
+      end
+    end
+  end
+
+  it "allows editing the schedule" do
+    visit "/gpdo/schedules/#{schedule.number}/edit"
+    expect(page).to have_selector("h1", text: "Edit schedule")
+    expect(page).to have_link("Back", href: "/gpdo/schedules")
+    # Schedule number is readonly
+    expect(page).to have_selector("#policy-schedule-number-field[readonly]")
+
+    fill_in "Name", with: "Permitted Development Rights"
+    click_button "Save"
+
+    expect(page).to have_content("GPDO schedule successfully updated")
+
+    within(".govuk-table") do
+      within "tbody" do
+        within "tr:nth-child(1)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "Schedule 2 - Permitted Development Rights")
+        end
+      end
+    end
+  end
+
+  context "when deleting the legislation" do
+    let(:schedule3) { create(:policy_schedule, number: 3, name: "Procedures for Article 4 directions") }
+    let!(:policy_part) { create(:policy_part, policy_schedule: schedule3) }
+
+    it "allows deleting the legislation when no policy part is associated", :capybara do
+      visit "/gpdo/schedules/2/edit"
+      accept_confirm(text: "Are you sure?") do
+        click_link("Remove")
+      end
+
+      expect(page).to have_content("GPDO schedule successfully removed")
+      expect(page).not_to have_content("Schedule 2 - Permitted development rights")
+    end
+
+    it "does not allow deleting the legislation when a policy part is associated" do
+      visit "/gpdo/schedules/3/edit"
+      expect(page).not_to have_link("Remove")
+    end
+  end
+end

--- a/spec/factories/policy_schedule.rb
+++ b/spec/factories/policy_schedule.rb
@@ -2,6 +2,7 @@
 
 FactoryBot.define do
   factory :policy_schedule do
-    sequence(:number)
+    number { 2 }
+    name { "Permitted development rights" }
   end
 end

--- a/spec/models/policy_schedule_spec.rb
+++ b/spec/models/policy_schedule_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe PolicySchedule, type: :model do
     describe "#number" do
       it "validates presence" do
         policy_schedule.number = nil
-        expect { policy_schedule.valid? }.to change { policy_schedule.errors[:number] }.to ["can't be blank"]
+        expect { policy_schedule.valid? }.to change { policy_schedule.errors[:number] }.to ["Enter a number for the schedule", "The schedule number must be a number"]
+      end
+
+      it "validates numericality" do
+        policy_schedule.number = "NaN"
+        expect { policy_schedule.valid? }.to change { policy_schedule.errors[:number] }.to ["The schedule number must be a number"]
       end
 
       it "validates uniqueness" do


### PR DESCRIPTION
### Description of change

Create and view GPDO schedules - https://www.legislation.gov.uk/uksi/2015/596/contents
- Schedule number is readonly
- Only permit to remove schedule if no policy part is associated
- Use schedule number in parameters instead of primary id

### Story Link

https://trello.com/c/h0qQ79C9/3132-create-and-view-policy-schedules