### PR TITLE
Filter neighbour list based on clicks

### DIFF
--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -49,20 +49,22 @@
         <a href="#" class="govuk-back-link" data-action="map#toggleTab" data-map-toggle-param="menu">Back</a><br>
         <div class="map-data-scroll-container">
           <h3>All neighbours</h3>
-          <ul class="govuk-list govuk-list--spaced">
-            <% planning_application.consultation.neighbours.each do |neighbour| %>
-              <li>
-                <strong class="govuk-body-s govuk-!-font-weight-bold"><%= neighbour.address %></strong><br>
-                <%= render StatusTags::BaseComponent.new(
-                      status: neighbour.neighbour_responses.last&.summary_tag || :new,
-                      html_attributes: {class: "govuk-!-font-size-16"}
-                    ) %>
-                <% if neighbour.neighbour_responses.last&.tags&.present? %>
-                  <p class="govuk-body govuk-body-s"><%== neighbour.neighbour_responses.last&.tags&.map(&:humanize)&.compact&.join(" &middot; ") %></p>
-                <% end %>
-              </li>
-            <% end %>
-          </ul>
+          <% if planning_application.consultation.neighbours.present? %>
+            <ul class="govuk-list govuk-list--spaced">
+              <% planning_application.consultation.neighbours.each do |neighbour| %>
+                <li data-lonlat="<%= neighbour.lonlat&.longitude&.truncate(5) %>,<%= neighbour.lonlat&.latitude&.truncate(5) %>">
+                  <strong class="govuk-body-s govuk-!-font-weight-bold"><%= neighbour.address %></strong><br>
+                  <%= render StatusTags::BaseComponent.new(
+                        status: neighbour.neighbour_responses.last&.summary_tag || :new,
+                        html_attributes: {class: "govuk-!-font-size-16"}
+                      ) %>
+                  <% if neighbour.neighbour_responses.last&.tags&.present? %>
+                    <p class="govuk-body govuk-body-s"><%== neighbour.neighbour_responses.last&.tags&.map(&:humanize)&.compact&.join(" &middot; ") %></p>
+                  <% end %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -48,7 +48,7 @@
       <div class="map-data-tab map-data-neighbours govuk-!-display-none">
         <a href="#" class="govuk-back-link" data-action="map#toggleTab" data-map-toggle-param="menu">Back</a><br>
         <div class="map-data-scroll-container">
-          <h3>All neighbours</h3>
+          <h3 class="govuk-heading-s">All neighbours</h3>
           <% if planning_application.consultation.neighbours.present? %>
             <ul class="govuk-list govuk-list--spaced">
               <% planning_application.consultation.neighbours.each do |neighbour| %>

--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -11,16 +11,14 @@
     <%= t(".site_map_drawn_by", name: site_map_drawn_by) %>
   </p>
   <%= tag.div id: :"map-container", data: {
-
         controller: :map,
         latLong: [planning_application.latitude, planning_application.longitude].join(","),
         layers: {
           redline: planning_application.boundary_geojson,
           neighbours: neighbours_layers
         }
-
       } do %>
-  <%= tag.div id: :map %>
+    <%= tag.div id: :map %>
 
     <button type="button" class="map-data-toggle" data-action="map#showMapData">Show data</button>
     <div class="map-data govuk-!-display-none">

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -82,7 +82,7 @@ export default class extends Controller {
     }
 
     return L.geoJson(neighboursCollection, {
-      pointToLayer: (feature, latlng) => {
+      pointToLayer: (_feature, latlng) => {
         return L.circleMarker(latlng, neighbourMarkerOptions)
       },
     })

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -83,7 +83,12 @@ export default class extends Controller {
 
     return L.geoJson(neighboursCollection, {
       pointToLayer: (_feature, latlng) => {
-        return L.circleMarker(latlng, neighbourMarkerOptions)
+        const marker = L.circleMarker(latlng, neighbourMarkerOptions)
+        marker.on("click", (_ev) => {
+          this.filterNeighbourList(latlng)
+        })
+
+        return marker
       },
     })
   }
@@ -100,10 +105,12 @@ export default class extends Controller {
     ev.target.parentNode.parentNode
       .querySelector(".map-data-toggle")
       .classList.remove("govuk-!-display-none")
+    this.filterNeighbourList(null)
   }
 
   toggleTab(ev) {
     ev.preventDefault()
+    this.filterNeighbourList(null)
     for (const el of this.element.querySelectorAll(".map-data-tab")) {
       if (el.classList.contains(`map-data-${ev.params.toggle}`)) {
         el.classList.remove("govuk-!-display-none")
@@ -111,5 +118,38 @@ export default class extends Controller {
         el.classList.add("govuk-!-display-none")
       }
     }
+  }
+
+  filterNeighbourList(latlng) {
+    if (latlng !== null) {
+      this.showMapData({ target: this.element.querySelector("button") })
+      this.toggleTab({
+        params: { toggle: "neighbours" },
+        preventDefault: () => {},
+      })
+    }
+    const lonlatStr =
+      latlng === null ||
+      `${this.trunc(latlng.lng, 5)},${this.trunc(latlng.lat, 5)}`
+
+    const els = this.element.querySelectorAll("li")
+    for (const el of els) {
+      if (latlng === null || el.dataset.lonlat === lonlatStr) {
+        el.classList.remove("govuk-!-display-none")
+      } else {
+        el.classList.add("govuk-!-display-none")
+      }
+    }
+  }
+
+  trunc(num, digits) {
+    const sign = Math.abs(num) === num ? "" : "-"
+    const whole = Math.trunc(num)
+    const remainder = num - whole
+    const decimals = String(remainder)
+      .split(".")[1]
+      .slice(0, digits)
+      .replace(/0+$/, "")
+    return `${sign}${whole}.${decimals}`
   }
 }

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -140,6 +140,9 @@ export default class extends Controller {
         el.classList.add("govuk-!-display-none")
       }
     }
+
+    const heading = this.element.querySelector("h3")
+    heading.innerHTML = latlng === null ? "All neighbours" : "Neighbours"
   }
 
   trunc(num, digits) {


### PR DESCRIPTION
### Description of change

Allow clicking on a marker to limit the popup to neighbours at that location.

Reset the popup on close.

### Story Link

https://trello.com/c/McVmEwzf/3175-show-selected-neighbour-response-in-map-metadata-pane

### Decisions / Known issues

There might be multiple markers at a given location (for example in a block of flats), so we can't index by marker, rather by address. However in that case we have to be careful about the precision. The floating-point numbers as they're received by leaflet functions have far too many decimal places to be meaningful, and I didn't want to risk a mismatch through two points differing by a few centimetres or something, so I've truncated them to five decimal places, [which should still be more than enough](https://xkcd.com/2170/).

I tried four decimal places but that seemed to be a little too inaccurate and include some that were definitely meant for another popup. On the other hand it might be better to be imprecise and potentially show nearby addresses in the popup than to exclude some addresses through excessive precision that's invisible to the user.