### PR TITLE
Add fee details to API response

### DIFF
--- a/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
@@ -3,5 +3,5 @@
 json.partial! "bops_api/v2/shared/metadata"
 
 json.data @planning_applications.each do |planning_application|
-  json.partial! "bops_api/v2/shared/show", planning_application:
+  json.partial! "bops_api/v2/public/shared/show", planning_application:
 end

--- a/engines/bops_api/app/views/bops_api/v2/public/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/shared/_show.json.jbuilder
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+json.partial! "bops_api/v2/shared/application", planning_application: planning_application
+
+json.property do
+  json.address do
+    json.latitude planning_application.latitude
+    json.longitude planning_application.longitude
+    json.title planning_application.address_1
+    json.singleLine planning_application.full_address
+    json.uprn planning_application.uprn
+    json.town planning_application.town
+    json.postcode planning_application.postcode
+  end
+  json.boundary do
+    json.site planning_application.boundary_geojson
+  end
+end
+json.proposal do
+  json.description planning_application.description
+  if planning_application.reporting_type_detail.present?
+    json.reportingType do
+      json.code planning_application.reporting_type_detail.code
+      json.description planning_application.reporting_type_detail.description
+    end
+  else
+    json.reportingType nil
+  end
+  json.ownerIsPlanningAuthority planning_application.regulation
+end
+json.applicant do
+  json.type planning_application.params_v2&.dig(:data, :applicant, :type)
+  json.address planning_application.params_v2&.dig(:data, :applicant, :address)
+  json.ownership planning_application.applicant_interest
+  json.agent do
+    json.address planning_application.params_v2&.dig(:data, :applicant, :agent, :address)
+  end
+end
+json.officer do
+  if (officer = planning_application.user)
+    json.name officer.name
+  else
+    json.null!
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
@@ -3,3 +3,5 @@
 json.key_format! camelize: :lower
 
 json.partial! "bops_api/v2/public/shared/show", planning_application: planning_application
+
+json.applicationFee planning_application.fee_calculation

--- a/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
@@ -2,46 +2,4 @@
 
 json.key_format! camelize: :lower
 
-json.partial! "bops_api/v2/shared/application", planning_application: planning_application
-
-json.property do
-  json.address do
-    json.latitude planning_application.latitude
-    json.longitude planning_application.longitude
-    json.title planning_application.address_1
-    json.singleLine planning_application.full_address
-    json.uprn planning_application.uprn
-    json.town planning_application.town
-    json.postcode planning_application.postcode
-  end
-  json.boundary do
-    json.site planning_application.boundary_geojson
-  end
-end
-json.proposal do
-  json.description planning_application.description
-  if planning_application.reporting_type_detail.present?
-    json.reportingType do
-      json.code planning_application.reporting_type_detail.code
-      json.description planning_application.reporting_type_detail.description
-    end
-  else
-    json.reportingType nil
-  end
-  json.ownerIsPlanningAuthority planning_application.regulation
-end
-json.applicant do
-  json.type planning_application.params_v2&.dig(:data, :applicant, :type)
-  json.address planning_application.params_v2&.dig(:data, :applicant, :address)
-  json.ownership planning_application.applicant_interest
-  json.agent do
-    json.address planning_application.params_v2&.dig(:data, :applicant, :agent, :address)
-  end
-end
-json.officer do
-  if (officer = planning_application.user)
-    json.name officer.name
-  else
-    json.null!
-  end
-end
+json.partial! "bops_api/v2/public/shared/show", planning_application: planning_application

--- a/engines/bops_api/schemas/odp/v0.7.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/search.json
@@ -358,6 +358,16 @@
           ]
         }
       ]
+    },
+    "applicationFee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ApplicationFee"
+        },
+        {
+          "$ref": "#/definitions/ApplicationFeeNotApplicable"
+        }
+      ]
     }
   },
   "required": [

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -6,7 +6,7 @@ require "rswag/specs"
 Dir[BopsApi::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
-  config.openapi_strict_schema_validation = true
+  config.openapi_no_additional_properties = true if config.respond_to? :openapi_no_additional_properties
   config.openapi_root = BopsApi::Engine.root.join("swagger").to_s
   config.openapi_format = :yaml
 


### PR DESCRIPTION
This divides the 'search' partial into public and authenticated partials. The authenticated partial includes the public partial, so that it's a strict superset of what's publicly available.

I'm using the same schema for both, with the authenticated-only properties simply left as optional, but in future we might want separate public and authenticated schemas.

https://trello.com/c/Srks2tMi/3088-expansion-pack-4-fee-info-for-authenticated-search-api