### PR TITLE
Add and edit preapplication services

### DIFF
--- a/app/controllers/planning_applications/additional_services_controller.rb
+++ b/app/controllers/planning_applications/additional_services_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  class AdditionalServicesController < AuthenticationController
+    before_action :set_planning_application
+    before_action :redirect_to_reference_url
+    before_action :redirect_unless_preapp
+
+    def edit
+    end
+
+    def update
+      services = additional_services_names.map { |name| @planning_application.additional_services.find_or_initialize_by(name: name) }
+      if (@planning_application.additional_services = services).map(&:save)
+        redirect_to planning_application_path(@planning_application), notice: t(".success")
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def additional_services_names
+      params.require(:planning_application).require(:additional_services).select(&:present?).map(&:to_sym)
+    end
+
+    def redirect_unless_preapp
+      # this will need to change if we support additional services on anything but preapps
+      return if @planning_application.pre_application?
+
+      redirect_to @planning_application, alert: "Cannot edit pre-application services on application of type ‘#{@planning_application.application_type.full_name}’"
+    end
+  end
+end

--- a/app/models/additional_service.rb
+++ b/app/models/additional_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AdditionalService < ApplicationRecord
+  belongs_to :planning_application
+
+  def name
+    super.to_sym
+  end
+end

--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -232,6 +232,10 @@ class ApplicationType < ApplicationRecord
     code.include?(".retro")
   end
 
+  def pre_application?
+    code == "preApp" || code.start_with?("preApp.")
+  end
+
   def work_status
     if retrospective?
       "retrospective"

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -59,6 +59,7 @@ class PlanningApplication < ApplicationRecord
     has_many :new_policy_classes, through: :planning_application_policy_classes
     has_many :planning_application_policy_sections
     has_many :policy_sections, through: :planning_application_policy_sections
+    has_many :preapplication_services
 
     with_options required: false do
       has_one :appeal

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -59,7 +59,7 @@ class PlanningApplication < ApplicationRecord
     has_many :new_policy_classes, through: :planning_application_policy_classes
     has_many :planning_application_policy_sections
     has_many :policy_sections, through: :planning_application_policy_sections
-    has_many :preapplication_services
+    has_many :additional_services
 
     with_options required: false do
       has_one :appeal
@@ -90,6 +90,7 @@ class PlanningApplication < ApplicationRecord
     delegate :publicity_consultation_feature?
     delegate :prior_approval?
     delegate :selected_reporting_types?
+    delegate :pre_application?
   end
 
   delegate :reviewer_group_email, to: :local_authority

--- a/app/models/preapplication_service.rb
+++ b/app/models/preapplication_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class PreapplicationService < AdditionalService
+  TYPES = %i[
+    written_advice
+    meeting
+    site_visit
+  ].freeze
+end

--- a/app/views/planning_applications/additional_services/edit.html.erb
+++ b/app/views/planning_applications/additional_services/edit.html.erb
@@ -1,0 +1,34 @@
+<% content_for :page_title do %>
+  Pre-application services - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
+<% content_for :title, "Pre-application services" %>
+
+<%= render(
+      partial: "shared/proposal_header",
+      locals: {heading: "Edit pre-application services"}
+    ) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @planning_application,
+          url: planning_application_additional_services_url(@planning_application) do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_check_boxes_fieldset :additional_services,
+            legend: {text: "Select required services"} do %>
+            <% PreapplicationService::TYPES.each do |type| %>
+              <%= form.govuk_check_box :additional_services, type, label: {text: type.to_s.humanize}, checked: @planning_application.additional_services.map(&:name).include?(type) %>
+            <% end %>
+      <% end %>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Save", class: "govuk-button", data: {module: "govuk-button"} %>
+        <%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -43,6 +43,15 @@
     <p class="govuk-body">
       Application type: <strong><%= @planning_application.application_type.description %></strong>
     </p>
