### PR TITLE
Add ability to search via address

### DIFF
--- a/app/services/planning_application_search.rb
+++ b/app/services/planning_application_search.rb
@@ -108,7 +108,7 @@ class PlanningApplicationSearch
   end
 
   def records_matching_query
-    records_matching_reference.presence || records_matching_description
+    records_matching_reference.presence || records_matching_address.presence || records_matching_description
   end
 
   def records_matching_reference
@@ -123,6 +123,10 @@ class PlanningApplicationSearch
       .select(sanitized_select_sql)
       .where(where_sql, query_terms)
       .order(rank: :desc)
+  end
+
+  def records_matching_address
+    current_planning_applications.where("address_search @@ to_tsquery('simple', ?)", address_query_terms)
   end
 
   def sanitized_select_sql
@@ -143,6 +147,10 @@ class PlanningApplicationSearch
 
   def query_terms
     @query_terms ||= query.split.join(" | ")
+  end
+
+  def address_query_terms
+    @address_query_terms ||= query.split.map { |term| term }.join(" & ")
   end
 
   def query_submitted?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1711,7 +1711,7 @@ en:
       clear_search: Clear search
       find_an_application: Find an application
       search: Search
-      you_can_search: You can search by application number or description
+      you_can_search: You can search by application number, description or address
     site_notices:
       confirmation_requests:
         create:

--- a/db/migrate/20241016135118_add_address_search_to_planning_applications.rb
+++ b/db/migrate/20241016135118_add_address_search_to_planning_applications.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddAddressSearchToPlanningApplications < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    sql = <<~SQL.squish
+      to_tsvector('simple',
+        COALESCE(address_1, '') || ' ' ||
+        COALESCE(address_2, '') || ' ' ||
+        COALESCE(town, '') || ' ' ||
+        COALESCE(county, '') || ' ' ||
+        COALESCE(postcode, '')
+      )
+    SQL
+
+    add_column :planning_applications, :address_search, :tsvector, as: sql, stored: true
+    add_index :planning_applications, :address_search, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20241018100002_add_normalised_postcode_index_to_planning_applications.rb
+++ b/db/migrate/20241018100002_add_normalised_postcode_index_to_planning_applications.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddNormalisedPostcodeIndexToPlanningApplications < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :planning_applications, "LOWER(replace(postcode, ' ', ''))", algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_07_124511) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_16_135118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -788,8 +788,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_07_124511) do
     t.boolean "ownership_certificate_checked", default: false, null: false
     t.datetime "published_at"
     t.boolean "site_history_checked", default: false, null: false
+    t.virtual "address_search", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((((((((COALESCE(address_1, ''::character varying))::text || ' '::text) || (COALESCE(address_2, ''::character varying))::text) || ' '::text) || (COALESCE(town, ''::character varying))::text) || ' '::text) || (COALESCE(county, ''::character varying))::text) || ' '::text) || (COALESCE(postcode, ''::character varying))::text))", stored: true
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
+    t.index ["address_search"], name: "ix_planning_applications_on_address_search", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true
     t.index ["application_type_id"], name: "ix_planning_applications_on_application_type_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_16_135118) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -790,6 +790,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_16_135118) do
     t.boolean "site_history_checked", default: false, null: false
     t.virtual "address_search", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((((((((COALESCE(address_1, ''::character varying))::text || ' '::text) || (COALESCE(address_2, ''::character varying))::text) || ' '::text) || (COALESCE(town, ''::character varying))::text) || ' '::text) || (COALESCE(county, ''::character varying))::text) || ' '::text) || (COALESCE(postcode, ''::character varying))::text))", stored: true
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
+    t.index "lower(replace((postcode)::text, ' '::text, ''::text))", name: "ix_planning_applications_on_LOWER_replace_postcode"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
     t.index ["address_search"], name: "ix_planning_applications_on_address_search", using: :gin
     t.index ["api_user_id"], name: "ix_planning_applications_on_api_user_id"

