### PR TITLE
Add further application details to API response

### DIFF
--- a/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_application.json.jbuilder
@@ -8,6 +8,7 @@ json.application do
   json.reference planning_application.reference
   json.fullReference planning_application.reference_in_full
   json.targetDate planning_application.target_date
+  json.expiryDate planning_application.expiry_date
   json.receivedAt planning_application.received_at
   json.validAt planning_application.validated_at
   json.publishedAt planning_application.published_at
@@ -31,6 +32,16 @@ json.application do
         json.comment response.redacted_response
         json.receivedAt response.received_at
       end
+    end
+  end
+
+  json.pressNotice do
+    if (press_notice = planning_application.press_notice)
+      json.required press_notice.required
+      json.reason press_notice.reason
+      json.publishedAt press_notice.published_at
+    else
+      json.null!
     end
   end
 end

--- a/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/_show.json.jbuilder
@@ -38,3 +38,10 @@ json.applicant do
     json.address planning_application.params_v2&.dig(:data, :applicant, :agent, :address)
   end
 end
+json.officer do
+  if (officer = planning_application.user)
+    json.name officer.name
+  else
+    json.null!
+  end
+end

--- a/engines/bops_api/schemas/odp/v0.7.0/search.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/search.json
@@ -330,6 +330,24 @@
                 }
               },
               "required": ["type", "address", "ownership", "agent"]
+            },
+            "officer": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": ["string"]
+                    }
+                  },
+                  "required": [
+                    "name"
+                  ]
+                }, 
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "required": [

--- a/engines/bops_api/schemas/odp/v0.7.0/shared/definitions.json
+++ b/engines/bops_api/schemas/odp/v0.7.0/shared/definitions.json
@@ -30,6 +30,10 @@
           "format": "date",
           "type": ["string", "null"]
         },
+        "expiryDate": {
+          "format": "date",
+          "type": ["string", "null"]
+        },
         "receivedAt": {
           "format": "datetime",
           "type": "string"
@@ -105,6 +109,33 @@
           "required": [
             "startDate",
             "endDate"
+          ]
+        },
+        "pressNotice": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "required": {
+                  "type": "boolean"
+                },
+                "reason": {
+                  "type": ["string", "null"]
+                },
+                "publishedAt": {
+                  "format": "datetime",
+                  "type": ["string", "null"]
+                }
+              },
+              "required": [
+                "required",
+                "reason",
+                "publishedAt"
+              ]
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "BOPS public API" do
         schema "$ref" => "#/components/schemas/Documents"
 
         let(:reference) { planning_application.reference }
-        let(:planning_application) { create(:planning_application, :published, :with_boundary_geojson, :determined, documents: [document], local_authority:, application_type:) }
+        let(:planning_application) { create(:planning_application, :published, :with_boundary_geojson, :with_press_notice, :determined, documents: [document], local_authority:, application_type:) }
 
         run_test! do |response|
           data = JSON.parse(response.body)

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -17245,6 +17245,11 @@ components:
           type:
           - string
           - 'null'
+        expiryDate:
+          format: date
+          type:
+          - string
+          - 'null'
         receivedAt:
           format: datetime
           type: string
@@ -17318,6 +17323,26 @@ components:
           required:
           - startDate
           - endDate
+        pressNotice:
+          anyOf:
+          - type: object
+            properties:
+              required:
+                type: boolean
+              reason:
+                type:
+                - string
+                - 'null'
+              publishedAt:
+                format: datetime
+                type:
+                - string
+                - 'null'
+            required:
+            - required
+            - reason
+            - publishedAt
+          - type: 'null'
       required:
       - type
       - reference
@@ -17593,6 +17618,16 @@ components:
                 - address
                 - ownership
                 - agent
+              officer:
+                anyOf:
+                - type: object
+                  properties:
+                    name:
+                      type:
+                      - string
+                  required:
+                  - name
+                - type: 'null'
             required:
             - applicant
             - application
@@ -24752,6 +24787,7 @@ paths:
                         reportingType:
                           code: A123
                           description: fake reporting type
+                        ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
                         address:
@@ -24811,7 +24847,7 @@ paths:
                             properties: 
                       proposal:
                         description: Build a roof extension.
-                        reportingType:
+                        reportingType: 
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
@@ -25016,6 +25052,7 @@ paths:
                         reportingType:
                           code: A123
                           description: fake reporting type
+                        ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
                         address:
@@ -25075,7 +25112,7 @@ paths:
                             properties: 
                       proposal:
                         description: Build a roof extension.
-                        reportingType:
+                        reportingType: 
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -777,6 +777,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_press_notice do
+      after(:create) do |planning_application|
+        create(:press_notice, required: true, reasons: "A reason for press notice", planning_application:)
+      end
+    end
+
     trait :with_v2_params do
       after(:build) do |planning_application|
         planning_application.planx_planning_data = build(:planx_planning_data, params_v2: JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access, planning_application:)


### PR DESCRIPTION
### Description of change

Add further application details to API response when searching planning applications
- Officer name
- Expiry date
- Press notice details

### Story Link

https://trello.com/c/rWUBAjDe/3086-expansion-pack-3-application-things-for-public-and-authenticated-search-api

