### PR TITLE
Redesign task accordion header

### DIFF
--- a/engines/bops_core/app/assets/stylesheets/bops_core/components/_task_accordion.scss
+++ b/engines/bops_core/app/assets/stylesheets/bops_core/components/_task_accordion.scss
@@ -49,53 +49,30 @@
 
 .bops-task-accordion__section {
   border: 1px solid $govuk-border-colour;
-  padding: govuk-spacing(3);
   margin-top: govuk-spacing(3);
 
   &-content {
     display: none;
-    margin-top: govuk-spacing(3);
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(3);
   }
 
   &-header {
-    display: flex;
     align-items: center;
     margin: 0;
-  }
 
-  &-heading {
-    @include govuk-font($size: 19, $weight: bold);
-
-    flex-grow: 1;
-    margin: 0;
-  }
-
-  &-status {
-    flex-grow: 0;
-  }
-
-  &-controls {
-    flex-grow: 0;
-    margin-left: govuk-spacing(3);
-
-    button {
-      @include govuk-font($size: 19);
-
-      box-sizing: border-box;
-      display: block;
-
-      border-width: 0;
-      margin: 0;
-      padding: 0;
-
-      position: relative;
-
-      // Set size using rems to make the icon scale with text if user resizes text in their browser
-      width: govuk-px-to-rem(20px);
-      height: govuk-px-to-rem(20px);
-
-      color: $govuk-text-colour;
+    & > button {
       background: none;
+      box-sizing: border-box;
+      border: none;
+      color: $govuk-link-colour;
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding: govuk-spacing(3);
+      text-align: left;
+      width: 100%;
+      position: relative;
 
       cursor: pointer;
       -webkit-appearance: none;
@@ -106,46 +83,75 @@
         border: 0;
       }
 
+      &:hover {
+        background-color: govuk-colour("light-grey");
+        color: $govuk-text-colour;
+
+        &:before, &:after {
+          border-color: $govuk-text-colour;
+        }
+      }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
+        color: $govuk-text-colour;
+        outline: none;
+
+        &::before, &:after {
+          border-color: $govuk-text-colour;
+        }
+
+        & > .bops-task-accordion__section-heading {
+          box-shadow: 0 4px $govuk-text-colour;
+        }
+      }
+
       &:before {
         content: "";
         box-sizing: border-box;
         display: block;
-        border-top: govuk-px-to-rem(2px) solid $govuk-text-colour;
-        border-bottom: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        border-bottom: govuk-px-to-rem(3px) solid $govuk-link-colour;
         position: absolute;
-        width: govuk-px-to-rem(16px);
-        top: govuk-px-to-rem(8px);
-        left: govuk-px-to-rem(2px);
+        width: govuk-px-to-rem(14px);
+        top: govuk-px-to-rem(31px);
+        left: govuk-px-to-rem(11px);
+        transform-origin: bottom right;
+        transform: rotate(45deg);
       }
 
       &:after {
         content: "";
         box-sizing: border-box;
         display: block;
-        border-top: govuk-px-to-rem(2px) solid $govuk-text-colour;
-        border-bottom: govuk-px-to-rem(2px) solid $govuk-text-colour;
+        border-bottom: govuk-px-to-rem(3px) solid $govuk-link-colour;
         position: absolute;
-        width: govuk-px-to-rem(16px);
-        top: govuk-px-to-rem(8px);
-        left: govuk-px-to-rem(2px);
-        transform: rotate(90deg);
-      }
-
-      &:focus {
-        outline: $govuk-focus-width solid $govuk-focus-colour;
+        width: govuk-px-to-rem(14px);
+        top: govuk-px-to-rem(31px);
+        left: govuk-px-to-rem(25px);
+        transform-origin: bottom left;
+        transform: rotate(-45deg);
       }
     }
+  }
 
