### PR TITLE
Manage GPDO policy classes

### DIFF
--- a/app/models/new_policy_class.rb
+++ b/app/models/new_policy_class.rb
@@ -6,6 +6,12 @@ class NewPolicyClass < ApplicationRecord
   has_many :planning_application_policy_classes, dependent: :restrict_with_error
   has_many :planning_applications, through: :planning_application_policy_classes
 
-  validates :section, presence: true, uniqueness: {scope: :policy_part}
-  validates :name, presence: true
+  attr_readonly :section
+
+  with_options presence: true do
+    validates :section, uniqueness: {scope: :policy_part}
+    validates :name
+  end
+
+  validates :url, url: true
 end

--- a/app/models/policy_part.rb
+++ b/app/models/policy_part.rb
@@ -2,7 +2,7 @@
 
 class PolicyPart < ApplicationRecord
   belongs_to :policy_schedule
-  has_many :new_policy_classes, dependent: :destroy
+  has_many :new_policy_classes, -> { order(:section) }, dependent: :restrict_with_error
 
   with_options presence: true do
     validates :number, uniqueness: {scope: :policy_schedule}, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 20}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,12 @@ en:
               invalid: Enter a valid url for the legislation
             title:
               blank: Enter a title for the legislation
+        new_policy_class:
+          attributes:
+            name:
+              blank: Enter a description for the class
+            section:
+              blank: Enter a section for the class
         planning_application:
           attributes:
             application_type_id:

--- a/engines/bops_config/app/controllers/bops_config/gpdo/base_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/gpdo/base_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module Gpdo
+    class BaseController < ApplicationController
+      private
+
+      def set_policy_schedule
+        @schedule = PolicySchedule.find_by_number(policy_schedule_number)
+      end
+
+      def set_policy_schedules
+        @schedules = PolicySchedule.by_number
+      end
+
+      def policy_schedule_number
+        Integer(policy_schedule_number_params)
+      rescue
+        raise ActionController::BadRequest, "Invalid policy schedule number: #{policy_schedule_number_params.inspect}"
+      end
+
+      def set_policy_parts
+        @parts = @schedule.policy_parts
+      end
+
+      def policy_part_number
+        Integer(policy_part_number_params)
+      rescue
+        raise ActionController::BadRequest, "Invalid policy part number: #{policy_schedule_number_params.inspect}"
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/gpdo/policy_class_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/gpdo/policy_class_controller.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module BopsConfig
+  module Gpdo
+    class PolicyClassController < BaseController
+      before_action :set_policy_schedule
+      before_action :set_policy_part
+      before_action :build_policy_class, only: %i[new create]
+      before_action :set_policy_classes, only: %i[index]
+      before_action :set_policy_class, only: %i[edit update destroy]
+
+      def index
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def new
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def create
+        @policy_class.attributes = policy_class_params
+
+        respond_to do |format|
+          if @policy_class.save
+            format.html { redirect_to redirect_path, notice: t(".success") }
+          else
+            format.html { render :new }
+          end
+        end
+      end
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          format.html do
+            if @policy_class.update(policy_class_params.except(:section))
+              redirect_to redirect_path, notice: t(".success")
+            else
+              render :edit
+            end
+          end
+        end
+      end
+
+      def destroy
+        respond_to do |format|
+          format.html do
+            if @policy_class.destroy
+              redirect_to redirect_path, notice: t(".success")
+            else
+              render :edit
+            end
+          end
+        end
+      end
+
+      private
+
+      def policy_schedule_number_params
+        params[:policy_schedule_number]
+      end
+
+      def policy_part_number_params
+        params[:policy_part_number]
+      end
+
+      def policy_class_section
+        params[:section]
+      rescue
+        raise ActionController::BadRequest, "Invalid policy class section: #{params[:section].inspect}"
+      end
+
+      def policy_class_params
+        params.require(:new_policy_class).permit(*policy_class_attributes)
+      end
+
+      def policy_class_attributes
+        %i[section name url]
+      end
+
+      def build_policy_class
+        @policy_class = @part.new_policy_classes.new
+      end
+
+      def set_policy_class
+        @policy_class = set_policy_classes.find_by_section(policy_class_section)
+      end
+
+      def set_policy_classes
+        @policy_classes = @part.new_policy_classes
+      end
+
+      def set_policy_part
+        @part = set_policy_parts.find_by_number(policy_part_number)
+      end
+
+      def redirect_path
+        gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number)
+      end
+    end
+  end
+end

