### PR TITLE
Use Appsignal #report_error

### DIFF
--- a/app/controllers/api/v1/neighbour_responses_controller.rb
+++ b/app/controllers/api/v1/neighbour_responses_controller.rb
@@ -24,7 +24,7 @@ module Api
       end
 
       def send_failed_response(error)
-        Appsignal.send_error(error)
+        Appsignal.report_error(error)
 
         render json: {message: error.message.to_s || "Unable to create response"},
           status: :bad_request

--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -153,7 +153,7 @@ module PlanningApplications
       def validation_notice_request_error(exception)
         flash[:alert] = t("email_failure")
 
-        Appsignal.send_error(exception)
+        Appsignal.report_error(exception)
         render "planning_applications/show"
       end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -62,7 +62,7 @@ module Users
     end
 
     def notify_error(exception)
-      Appsignal.send_error(exception)
+      Appsignal.report_error(exception)
 
       session.delete(:mobile_number)
 

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -206,7 +206,7 @@ class ValidationRequest < ApplicationRecord
       )
     end
   rescue ActiveRecord::ActiveRecordError, AASM::InvalidTransition => e
-    Appsignal.send_error(e.message)
+    Appsignal.report_error(e.message)
   end
 
   def reset_update_counter!

--- a/app/services/constraints_creation_service.rb
+++ b/app/services/constraints_creation_service.rb
@@ -33,7 +33,7 @@ class ConstraintsCreationService
             metadata:
           )
         else
-          Appsignal.send_error("Unexpected constraint type: #{k}, category #{v["category"]}")
+          Appsignal.report_error("Unexpected constraint type: #{k}, category #{v["category"]}")
         end
       end
     end
@@ -46,7 +46,7 @@ class ConstraintsCreationService
       pa_constraint.update!(removed_at: Time.current)
     end
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
-    Appsignal.send_error(e)
+    Appsignal.report_error(e)
   end
 
   private

--- a/app/services/immunity_details_creation_service.rb
+++ b/app/services/immunity_details_creation_service.rb
@@ -14,7 +14,7 @@ class ImmunityDetailsCreationService
     create_evidence_groups
     fill_in_evidence_group_information
   rescue ActiveRecord::RecordInvalid, NoMethodError => e
-    Appsignal.send_error(e)
+    Appsignal.report_error(e)
   end
 
   private

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -38,7 +38,7 @@ class LetterSendingService
       )
     rescue Notifications::Client::RequestError => e
       letter_record.update!(status: "rejected", failure_reason: e.message)
-      Appsignal.send_error(e)
+      Appsignal.report_error(e)
       return
     end
 

--- a/engines/bops_api/app/controllers/concerns/bops_api/error_handler.rb
+++ b/engines/bops_api/app/controllers/concerns/bops_api/error_handler.rb
@@ -17,8 +17,8 @@ module BopsApi
       rescue_from StandardError do |exception|
         Appsignal.add_tags(appsignal_tags)
 
-        Appsignal.send_error(exception) do |transaction|
-          transaction.params = {params: params.to_unsafe_hash}
+        Appsignal.report_error(exception) do
+          Appsignal.add_params(params.to_unsafe_hash)
         end
 
         code = Rack::Utils.status_code(EXCEPTIONS[exception.class.name])

--- a/engines/bops_api/app/jobs/bops_api/create_neighbour_boundary_geojson_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/create_neighbour_boundary_geojson_job.rb
@@ -24,7 +24,7 @@ module BopsApi
 
       planning_application.update!(neighbour_boundary_geojson: geometry_collection(collection))
     rescue JSON::ParserError => exception
-      AppSignal.send_error(exception)
+      AppSignal.report_error(exception)
     end
 
     private

--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -153,7 +153,7 @@ module BopsApi
         end
       end
     rescue ActiveRecord::RecordInvalid, NoMethodError => e
-      Appsignal.send_error(e)
+      Appsignal.report_error(e)
     end
 
     def fetch_constraint_entities(planning_application_constraint, entities)

