### PR TITLE
Add assessment against legislation as an application type feature

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -82,6 +82,8 @@ class ApplicationType < ApplicationRecord
   end
 
   with_options to: :features do
+    delegate :assess_against_policies?
+    delegate :considerations?
     delegate :informatives?
     delegate :ownership_details?
     delegate :planning_conditions?

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -3,6 +3,8 @@
 class ApplicationTypeFeature
   include StoreModel::Model
 
+  attribute :assess_against_policies, :boolean, default: false
+  attribute :considerations, :boolean, default: false
   attribute :informatives, :boolean, default: false
   attribute :ownership_details, :boolean, default: true
   attribute :planning_conditions, :boolean, default: false

--- a/app/views/planning_applications/assessment/tasks/_assess_against_legislation.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_assess_against_legislation.html.erb
@@ -3,13 +3,14 @@
     Assess against legislation
   </h2>
   <ul class="app-task-list__items" id="assess-policy-section">
-    <% if @planning_application.application_type.name == "planning_permission" %>
-        <%= render(
-              TaskListItems::Assessment::ConsiderationsComponent.new(
-                planning_application: @planning_application
-              )
-            ) %>
-    <% else %>
+    <% if @planning_application.application_type.considerations? %>
+      <%= render(
+            TaskListItems::Assessment::ConsiderationsComponent.new(
+              planning_application: @planning_application
+            )
+          ) %>
+    <% end %>
+    <% if @planning_application.application_type.assess_against_policies? %>
       <% if @planning_application.no_policy_classes_after_assessment? %>
         <li class="app-task-list__item">
           <span class="app-task-list__task-name">

--- a/app/views/planning_applications/assessment/tasks/index.html.erb
+++ b/app/views/planning_applications/assessment/tasks/index.html.erb
@@ -33,7 +33,7 @@
       <%= render "assess_against_legislation" %>
 
       <% unless Bops.env.production? %>
-        <% unless @planning_application.application_type.name == "planning_permission" %>
+        <% if @planning_application.application_type.assess_against_policies? %>
           <%= render "assess_against_legislation_new" %>
         <% end %>
       <% end %>

--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -6,6 +6,8 @@
     - Q26
   suffix: LDCE
   determination_period_days: 56
+  features:
+    assess_against_policies: true
   steps:
     - validation
     - assessment
@@ -32,6 +34,8 @@
     - Q26
   suffix: LDCP
   determination_period_days: 56
+  features:
+    assess_against_policies: true
   steps:
     - validation
     - assessment
@@ -61,6 +65,8 @@
   suffix: PA1A
   determination_period_days: 56
   features:
+    assess_against_policies: true
+    considerations: true
     site_visits: true
   steps:
     - validation
@@ -93,6 +99,7 @@
   suffix: HAPP
   determination_period_days: 56
   features:
+    considerations: true
     permitted_development_rights: false
     site_visits: true
   steps:
@@ -123,6 +130,7 @@
     - Q21
   suffix: HAPR
   features:
+    considerations: true
     permitted_development_rights: false
     site_visits: true
   steps:

