### PR TITLE
Add reviewer interaction with policies

### DIFF
--- a/app/components/reviewing/planning_application_policy_class/link_component.rb
+++ b/app/components/reviewing/planning_application_policy_class/link_component.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Reviewing
+  module PlanningApplicationPolicyClass
+    class LinkComponent < ViewComponent::Base
+      erb_template <<~ERB
+        <%= govuk_link_to(link_text, link_path, aria: {describedby: link_text}) %>
+      ERB
+
+      def initialize(planning_application_policy_class:)
+        @planning_application_policy_class = planning_application_policy_class
+        @planning_application = planning_application_policy_class.planning_application
+        @policy_class = planning_application_policy_class.policy_class
+        @part = @policy_class.policy_part
+      end
+
+      attr_reader :planning_application, :planning_application_policy_class, :policy_class, :part
+
+      def link_path
+        case planning_application_policy_class.current_review.review_status
+        when "review_complete"
+          planning_application_review_policy_areas_policy_class_path(planning_application_policy_class.planning_application, planning_application_policy_class)
+        else
+          edit_planning_application_review_policy_areas_policy_class_path(
+            planning_application, planning_application_policy_class
+          )
+        end
+      end
+
+      def link_text
+        "Review assessment of Part #{part.number}, Class #{policy_class.section}"
+      end
+    end
+  end
+end

--- a/app/components/task_list_items/assessment/planning_application_policy_class_component.rb
+++ b/app/components/task_list_items/assessment/planning_application_policy_class_component.rb
@@ -29,11 +29,9 @@ module TaskListItems
       end
 
       def status
-        if planning_application_policy_class.current_review
-          planning_application_policy_class.current_review.status.to_sym
-        else
-          :not_started
-        end
+        return :not_started unless (review = planning_application_policy_class.current_review)
+
+        (review.updated? || review.complete?) ? :complete : review.status.to_sym
       end
     end
   end

--- a/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/assessment/policy_areas/policy_classes_controller.rb
@@ -4,7 +4,7 @@ module PlanningApplications
   module Assessment
     module PolicyAreas
       class PolicyClassesController < BaseController
-        before_action :ensure_can_assess_planning_application
+        before_action :ensure_can_assess_planning_application, only: %i[new create]
         before_action :find_policy_parts
         before_action :find_part, only: %i[new create]
         before_action :find_planning_application_policy_class, only: %i[edit update destroy]

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Review
+    module PolicyAreas
+      class PolicyClassesController < BaseController
+        before_action :find_planning_application_policy_class, only: %i[show edit update]
+        before_action :build_form, only: %i[edit update]
+        before_action :set_review, only: %i[show edit update]
+
+        def show
+          respond_to do |format|
+            format.html
+          end
+        end
+
+        def edit
+          respond_to do |format|
+            format.html
+          end
+        end
+
+        def update
+          @form.update(policy_section_status_params)
+
+          if @planning_application_policy_class.update_review(review_params)
+            redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+          else
+            render :edit
+          end
+        end
+
+        private
+
+        def find_planning_application_policy_class
+          @planning_application_policy_class = @planning_application.planning_application_policy_classes.find(params[:id])
+        end
+
+        def policy_section_status_params
+          params.require(:planning_application_policy_sections).permit(
+            params[:planning_application_policy_sections].keys.map do |key|
+              [key, [:status, {comments_attributes: [:id, :text]}]]
+            end.to_h
+          )
+        end
+
+        def build_form
+          @form = PolicySectionForm.new(
+            planning_application: @planning_application,
+            policy_class: @planning_application_policy_class.policy_class
+          )
+        end
+
+        def review_params
+          params.require(:review).permit(:review_status, :action, :comment).merge(reviewer: current_user, reviewed_at: Time.current)
+        end
+
+        def set_review
+          @review = @planning_application_policy_class.current_review
+        end
+      end
+    end
+  end
+end

--- a/app/form_models/policy_section_form.rb
+++ b/app/form_models/policy_section_form.rb
@@ -23,10 +23,13 @@ class PolicySectionForm
   def update(params)
     params.each do |policy_section_id, section_params|
       planning_application_policy_section = planning_application_policy_sections[policy_section_id.to_i]
