### PR TITLE
Add pre-application advice to swagger examples

### DIFF
--- a/engines/bops_api/app/controllers/concerns/bops_api/schema_validation.rb
+++ b/engines/bops_api/app/controllers/concerns/bops_api/schema_validation.rb
@@ -12,7 +12,8 @@ module BopsApi
     module ClassMethods
       def validate_schema!(name, **)
         before_action(**) do
-          schema = Schemas.find!(name, schema: request_schema)
+          name, version = schema_name_and_version
+          schema = Schemas.find!(name, version:)
 
           unless schema.valid?(request_parameters)
             raise BopsApi::Errors::InvalidRequestError, "We couldn’t process your request because some information is missing or incorrect."
@@ -31,6 +32,30 @@ module BopsApi
       request_metadata.fetch("schema")
     rescue KeyError
       raise BopsApi::Errors::InvalidRequestError, "We couldn’t process your request because some information is missing or incorrect."
+    end
+
+    def schema_name_and_version
+      uri = URI.parse(request_schema)
+
+      case uri.host
+      when "theopensystemslab.github.io"
+        odp_schema_name_and_version(uri.path)
+      else
+        raise BopsApi::Errors::InvalidRequestError, "We couldn’t process your request because some information is missing or incorrect."
+      end
+    end
+
+    def odp_schema_name_and_version(path)
+      case File.basename(path)
+      when "schema.json"
+        ["submission", "odp/#{File.basename(File.dirname(path))}"]
+      when "application.json"
+        ["submission", "odp/#{File.basename(File.dirname(path, 2))}"]
+      when "preApplication.json"
+        ["preApplication", "odp/#{File.basename(File.dirname(path, 2))}"]
+      else
+        raise BopsApi::Errors::InvalidRequestError, "We couldn’t process your request because some information is missing or incorrect."
+      end
     end
   end
 end

--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -50,8 +50,15 @@ module BopsApi
 
       document_checklist_items.each do |category, document_item|
         document_item.each do |document|
-          tags = document["value"]
-          description = document["description"]
+          if document.is_a?(Hash)
+            tags = document["value"]
+            description = document["description"]
+          elsif document.is_a?(String)
+            tags = document
+            description = document
+          else
+            raise "Unexpected document type when reading checklist items"
+          end
 
           document_checklist.document_checklist_items.create!(category:, tags:, description:)
         end

--- a/engines/bops_api/lib/bops_api/schemas.rb
+++ b/engines/bops_api/lib/bops_api/schemas.rb
@@ -2,26 +2,13 @@
 
 module BopsApi
   class Schemas
-    ODP_VERSIONS = {
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.2.1/schema.json" => "odp/v0.2.1",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.2.2/schema.json" => "odp/v0.2.2",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.2.3/schema.json" => "odp/v0.2.3",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.3.0/schema.json" => "odp/v0.3.0",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.4.0/schema.json" => "odp/v0.4.0",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.4.1/schema.json" => "odp/v0.4.1",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.5.0/schema.json" => "odp/v0.5.0",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.6.0/schema.json" => "odp/v0.6.0",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.0/schema.json" => "odp/v0.7.0",
-      "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/application.json" => "odp/v0.7.1"
-    }.freeze
-
     DEFAULT_ODP_VERSION = "odp/v0.7.1"
 
     class << self
-      def find!(name, version: nil, schema: nil)
-        cache.find!("#{version || ODP_VERSIONS.fetch(schema)}/#{name}.json")
+      def find!(name, version: nil)
+        cache.find!("#{version || DEFAULT_ODP_VERSION}/#{name}.json")
       rescue KeyError
-        raise BopsApi::Errors::SchemaNotFoundError, "Unable to find schema '#{schema}'"
+        raise BopsApi::Errors::SchemaNotFoundError, "Unable to find schema '#{version}/#{name}'"
       end
 
       private

