### PR TITLE
Allow revocation of API keys

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -19,4 +19,8 @@ class ApiUser < ApplicationRecord
       active.find_by(token: token)
     end
   end
+
+  def revoke!
+    touch(:revoked_at)
+  end
 end

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -8,12 +8,15 @@ class ApiUser < ApplicationRecord
 
   has_secure_token :token, length: 36
 
+  scope :active, -> { where(revoked_at: nil) }
+  scope :revoked, -> { where.not(revoked_at: nil) }
+
   validates :name, presence: true, uniqueness: {scope: :local_authority_id}
   validates :file_downloader, store_model: {allow_blank: true}
 
   class << self
     def authenticate(token)
-      find_by(token: token)
+      active.find_by(token: token)
     end
   end
 end

--- a/db/migrate/20240918110955_add_revoked_at_to_api_users.rb
+++ b/db/migrate/20240918110955_add_revoked_at_to_api_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddRevokedAtToApiUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :api_users, :revoked_at, :datetime, null: true
+    add_index :api_users, :revoked_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_10_082303) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_18_110955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -52,9 +52,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_10_082303) do
     t.bigint "local_authority_id"
     t.jsonb "file_downloader"
     t.string "service"
+    t.datetime "revoked_at"
     t.index ["local_authority_id", "name"], name: "ix_api_users_on_local_authority_id__name", unique: true
     t.index ["local_authority_id", "token"], name: "ix_api_users_on_local_authority_id__token", unique: true
     t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"
+    t.index ["revoked_at"], name: "ix_api_users_on_revoked_at"
   end
 
   create_table "application_types", force: :cascade do |t|

--- a/spec/requests/api/authentication_spec.rb
+++ b/spec/requests/api/authentication_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ApiUser", show_exceptions: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:revoked_at) { nil }
+  let(:api_user) { create(:api_user, local_authority:, revoked_at:) }
+
+  context "when the api key is revoked" do
+    let(:revoked_at) { Time.zone.now }
+
+    it "does not permit access" do
+      get("/api/v2/planning_applications", headers: {"CONTENT-TYPE": "application/json", Authorization: "Bearer #{api_user.token}"})
+      expect(response.status).to eq 401
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- **Add revoked_at column to api_users**
- **Limit api users to unrevoked by default**

### Story Link

https://trello.com/c/VNmws12n/3191-add-revokedat-column-to-apiuser

### Decisions [OPTIONAL]

I've used a default scope here, with caution, because we'll almost always want only unrevoked users. I've added scopes for showing revoked users and all users, just for convenience and as a reminder that they exist.
