### PR TITLE
Fix bank holiday option in global admin

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -77,6 +77,9 @@ Rails.application.configure do
   # Raises error for missing translations.
   config.i18n.raise_on_missing_translations = true
 
+  # Annotate rendered view with file names.
+  config.action_view.annotate_rendered_view_with_filenames = true
+
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 

--- a/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
@@ -35,6 +35,7 @@ module BopsConfig
           :ownership_details,
           :planning_conditions,
           :permitted_development_rights,
+          :consultations_skip_bank_holidays,
           {consultation_steps: []}
         ]
       end

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -29,11 +29,12 @@
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-        <%= ff.govuk_fieldset legend: {text: t("application_type_features.legends.consultation"), size: "s"} do %>
+        <%= ff.govuk_fieldset legend: {text: t("application_type_features.legends.consultation"), size: "s"}, class: "govuk-!-margin-bottom-6" do %>
           <%= ff.govuk_collection_check_boxes :consultation_steps,
                 Consultation::STEPS.map { |step| OpenStruct.new(id: step, name: t("labels.consultation_steps.#{step}", scope: :application_type_features)) },
                 :id, :name,
-                legend: {text: "Consultation steps", tag: "span", class: "govuk-visually-hidden"} %>
+                legend: {text: "Consultation steps", tag: "span", class: "govuk-visually-hidden"},
+                form_group: {class: "govuk-!-margin-bottom-2"} %>
           <%= ff.govuk_check_box :consultations_skip_bank_holidays, 1, 0, multiple: false, label: {text: t("application_type_features.labels.consultations_skip_bank_holidays")} %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Description of change

Allow the param through the controller

### Story Link

https://trello.com/c/9rNaBy0q/2498-deal-with-application-types-where-bank-holidays-are-excluded-from-the-consultation-period
