### PR TITLE
Add further applicant details to API response

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -638,6 +638,10 @@ class PlanningApplication < ApplicationRecord
     find_proposal_detail("Exactly how high are the eaves of the extension?")&.first&.response_values&.first
   end
 
+  def applicant_interest
+    params_v2&.dig(:data, :applicant, :ownership)
+  end
+
   def neighbour_addresses
     proposal_details.select { |detail| detail.question.include? "adjoining property" }&.map(&:response_values)&.flatten
   end

--- a/app/models/planx_planning_data.rb
+++ b/app/models/planx_planning_data.rb
@@ -2,4 +2,8 @@
 
 class PlanxPlanningData < ApplicationRecord
   belongs_to :planning_application
+
+  def params_v2
+    self[:params_v2]&.with_indifferent_access
+  end
 end

--- a/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
@@ -22,5 +22,10 @@ json.proposal do
   json.description planning_application.description
 end
 json.applicant do
+  json.type planning_application.params_v2&.dig(:data, :applicant, :type)
+  json.address planning_application.params_v2&.dig(:data, :applicant, :address)
   json.ownership planning_application.applicant_interest
+  json.agent do
+    json.address planning_application.params_v2&.dig(:data, :applicant, :agent, :address)
+  end
 end

--- a/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
@@ -21,3 +21,6 @@ end
 json.proposal do
   json.description planning_application.description
 end
+json.applicant do
+  json.ownership planning_application.applicant_interest
+end

--- a/engines/bops_api/schemas/odp/v0.7.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/search.json
@@ -261,6 +261,32 @@
             "applicant": {
               "type": "object",
               "properties": {
+                "address": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Address"
+                    },
+                    { "type": "null" }
+                  ]
+                },
+                "agent": {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "anyOf": [
+                            {
+                              "$ref": "#/definitions/Address"
+                            },
+                            { "type": "null" }
+                          ]
+                        }
+                      }
+                    },
+                    { "type": "null" }
+                  ]
+                },
                 "ownership": {
                   "anyOf": [
                     {
@@ -268,9 +294,15 @@
                     },
                     { "type": "null" }
                   ]
+                },
+                "type": {
+                  "anyOf": [
+                    { "type": "string" },
+                    { "type": "null" }
+                  ]
                 }
               },
-              "required": ["ownership"]
+              "required": ["type", "address", "ownership", "agent"]
             }
           },
           "required": [

--- a/engines/bops_api/schemas/odp/v0.7.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/search.json
@@ -257,9 +257,24 @@
               "required": [
                 "description"
               ]
+            },
+            "applicant": {
+              "type": "object",
+              "properties": {
+                "ownership": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Ownership"
+                    },
+                    { "type": "null" }
+                  ]
+                }
+              },
+              "required": ["ownership"]
             }
           },
           "required": [
+            "applicant",
             "application",
             "property",
             "proposal"

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/search.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/search.json
@@ -88,12 +88,26 @@
         "description": "householder extension"
       },
       "applicant": {
+        "type": "individual",
+        "address": {
+          "sameAsSiteAddress": true
+        },
         "ownership": {
           "interest": "owner.sole",
           "certificate": "a",
           "agriculturalTenants": false,
           "declaration": {
             "accurate": true
+          }
+        },
+        "agent": {
+          "address": {
+            "line1": "40 Stansfield Road",
+            "line2": "Brixton",
+            "town": "London",
+            "county": "Greater London",
+            "postcode": "SW9 9RZ",
+            "country": "UK"
           }
         }
       }
