### PR TITLE
Add local authority management of API tokens

### DIFF
--- a/app/controllers/api/v1/application_controller.rb
+++ b/app/controllers/api/v1/application_controller.rb
@@ -57,7 +57,7 @@ module Api
 
       def authenticate
         api_user = authenticate_or_request_with_http_token do |token, _options|
-          current_local_authority.api_users.find_by(token:)
+          current_local_authority.api_users.authenticate(token)
         end
 
         Current.api_user = api_user

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -22,7 +22,7 @@ class ApiUser < ApplicationRecord
 
   class << self
     def authenticate(token)
-      active.find_by(token: token)
+      active.find_by(token: token).tap { |user| user.try(:touch, :last_used_at) }
     end
 
     def generate_unique_secure_token(length: 36)

--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+require "base64"
+require "zlib"
+
 class ApiUser < ApplicationRecord
+  TOKEN_FORMAT = /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/
+
   attribute :file_downloader, FileDownloaders.to_type
 
   belongs_to :local_authority
@@ -12,11 +17,26 @@ class ApiUser < ApplicationRecord
   scope :revoked, -> { where.not(revoked_at: nil) }
 
   validates :name, presence: true, uniqueness: {scope: :local_authority_id}
+  validates :token, format: {with: TOKEN_FORMAT}
   validates :file_downloader, store_model: {allow_blank: true}
 
   class << self
     def authenticate(token)
       active.find_by(token: token)
+    end
+
+    def generate_unique_secure_token(length: 36)
+      super.then { |token| "bops_#{token}#{checksum(token)}" }
+    end
+
+    def valid_token?(token)
+      TOKEN_FORMAT.match?(token) && checksum(token[5..40]) == token[41..46]
+    end
+
+    private
+
+    def checksum(token)
+      Base64.urlsafe_encode64([Zlib.crc32(token)].pack("L"), padding: false)
     end
   end
 

--- a/app/models/file_downloaders.rb
+++ b/app/models/file_downloaders.rb
@@ -2,7 +2,7 @@
 
 module FileDownloaders
   Downloaders = StoreModel.one_of do |json|
-    const_get(json.fetch("type"))
+    const_get(json.with_indifferent_access.fetch("type"))
   rescue KeyError, NameError
     raise ArgumentError, "Missing file downloader type"
   end

--- a/app/models/file_downloaders/base_downloader.rb
+++ b/app/models/file_downloaders/base_downloader.rb
@@ -22,7 +22,7 @@ module FileDownloaders
       self.type = self.class.name.demodulize
     end
 
-    def authenticate(request)
+    def authenticate(connection)
       raise NotImplementedError, "Subclasses of BaseDownloader need to implement #authenticate"
     end
 

--- a/app/models/file_downloaders/no_authentication.rb
+++ b/app/models/file_downloaders/no_authentication.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module FileDownloaders
+  class NoAuthentication < BaseDownloader
+    def authenticate(connection)
+      # no-op
+    end
+  end
+end

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -70,12 +70,6 @@ class LocalAuthority < ApplicationRecord
     end
   end
 
-  def default_api_user
-    api_users.find_by(name: subdomain)
-  end
-
-  delegate :token, to: :default_api_user, allow_nil: true, prefix: :default_api
-
   private
 
   def council_code_exists

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,22 @@ en:
               blank: Removed reason for the permitted development rights can't be blank
             summary:
               blank: Immunity from enforcement summary can't be blank
+        file_downloaders/basic_authentication:
+          attributes:
+            password:
+              blank: Please enter the password
+            username:
+              blank: Please enter the username
+        file_downloaders/bearer_authentication:
+          attributes:
+            token:
+              blank: Please enter the bearer token value
+        file_downloaders/header_authentication:
+          attributes:
+            key:
+              blank: Please enter the name of the custom header
+            value:
+              blank: Please enter the value for the custom header
         recommendation_form:
           attributes:
             decision:
@@ -119,6 +135,13 @@ en:
   activerecord:
     errors:
       models:
+        api_user:
+          attributes:
+            file_downloader:
+              invalid: Document download authentication has problems
+            name:
+              blank: Please enter a name for this API token
+              taken: That name is already in use by an active token
         application_type:
           attributes:
             category:

--- a/db/migrate/20241021113049_add_last_used_at_to_api_users.rb
+++ b/db/migrate/20241021113049_add_last_used_at_to_api_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLastUsedAtToApiUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :api_users, :last_used_at, :datetime
+  end
+end

