### PR TITLE
Allow external redirects with allow_other_host: true

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -8,7 +8,7 @@ module Api
       def show
         raise ActiveRecord::RecordNotFound unless planning_application
         document = planning_application.documents.for_publication.find(params[:id])
-        redirect_to rails_public_blob_url(document.file)
+        redirect_to rails_public_blob_url(document.file), allow_other_host: true
       end
 
       def tags


### PR DESCRIPTION
### Description of change

- Allow external redirects with allow_other_host: true
- rails_public_blob_url was generating a same-origin url before but now we are getting an ActionController::Redirecting::UnsafeRedirectError

### Story Link

https://trello.com/c/1olcelpW/3147-documents-in-api-returning-500-error