--- a/engines/bops_api/schemas/odp/v0.7.1/preApplication.json
+++ b/engines/bops_api/schemas/odp/v0.7.1/preApplication.json
@@ -1,0 +1,6642 @@
+{
+  "$id": "v0.7.1",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "definitions": {
+    "Address": {
+      "additionalProperties": false,
+      "description": "Address information for a person associated with this application not at the property address",
+      "properties": {
+        "country": {
+          "type": "string"
+        },
+        "county": {
+          "type": "string"
+        },
+        "line1": {
+          "type": "string"
+        },
+        "line2": {
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "town": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "line1",
+        "town",
+        "postcode"
+      ],
+      "type": "object"
+    },
+    "Agent": {
+      "$id": "#Agent",
+      "additionalProperties": false,
+      "description": "Information about the agent or proxy who completed the application on behalf of someone else",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/UserAddress"
+        },
+        "agent": {
+          "additionalProperties": false,
+          "properties": {
+            "address": {
+              "$ref": "#/definitions/Address"
+            },
+            "company": {
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "type": "object"
+            },
+            "email": {
+              "$ref": "#/definitions/Email"
+            },
+            "name": {
+              "additionalProperties": false,
+              "properties": {
+                "first": {
+                  "type": "string"
+                },
+                "last": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "first",
+                "last"
+              ],
+              "type": "object"
+            },
+            "phone": {
+              "additionalProperties": false,
+              "properties": {
+                "primary": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "primary"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "address",
+            "email",
+            "name",
+            "phone"
+          ],
+          "type": "object"
+        },
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "maintenanceContact": {
+          "$ref": "#/definitions/MaintenanceContact"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        },
+        "siteContact": {
+          "$ref": "#/definitions/SiteContact"
+        },
+        "type": {
+          "enum": [
+            "individual",
+            "company",
+            "charity",
+            "public",
+            "parishCouncil"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "agent",
+        "email",
+        "name",
+        "phone",
+        "siteContact",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Applicant": {
+      "$id": "#Applicant",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/BaseApplicant"
+        },
+        {
+          "$ref": "#/definitions/Agent"
+        }
+      ],
+      "description": "The user who completed the application either for themself or on behalf of someone else"
+    },
+    "Area": {
+      "$id": "#Area",
+      "additionalProperties": false,
+      "properties": {
+        "hectares": {
+          "type": "number"
+        },
+        "squareMetres": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "squareMetres"
+      ],
+      "type": "object"
+    },
+    "BBox": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 4,
+          "minItems": 4,
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "number"
+          },
+          "maxItems": 6,
+          "minItems": 6,
+          "type": "array"
+        }
+      ],
+      "description": "Bounding box https://tools.ietf.org/html/rfc7946#section-5"
+    },
+    "BaseApplicant": {
+      "$id": "#BaseApplicant",
+      "additionalProperties": false,
+      "description": "Information about the user who completed the application for themself, or information about the person who the user applied on behalf of",
+      "properties": {
+        "address": {
+          "$ref": "#/definitions/UserAddress"
+        },
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "maintenanceContact": {
+          "$ref": "#/definitions/MaintenanceContact"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "ownership": {
+          "$ref": "#/definitions/Ownership"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        },
+        "siteContact": {
+          "$ref": "#/definitions/SiteContact"
+        },
+        "type": {
+          "enum": [
+            "individual",
+            "company",
+            "charity",
+            "public",
+            "parishCouncil"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "address",
+        "email",
+        "name",
+        "phone",
+        "siteContact",
+        "type"
+      ],
+      "type": "object"
+    },
+    "BasePlanningDesignation": {
+      "anyOf": [
+        {
+          "const": "article4",
+          "description": "Article 4 Direction area",
+          "type": "string"
+        },
+        {
+          "const": "article4.caz",
+          "description": "Central Activities Zone (CAZ)",
+          "type": "string"
+        },
+        {
+          "const": "brownfieldSite",
+          "description": "Brownfield site",
+          "type": "string"
+        },
+        {
+          "const": "designated",
+          "description": "Designated land",
+          "type": "string"
+        },
+        {
+          "const": "designated.AONB",
+          "description": "Area of Outstanding Natural Beauty (AONB)",
+          "type": "string"
+        },
+        {
+          "const": "designated.conservationArea",
+          "description": "Conservation Area",
+          "type": "string"
+        },
+        {
+          "const": "designated.nationalPark",
+          "description": "National Park",
+          "type": "string"
+        },
+        {
+          "const": "designated.nationalPark.broads",
+          "description": "National Park - Broads",
+          "type": "string"
+        },
+        {
+          "const": "designated.WHS",
+          "description": "UNESCO World Heritage Site or buffer zone",
+          "type": "string"
+        },
+        {
+          "const": "flood",
+          "description": "Flood Risk Zone",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.1",
+          "description": "Flood Risk Zone 1 - Low risk",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.2",
+          "description": "Flood Risk Zone 2 - Medium risk",
+          "type": "string"
+        },
+        {
+          "const": "flood.zone.3",
+          "description": "Flood Risk Zone 3 - High risk",
+          "type": "string"
+        },
+        {
+          "const": "greenBelt",
+          "description": "Green Belt",
+          "type": "string"
+        },
+        {
+          "const": "listed",
+          "description": "Listed Building",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.I",
+          "description": "Listed Building - Grade I",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.II",
+          "description": "Listed Building - Grade II",
+          "type": "string"
+        },
+        {
+          "const": "listed.grade.II*",
+          "description": "Listed Building - Grade II*",
+          "type": "string"
+        },
+        {
+          "const": "locallyListed",
+          "description": "Locally Listed Building",
+          "type": "string"
+        },
+        {
+          "const": "monument",
+          "description": "Site of a Scheduled Monument",
+          "type": "string"
+        },
+        {
+          "const": "nature.ASNW",
+          "description": "Ancient Semi-Natural Woodland (ASNW)",
+          "type": "string"
+        },
+        {
+          "const": "nature.ramsarSite",
+          "description": "Ramsar site",
+          "type": "string"
+        },
+        {
+          "const": "nature.SAC",
+          "description": "Special Area of Conservation (SAC)",
+          "type": "string"
+        },
+        {
+          "const": "nature.SPA",
+          "description": "Special Protection Area (SPA)",
+          "type": "string"
+        },
+        {
+          "const": "nature.SSSI",
+          "description": "Site of Special Scientific Interest (SSSI)",
+          "type": "string"
+        },
+        {
+          "const": "registeredPark",
+          "description": "Historic Park or Garden",
+          "type": "string"
+        },
+        {
+          "const": "road.classified",
+          "description": "Classified Road",
+          "type": "string"
+        },
+        {
+          "const": "tpo",
+          "description": "Tree Preservation Order (TPO) or zone",
+          "type": "string"
+        }
+      ]
+    },
+    "CalculateMetadata": {
+      "$id": "#CalculateMetadata",
+      "additionalProperties": false,
+      "description": "Metadata associated with PlanX Calculate components used to determine fees throughout a service",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "policyRefs": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "url": {
+                "$ref": "#/definitions/URL"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "ContactDetails": {
+      "additionalProperties": false,
+      "description": "Contact details for a person associated with this application",
+      "properties": {
+        "company": {
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        },
+        "email": {
+          "$ref": "#/definitions/Email"
+        },
+        "name": {
+          "additionalProperties": false,
+          "properties": {
+            "first": {
+              "type": "string"
+            },
+            "last": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "first",
+            "last"
+          ],
+          "type": "object"
+        },
+        "phone": {
+          "additionalProperties": false,
+          "properties": {
+            "primary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "primary"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "email",
+        "phone"
+      ],
+      "title": "#ContactDetails",
+      "type": "object"
+    },
+    "Date": {
+      "format": "date",
+      "type": "string"
+    },
+    "DateTime": {
+      "description": "Regex-based implementation of iso-date-time until available in ajv-formats@3.0.0",
+      "format": "date-time",
+      "pattern": "^([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\\.[0-9]+)?(([Zz])|([\\+|\\-]([01][0-9]|2[0-3]):[0-5][0-9]))$",
+      "type": "string"
+    },
+    "Declaration": {
+      "additionalProperties": false,
+      "description": "Declarations about the accuracy of this application and any personal connections to the receiving authority",
+      "properties": {
+        "accurate": {
+          "type": "boolean"
+        },
+        "connection": {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "type": "string"
+            },
+            "value": {
+              "enum": [
+                "employee",
+                "relation.employee",
+                "electedMember",
+                "relation.electedMember",
+                "none"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "value"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "accurate",
+        "connection"
+      ],
+      "title": "#Declaration",
+      "type": "object"
+    },
+    "Email": {
+      "format": "email",
+      "type": "string"
+    },
+    "Entity": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "text": {
+                  "const": "Planning Data",
+                  "type": "string"
+                },
+                "url": {
+                  "$ref": "#/definitions/URL"
+                }
+              },
+              "required": [
+                "text",
+                "url"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "text": {
+                  "const": "Ordnance Survey MasterMap Highways",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "text"
+              ],
+              "type": "object"
+            }
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "source"
+      ],
+      "type": "object"
+    },
+    "Feature": {
+      "additionalProperties": false,
+      "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometry": {
+          "$ref": "#/definitions/Geometry",
+          "description": "The feature's geometry"
+        },
+        "id": {
+          "description": "A value that uniquely identifies this feature in a https://tools.ietf.org/html/rfc7946#section-3.2.",
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/GeoJsonProperties",
+          "description": "Properties associated with this feature."
+        },
+        "type": {
+          "const": "Feature",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry",
+        "properties",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Feature<Geometry,GeoJsonProperties>": {
+      "additionalProperties": false,
+      "description": "A feature object which contains a geometry and associated properties. https://tools.ietf.org/html/rfc7946#section-3.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometry": {
+          "$ref": "#/definitions/Geometry",
+          "description": "The feature's geometry"
+        },
+        "id": {
+          "description": "A value that uniquely identifies this feature in a https://tools.ietf.org/html/rfc7946#section-3.2.",
+          "type": [
+            "string",
+            "number"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/GeoJsonProperties",
+          "description": "Properties associated with this feature."
+        },
+        "type": {
+          "const": "Feature",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometry",
+        "properties",
+        "type"
+      ],
+      "type": "object"
+    },
+    "FeatureCollection": {
+      "additionalProperties": false,
+      "description": "A collection of feature objects.  https://tools.ietf.org/html/rfc7946#section-3.3",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "features": {
+          "items": {
+            "$ref": "#/definitions/Feature%3CGeometry%2CGeoJsonProperties%3E"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "FeatureCollection",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "features",
+        "type"
+      ],
+      "type": "object"
+    },
+    "FeeExplanation": {
+      "$id": "#FeeExplanation",
+      "additionalProperties": false,
+      "description": "An explanation, including policy references, of the fees associated with this application",
+      "properties": {
+        "calculated": {
+          "items": {
+            "$ref": "#/definitions/CalculateMetadata"
+          },
+          "type": "array"
+        },
+        "category": {
+          "additionalProperties": false,
+          "description": "Breakdown of calculated fee by category of development, based on the scales defined in The Town and Country Planning Regulations https://www.legislation.gov.uk/uksi/2012/2920/schedule/1/part/2",
+          "properties": {
+            "eight": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "eleven": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "one"
+              ],
+              "type": "object"
+            },
+            "five": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "four": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "fourteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "nine": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "one": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "sixAndSeven": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "ten": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "thirteen": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "three": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            },
+            "twelve": {
+              "additionalProperties": false,
+              "properties": {
+                "one": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                },
+                "two": {
+                  "items": {
+                    "$ref": "#/definitions/CalculateMetadata"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "two": {
+              "items": {
+                "$ref": "#/definitions/CalculateMetadata"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "payable": {
+          "items": {
+            "$ref": "#/definitions/CalculateMetadata"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "calculated",
+        "payable"
+      ],
+      "type": "object"
+    },
+    "FeeExplanationNotApplicable": {
+      "$id": "#FeeExplanationNotApplicable",
+      "additionalProperties": false,
+      "description": "An indicator that an application fee does not apply to this application type or journey, therefore there is not an explanation of how it was calculated",
+      "properties": {
+        "notApplicable": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "notApplicable"
+      ],
+      "type": "object"
+    },
+    "File": {
+      "$id": "#File",
+      "additionalProperties": false,
+      "description": "File uploaded and labeled by the user to support the application",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ],
+      "type": "object"
+    },
+    "GeoBoundary": {
+      "additionalProperties": false,
+      "properties": {
+        "area": {
+          "$ref": "#/definitions/Area"
+        },
+        "site": {
+          "$ref": "#/definitions/GeoJSON"
+        }
+      },
+      "required": [
+        "site",
+        "area"
+      ],
+      "type": "object"
+    },
+    "GeoJSON": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Geometry"
+        },
+        {
+          "$ref": "#/definitions/Feature"
+        },
+        {
+          "$ref": "#/definitions/FeatureCollection"
+        }
+      ],
+      "description": "Union of GeoJSON objects."
+    },
+    "GeoJsonProperties": {
+      "anyOf": [
+        {
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "Geometry": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Point"
+        },
+        {
+          "$ref": "#/definitions/MultiPoint"
+        },
+        {
+          "$ref": "#/definitions/LineString"
+        },
+        {
+          "$ref": "#/definitions/MultiLineString"
+        },
+        {
+          "$ref": "#/definitions/Polygon"
+        },
+        {
+          "$ref": "#/definitions/MultiPolygon"
+        },
+        {
+          "$ref": "#/definitions/GeometryCollection"
+        }
+      ],
+      "description": "Geometry object. https://tools.ietf.org/html/rfc7946#section-3"
+    },
+    "GeometryCollection": {
+      "additionalProperties": false,
+      "description": "Geometry Collection https://tools.ietf.org/html/rfc7946#section-3.1.8",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "geometries": {
+          "items": {
+            "$ref": "#/definitions/Geometry"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "GeometryCollection",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "geometries",
+        "type"
+      ],
+      "type": "object"
+    },
+    "LineString": {
+      "additionalProperties": false,
+      "description": "LineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.4",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "$ref": "#/definitions/Position"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "LineString",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MaintenanceContact": {
+      "$id": "#MaintenanceContact",
+      "description": "Contact information for the person(s) responsible for maintenance while the works are carried out",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "address": {
+            "$ref": "#/definitions/Address"
+          },
+          "contact": {
+            "$ref": "#/definitions/ContactDetails"
+          },
+          "when": {
+            "enum": [
+              "duringConstruction",
+              "afterConstruction",
+              "duringAndAfterConstruction"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "when",
+          "address",
+          "contact"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "MultiLineString": {
+      "additionalProperties": false,
+      "description": "MultiLineString geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.5",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "$ref": "#/definitions/Position"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiLineString",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MultiPoint": {
+      "additionalProperties": false,
+      "description": "MultiPoint geometry object.  https://tools.ietf.org/html/rfc7946#section-3.1.3",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "$ref": "#/definitions/Position"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiPoint",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "MultiPolygon": {
+      "additionalProperties": false,
+      "description": "MultiPolygon geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.7",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "items": {
+                "$ref": "#/definitions/Position"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "MultiPolygon",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "OSAddress": {
+      "additionalProperties": false,
+      "description": "Address information for sites with a known address sourced from Ordnance Survey AddressBase Premium LPI source",
+      "properties": {
+        "latitude": {
+          "description": "Latitude coordinate in EPSG:4326 (WGS84)",
+          "type": "number"
+        },
+        "longitude": {
+          "description": "Longitude coordinate in EPSG:4326 (WGS84)",
+          "type": "number"
+        },
+        "organisation": {
+          "type": "string"
+        },
+        "pao": {
+          "description": "Combined `PAO_START_NUMBER`, `PAO_START_SUFFIX`, `PAO_TEXT` OS LPI properties",
+          "title": "Primary Addressable Object (PAO) start range and/or building description",
+          "type": "string"
+        },
+        "paoEnd": {
+          "description": "Combined `PAO_END_NUMBER`, `PAO_END_SUFFIX` OS LPI properties",
+          "title": "Primary Addressable Object (PAO) end range",
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "sao": {
+          "description": "Combined `SAO_START_NUMBER`, `SAO_START_SUFFIX`, `SAO_TEXT` OS LPI properties",
+          "title": "Secondary Addressable Object (SAO) start range and/or building description",
+          "type": "string"
+        },
+        "saoEnd": {
+          "description": "Combined `SAO_END_NUMBER`, `SAO_END_SUFFIX` OS LPI properties",
+          "title": "Secondary Addressable Object (SAO) end range",
+          "type": "string"
+        },
+        "singleLine": {
+          "type": "string"
+        },
+        "source": {
+          "const": "Ordnance Survey",
+          "type": "string"
+        },
+        "street": {
+          "type": "string"
+        },
+        "title": {
+          "description": "Single line address description",
+          "type": "string"
+        },
+        "town": {
+          "type": "string"
+        },
+        "uprn": {
+          "maxLength": 12,
+          "title": "Unique Property Reference Number",
+          "type": "string"
+        },
+        "usrn": {
+          "maxLength": 8,
+          "title": "Unique Street Reference Number",
+          "type": "string"
+        },
+        "x": {
+          "description": "Easting coordinate in British National Grid (OSGB36)",
+          "type": "number"
+        },
+        "y": {
+          "description": "Northing coordinate in British National Grid (OSGB36)",
+          "type": "number"
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude",
+        "pao",
+        "postcode",
+        "singleLine",
+        "source",
+        "street",
+        "title",
+        "town",
+        "uprn",
+        "usrn",
+        "x",
+        "y"
+      ],
+      "title": "#OSAddress",
+      "type": "object"
+    },
+    "Owners": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/OwnersNoticeGiven"
+        },
+        {
+          "$ref": "#/definitions/OwnersNoNoticeGiven"
+        },
+        {
+          "$ref": "#/definitions/OwnersNoticeDate"
+        }
+      ],
+      "description": "Names and addresses of all known owners and agricultural tenants who are not the applicant, including confirmation or date of notice, or reason requisite notice has not been given if applicable",
+      "title": "#Owners"
+    },
+    "OwnersInterest": {
+      "enum": [
+        "owner",
+        "lessee",
+        "occupier",
+        "other"
+      ],
+      "type": "string"
+    },
+    "OwnersNoNoticeGiven": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "$ref": "#/definitions/OwnersInterest"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noNoticeReason": {
+          "type": "string"
+        },
+        "noticeGiven": {
+          "const": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noNoticeReason",
+        "noticeGiven"
+      ],
+      "type": "object"
+    },
+    "OwnersNoticeDate": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "$ref": "#/definitions/OwnersInterest"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noticeDate": {
+          "$ref": "#/definitions/Date"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noticeDate"
+      ],
+      "type": "object"
+    },
+    "OwnersNoticeGiven": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Address"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        },
+        "interest": {
+          "$ref": "#/definitions/OwnersInterest"
+        },
+        "name": {
+          "type": "string"
+        },
+        "noticeGiven": {
+          "const": true,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "address",
+        "name",
+        "noticeGiven"
+      ],
+      "type": "object"
+    },
+    "Ownership": {
+      "additionalProperties": false,
+      "description": "Information about the ownership certificate and property owners, if different than the applicant",
+      "properties": {
+        "agriculturalTenants": {
+          "description": "Does the land have any agricultural tenants?",
+          "type": "boolean"
+        },
+        "certificate": {
+          "enum": [
+            "a",
+            "b",
+            "c",
+            "d"
+          ],
+          "type": "string"
+        },
+        "declaration": {
+          "additionalProperties": false,
+          "description": "Declaration of the accuracy of the ownership certificate, including reasonable steps taken to find all owners and publish notice",
+          "properties": {
+            "accurate": {
+              "const": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "accurate"
+          ],
+          "type": "object"
+        },
+        "interest": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OwnersInterest"
+            },
+            {
+              "const": "owner.sole",
+              "type": "string"
+            },
+            {
+              "const": "owner.co",
+              "type": "string"
+            }
+          ]
+        },
+        "noticeGiven": {
+          "description": "Has requisite notice been given to all the known owners and agricultural tenants?",
+          "type": "boolean"
+        },
+        "noticePublished": {
+          "additionalProperties": false,
+          "description": "Has a notice of the application been published in a newspaper circulating in the area where the land is situated?",
+          "properties": {
+            "date": {
+              "$ref": "#/definitions/Date"
+            },
+            "newspaperName": {
+              "type": "string"
+            },
+            "status": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "status"
+          ],
+          "type": "object"
+        },
+        "owners": {
+          "items": {
+            "$ref": "#/definitions/Owners"
+          },
+          "type": "array"
+        },
+        "ownersKnown": {
+          "description": "Do you know the names and addresses of all owners and agricultural tenants?",
+          "enum": [
+            "all",
+            "some",
+            "none"
+          ],
+          "type": "string"
+        }
+      },
+      "title": "#Ownership",
+      "type": "object"
+    },
+    "PlanningDesignation": {
+      "$id": "#PlanningDesignation",
+      "anyOf": [
+        {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Article 4 Direction area",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "article4",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Central Activities Zone (CAZ)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "article4.caz",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Brownfield site",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "brownfieldSite",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Designated land",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Area of Outstanding Natural Beauty (AONB)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.AONB",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Conservation Area",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.conservationArea",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "National Park",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.nationalPark",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "National Park - Broads",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.nationalPark.broads",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "UNESCO World Heritage Site or buffer zone",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.WHS",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 1 - Low risk",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.1",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 2 - Medium risk",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.2",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 3 - High risk",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.3",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Green Belt",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "greenBelt",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade I",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.I",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade II",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.II",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade II*",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.II*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Locally Listed Building",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "locallyListed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Site of a Scheduled Monument",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "monument",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Ancient Semi-Natural Woodland (ASNW)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.ASNW",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Ramsar site",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.ramsarSite",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Special Area of Conservation (SAC)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SAC",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Special Protection Area (SPA)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SPA",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Site of Special Scientific Interest (SSSI)",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SSSI",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic Park or Garden",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "registeredPark",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Classified Road",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "road.classified",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Tree Preservation Order (TPO) or zone",
+                  "type": "string"
+                },
+                "intersects": {
+                  "const": false,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "tpo",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            }
+          ],
+          "description": "A planning designation that does not intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects"
+        },
+        {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Article 4 Direction area",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "article4",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Central Activities Zone (CAZ)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "article4.caz",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Brownfield site",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "brownfieldSite",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Designated land",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Area of Outstanding Natural Beauty (AONB)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.AONB",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Conservation Area",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.conservationArea",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "National Park",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.nationalPark",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "National Park - Broads",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.nationalPark.broads",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "UNESCO World Heritage Site or buffer zone",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "designated.WHS",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 1 - Low risk",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.1",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 2 - Medium risk",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.2",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Flood Risk Zone 3 - High risk",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "flood.zone.3",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Green Belt",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "greenBelt",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade I",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.I",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade II",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.II",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Listed Building - Grade II*",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "listed.grade.II*",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Locally Listed Building",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "locallyListed",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Site of a Scheduled Monument",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "monument",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Ancient Semi-Natural Woodland (ASNW)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.ASNW",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Ramsar site",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.ramsarSite",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Special Area of Conservation (SAC)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SAC",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Special Protection Area (SPA)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SPA",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Site of Special Scientific Interest (SSSI)",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "nature.SSSI",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Historic Park or Garden",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "registeredPark",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Classified Road",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "road.classified",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            },
+            {
+              "additionalProperties": false,
+              "properties": {
+                "description": {
+                  "const": "Tree Preservation Order (TPO) or zone",
+                  "type": "string"
+                },
+                "entities": {
+                  "items": {
+                    "$ref": "#/definitions/Entity"
+                  },
+                  "type": "array"
+                },
+                "intersects": {
+                  "const": true,
+                  "type": "boolean"
+                },
+                "value": {
+                  "const": "tpo",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "description",
+                "intersects",
+                "value"
+              ],
+              "type": "object"
+            }
+          ],
+          "description": "A planning designation that does intersect with the proposed site, per the DE-9IM spatial relationship definition of intersects"
+        }
+      ],
+      "description": "Planning designations that may intersect with the proposed site determined by spatial queries against Planning Data (planning.data.gov.uk) and Ordnance Survey"
+    },
+    "Point": {
+      "additionalProperties": false,
+      "description": "Point geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.2",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "$ref": "#/definitions/Position"
+        },
+        "type": {
+          "const": "Point",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Polygon": {
+      "additionalProperties": false,
+      "description": "Polygon geometry object. https://tools.ietf.org/html/rfc7946#section-3.1.6",
+      "properties": {
+        "bbox": {
+          "$ref": "#/definitions/BBox",
+          "description": "Bounding box of the coordinate range of the object's Geometries, Features, or Feature Collections. The value of the bbox member is an array of length 2*n where n is the number of dimensions represented in the contained geometries, with all axes of the most southwesterly point followed by all axes of the more northeasterly point. The axes order of a bbox follows the axes order of geometries. https://tools.ietf.org/html/rfc7946#section-5"
+        },
+        "coordinates": {
+          "items": {
+            "items": {
+              "$ref": "#/definitions/Position"
+            },
+            "type": "array"
+          },
+          "type": "array"
+        },
+        "type": {
+          "const": "Polygon",
+          "description": "Specifies the type of GeoJSON object.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "coordinates",
+        "type"
+      ],
+      "type": "object"
+    },
+    "Position": {
+      "description": "A Position is an array of coordinates. https://tools.ietf.org/html/rfc7946#section-3.1.1 Array should contain between two and three elements. The previous GeoJSON specification allowed more elements (e.g., which could be used to represent M values), but the current specification only allows X, Y, and (optionally) Z to be defined.",
+      "items": {
+        "type": "number"
+      },
+      "type": "array"
+    },
+    "PreApplicationData": {
+      "$id": "#PreApplicationData",
+      "additionalProperties": false,
+      "description": "Information about this planning pre-application",
+      "properties": {
+        "declaration": {
+          "$ref": "#/definitions/Declaration"
+        },
+        "fee": {
+          "additionalProperties": false,
+          "properties": {
+            "payable": {
+              "description": "Total payable fee after any exemptions or reductions in GBP",
+              "type": "number"
+            },
+            "reference": {
+              "additionalProperties": false,
+              "properties": {
+                "govPay": {
+                  "description": "GOV.UK Pay payment reference number",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "govPay"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "payable"
+          ],
+          "type": "object"
+        },
+        "information": {
+          "additionalProperties": false,
+          "properties": {
+            "harmful": {
+              "additionalProperties": false,
+              "properties": {
+                "applicable": {
+                  "description": "Would disclosure of any of the information provided by the user in the pre-application harm someone's commercial interests?",
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "applicable"
+              ],
+              "type": "object"
+            },
+            "sensitive": {
+              "additionalProperties": false,
+              "properties": {
+                "applicable": {
+                  "description": "Is any of of the information provided by the user in the pre-application sensitive?",
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "applicable"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "harmful",
+            "sensitive"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "$ref": "#/definitions/PreApplicationType"
+        }
+      },
+      "required": [
+        "type",
+        "fee",
+        "declaration",
+        "information"
+      ],
+      "type": "object"
+    },
+    "PreApplicationType": {
+      "$id": "#PreApplicationType",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Householder",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.householder",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Minor",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.minor",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "description": {
+              "const": "Pre-application advice - Major",
+              "type": "string"
+            },
+            "value": {
+              "const": "preApp.major",
+              "type": "string"
+            }
+          },
+          "required": [
+            "value",
+            "description"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Planning application types"
+    },
+    "Property": {
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ProposedAddress"
+            },
+            {
+              "$ref": "#/definitions/OSAddress"
+            }
+          ]
+        },
+        "boundary": {
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "HM Land Registry Index polygon for this property, commonly referred to as the blue line boundary, sourced from planning.data.gov.uk/dataset/title-boundary"
+        },
+        "localAuthorityDistrict": {
+          "description": "Current and historic UK Local Authority Districts that contain this address sourced from planning.data.gov.uk/dataset/local-authority-district",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "planning": {
+          "additionalProperties": false,
+          "description": "Planning constraints and policies that intersect with this site and may impact or restrict development",
+          "properties": {
+            "designations": {
+              "items": {
+                "$ref": "#/definitions/PlanningDesignation"
+              },
+              "type": "array"
+            },
+            "sources": {
+              "description": "A list of open data requests or websites that explain how these constraints were sourced",
+              "items": {
+                "$ref": "#/definitions/URL"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "sources"
+          ],
+          "type": "object"
+        },
+        "region": {
+          "$ref": "#/definitions/Region"
+        },
+        "type": {
+          "$ref": "#/definitions/PropertyType"
+        }
+      },
+      "required": [
+        "address",
+        "region",
+        "localAuthorityDistrict",
+        "type"
+      ],
+      "type": "object"
+    },
+    "PropertyType": {
+      "$id": "#PropertyType",
+      "anyOf": [
+        {
+          "const": "commercial",
+          "description": "Commercial",
+          "type": "string"
+        },
+        {
+          "const": "commercial.abattoir",
+          "description": "Slaughter House / Abattoir",
+          "type": "string"
+        },
+        {
+          "const": "commercial.agriculture",
+          "description": "Agricultural",
+          "type": "string"
+        },
+        {
+          "const": "commercial.agriculture.farm",
+          "description": "Farm / Non-Residential Associated Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.ancillary",
+          "description": "Ancillary Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals",
+          "description": "Animal Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian",
+          "description": "Equestrian",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian.racing",
+          "description": "Horse Racing / Breeding Stable",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.equestrian.riding",
+          "description": "Commercial Stabling / Riding",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.kennelsCattery",
+          "description": "Cattery / Kennel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary",
+          "description": "Animal / Bird / Marine Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary.animals",
+          "description": "Animal Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.sanctuary.marine",
+          "description": "Marine Sanctuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.services",
+          "description": "Animal Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.services.quarantine",
+          "description": "Animal Quarantining",
+          "type": "string"
+        },
+        {
+          "const": "commercial.animals.vet",
+          "description": "Vet / Animal Medical Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community",
+          "description": "Community Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.CCTV",
+          "description": "CCTV",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.cemetery",
+          "description": "Cemetery / Crematorium / Graveyard. In Current Use.",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.Cemetery",
+          "description": "Cemetery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.chapelOfRest",
+          "description": "Chapel Of Rest",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.columbarium",
+          "description": "Columbarium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.crematorium",
+          "description": "Crematorium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.military",
+          "description": "Military Cemetery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.Cemetery.mortuary",
+          "description": "Mortuary",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.court",
+          "description": "Law Court",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.employment",
+          "description": "Job Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.hall",
+          "description": "Public / Village Hall / Other Community Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.hall.club",
+          "description": "Youth Recreational / Social Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.HWRC",
+          "description": "Public Household Waste Recycling Centre (HWRC)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison",
+          "description": "Prison",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.detention",
+          "description": "HM Detention Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.secureResidential",
+          "description": "Secure Residential Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.prison.service",
+          "description": "HM Prison Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.recycling",
+          "description": "Recycling Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.religious",
+          "description": "Church Hall / Religious Meeting Place / Hall",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.services",
+          "description": "Community Service Centre / Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.community.wc",
+          "description": "Public Convenience",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education",
+          "description": "Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college",
+          "description": "College",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college.further",
+          "description": "Further Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.college.higher",
+          "description": "Higher Education",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.nursery",
+          "description": "Children's Nursery / Crèche",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.other",
+          "description": "Other Educational Establishment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school",
+          "description": "Preparatory / First / Primary / Infant / Junior / Middle School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.first",
+          "description": "First School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.infant",
+          "description": "Infant School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.junior",
+          "description": "Junior School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.middle",
+          "description": "Middle School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.primary.private",
+          "description": "Non State Primary / Preparatory School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.school.primary.state",
+          "description": "Primary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool",
+          "description": "Secondary / High School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool.private",
+          "description": "Non State Secondary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.secondarySchool.state",
+          "description": "Secondary School",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.specialNeeds",
+          "description": "Special Needs Establishment.",
+          "type": "string"
+        },
+        {
+          "const": "commercial.education.university",
+          "description": "University",
+          "type": "string"
+        },
+        {
+          "const": "commercial.emergency",
+          "description": "Emergency / Rescue Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish",
+          "description": "Fishery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.farm",
+          "description": "Fish Farming",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.hatchery",
+          "description": "Fish Hatchery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.oysters",
+          "description": "Oyster / Mussel Bed",
+          "type": "string"
+        },
+        {
+          "const": "commercial.fish.processing",
+          "description": "Fish Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest",
+          "description": "Hotel / Motel / Boarding / Guest House",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hostel",
+          "description": "Boarding / Guest House / Bed And Breakfast / Youth Hostel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hostel.youth",
+          "description": "Youth Hostel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.hotel",
+          "description": "Hotel/Motel",
+          "type": "string"
+        },
+        {
+          "const": "commercial.guest.shortLet",
+          "description": "Holiday Let/Accommodation/Short-Term Let Other Than CH01",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture",
+          "description": "Horticulture",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.smallholding",
+          "description": "Smallholding",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.vineyard",
+          "description": "Vineyard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.horticulture.watercress",
+          "description": "Watercress Bed",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial",
+          "description": "Industrial Applicable to manufacturing, engineering, maintenance, storage / wholesale distribution and extraction sites",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution",
+          "description": "Wholesale Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution.solidFuel",
+          "description": "Solid Fuel Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.distribution.timber",
+          "description": "Timber Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction",
+          "description": "Mineral / Ore Working / Quarry / Mine",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.distribution",
+          "description": "Mineral Distribution / Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.mining",
+          "description": "Mineral Mining / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.oilGas",
+          "description": "Oil / Gas Extraction / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.processing",
+          "description": "Mineral Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.extraction.quarrying",
+          "description": "Mineral Quarrying / Open Extraction / Active",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.incineration",
+          "description": "Incinerator / Waste Transfer Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light",
+          "description": "Workshop / Light Industrial",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.garage",
+          "description": "Servicing Garage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage",
+          "description": "Warehouse / Store / Storage Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.crops",
+          "description": "Crop Handling / Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.post",
+          "description": "Postal Sorting / Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.solidFuel",
+          "description": "Solid Fuel Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.light.storage.timber",
+          "description": "Timber Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.maintenanceDepot",
+          "description": "Maintenance Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing",
+          "description": "Factory/Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.aircraft",
+          "description": "Aircraft Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.beer",
+          "description": "Brewery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.boats",
+          "description": "Boat Building",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.bricks",
+          "description": "Brick Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.cement",
+          "description": "Cement Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.chemicals",
+          "description": "Chemical Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.cider",
+          "description": "Cider Manufacture",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.dairy",
+          "description": "Dairy Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.distillery",
+          "description": "Distillery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.flour",
+          "description": "Flour Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.food",
+          "description": "Food Processing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.glass",
+          "description": "Glassworks",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.hops",
+          "description": "Oast House",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.oil",
+          "description": "Oil Refining",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.other",
+          "description": "Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.paper",
+          "description": "Paper Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.pottery",
+          "description": "Pottery Manufacturing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.printing",
+          "description": "Printing Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.ships",
+          "description": "Shipyard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.steel",
+          "description": "Steel Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.sugar",
+          "description": "Sugar Refinery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.timber",
+          "description": "Timber Mill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.manufacturing.wine",
+          "description": "Winery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.industrial.recycling",
+          "description": "Recycling Plant",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure",
+          "description": "Leisure - Applicable to recreational sites and enterprises",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.amusements",
+          "description": "Amusements",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.amusements.pier",
+          "description": "Leisure Pier",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena",
+          "description": "Arena / Stadium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena.showground",
+          "description": "Showground",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.arena.stadium",
+          "description": "Stadium",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.beachHut",
+          "description": "Beach Hut (Recreational, Non-Residential Use Only)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.club.private",
+          "description": "Licensed Private Members' Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.club.social",
+          "description": "Recreational / Social Club",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment",
+          "description": "Bingo Hall / Cinema / Conference / Exhibition Centre / Theatre / Concert Hall",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.cinema",
+          "description": "Cinema",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.exhibition",
+          "description": "Conference / Exhibition Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.mixed",
+          "description": "Entertainment Complex",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.entertainment.theatre",
+          "description": "Theatre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday",
+          "description": "Holiday / Campsite",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.accommodation",
+          "description": "Holiday Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.camping",
+          "description": "Camping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.caravanning",
+          "description": "Caravanning",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.centre",
+          "description": "Holiday Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.holiday.youth",
+          "description": "Youth Organisation Camp",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.library",
+          "description": "Library",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.library.readingRoom",
+          "description": "Reading Room",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum",
+          "description": "Museum / Gallery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.art",
+          "description": "Art Centre / Gallery",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.aviation",
+          "description": "Aviation Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.heritage",
+          "description": "Heritage Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.industrial",
+          "description": "Industrial Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.maritime",
+          "description": "Maritime Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.military",
+          "description": "Military Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.science",
+          "description": "Science Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.museum.transport",
+          "description": "Transport Museum",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.amusement",
+          "description": "Amusement Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.aquatic",
+          "description": "Aquatic Attraction",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.model",
+          "description": "Model Village Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.wildlife",
+          "description": "Wildlife / Zoological Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.park.zoo",
+          "description": "Zoo / Theme Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport",
+          "description": "Indoor / Outdoor Leisure / Sporting Activity / Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.athletics",
+          "description": "Athletics Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.bowls",
+          "description": "Bowls Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.centre",
+          "description": "Activity / Leisure / Sports Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.cricket",
+          "description": "Cricket Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.curling",
+          "description": "Curling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.cycling",
+          "description": "Cycling Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.dogracing",
+          "description": "Greyhound Racing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.equestrian",
+          "description": "Equestrian Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.firing",
+          "description": "Civilian Firing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.fishing",
+          "description": "Fishing / Angling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.football",
+          "description": "Football Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.gliding",
+          "description": "Gliding Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.golf",
+          "description": "Golf Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.historicVehicles",
+          "description": "Historic Vessel / Aircraft / Vehicle",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.hockey",
+          "description": "Hockey Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.horseracing",
+          "description": "Horse Racing Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.model",
+          "description": "Model Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.motor",
+          "description": "Motor Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.playingField",
+          "description": "Playing Field",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.racquet",
+          "description": "Racquet Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.recreationGround",
+          "description": "Recreation Ground",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.rugby",
+          "description": "Rugby Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.shinty",
+          "description": "Shinty Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.skateboarding",
+          "description": "Skateboarding Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.swimming",
+          "description": "Diving / Swimming Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.tennis",
+          "description": "Public Tennis Court",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.tenpin",
+          "description": "Tenpin Bowling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.water",
+          "description": "Water Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.wildlife",
+          "description": "Wildlife Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.leisure.sport.winter",
+          "description": "Winter Sports Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical",
+          "description": "Medical",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.assessment",
+          "description": "Assessment / Development Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care",
+          "description": "Hospital / Hospice",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care.home",
+          "description": "Care home/Hospice",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.care.hospital",
+          "description": "Hospital",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.dentist",
+          "description": "Dentist",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.GP",
+          "description": "General Practice Surgery / Clinic",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.healthCentre",
+          "description": "Health Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.healthServices",
+          "description": "Health Care Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.lab",
+          "description": "Medical / Testing / Research Laboratory",
+          "type": "string"
+        },
+        {
+          "const": "commercial.medical.professional",
+          "description": "Professional Medical Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office",
+          "description": "Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.broadcasting",
+          "description": "Broadcasting (TV / Radio)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace",
+          "description": "Office / Work Studio",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.embassy",
+          "description": "Embassy /, High Commission / Consulate",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.film",
+          "description": "Film Studio",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.gov.local",
+          "description": "Local Government Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.office.workspace.gov.national",
+          "description": "Central Government Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail",
+          "description": "Retail",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.atm",
+          "description": "Automated Teller Machine (ATM)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.drinking",
+          "description": "Public House / Bar / Nightclub",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.financial",
+          "description": "Bank / Financial Service",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.fuel",
+          "description": "Petrol Filling Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.licensedPremises",
+          "description": "Other Licensed Premise / Vendor",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market",
+          "description": "Market (Indoor / Outdoor)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.fish",
+          "description": "Fish Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.fruit",
+          "description": "Fruit / Vegetable Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.market.livestock",
+          "description": "Livestock Market",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.post",
+          "description": "Post Office",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.restaurant",
+          "description": "Restaurant / Cafeteria",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.services",
+          "description": "Retail Service Agent",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.shop",
+          "description": "Shop",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.shop.gardenCentre",
+          "description": "Garden Centre",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.showroom",
+          "description": "Shop / Showroom",
+          "type": "string"
+        },
+        {
+          "const": "commercial.retail.takeaway",
+          "description": "Fast Food Outlet / Takeaway (Hot / Cold)",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand",
+          "description": "Storage Land",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand.building",
+          "description": "Builders' Yard",
+          "type": "string"
+        },
+        {
+          "const": "commercial.storageLand.general",
+          "description": "General Storage Land",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport",
+          "description": "Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air",
+          "description": "Airfield / Airstrip / Airport / Air Transport Infrastructure Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.airfield",
+          "description": "Airfield",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.airport",
+          "description": "Airport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.helicopterStation",
+          "description": "Helicopter Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.heliport",
+          "description": "Heliport / Helipad",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.infrastructure",
+          "description": "Air Transport Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.air.passengerTerminal",
+          "description": "Air Passenger Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.bus",
+          "description": "Bus Shelter",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock",
+          "description": "Harbour / Port / Dock / Dockyard / Slipway / Landing Stage / Pier / Jetty / Pontoon / Terminal / Berthing / Quay",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.ferry.passengers",
+          "description": "Passenger Ferry Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.ferry.vehicles",
+          "description": "Vehicular Ferry Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.generalBerth",
+          "description": "Non-Tanker Nautical Berthing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.passenger",
+          "description": "Ship Passenger Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.refuelling",
+          "description": "Nautical Refuelling Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.slipway",
+          "description": "Slipway",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.dock.tankerBerth",
+          "description": "Tanker Berthing",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight",
+          "description": "Goods Freight Handling / Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.air",
+          "description": "Air Freight Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.container",
+          "description": "Container Freight",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.rail",
+          "description": "Rail Freight Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.freight.road",
+          "description": "Road Freight Transport",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure",
+          "description": "Transport Related Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.aqueduct",
+          "description": "Aqueduct",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.lock",
+          "description": "Lock",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.weighing",
+          "description": "Weighbridge / Load Gauge",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.infrastructure.weir",
+          "description": "Weir",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.marina",
+          "description": "Marina",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.mooring",
+          "description": "Mooring",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.overnightLorryPark",
+          "description": "Overnight Lorry Park",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking",
+          "description": "Car / Coach / Commercial Vehicle / Taxi Parking / Park And Ride Site",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.car",
+          "description": "Public Car Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.coach",
+          "description": "Public Coach Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.commercialVehicle",
+          "description": "Public Commercial Vehicle Parking",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.parking.parkAndRide",
+          "description": "Public Park And Ride",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.railAsset",
+          "description": "Railway Asset",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage",
+          "description": "Vehicle Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage.boat",
+          "description": "Boat Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.storage.bus",
+          "description": "Bus / Coach Depot",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal",
+          "description": "Station / Interchange / Terminal / Halt",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.train",
+          "description": "Train station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.bus",
+          "description": "Bus station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.terminal.vehicularRail",
+          "description": "Vehicular Rail Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track",
+          "description": "Transport Track / Way",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.cable",
+          "description": "Chair Lift / Cable Car / Ski Tow",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.cliff",
+          "description": "Cliff Railway",
+          "type": "string"
+        },
+        {
+          "const": "commercial.transport.track.monorail",
+          "description": "Monorail",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility",
+          "description": "Utility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.dam",
+          "description": "Dam",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity",
+          "description": "Power Station / Energy Production",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.distribution",
+          "description": "Electricity Distribution Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.production",
+          "description": "Electricity Production Facility",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.windFarm",
+          "description": "Wind Farm",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.electricity.windTurbine",
+          "description": "Wind Turbine",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.landfill",
+          "description": "Landfill",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas",
+          "description": "Gas / Oil Storage / Distribution",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.gasGovernor",
+          "description": "Gas Governor",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.gasHolder",
+          "description": "Gas Holder",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.oilGas.oilTerminal",
+          "description": "Oil Terminal",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other",
+          "description": "Other Utility Use",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.cableTerminal",
+          "description": "Cable Terminal Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.observatory",
+          "description": "Observatory",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.radar",
+          "description": "Radar Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.other.satelliteEarth",
+          "description": "Satellite Earth Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.publicPhone.box",
+          "description": "Telephone Box",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.publicPhone.other",
+          "description": "Other Public Telephones",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.SubStation",
+          "description": "Electricity Sub-Station",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms",
+          "description": "Telecommunication",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms.exchange",
+          "description": "Telephone Exchange",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.telecoms.mast",
+          "description": "Telecommunications Mast",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.wasteManagement",
+          "description": "Waste Management",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water",
+          "description": "Pump House / Pumping Station / Water Tower",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.pump.control",
+          "description": "Water Controlling / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.pump.distribution",
+          "description": "Water Distribution / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.qualityMonitoring",
+          "description": "Water Quality Monitoring",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.storage",
+          "description": "Water Storage",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment",
+          "description": "Water / Waste Water / Sewage Treatment Works",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment.waste",
+          "description": "Waste Water Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.waterTreatment.water",
+          "description": "Water Treatment",
+          "type": "string"
+        },
+        {
+          "const": "commercial.utility.water.waste",
+          "description": "Waste Water Distribution / Pumping",
+          "type": "string"
+        },
+        {
+          "const": "dualUse",
+          "description": "Dual Use",
+          "type": "string"
+        },
+        {
+          "const": "object",
+          "description": "Object of Interest",
+          "type": "string"
+        },
+        {
+          "const": "object.archaeological",
+          "description": "Archaeological Dig Site",
+          "type": "string"
+        },
+        {
+          "const": "object.monument",
+          "description": "Monument",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.memorial",
+          "description": "Memorial / Market Cross",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other",
+          "description": "Other Structure",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.art",
+          "description": "Permanent Art Display / Sculpture",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.boundaryStone",
+          "description": "Boundary Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.waterFeature",
+          "description": "Cascade / Fountain",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.other.windmill",
+          "description": "Windmill (Inactive)",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.ruin",
+          "description": "Castle / Historic Ruin",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.statue",
+          "description": "Statue",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical",
+          "description": "Obelisk / Milestone / Standing Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical.obelisk",
+          "description": "Obelisk",
+          "type": "string"
+        },
+        {
+          "const": "object.monument.vertical.standingStone",
+          "description": "Standing Stone",
+          "type": "string"
+        },
+        {
+          "const": "object.religious",
+          "description": "Place Of Worship",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building",
+          "description": "Religious building",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.abbey",
+          "description": "Abbey",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.cathedral",
+          "description": "Cathedral",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.chapel",
+          "description": "Chapel",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.church",
+          "description": "Church",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.gurdwara",
+          "description": "Gurdwara",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.kingdomHall",
+          "description": "Kingdom Hall",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.lychGate",
+          "description": "Lych Gate",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.minster",
+          "description": "Minster",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.mosque",
+          "description": "Mosque",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.stupa",
+          "description": "Stupa",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.synagogue",
+          "description": "Synagogue",
+          "type": "string"
+        },
+        {
+          "const": "object.religious.building.temple",
+          "description": "Temple",
+          "type": "string"
+        },
+        {
+          "const": "object.statelyHome",
+          "description": "Stately Home",
+          "type": "string"
+        },
+        {
+          "const": "object.underground",
+          "description": "Underground Feature",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.cave",
+          "description": "Cave",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.hole",
+          "description": "Pothole / Natural Hole",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other",
+          "description": "Other Underground Feature",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.cellar",
+          "description": "Cellar",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction",
+          "description": "Disused Mine",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.mine",
+          "description": "Mineral Mining / Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.oilGas",
+          "description": "Oil And / Gas Extraction/ Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.extraction.quarry",
+          "description": "Mineral Quarrying And / Open Extraction / Inactive",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water",
+          "description": "Well / Spring",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water.spring",
+          "description": "Spring",
+          "type": "string"
+        },
+        {
+          "const": "object.underground.other.water.well",
+          "description": "Well",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture",
+          "description": "Agricultural Support Objects",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.currick",
+          "description": "Currick",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.fishPen",
+          "description": "Fish Ladder / Lock / Pen / Trap",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.livestockPen",
+          "description": "Livestock Pen / Dip",
+          "type": "string"
+        },
+        {
+          "const": "other.agriculture.slurry",
+          "description": "Slurry Bed / Pit",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal",
+          "description": "Coastal Protection / Flood Prevention",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.floodGate",
+          "description": "Flood Gate / Flood Sluice Gate / Flood Valve",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.groyne",
+          "description": "Groyne",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.ripRap",
+          "description": "Rip-Rap",
+          "type": "string"
+        },
+        {
+          "const": "other.coastal.wall",
+          "description": "Boulder Wall / Sea Wall",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency",
+          "description": "Emergency Support",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.fire",
+          "description": "Fire Alarm Structure / Fire Observation Tower / Fire Beater Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.firstAid",
+          "description": "Beach Office / First Aid Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.floatAids",
+          "description": "LIfe / Belt / Buoy / Float / Jacket / Safety Rope",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.lifeguard",
+          "description": "Lifeguard Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.telephone",
+          "description": "Emergency Telephone (Non Motorway)",
+          "type": "string"
+        },
+        {
+          "const": "other.emergency.warning",
+          "description": "Emergency Equipment Point / Emergency Siren / Warning Flag",
+          "type": "string"
+        },
+        {
+          "const": "other.historic",
+          "description": "Historical Site / Object",
+          "type": "string"
+        },
+        {
+          "const": "other.historic.structure",
+          "description": "Historic Structure / Object",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial",
+          "description": "Industrial Support",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.aditIncline",
+          "description": "Adit / Incline / Level",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.caissonDock",
+          "description": "Caisson / Dry Dock / Grid",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.channel",
+          "description": "Channel / Conveyor / Conduit / Pipe",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.chimney",
+          "description": "Chimney / Flue",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.coolingTower",
+          "description": "Cooling Tower",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.crane",
+          "description": "Crane / Hoist / Winch / Material Elevator",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.discharge",
+          "description": "Grab / Skip / Other Industrial Waste Machinery / Discharging",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.flareStack",
+          "description": "Flare Stack",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.kiln",
+          "description": "Kiln / Oven / Smelter",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.manholeShaft",
+          "description": "Manhole / Shaft",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.overflowSluiceValve",
+          "description": "Industrial Overflow / Sluice / Valve / Valve Housing",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.pylon.electricity",
+          "description": "Electricity Distribution Pole / Pylon",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.pylon.telecom",
+          "description": "Telephone Pole / Post",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.siloTank",
+          "description": "Hopper / Silo / Cistern / Tank",
+          "type": "string"
+        },
+        {
+          "const": "other.industrial.solarPanel",
+          "description": "Solar Panel / Waterwheel",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure",
+          "description": "Sport / Leisure Support",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.gallop",
+          "description": "Gallop / Ride",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.hide",
+          "description": "Butt / Hide",
+          "type": "string"
+        },
+        {
+          "const": "other.leisure.modelRailway",
+          "description": "Miniature Railway",
+          "type": "string"
+        },
+        {
+          "const": "other.mail",
+          "description": "Royal Mail Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.additionalAddressee",
+          "description": "Additional Mail / Packet Addressee",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.deliveryBox",
+          "description": "Postal Delivery Box / Pouch",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.POBox",
+          "description": "PO Box",
+          "type": "string"
+        },
+        {
+          "const": "other.mail.postBox",
+          "description": "Postal Box",
+          "type": "string"
+        },
+        {
+          "const": "other.natural",
+          "description": "Significant Natural Object",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.hole",
+          "description": "Natural Hole (Blow / Shake / Swallow)",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.rock",
+          "description": "Boundary / Significant Rock / Boulder",
+          "type": "string"
+        },
+        {
+          "const": "other.natural.tree",
+          "description": "Boundary / Significant / Historic Tree / Pollard",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.guidePost",
+          "description": "Guide Post",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.nautical.beacon",
+          "description": "Nautical Navigation Beacon / Light",
+          "type": "string"
+        },
+        {
+          "const": "other.navigation.road",
+          "description": "Aid To Road Navigation",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental",
+          "description": "Ornamental / Cultural Object",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.maze",
+          "description": "Maze",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.object",
+          "description": "Simple Ornamental Object",
+          "type": "string"
+        },
+        {
+          "const": "other.ornamental.tomb",
+          "description": "Mausoleum / Tomb / Grave",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific",
+          "description": "Scientific / Observation Support",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.astronomy",
+          "description": "Telescope / Observation Infrastructure / Astronomy",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.meteo",
+          "description": "Meteorological Station / Equipment",
+          "type": "string"
+        },
+        {
+          "const": "other.scientific.radarSatellite",
+          "description": "Radar / Satellite Infrastructure",
+          "type": "string"
+        },
+        {
+          "const": "other.streetFurniture",
+          "description": "Street Furniture",
+          "type": "string"
+        },
+        {
+          "const": "other.transport",
+          "description": "Transport Support",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.bridge",
+          "description": "Footbridge / Walkway",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.cattleGridFord",
+          "description": "Cattle Grid / Ford",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.customs",
+          "description": "Customs Inspection Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.goodsTramway",
+          "description": "Goods Tramway",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.layby",
+          "description": "Lay-By",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.mailPickUp",
+          "description": "Mail Pick Up",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.post",
+          "description": "Pole / Post / Bollard (Restricting Vehicular Access)",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.buffer",
+          "description": "Railway Buffer",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.crossing.pedestrian",
+          "description": "Railway Pedestrian Crossing",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.crossing.vehicles",
+          "description": "Level Crossing",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.drag",
+          "description": "Rail Drag",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.infrastructure",
+          "description": "Rail Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.lighting",
+          "description": "Railway Lighting",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.marker.km",
+          "description": "Rail Kilometre Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.market.mile",
+          "description": "Rail Mile Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.signals",
+          "description": "Rail Signalling",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.traverse",
+          "description": "Railway Traverse",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.turntable",
+          "description": "Railway Turntable",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.rail.weighbridge",
+          "description": "Rail Weighbridge",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.drag",
+          "description": "Road Drag",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.infrastructure",
+          "description": "Road Infrastructure Services",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.marker.mile",
+          "description": "Road Mile Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.market.km",
+          "description": "Road Kilometre Distance Marker",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.turntable",
+          "description": "Road Turntable",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.road.vehicleDip",
+          "description": "Vehicle Dip",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.stepsLiftEscalator",
+          "description": "Elevator / Escalator / Steps",
+          "type": "string"
+        },
+        {
+          "const": "other.transport.subway",
+          "description": "Subway / Underpass",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported",
+          "description": "Unsupported Site",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.cycleParking",
+          "description": "Cycle Parking Facility",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.picnic",
+          "description": "Picnic / Barbecue Site",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.shelter",
+          "description": "Shelter (Not Including Bus Shelter)",
+          "type": "string"
+        },
+        {
+          "const": "other.unsupported.travellingPersons",
+          "description": "Travelling Persons Site",
+          "type": "string"
+        },
+        {
+          "const": "parent.street",
+          "description": "Street Record",
+          "type": "string"
+        },
+        {
+          "const": "residential",
+          "description": "Residential",
+          "type": "string"
+        },
+        {
+          "const": "residential.building",
+          "description": "Ancillary Building",
+          "type": "string"
+        },
+        {
+          "const": "residential.carParkingSpace",
+          "description": "Car Park Space",
+          "type": "string"
+        },
+        {
+          "const": "residential.carParkingSpace.allocated",
+          "description": "Allocated Parking",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling",
+          "description": "Residential dwelling",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.boat",
+          "description": "House Boat",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.caravan",
+          "description": "Caravan",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.flat",
+          "description": "Flat",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.holiday",
+          "description": "Privately Owned Holiday Caravan / Chalet",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.detached",
+          "description": "Detached",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.semiDetached",
+          "description": "Semi-detached",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.house.terrace",
+          "description": "Terrace",
+          "type": "string"
+        },
+        {
+          "const": "residential.dwelling.shelteredAccommodation",
+          "description": "Sheltered Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "residential.garage",
+          "description": "Garage",
+          "type": "string"
+        },
+        {
+          "const": "residential.garage.court",
+          "description": "Lock-Up Garage / Garage Court",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO",
+          "description": "House In Multiple Occupation",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.bedsit",
+          "description": "HMO Bedsit / Other Non Self Contained Accommodation",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.parent",
+          "description": "HMO Parent",
+          "type": "string"
+        },
+        {
+          "const": "residential.HMO.undivided",
+          "description": "HMO Not Further Divided",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution",
+          "description": "Residential Institution",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.care",
+          "description": "Care / Nursing Home",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.communal",
+          "description": "Communal Residence",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.education",
+          "description": "Residential Education",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.noncommercial",
+          "description": "Non-Commercial Lodgings",
+          "type": "string"
+        },
+        {
+          "const": "residential.institution.religious",
+          "description": "Religious Community",
+          "type": "string"
+        },
+        {
+          "const": "unclassified",
+          "description": "Unclassified",
+          "type": "string"
+        },
+        {
+          "const": "unclassified.awaitingclassification",
+          "description": "Awaiting Classification",
+          "type": "string"
+        },
+        {
+          "const": "unclassified.pendingInvestigation",
+          "description": "Pending Internal Investigation",
+          "type": "string"
+        }
+      ],
+      "description": "Property types derived from Basic Land and Property Unit (BLPU) classification codes"
+    },
+    "Proposal": {
+      "additionalProperties": false,
+      "properties": {
+        "boundary": {
+          "$ref": "#/definitions/GeoBoundary",
+          "description": "Location plan boundary proposed by the user, commonly referred to as the red line boundary"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "type": "object"
+    },
+    "ProposedAddress": {
+      "additionalProperties": false,
+      "description": "Address information for sites without a known Unique Property Reference Number (UPRN)",
+      "properties": {
+        "latitude": {
+          "description": "Latitude coordinate in EPSG:4326 (WGS84)",
+          "type": "number"
+        },
+        "longitude": {
+          "description": "Longitude coordinate in EPSG:4326 (WGS84)",
+          "type": "number"
+        },
+        "source": {
+          "const": "Proposed by applicant",
+          "type": "string"
+        },
+        "title": {
+          "description": "Single line address description",
+          "type": "string"
+        },
+        "x": {
+          "description": "Easting coordinate in British National Grid (OSGB36)",
+          "type": "number"
+        },
+        "y": {
+          "description": "Northing coordinate in British National Grid (OSGB36)",
+          "type": "number"
+        }
+      },
+      "required": [
+        "latitude",
+        "longitude",
+        "source",
+        "title",
+        "x",
+        "y"
+      ],
+      "title": "#ProposedAddress",
+      "type": "object"
+    },
+    "PrototypeFileType": {
+      "$id": "#FileType",
+      "anyOf": [
+        {
+          "const": "accessRoadsRightsOfWayDetails",
+          "description": "Details of impact on access, roads, and rights of way",
+          "type": "string"
+        },
+        {
+          "const": "affordableHousingStatement",
+          "description": "Affordable housing statement",
+          "type": "string"
+        },
+        {
+          "const": "arboriculturistReport",
+          "description": "Arboriculturist report",
+          "type": "string"
+        },
+        {
+          "const": "bankStatement",
+          "description": "Bank statement",
+          "type": "string"
+        },
+        {
+          "const": "basementImpactStatement",
+          "description": "Basement impact statement",
+          "type": "string"
+        },
+        {
+          "const": "bioaerosolAssessment",
+          "description": "Bio-aerosol assessment",
+          "type": "string"
+        },
+        {
+          "const": "birdstrikeRiskManagementPlan",
+          "description": "Birdstrike risk management plan",
+          "type": "string"
+        },
+        {
+          "const": "boreholeOrTrialPitAnalysis",
+          "description": "Borehole or trial pit analysis",
+          "type": "string"
+        },
+        {
+          "const": "buildingControlCertificate",
+          "description": "Building control certificate",
+          "type": "string"
+        },
+        {
+          "const": "conditionSurvey",
+          "description": "Structural or building condition survey",
+          "type": "string"
+        },
+        {
+          "const": "constructionInvoice",
+          "description": "Construction invoice",
+          "type": "string"
+        },
+        {
+          "const": "contaminationReport",
+          "description": "Contamination report",
+          "type": "string"
+        },
+        {
+          "const": "councilTaxBill",
+          "description": "Council tax bill",
+          "type": "string"
+        },
+        {
+          "const": "crimePreventionStrategy",
+          "description": "Crime prevention strategy",
+          "type": "string"
+        },
+        {
+          "const": "designAndAccessStatement",
+          "description": "Design and Access Statement",
+          "type": "string"
+        },
+        {
+          "const": "disabilityExemptionEvidence",
+          "description": "Evidence for application fee exemption - disability",
+          "type": "string"
+        },
+        {
+          "const": "ecologyReport",
+          "description": "Ecology report",
+          "type": "string"
+        },
+        {
+          "const": "elevations.existing",
+          "description": "Elevations - existing",
+          "type": "string"
+        },
+        {
+          "const": "elevations.proposed",
+          "description": "Elevations - proposed",
+          "type": "string"
+        },
+        {
+          "const": "emissionsMitigationAndMonitoringScheme",
+          "description": "Scheme for mitigation and monitoring of emissions (dust, odour and vibrations)",
+          "type": "string"
+        },
+        {
+          "const": "energyStatement",
+          "description": "Energy statement",
+          "type": "string"
+        },
+        {
+          "const": "environmentalImpactAssessment",
+          "description": "Environmental Impact Assessment (EIA)",
+          "type": "string"
+        },
+        {
+          "const": "externalMaterialsDetails",
+          "description": "External materials details",
+          "type": "string"
+        },
+        {
+          "const": "fireSafetyReport",
+          "description": "Fire safety report",
+          "type": "string"
+        },
+        {
+          "const": "floodRiskAssessment",
+          "description": "Flood risk assessment (FRA)",
+          "type": "string"
+        },
+        {
+          "const": "floorPlan.existing",
+          "description": "Floor plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "floorPlan.proposed",
+          "description": "Floor plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "foulDrainageAssessment",
+          "description": "Foul drainage assessment",
+          "type": "string"
+        },
+        {
+          "const": "geodiversityAssessment",
+          "description": "Geodiversity assessment",
+          "type": "string"
+        },
+        {
+          "const": "hedgerowsInformation",
+          "description": "Plans showing the stretches of hedgerows to be removed",
+          "type": "string"
+        },
+        {
+          "const": "hedgerowsInformation.plantingDate",
+          "description": "Evidence of the date of planting of the removed hedgerows",
+          "type": "string"
+        },
+        {
+          "const": "heritageStatement",
+          "description": "Heritage Statement",
+          "type": "string"
+        },
+        {
+          "const": "hydrologicalAssessment",
+          "description": "Hydrological and hydrogeological assessment",
+          "type": "string"
+        },
+        {
+          "const": "hydrologyReport",
+          "description": "Hydrology report",
+          "type": "string"
+        },
+        {
+          "const": "internalElevations",
+          "description": "Internal elevations",
+          "type": "string"
+        },
+        {
+          "const": "internalSections",
+          "description": "Internal sections",
+          "type": "string"
+        },
+        {
+          "const": "joinersReport",
+          "description": "Joiner's report",
+          "type": "string"
+        },
+        {
+          "const": "joinerySections",
+          "description": "Joinery section report",
+          "type": "string"
+        },
+        {
+          "const": "landContaminationAssessment",
+          "description": "Land contamination assessment",
+          "type": "string"
+        },
+        {
+          "const": "landscapeAndVisualImpactAssessment",
+          "description": "Landscape and visual impact assessment (LVIA)",
+          "type": "string"
+        },
+        {
+          "const": "landscapeStrategy",
+          "description": "Landscape strategy or landscape plan",
+          "type": "string"
+        },
+        {
+          "const": "lightingAssessment",
+          "description": "Lighting assessment",
+          "type": "string"
+        },
+        {
+          "const": "litterVerminAndBirdControlDetails",
+          "description": "Details of litter, vermin and bird control",
+          "type": "string"
+        },
+        {
+          "const": "locationPlan",
+          "description": "Location plan",
+          "type": "string"
+        },
+        {
+          "const": "methodStatement",
+          "description": "Method statement",
+          "type": "string"
+        },
+        {
+          "const": "mineralsAndWasteAssessment",
+          "description": "Minerals and waste assessment",
+          "type": "string"
+        },
+        {
+          "const": "necessaryInformation",
+          "description": "Information the authority considers necessary for the application",
+          "type": "string"
+        },
+        {
+          "const": "newDwellingsSchedule",
+          "description": "New dwellings schedule",
+          "type": "string"
+        },
+        {
+          "const": "noiseAssessment",
+          "description": "Noise assessment",
+          "type": "string"
+        },
+        {
+          "const": "openSpaceAssessment",
+          "description": "Open space assessment",
+          "type": "string"
+        },
+        {
+          "const": "otherDocument",
+          "description": "Other - document",
+          "type": "string"
+        },
+        {
+          "const": "otherDrawing",
+          "description": "Other - drawing",
+          "type": "string"
+        },
+        {
+          "const": "otherEvidence",
+          "description": "Other - evidence or correspondence",
+          "type": "string"
+        },
+        {
+          "const": "otherSupporting",
+          "description": "Other - supporting document",
+          "type": "string"
+        },
+        {
+          "const": "parkingPlan",
+          "description": "Parking plan",
+          "type": "string"
+        },
+        {
+          "const": "photographs.existing",
+          "description": "Photographs - existing",
+          "type": "string"
+        },
+        {
+          "const": "photographs.proposed",
+          "description": "Photographs - proposed",
+          "type": "string"
+        },
+        {
+          "const": "planningStatement",
+          "description": "Planning statement",
+          "type": "string"
+        },
+        {
+          "const": "recycleWasteStorageDetails",
+          "description": "Recyclable waste storage details",
+          "type": "string"
+        },
+        {
+          "const": "relevantInformation",
+          "description": "Information the applicant considers relevant to the application",
+          "type": "string"
+        },
+        {
+          "const": "residentialUnitsDetails",
+          "description": "Residential units details",
+          "type": "string"
+        },
+        {
+          "const": "roofPlan.existing",
+          "description": "Roof plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "roofPlan.proposed",
+          "description": "Roof plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sections.existing",
+          "description": "Sections - existing",
+          "type": "string"
+        },
+        {
+          "const": "sections.proposed",
+          "description": "Sections - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sitePlan.existing",
+          "description": "Site plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "sitePlan.proposed",
+          "description": "Site plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "sketchPlan",
+          "description": "Sketch plan",
+          "type": "string"
+        },
+        {
+          "const": "statementOfCommunityInvolvement",
+          "description": "Statement of community involvement",
+          "type": "string"
+        },
+        {
+          "const": "statutoryDeclaration",
+          "description": "Statutory declaration",
+          "type": "string"
+        },
+        {
+          "const": "storageTreatmentAndWasteDisposalDetails",
+          "description": "Details of storage treatment or disposal of waste",
+          "type": "string"
+        },
+        {
+          "const": "streetScene",
+          "description": "Street scene drawing",
+          "type": "string"
+        },
+        {
+          "const": "subsidenceReport",
+          "description": "Subsidence report",
+          "type": "string"
+        },
+        {
+          "const": "sunlightAndDaylightReport",
+          "description": "Sunlight and daylight report",
+          "type": "string"
+        },
+        {
+          "const": "sustainabilityStatement",
+          "description": "Sustainability statement",
+          "type": "string"
+        },
+        {
+          "const": "technicalEvidence",
+          "description": "Technical evidence",
+          "type": "string"
+        },
+        {
+          "const": "technicalSpecification",
+          "description": "Technical specification",
+          "type": "string"
+        },
+        {
+          "const": "tenancyAgreement",
+          "description": "Tenancy agreement",
+          "type": "string"
+        },
+        {
+          "const": "tenancyInvoice",
+          "description": "Tenancy invoice",
+          "type": "string"
+        },
+        {
+          "const": "townCentreImpactAssessment",
+          "description": "Town centre uses - Impact assessment",
+          "type": "string"
+        },
+        {
+          "const": "townCentreSequentialAssessment",
+          "description": "Town centre uses - Sequential assessment",
+          "type": "string"
+        },
+        {
+          "const": "transportAssessment",
+          "description": "Transport assessment",
+          "type": "string"
+        },
+        {
+          "const": "travelPlan",
+          "description": "Travel plan",
+          "type": "string"
+        },
+        {
+          "const": "treeAndHedgeLocation",
+          "description": "Location of trees and hedges",
+          "type": "string"
+        },
+        {
+          "const": "treeAndHedgeRemovedOrPruned",
+          "description": "Removed or pruned trees and hedges",
+          "type": "string"
+        },
+        {
+          "const": "treeCanopyCalculator",
+          "description": "Tree canopy calculator",
+          "type": "string"
+        },
+        {
+          "const": "treeConditionReport",
+          "description": "Tree condition report",
+          "type": "string"
+        },
+        {
+          "const": "treePlan",
+          "description": "Tree plan",
+          "type": "string"
+        },
+        {
+          "const": "treesReport",
+          "description": "Trees report",
+          "type": "string"
+        },
+        {
+          "const": "unitPlan.existing",
+          "description": "Unit plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "unitPlan.proposed",
+          "description": "Unit plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "usePlan.existing",
+          "description": "Use plan - existing",
+          "type": "string"
+        },
+        {
+          "const": "usePlan.proposed",
+          "description": "Use plan - proposed",
+          "type": "string"
+        },
+        {
+          "const": "utilityBill",
+          "description": "Utility bill",
+          "type": "string"
+        },
+        {
+          "const": "utilitiesStatement",
+          "description": "Utilities statement",
+          "type": "string"
+        },
+        {
+          "const": "ventilationStatement",
+          "description": "Ventilation or extraction statement",
+          "type": "string"
+        },
+        {
+          "const": "viabilityAppraisal",
+          "description": "Viability Appraisal",
+          "type": "string"
+        },
+        {
+          "const": "visualisations",
+          "description": "Visualisations",
+          "type": "string"
+        },
+        {
+          "const": "wasteAndRecyclingStrategy",
+          "description": "Waste and recycling strategy",
+          "type": "string"
+        },
+        {
+          "const": "wasteStorageDetails",
+          "description": "Waste storage details",
+          "type": "string"
+        },
+        {
+          "const": "waterEnvironmentAssessment",
+          "description": "Water environment assessment",
+          "type": "string"
+        }
+      ],
+      "description": "Types of planning documents and drawings"
+    },
+    "PrototypePlanXMetadata": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/UUID",
+          "description": "Unique identifier for this application"
+        },
+        "organisation": {
+          "description": "The reference code for the organisation responsible for processing this planning application, sourced from planning.data.gov.uk/dataset/local-authority",
+          "maxLength": 4,
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/definitions/URL"
+        },
+        "service": {
+          "additionalProperties": false,
+          "properties": {
+            "fee": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FeeExplanation"
+                },
+                {
+                  "$ref": "#/definitions/FeeExplanationNotApplicable"
+                }
+              ]
+            },
+            "files": {
+              "$ref": "#/definitions/PrototypeRequestedFiles"
+            },
+            "flowId": {
+              "$ref": "#/definitions/UUID"
+            },
+            "overrides": {
+              "$ref": "#/definitions/UserOverrides"
+            },
+            "url": {
+              "$ref": "#/definitions/URL"
+            }
+          },
+          "required": [
+            "flowId",
+            "url",
+            "files",
+            "fee"
+          ],
+          "type": "object"
+        },
+        "source": {
+          "const": "PlanX",
+          "type": "string"
+        },
+        "submittedAt": {
+          "$ref": "#/definitions/DateTime"
+        }
+      },
+      "required": [
+        "id",
+        "organisation",
+        "schema",
+        "service",
+        "source",
+        "submittedAt"
+      ],
+      "type": "object"
+    },
+    "PrototypeRequestedFiles": {
+      "additionalProperties": false,
+      "description": "File types requested by this service. Schema[\"files\"] will be a subset of this list based on the user's journey through the service",
+      "properties": {
+        "optional": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        },
+        "recommended": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        },
+        "required": {
+          "items": {
+            "$ref": "#/definitions/PrototypeFileType"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "required",
+        "recommended",
+        "optional"
+      ],
+      "type": "object"
+    },
+    "QuestionAndResponses": {
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/QuestionMetaData"
+        },
+        "question": {
+          "type": "string"
+        },
+        "responses": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/Response"
+              },
+              "type": "array"
+            },
+            {
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "required": [
+        "question",
+        "responses"
+      ],
+      "type": "object"
+    },
+    "QuestionMetaData": {
+      "additionalProperties": false,
+      "properties": {
+        "autoAnswered": {
+          "type": "boolean"
+        },
+        "policyRefs": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "text": {
+                "type": "string"
+              },
+              "url": {
+                "$ref": "#/definitions/URL"
+              }
+            },
+            "required": [
+              "text"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "sectionName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Region": {
+      "description": "The region in England that contains this address sourced from planning.data.gov.uk/dataset/region, where London is a proxy for the Greater London Authority (GLA) area",
+      "enum": [
+        "North East",
+        "North West",
+        "Yorkshire and The Humber",
+        "East Midlands",
+        "West Midlands",
+        "East of England",
+        "London",
+        "South East",
+        "South West"
+      ],
+      "title": "#Region",
+      "type": "string"
+    },
+    "Response": {
+      "additionalProperties": false,
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/ResponseMetaData"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "ResponseMetaData": {
+      "additionalProperties": false,
+      "properties": {
+        "flags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/Response"
+              },
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "Responses": {
+      "$id": "#Responses",
+      "description": "The ordered list of questions, answers, and their metadata for the application",
+      "items": {
+        "$ref": "#/definitions/QuestionAndResponses"
+      },
+      "type": "array"
+    },
+    "SiteContact": {
+      "$id": "#SiteContact",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "role": {
+              "enum": [
+                "applicant",
+                "agent",
+                "proxy"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "role"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/SiteContactOther"
+        }
+      ],
+      "description": "Contact information for the site visit"
+    },
+    "SiteContactOther": {
+      "$id": "#SiteContactOther",
+      "additionalProperties": false,
+      "description": "Contact information for the site visit when the SiteContact's role is 'other'",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "role": {
+          "const": "other",
+          "type": "string"
+        }
+      },
+      "required": [
+        "role",
+        "name",
+        "email",
+        "phone"
+      ],
+      "type": "object"
+    },
+    "URL": {
+      "format": "uri",
+      "pattern": "^https?://",
+      "type": "string"
+    },
+    "UUID": {
+      "format": "uuid",
+      "type": "string"
+    },
+    "User": {
+      "$id": "User",
+      "additionalProperties": false,
+      "description": "The role of the user who completed the application",
+      "properties": {
+        "role": {
+          "enum": [
+            "applicant",
+            "agent",
+            "proxy"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "role"
+      ],
+      "type": "object"
+    },
+    "UserAddress": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "sameAsSiteAddress": {
+              "const": true,
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "sameAsSiteAddress"
+          ],
+          "type": "object"
+        },
+        {
+          "$ref": "#/definitions/UserAddressNotSameSite"
+        }
+      ],
+      "description": "Address information for the applicant",
+      "title": "#UserAddress"
+    },
+    "UserAddressNotSameSite": {
+      "additionalProperties": false,
+      "description": "Address information for an applicant with contact information that differs from the property address",
+      "properties": {
+        "country": {
+          "type": "string"
+        },
+        "county": {
+          "type": "string"
+        },
+        "line1": {
+          "type": "string"
+        },
+        "line2": {
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "sameAsSiteAddress": {
+          "const": false,
+          "type": "boolean"
+        },
+        "town": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "line1",
+        "postcode",
+        "sameAsSiteAddress",
+        "town"
+      ],
+      "title": "#UserAddressNotSameSite",
+      "type": "object"
+    },
+    "UserOverrides": {
+      "additionalProperties": false,
+      "description": "Administrative data suggested by PlanX which the user overrode or changed",
+      "properties": {
+        "property": {
+          "additionalProperties": false,
+          "properties": {
+            "planning": {
+              "additionalProperties": false,
+              "properties": {
+                "designations": {
+                  "items": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "entities": {
+                        "items": {
+                          "additionalProperties": false,
+                          "properties": {
+                            "description": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "source": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "text": {
+                                      "const": "Planning Data",
+                                      "type": "string"
+                                    },
+                                    "url": {
+                                      "$ref": "#/definitions/URL"
+                                    }
+                                  },
+                                  "required": [
+                                    "text",
+                                    "url"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "text": {
+                                      "const": "Ordnance Survey MasterMap Highways",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "text"
+                                  ],
+                                  "type": "object"
+                                }
+                              ]
+                            },
+                            "userReason": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "name",
+                            "source",
+                            "userReason"
+                          ],
+                          "type": "object"
+                        },
+                        "type": "array"
+                      },
+                      "sourceIntersects": {
+                        "const": true,
+                        "type": "boolean"
+                      },
+                      "userIntersects": {
+                        "const": false,
+                        "type": "boolean"
+                      },
+                      "value": {
+                        "$ref": "#/definitions/BasePlanningDesignation"
+                      }
+                    },
+                    "required": [
+                      "value",
+                      "sourceIntersects",
+                      "userIntersects",
+                      "entities"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "designations"
+              ],
+              "type": "object"
+            },
+            "type": {
+              "additionalProperties": false,
+              "properties": {
+                "sourceType": {
+                  "type": "string"
+                },
+                "userType": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "sourceType",
+                "userType"
+              ],
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "description": "The root specification for a planning pre-application in England generated by a digital planning service",
+  "properties": {
+    "applicationType": {
+      "const": "preApp",
+      "type": "string"
+    },
+    "data": {
+      "additionalProperties": false,
+      "properties": {
+        "applicant": {
+          "$ref": "#/definitions/Applicant"
+        },
+        "application": {
+          "$ref": "#/definitions/PreApplicationData"
+        },
+        "property": {
+          "$ref": "#/definitions/Property"
+        },
+        "proposal": {
+          "$ref": "#/definitions/Proposal"
+        },
+        "user": {
+          "$ref": "#/definitions/User"
+        }
+      },
+      "required": [
+        "application",
+        "user",
+        "applicant",
+        "property",
+        "proposal"
+      ],
+      "type": "object"
+    },
+    "files": {
+      "items": {
+        "$ref": "#/definitions/File"
+      },
+      "type": "array"
+    },
+    "metadata": {
+      "$ref": "#/definitions/PrototypePlanXMetadata"
+    },
+    "responses": {
+      "$ref": "#/definitions/Responses"
+    }
+  },
+  "required": [
+    "applicationType",
+    "data",
+    "responses",
+    "files",
+    "metadata"
+  ],
+  "title": "PreApplication",
+  "type": "object"
+}

--- a/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe BopsApi::V2::PlanningApplicationsController, type: :controller do
         application/priorApproval/extendUniversity.json
         application/priorApproval/largerExtension.json
         application/priorApproval/solarPanels.json
+        preApplication.json
       ].each do |example|
         it "#{example} can be submitted successfully" do
           post :create, as: :json, body: examples_root.join(version, example).read

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.1/preApplication.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.1/preApplication.json
@@ -1,0 +1,655 @@
+{
+  "applicationType": "preApp",
+  "data": {
+    "user": {
+      "role": "applicant"
+    },
+    "applicant": {
+      "type": "individual",
+      "name": {
+        "first": "Ted",
+        "last": "Hughes"
+      },
+      "email": "ted@poetlaureates.org",
+      "phone": {
+        "primary": "0123456789"
+      },
+      "company": {
+        "name": "Poet Laureates"
+      },
+      "address": {
+        "sameAsSiteAddress": true
+      },
+      "siteContact": {
+        "role": "applicant"
+      }
+    },
+    "property": {
+      "address": {
+        "latitude": 53.5020957,
+        "longitude": -1.0205473,
+        "x": 465065,
+        "y": 401044,
+        "title": "75, MAIN STREET, AUCKLEY",
+        "source": "Ordnance Survey",
+        "uprn": "100050747612",
+        "usrn": "11201833",
+        "pao": "75",
+        "street": "MAIN STREET",
+        "town": "DONCASTER",
+        "postcode": "DN9 3HW",
+        "singleLine": "75, MAIN STREET, AUCKLEY, DONCASTER, DN9 3HW"
+      },
+      "localAuthorityDistrict": [
+        "Doncaster"
+      ],
+      "region": "Yorkshire and The Humber",
+      "type": "residential.dwelling.house.detached",
+      "planning": {
+        "sources": [
+          "https://api.editor.planx.dev/gis/doncaster?geom=MULTIPOLYGON+%28%28%28-1.0206931342729486+53.50213165258532%2C+-1.020646+53.502065000000016%2C+-1.020719+53.502047000000005%2C+-1.0206422209739665+53.50198572771234%2C+-1.020557+53.501923000000005%2C+-1.020433+53.50195500000001%2C+-1.0205027461051923+53.50206709121434%2C+-1.020549684762953+53.50215722902928%2C+-1.0206931342729486+53.50213165258532%29%29%29&analytics=false&sessionId=1a768034-c07a-4cd5-92b6-fc4a1fd0abd4",
+          "https://api.editor.planx.dev/roads?usrn=11201833"
+        ],
+        "designations": [
+          {
+            "value": "tpo",
+            "description": "Tree Preservation Order (TPO) or zone",
+            "intersects": false
+          },
+          {
+            "value": "flood",
+            "description": "Flood Risk Zone",
+            "intersects": false
+          },
+          {
+            "value": "listed",
+            "description": "Listed Building",
+            "intersects": false
+          },
+          {
+            "value": "article4",
+            "description": "Article 4 Direction area",
+            "intersects": false
+          },
+          {
+            "value": "monument",
+            "description": "Site of a Scheduled Monument",
+            "intersects": false
+          },
+          {
+            "value": "greenBelt",
+            "description": "Green Belt",
+            "intersects": false
+          },
+          {
+            "value": "designated",
+            "description": "Designated land",
+            "intersects": false
+          },
+          {
+            "value": "nature.SAC",
+            "description": "Special Area of Conservation (SAC)",
+            "intersects": false
+          },
+          {
+            "value": "nature.SPA",
+            "description": "Special Protection Area (SPA)",
+            "intersects": false
+          },
+          {
+            "value": "nature.ASNW",
+            "description": "Ancient Semi-Natural Woodland (ASNW)",
+            "intersects": false
+          },
+          {
+            "value": "nature.SSSI",
+            "description": "Site of Special Scientific Interest (SSSI)",
+            "intersects": false
+          },
+          {
+            "value": "brownfieldSite",
+            "description": "Brownfield site",
+            "intersects": false
+          },
+          {
+            "value": "designated.WHS",
+            "description": "UNESCO World Heritage Site or buffer zone",
+            "intersects": false
+          },
+          {
+            "value": "registeredPark",
+            "description": "Historic Park or Garden",
+            "intersects": false
+          },
+          {
+            "value": "designated.AONB",
+            "description": "Area of Outstanding Natural Beauty (AONB)",
+            "intersects": false
+          },
+          {
+            "value": "nature.ramsarSite",
+            "description": "Ramsar site",
+            "intersects": false
+          },
+          {
+            "value": "designated.nationalPark",
+            "description": "National Park",
+            "intersects": false
+          },
+          {
+            "value": "designated.conservationArea",
+            "description": "Conservation Area",
+            "intersects": false
+          },
+          {
+            "value": "designated.nationalPark.broads",
+            "description": "National Park - Broads",
+            "intersects": false
+          },
+          {
+            "value": "road.classified",
+            "description": "Classified Road",
+            "intersects": true,
+            "entities": [
+              {
+                "name": "Main Street - B Road",
+                "source": {
+                  "text": "Ordnance Survey MasterMap Highways"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "boundary": {
+        "site": {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -1.020687,
+                    53.502123
+                  ],
+                  [
+                    -1.020646,
+                    53.502065
+                  ],
+                  [
+                    -1.020719,
+                    53.502047
+                  ],
+                  [
+                    -1.020557,
+                    53.501923
+                  ],
+                  [
+                    -1.020433,
+                    53.501955
+                  ],
+                  [
+                    -1.020543,
+                    53.502144
+                  ],
+                  [
+                    -1.020687,
+                    53.502123
+                  ]
+                ]
+              ]
+            ]
+          },
+          "properties": {
+            "name": "",
+            "entity": 12000365388,
+            "prefix": "title-boundary",
+            "dataset": "title-boundary",
+            "end-date": "",
+            "typology": "geography",
+            "reference": "30240506",
+            "entry-date": "2024-05-06",
+            "start-date": "2009-12-10",
+            "organisation-entity": "13"
+          }
+        },
+        "area": {
+          "hectares": 0.025664,
+          "squareMetres": 256.64
+        }
+      }
+    },
+    "application": {
+      "type": {
+        "value": "preApp",
+        "description": "Pre-application advice"
+      },
+      "fee": {
+        "payable": 450,
+        "reference": {
+          "govPay": "8tdudifjrg7va2ud2nptc6iedf"
+        }
+      },
+      "declaration": {
+        "accurate": true,
+        "connection": {
+          "value": "none"
+        }
+      },
+      "information": {
+        "harmful": {
+          "applicable": false
+        },
+        "sensitive": {
+          "applicable": false
+        }
+      }
+    },
+    "proposal": {
+      "description": "Add a conservatory onto the rear of my first storey to use as a reading room and library.",
+      "boundary": {
+        "site": {
+          "type": "Feature",
+          "geometry": {
+            "type": "MultiPolygon",
+            "coordinates": [
+              [
+                [
+                  [
+                    -1.0206931342729486,
+                    53.50213165258532
+                  ],
+                  [
+                    -1.020646,
+                    53.502065000000016
+                  ],
+                  [
+                    -1.020719,
+                    53.502047000000005
+                  ],
+                  [
+                    -1.0206422209739665,
+                    53.50198572771234
+                  ],
+                  [
+                    -1.020557,
+                    53.501923000000005
+                  ],
+                  [
+                    -1.020433,
+                    53.50195500000001
+                  ],
+                  [
+                    -1.0205027461051923,
+                    53.50206709121434
+                  ],
+                  [
+                    -1.020549684762953,
+                    53.50215722902928
+                  ],
+                  [
+                    -1.0206931342729486,
+                    53.50213165258532
+                  ]
+                ]
+              ]
+            ]
+          },
+          "properties": {
+            "name": "",
+            "label": "1",
+            "entity": 12000365388,
+            "prefix": "title-boundary",
+            "dataset": "title-boundary",
+            "end-date": "",
+            "typology": "geography",
+            "reference": "30240506",
+            "entry-date": "2024-05-06",
+            "start-date": "2009-12-10",
+            "area.hectares": 0.026773,
+            "area.squareMetres": 267.73,
+            "organisation-entity": "13",
+            "planx_user_action": "Amended the title boundary"
+          }
+        },
+        "area": {
+          "hectares": 0.026773,
+          "squareMetres": 267.73
+        }
+      }
+    }
+  },
+  "responses": [
+    {
+      "question": "This is a new service",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "Is the property in Doncaster?",
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "What type of property is it?",
+      "responses": [
+        {
+          "value": "House"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "What type of house is it?",
+      "responses": [
+        {
+          "value": "Detached"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "Is the property in a flood zone?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "Does the property include any heritage assets?",
+      "responses": [
+        {
+          "value": "None of these"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "The property"
+      }
+    },
+    {
+      "question": "What type of application is it?",
+      "responses": [
+        {
+          "value": "Pre application advice"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Are you applying on behalf of someone else?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Can a planning officer see the works from public land?",
+      "responses": [
+        {
+          "value": "Yes, it's visible from the road or somewhere else"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Which of these best describes you?",
+      "responses": [
+        {
+          "value": "Private individual"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Your contact details",
+      "responses": [
+        {
+          "value": "Ted Hughes Poet Laureates 0123456789 ted@poetlaureates.org"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Is your contact address the same as the property address?",
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "We may need to visit the site to assess your application. If we do, who should we contact to arrange the visit?",
+      "responses": [
+        {
+          "value": "Me, the applicant"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "What type of application is this?",
+      "responses": [
+        {
+          "value": "Other"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "About the applicant"
+      }
+    },
+    {
+      "question": "Which of these best describes your project?",
+      "responses": [
+        {
+          "value": "Works or extensions to a house"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the project"
+      }
+    },
+    {
+      "question": "Does the site contain a tree protected by a Tree Preservation Order?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "About the project"
+      }
+    },
+    {
+      "question": "Are there any trees on the property?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the project"
+      }
+    },
+    {
+      "question": "Does the development build over existing utilities?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "About the project"
+      }
+    },
+    {
+      "question": "What type of pre-application are you applying for?",
+      "responses": [
+        {
+          "value": "Non-major pre application"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "Pre application advice offers"
+      }
+    },
+    {
+      "question": "Planning Pre-Application Advice Services",
+      "responses": [
+        {
+          "value": "Written advice (£450)"
+        }
+      ],
+      "metadata": {
+        "sectionName": "Pre application advice offers"
+      }
+    },
+    {
+      "question": "What type of application is this?",
+      "responses": [
+        {
+          "value": "None of these"
+        }
+      ],
+      "metadata": {
+        "autoAnswered": true,
+        "sectionName": "Review and confirm"
+      }
+    },
+    {
+      "question": "Connections with City of Doncaster Council",
+      "responses": [
+        {
+          "value": "None of the above apply to me"
+        }
+      ],
+      "metadata": {
+        "sectionName": "Review and confirm"
+      }
+    },
+    {
+      "question": "Confirm the information in this application is correct",
+      "responses": [
+        {
+          "value": "I confirm that the information contained in this application is truthful, accurate and complete, to the best of my knowledge"
+        }
+      ],
+      "metadata": {
+        "sectionName": "Review and confirm"
+      }
+    },
+    {
+      "question": "Would disclosure of any of the information you have provided harm someone's commercial interests?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "Pay and send"
+      }
+    },
+    {
+      "question": "Is any of the information you have provided sensitive?",
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "sectionName": "Pay and send"
+      }
+    }
+  ],
+  "files": [
+    {
+      "name": "https://api.editor.planx.dev/file/private/fomris6d/correspondence.pdf",
+      "type": [
+        "otherSupporting"
+      ]
+    },
+    {
+      "name": "https://api.editor.planx.dev/file/private/7xsm1un0/myPlans.pdf",
+      "type": [
+        "sitePlan.existing",
+        "sitePlan.proposed"
+      ]
+    }
+  ],
+  "metadata": {
+    "id": "1a768034-c07a-4cd5-92b6-fc4a1fd0abd4",
+    "organisation": "DNC",
+    "submittedAt": "2024-11-25T07:30:05.995Z",
+    "source": "PlanX",
+    "service": {
+      "flowId": "426494e7-34a2-4a94-a554-8ecc5e20e3ef",
+      "url": "https://editor.planx.uk/doncaster/pre-application-advice/published",
+      "files": {
+        "required": [
+          "sitePlan.proposed"
+        ],
+        "recommended": [
+          "sitePlan.existing",
+          "elevations.existing",
+          "elevations.proposed",
+          "floorPlan.existing",
+          "floorPlan.proposed",
+          "photographs.existing",
+          "otherSupporting"
+        ],
+        "optional": []
+      },
+      "fee": {
+        "payable": [],
+        "calculated": []
+      }
+    },
+    "schema": "https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/preApplication.json"
+  }
+}

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "BOPS API" do
     create(:application_type, :pa_part7_classM)
     create(:application_type, :minor)
     create(:application_type, :major)
+    create(:application_type, :pre_application)
 
     Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
@@ -72,7 +73,8 @@ RSpec.describe "BOPS API" do
         %w[PA3MA application/priorApproval/convertCommercialToHome.json],
         %w[PA7M application/priorApproval/extendUniversity.json],
         %w[PA1A application/priorApproval/largerExtension.json],
-        %w[PA14J application/priorApproval/solarPanels.json]
+        %w[PA14J application/priorApproval/solarPanels.json],
+        %w[PRE preApplication.json]
       ].each do |suffix, fixture|
         value = example_fixture(fixture, symbolize_names: true)
         name = value.dig(:data, :application, :type, :value)

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -18191,8 +18191,8 @@ paths:
                     links:
                       first: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
                       last: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
-                      prev:
-                      next:
+                      prev: 
+                      next: 
                     data:
                     - type: FeeChangeValidationRequest
                       state: open
@@ -18201,12 +18201,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.073+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         suggestion: test change
                     - type: AdditionalDocumentValidationRequest
@@ -18216,12 +18216,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.081+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         document_request_type: test
                     - type: OtherChangeValidationRequest
@@ -18231,12 +18231,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.090+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         suggestion: test change
                     - type: DescriptionChangeValidationRequest
@@ -18244,13 +18244,13 @@ paths:
                       post_validation: false
                       created_at: '2024-04-23T15:17:00.174+01:00'
                       notified_at: '2024-04-23T15:17:00.290+01:00'
-                      reason:
+                      reason: 
                       response_due: '2024-04-30'
-                      response:
-                      rejection_reason:
+                      response: 
+                      rejection_reason: 
                       approved: true
-                      cancel_reason:
-                      cancelled_at:
+                      cancel_reason: 
+                      cancelled_at: 
                       closed_at: '2024-04-23T15:19:38.912+01:00'
                       specific_attributes:
                         previous_description: Roof extension to the rear of the property,
@@ -18264,12 +18264,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.058+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
+                      response: 
+                      rejection_reason: 
                       approved: true
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         new_geojson:
                           type: FeatureCollection
@@ -18288,7 +18288,7 @@ paths:
                                   - 51.4655038504508
                                 - - -0.11835515499115692
                                   - 51.465546460366994
-                            properties:
+                            properties: 
                         original_geojson:
                           type: Feature
                           geometry:
@@ -18304,7 +18304,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties:
+                          properties: 
         '401':
           description: with missing or invalid credentials
           content:
@@ -18386,6 +18386,10 @@ paths:
                 Prior Approval - Install or change solar panels:
                   value:
                     id: BUC-23-00100-PA14J
+                    message: Application successfully created
+                Pre-application advice:
+                  value:
+                    id: BUC-23-00100-PRE
                     message: Application successfully created
               schema:
                 "$ref": "#/components/schemas/SubmissionResponse"
@@ -19955,7 +19959,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -20114,7 +20118,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -20918,7 +20922,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -21021,7 +21025,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -22968,7 +22972,7 @@ paths:
                                 - 51.512609937924225
                               - - -0.5202563671906586
                                 - 51.51349326091676
-                          properties:
+                          properties: 
                         area:
                           hectares: 6.1751949999999995
                           squareMetres: 61751.95
@@ -24074,7 +24078,7 @@ paths:
                                 - 52.00027971842326
                               - - -0.8271436393261123
                                 - 52.00047292273189
-                          properties:
+                          properties: 
                         area:
                           hectares: 0.069395
                           squareMetres: 693.95
@@ -29627,6 +29631,383 @@ paths:
                         - description: "<p>This application does not qualify for any
                             exemptions or reductions</p>"
                     schema: https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/application.json
+              preApp:
+                summary: Pre-application advice
+                value:
+                  applicationType: preApp
+                  data:
+                    user:
+                      role: applicant
+                    applicant:
+                      type: individual
+                      name:
+                        first: Ted
+                        last: Hughes
+                      email: ted@poetlaureates.org
+                      phone:
+                        primary: '0123456789'
+                      company:
+                        name: Poet Laureates
+                      address:
+                        sameAsSiteAddress: true
+                      siteContact:
+                        role: applicant
+                    property:
+                      address:
+                        latitude: 53.5020957
+                        longitude: -1.0205473
+                        x: 465065
+                        "y": 401044
+                        title: 75, MAIN STREET, AUCKLEY
+                        source: Ordnance Survey
+                        uprn: '100050747612'
+                        usrn: '11201833'
+                        pao: '75'
+                        street: MAIN STREET
+                        town: DONCASTER
+                        postcode: DN9 3HW
+                        singleLine: 75, MAIN STREET, AUCKLEY, DONCASTER, DN9 3HW
+                      localAuthorityDistrict:
+                      - Doncaster
+                      region: Yorkshire and The Humber
+                      type: residential.dwelling.house.detached
+                      planning:
+                        sources:
+                        - https://api.editor.planx.dev/gis/doncaster?geom=MULTIPOLYGON+%28%28%28-1.0206931342729486+53.50213165258532%2C+-1.020646+53.502065000000016%2C+-1.020719+53.502047000000005%2C+-1.0206422209739665+53.50198572771234%2C+-1.020557+53.501923000000005%2C+-1.020433+53.50195500000001%2C+-1.0205027461051923+53.50206709121434%2C+-1.020549684762953+53.50215722902928%2C+-1.0206931342729486+53.50213165258532%29%29%29&analytics=false&sessionId=1a768034-c07a-4cd5-92b6-fc4a1fd0abd4
+                        - https://api.editor.planx.dev/roads?usrn=11201833
+                        designations:
+                        - value: tpo
+                          description: Tree Preservation Order (TPO) or zone
+                          intersects: false
+                        - value: flood
+                          description: Flood Risk Zone
+                          intersects: false
+                        - value: listed
+                          description: Listed Building
+                          intersects: false
+                        - value: article4
+                          description: Article 4 Direction area
+                          intersects: false
+                        - value: monument
+                          description: Site of a Scheduled Monument
+                          intersects: false
+                        - value: greenBelt
+                          description: Green Belt
+                          intersects: false
+                        - value: designated
+                          description: Designated land
+                          intersects: false
+                        - value: nature.SAC
+                          description: Special Area of Conservation (SAC)
+                          intersects: false
+                        - value: nature.SPA
+                          description: Special Protection Area (SPA)
+                          intersects: false
+                        - value: nature.ASNW
+                          description: Ancient Semi-Natural Woodland (ASNW)
+                          intersects: false
+                        - value: nature.SSSI
+                          description: Site of Special Scientific Interest (SSSI)
+                          intersects: false
+                        - value: brownfieldSite
+                          description: Brownfield site
+                          intersects: false
+                        - value: designated.WHS
+                          description: UNESCO World Heritage Site or buffer zone
+                          intersects: false
+                        - value: registeredPark
+                          description: Historic Park or Garden
+                          intersects: false
+                        - value: designated.AONB
+                          description: Area of Outstanding Natural Beauty (AONB)
+                          intersects: false
+                        - value: nature.ramsarSite
+                          description: Ramsar site
+                          intersects: false
+                        - value: designated.nationalPark
+                          description: National Park
+                          intersects: false
+                        - value: designated.conservationArea
+                          description: Conservation Area
+                          intersects: false
+                        - value: designated.nationalPark.broads
+                          description: National Park - Broads
+                          intersects: false
+                        - value: road.classified
+                          description: Classified Road
+                          intersects: true
+                          entities:
+                          - name: Main Street - B Road
+                            source:
+                              text: Ordnance Survey MasterMap Highways
+                      boundary:
+                        site:
+                          type: Feature
+                          geometry:
+                            type: MultiPolygon
+                            coordinates:
+                            - - - - -1.020687
+                                  - 53.502123
+                                - - -1.020646
+                                  - 53.502065
+                                - - -1.020719
+                                  - 53.502047
+                                - - -1.020557
+                                  - 53.501923
+                                - - -1.020433
+                                  - 53.501955
+                                - - -1.020543
+                                  - 53.502144
+                                - - -1.020687
+                                  - 53.502123
+                          properties:
+                            name: ''
+                            entity: 12000365388
+                            prefix: title-boundary
+                            dataset: title-boundary
+                            end-date: ''
+                            typology: geography
+                            reference: '30240506'
+                            entry-date: '2024-05-06'
+                            start-date: '2009-12-10'
+                            organisation-entity: '13'
+                        area:
+                          hectares: 0.025664
+                          squareMetres: 256.64
+                    application:
+                      type:
+                        value: preApp
+                        description: Pre-application advice
+                      fee:
+                        payable: 450
+                        reference:
+                          govPay: 8tdudifjrg7va2ud2nptc6iedf
+                      declaration:
+                        accurate: true
+                        connection:
+                          value: none
+                      information:
+                        harmful:
+                          applicable: false
+                        sensitive:
+                          applicable: false
+                    proposal:
+                      description: Add a conservatory onto the rear of my first storey
+                        to use as a reading room and library.
+                      boundary:
+                        site:
+                          type: Feature
+                          geometry:
+                            type: MultiPolygon
+                            coordinates:
+                            - - - - -1.0206931342729486
+                                  - 53.50213165258532
+                                - - -1.020646
+                                  - 53.502065000000016
+                                - - -1.020719
+                                  - 53.502047000000005
+                                - - -1.0206422209739665
+                                  - 53.50198572771234
+                                - - -1.020557
+                                  - 53.501923000000005
+                                - - -1.020433
+                                  - 53.50195500000001
+                                - - -1.0205027461051923
+                                  - 53.50206709121434
+                                - - -1.020549684762953
+                                  - 53.50215722902928
+                                - - -1.0206931342729486
+                                  - 53.50213165258532
+                          properties:
+                            name: ''
+                            label: '1'
+                            entity: 12000365388
+                            prefix: title-boundary
+                            dataset: title-boundary
+                            end-date: ''
+                            typology: geography
+                            reference: '30240506'
+                            entry-date: '2024-05-06'
+                            start-date: '2009-12-10'
+                            area.hectares: 0.026773
+                            area.squareMetres: 267.73
+                            organisation-entity: '13'
+                            planx_user_action: Amended the title boundary
+                        area:
+                          hectares: 0.026773
+                          squareMetres: 267.73
+                  responses:
+                  - question: This is a new service
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: The property
+                  - question: Is the property in Doncaster?
+                    responses:
+                    - value: 'Yes'
+                    metadata:
+                      autoAnswered: true
+                      sectionName: The property
+                  - question: What type of property is it?
+                    responses:
+                    - value: House
+                    metadata:
+                      autoAnswered: true
+                      sectionName: The property
+                  - question: What type of house is it?
+                    responses:
+                    - value: Detached
+                    metadata:
+                      autoAnswered: true
+                      sectionName: The property
+                  - question: Is the property in a flood zone?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      autoAnswered: true
+                      sectionName: The property
+                  - question: Does the property include any heritage assets?
+                    responses:
+                    - value: None of these
+                    metadata:
+                      autoAnswered: true
+                      sectionName: The property
+                  - question: What type of application is it?
+                    responses:
+                    - value: Pre application advice
+                    metadata:
+                      autoAnswered: true
+                      sectionName: About the applicant
+                  - question: Are you applying on behalf of someone else?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: About the applicant
+                  - question: Can a planning officer see the works from public land?
+                    responses:
+                    - value: Yes, it's visible from the road or somewhere else
+                    metadata:
+                      sectionName: About the applicant
+                  - question: Which of these best describes you?
+                    responses:
+                    - value: Private individual
+                    metadata:
+                      sectionName: About the applicant
+                  - question: Your contact details
+                    responses:
+                    - value: Ted Hughes Poet Laureates 0123456789 ted@poetlaureates.org
+                    metadata:
+                      sectionName: About the applicant
+                  - question: Is your contact address the same as the property address?
+                    responses:
+                    - value: 'Yes'
+                    metadata:
+                      sectionName: About the applicant
+                  - question: We may need to visit the site to assess your application.
+                      If we do, who should we contact to arrange the visit?
+                    responses:
+                    - value: Me, the applicant
+                    metadata:
+                      sectionName: About the applicant
+                  - question: What type of application is this?
+                    responses:
+                    - value: Other
+                    metadata:
+                      autoAnswered: true
+                      sectionName: About the applicant
+                  - question: Which of these best describes your project?
+                    responses:
+                    - value: Works or extensions to a house
+                    metadata:
+                      sectionName: About the project
+                  - question: Does the site contain a tree protected by a Tree Preservation
+                      Order?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      autoAnswered: true
+                      sectionName: About the project
+                  - question: Are there any trees on the property?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: About the project
+                  - question: Does the development build over existing utilities?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: About the project
+                  - question: What type of pre-application are you applying for?
+                    responses:
+                    - value: Non-major pre application
+                    metadata:
+                      autoAnswered: true
+                      sectionName: Pre application advice offers
+                  - question: Planning Pre-Application Advice Services
+                    responses:
+                    - value: Written advice (£450)
+                    metadata:
+                      sectionName: Pre application advice offers
+                  - question: What type of application is this?
+                    responses:
+                    - value: None of these
+                    metadata:
+                      autoAnswered: true
+                      sectionName: Review and confirm
+                  - question: Connections with City of Doncaster Council
+                    responses:
+                    - value: None of the above apply to me
+                    metadata:
+                      sectionName: Review and confirm
+                  - question: Confirm the information in this application is correct
+                    responses:
+                    - value: I confirm that the information contained in this application
+                        is truthful, accurate and complete, to the best of my knowledge
+                    metadata:
+                      sectionName: Review and confirm
+                  - question: Would disclosure of any of the information you have
+                      provided harm someone's commercial interests?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: Pay and send
+                  - question: Is any of the information you have provided sensitive?
+                    responses:
+                    - value: 'No'
+                    metadata:
+                      sectionName: Pay and send
+                  files:
+                  - name: https://api.editor.planx.dev/file/private/fomris6d/correspondence.pdf
+                    type:
+                    - otherSupporting
+                  - name: https://api.editor.planx.dev/file/private/7xsm1un0/myPlans.pdf
+                    type:
+                    - sitePlan.existing
+                    - sitePlan.proposed
+                  metadata:
+                    id: 1a768034-c07a-4cd5-92b6-fc4a1fd0abd4
+                    organisation: DNC
+                    submittedAt: '2024-11-25T07:30:05.995Z'
+                    source: PlanX
+                    service:
+                      flowId: 426494e7-34a2-4a94-a554-8ecc5e20e3ef
+                      url: https://editor.planx.uk/doncaster/pre-application-advice/published
+                      files:
+                        required:
+                        - sitePlan.proposed
+                        recommended:
+                        - sitePlan.existing
+                        - elevations.existing
+                        - elevations.proposed
+                        - floorPlan.existing
+                        - floorPlan.proposed
+                        - photographs.existing
+                        - otherSupporting
+                        optional: []
+                      fee:
+                        payable: []
+                        calculated: []
+                    schema: https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.1/schemas/preApplication.json
     get:
       summary: Retrieves planning applications
       tags:
@@ -29676,10 +30057,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -29693,11 +30074,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -29718,12 +30099,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude:
-                        longitude:
+                        latitude: 
+                        longitude: 
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -29739,28 +30120,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role:
-                      awaiting_determination_at:
-                      to_be_reviewed_at:
+                      user_role: 
+                      awaiting_determination_at: 
+                      to_be_reviewed_at: 
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at:
+                      in_assessment_at: 
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag:
-                      result_heading:
-                      result_description:
-                      result_override:
-                      returned_at:
-                      started_at:
+                      result_flag: 
+                      result_heading: 
+                      result_description: 
+                      result_override: 
+                      returned_at: 
+                      started_at: 
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -29777,14 +30158,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties:
+                        properties: 
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2:
-                        county:
+                        address_2: 
+                        county: 
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -29795,7 +30176,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date:
+                        end_date: 
                       make_public: false
                 ids:
                   value:
@@ -29815,10 +30196,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -29832,11 +30213,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -29857,12 +30238,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude:
-                        longitude:
+                        latitude: 
+                        longitude: 
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -29878,28 +30259,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role:
-                      awaiting_determination_at:
-                      to_be_reviewed_at:
+                      user_role: 
+                      awaiting_determination_at: 
+                      to_be_reviewed_at: 
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at:
+                      determined_at: 
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at:
+                      in_assessment_at: 
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag:
-                      result_heading:
-                      result_description:
-                      result_override:
-                      returned_at:
-                      started_at:
+                      result_flag: 
+                      result_heading: 
+                      result_description: 
+                      result_override: 
+                      returned_at: 
+                      started_at: 
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -29916,14 +30297,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties:
+                        properties: 
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2:
-                        county:
+                        address_2: 
+                        county: 
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -29934,7 +30315,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date:
+                        end_date: 
                       make_public: false
         '401':
           description: with missing or invalid credentials
@@ -29998,13 +30379,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at:
+                      invalidated_at: 
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -30015,11 +30396,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -30038,7 +30419,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties:
+                          properties: 
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -30075,7 +30456,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -30130,13 +30511,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at:
+                      to_be_reviewed_at: 
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at:
+                      invalidated_at: 
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -30147,11 +30528,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at:
-                      started_at:
+                      returned_at: 
+                      started_at: 
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at:
+                      withdrawn_at: 
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -30170,7 +30551,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties:
+                          properties: 
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -30207,7 +30588,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county:
+                        county: 
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -30276,19 +30657,19 @@ paths:
                     applicant_first_name: Albert
                     applicant_last_name: Manteras
                     user_role: agent
-                    awaiting_determination_at:
-                    to_be_reviewed_at:
+                    awaiting_determination_at: 
+                    to_be_reviewed_at: 
                     created_at: '2023-05-23T09:39:04.197+01:00'
                     description: This is a long winded description, bla bla bla a
                       single storey ground floor rear extension; replacement of existing
                       garage door with brick infill and a new window; replacement
                       of the existing windows with double glazed windows, installation
                       of rooflight
-                    determined_at:
+                    determined_at: 
                     determination_date: '2024-03-06'
                     id: 2
-                    invalidated_at:
-                    in_assessment_at:
+                    invalidated_at: 
+                    in_assessment_at: 
                     payment_reference: PAY1
                     payment_amount: '0.0'
                     result_flag: Planning permission / Permission needed
@@ -30297,11 +30678,11 @@ paths:
                     result_description: Based on the information you have provided,
                       we do not think this is eligible for a Lawful Development Certificate
                     result_override: This was my reason for rejecting the result
-                    returned_at:
-                    started_at:
+                    returned_at: 
+                    started_at: 
                     status: not_started
                     target_date: '2023-06-27'
-                    withdrawn_at:
+                    withdrawn_at: 
                     work_status: proposed
                     boundary_geojson:
                       type: Feature
@@ -30384,10 +30765,10 @@ paths:
                       targetDate: '2024-05-15'
                       receivedAt: '2024-04-17T00:00:00.000+01:00'
                       validAt: '2024-04-12T00:00:00.000+01:00'
-                      publishedAt:
-                      determinedAt:
+                      publishedAt: 
+                      determinedAt: 
                       status: in_assessment
-                      decision:
+                      decision: 
                       consultation:
                         startDate: '2024-04-15'
                         endDate: '2024-05-07'
@@ -30467,7 +30848,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties:
+                              properties: 
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -30567,7 +30948,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties:
+                              properties: 
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -30802,9 +31183,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt:
-                        determinedAt:
-                        decision:
+                        publishedAt: 
+                        determinedAt: 
+                        decision: 
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -30911,10 +31292,10 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties:
+                            properties: 
                       proposal:
                         description: Build a roof extension.
-                        reportingType:
+                        reportingType: 
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
@@ -30976,8 +31357,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt:
-                      decision:
+                      determinedAt: 
+                      decision: 
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -30991,7 +31372,7 @@ paths:
                       - value: sections.proposed
                         description: Sections - proposed
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription:
+                      applicantDescription: 
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -31001,7 +31382,7 @@ paths:
                       - value: internal.siteNotice
                         description: Site Notice
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription:
+                      applicantDescription: 
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -31070,9 +31451,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt:
-                        determinedAt:
-                        decision:
+                        publishedAt: 
+                        determinedAt: 
+                        decision: 
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -31179,10 +31560,10 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties:
+                            properties: 
                       proposal:
                         description: Build a roof extension.
-                        reportingType:
+                        reportingType: 
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
@@ -31241,8 +31622,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt:
-                      decision:
+                      determinedAt: 
+                      decision: 
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -31366,8 +31747,8 @@ paths:
                     links:
                       first: http://southwark.bops.localhost:3000/api/v2/validation_requests?page=1
                       last: http://southwark.bops.localhost:3000/api/v2/validation_requests?page=1
-                      prev:
-                      next:
+                      prev: 
+                      next: 
                     data:
                     - planning_application:
                         reference: 24-00593-HAPP
@@ -31378,12 +31759,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.073+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         suggestion: test change
                     - planning_application:
@@ -31395,12 +31776,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.081+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         document_request_type: test
                     - planning_application:
@@ -31412,12 +31793,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.090+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
-                      approved:
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      response: 
+                      rejection_reason: 
+                      approved: 
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         suggestion: test change
                     - planning_application:
@@ -31427,13 +31808,13 @@ paths:
                       post_validation: false
                       created_at: '2024-04-23T15:17:00.174+01:00'
                       notified_at: '2024-04-23T15:17:00.290+01:00'
-                      reason:
+                      reason: 
                       response_due: '2024-04-30'
-                      response:
-                      rejection_reason:
+                      response: 
+                      rejection_reason: 
                       approved: true
-                      cancel_reason:
-                      cancelled_at:
+                      cancel_reason: 
+                      cancelled_at: 
                       closed_at: '2024-04-23T15:19:38.912+01:00'
                       specific_attributes:
                         previous_description: Roof extension to the rear of the property,
@@ -31449,12 +31830,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.058+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response:
-                      rejection_reason:
+                      response: 
+                      rejection_reason: 
                       approved: true
-                      cancel_reason:
-                      cancelled_at:
-                      closed_at:
+                      cancel_reason: 
+                      cancelled_at: 
+                      closed_at: 
                       specific_attributes:
                         new_geojson:
                           type: FeatureCollection
@@ -31473,7 +31854,7 @@ paths:
                                   - 51.4655038504508
                                 - - -0.11835515499115692
                                   - 51.465546460366994
-                            properties:
+                            properties: 
                         original_geojson:
                           type: Feature
                           geometry:
@@ -31489,7 +31870,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties:
+                          properties: 
               schema:
                 "$ref": "#/components/schemas/ValidationRequests"
         '401':

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -555,6 +555,11 @@ FactoryBot.define do
       suffix { "LDC" }
     end
 
+    trait :pre_application do
+      code { "preApp" }
+      suffix { "PRE" }
+    end
+
     trait :without_consultation do
       features {
         {


### PR DESCRIPTION
### Description of change

Add pre-application example to swagger

### Story Link

https://trello.com/c/iWGN8LwR

### Known issues

The main branch of the ODP schemas repo has a broken version of the pre-application schema and example because the build scripts were failing. To workaround this the PR uses a fixed version from https://github.com/theopensystemslab/digital-planning-data-schemas/pull/281 which adds the `data.application.type`. The intent is to migrate to a root level `applicationType` key but this is left until the work on the prototypeApplication schema is complete.

The format of the files in the pre-application example is different to the application schema with a simple string being returned instead of an object. To workaround this we do a type check and copy the tag to both the `tags` and `description` column because there's no lookup within BOPS for the description.