### PR TITLE
Add task accordion for the review page

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -4,6 +4,7 @@ $govuk-page-width: 1100px;
 
 @import "govuk-frontend/dist/govuk/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
+@import "bops_core/components/task_accordion";
 @import "components/buttons";
 @import "components/documents";
 @import "components/flashes";

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -70,6 +70,12 @@ application.register("show-more-text", ShowMoreTextController)
 import SubmitFormController from "./submit_form_controller.js"
 application.register("submit-form", SubmitFormController)
 
+import TaskAccordionController from "./task_accordion_controller.js"
+application.register("task-accordion", TaskAccordionController)
+
+import TaskAccordionSectionController from "./task_accordion_section_controller.js"
+application.register("task-accordion-section", TaskAccordionSectionController)
+
 import ToggleController from "./toggle_controller.js"
 application.register("toggle", ToggleController)
 

--- a/app/javascript/controllers/task_accordion_controller.js
+++ b/app/javascript/controllers/task_accordion_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    expandAllText: { type: String, default: "Expand all" },
+    collapseAllText: { type: String, default: "Collapse all" },
+    className: {
+      type: String,
+      default: "bops-task-accordion__section--expanded",
+    },
+  }
+
+  toggleAll(event) {
+    if (this.isExpanded) {
+      this.sections.forEach((section) => {
+        section.classList.remove(this.classNameValue)
+      })
+
+      this.buttonText.textContent = this.expandAllTextValue
+    } else {
+      this.sections.forEach((section) => {
+        section.classList.add(this.classNameValue)
+      })
+
+      this.buttonText.textContent = this.collapseAllTextValue
+    }
+  }
+
+  sectionToggled(event) {
+    if (this.isExpanded) {
+      this.buttonText.textContent = this.collapseAllTextValue
+    } else {
+      this.buttonText.textContent = this.expandAllTextValue
+    }
+  }
+
+  get sections() {
+    return Array.from(
+      this.element.querySelectorAll("div.bops-task-accordion__section"),
+    )
+  }
+
+  get isExpanded() {
+    return this.sections.every((section) => {
+      return section.classList.contains(this.classNameValue)
+    })
+  }
+
+  get buttonText() {
+    return this.element.querySelector(
+      "div.bops-task-accordion-controls button span",
+    )
+  }
+}

--- a/app/javascript/controllers/task_accordion_section_controller.js
+++ b/app/javascript/controllers/task_accordion_section_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = {
+    expandText: { type: String, default: "Expand" },
+    collapseText: { type: String, default: "Collapse" },
+    className: {
+      type: String,
+      default: "bops-task-accordion__section--expanded",
+    },
+  }
+
+  toggle(event) {
+    this.element.classList.toggle(this.classNameValue)
+
+    if (this.isExpanded) {
+      this.buttonText.textContent = this.collapseTextValue
+    } else {
+      this.buttonText.textContent = this.expandTextValue
+    }
+
+    this.dispatch("toggled")
+  }
+
+  get isExpanded() {
+    return this.element.classList.contains(this.classNameValue)
+  }
+
+  get buttonText() {
+    return this.element.querySelector("button span")
+  }
+}

