### PR TITLE
Add policy classes in assessment area

### DIFF
--- a/app/components/task_list_items/assessment/planning_application_policy_class_component.rb
+++ b/app/components/task_list_items/assessment/planning_application_policy_class_component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  module Assessment
+    class PlanningApplicationPolicyClassComponent < TaskListItems::BaseComponent
+      def initialize(planning_application_policy_class:, planning_application:)
+        @planning_application = planning_application
+        @policy_class = planning_application_policy_class.new_policy_class
+        @part = @policy_class.policy_part
+      end
+
+      private
+
+      attr_reader :policy_class, :planning_application
+
+      def link_text
+        "Part #{@part.number}, Class #{@policy_class.section}"
+      end
+
+      def link_path
+        "#"
+      end
+
+      def status_tag_component
+        StatusTags::BaseComponent.new(status:)
+      end
+
+      def status
+        :in_progress
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/assessment/base_controller.rb
+++ b/app/controllers/planning_applications/assessment/base_controller.rb
@@ -20,6 +20,10 @@ module PlanningApplications
         redirect_to planning_application_path(@planning_application),
           alert: t("planning_applications.assessment.base.not_validated")
       end
+
+      def ensure_can_assess_planning_application
+        render plain: "forbidden", status: :forbidden and return unless @planning_application.can_assess?
+      end
     end
   end
 end

--- a/app/controllers/planning_applications/assessment/policy_areas/parts_controller.rb
+++ b/app/controllers/planning_applications/assessment/policy_areas/parts_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Assessment
+    module PolicyAreas
+      class PartsController < BaseController
+        before_action :ensure_can_assess_planning_application
+        before_action :find_policy_parts
+
+        def index
+          respond_to do |format|
+            format.html
+          end
+        end
+
+        private
+
+        def find_policy_parts
+          @policy_parts = PolicySchedule.schedule_2.policy_parts
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Assessment
+    module PolicyAreas
+      class PolicyClassesController < BaseController
+        before_action :ensure_can_assess_planning_application
+        before_action :find_policy_parts
+        before_action :find_part, only: %i[new create]
+
+        def new
+          respond_to do |format|
+            format.html
+          end
+        end
+
+        def create
+          class_ids = params[:new_policy_classes].compact_blank
+
+          @part.new_policy_classes.where(id: class_ids).find_each do |policy_class|
+            @planning_application.planning_application_policy_classes.find_or_create_by!(new_policy_class_id: policy_class.id)
+          end
+
+          redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+        end
+
+        private
+
+        def find_policy_parts
+          @policy_parts = PolicySchedule.schedule_2.policy_parts
+        end
+
+        def find_part
+          @part = @policy_parts.find_by_number(params[:part])
+        end
+      end
+    end
+  end
+end

--- a/app/models/new_policy_class.rb
+++ b/app/models/new_policy_class.rb
@@ -14,4 +14,10 @@ class NewPolicyClass < ApplicationRecord
   end
 
   validates :url, url: true
+
+  class << self
+    def menu
+      pluck(:id, :section, :name)
+    end
+  end
 end

--- a/app/models/policy_schedule.rb
+++ b/app/models/policy_schedule.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PolicySchedule < ApplicationRecord
+  PERMITTED_DEVELOPMENT_RIGHTS_SCHEDULE_NUMBER = 2
+
   has_many :policy_parts, -> { order(:number) }, dependent: :restrict_with_error
 
   validates :number, presence: true, uniqueness: true, numericality: {greater_than_or_equal_to: 1, less_than_or_equal_to: 4}
@@ -8,6 +10,7 @@ class PolicySchedule < ApplicationRecord
   attr_readonly :number
 
   scope :by_number, -> { order(number: :asc) }
+  scope :schedule_2, -> { find_by_number(PERMITTED_DEVELOPMENT_RIGHTS_SCHEDULE_NUMBER) }
 
   def full_name
     if name.present?

