### PR TITLE
Block is yielded with error instance as the second parameter

### DIFF
--- a/app/jobs/constraint_query_update_job.rb
+++ b/app/jobs/constraint_query_update_job.rb
@@ -5,8 +5,8 @@ require "faraday"
 class ConstraintQueryUpdateJob < ApplicationJob
   queue_as :high_priority
 
-  retry_on(Faraday::TimeoutError, attempts: 12, wait: 5.minutes, jitter: 0) do |error|
-    Appsignal.send_exception(error)
+  retry_on(Faraday::TimeoutError, attempts: 12, wait: 5.minutes, jitter: 0) do |_, error|
+    Appsignal.report_error(error)
   end
 
   def perform(planning_application:)

--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -7,11 +7,11 @@ module BopsApi
   class PlanningApplicationDependencyJob < ApplicationJob
     queue_as :submissions
 
-    retry_on(StandardError, attempts: 5, wait: 5.minutes, jitter: 0) do |error|
+    retry_on(StandardError, attempts: 5, wait: 5.minutes, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 
-    retry_on(Faraday::TimeoutError, attempts: 5, wait: 5.minutes, jitter: 0) do |error|
+    retry_on(Faraday::TimeoutError, attempts: 5, wait: 5.minutes, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 


### PR DESCRIPTION
### Description of change

https://api.rubyonrails.org/classes/ActiveJob/Exceptions/ClassMethods.html#method-i-retry_on

Block is yielded with error instance as the second parameter

