### PR TITLE
Retry PlanningApplicationDependencyJob every 2 mins

### DIFF
--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -7,11 +7,11 @@ module BopsApi
   class PlanningApplicationDependencyJob < ApplicationJob
     queue_as :submissions
 
-    retry_on(StandardError, attempts: 5, wait: 5.minutes, jitter: 0) do |_, error|
+    retry_on(StandardError, attempts: 5, wait: 2.minutes, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 
-    retry_on(Faraday::TimeoutError, attempts: 5, wait: 5.minutes, jitter: 0) do |_, error|
+    retry_on(Faraday::TimeoutError, attempts: 5, wait: 2.minutes, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 


### PR DESCRIPTION
- 5 mins is on the longer side to wait for an application to appear after submission. We want this to appear timely in BOPS and 2 minutes should be enough to ensure the application has been committed.