@@ -149,6 +163,13 @@
         "description": "Build a roof extension."
       },
       "applicant": {
+        "type": "individual",
+        "address": {
+          "sameAsSiteAddress": true
+        },
+        "siteContact": {
+          "role": "applicant"
+        },
         "ownership": {
           "interest": "occupier",
           "owners": [
@@ -166,6 +187,16 @@
               "noticeGiven": true
             }
           ]
+        },
+        "agent": {
+          "address": {
+            "line1": "The Tree",
+            "line2": "One Tree Hill",
+            "town": "Great Tunnelling",
+            "county": "",
+            "postcode": "F0XH0L3",
+            "country": ""
+          }
         }
       }
     }

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/search.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/search.json
@@ -86,6 +86,16 @@
       },
       "proposal": {
         "description": "householder extension"
+      },
+      "applicant": {
+        "ownership": {
+          "interest": "owner.sole",
+          "certificate": "a",
+          "agriculturalTenants": false,
+          "declaration": {
+            "accurate": true
+          }
+        }
       }
     },
     {
@@ -137,6 +147,26 @@
       },
       "proposal": {
         "description": "Build a roof extension."
+      },
+      "applicant": {
+        "ownership": {
+          "interest": "occupier",
+          "owners": [
+            {
+              "interest": "owner",
+              "name": "Matilda Wormwood",
+              "address": {
+                "town": "Reading",
+                "line1": "9, Library Way",
+                "line2": "",
+                "county": "",
+                "country": "UK",
+                "postcode": "L1T3R8Y"
+              },
+              "noticeGiven": true
+            }
+          ]
+        }
       }
     }
   ]

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -17551,12 +17551,32 @@ components:
               applicant:
                 type: object
                 properties:
+                  address:
+                    anyOf:
+                    - "$ref": "#/components/definitions/Address"
+                    - type: 'null'
+                  agent:
+                    anyOf:
+                    - type: object
+                      properties:
+                        address:
+                          anyOf:
+                          - "$ref": "#/components/definitions/Address"
+                          - type: 'null'
+                    - type: 'null'
                   ownership:
                     anyOf:
                     - "$ref": "#/components/definitions/Ownership"
                     - type: 'null'
+                  type:
+                    anyOf:
+                    - type: string
+                    - type: 'null'
                 required:
+                - type
+                - address
                 - ownership
+                - agent
             required:
             - applicant
             - application
@@ -24422,12 +24442,23 @@ paths:
                       proposal:
                         description: householder extension
                       applicant:
+                        type: individual
+                        address:
+                          sameAsSiteAddress: true
                         ownership:
                           interest: owner.sole
                           certificate: a
                           agriculturalTenants: false
                           declaration:
                             accurate: true
+                        agent:
+                          address:
+                            line1: 40 Stansfield Road
+                            line2: Brixton
+                            town: London
+                            county: Greater London
+                            postcode: SW9 9RZ
+                            country: UK
                     - application:
                         type:
                           value: pp.full.householder
@@ -24470,6 +24501,11 @@ paths:
                       proposal:
                         description: Build a roof extension.
                       applicant:
+                        type: individual
+                        address:
+                          sameAsSiteAddress: true
+                        siteContact:
+                          role: applicant
                         ownership:
                           interest: occupier
                           owners:
@@ -24483,6 +24519,14 @@ paths:
                               country: UK
                               postcode: L1T3R8Y
                             noticeGiven: true
+                        agent:
+                          address:
+                            line1: The Tree
+                            line2: One Tree Hill
+                            town: Great Tunnelling
+                            county: ''
+                            postcode: F0XH0L3
+                            country: ''
               schema:
                 "$ref": "#/components/schemas/Search"
   "/api/v2/public/planning_applications/{reference}/documents":
@@ -24657,12 +24701,23 @@ paths:
                       proposal:
                         description: householder extension
                       applicant:
+                        type: individual
+                        address:
+                          sameAsSiteAddress: true
                         ownership:
                           interest: owner.sole
                           certificate: a
                           agriculturalTenants: false
                           declaration:
                             accurate: true
+                        agent:
+                          address:
+                            line1: 40 Stansfield Road
+                            line2: Brixton
+                            town: London
+                            county: Greater London
+                            postcode: SW9 9RZ
+                            country: UK
                     - application:
                         type:
                           value: pp.full.householder
@@ -24705,6 +24760,11 @@ paths:
                       proposal:
                         description: Build a roof extension.
                       applicant:
+                        type: individual
+                        address:
+                          sameAsSiteAddress: true
+                        siteContact:
+                          role: applicant
                         ownership:
                           interest: occupier
                           owners:
@@ -24718,6 +24778,14 @@ paths:
                               country: UK
                               postcode: L1T3R8Y
                             noticeGiven: true