--- a/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
@@ -31,6 +31,8 @@ module BopsConfig
 
       def features_attributes
         [
+          :assess_against_policies,
+          :considerations,
           :informatives,
           :ownership_details,
           :planning_conditions,

--- a/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/features/edit.html.erb
@@ -21,6 +21,8 @@
 
       <%= form.fields_for :features, @application_type.features do |ff| %>
         <%= ff.govuk_fieldset legend: {text: t("application_type_features.legends.check_application_details"), size: "s"} do %>
+          <%= ff.govuk_check_box :assess_against_policies, 1, 0, multiple: false, label: {text: t("application_type_features.labels.assess_against_policies")} %>
+          <%= ff.govuk_check_box :considerations, 1, 0, multiple: false, label: {text: t("application_type_features.labels.considerations")} %>
           <%= ff.govuk_check_box :informatives, 1, 0, multiple: false, label: {text: t("application_type_features.labels.informatives")} %>
           <%= ff.govuk_check_box :ownership_details, 1, 0, multiple: false, label: {text: t("application_type_features.labels.ownership_details")} %>
           <%= ff.govuk_check_box :planning_conditions, 1, 0, multiple: false, label: {text: t("application_type_features.labels.planning_conditions")} %>

--- a/engines/bops_config/app/views/bops_config/application_types/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/show.html.erb
@@ -59,8 +59,14 @@
             row.with_value { %>
               <p class="govuk-body"><strong>Application details</strong></p>
               <ul class="govuk-list govuk-list--bullet">
+                <% if @application_type.assess_against_policies? %>
+                  <li><%= t("application_type_features.labels.assess_against_policies") %></li>
+                <% end %>
                 <% if @application_type.informatives? %>
                   <li><%= t("application_type_features.labels.informatives") %></li>
+                <% end %>
+                <% if @application_type.considerations? %>
+                  <li><%= t("application_type_features.labels.considerations") %></li>
                 <% end %>
                 <% if @application_type.ownership_details? %>
                   <li><%= t("application_type_features.labels.ownership_details") %></li>

--- a/engines/bops_config/config/locales/application_type_features.yml
+++ b/engines/bops_config/config/locales/application_type_features.yml
@@ -1,6 +1,8 @@
 en:
   application_type_features:
     labels:
+      assess_against_policies: "Assess policies and guidance"
+      considerations: "Assess considerations"
       consultations_skip_bank_holidays: "Extend consultation periods that contain bank holidays"
       informatives: "Add informatives"
       ownership_details: "Ownership details"

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
 
     check "Check permitted development rights"
     check "Neighbours consultation"
+    check "Assess considerations"
     click_button "Continue"
 
     expect(page).to have_content("Features successfully updated")
@@ -177,6 +178,8 @@ RSpec.describe "Application Types", type: :system, capybara: true do
     expect(page).to have_selector("dl div:nth-child(10) dd span:nth-child(2)", text: "Sustainability statement")
     expect(page).to have_selector("dl div:nth-child(11) dd", text: "Granted, Refused")
     expect(page).to have_selector("dl div:nth-child(12) dd", text: "Inactive")
+    expect(page).not_to have_selector("li", text: "Assess against policies and guidance")
+    expect(page).to have_selector("li", text: "Assess considerations")
   end
 
   it "allows editing of an inactive application type" do

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -13,6 +13,12 @@ FactoryBot.define do
       category { "certificate-of-lawfulness" }
       reporting_types { %w[Q26] }
 
+      features {
+        {
+          assess_against_policies: true
+        }
+      }
+
       assessment_details do
         %w[
           summary_of_work
@@ -83,6 +89,7 @@ FactoryBot.define do
 
       features {
         {
+          "assess_against_policies" => true,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []
@@ -100,6 +107,7 @@ FactoryBot.define do
 
       features {
         {
+          "assess_against_policies" => true,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []
@@ -118,6 +126,7 @@ FactoryBot.define do
       steps { %w[validation consultation assessment review] }
       features {
         {
+          "assess_against_policies" => true,
           "planning_conditions" => false,
           "permitted_development_rights" => false,
           "site_visits" => false,
@@ -191,6 +200,8 @@ FactoryBot.define do
       reporting_types { %w[PA1] }
       features {
         {
+          "assess_against_policies" => true,
+          "considerations" => true,
           "site_visits" => true,
           "consultation_steps" => ["neighbour", "publicity", "consultee"]
         }
@@ -334,6 +345,7 @@ FactoryBot.define do
       steps { %w[validation consultation assessment review] }
       features {
         {
+          "considerations" => true,
           "informatives" => true,
           "planning_conditions" => true,
           "permitted_development_rights" => false,


### PR DESCRIPTION
### Description of change

Replacing some conditionals based on application type with an application type feature associated with the appropriate types.

At the same time enabling separate conditionals for two features that were previously considered mutually exclusive.

### Story Link

https://trello.com/c/tqG7H2Tw/3173-add-assess-against-legislation-as-choose-a-feature-option-in-global-admin

https://trello.com/c/KL5uvleQ/3164-able-to-assess-against-policies-for-prior-approval