### PR TITLE
Configure concurrency based on RAILS_MAX_THREADS

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,9 +1,5 @@
 ---
-:concurrency: 5
-staging:
-  :concurrency: 10
-production:
-  :concurrency: 10
+:concurrency: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 :queues:
   - low_priority
   - high_priority


### PR DESCRIPTION
The database pool size is based on this so the number of Sidekiq threads should match otherwise we'll get errors when checking out a connection.
