### PR TITLE
Track history of neighbour letters

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -126,10 +126,7 @@ module PlanningApplications
     end
 
     def deliver_letters!
-      batch = NeighbourLetterBatch.new(text: @consultation.neighbour_letter_text)
-      neighbours_to_contact.each do |neighbour|
-        LetterSendingService.new(neighbour, @consultation.neighbour_letter_text, resend_reason:, letter_type: :consultation, batch:).deliver!
-      end
+      LetterSendingService.new(@consultation.neighbour_letter_text, consultation: @consultation, resend_reason:, letter_type: :consultation).deliver_batch!(neighbours_to_contact)
     end
 
     def neighbours_to_contact

--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -126,8 +126,9 @@ module PlanningApplications
     end
 
     def deliver_letters!
+      batch = NeighbourLetterBatch.new(text: @consultation.neighbour_letter_text)
       neighbours_to_contact.each do |neighbour|
-        LetterSendingService.new(neighbour, @consultation.neighbour_letter_text, resend_reason:, letter_type: :consultation).deliver!
+        LetterSendingService.new(neighbour, @consultation.neighbour_letter_text, resend_reason:, letter_type: :consultation, batch:).deliver!
       end
     end
 

--- a/app/controllers/planning_applications/review/notifications_controller.rb
+++ b/app/controllers/planning_applications/review/notifications_controller.rb
@@ -42,7 +42,7 @@ module PlanningApplications
           if neighbour.neighbour_responses.last.email.present?
             SendCommitteeDecisionEmailJob.perform_later(neighbour, @planning_application.planning_application)
           else
-            LetterSendingService.new(neighbour, @committee_decision.notification_content, letter_type: :committee).deliver!
+            LetterSendingService.new(@committee_decision.notification_content, consultation: @planning_application.consultation, letter_type: :committee).deliver!(neighbour)
           end
         end
       end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -33,6 +33,7 @@ class Consultation < ApplicationRecord
   belongs_to :planning_application
 
   has_many :reviews, as: :owner, dependent: :destroy, class_name: "Review"
+  has_many :neighbour_letter_batches, dependent: :destroy
 
   with_options to: :planning_application do
     delegate :local_authority

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -2,6 +2,7 @@
 
 class NeighbourLetter < ApplicationRecord
   belongs_to :neighbour
+  belongs_to :batch, optional: true, class_name: :NeighbourLetterBatch
 
   validates :resend_reason, absence: true, unless: :allowed_resend_reason?
   validates :resend_reason, presence: true, if: :needs_resend_reason?

--- a/app/models/neighbour_letter_batch.rb
+++ b/app/models/neighbour_letter_batch.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class NeighbourLetterBatch < ApplicationRecord
+  belongs_to :consultation
+  has_many :neighbour_letters, dependent: :destroy, inverse_of: :batch
+end

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -3,7 +3,7 @@
 require "notifications/client"
 
 class LetterSendingService
-  attr_reader :consultation, :letter_content, :resend_reason
+  attr_reader :consultation, :letter_content, :local_authority, :resend_reason
 
   def initialize(letter_content, consultation:, letter_type:, resend_reason: nil)
     @consultation = consultation
@@ -36,7 +36,7 @@ class LetterSendingService
 
     begin
       response = client.send_letter(
-        template_id: @local_authority.letter_template_id,
+        template_id: local_authority.letter_template_id,
         personalisation:
       )
     rescue Notifications::Client::RequestError => e
@@ -64,9 +64,9 @@ class LetterSendingService
 
   def heading
     if consultation_letter?
-      @consultation.neighbour_letter_header
+      consultation.neighbour_letter_header
     else
-      @consultation.planning_application.application_type.legislation_title
+      consultation.planning_application.application_type.legislation_title
     end
   end
 
@@ -75,7 +75,7 @@ class LetterSendingService
   end
 
   def client
-    @client ||= Notifications::Client.new(@local_authority.notify_api_key_for_letters)
+    @client ||= Notifications::Client.new(local_authority.notify_api_key_for_letters)
   end
 
   def update_letter!(letter_record, response)

