### PR TITLE
Allow marking planning applications as deleted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,12 @@ gem "appsignal"
 gem "aws-sdk-s3", require: false
 gem "bootsnap", ">= 1.4.2", require: false
 gem "business_time"
+gem "commonmarker", "~> 0.23.10"
 gem "daemons"
 gem "dartsass-rails"
 gem "devise"
 gem "devise-two-factor"
+gem "discard", "~> 1.4"
 gem "faker", require: false
 gem "faraday", "~> 2", require: false
 gem "grover"
@@ -94,5 +96,3 @@ group :test do
   gem "openapi3_parser", require: false
   gem "webmock"
 end
-
-gem "commonmarker", "~> 0.23.10"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,8 @@ GEM
       railties (~> 7.0)
       rotp (~> 6.0)
     diff-lcs (1.5.1)
+    discard (1.4.0)
+      activerecord (>= 4.2, < 9.0)
     dotenv (3.1.4)
     dotenv-rails (3.1.4)
       dotenv (= 3.1.4)
@@ -685,6 +687,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise-two-factor
+  discard (~> 1.4)
   dotenv-rails
   email_spec
   erb_lint

--- a/app/controllers/planning_applications/withdraw_or_cancels_controller.rb
+++ b/app/controllers/planning_applications/withdraw_or_cancels_controller.rb
@@ -21,7 +21,14 @@ module PlanningApplications
           planning_application_status, withdrawn_or_cancellation_comment, document_params
         )
 
-        format.html { redirect_to @planning_application, notice: t(".#{planning_application_status}") }
+        format.html {
+          if planning_application_status.to_sym == :deleted
+            redirect_to "/", notice:
+              "Planning application #{@planning_application.reference} was deleted: #{withdrawn_or_cancellation_comment}"
+          else
+            redirect_to @planning_application, notice: t(".#{planning_application_status}")
+          end
+        }
       end
     end
 

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -34,7 +34,7 @@ class ApplicationType < ApplicationRecord
   enum :status, %i[inactive active retired].index_with(&:to_s)
 
   belongs_to :legislation, optional: true
-  has_many :planning_applications, dependent: :restrict_with_exception
+  has_many :planning_applications, -> { kept }, dependent: :restrict_with_exception
 
   accepts_nested_attributes_for :legislation, :document_tags
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -3,7 +3,7 @@
 class LocalAuthority < ApplicationRecord
   with_options dependent: :destroy do
     has_many :users
-    has_many :planning_applications
+    has_many :planning_applications, -> { kept }
     has_many :constraints
     has_many :contacts
     has_many :informatives

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -9,11 +9,15 @@ class PlanningApplication < ApplicationRecord
 
   include Auditable
 
+  include Discard::Model
+
   include PlanningApplicationDecorator
 
   include PlanningApplicationStatus
 
   include PlanningApplication::Notification
+
+  self.discard_column = :deleted_at
 
   self.ignored_columns += %i[work_status make_public]
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -623,7 +623,11 @@ class PlanningApplication < ApplicationRecord
 
     transaction do
       update!(document_params) if document_params
-      send(event, status.to_sym, comment)
+      if status.to_sym == :deleted
+        discard!
+      else
+        send(event, status.to_sym, comment)
+      end
     end
   rescue ActiveRecord::ActiveRecordError, AASM::InvalidTransition => e
     raise WithdrawOrCancelError, e.message
@@ -1141,6 +1145,8 @@ class PlanningApplication < ApplicationRecord
       "return!"
     when "closed"
       "close!"
+    when "deleted"
+      "discard!"
     else
       raise ArgumentError, "The status provided: #{status} is not valid"
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
 
   include EmailConfirmable
 
-  has_many :planning_applications, dependent: :nullify
+  has_many :planning_applications, -> { kept }, dependent: :nullify
   has_many :audits, dependent: :nullify
   has_many :comments, dependent: :nullify
   belongs_to :local_authority, optional: true

--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -55,5 +55,11 @@
             @planning_application
           ), warning: true %>
     </div>
+  <% else %>
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to t(".delete"), planning_application_withdraw_or_cancel_path(
+            @planning_application
+          ), warning: true %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/withdraw_or_cancels/show.html.erb
+++ b/app/views/planning_applications/withdraw_or_cancels/show.html.erb
@@ -56,6 +56,13 @@
                     <%= form.radio_button :status, "closed", class: "govuk-radios__input", id: "closed", "aria-controls": "conditional-status-closed-conditional", "aria-expanded": "false" %>
                     <%= form.label :closed, "Cancelled for other reason", class: "govuk-label govuk-radios__label", for: "closed" %>
                   </div>
