### PR TITLE
Exclude cancelled terms from review list

### DIFF
--- a/app/views/planning_applications/review/heads_of_terms/_terms_summary.html.erb
+++ b/app/views/planning_applications/review/heads_of_terms/_terms_summary.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Summary of heads of terms</h2>
-<% if @planning_application.heads_of_term.present? %>
+<% if @planning_application.heads_of_term.terms.not_cancelled.present? %>
   <ol class="govuk-list govuk-list--number">
-    <% @planning_application.heads_of_term&.terms&.each do |term| %>
+    <% @planning_application.heads_of_term.terms.not_cancelled.each do |term| %>
       <li>
         <div class="govuk-!-margin-bottom-7">
           <h2 class="govuk-heading-s"><%= term.title %></h2>


### PR DESCRIPTION
### Description of change

Cancelled heads of termses were mistakenly displayed in the review list when they should be excluded.

### Story Link

https://trello.com/c/Ae4hmaT1/26-redesign-of-review-heads-of-terms