--- a/db/migrate/20241022084734_alter_api_user_unique_name_index.rb
+++ b/db/migrate/20241022084734_alter_api_user_unique_name_index.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AlterApiUserUniqueNameIndex < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        remove_index :api_users, [:local_authority_id, :name], unique: true, algorithm: :concurrently
+        add_index :api_users, [:local_authority_id, :name], unique: true, where: "revoked_at IS NULL", algorithm: :concurrently
+      end
+
+      dir.down do
+        remove_index :api_users, [:local_authority_id, :name], unique: true, where: "revoked_at IS NULL", algorithm: :concurrently
+        add_index :api_users, [:local_authority_id, :name], unique: true, algorithm: :concurrently
+      end
+    end
+  end
+end

--- a/db/migrate/20241023045445_add_default_to_api_user_file_downloader.rb
+++ b/db/migrate/20241023045445_add_default_to_api_user_file_downloader.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddDefaultToApiUserFileDownloader < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default(:api_users, :file_downloader, from: nil, to: {type: "NoAuthentication"})
+
+    up_only do
+      safety_assured do
+        execute <<~SQL
+          UPDATE api_users
+          SET file_downloader = '{"type": "NoAuthentication"}'
+          WHERE file_downloader IS NULL
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_21_113049) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_23_045445) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -50,11 +50,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_21_113049) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "local_authority_id"
-    t.jsonb "file_downloader"
+    t.jsonb "file_downloader", default: {"type"=>"NoAuthentication"}
     t.string "service"
     t.datetime "revoked_at"
     t.datetime "last_used_at"
-    t.index ["local_authority_id", "name"], name: "ix_api_users_on_local_authority_id__name", unique: true
+    t.index ["local_authority_id", "name"], name: "ix_api_users_on_local_authority_id__name", unique: true, where: "(revoked_at IS NULL)"
     t.index ["local_authority_id", "token"], name: "ix_api_users_on_local_authority_id__token", unique: true
     t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"
     t.index ["revoked_at"], name: "ix_api_users_on_revoked_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_21_113049) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_18_100002) do
     t.jsonb "file_downloader"
     t.string "service"
     t.datetime "revoked_at"
+    t.datetime "last_used_at"
     t.index ["local_authority_id", "name"], name: "ix_api_users_on_local_authority_id__name", unique: true
     t.index ["local_authority_id", "token"], name: "ix_api_users_on_local_authority_id__token", unique: true
     t.index ["local_authority_id"], name: "ix_api_users_on_local_authority_id"

--- a/engines/bops_admin/app/controllers/bops_admin/tokens_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/tokens_controller.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  class TokensController < ApplicationController
+    before_action :set_tokens, only: %i[index]
+    before_action :build_token, only: %i[new create]
+    before_action :set_token, only: %i[edit update destroy]
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      respond_to do |format|
+        if @token.save
+          format.html { render :show }
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @token.update(token_params)
+          format.html do
+            redirect_to tokens_url, notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        format.html do
+          if @token.revoke!
+            redirect_to tokens_url, notice: t(".success")
+          else
+            redirect_to tokens_url, notice: t(".failure")
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_tokens
+      @tokens = current_local_authority.api_users.by_name
+    end
+
+    def build_token
+      @token = current_local_authority.api_users.new(token_params)
+    end
+
+    def set_token
+      @token = current_local_authority.api_users.find(params[:id])
+    end
+
+    def token_params
+      params.fetch(:token, {}).permit(*token_attributes, file_downloader_attributes:)
+    end
+
+    def token_attributes
+      %i[name service]
+    end
+
+    def file_downloader_attributes
+      %i[type username password token key value]
+    end
+  end
+end

--- a/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
@@ -23,6 +23,8 @@ module BopsAdmin
       case controller_name
       when "dashboard"
         "dashboard"
+      when "tokens"
+        "tokens"
       when "users"
         "users"
       when "consultees"
@@ -45,6 +47,7 @@ module BopsAdmin
         {link: {text: "Informatives", href: informatives_path}, current: active_page_key?("informatives")},
         {link: {text: "Policy", href: policy_root_path}, current: active_page_key?("policy")},
         {link: {text: "Users", href: users_path}, current: active_page_key?("users")},
+        {link: {text: "API tokens", href: tokens_path}, current: active_page_key?("tokens")},
         {link: {text: "Profile", href: profile_path}, current: active_page_key?("profile")}
       ]
     end

--- a/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
@@ -17,15 +17,6 @@
 
     <div class="govuk-form-group govuk-!-margin-top-5">
       <ol class="govuk-list">