--- a/engines/bops_api/app/services/bops_api/application/search_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/search_service.rb
@@ -20,7 +20,7 @@ module BopsApi
       def search
         return scope if query.blank?
 
-        search_reference.presence || search_description
+        search_reference.presence || search_address.presence || search_description
       end
 
       def search_reference
@@ -34,6 +34,10 @@ module BopsApi
         scope.select(sanitized_select_sql)
           .where(where_sql, query_terms)
           .order(rank: :desc)
+      end
+
+      def search_address
+        scope.where("address_search @@ to_tsquery('simple', ?)", address_query_terms)
       end
 
       def sanitized_select_sql
@@ -54,6 +58,10 @@ module BopsApi
 
       def query_terms
         @query_terms ||= query.split.join(" | ")
+      end
+
+      def address_query_terms
+        @query_terms ||= query.split.map { |term| term }.join(" & ")
       end
     end
   end

--- a/engines/bops_api/spec/services/application/search_service_spec.rb
+++ b/engines/bops_api/spec/services/application/search_service_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::Application::SearchService do
+  let(:scope) { PlanningApplication.all }
+  let(:params) { {} }
+  let(:service) { described_class.new(scope, params) }
+  let(:pagy_and_results) { service.call }
+  let(:pagy) { pagy_and_results.first }
+  let(:results) { pagy_and_results.last }
+
+  describe "call" do
+    context "when page and maxresults are provided" do
+      before do
+        create_list(:planning_application, 25)
+      end
+
+      let(:params) { {page: 2, maxresults: 5} }
+
+      it "paginates the results correctly" do
+        expect(pagy).to have_attributes(
+          page: 2,
+          items: 5,
+          count: 25,
+          pages: 5,
+          from: 6,
+          to: 10
+        )
+      end
+
+      context "when exceeding the maxresults limit" do
+        let(:params) { {maxresults: 50} }
+
+        it "limits the results to MAXRESULTS_LIMIT" do
+          expect(pagy.items).to eq(BopsApi::Pagination::MAXRESULTS_LIMIT)
+        end
+      end
+    end
+
+    context "when performing a search" do
+      let!(:matching_reference) { create(:planning_application) }
+      let!(:matching_description) { create(:planning_application, description: "This is a unique description") }
+      let!(:matching_address) { create(:planning_application, address_1: "123 Unique Road", county: "Greater London", town: "Unique Town", postcode: "123 XYZ") }
+
+      context "when searching by reference" do
+        let(:params) { {q: matching_reference.reference} }
+
+        it "returns applications matching the reference" do
+          expect(results).to include(matching_reference)
+          expect(results).not_to include(matching_description, matching_address)
+        end
+      end
+
+      context "when searching by description" do
+        let(:params) { {q: "unique description"} }
+
+        it "returns applications matching the description" do
+          expect(results).to include(matching_description)
+          expect(results).not_to include(matching_reference, matching_address)
+        end
+      end
+
+      context "when searching by address" do
+        context "with address lines" do
+          let(:params) { {q: "123 unique Road Unique town"} }
+
+          it "returns applications matching the address" do
+            expect(results).to include(matching_address)
+            expect(results).not_to include(matching_reference, matching_description)
+          end
+        end
+
+        context "with postcode" do
+          let(:params) { {q: "123 xyz"} }
+
+          it "returns applications matching the address" do
+            expect(results).to include(matching_address)
+            expect(results).not_to include(matching_reference, matching_description)
+          end
+        end
+      end
+
+      context "when no search term matches" do
+        let(:params) { {q: "noresults"} }
+
+        it "returns no results" do
+          expect(results).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/services/application/search_service_spec.rb
+++ b/engines/bops_api/spec/services/application/search_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe BopsApi::Application::SearchService do
     context "when performing a search" do
       let!(:matching_reference) { create(:planning_application) }
       let!(:matching_description) { create(:planning_application, description: "This is a unique description") }
