### PR TITLE
Use correct file api-key

### DIFF
--- a/app/models/file_downloaders/base_downloader.rb
+++ b/app/models/file_downloaders/base_downloader.rb
@@ -26,12 +26,16 @@ module FileDownloaders
       raise NotImplementedError, "Subclasses of BaseDownloader need to implement #authenticate"
     end
 
-    def get(url)
+    def get(url:, from_production: false)
       Tempfile.new("bops-document-download", encoding: "ascii-8bit").tap do |file|
         uri = URI.parse(url)
 
         connection = Faraday.new(uri.origin) do |faraday|
-          authenticate(faraday)
+          if from_production
+            faraday.headers["api-key"] = Rails.configuration.planx_file_production_api_key
+          else
+            authenticate(faraday)
+          end
 
           faraday.response :raise_error
         end

--- a/engines/bops_api/app/services/bops_api/application/documents_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/documents_service.rb
@@ -28,7 +28,7 @@ module BopsApi
           raise Errors::FileDownloaderNotConfiguredError, "Please configure the file downloader for API user '#{user.id}'"
         end
 
-        file = user.file_downloader.get(url)
+        file = user.file_downloader.get(url: url, from_production: planning_application.from_production?)
         name = URI.decode_uri_component(File.basename(URI.parse(url).path))
 
         planning_application.documents.create! do |document|

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -535,6 +535,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           allow(ENV).to receive(:fetch).and_call_original
           allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("production")
           params[:metadata][:source] = "BOPS production"
+          Rails.configuration.planx_file_production_api_key = "G41sAys9uPMUVBH5WUKsYE4H"
         end
 
         it "calls the post application to staging job" do

--- a/spec/models/file_downloaders_spec.rb
+++ b/spec/models/file_downloaders_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FileDownloaders, type: :model do
 
   before do
     stubbed_request.to_return(response)
-    subject.get(url)
+    subject.get(url: url)
   end
 
   describe FileDownloaders::BasicAuthentication do


### PR DESCRIPTION
### Description of change

- When posting production cases into staging, we are using the wrong api-key for file authentication

### Story Link

https://trello.com/c/FYWWuQt7/3074-investigate-production-cases-not-being-pulled-through-to-staging
