### PR TITLE
Use correct scope to find site notice as well as other documents

### DIFF
--- a/app/controllers/api/v1/documents_controller.rb
+++ b/app/controllers/api/v1/documents_controller.rb
@@ -7,7 +7,7 @@ module Api
 
       def show
         raise ActiveRecord::RecordNotFound unless planning_application
-        document = planning_application.documents.for_publication.find(params[:id])
+        document = planning_application.documents_for_publication.find(params[:id])
         redirect_to rails_public_blob_url(document.file), allow_other_host: true
       end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -285,7 +285,7 @@ class Document < ApplicationRecord
   end
 
   def published?
-    self.class.for_publication.where(id:).any?
+    publishable? && unarchived?
   end
 
   def received_at_or_created

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -941,7 +941,8 @@ class PlanningApplication < ApplicationRecord
   end
 
   def documents_for_publication
-    documents.for_publication + site_notice_documents_for_publication
+    ids = documents.for_publication.pluck(:id) + site_notice_documents_for_publication.pluck(:id)
+    Document.unscoped.where(id: ids)
   end
 
   def to_param

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "BOPS public API" do
           run_test! do |response|
             data = JSON.parse(response.body)
             expect(data["application"]["reference"]).to eq(planning_application.reference)
-            expect(data["files"].count).to be(2)
+            expect(data["files"].count).to eq(2)
             expect(data["files"].last["name"]).to eq("site-notice.jpg")
             expect(data["files"].last["type"].first["description"]).to eq("Site Notice")
           end


### PR DESCRIPTION
Default document scope excludes site notices so this was failing to be looked up when returned by the api controller, even though it was listed (because listing used the correct scope).