--- a/engines/bops_config/app/controllers/bops_config/gpdo/policy_parts_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/gpdo/policy_parts_controller.rb
@@ -2,7 +2,7 @@
 
 module BopsConfig
   module Gpdo
-    class PolicyPartsController < ApplicationController
+    class PolicyPartsController < BaseController
       before_action :set_policy_schedule
       before_action :build_policy_part, only: %i[new create]
       before_action :set_policy_parts, only: %i[index]
@@ -41,7 +41,7 @@ module BopsConfig
       def update
         respond_to do |format|
           format.html do
-            if @part.update(policy_part_params.except(:number))
+            if @part.update(policy_part_params)
               redirect_to gpdo_policy_schedule_policy_parts_path, notice: t(".success")
             else
               render :edit
@@ -64,14 +64,12 @@ module BopsConfig
 
       private
 
-      def policy_schedule_number
-        Integer(params[:policy_schedule_number])
-      rescue
-        raise ActionController::BadRequest, "Invalid policy schedule number: #{params[:number].inspect}"
+      def policy_schedule_number_params
+        params[:policy_schedule_number]
       end
 
-      def set_policy_schedule
-        @schedule = PolicySchedule.find_by_number(policy_schedule_number)
+      def policy_part_number_params
+        params[:number]
       end
 
       def policy_part_params
@@ -88,16 +86,6 @@ module BopsConfig
 
       def set_policy_part
         @part = set_policy_parts.find_by_number(policy_part_number)
-      end
-
-      def set_policy_parts
-        @parts = @schedule.policy_parts
-      end
-
-      def policy_part_number
-        Integer(params[:number])
-      rescue
-        raise ActionController::BadRequest, "Invalid policy part number: #{params[:number].inspect}"
       end
     end
   end

--- a/engines/bops_config/app/controllers/bops_config/gpdo/policy_schedules_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/gpdo/policy_schedules_controller.rb
@@ -2,7 +2,7 @@
 
 module BopsConfig
   module Gpdo
-    class PolicySchedulesController < ApplicationController
+    class PolicySchedulesController < BaseController
       before_action :build_policy_schedule, only: %i[new create]
       before_action :set_policy_schedules, only: %i[index]
       before_action :set_policy_schedule, only: %i[edit update destroy]
@@ -81,18 +81,8 @@ module BopsConfig
         @schedule = PolicySchedule.new
       end
 
-      def set_policy_schedule
-        @schedule = PolicySchedule.find_by_number(policy_schedule_number)
-      end
-
-      def set_policy_schedules
-        @schedules = PolicySchedule.by_number
-      end
-
-      def policy_schedule_number
-        Integer(params[:number])
-      rescue
-        raise ActionController::BadRequest, "Invalid policy schedule number: #{params[:number].inspect}"
+      def policy_schedule_number_params
+        params[:number]
       end
     end
   end

--- a/engines/bops_config/app/helpers/bops_config/application_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_helper.rb
@@ -33,7 +33,9 @@ module BopsConfig
         "decisions" => "decisions",
         "statuses" => "application_types",
         "reporting_types" => "reporting_types",
-        "policy_schedules" => "policy_schedules"
+        "policy_schedules" => "gpdo",
+        "policy_parts" => "gpdo",
+        "policy_class" => "gpdo"
       }
 
       page_keys.fetch(controller_name, "dashboard")
@@ -47,7 +49,7 @@ module BopsConfig
         {link: {text: "Legislation", href: legislation_index_path}, current: active_page_key?("legislation")},
         {link: {text: "Reporting types", href: reporting_types_path}, current: active_page_key?("reporting_types")},
         {link: {text: "Decisions", href: decisions_path}, current: active_page_key?("decisions")},