+                  <div class="govuk-radios__item">
+                    <%= form.radio_button :status, "deleted", class: "govuk-radios__input", id: "deleted", "aria-controls": "conditional-status-deleted-conditional", "aria-expanded": "false" %>
+                    <%= form.label :deleted, "Deleted entirely (caution!)", class: "govuk-label govuk-radios__label", for: "deleted" %>
+                  </div>
+                  <div id="deleted-hint" class="govuk-hint">
+                    Do not use this for live data
+                  </div>
                 </div>
               </div>
             </div>

--- a/app/views/planning_applications/withdraw_or_cancels/show.html.erb
+++ b/app/views/planning_applications/withdraw_or_cancels/show.html.erb
@@ -25,6 +25,11 @@
             <p class="govuk-body">
               This application has been determined and cannot be withdrawn or cancelled.
             </p>
+            <%= form.hidden_field :status, value: :deleted %>
+            <h2 class="govuk-heading-m">Delete application entirely (caution!)</h2>
+            <div id="deleted-hint" class="govuk-hint">
+              Do not use this for live data
+            </div>
           <% elsif !@planning_application.in_progress? %>
             <p class="govuk-body">
               This application has already been withdrawn or cancelled.
@@ -32,6 +37,12 @@
             <p class="govuk-body">
               Comment: <%= @planning_application.closed_or_cancellation_comment %>
             </p>
+
+            <%= form.hidden_field :status, value: :deleted %>
+            <h2 class="govuk-heading-m">Delete application entirely (caution!)</h2>
+            <div id="deleted-hint" class="govuk-hint">
+              Do not use this for live data
+            </div>
           <% else %>
             <h2 class="govuk-heading-m">How should this application be finally disposed of?</h2>
             <span class="govuk-hint">The application status will change based on your selection</span>
@@ -66,13 +77,15 @@
                 </div>
               </div>
             </div>
+          <% end %>
 
-            <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-              <div class="govuk-form-group">
-                <%= form.label :closed_or_cancellation_comment, "Provide a reason", class: "govuk-label govuk-label--s" %>
-                <%= form.text_area :closed_or_cancellation_comment, class: "govuk-textarea", rows: "5", "aria-describedby": "cancellation-comment-hint" %>
-              </div>
+          <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+            <div class="govuk-form-group">
+              <%= form.label :closed_or_cancellation_comment, "Provide a reason", class: "govuk-label govuk-label--s" %>
+              <%= form.text_area :closed_or_cancellation_comment, class: "govuk-textarea", rows: "5", "aria-describedby": "cancellation-comment-hint" %>
+            </div>
 
+            <% if !@planning_application.determined? %>
               <%= form.fields_for :documents, @planning_application.documents.new do |document_attributes| %>
                 <%= document_attributes.hidden_field :redacted, value: true %>
                 <%= document_attributes.govuk_file_field(
@@ -82,13 +95,15 @@
                       direct_upload: true
                     ) %>
               <% end %>
-            </div>
-          <% end %>
+            <% end %>
+          </div>
         </fieldset>
 
         <div class="govuk-button-group govuk-!-padding-top-7">
           <% if @planning_application.in_progress? %>
             <%= form.submit "Withdraw or cancel application", class: "govuk-button govuk-button--warning" %>
+          <% else %>
+            <%= form.submit "Delete application", class: "govuk-button govuk-button--warning" %>
           <% end %>
 
           <%= back_link %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2077,6 +2077,7 @@ en:
       assess_recommendation: Assess recommendation
       awaiting_approval_to: Awaiting approval to a description change (sent on %{date})
       back: Back
+      delete: Delete application
       details: Details
       view_all_requests: View all requests.
       withdraw_or_cancel: Withdraw or cancel application

