### PR TITLE
Allow v0.7.1 ODP submissions with an alternative schema url

### DIFF
--- a/engines/bops_api/lib/bops_api/schemas.rb
+++ b/engines/bops_api/lib/bops_api/schemas.rb
@@ -12,6 +12,7 @@ module BopsApi
       "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.5.0/schema.json" => "odp/v0.5.0",
       "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.6.0/schema.json" => "odp/v0.6.0",
       "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.0/schema.json" => "odp/v0.7.0",
+      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schema.json" => "odp/v0.7.1",
       "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/application.json" => "odp/v0.7.1"
     }.freeze
 

--- a/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
@@ -77,11 +77,31 @@ RSpec.describe BopsApi::V2::PlanningApplicationsController, type: :controller do
         application/priorApproval/largerExtension.json
         application/priorApproval/solarPanels.json
       ].each do |example|
-        it "#{example} can be submitted successfully" do
-          post :create, as: :json, body: examples_root.join(version, example).read
+        context "with the new schema url" do
+          let(:json) { examples_root.join(version, example).read }
 
-          expect(response).to have_http_status(:ok)
-          expect(response).to render_template("bops_api/v2/planning_applications/create")
+          it "#{example} can be submitted successfully" do
+            post :create, as: :json, body: json
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template("bops_api/v2/planning_applications/create")
+          end
+        end
+
+        context "with the old schema url" do
+          let(:json) do
+            examples_root.join(version, example).read.gsub(
+              "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/application.json",
+              "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schema.json"
+            )
+          end
+
+          it "#{example} can be submitted successfully" do
+            post :create, as: :json, body: json
+
+            expect(response).to have_http_status(:ok)
+            expect(response).to render_template("bops_api/v2/planning_applications/create")
+          end
         end
       end
     end


### PR DESCRIPTION
What's being sent doesn't match what's on GitHub.