-        <% if current_local_authority.default_api_token.present? %>
-          <li>
-            <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5"><%= t(".api_key") %></h2>
-            <div class="govuk-hint govuk-!-margin-bottom-2"><%= t(".api_key_hint_html", swagger_link: govuk_link_to("swagger", bops_api.v2_docs_path, new_tab: true)) %></div>
-            <p class="govuk-body govuk-!-margin-0">
-              <%= current_local_authority.default_api_token %>
-            </p>
-          </li>
-        <% end %>
         <li>
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-5"><%= t(".signatory_name") %></h2>
           <div class="govuk-hint govuk-!-margin-bottom-2"><%= t(".signatory_name_hint") %></div>

--- a/engines/bops_admin/app/views/bops_admin/tokens/_file_downloader.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/_file_downloader.html.erb
@@ -1,0 +1,20 @@
+<% if file_downloader.errors.any? %>
+  <a name="token-file-downloader-field-error"></a>
+<% end %>
+
+<%= form.fields :file_downloader do |fields| %>
+  <%= fields.govuk_radio_buttons_fieldset(:type, legend: {size: "m", text: t(".legend")}, hint: {text: t(".hint")}) do %>
+    <%= fields.govuk_radio_button :type, "NoAuthentication", label: {text: t(".labels.no_authentication")} %>
+    <%= fields.govuk_radio_button :type, "BasicAuthentication", label: {text: t(".labels.basic_authentication")} do %>
+      <%= fields.govuk_text_field :username, label: {text: t(".labels.username")} %>
+      <%= fields.govuk_text_field :password, label: {text: t(".labels.password")} %>
+    <% end %>
+    <%= fields.govuk_radio_button :type, "BearerAuthentication", label: {text: t(".labels.bearer_authentication")} do %>
+      <%= fields.govuk_text_field :token, label: {text: t(".labels.token")} %>
+    <% end %>
+    <%= fields.govuk_radio_button :type, "HeaderAuthentication", label: {text: t(".labels.header_authentication")} do %>
+      <%= fields.govuk_text_field :key, label: {text: t(".labels.key")} %>
+      <%= fields.govuk_text_field :value, label: {text: t(".labels.value")} %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/tokens/_table.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/_table.html.erb
@@ -1,0 +1,58 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Service</th>
+      <th scope="col" class="govuk-table__header">Last used at</th>
+      <% if revoked %>
+        <th scope="col" class="govuk-table__header">
+          Revoked at
+        </th>
+      <% else %>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">
+          &nbsp;
+        </th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <% if tokens.empty? %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell" colspan="4">
+          <% if revoked %>
+            <%= t(".no_revoked_tokens") %>
+          <% else %>
+            <%= t(".no_active_tokens") %>
+          <% end %>
+        </td>
+      </tr>
+    <% else %>
+      <% tokens.each do |token| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <%= token.name %>
+          </td>
+          <td class="govuk-table__cell">
+            <%= token.service %>
+          </td>
+          <td class="govuk-table__cell">
+            <% if token.last_used_at? %>
+              <%= token.last_used_at.to_fs(:rfc822) %>
+            <% else %>
+              &ndash;
+            <% end %>
+          </td>
+          <% if revoked %>
+            <td class="govuk-table__cell">
+              <%= token.revoked_at.to_fs(:rfc822) %>
+            </td>
+          <% else %>
+            <td class="govuk-table__cell govuk-table__cell--numeric">
+              <%= govuk_link_to t(".edit"), edit_token_path(token) %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>

