### PR TITLE
Comment policy sections

### DIFF
--- a/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
@@ -75,7 +75,11 @@ module PlanningApplications
         end
 
         def policy_section_status_params
-          params.require(:planning_application_policy_sections)
+          params.require(:planning_application_policy_sections).permit(
+            params[:planning_application_policy_sections].keys.map do |key|
+              [key, [:status, {comments_attributes: [:id, :text]}]]
+            end.to_h
+          )
         end
 
         def build_form

--- a/app/form_models/policy_section_form.rb
+++ b/app/form_models/policy_section_form.rb
@@ -23,7 +23,10 @@ class PolicySectionForm
   def update(params)
     params.each do |policy_section_id, section_params|
       planning_application_policy_section = planning_application_policy_sections[policy_section_id.to_i]
-      planning_application_policy_section.update(status: section_params[:status])
+      planning_application_policy_section.update!(
+        status: section_params[:status],
+        comments_attributes: section_params[:comments_attributes]
+      )
     end
   end
 end

--- a/app/models/planning_application_policy_section.rb
+++ b/app/models/planning_application_policy_section.rb
@@ -4,6 +4,19 @@ class PlanningApplicationPolicySection < ApplicationRecord
   belongs_to :planning_application
   belongs_to :policy_section
 
+  has_many(
+    :comments,
+    -> { order(:created_at) },
+    as: :commentable,
+    inverse_of: :commentable,
+    dependent: :destroy
+  )
+
+  accepts_nested_attributes_for(
+    :comments,
+    reject_if: :reject_comment?
+  )
+
   validates :status, presence: true
 
   enum(
@@ -14,4 +27,22 @@ class PlanningApplicationPolicySection < ApplicationRecord
     },
     _default: :to_be_determined
   )
+
+  def last_comment
+    @last_comment ||= persisted_comments.last
+  end
+
+  def previous_comments
+    persisted_comments - [last_comment]
+  end
+
+  private
+
+  def persisted_comments
+    comments.select(&:persisted?)
+  end
+
+  def reject_comment?(attributes)
+    attributes[:text].blank? || attributes[:text] == last_comment&.text
+  end
 end

--- a/app/models/policy_section.rb
+++ b/app/models/policy_section.rb
@@ -29,4 +29,8 @@ class PolicySection < ApplicationRecord
   def full_section
     "#{policy_class.section}.#{section}"
   end
+
+  def planning_application_policy_section
+    planning_application_policy_sections.last
+  end
 end

--- a/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
@@ -23,10 +23,24 @@
 
       <% table.with_body do |body| %>
         <% @planning_application_policy_class.policy_class.policy_sections.each do |policy_section| %>
+          <% pa_policy_section = policy_section.planning_application_policy_section %>
           <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
             <% row.with_cell do %>
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
               <%= render(FormattedContentComponent.new(text: policy_section.description)) %>
+
+              <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.id}][comments_attributes][0][text]",
+                    label: {text: "Add comment", class: "govuk-label govuk-label--s"},
+                    value: pa_policy_section&.last_comment&.text,
+                    class: "govuk-textarea govuk-!-margin-bottom-2",
+                    rows: 2 %>
+
+              <% if pa_policy_section %>
+                <%= render(
+                      partial: "shared/policy_classes/previous_comments",
+                      locals: {previous_comments: pa_policy_section.previous_comments}
+                    ) %>
+              <% end %>
             <% end %>
             <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
               <% row.with_cell do %>

--- a/app/views/shared/policy_classes/_previous_comments.html.erb
+++ b/app/views/shared/policy_classes/_previous_comments.html.erb
@@ -5,8 +5,8 @@
         <%= t(".previous_comments") %>
       </span>
     </summary>
-    <div class="govuk-details__text">
-      <% previous_comments.reverse_each do |comment| %>
+    <% previous_comments.reverse_each do |comment| %>
+      <div class="govuk-details__text" id="<%= dom_id(comment) %>">
         <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">
           <%= existing_policy_comment_label(comment) %>
         </p>
@@ -18,7 +18,7 @@
           </p>
         <% end %>
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--s">
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </details>
 <% end %>


### PR DESCRIPTION
### Description of change

- Add individual comments to each of the policy sections.
- If a comment is updated, then we create a new comment and store the previous so we can have an audit trail.
- Reject a comment if it is blank

### Story Link

https://trello.com/c/0T5e919f/3171-add-comments-to-policy-sections-when-assessing-a-policy-class

