### PR TITLE
Fix incorrectly-updated routes

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -6,7 +6,7 @@ class PlanningApplicationMailer < ApplicationMailer
 
   def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application
-    @host = host
+    @decision_notice_url = decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.id, format: "pdf", host: host)
 
     view_mail(
       NOTIFY_TEMPLATE_ID,

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -386,7 +386,7 @@ class Consultation < ApplicationRecord
   end
 
   def application_link
-    "#{local_authority.applicants_url}/planning_applications/#{planning_application.reference}"
+    "#{local_authority.applicants_url}/planning_applications/#{planning_application.id}"
   end
 
   def period_days

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -400,7 +400,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def site_notice_link
-    "#{local_authority.applicants_url}/planning_applications/#{reference}/site_notices/download"
+    "#{local_authority.applicants_url}/planning_applications/#{id}/site_notices/download"
   end
 
   def last_site_notice_audit

--- a/app/views/planning_application_mailer/decision_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/decision_notice_mail.text.erb
@@ -7,13 +7,13 @@ Address: <%= @planning_application.full_address %>
 <% if @planning_application.refused? %>
   We regret to inform you that your application for a <%= @planning_application.application_type.human_name %> has been refused. For details of our decision, go to:
 
-  <%= decision_notice_api_v1_planning_application_url(@planning_application, format: "pdf", host: @host) %>
+  <%= @decision_notice_url %>
 
   To appeal this decision, read [Appeal a decision about a lawful development certificate on GOV.UK](https://www.gov.uk/appeal-lawful-development-certificate-decision).
 <% else %>
   We are pleased to inform you that a decision has been made to grant you a <%= @planning_application.application_type.human_name %>. To see your certificate, go to:
 
-  <%= decision_notice_api_v1_planning_application_url(@planning_application, format: "pdf", host: @host) %>
+  <%= @decision_notice_url %>
 <% end %>
 
 If you have any questions about your application, contact us at <%= @planning_application.local_authority.email_address %>.

--- a/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
@@ -15,6 +15,6 @@ end
 if @planning_application.decision
   json.decisionNotice do
     json.name "decision-notice-#{@planning_application.reference_in_full}.pdf"
-    json.url main_app.decision_notice_api_v1_planning_application_url(@planning_application, format: "pdf")
+    json.url main_app.decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.id, format: "pdf")
   end
 end

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "BOPS public API" do
           expect(data["application"]["reference"]).to eq(planning_application.reference)
           expect(data["files"]).not_to be_empty
           expect(data["decisionNotice"]["name"]).to eq("decision-notice-PlanX-24-00100-HAPP.pdf")
-          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf")
+          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf")
         end
       end
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes a link to the decision notice" do
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
+        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
       )
     end
 
@@ -130,7 +130,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "includes a link to the decision notice" do
         expect(mail_body).to include(
-          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
+          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
         )
       end
 
@@ -900,7 +900,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "A prior approval application has been made for the development described below:"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}"
       )
     end
 
@@ -988,7 +988,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "As part of the application process"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
       )
     end
   end
@@ -1058,7 +1058,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "The site notice for this application is ready for display"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
       )
     end
   end


### PR DESCRIPTION
### Description of change

Fixing some URLs that were incorrectly modified to use references. These URLs actually point to bops-applicants which still uses IDs and so should not be updated.

### Story Link
https://trello.com/c/xt7RObqN/2847-base-bops-url-routes-on-application-number-rather-than-primary-id