### PR TITLE
Tidy up Notify key usage

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -114,6 +114,7 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RAILS_ENV: test
           NOTIFY_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
+          NOTIFY_LETTER_API_KEY: ${{ secrets.NOTIFY_API_KEY }}
           OTP_SECRET_ENCRYPTION_KEY: ${{ secrets.OTP_SECRET_ENCRYPTION_KEY }}
           SPEC_OPTS: '-f doc --force-color --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}" ${{ inputs.additional_spec_opts }}'
         run: |

--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -90,9 +90,7 @@ module PlanningApplications
     end
 
     def update_letter_statuses
-      notify_key = @planning_application.local_authority.notify_api_key_for_letters
-
-      NeighbourLetterStatusUpdateJob.perform_later(@consultation, notify_key)
+      NeighbourLetterStatusUpdateJob.perform_later(@consultation)
     end
 
     def ensure_public_portal_is_active

--- a/app/jobs/neighbour_letter_status_update_job.rb
+++ b/app/jobs/neighbour_letter_status_update_job.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class NeighbourLetterStatusUpdateJob < ApplicationJob
-  def perform(consultation, notify_key)
+  def perform(consultation)
     letters = consultation.neighbour_letters.includes(:neighbour).where.not(status: "received")
 
     letters.each do |letter|
-      letter.update_status(notify_key)
+      letter.update_status
     end
   end
 end

--- a/app/models/neighbour_letter.rb
+++ b/app/models/neighbour_letter.rb
@@ -22,11 +22,11 @@ class NeighbourLetter < ApplicationRecord
   scope :failed, -> { where(status: FAILURE_STATUSES) }
   scope :sent, -> { where.not(status: FAILURE_STATUSES) }
 
-  def update_status(notify_key)
+  def update_status
     return false if notify_id.blank?
 
     begin
-      response = Notifications::Client.new(notify_key).get_notification(notify_id)
+      response = Notifications::Client.new(notify_api_key).get_notification(notify_id)
     rescue Notifications::Client::RequestError
       return
     end

--- a/spec/models/neighbour_letter_spec.rb
+++ b/spec/models/neighbour_letter_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe NeighbourLetter do
     it "updates the letter's status from notify" do
       notify_request = stub_get_notify_status(notify_id: neighbour_letter.notify_id)
 
-      neighbour_letter.update_status(Rails.configuration.default_notify_api_key)
+      neighbour_letter.update_status
       expect(notify_request).to have_been_requested
 
       expect(neighbour_letter.status).to eq("received")


### PR DESCRIPTION
Avoid passing around a Notify API key that is looked up in the same model anyway