### PR TITLE
Do not call with_indifferent_access for a string

### DIFF
--- a/app/models/planx_planning_data.rb
+++ b/app/models/planx_planning_data.rb
@@ -4,6 +4,8 @@ class PlanxPlanningData < ApplicationRecord
   belongs_to :planning_application
 
   def params_v2
+    return super if self[:params_v2].is_a?(String)
+
     self[:params_v2]&.with_indifferent_access
   end
 end


### PR DESCRIPTION
### Description of change

- Do not use with_indifferent_access for instances of a String.

https://appsignal.com/southwark-bops/sites/63efadfcd2a5e42c27a8518c/exceptions/incidents/614/samples/timestamp/2024-09-26T15:02:58Z