--- a/engines/bops_core/app/assets/stylesheets/bops_core/components/_task_accordion.scss
+++ b/engines/bops_core/app/assets/stylesheets/bops_core/components/_task_accordion.scss
@@ -1,0 +1,192 @@
+.bops-task-accordion {
+  @include govuk-responsive-margin(6, "bottom");
+
+  &-header {
+    display: flex;
+    align-items: center;
+  }
+
+  &-heading {
+    @include govuk-font($size: 24, $weight: bold);
+
+    flex-grow: 1;
+    margin: 0;
+  }
+
+  &-controls {
+    flex-grow: 0;
+    margin-left: govuk-spacing(3);
+
+    button {
+      @include govuk-font($size: 19);
+
+      border-width: 0;
+      margin: 0;
+      padding: 0;
+
+      color: $govuk-link-colour;
+      background: none;
+
+      cursor: pointer;
+      -webkit-appearance: none;
+
+      // Remove default button focus outline in Firefox
+      &::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+      }
+
+      &:hover {
+        text-decoration: underline;
+      }
+
+      &:focus {
+        @include govuk-focused-text;
+      }
+    }
+  }
+}
+
+.bops-task-accordion__section {
+  border: 1px solid $govuk-border-colour;
+  padding: govuk-spacing(3);
+  margin-top: govuk-spacing(3);
+
+  &-content {
+    display: none;
+    margin-top: govuk-spacing(3);
+  }
+
+  &-header {
+    display: flex;
+    align-items: center;
+    margin: 0;
+  }
+
+  &-heading {
+    @include govuk-font($size: 19, $weight: bold);
+
+    flex-grow: 1;
+    margin: 0;
+  }
+
+  &-status {
+    flex-grow: 0;
+  }
+
+  &-controls {
+    flex-grow: 0;
+    margin-left: govuk-spacing(3);
+
+    button {
+      @include govuk-font($size: 19);
+
+      box-sizing: border-box;
+      display: block;
+
+      border-width: 0;
+      margin: 0;
+      padding: 0;
+
+      position: relative;
+
+      // Set size using rems to make the icon scale with text if user resizes text in their browser
+      width: govuk-px-to-rem(20px);
+      height: govuk-px-to-rem(20px);
+
+      color: $govuk-text-colour;
+      background: none;
+
+      cursor: pointer;
+      -webkit-appearance: none;
+
+      // Remove default button focus outline in Firefox
+      &::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+      }
+
+      &:before {
+        content: "";
+        box-sizing: border-box;
+        display: block;
+        border-top: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        border-bottom: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        position: absolute;
+        width: govuk-px-to-rem(16px);
+        top: govuk-px-to-rem(8px);
+        left: govuk-px-to-rem(2px);
+      }
+
+      &:after {
+        content: "";
+        box-sizing: border-box;
+        display: block;
+        border-top: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        border-bottom: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        position: absolute;
+        width: govuk-px-to-rem(16px);
+        top: govuk-px-to-rem(8px);
+        left: govuk-px-to-rem(2px);
+        transform: rotate(90deg);
+      }
+
+      &:focus {
+        outline: $govuk-focus-width solid $govuk-focus-colour;
+      }
+    }
+
+    & .bops-task-accordion__section__expand-text {
+      @include govuk-visually-hidden;
+    }
+  }
+
+  &-block {
+    border: 1px solid $govuk-border-colour;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
+
+    & > :first-child {
+      margin-top: 0;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  &-divider {
+    border: none;
+    border-bottom: 1px solid $govuk-border-colour;
+    height: 0px;
+    margin-top: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
+  }
+
+  &-footer {
+    & > :first-child {
+      margin-top: 0;
+    }
+
+    & > :last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.bops-task-accordion__section--expanded {
+  .bops-task-accordion__section {
+    &-content {
+      display: block;
+    }
+
+    &-controls {
+      & > button {
+        &:after {
+          display: none;
+        }
+      }
+    }
+  }
+}

--- a/engines/bops_core/app/components/bops_core/task_accordion_component.rb
+++ b/engines/bops_core/app/components/bops_core/task_accordion_component.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+module BopsCore
+  class TaskAccordionComponent < ViewComponent::Base
+    class HeadingComponent < ViewComponent::Base
+      attr_reader :text, :level
+
+      def initialize(text:, level: 2)
+        fail(ArgumentError, "level must be 1-6") unless level.in?(1..6)
+
+        @text = text
+        @level = level
+      end
+
+      def call
+        content_tag("h#{level}", text, class: "bops-task-accordion-heading")
+      end
+    end
+
+    class ExpandAllButtonComponent < ViewComponent::Base
+      attr_reader :expanded
+
+      def initialize(expanded: false)
+        @expanded = expanded
+      end
+
+      def call
+        tag.button(**button_attributes) do
+          tag.span(button_text, **text_attributes)
+        end
+      end
+
+      private
+
+      def button_attributes
+        {
+          aria: {expanded:},
+          class: "bops-task-accordion__expand-all",
+          data: {
+            action: "click->task-accordion#toggleAll"
+          }
+        }
+      end
+
+      def button_text
+        expanded ? "Collapse all" : "Expand all"
+      end
+
+      def text_attributes
+        {class: "bops-task-accordion__expand-all-text"}
+      end
+    end
+
+    class SectionComponent < ViewComponent::Base
+      class HeadingComponent < ViewComponent::Base
+        attr_reader :text, :level
+
+        def initialize(text:, level: 3)
+          fail(ArgumentError, "level must be 1-6") unless level.in?(1..6)
+
+          @text = text
+          @level = level
+        end
+
+        def call
+          content_tag("h#{level}", text, class: "bops-task-accordion__section-heading")
+        end
+      end
+
+      class ExpandButtonComponent < ViewComponent::Base
+        attr_reader :expanded
+
+        def initialize(expanded: false)
+          @expanded = expanded
+        end
+
+        def call
+          tag.button(**button_attributes) do
+            tag.span(button_text, **text_attributes)
+          end
+        end
+
+        private
+
+        def button_attributes
+          {
+            aria: {expanded:},
+            class: "bops-task-accordion__section-expand",
+            data: {
+              action: "click->task-accordion-section#toggle"
+            }
+          }
+        end
+
+        def button_text
+          expanded ? "Collapse" : "Expand"
+        end
+
+        def text_attributes
+          {class: "bops-task-accordion__section__expand-text"}
+        end
+      end
+
+      erb_template <<~ERB
+        <%= tag.div(**html_attributes) do %>
+          <div class="bops-task-accordion__section-header">
+            <%= heading %>
+            <div class="bops-task-accordion__section-status">
+              <%= status %>
+            </div>
+            <div class="bops-task-accordion__section-controls">
+              <%= expand_button %>
+            </div>
+          </div>
+          <div class="bops-task-accordion__section-content">
+            <% blocks.each do |block| %>
+              <div class="bops-task-accordion__section-block">
+                <%= block %>
+              </div>
+            <% end %>
+            <hr class="bops-task-accordion__section-divider">
+            <div class="bops-task-accordion__section-footer">
+              <%= footer %>
+            </div>
+          </div>
+        <% end %>
+      ERB
+
+      renders_one :heading, "HeadingComponent"
+      renders_one :expand_button, "ExpandButtonComponent"
+      renders_one :status
+      renders_one :footer
+      renders_many :blocks
+
+      attr_reader :expanded
+
+      def before_render
+        with_expand_button(expanded: expanded) if expand_button.blank?
+      end
+
+      def initialize(heading: {}, expanded: false)
+        @expanded = expanded
+
+        if heading.present?
+          with_heading(**heading)
+        end
+      end
+
+      private
+
+      def html_attributes
+        {
+          class: class_names(
+            "bops-task-accordion__section",
+            "bops-task-accordion__section--expanded" => expanded
+          ),
+          data: {
+            controller: "task-accordion-section"
+          }
+        }
+      end
+    end
+
+    erb_template <<~ERB
+      <%= tag.div(**html_attributes) do %>
+        <div class="bops-task-accordion-header">
+          <%= heading %>
+          <div class="bops-task-accordion-controls">
+            <%= expand_all_button %>
+          </div>
+        </div>
+        <% sections.each do |section| %>
+          <%= section %>
+        <% end %>
+      <% end %>
+    ERB
+
+    renders_one :heading, "HeadingComponent"
+    renders_one :expand_all_button, "ExpandAllButtonComponent"
+    renders_many :sections, "SectionComponent"
+
+    attr_reader :expanded
+
+    def before_render
+      with_expand_all_button(expanded: expanded) if expand_all_button.blank?
+    end
+
+    def initialize(heading: {}, expanded: false)
+      @expanded = expanded
+
+      if heading.present?
+        with_heading(**heading)
+      end
+    end
+
+    private
+
+    def html_attributes
+      {
+        class: "bops-task-accordion",
+        data: {
+          controller: "task-accordion",
+          action: "task-accordion-section:toggled->task-accordion#sectionToggled"
+        }
+      }
+    end
+  end
+end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -6,7 +6,8 @@ module BopsCore
 
     {
       govuk_primary_navigation: "GovukComponent::PrimaryNavigationComponent",
-      govuk_secondary_navigation: "GovukComponent::SecondaryNavigationComponent"
+      govuk_secondary_navigation: "GovukComponent::SecondaryNavigationComponent",
+      bops_task_accordion: "BopsCore::TaskAccordionComponent"
     }.each do |name, klass|
       define_method(name) do |*args, **kwargs, &block|
         capture do

--- a/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
+++ b/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
+  let(:kwargs) do
+    {heading: {text: "Review assessment"}, expanded: true}
+  end
+
+  subject! do
+    render_inline(described_class.new(**kwargs)) do |accordion|
+      accordion.with_section(expanded: true) do |section|
+        section.with_heading(text: "Assessment summaries")
+
+        section.with_status do
+          helper.govuk_tag(text: "Not Started")
+        end
+
+        section.with_block do
+          <<~HTML.html_safe
+            <h3 class="govuk-heading-s">Summary of works</h3>
+            <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          HTML
+        end
+
+        section.with_block do
+          <<~HTML.html_safe
+            <h3 class="govuk-heading-s">Site description</h3>
+            <p class="govuk-body">Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
+          HTML
+        end
+
+        section.with_footer do
+          <<~HTML.html_safe
+            <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="action-agree" name="action" type="radio" value="agree">
+                <label class="govuk-label govuk-radios__label" for="action-agree">
+                  Agree
+                </label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="action-return-with-comments" name="action" type="radio" value="return-with-comments">
+                <label class="govuk-label govuk-radios__label" for="action-return-with-comments">
+                  Return with comments
+                </label>
+              </div>
+            </div>
+          HTML
+        end
+      end
+    end
+  end
+
+  it "renders a task accordion component" do
+    within "div.bops-task-accordion" do
+      expect(element["data-controller"]).to eq("task-accordion")
+      expect(element["data-action"]).to eq("task-accordion-section:toggled->task-accordion#sectionToggled")
+
+      within "div.bops-task-accordion-header" do
+        within "h2.bops-task-accordion-heading" do
+          expect(element.text).to eq("Review assessment")
+        end
+
+        within "div.bops-task-accordion-controls" do
+          expect(element).to have_button("Collapse all")
+        end
+      end
+
+      within "div.bops-task-accordion__section:nth-of-type(1)" do
+        expect(element["data-controller"]).to eq("task-accordion-section")
+
+        within "div.bops-task-accordion__section-controls" do
+          expect(element).to have_button("Collapse")
+        end
+
+        within "div.bops-task-accordion__section-block:nth-of-type(1)" do
+          expect(element).to have_selector("h3", text: "Summary of works")
+        end
+
+        within "div.bops-task-accordion__section-block:nth-of-type(2)" do
+          expect(element).to have_selector("h3", text: "Site description")
+        end
+
+        within "div.bops-task-accordion__section-footer" do
+          expect(element).to have_unchecked_field("Agree")
+          expect(element).to have_unchecked_field("Return with comments")
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/support/components.rb
+++ b/engines/bops_core/spec/support/components.rb
@@ -2,6 +2,13 @@
 
 require "view_component/test_helpers"
 
+RSpec.shared_context "helpers" do
+  let(:lookup_context) { ActionView::LookupContext.new(ActionController::Base.view_paths) }
+  let(:assigns) { {} }
+  let(:controller) { ActionController::Base.new }
+  let(:helper) { ActionView::Base.new(lookup_context, assigns, controller) }
+end
+
 RSpec.configure do |config|
   helpers = Module.new do
     def scopes
@@ -27,4 +34,5 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
   config.include helpers, type: :component
+  config.include_context "helpers", type: :component
 end


### PR DESCRIPTION
### Description of change

Example syntax:

``` erb
<%= bops_task_accordion do |accordion| %>
  <% accordion.with_heading(text: "Group heading") %>

  <%= accordion.with_section do |section| %>
    <% section.with_heading(text: "Section heading") %>

    <% section.with_status do %>
      <%= govuk_tag(text: "Not Started") %>
    <% end %>

    <% section.with_block do %>
      <!-- HTML block wrapped with grey box -->
    <% end %>

    <% section.with_block do %>
      <!-- HTML block wrapped with grey box -->
    <% end %>

    <% section.with_footer do %>
      <!-- HTML footer for review form -->
    <% end %>
  <% end %>
<% end %>
```

The `with_section` can be called multiple times for multiple tasks. Similarly, `with_block` can be called multiple times for multiple grey boxes within a section.

TODO: Support for specifying element ids and additional classes.

### Story Link

https://trello.com/c/zZjmHi7i

### Screenshots

![image](https://github.com/user-attachments/assets/882c5740-f631-424e-be61-d50960461e40)
![image](https://github.com/user-attachments/assets/3c21c8de-bada-41f2-8302-5afc5cf36843)
