### PR TITLE
Don't pin to a specific postgis minor/patch version: major is enough

### DIFF
--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -1,7 +1,6 @@
 FROM postgres:14-bullseye
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.5.0+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
@@ -10,7 +9,7 @@ RUN apt-get update \
            #   fix: https://github.com/postgis/docker-postgis/issues/307
            ca-certificates \
            \
-           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
+           postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
       && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Only one postgis version ever exists in the archive at a time, so it's impossible to be using a 'wrong' version, it'll simply break when our dockerfile gets out of date.