### PR TITLE
Replace planning history with new model of site history

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -24,13 +24,10 @@
     </p>
   <% end %>
 </section>
-<% if past_applications.present? %>
-  <section id="past-applications-section" class="govuk-!-margin-bottom-7">
-    <h3 class="govuk-heading-m"><%= t(".planning_history") %></h3>
-    <h4 class="govuk-heading-s"><%= past_applications.entry %></h4>
-    <%= render(FormattedContentComponent.new(text: past_applications.additional_information)) %>
-  </section>
-<% end %>
+<section id="site-histories-section" class="govuk-!-margin-bottom-7">
+  <h3 class="govuk-heading-m"><%= t(".site_history") %></h3>
+  <%= render "planning_applications/assessment/site_histories/table", site_histories: site_histories, show_action: false %>
+</section>
 <% if immunity_detail && review_immunity_detail = immunity_detail.current_enforcement_review_immunity_detail %>
   <section id="immunity-section">
     <%= render(

--- a/app/components/planning_applications/assessment/assessment_report_component.rb
+++ b/app/components/planning_applications/assessment/assessment_report_component.rb
@@ -21,7 +21,7 @@ module PlanningApplications
 
       delegate(
         :constraints,
-        :past_applications,
+        :site_histories,
         :summary_of_work,
         :site_description,
         :consultation_summary,

--- a/app/views/planning_applications/assessment/permitted_development_rights/_planning_history.html.erb
+++ b/app/views/planning_applications/assessment/permitted_development_rights/_planning_history.html.erb
@@ -1,20 +1,11 @@
 <section id="planning-history-section" class="govuk-!-margin-bottom-7">
   <h2 class="govuk-heading-m govuk-!-margin-top-5">
-    Planning history
+    Site history
   </h2>
 
-  <div class="govuk-!-margin-left-3 govuk-!-padding-bottom-3">
-    <% if past_application = @planning_application.past_applications %>
-      <ul class="govuk-list">
-        <li><p><strong><%= past_application.additional_information %></strong></p></li>
-        <li><p><%= past_application.entry %><p></li>
-        <%= govuk_link_to "Edit history", edit_planning_application_assessment_assessment_detail_path(@planning_application, past_application), class: "govuk-body" %>
-      </ul>
-    <% else %>
-      <p class="govuk-body">
-        There is no relevant planning history
-      </p>
-      <%= govuk_link_to "Edit history", new_planning_application_assessment_assessment_detail_path(@planning_application, category: "past_applications"), class: "govuk-body" %>
-    <% end %>
-  </div>
+  <%= render "planning_applications/assessment/site_histories/table", site_histories: @planning_application.site_histories, show_action: false %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to "Show details", planning_application_assessment_site_histories_path(@planning_application) %>
+  </p>
 </section>

--- a/app/views/planning_applications/review/immunity_enforcements/_planning_history.html.erb
+++ b/app/views/planning_applications/review/immunity_enforcements/_planning_history.html.erb
@@ -3,14 +3,5 @@
     Historical information related to the property or to adjoining properties
   </h3>
 
-  <% if past_application = @planning_application.past_applications %>
-    <ul class="govuk-list">
-      <li><p><strong><%= past_application.additional_information %></strong></p></li>
-      <li><p><%= past_application.entry %><p></li>
-    </ul>
-  <% else %>
-    <p class="govuk-body">
-      There is no relevant planning history
-    </p>
-  <% end %>
+  <%= render "planning_applications/assessment/site_histories/table", site_histories: @planning_application.site_histories, show_action: false %>
 </section>

--- a/app/views/planning_applications/review/permitted_development_rights/_planning_history.html.erb
+++ b/app/views/planning_applications/review/permitted_development_rights/_planning_history.html.erb
@@ -3,14 +3,5 @@
     Historical information related to the property or to adjoining properties
   </h3>
 
-  <% if past_application = @planning_application.past_applications %>
-    <ul class="govuk-list">
-      <li><p><strong><%= past_application.additional_information %></strong></p></li>
-      <li><p><%= past_application.entry %><p></li>
-    </ul>
-  <% else %>
-    <p class="govuk-body">
-      There is no relevant planning history
-    </p>
-  <% end %>
+  <%= render "planning_applications/assessment/site_histories/table", site_histories: @planning_application.site_histories, show_action: false %>
 </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1122,7 +1122,7 @@ en:
         no_considerations_assessed: There is no assessment against policies and guidance
         no_documents_listed: There are no documents listed on the decision notice.
         no_legislation_assessed: There is no legislation assessment for this application.
-        planning_history: Planning history
+        site_history: Site history
         summary_of_works: Summary of works
       base:
         not_validated: The planning application must be validated before assessment can begin

--- a/spec/factories/site_history.rb
+++ b/spec/factories/site_history.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :site_history do
+    planning_application
+
+    application_number { "REF123" }
+    description { "An entry for planning history" }
+    date { "10/02/1980" }
+    decision { :granted }
+  end
+end

--- a/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe "Permitted development right" do
         end
 
         within("#planning-history-section") do
-          expect(page).to have_content("Planning history")
+          expect(page).to have_selector("h2", text: "Site history")
+          expect(page).to have_content("There is no site history for this property.")
         end
       end
 

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
 
     create(
       :assessment_detail,
-      :past_applications,
-      planning_application:,
-      entry: "22-00999-LDCP",
-      additional_information: "This is the past application history summary."
-    )
-
-    create(
-      :assessment_detail,
       :summary_of_work,
       planning_application:,
       entry: "This is the summary of work."
@@ -82,6 +74,13 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
       :consultation_summary,
       planning_application:,
       entry: "This is the consultation summary."
+    )
+
+    create(
+      :site_history,
+      planning_application:,
+      application_number: "22-00999-LDCP",
+      description: "This is the past application history summary."
     )
 
     create(

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -776,7 +776,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       let!(:summary_of_work) { create(:assessment_detail, :summary_of_work, entry: "A summary of work entry", planning_application:) }
       let!(:additional_evidence) { create(:assessment_detail, :additional_evidence, entry: "An additional evidence entry", planning_application:) }
       let!(:site_description) { create(:assessment_detail, :site_description, entry: "A site description entry", planning_application:) }
-      let!(:past_applications) { create(:assessment_detail, :past_applications, entry: "An entry for planning history", additional_information: "REF123", planning_application:) }
+      let!(:site_history) { create(:site_history, planning_application:) }
 
       let!(:neighbour) { create(:neighbour, consultation: planning_application.consultation) }
       let!(:neighbour_response1) { create(:neighbour_response, summary_tag: "objection", neighbour:) }
@@ -798,8 +798,8 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_link("Edit constraints")
         end
 
-        within("#past-applications-section") do
-          expect(page).to have_selector("h3", text: "Planning history")
+        within("#site-histories-section") do
+          expect(page).to have_selector("h3", text: "Site history")
           expect(page).to have_content("REF123")
           expect(page).to have_content("An entry for planning history")
         end
@@ -852,7 +852,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         visit "/planning_applications/#{planning_application.reference}/submit_recommendation"
         expect(page).to have_css("#constraints-section")
-        expect(page).to have_css("#past-applications-section")
+        expect(page).to have_css("#site-histories-section")
         expect(page).to have_css("#summary-of-works-section")
         expect(page).to have_css("#site-description-section")
         expect(page).to have_css("#permitted-development-rights-section")


### PR DESCRIPTION
### Description of change

Replace planning history with new model of site history:

#### Assessment:
 - Permitted development rights
 - Make draft recommendation
 - Review and submit recommendation within (Assessment report details)

#### Review
- Review immunity enforcements
- Review permitted development rights

### Story Link

https://trello.com/c/ElZzx1WL

### Screenshots

#### Before
![Screenshot 2024-10-03 at 13 18 13](https://github.com/user-attachments/assets/8b5a0896-e126-474a-80d6-72b3eba46f0e)

#### After
![Screenshot 2024-10-02 at 16 02 59](https://github.com/user-attachments/assets/82d5a915-11bc-44f6-905d-a37941aafe92)