--- a/db/migrate/20241010141846_create_neighbour_letter_batches.rb
+++ b/db/migrate/20241010141846_create_neighbour_letter_batches.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateNeighbourLetterBatches < ActiveRecord::Migration[7.1]
+  def change
+    create_table :neighbour_letter_batches do |t|
+      t.references :consultation, foreign_key: true
+      t.string :text
+
+      t.timestamps
+    end
+
+    safety_assured {
+      change_table :neighbour_letters, bulk: true do |t|
+        t.references :batch, foreign_key: {to_table: :neighbour_letter_batches}
+      end
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -557,6 +557,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
     t.index ["local_policy_id"], name: "ix_local_policy_areas_on_local_policy_id"
   end
 
+  create_table "neighbour_letter_batches", force: :cascade do |t|
+    t.bigint "consultation_id"
+    t.string "text"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["consultation_id"], name: "ix_neighbour_letter_batches_on_consultation_id"
+  end
+
   create_table "neighbour_letters", force: :cascade do |t|
     t.bigint "neighbour_id", null: false
     t.string "text"
@@ -569,6 +577,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
     t.string "status_updated_at"
     t.string "failure_reason"
     t.string "resend_reason"
+    t.bigint "batch_id"
+    t.index ["batch_id"], name: "ix_neighbour_letters_on_batch_id"
     t.index ["neighbour_id"], name: "ix_neighbour_letters_on_neighbour_id"
   end
 
@@ -1097,6 +1107,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
   add_foreign_key "local_authority_policy_references", "local_authorities"
   add_foreign_key "local_policies", "planning_applications"
   add_foreign_key "local_policy_areas", "local_policies"
+  add_foreign_key "neighbour_letter_batches", "consultations"
+  add_foreign_key "neighbour_letters", "neighbour_letter_batches", column: "batch_id"
   add_foreign_key "neighbour_letters", "neighbours"
   add_foreign_key "neighbour_responses", "consultations"
   add_foreign_key "neighbour_responses", "neighbours"

--- a/spec/factories/neighbour.rb
+++ b/spec/factories/neighbour.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :neighbour do
-    address { "123, Made Up Street, London, W5 67S" }
+    address { Faker::Address.full_address }
     consultation
   end
 end

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -5,7 +5,6 @@ require "rails_helper"
 RSpec.describe LetterSendingService do
   let!(:planning_application) { create(:planning_application, :planning_permission) }
   let(:neighbour) { create(:neighbour, consultation: planning_application.consultation) }
-  let(:letter_sender) { described_class }
 
   describe "#deliver!" do
     let(:user) { create(:user) }
@@ -26,7 +25,7 @@ RSpec.describe LetterSendingService do
         it "makes a request and records it in the model" do
           letter_content = "Application received: #{neighbour.consultation.planning_application.received_at.to_fs(:day_month_year_slashes)}"
           notify_request = stub_send_letter(status: 200)
-          letter_sender.new(neighbour, letter_content, letter_type: :consultation).deliver!
+          described_class.new(neighbour, letter_content, letter_type: :consultation).deliver!
 
           expect(notify_request).to have_been_requested
 
@@ -49,7 +48,7 @@ RSpec.describe LetterSendingService do
           expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
-          letter_sender.new(neighbour, "Hi", letter_type: :consultation).deliver!
+          described_class.new(neighbour, "Hi", letter_type: :consultation).deliver!
 
           expect(notify_request).to have_been_requested
 
@@ -74,7 +73,7 @@ RSpec.describe LetterSendingService do
         it "makes a request and records it in the model" do
           letter_content = "Application is going to committee"
           notify_request = stub_send_letter(status: 200)
-          letter_sender.new(neighbour, letter_content, letter_type: :committee).deliver!
+          described_class.new(neighbour, letter_content, letter_type: :committee).deliver!
 
           expect(notify_request).to have_been_requested
 
@@ -97,7 +96,7 @@ RSpec.describe LetterSendingService do
           expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
-          letter_sender.new(neighbour, "Hi", letter_type: :committee).deliver!
+          described_class.new(neighbour, "Hi", letter_type: :committee).deliver!
 
           expect(notify_request).to have_been_requested
 

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe LetterSendingService do
   let!(:planning_application) { create(:planning_application, :planning_permission) }
-  let(:neighbour) { create(:neighbour, consultation: planning_application.consultation) }
+  let(:consultation) { planning_application.consultation }
+  let(:neighbour) { create(:neighbour, consultation:) }
 
   describe "#deliver!" do
     let(:user) { create(:user) }
@@ -25,7 +26,7 @@ RSpec.describe LetterSendingService do
         it "makes a request and records it in the model" do
           letter_content = "Application received: #{neighbour.consultation.planning_application.received_at.to_fs(:day_month_year_slashes)}"
           notify_request = stub_send_letter(status: 200)
-          described_class.new(neighbour, letter_content, letter_type: :consultation).deliver!
+          described_class.new(letter_content, consultation:, letter_type: :consultation).deliver!(neighbour)
 
           expect(notify_request).to have_been_requested
 
@@ -48,7 +49,7 @@ RSpec.describe LetterSendingService do
           expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
-          described_class.new(neighbour, "Hi", letter_type: :consultation).deliver!
+          described_class.new("Hi", consultation:, letter_type: :consultation).deliver!(neighbour)
 
           expect(notify_request).to have_been_requested
 
@@ -73,7 +74,7 @@ RSpec.describe LetterSendingService do
         it "makes a request and records it in the model" do
           letter_content = "Application is going to committee"
           notify_request = stub_send_letter(status: 200)
-          described_class.new(neighbour, letter_content, letter_type: :committee).deliver!
+          described_class.new(letter_content, consultation:, letter_type: :committee).deliver!(neighbour)
 
           expect(notify_request).to have_been_requested
 
@@ -96,7 +97,7 @@ RSpec.describe LetterSendingService do
           expect(Appsignal).to receive(:report_error)
 
           notify_request = stub_send_letter(status:)
-          described_class.new(neighbour, "Hi", letter_type: :committee).deliver!
+          described_class.new("Hi", consultation:, letter_type: :committee).deliver!(neighbour)
 
           expect(notify_request).to have_been_requested
 

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
       sign_in assessor
       visit "/planning_applications/#{planning_application.reference}"
 
-      neighbour = create(:neighbour, consultation:)
+      neighbour = create(:neighbour, consultation:, address: "123, Made Up Street, London, W5 67S")
       neighbour_letter = create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
 
       stub_send_letter(status: 200)


### PR DESCRIPTION
### Description of change

Tracking a history of batches of letters, so that groups of letters sent at the same time as each other can be seen, including the recipients and the text.

### Story Link

https://trello.com/c/8eLmtFtA/3232-store-history-of-neighbour-letters


### Known issues [OPTIONAL]

This currently only applies to letters sent as part of a consultation, and conversely we can't yet send email updates as part of the consultation (only committee decisions). There's [a card for refactoring to make that possible](https://trello.com/c/PRmqbLxM/3247-refactor-lettersendingservice-to-send-emails-as-needed).
