### PR TITLE
Validate for document when confirming site notice

### DIFF
--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -19,6 +19,8 @@ class SiteNotice < ApplicationRecord
       date: {
         on_or_before: :current
       }
+
+    validate :document_presence
   end
 
   with_options format: {with: URI::MailTo::EMAIL_REGEXP} do
@@ -100,5 +102,9 @@ class SiteNotice < ApplicationRecord
 
     raise NotCreatableError,
       "Cannot create site notice when application type does not permit this feature."
+  end
+
+  def document_presence
+    errors.add(:documents, "Upload a photo or document of the site notice to continue") if documents.empty?
   end
 end

--- a/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/confirm_site_notice_spec.rb
@@ -54,8 +54,10 @@ RSpec.describe "Confirm site notice", js: true do
     fill_in "Month", with: "02"
     fill_in "Year", with: "2023"
 
-    attach_file("Upload evidence of site notice in place", "spec/fixtures/images/proposed-floorplan.png")
+    click_button "Save and mark as complete"
+    expect(page).to have_selector("[role=alert] li", text: "Upload a photo or document of the site notice to continue")
 
+    attach_file("Upload evidence of site notice in place", "spec/fixtures/images/proposed-floorplan.png")
     click_button "Save and mark as complete"
     expect(page).to have_content("Site notice was successfully updated")
     expect(list_item("Confirm site notice")).to have_content("Complete")


### PR DESCRIPTION
### Description of change

Validate for document when confirming site notice

### Story Link

https://trello.com/c/88K6NLeD/3244-site-notice-bug

