### PR TITLE
Fix neighbour responses summary tag

### DIFF
--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -55,7 +55,7 @@
                 <li data-lonlat="<%= neighbour.lonlat&.longitude&.truncate(5) %>,<%= neighbour.lonlat&.latitude&.truncate(5) %>">
                   <strong class="govuk-body-s govuk-!-font-weight-bold"><%= neighbour.address %></strong><br>
                   <%= render StatusTags::BaseComponent.new(
-                        status: neighbour.neighbour_responses.last&.summary_tag || :new,
+                        status: neighbour.neighbour_responses.last&.summary_tag || :none,
                         html_attributes: {class: "govuk-!-font-size-16"}
                       ) %>
                   <% if neighbour.neighbour_responses.last&.tags&.present? %>

--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -25,9 +25,9 @@ module StatusTags
 
     def colour
       case status.to_sym
-      when :approved, :auto_approved
+      when :approved, :auto_approved, :supportive
         "green"
-      when :not_started, :new, :review_not_started, :not_consulted
+      when :not_started, :new, :review_not_started, :not_consulted, :none
         "blue"
       when :in_progress, :awaiting_response
         "light-blue"

--- a/app/views/planning_applications/review/tasks/_neighbours_table.html.erb
+++ b/app/views/planning_applications/review/tasks/_neighbours_table.html.erb
@@ -21,8 +21,12 @@
             <% end %>
           </td>
           <td class="govuk-table__cell">
-            <% neighbour.neighbour_responses.each do |response| %>
-              <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+            <% if neighbour.neighbour_responses.blank? %>
+              <%= render(StatusTags::BaseComponent.new(status: :none)) %>
+            <% else %>
+              <% neighbour.neighbour_responses.each do |response| %>
+                <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+              <% end %>
             <% end %>
           </td>
         </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2071,6 +2071,7 @@ en:
       technical_failure: Technical failure
     neutral: Neutral
     new: New
+    none: None
     not_assigned: Not assigned
     not_consulted: Not consulted
     not_required: Not required


### PR DESCRIPTION
### Description of change

Fix neighbour responses summary tag

- When the summary tag is supportive, then make it green.
- When is blank, show it as none and make it blue.

### Story Link

https://trello.com/c/kigOOWMD

### Screenshots

![Screenshot 2024-10-08 at 18 43 46](https://github.com/user-attachments/assets/30f62c2e-2946-4172-911e-673bdc629a8e)
