### PR TITLE
Add validation requests to API

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/authenticated_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/authenticated_controller.rb
@@ -25,6 +25,10 @@ module BopsApi
           render json: json, status: :unauthorized
         end
       end
+
+      def planning_applications_scope
+        @local_authority.planning_applications.includes(:user)
+      end
     end
   end
 end

--- a/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/planning_applications_controller.rb
@@ -78,10 +78,6 @@ module BopsApi
         @query_service ||= Application::QueryService.new(scope, query_params)
       end
 
-      def planning_applications_scope
-        @local_authority.planning_applications.includes(:user)
-      end
-
       def determined_planning_applications_scope
         planning_applications_scope.determined.by_determined_at_desc
       end

--- a/engines/bops_api/app/controllers/bops_api/v2/validation_requests_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/validation_requests_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    class ValidationRequestsController < AuthenticatedController
+      def index
+        @planning_application = find_planning_application(params[:planning_application_id])
+        @pagy, @validation_requests = query_service.call
+
+        respond_to do |format|
+          format.json
+        end
+      end
+
+      private
+
+      def planning_applications_scope
+        @local_authority.planning_applications.includes(:user)
+      end
+
+      def query_service(scope = @planning_application.validation_requests)
+        @query_service ||= ValidationRequest::QueryService.new(scope, query_params)
+      end
+
+      def query_params
+        params.permit(:type)
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/controllers/concerns/bops_api/error_handler.rb
+++ b/engines/bops_api/app/controllers/concerns/bops_api/error_handler.rb
@@ -5,6 +5,7 @@ module BopsApi
     extend ActiveSupport::Concern
 
     EXCEPTIONS = Hash.new(:internal_server_error).merge(
+      "ActionController::BadRequest" => :bad_request,
       "ActiveRecord::RecordNotFound" => :not_found,
       "ActiveRecord::RecordInvalid" => :unprocessable_entity,
       "ActiveRecord::RecordNotSaved" => :unprocessable_entity,

--- a/engines/bops_api/app/services/bops_api/validation_request/query_service.rb
+++ b/engines/bops_api/app/services/bops_api/validation_request/query_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module ValidationRequest
+    class QueryService
+      def initialize(scope, params)
+        @scope = scope
+        @params = params
+      end
+
+      attr_reader :scope, :params
+
+      def call
+        Pagination.new(scope: filter_by_type, params:).paginate
+      end
+
+      private
+
+      def filter_by_type
+        return scope if params[:type].blank?
+
+        scope.where(type: params[:type])
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/planning_applications/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/planning_applications/index.json.jbuilder
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
-json.metadata do
-  json.page @pagy.page
-  json.results @pagy.items
-  json.from @pagy.from
-  json.to @pagy.to
-  json.total_pages @pagy.pages
-  json.total_results @pagy.count
-end
+json.partial! "bops_api/v2/shared/metadata"
 
 json.data @planning_applications.each do |planning_application|
   json.partial! "show", planning_application:

--- a/engines/bops_api/app/views/bops_api/v2/validation_requests/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/validation_requests/index.json.jbuilder
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+json.partial! "bops_api/v2/shared/metadata"
+
+json.data @validation_requests.each do |validation_request|
+  json.extract! validation_request,
+    :type,
+    :state,
+    :post_validation,
+    :created_at,
+    :notified_at,
+    :reason,
+    :response_due,
+    :response,
+    :rejection_reason,
+    :approved,
+    :cancel_reason,
+    :cancelled_at,
+    :closed_at,
+    :specific_attributes
+end

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -17,6 +17,8 @@ BopsApi::Engine.routes.draw do
         get :determined, on: :collection
         get :submission, on: :member
         get :search, on: :collection
+
+        resources :validation_requests, only: [:index]
       end
 
       namespace :public do

--- a/engines/bops_api/schemas/odp/v0.7.0/validationRequests.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/validationRequests.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "page": {
+          "type": "integer"
+        },
+        "results": {
+          "type": "integer"
+        },
+        "from": {
+          "type": "integer"
+        },
+        "to": {
+          "type": "integer"
+        },
+        "total_pages": {
+          "type": "integer"
+        },
+        "total_results": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "page",
+        "results",
+        "from",
+        "to",
+        "total_pages",
+        "total_results"
+      ]
+    },
+    "links": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string"
+        },
+        "last": {
+          "type": "string"
+        },
+        "prev": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "next": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "first",
+        "last",
+        "prev",
+        "next"
+      ]
+    },
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "post_validation": {
+            "type": ["boolean", "null"]
+          },
+          "created_at": {
+            "format": "datetime",
+            "type": "string"
+          },
+          "notified_at": {
+            "format": "datetime",
+            "type": ["string", "null"]
+          },
+          "reason": {
+            "type": ["null", "string"]
+          },
+          "response_due": {
+            "type": "string",
+            "format": "date"
+          },
+          "response": {
+            "type": ["null", "string"]
+          },
+          "rejection_reason": {
+            "type": ["null", "string"]
+          },
+          "approved": {
+            "type": ["boolean", "null"]
+          },
+          "cancel_reason": {
+            "type": ["null", "string"]
+          },
+          "cancelled_at": {
+            "format": "datetime",
+            "type": ["string", "null"]
+          },
+          "closed_at": {
+            "format": "datetime",
+            "type": ["string", "null"]
+          },
+          "specific_attributes": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "state",
+          "post_validation",
+          "created_at",
+          "notified_at",
+          "reason",
+          "response_due",
+          "approved",
+          "closed_at",
+          "specific_attributes"
+        ]
+      }
+    }
+  },
+  "required": [
+    "metadata",
+    "links",
+    "data"
+  ]
+}

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/validationRequests.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.0/validationRequests.json
@@ -1,0 +1,175 @@
+{
+  "metadata": {
+    "page": 1,
+    "results": 10,
+    "from": 1,
+    "to": 5,
+    "total_pages": 1,
+    "total_results": 5
+  },
+  "links": {
+    "first": "http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1",
+    "last": "http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1",
+    "prev": null,
+    "next": null
+  },
+  "data": [
+    {
+      "type": "FeeChangeValidationRequest",
+      "state": "open",
+      "post_validation": false,
+      "created_at": "2024-04-23T15:17:36.210+01:00",
+      "notified_at": "2024-04-23T15:17:50.073+01:00",
+      "reason": "test change",
+      "response_due": "2024-05-15",
+      "response": null,
+      "rejection_reason": null,
+      "approved": null,
+      "cancel_reason": null,
+      "cancelled_at": null,
+      "closed_at": null,
+      "specific_attributes": {
+        "suggestion": "test change"
+      }
+    },
+    {
+      "type": "AdditionalDocumentValidationRequest",
+      "state": "open",
+      "post_validation": false,
+      "created_at": "2024-04-23T15:17:16.660+01:00",
+      "notified_at": "2024-04-23T15:17:50.081+01:00",
+      "reason": "test",
+      "response_due": "2024-05-15",
+      "response": null,
+      "rejection_reason": null,
+      "approved": null,
+      "cancel_reason": null,
+      "cancelled_at": null,
+      "closed_at": null,
+      "specific_attributes": {
+        "document_request_type": "test"
+      }
+    },
+    {
+      "type": "OtherChangeValidationRequest",
+      "state": "open",
+      "post_validation": false,
+      "created_at": "2024-04-23T15:17:46.396+01:00",
+      "notified_at": "2024-04-23T15:17:50.090+01:00",
+      "reason": "test change",
+      "response_due": "2024-05-15",
+      "response": null,
+      "rejection_reason": null,
+      "approved": null,
+      "cancel_reason": null,
+      "cancelled_at": null,
+      "closed_at": null,
+      "specific_attributes": {
+        "suggestion": "test change"
+      }
+    },
+    {
+      "type": "DescriptionChangeValidationRequest",
+      "state": "closed",
+      "post_validation": false,
+      "created_at": "2024-04-23T15:17:00.174+01:00",
+      "notified_at": "2024-04-23T15:17:00.290+01:00",
+      "reason": null,
+      "response_due": "2024-04-30",
+      "response": null,
+      "rejection_reason": null,
+      "approved": true,
+      "cancel_reason": null,
+      "cancelled_at": null,
+      "closed_at": "2024-04-23T15:19:38.912+01:00",
+      "specific_attributes": {
+        "previous_description": "Roof extension to the rear of the property, incorporating starship launchpad.",
+        "proposed_description": "test validation Roof extension to the rear of the property, incorporating starship launchpad."
+      }
+    },
+    {
+      "type": "RedLineBoundaryChangeValidationRequest",
+      "state": "closed",
+      "post_validation": false,
+      "created_at": "2024-04-23T15:16:43.993+01:00",
+      "notified_at": "2024-04-23T15:17:50.058+01:00",
+      "reason": "test",
+      "response_due": "2024-05-15",
+      "response": null,
+      "rejection_reason": null,
+      "approved": true,
+      "cancel_reason": null,
+      "cancelled_at": null,
+      "closed_at": null,
+      "specific_attributes": {
+        "new_geojson": {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                  [
+                    [
+                      -0.11835515499115692,
+                      51.465546460366994
+                    ],
+                    [
+                      -0.11852815747261736,
+                      51.465746977085615
+                    ],
+                    [
+                      -0.1186569035053321,
+                      51.465703531871384
+                    ],
+                    [
+                      -0.11848390102387167,
+                      51.4655038504508
+                    ],
+                    [
+                      -0.11835515499115692,
+                      51.465546460366994
+                    ]
+                  ]
+                ]
+              },
+              "properties": null
+            }
+          ]
+        },
+        "original_geojson": {
+          "type": "Feature",
+          "geometry": {
+            "type": "Polygon",
+            "coordinates": [
+              [
+                [
+                  -0.1186569035053321,
+                  51.465703531871384
+                ],
+                [
+                  -0.1185938715934822,
+                  51.465724418998775
+                ],
+                [
+                  -0.1184195280075143,
+                  51.46552473766957
+                ],
+                [
+                  -0.11848390102387167,
+                  51.4655038504508
+                ],
+                [
+                  -0.1186569035053321,
+                  51.465703531871384
+                ]
+              ]
+            ]
+          },
+          "properties": null
+        }
+      }
+    }
+  ]
+}