--- a/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title do %>
+  <%= t(".edit_token") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "API tokens", tokens_path %>
+
+<% content_for :title, t(".edit_token") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      <%= t(".edit_token") %>
+    </h1>
+
+    <%= form_with model: @token, scope: :token, url: token_path(@token) do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_fieldset(legend: {text: nil}) do %>
+        <%= form.govuk_text_field :name, hint: {text: t(".hints.name")} %>
+        <%= form.govuk_text_field :service, hint: {text: t(".hints.service")} %>
+      <% end %>
+
+      <%= render "file_downloader", form: form, file_downloader: @token.file_downloader %>
+
+      <%= form.govuk_submit(t(".submit")) do %>
+        <%= govuk_button_link_to t(".revoke"), token_path(@token), warning: true, method: :delete, data: {confirm: t(".confirm")} %>
+        <%= govuk_button_link_to t("back"), tokens_path, secondary: true %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/tokens/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/index.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title do %>
+  <%= t(".tokens") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".tokens") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">
+      <%= t(".tokens") %>
+    </h1>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <ul class="govuk-tabs__list">
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+          <a class="govuk-tabs__tab" href="#active">
+            <%= t(".active") %>
+          </a>
+        </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#revoked">
+            <%= t(".revoked") %>
+          </a>
+        </li>
+      </ul>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="active">
+        <%= render("table", tokens: @tokens.select(&:active?), revoked: false) %>
+      </div>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="revoked">
+        <%= render("table", tokens: @tokens.select(&:revoked?), revoked: true) %>
+      </div>
+    </div>
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to t(".add_token"), new_token_path %>
+      <%= govuk_button_link_to t("back"), tokens_path, secondary: true %>
+    </div>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/tokens/new.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/new.html.erb
@@ -1,0 +1,30 @@
+<% content_for :page_title do %>
+  <%= t(".add_token") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "API tokens", tokens_path %>
+
+<% content_for :title, t(".add_token") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">
+      <%= t(".add_token") %>
+    </h1>
+
+    <%= form_with model: @token, scope: :token, url: tokens_path do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_fieldset(legend: {text: nil}) do %>
+        <%= form.govuk_text_field :name, hint: {text: t(".hints.name")} %>
+        <%= form.govuk_text_field :service, hint: {text: t(".hints.service")} %>
+      <% end %>
+
+      <%= render "file_downloader", form: form, file_downloader: @token.file_downloader %>
+
+      <%= form.govuk_submit(t(".submit")) do %>
+        <%= govuk_button_link_to t("back"), tokens_path, secondary: true %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/tokens/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/show.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title do %>
+  <%= t(".add_token") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "API tokens", tokens_path %>
+
+<% content_for :title, t(".add_token") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= govuk_panel(title_text: t(".new_token_title")) do %>
+      <%= t(".new_token_body_html", token: @token.value) %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= t(".new_token_warning") %>
+    </p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to t(".back_to_token_list"), tokens_path %>
+    </p>
+  </div>
+</div>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -260,6 +260,60 @@ en:
         telephone_number_hint: This is the number that applicants or neighbours can call if they need information in alternative formats.
       update:
         profile_successfully_updated: Council information successfully updated
+    tokens:
+      create:
+        success: API token successfully created
+      destroy:
+        failure: Unable to revoke API token - please contact support
+        success: API token successfully revoked
+      edit:
+        confirm: Are you sure you want to revoke this API token?
+        edit_token: Edit API token
+        hints:
+          name: A unique name for this token, typically the name of an individual or organisation
+          service: A description for what is using this token - if it's for submission of planning applications it should be the name of the service, e.g. PlanX
+        revoke: Revoke
+        submit: Save
+      file_downloader:
+        hint: If this token is for a planning application submission service such as Planning Portal or PlanX please specify the type of authentication it uses to download documents associated with the planning application
+        labels:
+          basic_authentication: Username and password
+          bearer_authentication: Bearer token
+          header_authentication: Custom header
+          key: Header name
+          no_authentication: None
+          password: Password
+          token: Token value
+          username: Username
+          value: Header value
+        legend: Authentication for downloading documents
+      index:
+        active: Active
+        add_token: Add API token
+        revoked: Revoked
+        tokens: API tokens
+      new:
+        add_token: Add API token
+        hints:
+          name: A unique name for this token, typically the name of an individual or organisation
+          service: A description for what is using this token - if it's for submission of planning applications it should be the name of the service, e.g. PlanX
+        submit: Save
+      show:
+        add_token: Add API token
+        back_to_token_list: Return to the list of API tokens
+        new_token_body_html: |
+          <small>
+            Your new API token secret is<br>
+            <strong>%{token}</strong>
+          </small>
+        new_token_title: API token generated
+        new_token_warning: The secret will only be visible on this page so please copy it before navigating away.
+      table:
+        edit: Edit
+        no_active_tokens: There are no active API tokens
+        no_revoked_tokens: There are no revoked API tokens
+      update:
+        success: API token successfully updated
     users:
       create:
         user_successfully_created: User successfully created

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -227,8 +227,6 @@ en:
         telephone_number: Contact telephone (optional)
         telephone_number_hint: This is the number that applicants or neighbours can call if they need information in alternative formats.
       show:
-        api_key: API key
-        api_key_hint_html: This is the api key which can be used on %{swagger_link} to generate more test planning application data.
         document_checklist: Document checklist
         document_checklist_hint: Link to a document checklist that applicants use when submitting applications
         email_address: Email

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -20,6 +20,8 @@ BopsAdmin::Engine.routes.draw do
     end
   end
 
