### PR TITLE
NeighbourCoordinatesUpdateJob should not be triggered until the transaction has been committed

### DIFF
--- a/app/models/neighbour.rb
+++ b/app/models/neighbour.rb
@@ -18,7 +18,7 @@ class Neighbour < ApplicationRecord
 
   validate :validate_address_format
 
-  after_save :update_lonlat, if: :saved_change_to_address?
+  after_save_commit :update_lonlat, if: :saved_change_to_address?
 
   accepts_nested_attributes_for :neighbour_responses
 


### PR DESCRIPTION
Possibility of a race condition if the job runs before the record has finished saving (or if it gets rolled back)