--- a/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS API" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:southwark) { create(:local_authority, :southwark) }
+  let(:application_type) { create(:application_type) }
+  let!(:planning_application) { create(:planning_application, :invalidated, :with_boundary_geojson, local_authority:, application_type:) }
+
+  let!(:red_line_boundary_change_validation_request) do
+    create(
+      :red_line_boundary_change_validation_request,
+      planning_application:,
+      state: :open
+    )
+  end
+  let!(:other_change_validation_request) do
+    create(
+      :other_change_validation_request,
+      planning_application:,
+      state: :closed
+    )
+  end
+  let!(:description_change_validation_request) do
+    create(
+      :description_change_validation_request,
+      planning_application:,
+      state: :closed
+    )
+  end
+
+  before do
+    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
+    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx", local_authority: southwark)
+    create(:application_type, :ldc_existing)
+
+    Rails.configuration.os_vector_tiles_api_key = "testtest"
+  end
+
+  let(:Authorization) { "Bearer bRPkCPjaZExpUYptBJDVFzss" }
+  let(:type) { "" }
+
+  path "/api/v2/planning_applications/{reference}/validation_requests" do
+    it "validates successfully against the example validation requests json" do
+      resolved_schema = load_and_resolve_schema(name: "validationRequests", version: "odp/v0.7.0")
+
+      schemer = JSONSchemer.schema(resolved_schema)
+      example_json = example_fixture("validationRequests.json")
+      expect(schemer.valid?(example_json)).to eq(true)
+    end
+
+    get "Retrieves the validation requests for an application" do
+      tags "Validation requests"
+      security [bearerAuth: []]
+      produces "application/json"
+
+      parameter name: :type, in: :query, schema: {
+        type: :string,
+        enum: [
+          "AdditionalDocumentValidationRequest",
+          "DescriptionChangeValidationRequest",
+          "RedLineBoundaryChangeValidationRequest",
+          "ReplacementDocumentValidationRequest",
+          "OwnershipCertificateValidationRequest",
+          "OtherChangeValidationRequest",
+          "FeeChangeValidationRequest",
+          "PreCommencementConditionValidationRequest",
+          "HeadsOfTermsValidationRequest",
+          "TimeExtensionValidationRequest"
+        ]
+      }
+
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
+
+      response "200", "returns application validation requests when searching by the reference and type" do
+        schema "$ref" => "#/components/schemas/ValidationRequests"
+
+        let(:reference) { planning_application.reference }
+        let(:type) { "RedLineBoundaryChangeValidationRequest" }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          metadata = data["metadata"]
+
+          expect(metadata).to eq(
+            {
+              "page" => 1,
+              "results" => 10,
+              "from" => 1,
+              "to" => 1,
+              "total_pages" => 1,
+              "total_results" => 1
+            }
+          )
+
+          type = data["data"].pluck("type").uniq
+          expect(type).to eq(["RedLineBoundaryChangeValidationRequest"])
+        end
+      end
+
+      response "200", "returns application validation requests when searching by the reference" do
+        example "application/json", :default, example_fixture("validationRequests.json")
+        schema "$ref" => "#/components/schemas/ValidationRequests"
+
+        let(:reference) { planning_application.reference }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          metadata = data["metadata"]
+
+          expect(metadata).to eq(
+            {
+              "page" => 1,
+              "results" => 10,
+              "from" => 1,
+              "to" => 3,
+              "total_pages" => 1,
+              "total_results" => 3
+            }
+          )
+
+          type = data["data"].pluck("type")
+          expect(type).to eq(["RedLineBoundaryChangeValidationRequest", "OtherChangeValidationRequest", "DescriptionChangeValidationRequest"])
+        end
+      end
+
+      response "401", "with missing or invalid credentials" do
+        schema "$ref" => "#/components/schemas/UnauthorizedError"
+
+        example "application/json", :default, {
+          error: {
+            code: 401,
+            message: "Unauthorized"
+          }
+        }
+
+        let(:Authorization) { "Bearer invalid-credentials" }
+        let(:reference) { planning_application.reference }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   search_json = BopsApi::Schemas.find!("search", version:).value
   application_submission_json = BopsApi::Schemas.find!("applicationSubmission", version:).value
   documents_json = BopsApi::Schemas.find!("documents", version:).value