--- a/engines/bops_api/app/jobs/bops_api/post_application_to_staging_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/post_application_to_staging_job.rb
@@ -8,7 +8,7 @@ module BopsApi
       if (submission = planning_application.params_v2)
         Apis::Bops::Query.new.post(local_authority.subdomain, submission)
       else
-        Appsignal.send_error("Unable to find submission data for planning application with id: #{planning_application.id}")
+        Appsignal.report_error("Unable to find submission data for planning application with id: #{planning_application.id}")
       end
     end
   end

--- a/engines/bops_api/spec/jobs/post_application_to_staging_job_spec.rb
+++ b/engines/bops_api/spec/jobs/post_application_to_staging_job_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe BopsApi::PostApplicationToStagingJob, type: :job do
 
   context "when there is no ODP submission" do
     it "sends an error to AppSignal" do
-      expect(Appsignal).to receive(:send_error).with("Unable to find submission data for planning application with id: #{planning_application.id}")
+      expect(Appsignal).to receive(:report_error).with("Unable to find submission data for planning application with id: #{planning_application.id}")
 
       described_class.perform_now(planning_application.local_authority, planning_application)
     end

--- a/spec/models/validation_request_spec.rb
+++ b/spec/models/validation_request_spec.rb
@@ -483,7 +483,7 @@ RSpec.describe ValidationRequest do
         let!(:request) { create(:red_line_boundary_change_validation_request, :pending) }
 
         it "sends the error to Appsignal" do
-          expect(Appsignal).to receive(:send_error).with("Event 'auto_close' cannot transition from 'pending'.")
+          expect(Appsignal).to receive(:report_error).with("Event 'auto_close' cannot transition from 'pending'.")
 
           expect { request.auto_close_request! }
             .not_to change(Audit, :count)
@@ -501,7 +501,7 @@ RSpec.describe ValidationRequest do
         end
 
         it "sends the error to Appsignal" do
-          expect(Appsignal).to receive(:send_error).with("ActiveRecord::ActiveRecordError")
+          expect(Appsignal).to receive(:report_error).with("ActiveRecord::ActiveRecordError")
 
           expect { request.auto_close_request! }
             .not_to change(Audit, :count)

--- a/spec/services/constraints_creation_service_spec.rb
+++ b/spec/services/constraints_creation_service_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe ConstraintsCreationService, type: :service do
       let!(:constraint2) { create(:constraint, :tpo) }
 
       it "creates the non existing constraints and planning application constraints" do
-        expect(Appsignal).to receive(:send_error).with("Unexpected constraint type: listed, category Heritage and conservation")
-        expect(Appsignal).to receive(:send_error).with("Unexpected constraint type: designated, category ")
+        expect(Appsignal).to receive(:report_error).with("Unexpected constraint type: listed, category Heritage and conservation")
+        expect(Appsignal).to receive(:report_error).with("Unexpected constraint type: designated, category ")
 
         expect do
           create_constraints
@@ -79,7 +79,7 @@ RSpec.describe ConstraintsCreationService, type: :service do
         end
 
         it "raises an error" do
-          expect(Appsignal).to receive(:send_error).exactly(4).times
+          expect(Appsignal).to receive(:report_error).exactly(4).times
 
           create_constraints
         end

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe LetterSendingService do
         let(:status) { 500 }
 
         it "makes a request but does not record a sending date" do
-          expect(Appsignal).to receive(:send_error)
+          expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
           letter_sender.new(neighbour, "Hi", letter_type: :consultation).deliver!
@@ -94,7 +94,7 @@ RSpec.describe LetterSendingService do
         let(:status) { 500 }
 
         it "makes a request but does not record a sending date" do
-          expect(Appsignal).to receive(:send_error)
+          expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
           letter_sender.new(neighbour, "Hi", letter_type: :committee).deliver!


### PR DESCRIPTION
### Description of change

https://docs.appsignal.com/ruby/instrumentation/exception-handling.html#appsignalreport_error

Since upgrading AppSignal version to 4+, the previous send_error method is deprecated