+                        agent:
+                          address:
+                            line1: The Tree
+                            line2: One Tree Hill
+                            town: Great Tunnelling
+                            county: ''
+                            postcode: F0XH0L3
+                            country: ''
   "/api/v2/public/planning_applications/{reference}":
     get:
       summary: Retrieves a planning application

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -18109,7 +18109,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -18268,7 +18268,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -19072,7 +19072,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -19175,7 +19175,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -22357,7 +22357,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.012592
                           squareMetres: 125.92
@@ -22457,7 +22457,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.012592
                           squareMetres: 125.92
@@ -23250,10 +23250,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -23267,11 +23267,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23292,12 +23292,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude: 
-                        longitude: 
+                        latitude:
+                        longitude:
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -23313,28 +23313,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role: 
-                      awaiting_determination_at: 
-                      to_be_reviewed_at: 
+                      user_role:
+                      awaiting_determination_at:
+                      to_be_reviewed_at:
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at: 
+                      in_assessment_at:
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag: 
-                      result_heading: 
-                      result_description: 
-                      result_override: 
-                      returned_at: 
-                      started_at: 
+                      result_flag:
+                      result_heading:
+                      result_description:
+                      result_override:
+                      returned_at:
+                      started_at:
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23351,14 +23351,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties: 
+                        properties:
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2: 
-                        county: 
+                        address_2:
+                        county:
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -23369,7 +23369,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date: 
+                        end_date:
                       make_public: false
                 ids:
                   value:
@@ -23389,10 +23389,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -23406,11 +23406,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23431,12 +23431,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude: 
-                        longitude: 
+                        latitude:
+                        longitude:
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -23452,28 +23452,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role: 
-                      awaiting_determination_at: 
-                      to_be_reviewed_at: 
+                      user_role:
+                      awaiting_determination_at:
+                      to_be_reviewed_at:
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at: 
+                      in_assessment_at:
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag: 
-                      result_heading: 
-                      result_description: 
-                      result_override: 
-                      returned_at: 
-                      started_at: 
+                      result_flag:
+                      result_heading:
+                      result_description:
+                      result_override:
+                      returned_at:
+                      started_at:
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23490,14 +23490,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties: 
+                        properties:
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2: 
-                        county: 
+                        address_2:
+                        county:
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -23508,7 +23508,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date: 
+                        end_date:
                       make_public: false
         '401':
           description: with missing or invalid credentials
@@ -23570,13 +23570,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at: 
+                      invalidated_at:
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -23587,11 +23587,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -23610,7 +23610,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties: 
+                          properties:
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -23647,7 +23647,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -23702,13 +23702,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at: 
+                      invalidated_at:
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -23719,11 +23719,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -23742,7 +23742,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties: 
+                          properties:
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -23779,7 +23779,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -23848,19 +23848,19 @@ paths:
                     applicant_first_name: Albert
                     applicant_last_name: Manteras
                     user_role: agent
-                    awaiting_determination_at: 
-                    to_be_reviewed_at: 
+                    awaiting_determination_at:
+                    to_be_reviewed_at:
                     created_at: '2023-05-23T09:39:04.197+01:00'
                     description: This is a long winded description, bla bla bla a
                       single storey ground floor rear extension; replacement of existing
                       garage door with brick infill and a new window; replacement
                       of the existing windows with double glazed windows, installation
                       of rooflight
-                    determined_at: 
+                    determined_at:
                     determination_date: '2024-03-06'
                     id: 2
-                    invalidated_at: 
-                    in_assessment_at: 
+                    invalidated_at:
+                    in_assessment_at:
                     payment_reference: PAY1
                     payment_amount: '0.0'
                     result_flag: Planning permission / Permission needed
@@ -23869,11 +23869,11 @@ paths:
                     result_description: Based on the information you have provided,
                       we do not think this is eligible for a Lawful Development Certificate
                     result_override: This was my reason for rejecting the result
-                    returned_at: 
-                    started_at: 
+                    returned_at:
+                    started_at:
                     status: not_started
                     target_date: '2023-06-27'
-                    withdrawn_at: 
+                    withdrawn_at:
                     work_status: proposed
                     boundary_geojson:
                       type: Feature
@@ -23956,10 +23956,10 @@ paths:
                       targetDate: '2024-05-15'
                       receivedAt: '2024-04-17T00:00:00.000+01:00'
                       validAt: '2024-04-12T00:00:00.000+01:00'
