### PR TITLE
Remove received_at method, rely on column

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -452,10 +452,6 @@ class PlanningApplication < ApplicationRecord
     documents.for_display
   end
 
-  def received_at
-    super || (Time.next_immediate_business_day(created_at) if created_at)
-  end
-
   def valid_from
     return nil unless validated?
 


### PR DESCRIPTION
Can be merged once #2021 has been deployed.

https://trello.com/c/bSuqVcIN/3284-search-api-default-sort-no-query-seems-incorrect