+  resources :tokens, except: %i[show]
+
   resources :users, except: %i[show destroy] do
     get :resend_invite, on: :member
   end

--- a/engines/bops_admin/spec/system/profile_spec.rb
+++ b/engines/bops_admin/spec/system/profile_spec.rb
@@ -36,9 +36,6 @@ RSpec.describe "Profile", type: :system do
   it "shows the correct hint text for the council's profile" do
     visit "/admin/profile"
 
-    expect(page).to have_content("This is the api key which can be used on swagger (opens in new tab) to generate more test planning application data.")
-    expect(page).to have_link("swagger", href: "/api/v2/docs")
-
     expect(page).to have_content("the person whose signature")
     expect(page).to have_content("job title of the person whose signature")
     expect(page).to have_content("the contact address that will appear on decision notices")

--- a/engines/bops_admin/spec/system/tokens_spec.rb
+++ b/engines/bops_admin/spec/system/tokens_spec.rb
@@ -1,0 +1,273 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "API Tokens", :capybara do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :administrator, local_authority:) }
+  let(:last_token) { ApiUser.last }
+
+  around do |example|
+    travel_to("2024-10-22T10:30:00Z") { example.run }
+  end
+
+  before do
+    sign_in(user)
+
+    create(:api_user, name: "Active Token", service: "PlanX", last_used_at: 1.week.ago)
+    create(:api_user, name: "Revoked Token", service: "PlanX", last_used_at: 2.weeks.ago, revoked_at: 1.week.ago)
+  end
+
+  it "shows a list of active tokens" do
+    visit "/admin/tokens#active"
+
+    expect(page).to have_selector("h1", text: "API tokens")
+    expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+    within "#active table" do
+      within "thead tr:nth-child(1)" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Name")
+        expect(page).to have_selector("th:nth-child(2)", text: "Service")
+        expect(page).to have_selector("th:nth-child(3)", text: "Last used at")
+      end
+
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "Active Token")
+        expect(page).to have_selector("td:nth-child(2)", text: "PlanX")
+        expect(page).to have_selector("td:nth-child(3)", text: "Tue, 15 Oct 2024 11:30:00 +0100")
+      end
+    end
+  end
+
+  it "shows a list of revoked tokens" do
+    visit "/admin/tokens#revoked"
+
+    expect(page).to have_selector("h1", text: "API tokens")
+    expect(page).to have_selector("a[aria-selected=true]", text: "Revoked")
+
+    within "#revoked table" do
+      within "thead tr:nth-child(1)" do
+        expect(page).to have_selector("th:nth-child(1)", text: "Name")
+        expect(page).to have_selector("th:nth-child(2)", text: "Service")
+        expect(page).to have_selector("th:nth-child(3)", text: "Last used at")
+        expect(page).to have_selector("th:nth-child(4)", text: "Revoked at")
+      end
+
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "Revoked Token")
+        expect(page).to have_selector("td:nth-child(2)", text: "PlanX")
+        expect(page).to have_selector("td:nth-child(3)", text: "Tue, 08 Oct 2024 11:30:00 +0100")
+        expect(page).to have_selector("td:nth-child(4)", text: "Tue, 15 Oct 2024 11:30:00 +0100")
+      end
+    end
+  end
+
+  it "allows a token to be revoked" do
+    visit "/admin/tokens"
+
+    expect(page).to have_selector("h1", text: "API tokens")
+    expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+    within "#active table" do
+      within "tbody tr:nth-child(1)" do
+        click_link "Edit"
+      end
+    end
+
+    expect(page).to have_selector("h1", text: "Edit API token")
+
+    accept_confirm(text: "Are you sure you want to revoke this API token?") do
+      click_link("Revoke")
+    end
+
+    expect(page).to have_selector("[role=alert] p", text: "API token successfully revoked")
+
+    within "#active table" do
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "There are no active API tokens")
+      end
+    end
+
+    within "#revoked table" do
+      within "tbody tr:nth-child(1)" do
+        expect(page).to have_selector("td:nth-child(1)", text: "Active Token")
+        expect(page).to have_selector("td:nth-child(4)", text: "Tue, 22 Oct 2024 11:30:00 +0100")
+      end
+    end
+  end
+
+  context "with no download authentication" do
+    it "allows a token to be created" do
+      visit "/admin/tokens"
+
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      click_link "Add API token"
+      expect(page).to have_selector("h1", text: "Add API token")
+
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Please enter a name for this API token")
+
+      fill_in "Name", with: "Active Token"
+
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "That name is already in use by an active token")
+
+      fill_in "Name", with: "New Token"
+      fill_in "Service", with: "Service Name"
+
+      click_button "Save"
+      expect(page).to have_selector("h1", text: "API token generated")
+      expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
+
+      click_link "Return to the list of API tokens"
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      within "#active table" do
+        within "tbody tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "New Token")
+          expect(page).to have_selector("td:nth-child(2)", text: "Service Name")
+          expect(page).to have_selector("td:nth-child(3)", text: "–")
+        end
+      end
+    end
+  end
+
+  context "with basic authentication" do
+    it "allows a token to be created" do
+      visit "/admin/tokens"
+
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      click_link "Add API token"
+      expect(page).to have_selector("h1", text: "Add API token")
+
+      fill_in "Name", with: "New Token"
+      fill_in "Service", with: "Service Name"
+
+      within_fieldset "Authentication for downloading documents" do
+        choose "Username and password"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Document download authentication has problems")
+
+      within_fieldset "Authentication for downloading documents" do
+        expect(page).to have_selector("p.govuk-error-message", text: "Please enter the username")
+        expect(page).to have_selector("p.govuk-error-message", text: "Please enter the password")
+
+        fill_in "Username", with: "Username"
+        fill_in "Password", with: "Password"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("h1", text: "API token generated")
+      expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
+
+      click_link "Return to the list of API tokens"
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      within "#active table" do
+        within "tbody tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "New Token")
+          expect(page).to have_selector("td:nth-child(2)", text: "Service Name")
+          expect(page).to have_selector("td:nth-child(3)", text: "–")
+        end
+      end
+    end
+  end
+
+  context "with bearer authentication" do
+    it "allows a token to be created" do
+      visit "/admin/tokens"
+
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      click_link "Add API token"
+      expect(page).to have_selector("h1", text: "Add API token")
+
+      fill_in "Name", with: "New Token"
+      fill_in "Service", with: "Service Name"
+
+      within_fieldset "Authentication for downloading documents" do
+        choose "Bearer token"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Document download authentication has problems")
+
+      within_fieldset "Authentication for downloading documents" do
+        expect(page).to have_selector("p.govuk-error-message", text: "Please enter the bearer token value")
+
+        fill_in "Token value", with: "thisisasecret"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("h1", text: "API token generated")
+      expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
+
+      click_link "Return to the list of API tokens"
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      within "#active table" do
+        within "tbody tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "New Token")
+          expect(page).to have_selector("td:nth-child(2)", text: "Service Name")
+          expect(page).to have_selector("td:nth-child(3)", text: "–")
+        end
+      end
+    end
+  end
+
+  context "with header authentication" do
+    it "allows a token to be created" do
+      visit "/admin/tokens"
+
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      click_link "Add API token"
+      expect(page).to have_selector("h1", text: "Add API token")
+
+      fill_in "Name", with: "New Token"
+      fill_in "Service", with: "Service Name"
+
+      within_fieldset "Authentication for downloading documents" do
+        choose "Custom header"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Document download authentication has problems")
+
+      within_fieldset "Authentication for downloading documents" do
+        expect(page).to have_selector("p.govuk-error-message", text: "Please enter the name of the custom header")
+        expect(page).to have_selector("p.govuk-error-message", text: "Please enter the value for the custom header")
+
+        fill_in "Header name", with: "api-key"
+        fill_in "Header value", with: "thisisasecret"
+      end
+
+      click_button "Save"
+      expect(page).to have_selector("h1", text: "API token generated")
+      expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
+
+      click_link "Return to the list of API tokens"
+      expect(page).to have_selector("h1", text: "API tokens")
+      expect(page).to have_selector("a[aria-selected=true]", text: "Active")
+
+      within "#active table" do
+        within "tbody tr:nth-child(2)" do
+          expect(page).to have_selector("td:nth-child(1)", text: "New Token")
+          expect(page).to have_selector("td:nth-child(2)", text: "Service Name")
+          expect(page).to have_selector("td:nth-child(3)", text: "–")
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BopsApi::V2::PlanningApplicationsController, type: :controller do
   routes { BopsApi::Engine.routes }
 
   before do
