### PR TITLE
Add contact/feedback link to BOPS footer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,10 +10,6 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_back_path
 
-  attr_reader :current_local_authority
-
-  helper_method :current_local_authority
-
   def after_sign_in_path_for(resource)
     if session[:mobile_number] && !resource.mobile_number?
       resource.assign_mobile_number!(session[:mobile_number])
@@ -91,8 +87,14 @@ class ApplicationController < ActionController::Base
   end
 
   def find_current_local_authority_from_subdomain
-    @current_local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)
+    Current.local_authority ||= LocalAuthority.find_by(subdomain: request.subdomains.first)
   end
+
+  def current_local_authority
+    Current.local_authority
+  end
+
+  helper_method :current_local_authority
 
   def prevent_caching
     response.headers["Cache-Control"] = "no-cache, no-store"

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -3,4 +3,5 @@
 class Current < ActiveSupport::CurrentAttributes
   attribute :user
   attribute :api_user
+  attribute :local_authority
 end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,0 +1,15 @@
+<footer class="govuk-footer app-footer">
+  <div class="govuk-width-container app-width-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-visually-hidden">Support links</h2>
+        <ul class="govuk-footer__inline-list">
+          <li class="govuk-footer__inline-list-item">
+            <%= tag.a href: "mailto:#{current_local_authority.feedback_email}", class: "govuk-footer__link" do %>
+              Contact
+            <% end %>
+          </li>
+        </ul>
+    </div>
+  </div>
+</footer>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -4,11 +4,13 @@
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <h2 class="govuk-visually-hidden">Support links</h2>
         <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item">
-            <%= tag.a href: "mailto:#{current_local_authority.feedback_email}", class: "govuk-footer__link" do %>
-              Contact
-            <% end %>
-          </li>
+          <% if current_local_authority %>
+            <li class="govuk-footer__inline-list-item">
+              <%= tag.a href: "mailto:#{current_local_authority.feedback_email}", class: "govuk-footer__link" do %>
+                Contact
+              <% end %>
+            </li>
+          <% end %>
         </ul>
     </div>
   </div>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -5,7 +5,7 @@
             home_path,
             class: "govuk-header__link govuk-header__link--homepage"
           ) do %>
-        <% if @current_local_authority %>
+        <% if current_local_authority %>
           <span class="govuk-header__service-name">
             <%= current_local_authority.short_name %>
           </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,7 @@
         <%= yield %>
       </main>
     </div>
+    <%= render "application/footer" %>
     <%= javascript_include_tag "govuk" %>
   </body>
 </html>

--- a/engines/bops_config/app/controllers/bops_config/application_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_controller.rb
@@ -42,5 +42,10 @@ module BopsConfig
     rescue
       raise ActionController::BadRequest, "Invalid application type id: #{params[application_type_param].inspect}"
     end
+
+    def current_local_authority
+      nil
+    end
+    helper_method :current_local_authority
   end
 end

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -450,7 +450,7 @@ RSpec.describe "checking consistency" do
     within(form_group) { choose("No") }
     click_link("Request a change to the red line boundary")
 
-    find(".govuk-visually-hidden", visible: false).set(
+    find("#validation-request-new-geojson-field", visible: false).set(
       {
         type: "FeatureCollection",
         features: [

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       map = find("my-map")
       expect(map["showCentreMarker"]).to eq("true")
 
-      find(".govuk-visually-hidden",
+      find("#validation-request-new-geojson-field",
         visible: false).set({"type" => "Feature", "properties" => {}, "geometry" => {"type" => "Polygon", "coordinates" => [[[-0.076715, 51.501166], [-0.07695, 51.500673], [-0.076, 51.500763], [-0.076715, 51.501166]]]}}.to_json)
       fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Coordinates look wrong"
       click_button "Send request"
@@ -184,7 +184,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
 
     context "when red line boundary is not drawn and reason not provided" do
       before do
-        find(".govuk-visually-hidden", visible: false).set ""
+        find("#validation-request-new-geojson-field", visible: false).set ""
         fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: " "
         click_button "Send request"
       end
@@ -198,7 +198,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
 
     context "when red line boundary is not drawn" do
       before do
-        find(".govuk-visually-hidden", visible: false).set ""
+        find("#validation-request-new-geojson-field", visible: false).set ""
         fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Wrong line"
         click_button "Send request"
       end
@@ -252,7 +252,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       end
 
       before do
-        find(".govuk-visually-hidden", visible: false).set(new_geojson.to_json)
+        find("#validation-request-new-geojson-field", visible: false).set(new_geojson.to_json)
         fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: ""
         click_button "Send request"
       end
@@ -299,7 +299,7 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
       expect(map["showCentreMarker"]).to eq("true")
 
       # Draw proposed red line boundary
-      find(".govuk-visually-hidden", visible: false).set({"type" => "Feature", "properties" => {}, "geometry" => {"type" => "Polygon", "coordinates" => [[[-0.076715, 51.501166], [-0.07695, 51.500673], [-0.076, 51.500763], [-0.076715, 51.501166]]]}}.to_json)
+      find("#validation-request-new-geojson-field", visible: false).set({"type" => "Feature", "properties" => {}, "geometry" => {"type" => "Polygon", "coordinates" => [[[-0.076715, 51.501166], [-0.07695, 51.500673], [-0.076, 51.500763], [-0.076715, 51.501166]]]}}.to_json)
 
       fill_in "Explain to the applicant why changes are proposed to the red line boundary", with: "Amendment request"
       click_button "Send request"


### PR DESCRIPTION
### Description of change

Add a footer to BOPS with a contact/feedback link

### Story Link

https://trello.com/c/1uOmbvgH/3130-add-email-address-to-all-bops-pages-for-feedback

### Screenshots

<img width="1145" alt="Screenshot 2024-10-08 at 10 33 29" src="https://github.com/user-attachments/assets/2cd45afd-7b4f-4fcd-907a-36b6a149e3da">