-      planning_application_policy_section.update!(
+
+      update_attributes = {
         status: section_params[:status],
         comments_attributes: section_params[:comments_attributes]
-      )
+      }.compact
+
+      planning_application_policy_section.update!(update_attributes)
     end
   end
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -180,7 +180,8 @@ class Review < ApplicationRecord
 
   def all_policies_are_determined
     return unless status == "complete"
-    return if owner.policy_class.planning_application_policy_sections.none?(&:to_be_determined?)
+    policies = owner.policy_class.planning_application_policy_sections.where(planning_application_id: owner.planning_application)
+    return if policies.none?(&:to_be_determined?)
 
     errors.add(:base, :policies_to_be_determined)
   end

--- a/app/views/planning_applications/review/policy_areas/policy_classes/_summary.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/_summary.html.erb
@@ -1,0 +1,41 @@
+<% content_for :page_title do %>
+  <%= t(".review") %> - <%= t("page_title") %>
+<% end %>
+<% render(
+     partial: "shared/review_task_breadcrumbs",
+     locals: {
+       planning_application: planning_application,
+       current_page: t(
+         ".review_policy_class",
+         part: policy_class.policy_part_number,
+         class: policy_class.section
+       )
+     }
+   ) %>
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: t(".review_policy_class", part: policy_class.policy_part_number, class: policy_class.section)}
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m govuk-!-padding-bottom-3">
+      <%= policy_class.name.upcase_first %>
+    </h2>
+
+    <p class="govuk-body">
+      <%= t(".complete_the_assessment") %>
+    <p class="govuk-body">
+      <%= govuk_link_to(
+            t(".open_legislation_in"),
+            policy_class.url,
+            new_tab: ""
+          ) %>
+    </p>
+    <%= govuk_accordion do |accordion|
+          accordion.with_section(heading_text: "Constraints") do
+            render(partial: "shared/constraints")
+          end
+        end %>
+  </div>
+</div>

--- a/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
@@ -7,20 +7,10 @@
       }
     ) %>
 
-<% if @review.comment.present? %>
-  <div class="govuk-inset-text" id="reviewer_comment">
-    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-      Reviewer comment:
-    </p>
-    <p class="govuk-body govuk-!-margin-top-1"><%= @review.created_at.to_fs %></p>
-    <p class="govuk-body italic"><%= @review.comment %></p>
-  </div>
-<% end %>
-
 <% if @planning_application_policy_class.policy_class.policy_sections.any? %>
   <%= govuk_error_summary(@review) %>
 
-  <%= form_with url: planning_application_assessment_policy_areas_policy_class_path(@planning_application, @planning_application_policy_class), method: :patch, html: {data: unsaved_changes_data} do |form| %>
+  <%= form_with url: planning_application_review_policy_areas_policy_class_path(@planning_application, @planning_application_policy_class), method: :patch, html: {data: unsaved_changes_data} do |form| %>
     <%= govuk_table(id: "policy-sections") do |table| %>
       <% table.with_head do |head| %>
         <% head.with_row do |row| %>
@@ -60,6 +50,7 @@
                         status,
                         checked: @form.planning_application_policy_sections[policy_section.id].status == status,
                         label: {hidden: true},
+                        disabled: true,
                         class: "govuk-radios__input"
                       ) %>
                 </div>
@@ -70,11 +61,28 @@
       <% end %>
     <% end %>
 
