### PR TITLE
Don't exclude pre-review applications for reviewers

### DIFF
--- a/app/services/planning_application_search.rb
+++ b/app/services/planning_application_search.rb
@@ -5,7 +5,6 @@ class PlanningApplicationSearch
   include ActiveModel::Attributes
 
   STATUSES = %w[not_started invalidated in_assessment awaiting_determination to_be_reviewed].freeze
-  REVIEWER_STATUSES = %w[awaiting_determination to_be_reviewed].freeze
 
   APPLICATION_TYPES = ApplicationType::NAME_ORDER
 
@@ -46,11 +45,7 @@ class PlanningApplicationSearch
   end
 
   def statuses
-    if reviewer? && exclude_others?
-      REVIEWER_STATUSES
-    else
-      STATUSES
-    end
+    STATUSES
   end
 
   def application_types

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe "filtering planning applications", type: :system, capybara: true 
           expect(page).to have_content("Your live applications")
           expect(page).to have_content(other_awaiting_determination_planning_application.reference)
           expect(page).to have_content(other_to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
+          expect(page).to have_content(in_assessment_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
           expect(page).not_to have_content(other_closed_planning_application.reference)
 

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -675,19 +675,6 @@ RSpec.describe "Planning Application index page", type: :system do
       end
     end
 
-    it "Only Planning Applications that are awaiting_determination are present in this tab" do
-      find("span", text: "Filters").click
-      uncheck "To be reviewed"
-      click_button "Apply filters"
-
-      within(selected_govuk_tab) do
-        expect(page).to have_link(reviewer_planning_application_started.reference)
-        expect(page).not_to have_link(planning_application_1.reference)
-        expect(page).not_to have_link(planning_application_2.reference)
-        expect(page).not_to have_link(planning_application_completed.reference)
-      end
-    end
-
     it "Only Planning Applications that are determined are present in this tab" do
       click_link "Closed"
 


### PR DESCRIPTION
If assigned to a user it's probably for a reason. This filter makes it difficult for a reviewer to see all the cases assigned to them, as it will default to only certain states if filters aren't set. (It might work if they select every status in the filter options (untested) but if they select none it defaults.)

This brings the reviewer behaviour in line with the assessor behaviour: an assessor is always (I think) shown any application assigned to them in the 'my applications' tab.