--- a/db/migrate/20241203135411_add_deleted_at_to_planning_application.rb
+++ b/db/migrate/20241203135411_add_deleted_at_to_planning_application.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeletedAtToPlanningApplication < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :planning_applications, :deleted_at, :datetime
+    add_index :planning_applications, :deleted_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_02_074837) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_03_135411) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -815,6 +815,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_02_074837) do
     t.datetime "published_at"
     t.boolean "site_history_checked", default: false, null: false
     t.virtual "address_search", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((((((((COALESCE(address_1, ''::character varying))::text || ' '::text) || (COALESCE(address_2, ''::character varying))::text) || ' '::text) || (COALESCE(town, ''::character varying))::text) || ' '::text) || (COALESCE(county, ''::character varying))::text) || ' '::text) || (COALESCE(postcode, ''::character varying))::text))", stored: true
+    t.datetime "deleted_at"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "lower(replace((postcode)::text, ' '::text, ''::text))", name: "ix_planning_applications_on_LOWER_replace_postcode"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
@@ -823,6 +824,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_02_074837) do
     t.index ["application_number", "local_authority_id"], name: "ix_planning_applications_on_application_number__local_authority", unique: true
     t.index ["application_type_id"], name: "ix_planning_applications_on_application_type_id"
     t.index ["boundary_created_by_id"], name: "ix_planning_applications_on_boundary_created_by_id"
+    t.index ["deleted_at"], name: "ix_planning_applications_on_deleted_at"
     t.index ["local_authority_id"], name: "index_planning_applications_on_local_authority_id"
     t.index ["lonlat"], name: "ix_planning_applications_on_lonlat", using: :gist
     t.index ["reference", "local_authority_id"], name: "ix_planning_applications_on_reference__local_authority_id", unique: true

--- a/spec/system/planning_applications/withdraw_or_cancel_spec.rb
+++ b/spec/system/planning_applications/withdraw_or_cancel_spec.rb
@@ -69,6 +69,23 @@ RSpec.describe "Withdraw or cancel" do
       expect(page).not_to have_content("Assigned to:")
     end
 
+    it "can delete an application" do
+      click_link "Withdraw or cancel application"
+      choose "Deleted entirely (caution!)"
+      fill_in "Provide a reason", with: "Deleted reason"
+      click_button "Withdraw or cancel application"
+
+      expect(page).to have_content("Planning application #{planning_application.reference} was deleted: Deleted reason")
+
+      planning_application.reload
+
+      expect(planning_application.deleted_at).not_to be_nil
+
+      expect {
+        visit "/planning_applications/#{planning_application.reference}"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "errors if no option chosen" do
       click_link "Withdraw or cancel application"
       click_button "Withdraw or cancel application"

--- a/spec/system/planning_applications/withdraw_or_cancel_spec.rb
+++ b/spec/system/planning_applications/withdraw_or_cancel_spec.rb
@@ -107,6 +107,22 @@ RSpec.describe "Withdraw or cancel" do
       expect(page).to have_content("This application has been determined and cannot be withdrawn or cancelled")
     end
 
+    it "can delete an application" do
+      click_link "Delete application"
+      fill_in "Provide a reason", with: "Deleted reason"
+      click_button "Delete application"
+
+      expect(page).to have_content("Planning application #{planning_application.reference} was deleted: Deleted reason")
+
+      planning_application.reload
+
+      expect(planning_application.deleted_at).not_to be_nil
+
+      expect {
+        visit "/planning_applications/#{planning_application.reference}"
+      }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it "allows viewing the application details, documents and tasks" do
       within(".govuk-notification-banner") do
         expect(page).to have_selector(".govuk-notification-banner__heading", text: "This application has been determined.")


### PR DESCRIPTION
### Description of change

Allow deleting an application (in exceptional cases) from the withdraw/cancel page.

### Story Link

https://trello.com/c/NYso835S/70-ability-to-delete-test-data-from-production

### Screenshots

<img width="642" alt="Screenshot 2024-12-03 at 15 53 23" src="https://github.com/user-attachments/assets/387f9f23-7670-47b2-94e4-a34ec9646363">

<img width="1131" alt="Screenshot 2024-12-03 at 15 56 30" src="https://github.com/user-attachments/assets/f2ff8c2b-bf9c-47da-b3ef-88f030405294">

### Decisions [OPTIONAL]

I've used the [discard](https://github.com/jhawthorn/discard) gem. I think we can do without adding a default scope, since we can simply add this to the relevant relationships, but if it proves to be an issue we can always return to it.

### Known issues [OPTIONAL]

Things you know need further follow on work but aren't in scope of this issue

1. issue1
2. issue2

### Further testing or sign off required [OPTIONAL]

e.g.

1. product manager to sign off view templates