+
+    <% if @planning_application.pre_application? %>
+      <p class="govuk-body" id="additional-services">
+        Requested services:
+        <%- @planning_application.additional_services.each_with_index do |service, i| -%><%- if i > 0 %>, <% end -%>
+          <strong><%= service.name.to_s.humanize %></strong><% end %>
+        <%= govuk_link_to "Change", edit_planning_application_additional_services_path(@planning_application) %>
+      </p>
+    <% end %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,6 +928,9 @@ en:
     successfully_created: Permitted development rights response was successfully created
     successfully_updated: Permitted development rights response was successfully updated
   planning_applications:
+    additional_services:
+      update:
+        success: Pre-application services updated
     appeals:
       create:
         success: Application was successfully marked for appeal

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Rails.application.routes.draw do
           patch :update, on: :collection
         end
 
+        resource :additional_services, only: %i[edit update], on: :collection
+
         resource :press_notice, only: %i[new show create update] do
           resource :confirmation, only: %i[show edit update], controller: "press_notices/confirmations"
           resources :confirmation_requests, only: %i[create], controller: "press_notices/confirmation_requests"

--- a/db/migrate/20241205144943_create_additional_services.rb
+++ b/db/migrate/20241205144943_create_additional_services.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateAdditionalServices < ActiveRecord::Migration[7.2]
+  def change
+    create_table :additional_services do |t|
+      t.string :type
+      t.string :name
+      t.references :planning_application, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,6 +44,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_163303) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "additional_services", force: :cascade do |t|
+    t.string "type"
+    t.string "name"
+    t.bigint "planning_application_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["planning_application_id"], name: "ix_additional_services_on_planning_application_id"
+  end
+
   create_table "api_users", force: :cascade do |t|
     t.string "name", null: false
     t.string "token", null: false
@@ -1084,6 +1093,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_163303) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "additional_services", "planning_applications"
   add_foreign_key "api_users", "local_authorities"
   add_foreign_key "appeals", "planning_applications"
   add_foreign_key "application_types", "legislation"

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -798,5 +798,9 @@ FactoryBot.define do
     trait :published do
       published_at { Time.zone.now }
     end
+
+    trait :pre_application do
+      application_type { create(:application_type, :pre_application) }
+    end
   end
 end

--- a/spec/system/planning_applications/preapplications_spec.rb
+++ b/spec/system/planning_applications/preapplications_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "assigning planning application" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority:) }
+
+  context "when application is a preapp" do
+    let(:planning_application) { create(:planning_application, :pre_application, local_authority:) }
+
+    before do
+      sign_in(assessor)
+      visit "/planning_applications/#{planning_application.reference}/"
+    end
+
+    it "shows preapp services option" do
+      expect(page).to have_content("Requested services: Change")
+    end
+
+    it "can edit preapp services" do
+      within "#additional-services" do
+        click_on "Change"
+      end
+
+      check "Site visit"
+      click_button "Save"
+      expect(page).to have_content("Requested services: Site visit Change")
+    end
+  end
+
+  context "when application is not a preapp" do
+    let(:planning_application) { create(:planning_application, :ldc_proposed, local_authority:) }
+
+    before do
+      sign_in(assessor)
+      visit "/planning_applications/#{planning_application.reference}/"
+    end
+
+    it "does not show preapp services" do
+      expect(page).not_to have_content("Requested services:")
+    end
+
+    it "cannot edit preapp services" do
+      visit "/planning_applications/#{planning_application.reference}/additional_services/edit"
+      expect(page).to have_content("Cannot edit pre-application services")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add preapplication services to an application and allow editing them

### Story Link

https://trello.com/c/zqIX6axa/198-able-to-see-any-additional-services-required-to-be-provided-during-pre-app

### Screenshots

<img width="681" alt="Screenshot 2024-12-10 at 14 37 28" src="https://github.com/user-attachments/assets/be5a3c4b-3094-414f-9475-c4aa2c73b7de">

<img width="737" alt="Screenshot 2024-12-10 at 14 37 36" src="https://github.com/user-attachments/assets/aa3d6593-8399-445a-9e1e-2183db933167">