-    & .bops-task-accordion__section__expand-text {
-      @include govuk-visually-hidden;
-    }
+  &-heading {
+    @include govuk-font($size: 19, $weight: bold);
+
+    flex-grow: 0;
+    margin: 0;
+    margin-left: govuk-spacing(6);
+  }
+
+  &-status {
+    flex-grow: 0;
   }
 
   &-block {
     border: 1px solid $govuk-border-colour;
     background-color: govuk-colour("light-grey");
     padding: govuk-spacing(3);
-    margin-bottom: govuk-spacing(3);
+    margin: govuk-spacing(3);
+    margin-top: govuk-spacing(1);
 
     & > :first-child {
       margin-top: 0;
@@ -160,11 +166,12 @@
     border: none;
     border-bottom: 1px solid $govuk-border-colour;
     height: 0px;
-    margin-top: govuk-spacing(3);
-    margin-bottom: govuk-spacing(3);
+    margin: govuk-spacing(3);
   }
 
   &-footer {
+    margin: govuk-spacing(3);
+
     & > :first-child {
       margin-top: 0;
     }
@@ -177,16 +184,27 @@
 
 .bops-task-accordion__section--expanded {
   .bops-task-accordion__section {
-    &-content {
-      display: block;
-    }
 
-    &-controls {
+    &-header {
       & > button {
+        &:before {
+          top: govuk-px-to-rem(21px);
+          left: govuk-px-to-rem(11px);
+          transform-origin: top right;
+          transform: rotate(-45deg);
+        }
+
         &:after {
-          display: none;
+          top: govuk-px-to-rem(21px);
+          left: govuk-px-to-rem(25px);
+          transform-origin: top left;
+          transform: rotate(45deg);
         }
       }
+    }
+
+    &-content {
+      display: block;
     }
   }
 }

--- a/engines/bops_core/app/components/bops_core/task_accordion_component.rb
+++ b/engines/bops_core/app/components/bops_core/task_accordion_component.rb
@@ -271,7 +271,6 @@ module BopsCore
       with_expand_all_button(expanded: expanded) if expand_all_button.blank?
     end
 
-
     def initialize(heading: {}, expanded: false, **html_attributes)
       @expanded = expanded
 

--- a/engines/bops_core/app/components/bops_core/task_accordion_component.rb
+++ b/engines/bops_core/app/components/bops_core/task_accordion_component.rb
@@ -32,10 +32,10 @@ module BopsCore
       def initialize(text:, level: 2, **html_attributes)
         fail(ArgumentError, "level must be 1-6") unless level.in?(1..6)
 
-        super(**html_attributes)
-
         @text = text
         @level = level
+
+        super(**html_attributes)
       end
 
       def call
@@ -55,9 +55,8 @@ module BopsCore
       attr_reader :expanded
 
       def initialize(expanded: false, **html_attributes)
-        super(**html_attributes)
-
         @expanded = expanded
+        super(**html_attributes)
       end
 
       def call
@@ -97,10 +96,10 @@ module BopsCore
         def initialize(text:, level: 3, **html_attributes)
           fail(ArgumentError, "level must be 1-6") unless level.in?(1..6)
 
-          super(**html_attributes)
-
           @text = text
           @level = level
+
+          super(**html_attributes)
         end
 
         def call
@@ -114,8 +113,8 @@ module BopsCore
         attr_reader :expanded
 
         def initialize(expanded: false, **html_attributes)
-          super(**html_attributes)
           @expanded = expanded
+          super(**html_attributes)
         end
 
         def call
@@ -222,13 +221,13 @@ module BopsCore
       end
 
       def initialize(heading: {}, expanded: false, **html_attributes)
-        super(**html_attributes)
-
         @expanded = expanded
 
         if heading.present?
           with_heading(**heading)
         end
+
+        super(**html_attributes)
       end
 
       private
@@ -272,14 +271,15 @@ module BopsCore
       with_expand_all_button(expanded: expanded) if expand_all_button.blank?
     end
 
-    def initialize(heading: {}, expanded: false, **html_attributes)
-      super(**html_attributes)
 
+    def initialize(heading: {}, expanded: false, **html_attributes)
       @expanded = expanded
 
       if heading.present?
         with_heading(**heading)
       end
+
+      super(**html_attributes)
     end
 
     private

--- a/engines/bops_core/app/components/bops_core/task_accordion_component.rb
+++ b/engines/bops_core/app/components/bops_core/task_accordion_component.rb
@@ -263,7 +263,13 @@ module BopsCore
 
     renders_one :heading, "HeadingComponent"
     renders_one :expand_all_button, "ExpandAllButtonComponent"
-    renders_many :sections, "SectionComponent"
+    renders_many :sections, ->(heading: {}, expanded: false, **html_attributes, &block) do
+      if self.expanded
+        expanded = self.expanded
+      end
+
+      SectionComponent.new(heading:, expanded: self.expanded, **html_attributes, &block)
+    end
 
     attr_reader :expanded
 

--- a/engines/bops_core/app/javascript/controllers/task_accordion_controller.js
+++ b/engines/bops_core/app/javascript/controllers/task_accordion_controller.js
@@ -16,20 +16,24 @@ export default class extends Controller {
         section.classList.remove(this.classNameValue)
       })
 
+      this.button.ariaExpanded = "false"
       this.buttonText.textContent = this.expandAllTextValue
     } else {
       this.sections.forEach((section) => {
         section.classList.add(this.classNameValue)
       })
 
+      this.button.ariaExpanded = "true"
       this.buttonText.textContent = this.collapseAllTextValue
     }
   }
 
   sectionToggled(event) {
     if (this.isExpanded) {
+      this.button.ariaExpanded = "true"
       this.buttonText.textContent = this.collapseAllTextValue
     } else {
+      this.button.ariaExpanded = "false"
       this.buttonText.textContent = this.expandAllTextValue
     }
   }
@@ -46,9 +50,11 @@ export default class extends Controller {
     })
   }
 
+  get button() {
+    return this.element.querySelector("div.bops-task-accordion-controls button")
+  }
+
   get buttonText() {
-    return this.element.querySelector(
-      "div.bops-task-accordion-controls button span",
-    )
+    return this.button.querySelector("span")
   }
 }