-    token = "pUYptBJDVFzssbRPkCPjaZEx"
+    token = "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ"
     create(:api_user, token:, local_authority: southwark)
 
     request.set_header("HTTP_HOST", "southwark.bops.test")

--- a/engines/bops_api/spec/requests/v2/authentication_spec.rb
+++ b/engines/bops_api/spec/requests/v2/authentication_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rails_helper"
+require "swagger_helper"
 
 RSpec.describe "ApiUser" do
   let(:local_authority) { create(:local_authority, :default) }
@@ -14,7 +14,7 @@ RSpec.describe "ApiUser" do
   end
 
   context "when the api key is revoked" do
-    let(:revoked_at) { Time.zone.now }
+    let(:revoked_at) { 1.hour.ago }
 
     it "does not permit access" do
       get "/api/v2/ping", headers:, as: :json

--- a/engines/bops_api/spec/requests/v2/ping_spec.rb
+++ b/engines/bops_api/spec/requests/v2/ping_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe "BOPS API" do
   let(:southwark) { create(:local_authority, :southwark) }
 
   before do
-    create(:api_user, :planx, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
-    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx", local_authority: southwark)
-    create(:api_user, :swagger, token: "tBJDVFzPjabRPkCUYpZExpss", local_authority:)
+    create(:api_user, :planx, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
+    create(:api_user, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
+    create(:api_user, :swagger, token: "bops_CfmN6JWHTvQCzNcZGnq5kAniVSZ1MLJha68cCx_QPA", local_authority:)
   end
 
   path "/api/v2/ping" do
@@ -26,7 +26,7 @@ RSpec.describe "BOPS API" do
           timestamp: "2023-11-22T20:00:00.000Z"
         }
 
-        let(:Authorization) { "Bearer bRPkCPjaZExpUYptBJDVFzss" }
+        let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }
 
         run_test!
       end
@@ -39,7 +39,7 @@ RSpec.describe "BOPS API" do
           timestamp: "2023-11-22T20:00:00.000Z"
         }
 
