### PR TITLE
Ensure node exists in final docker image

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -72,6 +72,10 @@ RUN apt-get update -qq && \
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails
 
+# Copy installed version of node
+ENV PATH=/usr/local/node/bin:$PATH
+COPY --from=build /usr/local/node /usr/local/node
+
 # Write a REVISION file for Appsignal
 ARG REVISION
 RUN echo -n "$REVISION" > REVISION


### PR DESCRIPTION
### Description of change

Node was being built as a build dependency (for assets etc) but excluded from the final image. This led to PDF generation failing, since this depends on node existing at runtime.

We can fix this by copying across the installed node to the final image layer.