-    <%= form.govuk_submit "Save and mark as complete", name: "review[status]", value: "complete" do %>
-      <%= form.govuk_submit "Save and come back later", name: "review[status]", value: "in_progress", secondary: true %>
-      <%= govuk_button_link_to(t("back"), planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
+    <fieldset class="govuk-fieldset govuk-!-padding-bottom-5">
+      <div class="govuk-radios" data-module="govuk-radios">
+        <%= form.govuk_radio_button(:action, "accepted", label: {text: "Accept"}, name: "review[action]", checked: @planning_application_policy_class.current_review.accepted?) %>
+        <%= form.govuk_radio_button(
+              :action, "rejected", label: {text: "Return to officer with comment"}, name: "review[action]", checked: @planning_application_policy_class.current_review.rejected?
+            ) do %>
+          <%= form.govuk_text_area(
+                :comment,
+                label: {text: "Explain to the assessor why this needs reviewing"},
+                rows: 6,
+                name: "review[comment]",
+                value: @planning_application_policy_class.current_review.comment
+              ) %>
+        <% end %>
+      </div>
+    </fieldset>
+
+    <%= form.govuk_submit "Save and mark as complete", name: "review[review_status]", value: "review_complete" do %>
+      <%= form.govuk_submit "Save and come back later", name: "review[review_status]", value: "review_in_progress", secondary: true %>
+      <%= govuk_button_link_to(t("back"), planning_application_review_tasks_path(@planning_application), secondary: true) %>
     <% end %>
   <% end %>
 <% else %>
-  <%= govuk_button_link_to(t("back"), planning_application_assessment_tasks_path(@planning_application), secondary: true) %>
+  <%= govuk_button_link_to(t("back"), planning_application_review_tasks_path(@planning_application), secondary: true) %>
 <% end %>

--- a/app/views/planning_applications/review/policy_areas/policy_classes/show.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/show.html.erb
@@ -1,0 +1,35 @@
+<%= render(
+      partial: "summary",
+      locals: {
+        planning_application: @planning_application,
+        planning_application_policy_class: @planning_application_policy_class,
+        policy_class: @planning_application_policy_class.policy_class
+      }
+    ) %>
+
+  <%= form_with(
+        model: [@planning_application, @planning_application_policy_class],
+        url: planning_application_review_policy_areas_policy_class_path(@planning_application, @planning_application_policy_class)
+      ) do |form| %>
+    <fieldset class="govuk-fieldset govuk-!-padding-bottom-5">
+      <div class="govuk-radios" data-module="govuk-radios">
+        <%= form.govuk_radio_button(:action, "accepted", label: {text: "Accept"}, disabled: true, checked: @planning_application_policy_class.current_review.accepted?) %>
+        <%= form.govuk_radio_button(
+              :action, "rejected", label: {text: "Return to officer with comment"}, disabled: true, checked: @planning_application_policy_class.current_review.rejected?
+            ) do %>
+          <%= form.govuk_text_area(
+                :comment,
+                label: {text: "Explain to the assessor why this needs reviewing"},
+                rows: 6,
+                disabled: true,
+                value: @planning_application_policy_class.current_review.comment
+              ) %>
+        <% end %>
+      </div>
+    </fieldset>
+  <% end %>
+
+<div class="govuk-button-group">
+  <%= back_link %>
+  <%= govuk_link_to "Edit review of Part #{@planning_application_policy_class.policy_class.policy_part_number}, Class #{@planning_application_policy_class.policy_class.section}", edit_planning_application_review_policy_areas_policy_class_path(@planning_application, @planning_application_policy_class) %>
+</div>

--- a/app/views/planning_applications/review/tasks/_policy_classes_new.html.erb
+++ b/app/views/planning_applications/review/tasks/_policy_classes_new.html.erb
@@ -1,0 +1,20 @@
+<% planning_application.planning_application_policy_classes.order(:new_policy_class_id).each do |policy_class| %>
+  <% next if policy_class.current_review.not_started? || policy_class.current_review.in_progress? %>
+
+  <%= render TaskListItems::Reviewing::Component.new do |c| %>
+    <% c.with_link do %>
+      <%= render(Reviewing::PlanningApplicationPolicyClass::LinkComponent.new(planning_application_policy_class: policy_class)) %>
+    <% end %>
+
+    <% c.with_tag do %>
+      <div class="govuk-task-list__status app-task-list__task-tag">
+      <%= render(
+            StatusTags::ReviewComponent.new(
+              review_item: policy_class.current_review,
+              updated: policy_class.current_review.updated?
+            )
+          ) %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -91,6 +91,10 @@
 
   <%= render partial: "policy_classes", locals: {planning_application: @planning_application, policy_class: @policy_class} %>
 
+  <% if @planning_application.application_type.assess_against_policies? %>
+    <%= render partial: "policy_classes_new", locals: {planning_application: @planning_application, policy_class: @policy_class} %>
+  <% end %>
+
   <% if @planning_application.committee_decision&.current_review %>
     <%= render(
           TaskListItems::Reviewing::CommitteeComponent.new(

--- a/app/views/shared/policy_classes/_table.html.erb
+++ b/app/views/shared/policy_classes/_table.html.erb
@@ -8,7 +8,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell">
           <h3 class="govuk-heading-s">
-            <%= "#{policy_class.section}.#{policy.section}" %>
+            <%= "#{policy_class&.section}.#{policy&.section}" %>
           </h3>
           <p class="govuk-body">
             <%= render(FormattedContentComponent.new(text: policy.description)) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1547,6 +1547,22 @@ en:
       notifications:
         update:
           success: Notifications sent to neighbours and application in committee
+      policy_areas:
+        policy_classes:
+          show:
+            application: Application
+            home: Home
+            open_legislation_in: Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window
+            please_indicate_if: Complete the assessment to show whether the application complies or does not comply with the selected legislative class. You can add comments to provide more information to support your assessment.
+            review: Review
+            review_heading: Review - Part%{part}, Class %{class}
+          summary:
+            complete_the_assessment: Complete the assessment to show whether the application complies or does not comply with the selected legislative class. You can add comments to provide more information to support your assessment.
+            open_legislation_in: Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window
+            review: Review
+            review_policy_class: Review - Part %{part}, Class %{class}
+          update:
+            success: Review of publicity successfully added.
       policy_classes:
         comment:
           edit_comment: Edit comment

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -307,6 +307,10 @@ Rails.application.routes.draw do
 
           resources :permitted_development_rights, only: %i[show edit update]
 
+          namespace :policy_areas do
+            resources :policy_classes, only: %i[show edit update]
+          end
+
           resources :policy_classes, only: %i[edit update show]
 
           resources :tasks, only: :index

--- a/spec/factories/planning_application_policy_section.rb
+++ b/spec/factories/planning_application_policy_section.rb
@@ -4,5 +4,19 @@ FactoryBot.define do
   factory :planning_application_policy_section do
     association :policy_section
     association :planning_application
+
+    trait :complies do
+      status { "complies" }
+    end
+
+    trait :does_not_comply do
+      status { "does_not_comply" }
+    end
+
+    trait :with_comments do
+      after(:create) do |planning_application_policy_section|
+        create(:comment, text: "A comment", commentable: planning_application_policy_section, commentable_type: "PlanningApplicationPolicySection")
+      end
+    end
   end
 end

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -262,5 +262,117 @@ RSpec.describe "Reviewing Policy Class", type: :system do
 
       expect(page).to have_text("All policies must be assessed")
     end
+
+    context "when reviewing legislation with dynamic policies" do
+      let!(:schedule) { create(:policy_schedule, number: 2, name: "Permitted development rights") }
+      let!(:part1) { create(:policy_part, name: "Development within the curtilage of a dwellinghouse", number: 1, policy_schedule: schedule) }
+      let!(:policy_classA) { create(:new_policy_class, section: "A", name: "enlargement, improvement or other alteration of a dwellinghouse", policy_part: part1) }
+
+      let!(:policy_section1a) { create(:policy_section, section: "1a", description: "description for section 1a", new_policy_class: policy_classA) }
+      let!(:policy_section1b) { create(:policy_section, section: "1b", description: "description for section 1b", new_policy_class: policy_classA) }
+      let!(:policy_section2bii) { create(:policy_section, section: "2b(ii)", description: "description for section 2ab(ii)", new_policy_class: policy_classA) }
+
+      let!(:pa_policy_section1a) { create(:planning_application_policy_section, :complies, policy_section: policy_section1a, planning_application:) }
+      let!(:pa_policy_section1b) { create(:planning_application_policy_section, :complies, policy_section: policy_section1b, planning_application:) }
+      let!(:pa_policy_section2bii) { create(:planning_application_policy_section, :does_not_comply, :with_comments, policy_section: policy_section2bii, planning_application:) }
+
+      let!(:planning_application_policy_class) { create(:planning_application_policy_class, planning_application:, new_policy_class: policy_classA) }
+
+      before do
+        create(:review, owner_type: "PlanningApplicationPolicyClass", status: "complete", assessor: assessor, owner: planning_application_policy_class)
+      end
+
+      it "shows an error if no option is selected" do
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+        click_on "Review assessment of Part 1, Class A"
+        click_button "Save and mark as complete"
+        expect(page).to have_selector("[role=alert] li", text: "Select an option")
+      end
+
+      it "allows the reviewer to accept" do
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+        click_on "Review assessment of Part 1, Class A"
+        expect(page).to have_selector("h1", text: "Review - Part 1, Class A")
+
+        expect(page).to have_css("#policy-section-#{policy_section1a.id}")
+        expect(page).to have_css("#policy-section-#{policy_section1b.id}")
+        expect(page).to have_css("#policy-section-#{policy_section2bii.id}")
+
+        expect(page).to have_field("planning-application-policy-sections-#{policy_section1a.id}-status-complies-field", disabled: true)
+        expect(page).to have_field("planning-application-policy-sections-#{policy_section1b.id}-status-does-not-comply-field", disabled: true)
+        expect(page).to have_field("planning-application-policy-sections-#{policy_section2bii.id}-status-does-not-comply-field", disabled: true)
+
+        choose("Accept")
+        within("#policy-section-#{policy_section2bii.id}") do
+          fill_in("Add comment", with: "Reviewer comment")
+        end
+        click_button("Save and come back later")
+
+        expect(list_item("Review assessment of Part 1, Class A")).to have_content("In progress")
+        click_link("Part 1, Class A")
+
+        within("#policy-section-#{policy_section2bii.id}") do
+          expect(page).to have_field("Add comment", with: "Reviewer comment")
+
+          find("span", text: "Previous comments").click
+          expect(page).to have_content("A comment")
+        end
+
+        click_button("Save and mark as complete")
+        expect(page).to have_content("Review of publicity successfully added.")
+        expect(list_item("Review assessment of Part 1, Class A")).to have_content("Completed")
+      end
+
+      it "allows the reviewer to reject with a comment" do
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+        click_on "Review assessment of Part 1, Class A"
+        choose("Return to officer with comment")
+        click_button("Save and mark as complete")
+        expect(page).to have_selector("[role=alert] li", text: "Explain to the case officer why")
+
+        fill_in "Explain to the assessor why this needs reviewing", with: "Rejection reason"
+        click_button("Save and mark as complete")
+        expect(page).to have_content("Review of publicity successfully added.")
+
+        expect(list_item("Review assessment of Part 1, Class A")).to have_content("Awaiting changes")
+        click_on "Review assessment of Part 1, Class A"
+        click_on "Edit review of Part 1, Class A"
+        fill_in "Explain to the assessor why this needs reviewing", with: "Rejection reason edited"
+        click_button("Save and mark as complete")
+
+        sign_in assessor
+
+        visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+
+        expect(list_item("Part 1, Class A")).to have_content("To be reviewed")
+
+        click_link("Part 1, Class A")
+        within("#reviewer_comment") do
+          expect(page).to have_content("Reviewer comment:")
+          expect(page).to have_content("Rejection reason edited")
+        end
+
+        within("#policy-section-#{policy_section2bii.id}") do
+          choose(option: "complies")
+        end
+        click_button("Save and mark as complete")
+
+        expect(list_item("Part 1, Class A")).to have_content("Complete")
+
+        sign_in reviewer
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+        expect(list_item("Review assessment of Part 1, Class A")).to have_content("Updated")
+
+        click_on "Review assessment of Part 1, Class A"
+        choose "Accept"
+        click_on "Save and mark as complete"
+
+        expect(list_item("Review assessment of Part 1, Class A")).to have_content("Completed")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Add reviewer interaction with policies:

- Enable reviewer to accept or reject with a comment
- Update status appropriately to alert assessor that changes need to be made and to reviewer when updates are then made

### Story Link

https://trello.com/c/YRXNHUmu/3174-add-reviewer-interaction-with-assessment-against-policies

