### PR TITLE
Remove discard_on ActiveJob::DeserializationError

### DIFF
--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -6,7 +6,6 @@ require "uri"
 module BopsApi
   class PlanningApplicationDependencyJob < ApplicationJob
     queue_as :submissions
-    discard_on ActiveJob::DeserializationError
 
     retry_on(StandardError, attempts: 5, wait: 5.minutes, jitter: 0) do |error|
       Appsignal.report_error(error)


### PR DESCRIPTION
### Description of change

- Some applications are getting stuck in pending due to running the submissions job before the planning application had been committed to the database
- If we get an ActiveJob::DeserializationError, we will retry on StandardError

