### PR TITLE
Add more redirects to new-style routes

### DIFF
--- a/app/controllers/planning_applications/press_notices/confirmations_controller.rb
+++ b/app/controllers/planning_applications/press_notices/confirmations_controller.rb
@@ -9,6 +9,7 @@ module PlanningApplications
       before_action :ensure_publicity_is_permitted
       before_action :set_press_notice
       before_action :set_press_notices, only: :show
+      before_action :redirect_to_reference_url, only: %i[show edit]
 
       def show
         respond_to do |format|

--- a/app/controllers/planning_applications/press_notices_controller.rb
+++ b/app/controllers/planning_applications/press_notices_controller.rb
@@ -8,6 +8,7 @@ module PlanningApplications
     before_action :ensure_publicity_is_permitted
     before_action :build_press_notice, only: [:new, :create]
     before_action :set_press_notice, only: [:show, :update]
+    before_action :redirect_to_reference_url, only: %i[new show]
 
     def new
       respond_to do |format|

--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -10,6 +10,7 @@ module PlanningApplications
     before_action :set_site_notice, except: %i[new create]
     before_action :ensure_public_portal_is_active, only: :create
     before_action :ensure_application_is_assigned, only: :create
+    before_action :redirect_to_reference_url, only: %i[new show edit]
 
     def show
       respond_to do |format|


### PR DESCRIPTION
These are routes that appear in some emails, so although the old-style routes will continue to work, it's nice to have a redirect to the new-style ones.