### PR TITLE
Disable public ip addresses for the migration task

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -125,7 +125,7 @@ jobs:
           start_time=$(date -Iseconds)
           task_arn=$(aws ecs run-task --cluster $CLUSTER \
             --task-definition $TASK_DEFINITION --launch-type FARGATE \
-            --network-configuration '{"awsvpcConfiguration": {"subnets": ["'$BOPS_SUBNETS'"],"securityGroups": ["'$BOPS_SG'"],"assignPublicIp": "ENABLED"}}' | \
+            --network-configuration '{"awsvpcConfiguration": {"subnets": ["'$BOPS_SUBNETS'"],"securityGroups": ["'$BOPS_SG'"],"assignPublicIp": "DISABLED"}}' | \
              jq -r '.tasks[].taskArn')
           aws ecs wait tasks-stopped --cluster $CLUSTER --tasks "$task_arn"
           aws logs tail $LOG_GROUP --format short --since $start_time


### PR DESCRIPTION
There should be no need for a public ip address and it triggers a warning from AWS Security Hub every time it runs.