--- a/engines/bops_core/app/javascript/controllers/task_accordion_section_controller.js
+++ b/engines/bops_core/app/javascript/controllers/task_accordion_section_controller.js
@@ -2,8 +2,6 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static values = {
-    expandText: { type: String, default: "Expand" },
-    collapseText: { type: String, default: "Collapse" },
     className: {
       type: String,
       default: "bops-task-accordion__section--expanded",
@@ -15,10 +13,8 @@ export default class extends Controller {
 
     if (this.isExpanded) {
       this.button.ariaExpanded = "true"
-      this.buttonText.textContent = this.collapseTextValue
     } else {
       this.button.ariaExpanded = "false"
-      this.buttonText.textContent = this.expandTextValue
     }
 
     this.dispatch("toggled")
@@ -30,9 +26,5 @@ export default class extends Controller {
 
   get button() {
     return this.element.querySelector("button")
-  }
-
-  get buttonText() {
-    return this.button.querySelector("span")
   }
 }

--- a/engines/bops_core/app/javascript/controllers/task_accordion_section_controller.js
+++ b/engines/bops_core/app/javascript/controllers/task_accordion_section_controller.js
@@ -14,8 +14,10 @@ export default class extends Controller {
     this.element.classList.toggle(this.classNameValue)
 
     if (this.isExpanded) {
+      this.button.ariaExpanded = "true"
       this.buttonText.textContent = this.collapseTextValue
     } else {
+      this.button.ariaExpanded = "false"
       this.buttonText.textContent = this.expandTextValue
     }
 
@@ -26,7 +28,11 @@ export default class extends Controller {
     return this.element.classList.contains(this.classNameValue)
   }
 
+  get button() {
+    return this.element.querySelector("button")
+  }
+
   get buttonText() {
-    return this.element.querySelector("button span")
+    return this.button.querySelector("span")
   }
 }

--- a/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
+++ b/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
 
   subject! do
     render_inline(described_class.new(**kwargs)) do |accordion|
-      accordion.with_section(expanded: true, id: "assessment-summaries") do |section|
+      accordion.with_section(id: "assessment-summaries") do |section|
         section.with_heading(text: "Assessment summaries")
 
         section.with_status(id: "assessment-summaries-status") do

--- a/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
+++ b/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
 
           within "button" do
             expect(element["aria-expanded"]).to eq("true")
+            expect(element["type"]).to eq("button")
           end
         end
       end
@@ -81,20 +82,18 @@ RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
         expect(element["data-controller"]).to eq("task-accordion-section")
 
         within "div.bops-task-accordion__section-header" do
-          within "h3.bops-task-accordion__section-heading" do
-            expect(element.text).to eq("Assessment summaries")
-          end
+          within "button" do
+            expect(element["aria-expanded"]).to eq("true")
+            expect(element["data-action"]).to eq("click->task-accordion-section#toggle")
+            expect(element["type"]).to eq("button")
 
-          within "div.bops-task-accordion__section-status" do
-            expect(element["id"]).to eq("assessment-summaries-status")
-            expect(element).to have_selector("strong.govuk-tag", text: "Not Started")
-          end
+            within "h3.bops-task-accordion__section-heading" do
+              expect(element.text).to eq("Assessment summaries")
+            end
 
-          within "div.bops-task-accordion__section-controls" do
-            expect(element).to have_button("Collapse")
-
-            within "button" do
-              expect(element["aria-expanded"]).to eq("true")
+            within "div.bops-task-accordion__section-status" do
+              expect(element["id"]).to eq("assessment-summaries-status")
+              expect(element).to have_selector("strong.govuk-tag", text: "Not Started")
             end
           end
         end

--- a/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
+++ b/engines/bops_core/spec/components/bops_core/task_accordion_component_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
 
         within "div.bops-task-accordion-controls" do
           expect(element).to have_button("Collapse all")
+
+          within "button" do
+            expect(element["aria-expanded"]).to eq("true")
+          end
         end
       end
 
@@ -88,6 +92,10 @@ RSpec.describe(BopsCore::TaskAccordionComponent, type: :component) do
 
           within "div.bops-task-accordion__section-controls" do
             expect(element).to have_button("Collapse")
+
+            within "button" do
+              expect(element["aria-expanded"]).to eq("true")
+            end
           end
         end
 


### PR DESCRIPTION
### Description of change

Make the task accordion section header a button.

### Screenshots

Collapsed state:
![image](https://github.com/user-attachments/assets/3418068a-d00c-4823-963d-08e115b2f941)

Hover state:
![image](https://github.com/user-attachments/assets/f0294782-01e6-4e67-85a6-2ef63a10a0b6)

Focus state:
![image](https://github.com/user-attachments/assets/3a6bbed2-f2c9-461f-b653-60fff6818551)

Expanded state:
![image](https://github.com/user-attachments/assets/7916c496-6661-4fea-81a0-d72bea094fcd)