-                      publishedAt: 
-                      determinedAt: 
+                      publishedAt:
+                      determinedAt:
                       status: in_assessment
-                      decision: 
+                      decision:
                       consultation:
                         startDate: '2024-04-15'
                         endDate: '2024-05-07'
@@ -24039,7 +24039,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties: 
+                              properties:
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -24139,7 +24139,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties: 
+                              properties:
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -24372,9 +24372,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt: 
-                        determinedAt: 
-                        decision: 
+                        publishedAt:
+                        determinedAt:
+                        decision:
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -24466,7 +24466,7 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties: 
+                            properties:
                       proposal:
                         description: Build a roof extension.
                       applicant:
@@ -24516,8 +24516,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt: 
-                      decision: 
+                      determinedAt:
+                      decision:
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -24531,7 +24531,7 @@ paths:
                       - value: sections.proposed
                         description: Sections - proposed
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -24541,7 +24541,7 @@ paths:
                       - value: internal.siteNotice
                         description: Site Notice
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -24607,9 +24607,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt: 
-                        determinedAt: 
-                        decision: 
+                        publishedAt:
+                        determinedAt:
+                        decision:
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -24701,7 +24701,7 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties: 
+                            properties:
                       proposal:
                         description: Build a roof extension.
                       applicant:
@@ -24748,8 +24748,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt: 
-                      decision: 
+                      determinedAt:
+                      decision:
                       status: determined
                       consultation:
                         startDate: '2024-04-15'

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -17548,7 +17548,17 @@ components:
                     type: string
                 required:
                 - description
+              applicant:
+                type: object
+                properties:
+                  ownership:
+                    anyOf:
+                    - "$ref": "#/components/definitions/Ownership"
+                    - type: 'null'
+                required:
+                - ownership
             required:
+            - applicant
             - application
             - property
             - proposal
@@ -24411,6 +24421,13 @@ paths:
                               properties: {}
                       proposal:
                         description: householder extension
+                      applicant:
+                        ownership:
+                          interest: owner.sole
+                          certificate: a
+                          agriculturalTenants: false
+                          declaration:
+                            accurate: true
                     - application:
                         type:
                           value: pp.full.householder
@@ -24452,6 +24469,20 @@ paths:
                             properties: 
                       proposal:
                         description: Build a roof extension.
+                      applicant:
+                        ownership:
+                          interest: occupier
+                          owners:
+                          - interest: owner
+                            name: Matilda Wormwood
+                            address:
+                              town: Reading
+                              line1: 9, Library Way
+                              line2: ''
+                              county: ''
+                              country: UK
+                              postcode: L1T3R8Y
+                            noticeGiven: true
               schema:
                 "$ref": "#/components/schemas/Search"
   "/api/v2/public/planning_applications/{reference}/documents":
@@ -24625,6 +24656,13 @@ paths:
                               properties: {}
                       proposal:
                         description: householder extension
+                      applicant:
+                        ownership:
+                          interest: owner.sole
+                          certificate: a
+                          agriculturalTenants: false
+                          declaration:
+                            accurate: true
                     - application:
                         type:
                           value: pp.full.householder
@@ -24666,6 +24704,20 @@ paths:
                             properties: 
                       proposal:
                         description: Build a roof extension.
+                      applicant:
+                        ownership:
+                          interest: occupier
+                          owners:
+                          - interest: owner
+                            name: Matilda Wormwood
+                            address:
+                              town: Reading
+                              line1: 9, Library Way
+                              line2: ''
+                              county: ''
+                              country: UK
+                              postcode: L1T3R8Y
+                            noticeGiven: true
   "/api/v2/public/planning_applications/{reference}":
     get:
       summary: Retrieves a planning application


### PR DESCRIPTION
### Description of change

Add the applicant's interest in the property to the API response.

### Story Link

https://trello.com/c/n3Td8uQO/3083-additional-people-data-for-api

### Known issues

The proposal detail questions need some caution. The wording is (for obvious but unhelpful reasons) different depending on whether the application is completed by the applicant or the agent; and the final question appears to be the same in both cases, but might say 'owner' when the former question says 'co-owner'.