-        {link: {text: "GPDO", href: gpdo_policy_schedules_path}, current: active_page_key?("policy_schedules")}
+        {link: {text: "GPDO", href: gpdo_policy_schedules_path}, current: active_page_key?("gpdo")}
       ]
     end
   end

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_class/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_class/_form.html.erb
@@ -1,0 +1,19 @@
+<%= form_with model: [:gpdo, @schedule, @part, @policy_class], url: url do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <%= form.govuk_text_field :section, label: {text: t(".section_label")}, hint: {text: t(".section_hint")}, readonly: @policy_class.persisted? %>
+  <%= form.govuk_text_field :name, label: {text: t(".name_label")}, hint: {text: t(".name_hint")} %>
+  <%= form.govuk_text_field :url, label: {text: t(".url_label")}, hint: {text: t(".url_hint")} %>
+
+  <%= form.govuk_submit(t(".save")) do %>
+    <% if action_name == "edit" && @policy_class.policy_sections.none? %>
+      <%= govuk_button_link_to(t(".remove"),
+            gpdo_policy_schedule_policy_part_policy_class_path(@schedule.number, @part.number, @policy_class.section),
+            warning: true,
+            method: :delete,
+            data: {confirm: "Are you sure?"}) %>
+    <% end %>
+
+    <%= govuk_button_link_to t("back"), gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number), secondary: true %>
+  <% end %>
+<% end %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_class/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_class/_table.html.erb
@@ -1,9 +1,9 @@
-<% if @parts.any? %>
+<% if @policy_classes.any? %>
   <table class="govuk-table application-types-table">
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header">
-          Part
+          Class
         </th>
         <th scope="col" class="govuk-table__header">
           Description
@@ -15,16 +15,16 @@
     </thead>
 
     <tbody class="govuk-table__body">
-      <% @parts.each do |part| %>
+      <% @policy_classes.each do |policy_class| %>
         <tr class="govuk-table__row">
           <td class="govuk-table__cell">
-            <%= part.number %>
+            <%= policy_class.section %>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to part.name, gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, part.number) %>
+            <%= policy_class.name %>
           </td>
           <td class="govuk-table__cell">
-            <%= govuk_link_to t(".edit"), edit_gpdo_policy_schedule_policy_part_path(part.policy_schedule.number, part.number) %>
+            <%= govuk_link_to t(".edit"), edit_gpdo_policy_schedule_policy_part_policy_class_path(@schedule.number, @part.number, policy_class.section) %>
           </td>
         </tr>
       <% end %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_class/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_class/edit.html.erb
@@ -5,18 +5,20 @@
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "GPDO", gpdo_policy_schedules_path %>
 <% add_parent_breadcrumb_link "Schedule #{@schedule.number}", gpdo_policy_schedules_path %>
+<% add_parent_breadcrumb_link "Part #{@part.number}", gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number) %>
 
 <% content_for :title, t(".title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= @schedule.full_name %>
+      <%= t(".title") %>
     </h1>
+
     <p class="govuk-body">
-      <%= govuk_button_link_to t(".create_new"), new_gpdo_policy_schedule_policy_part_path(@schedule.number, @part) %>
+      Part <%= @part.number %> - <%= @part.name %>
     </p>
-    <%= render "table" %>
-    <%= govuk_button_link_to t("back"), gpdo_policy_schedules_path, secondary: true %>
+
+    <%= render "form", url: gpdo_policy_schedule_policy_part_policy_class_path(@schedule.number, @part.number, @policy_class.section) %>
   </div>
 </div>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_class/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_class/index.html.erb
@@ -5,16 +5,21 @@
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "GPDO", gpdo_policy_schedules_path %>
 <% add_parent_breadcrumb_link "Schedule #{@schedule.number}", gpdo_policy_schedules_path %>
+<% add_parent_breadcrumb_link "Part #{@part.number}", gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number) %>
 
 <% content_for :title, t(".title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= @schedule.full_name %>
+      Part <%= @part.number %>
+      <span class="govuk-caption-l">
+        <%= @part.name %>
+      </span>
     </h1>
+
     <p class="govuk-body">
-      <%= govuk_button_link_to t(".create_new"), new_gpdo_policy_schedule_policy_part_path(@schedule.number, @part) %>
+      <%= govuk_button_link_to t(".create_new"), new_gpdo_policy_schedule_policy_part_policy_class_path(@schedule.number, @part.number) %>
     </p>
     <%= render "table" %>
     <%= govuk_button_link_to t("back"), gpdo_policy_schedules_path, secondary: true %>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_class/new.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_class/new.html.erb
@@ -5,18 +5,20 @@
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "GPDO", gpdo_policy_schedules_path %>
 <% add_parent_breadcrumb_link "Schedule #{@schedule.number}", gpdo_policy_schedules_path %>
+<% add_parent_breadcrumb_link "Part #{@part.number}", gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number) %>
 
 <% content_for :title, t(".title") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      <%= @schedule.full_name %>
+      <%= t(".title") %>
     </h1>
+
     <p class="govuk-body">