-        let(:Authorization) { "Bearer tBJDVFzPjabRPkCUYpZExpss" }
+        let(:Authorization) { "Bearer bops_CfmN6JWHTvQCzNcZGnq5kAniVSZ1MLJha68cCx_QPA" }
 
         run_test!
       end
@@ -69,7 +69,7 @@ RSpec.describe "BOPS API" do
           }
         }
 
-        let(:Authorization) { "Bearer pUYptBJDVFzssbRPkCPjaZEx" }
+        let(:Authorization) { "Bearer bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ" }
 
         run_test!
       end

--- a/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe "BOPS API" do
   end
 
   before do
-    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
-    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx", local_authority: southwark)
+    create(:api_user, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
+    create(:api_user, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
     create(:application_type, :ldc_existing)
 
     Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
-  let(:Authorization) { "Bearer bRPkCPjaZExpUYptBJDVFzss" }
+  let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }
   let(:page) { 1 }
   let(:maxresults) { 5 }
 

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "BOPS API" do
   let(:application_type) { create(:application_type) }
 
   before do
-    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
-    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx", local_authority: southwark)
+    create(:api_user, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
+    create(:api_user, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
     create(:application_type, :ldc_existing)
     create(:application_type, :ldc_proposed)
     create(:application_type, :listed)
@@ -19,7 +19,7 @@ RSpec.describe "BOPS API" do
     Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
-  let(:Authorization) { "Bearer bRPkCPjaZExpUYptBJDVFzss" }
+  let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }
   let(:planning_application) { example_fixture("validPlanningPermission.json") }
   let(:send_email) { "true" }
 
@@ -152,7 +152,7 @@ RSpec.describe "BOPS API" do
           }
         }
 
-        let(:Authorization) { "Bearer pUYptBJDVFzssbRPkCPjaZEx" }
+        let(:Authorization) { "Bearer bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ" }
 
         run_test!
       end

--- a/engines/bops_api/spec/requests/v2/validation_requests_spec.rb
+++ b/engines/bops_api/spec/requests/v2/validation_requests_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe "BOPS API" do
   end
 
   before do
