### PR TITLE
Exclude specific statuses from 'published' scope

### DIFF
--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -8,6 +8,7 @@ module PlanningApplicationStatus
   include Auditable
 
   IN_PROGRESS_STATUSES = %i[not_started in_assessment invalidated awaiting_determination in_committee to_be_reviewed].freeze
+  PRIVATE_STATUSES = %i[invalidated not_started returned pending].freeze
 
   included do
     include AASM
@@ -22,6 +23,10 @@ module PlanningApplicationStatus
 
     scope :closed, lambda {
       where(status: %w[determined withdrawn returned closed])
+    }
+
+    scope :publishable, lambda {
+      where.not(status: PRIVATE_STATUSES)
     }
 
     aasm.attribute_name :status

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -121,7 +121,7 @@ class PlanningApplication < ApplicationRecord
   scope :for_user_and_null_users, ->(user_id) { where(user_id: [user_id, nil]) }
   scope :prior_approvals, -> { joins(:application_type).where(application_type: {name: :prior_approval}) }
   scope :accepted, -> { where.not(status: "pending") }
-  scope :published, -> { where.not(published_at: nil) }
+  scope :published, -> { publishable.where.not(published_at: nil) }
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create


### PR DESCRIPTION
### Description of change

Applications with certain statuses should not be listed as published even if a publication date exists.

### Story Link

https://trello.com/c/o61GfgJF/62-restrict-applications-shown-on-public-api-by-status