+  validation_requests_json = BopsApi::Schemas.find!("validationRequests", version:).value
   shared_definitions_json = BopsApi::Schemas.find!("shared/definitions", version:).value
 
   keys = %w[
@@ -41,6 +42,8 @@ RSpec.configure do |config|
   application_submission = application_submission_json.slice(*keys).deep_transform_values(&transformer)
 
   documents = documents_json.slice(*keys).deep_transform_values(&transformer)
+
+  validation_requests = validation_requests_json.slice(*keys).deep_transform_values(&transformer)
 
   config.openapi_specs = {
     "v2/swagger_doc.yaml" => {
@@ -80,6 +83,8 @@ RSpec.configure do |config|
           ApplicationSubmission: application_submission,
 
           Documents: documents,
+
+          ValidationRequests: validation_requests,
 
           Healthcheck: {
             type: "object",

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -17688,6 +17688,122 @@ components:
       - application
       - files
       type: object
+    ValidationRequests:
+      properties:
+        metadata:
+          type: object
+          properties:
+            page:
+              type: integer
+            results:
+              type: integer
+            from:
+              type: integer
+            to:
+              type: integer
+            total_pages:
+              type: integer
+            total_results:
+              type: integer
+          required:
+          - page
+          - results
+          - from
+          - to
+          - total_pages
+          - total_results
+        links:
+          type: object
+          properties:
+            first:
+              type: string
+            last:
+              type: string
+            prev:
+              type:
+              - string
+              - 'null'
+            next:
+              type:
+              - string
+              - 'null'
+          required:
+          - first
+          - last
+          - prev
+          - next
+        data:
+          type: array
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+              state:
+                type: string
+              post_validation:
+                type:
+                - boolean
+                - 'null'
+              created_at:
+                format: datetime
+                type: string
+              notified_at:
+                format: datetime
+                type:
+                - string
+                - 'null'
+              reason:
+                type:
+                - 'null'
+                - string
+              response_due:
+                type: string
+                format: date
+              response:
+                type:
+                - 'null'
+                - string
+              rejection_reason:
+                type:
+                - 'null'
+                - string
+              approved:
+                type:
+                - boolean
+                - 'null'
+              cancel_reason:
+                type:
+                - 'null'
+                - string
+              cancelled_at:
+                format: datetime
+                type:
+                - string
+                - 'null'
+              closed_at:
+                format: datetime
+                type:
+                - string
+                - 'null'
+              specific_attributes:
+                type: object
+            required:
+            - type
+            - state
+            - post_validation
+            - created_at
+            - notified_at
+            - reason
+            - response_due
+            - approved
+            - closed_at
+            - specific_attributes
+      required:
+      - metadata
+      - links
+      - data
+      type: object
     Healthcheck:
       type: object
       properties:
@@ -17836,6 +17952,182 @@ paths:
                 "$ref": "#/components/schemas/Healthcheck"
         '401':
           description: with a token from another api user
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    error:
+                      code: 401
+                      message: Unauthorized
+              schema:
+                "$ref": "#/components/schemas/UnauthorizedError"
+  "/api/v2/planning_applications/{reference}/validation_requests":
+    get:
+      summary: Retrieves the validation requests for an application
+      tags:
+      - Validation requests
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: type
+        in: query
+        schema:
+          type: string
+          enum:
+          - AdditionalDocumentValidationRequest
+          - DescriptionChangeValidationRequest
+          - RedLineBoundaryChangeValidationRequest
+          - ReplacementDocumentValidationRequest
+          - OwnershipCertificateValidationRequest
+          - OtherChangeValidationRequest
+          - FeeChangeValidationRequest
+          - PreCommencementConditionValidationRequest
+          - HeadsOfTermsValidationRequest
+          - TimeExtensionValidationRequest
+      - name: reference
+        in: path
+        schema:
+          type: string
+          description: The planning application reference
+        required: true
+      responses:
+        '200':
+          description: returns application validation requests when searching by the
+            reference
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationRequests"
+              examples:
+                default:
+                  value:
+                    metadata:
+                      page: 1
+                      results: 10
+                      from: 1
+                      to: 5
+                      total_pages: 1
+                      total_results: 5
+                    links:
+                      first: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
+                      last: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
+                      prev: 
+                      next: 
+                    data:
+                    - type: FeeChangeValidationRequest
+                      state: open
+                      post_validation: false
+                      created_at: '2024-04-23T15:17:36.210+01:00'
+                      notified_at: '2024-04-23T15:17:50.073+01:00'
+                      reason: test change
+                      response_due: '2024-05-15'
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
+                      specific_attributes:
+                        suggestion: test change
+                    - type: AdditionalDocumentValidationRequest
+                      state: open
+                      post_validation: false
+                      created_at: '2024-04-23T15:17:16.660+01:00'
+                      notified_at: '2024-04-23T15:17:50.081+01:00'
+                      reason: test
+                      response_due: '2024-05-15'
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
+                      specific_attributes:
+                        document_request_type: test
+                    - type: OtherChangeValidationRequest
+                      state: open
+                      post_validation: false
+                      created_at: '2024-04-23T15:17:46.396+01:00'
+                      notified_at: '2024-04-23T15:17:50.090+01:00'
+                      reason: test change
+                      response_due: '2024-05-15'
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
+                      specific_attributes:
+                        suggestion: test change
+                    - type: DescriptionChangeValidationRequest
+                      state: closed
+                      post_validation: false
+                      created_at: '2024-04-23T15:17:00.174+01:00'
+                      notified_at: '2024-04-23T15:17:00.290+01:00'
+                      reason: 
+                      response_due: '2024-04-30'
+                      response: 
+                      rejection_reason: 
+                      approved: true
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: '2024-04-23T15:19:38.912+01:00'
+                      specific_attributes:
+                        previous_description: Roof extension to the rear of the property,
+                          incorporating starship launchpad.
+                        proposed_description: test validation Roof extension to the
+                          rear of the property, incorporating starship launchpad.
+                    - type: RedLineBoundaryChangeValidationRequest
+                      state: closed
+                      post_validation: false
+                      created_at: '2024-04-23T15:16:43.993+01:00'
+                      notified_at: '2024-04-23T15:17:50.058+01:00'
+                      reason: test
+                      response_due: '2024-05-15'
+                      response: 
+                      rejection_reason: 
+                      approved: true
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
+                      specific_attributes:
+                        new_geojson:
+                          type: FeatureCollection
+                          features:
+                          - type: Feature
+                            geometry:
+                              type: Polygon
+                              coordinates:
+                              - - - -0.11835515499115692
+                                  - 51.465546460366994
+                                - - -0.11852815747261736
+                                  - 51.465746977085615
+                                - - -0.1186569035053321
+                                  - 51.465703531871384
+                                - - -0.11848390102387167
+                                  - 51.4655038504508
+                                - - -0.11835515499115692
+                                  - 51.465546460366994
+                            properties: 
+                        original_geojson:
+                          type: Feature
+                          geometry:
+                            type: Polygon
+                            coordinates:
+                            - - - -0.1186569035053321
+                                - 51.465703531871384
+                              - - -0.1185938715934822
+                                - 51.465724418998775
+                              - - -0.1184195280075143
+                                - 51.46552473766957
+                              - - -0.11848390102387167
+                                - 51.4655038504508
+                              - - -0.1186569035053321
+                                - 51.465703531871384
+                          properties: 
+        '401':
+          description: with missing or invalid credentials
           content:
             application/json:
               examples:
@@ -18129,7 +18421,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -18288,7 +18580,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -19092,7 +19384,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -19195,7 +19487,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -22377,7 +22669,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.012592
                           squareMetres: 125.92
@@ -22477,7 +22769,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.012592
                           squareMetres: 125.92
@@ -23270,10 +23562,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -23287,11 +23579,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23312,12 +23604,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude:
-                        longitude:
+                        latitude: 
+                        longitude: 
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -23333,28 +23625,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role:
-                      awaiting_determination_at:
-                      to_be_reviewed_at:
+                      user_role: 
+                      awaiting_determination_at: 
+                      to_be_reviewed_at: 
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at:
+                      in_assessment_at: 
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag:
-                      result_heading:
-                      result_description:
-                      result_override:
-                      returned_at:
-                      started_at:
+                      result_flag: 
+                      result_heading: 
+                      result_description: 
+                      result_override: 
+                      returned_at: 
+                      started_at: 
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23371,14 +23663,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties:
+                        properties: 
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2:
-                        county:
+                        address_2: 
+                        county: 
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -23389,7 +23681,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date:
+                        end_date: 
                       make_public: false
                 ids:
                   value:
@@ -23409,10 +23701,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -23426,11 +23718,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23451,12 +23743,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude:
-                        longitude:
+                        latitude: 
+                        longitude: 
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -23472,28 +23764,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role:
-                      awaiting_determination_at:
-                      to_be_reviewed_at:
+                      user_role: 
+                      awaiting_determination_at: 
+                      to_be_reviewed_at: 
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at:
+                      in_assessment_at: 
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag:
-                      result_heading:
-                      result_description:
-                      result_override:
-                      returned_at:
-                      started_at:
+                      result_flag: 
+                      result_heading: 
+                      result_description: 
+                      result_override: 
+                      returned_at: 
+                      started_at: 
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -23510,14 +23802,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties:
+                        properties: 
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2:
-                        county:
+                        address_2: 
+                        county: 
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -23528,7 +23820,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date:
+                        end_date: 
                       make_public: false
         '401':
           description: with missing or invalid credentials
@@ -23590,13 +23882,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at:
+                      invalidated_at: 
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -23607,11 +23899,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -23630,7 +23922,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties:
+                          properties: 
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -23667,7 +23959,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -23722,13 +24014,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at:
+                      invalidated_at: 
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -23739,11 +24031,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -23762,7 +24054,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties:
+                          properties: 
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -23799,7 +24091,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -23868,19 +24160,19 @@ paths:
                     applicant_first_name: Albert
                     applicant_last_name: Manteras
                     user_role: agent
-                    awaiting_determination_at:
-                    to_be_reviewed_at:
+                    awaiting_determination_at: 
+                    to_be_reviewed_at: 
                     created_at: '2023-05-23T09:39:04.197+01:00'
                     description: This is a long winded description, bla bla bla a
                       single storey ground floor rear extension; replacement of existing
                       garage door with brick infill and a new window; replacement
                       of the existing windows with double glazed windows, installation
                       of rooflight
-                    determined_at:
+                    determined_at: 
                     determination_date: '2024-03-06'
                     id: 2
-                    invalidated_at:
-                    in_assessment_at:
+                    invalidated_at: 
+                    in_assessment_at: 
                     payment_reference: PAY1
                     payment_amount: '0.0'
                     result_flag: Planning permission / Permission needed
@@ -23889,11 +24181,11 @@ paths:
                     result_description: Based on the information you have provided,
                       we do not think this is eligible for a Lawful Development Certificate
                     result_override: This was my reason for rejecting the result
-                    returned_at:
-                    started_at:
+                    returned_at: 
+                    started_at: 
                     status: not_started
                     target_date: '2023-06-27'
-                    withdrawn_at:
+                    withdrawn_at: 
                     work_status: proposed
                     boundary_geojson:
                       type: Feature
@@ -23976,10 +24268,10 @@ paths:
                       targetDate: '2024-05-15'
                       receivedAt: '2024-04-17T00:00:00.000+01:00'
                       validAt: '2024-04-12T00:00:00.000+01:00'
-                      publishedAt:
-                      determinedAt:
+                      publishedAt: 
+                      determinedAt: 
                       status: in_assessment
-                      decision:
+                      decision: 
                       consultation:
                         startDate: '2024-04-15'
                         endDate: '2024-05-07'
@@ -24059,7 +24351,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties:
+                              properties: 
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -24159,7 +24451,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties:
+                              properties: 
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -24392,9 +24684,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt:
-                        determinedAt:
-                        decision:
+                        publishedAt: 
+                        determinedAt: 
+                        decision: 
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -24497,7 +24789,7 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties:
+                            properties: 
                       proposal:
                         description: Build a roof extension.
                       applicant:
@@ -24560,8 +24852,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt:
-                      decision:
+                      determinedAt: 
+                      decision: 
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -24575,7 +24867,7 @@ paths:
                       - value: sections.proposed
                         description: Sections - proposed
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription:
+                      applicantDescription: 
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -24585,7 +24877,7 @@ paths:
                       - value: internal.siteNotice
                         description: Site Notice
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription:
+                      applicantDescription: 
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -24651,9 +24943,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt:
-                        determinedAt:
-                        decision:
+                        publishedAt: 
+                        determinedAt: 
+                        decision: 
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -24756,7 +25048,7 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties:
+                            properties: 
                       proposal:
                         description: Build a roof extension.
                       applicant:
@@ -24816,8 +25108,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt:
-                      decision:
+                      determinedAt: 
+                      decision: 
                       status: determined
                       consultation:
                         startDate: '2024-04-15'


### PR DESCRIPTION
### Description of change

Add authenticated endpoint for validation requests
- Add type query parameter to specify a validation request type

### Story Link

https://trello.com/c/A2SObrO2/3084-expansion-pack-1-validation-requests-for-authenticated-search-api