-    create(:api_user, token: "bRPkCPjaZExpUYptBJDVFzss", local_authority:)
-    create(:api_user, name: "other", token: "pUYptBJDVFzssbRPkCPjaZEx", local_authority: southwark)
+    create(:api_user, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
+    create(:api_user, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
     create(:application_type, :ldc_existing)
 
     Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
-  let(:Authorization) { "Bearer bRPkCPjaZExpUYptBJDVFzss" }
+  let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }
   let(:page) { 1 }
   let(:maxresults) { 5 }
 

--- a/engines/bops_api/spec/services/application/documents_service_spec.rb
+++ b/engines/bops_api/spec/services/application/documents_service_spec.rb
@@ -14,16 +14,6 @@ RSpec.describe BopsApi::Application::DocumentsService, type: :job do
   let(:description) { "Proposed site plan" }
   let(:files) { [{"name" => url, "type" => ["something"]}] }
 
-  context "when the file downloader isn't configured" do
-    let(:user) { create(:api_user, file_downloader: nil) }
-
-    it "raises an error" do
-      expect {
-        described_class.new(planning_application:, user:, files:).call!
-      }.to raise_error(BopsApi::Errors::FileDownloaderNotConfiguredError)
-    end
-  end
-
   context "when the tags are empty" do
     before do
       stub_request(:get, url).to_return(status: 200, body: "")

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ApiUser do
       api_user = build(:api_user, name: "test")
       api_user.save
 
-      expect(api_user.errors.messages[:name][0]).to eq("has already been taken")
+      expect(api_user.errors[:name]).to include("That name is already in use by an active token")
     end
 
     it "must have a token in the correct format" do
@@ -90,11 +90,11 @@ RSpec.describe ApiUser do
         end
 
         it "validates the presence of username" do
-          expect(errors[:username]).to include("can't be blank")
+          expect(errors[:username]).to include("Please enter the username")
         end
 
         it "validates the presence of password" do
-          expect(errors[:password]).to include("can't be blank")
+          expect(errors[:password]).to include("Please enter the password")
         end
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe ApiUser do
         end
 
         it "validates the presence of token" do
-          expect(errors[:token]).to include("can't be blank")
+          expect(errors[:token]).to include("Please enter the bearer token value")
         end
       end
     end
@@ -130,11 +130,11 @@ RSpec.describe ApiUser do
         end
 
         it "validates the presence of the header key" do
-          expect(errors[:key]).to include("can't be blank")
+          expect(errors[:key]).to include("Please enter the name of the custom header")
         end
 
         it "validates the presence of the header value" do
-          expect(errors[:value]).to include("can't be blank")
+          expect(errors[:value]).to include("Please enter the value for the custom header")
         end
       end
     end

--- a/spec/models/api_user_spec.rb
+++ b/spec/models/api_user_spec.rb
@@ -140,6 +140,36 @@ RSpec.describe ApiUser do
     end
   end
 
+  describe ".authenticate" do
+    let(:token) { "bops_xjqhZoM8AmM2ptLkNdGA4uY5Y8j1qoq1MHHwVTt-Mg" }
+
+    around do |example|
+      freeze_time { example.run }
+    end
+
+    context "when an API user with the token exists" do
+      let!(:api_user) { create(:api_user, token:) }
+
+      it "returns the API user" do
+        expect(described_class.authenticate(token)).to eq(api_user)
+      end
+
+      it "updates the last_used_at timestamp" do
+        expect {
+          described_class.authenticate(token)
+        }.to change {
+          api_user.reload.last_used_at
+        }.from(nil).to(Time.current)
+      end
+    end
+
+    context "when an API user with the token doesn't exist" do
+      it "returns nil" do
+        expect(described_class.authenticate(token)).to be_nil
+      end
+    end
+  end
+
   describe ".generate_unique_secure_token" do
     let(:pattern) { described_class::TOKEN_FORMAT }
     let(:token) { described_class.generate_unique_secure_token }


### PR DESCRIPTION
### Description of change

As more LPAs sign up to BOPS manually concierging API tokens becomes more of a roadblock and especially so when dealing with revocations. To address this add self-service generation and revocation of tokens to the LPA admin portal.

### Story Link

https://trello.com/c/zNruHDTe
https://trello.com/c/10i6BC3A

### Screenshots

![southwark bops localhost_3000_admin_tokens (1)](https://github.com/user-attachments/assets/b5d1c33b-4c7f-466d-949b-6ee965dea324)

![southwark bops localhost_3000_admin_tokens (2)](https://github.com/user-attachments/assets/e88706c4-1990-456a-8fb0-e51df0315069)

![southwark bops localhost_3000_admin_tokens_new](https://github.com/user-attachments/assets/6e0074e2-3e76-4c20-a6dd-70cfface606d)

![southwark bops localhost_3000_admin_tokens](https://github.com/user-attachments/assets/980f704a-890b-49a0-b302-59f1bf79f672)

### Known issues

We should hash the token in the database to protect against mass extraction like happened with Heroku and their cache of GitHub oauth tokens. However it seemed like gold-plating to do it in this PR.
