### PR TITLE
Do not show consultation related features for non supported application types

### DIFF
--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -17,7 +17,7 @@
           latLong: [planning_application.latitude, planning_application.longitude].join(","),
           layers: {
             redline: planning_application.boundary_geojson,
-            neighbours: planning_application.consultation.neighbour_responses
+            neighbours: planning_application.consultation && planning_application.consultation.neighbour_responses
               .group_by { |response| response.summary_tag.to_sym }
               .transform_values { |responses| responses.map { |response| RGeo::GeoJSON.encode(response.neighbour.lonlat) }.compact }
           }

--- a/app/views/planning_applications/neighbour_responses/index.html.erb
+++ b/app/views/planning_applications/neighbour_responses/index.html.erb
@@ -12,8 +12,10 @@
       locals: {heading: "View neighbour responses"}
     ) %>
 
-<h2 class="govuk-heading-m govuk-!-margin-top-7">Date consultation will end</h2>
-<p class="govuk-body"><%= @consultation.end_date.to_fs(:day_month_year_slashes) %></p>
+<% if @consultation.end_date %>
+  <h2 class="govuk-heading-m govuk-!-margin-top-7">Date consultation will end</h2>
+  <p class="govuk-body"><%= @consultation.end_date.to_fs(:day_month_year_slashes) %></p>
+<% end %>
 
 <h2 class="govuk-heading-m govuk-!-margin-top-7">Responses (<%= @neighbour_responses.count %>)</h2>
 <% if @neighbour_responses.any? %>

--- a/app/views/planning_applications/review/tasks/index.html.erb
+++ b/app/views/planning_applications/review/tasks/index.html.erb
@@ -44,17 +44,19 @@
                 }
               ) %>
         <% end %>
-        <% tabs.with_tab(label: (@planning_application&.consultation&.neighbour_responses&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbour_responses.count})" : "Neighbours (0)", id: "neighbours")  do %>
-          <h2 class="govuk-heading-m"><%= (@planning_application&.consultation&.neighbour_responses&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbour_responses.count})" : "Neighbours (0)" %></h2>
-          <p class="govuk-body">
-            <%= govuk_link_to "Show details", planning_application_consultation_neighbour_responses_path(@planning_application) %>
-          </p>
-        <% end %>
-        <% tabs.with_tab(label: (@planning_application&.consultation&.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)", id: "consultees")  do %>
-          <h2 class="govuk-heading-m"><%= (@planning_application&.consultation&.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)" %></h2>
-          <p class="govuk-body">
-            <%= govuk_link_to "Show details", planning_application_consultees_responses_path(@planning_application) %>
-          </p>
+        <% if @planning_application.application_type.consultation? %>
+          <% tabs.with_tab(label: (@planning_application.consultation.neighbour_responses&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbour_responses.count})" : "Neighbours (0)", id: "neighbours")  do %>
+            <h2 class="govuk-heading-m"><%= (@planning_application.consultation.neighbour_responses&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbour_responses.count})" : "Neighbours (0)" %></h2>
+            <p class="govuk-body">
+              <%= govuk_link_to "Show details", planning_application_consultation_neighbour_responses_path(@planning_application) %>
+            </p>
+          <% end %>
+          <% tabs.with_tab(label: (@planning_application.consultation.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)", id: "consultees")  do %>
+            <h2 class="govuk-heading-m"><%= (@planning_application.consultation.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)" %></h2>
+            <p class="govuk-body">
+              <%= govuk_link_to "Show details", planning_application_consultees_responses_path(@planning_application) %>
+            </p>
+          <% end %>
         <% end %>
         <% tabs.with_tab(label: (@planning_application&.documents&.count.to_i > 0) ? "Documents (#{@planning_application.documents.count})" : "Documents (0)", id: "documents")  do %>
           <h2 class="govuk-heading-m"><%= (@planning_application&.documents&.count.to_i > 0) ? "Documents (#{@planning_application.documents.count})" : "Documents (0)" %></h2>

--- a/app/views/shared/_dates_panel.html.erb
+++ b/app/views/shared/_dates_panel.html.erb
@@ -10,15 +10,17 @@
         <% end %>
       </h3>
     </div>
-    <div class="status-panel" id="consultation-end-date">
-      <p class="govuk-body">Consultation end</p>
-      <% if @planning_application.consultation.present? && @planning_application.consultation.end_date.present? %>
-        <h3 class="govuk-heading-s"><%= @planning_application.consultation.end_date.to_fs(:day_month_year_slashes) %></h3>
-        <p class="govuk-body"><span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span></p>
-      <% else %>
-        <h3 class="govuk-heading-s">Not yet started</h3>
-      <% end %>
-    </div>
+    <% if @planning_application.application_type.consultation? %>
+      <div class="status-panel" id="consultation-end-date">
+        <p class="govuk-body">Consultation end</p>
+        <% if @planning_application.consultation.present? && @planning_application.consultation.end_date.present? %>
+          <h3 class="govuk-heading-s"><%= @planning_application.consultation.end_date.to_fs(:day_month_year_slashes) %></h3>
+          <p class="govuk-body"><span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span></p>
+        <% else %>
+          <h3 class="govuk-heading-s">Not yet started</h3>
+        <% end %>
+      </div>
+    <% end %>
     <div class="status-panel" id="expiry-date">
       <p class="govuk-body"><%= @planning_application.next_date_label %></p>
       <h3 class="govuk-heading-s"><%= @planning_application.next_date.to_fs(:day_month_year_slashes) %></h3>

--- a/spec/system/planning_applications/review/tasks_index_spec.rb
+++ b/spec/system/planning_applications/review/tasks_index_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Reviewing Tasks Index" do
   let!(:planning_application) do
     create(
       :planning_application,
+      :planning_permission,
       :awaiting_determination,
       local_authority: default_local_authority
     )
@@ -59,6 +60,29 @@ RSpec.describe "Reviewing Tasks Index" do
       click_on "Back"
 
       expect(page).to have_title("Planning Application")
+    end
+
+    context "when application type does not support consultation" do
+      let!(:planning_application) do
+        create(
+          :planning_application,
+          :lawfulness_certificate,
+          :awaiting_determination,
+          local_authority: default_local_authority
+        )
+      end
+
+      it "does not show consultation sections in the review task" do
+        create(:recommendation, planning_application:)
+        visit "/planning_applications/#{planning_application.reference}"
+
+        click_on "Review and sign-off"
+
+        expect(page).to have_css("#constraints")
+        expect(page).not_to have_css("#neighbours")
+        expect(page).not_to have_css("#consultees")
+        expect(page).to have_css("#documents")
+      end
     end
 
     it "without awaiting determination there is no navigation" do


### PR DESCRIPTION
### Description of change

- Do not show consultation related features for non supported application types

### Story Link

https://trello.com/c/cHuPzE61/3146-fix-broken-review-page-when-consultation-does-not-exist