-      let!(:matching_address) { create(:planning_application, address_1: "123 Unique Road", county: "Greater London", town: "Unique Town", postcode: "123 XYZ") }
+      let!(:matching_address) { create(:planning_application, address_1: "123 Unique Road", county: "Greater London", town: "Unique Town", postcode: "SE21 7DN") }
 
       context "when searching by reference" do
         let(:params) { {q: matching_reference.reference} }
@@ -72,11 +72,22 @@ RSpec.describe BopsApi::Application::SearchService do
         end
 
         context "with postcode" do
-          let(:params) { {q: "123 xyz"} }
+          context "with exact postcode query" do
+            let(:params) { {q: "SE21 7DN"} }
 
-          it "returns applications matching the address" do
-            expect(results).to include(matching_address)
-            expect(results).not_to include(matching_reference, matching_description)
+            it "returns applications matching the postcode" do
+              expect(results).to include(matching_address)
+              expect(results).not_to include(matching_reference, matching_description)
+            end
+          end
+
+          context "with postcode query" do
+            let(:params) { {q: "se217Dn"} }
+
+            it "returns applications matching the postcode" do
+              expect(results).to include(matching_address)
+              expect(results).not_to include(matching_reference, matching_description)
+            end
           end
         end
       end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -215,6 +215,13 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).not_to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "sE228uR")
+        click_button("Search")
+
+        expect(page).not_to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
       end
     end
 

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
       :in_assessment,
       user:,
       local_authority:,
-      description: "Add a chimney stack"
+      description: "Add a chimney stack",
+      address_1: "11 Abbey Gardens",
+      address_2: "Southwark",
+      town: "London",
+      county: "Greater London",
+      postcode: "SE16 3RQ"
     )
   end
 
@@ -26,7 +31,12 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
       :in_assessment,
       user: nil,
       local_authority:,
-      description: "Add a patio"
+      description: "Add a patio",
+      address_1: "140, WOODWARDE ROAD",
+      address_2: "Dulwich",
+      town: "London",
+      county: "Greater London",
+      postcode: "SE22 8UR"
     )
   end
 
@@ -36,7 +46,12 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
       :to_be_reviewed,
       user: other_user,
       local_authority:,
-      description: "Add a skylight"
+      description: "Add a skylight",
+      address_1: "23 Abbey Gardens",
+      address_2: "Southwark",
+      town: "London",
+      county: "Greater London",
+      postcode: "SE16 3RQ"
     )
   end
 
@@ -145,6 +160,61 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
 
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
+      end
+    end
+
+    it "allows the user to search for planning applications with an address" do
+      click_link "View all applications"
+
+      within(govuk_tab_all) do
+        fill_in("Find an application", with: "11 Abbey Gardens")
+        click_button("Search")
+
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "20 Abbey Gardens")
+        click_button("Search")
+
+        expect(page).not_to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "GARDENS")
+        click_button("Search")
+
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+        expect(page).to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "140 woodwarde")
+        click_button("Search")
+
+        expect(page).not_to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "london")
+        click_button("Search")
+
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "southwark")
+        click_button("Search")
+
+        expect(page).to have_content(planning_application1.reference)
+        expect(page).not_to have_content(planning_application2.reference)
+        expect(page).to have_content(planning_application3.reference)
+
+        fill_in("Find an application", with: "se22 8UR")
+        click_button("Search")
+
+        expect(page).not_to have_content(planning_application1.reference)
+        expect(page).to have_content(planning_application2.reference)
+        expect(page).not_to have_content(planning_application3.reference)
       end
     end
 


### PR DESCRIPTION
### Description of change

Enable search by address on API and planning applications dashboard
- Add virtual address_search column to combine address fields and add index to this column to improve search performance
- Add this to the API and dashboard search

### Story Link

https://trello.com/c/ix7VwSXL/2944-the-ability-to-search-based-on-address
https://trello.com/c/Cd9TnjmO/2948-search-applications-by-address-on-the-application-dashboard