-      <%= govuk_button_link_to t(".create_new"), new_gpdo_policy_schedule_policy_part_path(@schedule.number, @part) %>
+      Part <%= @part.number %> - <%= @part.name %>
     </p>
-    <%= render "table" %>
-    <%= govuk_button_link_to t("back"), gpdo_policy_schedules_path, secondary: true %>
+
+    <%= render "form", url: gpdo_policy_schedule_policy_part_policy_class_index_path(@schedule.number, @part.number) %>
   </div>
 </div>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_schedules/index.html.erb
@@ -13,7 +13,7 @@
       <%= t(".title") %>
     </h1>
     <p class="govuk-body">
-      <%= govuk_button_link_to t(".create_new_schedule"), new_gpdo_policy_schedule_path %>
+      <%= govuk_button_link_to t(".create_new"), new_gpdo_policy_schedule_path %>
     </p>
     <%= render "table" %>
   </div>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -276,6 +276,31 @@ en:
       update:
         success: Decision successfully updated
     gpdo:
+      policy_class:
+        create:
+          success: GPDO class successfully created
+        destroy:
+          success: GPDO class successfully removed
+        edit:
+          title: Edit class
+        form:
+          name_hint: Enter class description
+          name_label: Description
+          remove: Remove
+          save: Save
+          section_hint: Enter class or section within the part, such as "A, AA, B"
+          section_label: Class
+          url_hint: Enter an optional link to the General Permitted Development Order
+          url_label: Link (optional)
+        index:
+          create_new: Create new class
+          title: Classes
+        new:
+          title: Create new class
+        table:
+          edit: Edit
+        update:
+          success: GPDO class successfully updated
       policy_parts:
         create:
           success: GPDO part successfully created
@@ -291,7 +316,7 @@ en:
           remove: Remove
           save: Save
         index:
-          create_new_part: Create new part
+          create_new: Create new part
           title: Parts
         new:
           title: Create new part
@@ -314,7 +339,7 @@ en:
           remove: Remove
           save: Save
         index:
-          create_new_schedule: Create new schedule
+          create_new: Create new schedule
           title: Schedules
         new:
           title: Create new schedule

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -33,7 +33,9 @@ BopsConfig::Engine.routes.draw do
 
     namespace :gpdo do
       resources :policy_schedules, param: :number, path: "schedule" do
-        resources :policy_parts, param: :number, path: "part"
+        resources :policy_parts, param: :number, path: "part" do
+          resources :policy_class, param: :section, path: "class"
+        end
       end
     end
   end

--- a/spec/models/new_policy_class_spec.rb
+++ b/spec/models/new_policy_class_spec.rb
@@ -9,19 +9,30 @@ RSpec.describe NewPolicyClass, type: :model do
     describe "#section" do
       it "validates presence" do
         policy_class.section = nil
-        expect { policy_class.valid? }.to change { policy_class.errors[:section] }.to ["can't be blank"]
+        expect { policy_class.valid? }.to change { policy_class.errors[:section] }.to ["Enter a section for the class"]
       end
 
       it "validates uniqueness within scope of policy_part_id" do
         create(:new_policy_class, section: policy_class.section, policy_part: policy_class.policy_part)
         expect { policy_class.valid? }.to change { policy_class.errors[:section] }.to ["has already been taken"]
       end
+
+      it "section is a readonly attribute" do
+        policy_class.section = "AA"
+        policy_class.save
+
+        expect {
+          policy_class.update(section: "B")
+        }.to raise_error(ActiveRecord::ReadonlyAttributeError)
+
+        expect(policy_class.reload.section).to eq("AA")
+      end
     end
 
     describe "#name" do
       it "validates presence" do
         policy_class.name = nil
-        expect { policy_class.valid? }.to change { policy_class.errors[:name] }.to ["can't be blank"]
+        expect { policy_class.valid? }.to change { policy_class.errors[:name] }.to ["Enter a description for the class"]
       end
     end
 


### PR DESCRIPTION
### Description of change

Manage GPDO policy classes
- Policy classes are children of policy parts
- Ability to add a class, description and url
- Do not allow removal of a policy class if there is an associated policy section

### Story Link

https://trello.com/c/YKikYle0/3134-create-and-view-policy-classes

![Screenshot 2024-08-23 at 11 43 24](https://github.com/user-attachments/assets/cb2b8706-78e9-414e-bd58-95265ce7ca23)
![Screenshot 2024-08-23 at 11 43 30](https://github.com/user-attachments/assets/bf44c098-39cf-4b29-b774-e07585f6f211)