--- a/app/views/planning_applications/assessment/policy_areas/parts/index.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/parts/index.html.erb
@@ -1,0 +1,61 @@
+<% content_for :page_title do %>
+  Assess - <%= t("page_title") %>
+<% end %>
+<% render(
+     partial: "shared/assessment_task_breadcrumbs",
+     locals: {
+       planning_application: @planning_application,
+       current_page: "Select the part"
+     }
+   ) %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Select the part"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          url: new_planning_application_assessment_policy_areas_policy_class_path(@planning_application),
+          method: :get,
+          html: {data: unsaved_changes_data}
+        ) do |form| %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <p class="govuk-body">
+              Select the relevant part of the legislation for your assessment.
+              Parts are defined in The Town and Country Planning
+              (General Permitted Development) (England) Order 2015
+              (GPDO), Schedule 2.
+            </p>
+            <p class="govuk-body">
+              <%= govuk_link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
+                    "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made",
+                    new_tab: "" %>
+            </p>
+          </legend>
+          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+            <% @policy_parts.each do |part| %>
+              <div class="govuk-radios__item">
+                <%= form.radio_button(
+                      :part, part.number,
+                      class: "govuk-radios__input"
+                    ) %>
+                <%= form.label :part, value: part.number, class: "govuk-label govuk-radios__label" do %>
+                  <strong>Part <%= part.number %></strong> - <%= part.name %>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Continue", class: "govuk-button" %>
+        <%= govuk_button_link_to "Back", planning_application_assessment_tasks_path(@planning_application), secondary: true %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/policy_areas/policy_classes/new.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/policy_classes/new.html.erb
@@ -1,0 +1,70 @@
+<% content_for :page_title do %>
+  Assess - <%= t("page_title") %>
+<% end %>
+<% render(
+     partial: "shared/assessment_task_breadcrumbs",
+     locals: {
+       planning_application: @planning_application,
+       current_page: "Add classes to assess"
+     }
+   ) %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Add classes to assess"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          url: planning_application_assessment_policy_areas_policy_classes_path(@planning_application),
+          html: {data: unsaved_changes_data}
+        ) do |form| %>
+      <%= form.hidden_field :part, value: @part.number %>
+      <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+          <div id="policy-class-hint" class="govuk-hint">
+            <p class="govuk-body">
+              Select the relevant class(es) to assess. Classes are defined
+              in The Town and Country Planning (General Permitted
+              Development) (England) Order 2015 (GPDO), Schedule 2, Part <%= @part.number %>.
+            </p>
+
+            <p class="govuk-body">
+              <%= govuk_link_to "Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window",
+                    "https://www.legislation.gov.uk/uksi/2015/596/schedule/2/made",
+                    new_tab: "" %>
+            </p>
+          </div>
+          <div class="govuk-checkboxes">
+            <%= form.collection_check_boxes(
+                  :new_policy_classes,
+                  @part.new_policy_classes.menu,
+                  :first,
+                  :last
+                ) do |b| %>
+              <div class="govuk-checkboxes__item">
+                <% if b.object.first.in?(@planning_application.planning_application_policy_classes.pluck(:new_policy_class_id)) %>
+                  <%= b.check_box(class: "govuk-checkboxes__input", disabled: true, checked: true) %>
+                <% else %>
+                  <%= b.check_box(class: "govuk-checkboxes__input") %>
+                <% end %>
+                <%= b.label(class: "govuk-label govuk-checkboxes__label") do %>
+                  <p class="govuk-body">
+                    <strong>Class <%= b.object.second %></strong>
+                    - <%= b.text %>
+                  </p>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        </fieldset>
+      </div>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Add classes", class: "govuk-button" %>
+        <%= govuk_button_link_to "Back", planning_application_assessment_policy_areas_parts_path(@planning_application, part: @part), secondary: true %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/tasks/_assess_against_legislation_new.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_assess_against_legislation_new.html.erb
@@ -1,0 +1,23 @@
+<li id="assess-against-legislation-new-tasks">
+  <h2 class="app-task-list__section">
+    Assess against legislation (in testing)
+  </h2>
+  <ul class="app-task-list__items">
+    <% @planning_application.planning_application_policy_classes.order(:new_policy_class_id).each do |pa_policy_class| %>
+      <%= render(
+            TaskListItems::Assessment::PlanningApplicationPolicyClassComponent.new(
+              planning_application_policy_class: pa_policy_class,
+              planning_application: @planning_application
+            )
+          ) %>
+    <% end %>
+
+    <% if @planning_application.can_assess? %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= govuk_link_to "Add new assessment area", planning_application_assessment_policy_areas_parts_path(@planning_application) %>
+        </span>
+      </li>
+    <% end %>
+  </ul>
+</li>

--- a/app/views/planning_applications/assessment/tasks/index.html.erb
+++ b/app/views/planning_applications/assessment/tasks/index.html.erb
@@ -32,6 +32,12 @@
 
       <%= render "assess_against_legislation" %>
 
+      <% unless Bops.env.production? %>
+        <% unless @planning_application.application_type.name == "planning_permission" %>
+          <%= render "assess_against_legislation_new" %>
+        <% end %>
+      <% end %>
+
       <%= render "complete_assessment" %>
     </ol>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1212,6 +1212,10 @@ en:
       ownership_certificates:
         update:
           success: Ownership certificate was checked
+      policy_areas:
+        policy_classes:
+          create:
+            success: Policy classes have been successfully added
       policy_classes:
         comment:
           delete_comment: Delete comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,11 @@ Rails.application.routes.draw do
             end
           end
 
+          namespace :policy_areas do
+            resources :parts, only: :index
+            resources :policy_classes, only: %i[new create]
+          end
+
           resources :heads_of_terms, only: %i[index new] do
             get :edit, on: :collection
             get :edit

--- a/db/migrate/20240910082303_add_unique_index_to_planning_application_policy_classes.rb
+++ b/db/migrate/20240910082303_add_unique_index_to_planning_application_policy_classes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToPlanningApplicationPolicyClasses < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :planning_application_policy_classes, [:new_policy_class_id, :planning_application_id], unique: true, algorithm: :concurrently, name: "ix_pa_policy_classes_on_new_policy_class_and_pa"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_28_115225) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_10_082303) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -686,6 +686,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_28_115225) do
     t.bigint "new_policy_class_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["new_policy_class_id", "planning_application_id"], name: "ix_pa_policy_classes_on_new_policy_class_and_pa", unique: true
     t.index ["new_policy_class_id"], name: "ix_planning_application_policy_classes_on_new_policy_class_id"
     t.index ["planning_application_id"], name: "ix_planning_application_policy_classes_on_planning_application_"
   end


### PR DESCRIPTION
### Description of change

- Use dynamic policies created in global admin

### Story Link

https://trello.com/c/LX8kHPTj/3169-add-new-assessment-area-using-dynamic-policy-data


### Decisions [OPTIONAL]

The existing functionality for assess against legislation is very indexed to the set of hardcoded policy references yml file and the previous schema set up.

It is going to be more trouble than it's worth to update the existing functionality so this is the first step to build in parallel and do a switch over once it's complete. This will just exist in staging for now

