### PR TITLE
Drop API user creation from the script

### DIFF
--- a/app/services/local_authority_creation_service.rb
+++ b/app/services/local_authority_creation_service.rb
@@ -28,7 +28,6 @@ class LocalAuthorityCreationService
 
   def setup
     local_authority
-    api_user
     create_administrator_user if admin_email
   end
 
@@ -40,10 +39,6 @@ class LocalAuthorityCreationService
       council_name:,
       applicants_url:
     )
-  end
-
-  def api_user
-    @api_user ||= ApiUser.find_or_create_by!(name: subdomain, local_authority:)
   end
 
   def create_administrator_user

--- a/spec/services/local_authority_creation_service_spec.rb
+++ b/spec/services/local_authority_creation_service_spec.rb
@@ -31,12 +31,6 @@ RSpec.describe LocalAuthorityCreationService do
           .by(1)
       end
 
-      it "creates the api_user" do
-        expect { service.call }
-          .to change(ApiUser, :count)
-          .by(1)
-      end
-
       it "creates the user" do
         expect { service.call }
           .to change(User, :count)


### PR DESCRIPTION
### Description of change

Drop API user creation from the script
- We now accommodate a view where LPa can create an API user for any service they want
