### PR TITLE
Add session ID to check fee page

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -101,8 +101,11 @@ class PlanningApplication < ApplicationRecord
     delegate :suffix, to: :application_type
     delegate :rejected_review?, to: :committee_decision
   end
-  delegate :params_v1, to: :planx_planning_data, allow_nil: true
-  delegate :params_v2, to: :planx_planning_data, allow_nil: true
+  with_options to: :planx_planning_data, allow_nil: true do
+    delegate :params_v1
+    delegate :params_v2
+    delegate :session_id
+  end
   delegate :work_status, to: :application_type
 
   delegate :lodged?, :validated?, :started?, :determined?, to: :appeal, allow_nil: true, prefix: true

--- a/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
+++ b/app/views/planning_applications/validation/fee_items/_fee_item_table.html.erb
@@ -1,11 +1,5 @@
-<h3 class="govuk-heading-m">Overview</h3>
+<h3 class="govuk-heading-m">Payment information</h3>
 <table class="govuk-table fee-table govuk-!-margin-bottom-2">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header"><%= t(".item") %></th>
-      <th scope="col" class="govuk-table__header"><%= t(".detail") %></th>
-    </tr>
-  </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
       <th scope="row" class="govuk-table__header"><%= t(".fee_paid") %></th>
@@ -25,8 +19,8 @@
       </td>
     </tr>
     <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header"><%= t(".description") %></th>
-      <td class="govuk-table__cell"><%= render(FormattedContentComponent.new(text: @planning_application.description)) %></td>
+      <th scope="row" class="govuk-table__header"><%= t(".session_id") %></th>
+      <td class="govuk-table__cell"><%= @planning_application.session_id %></td>
     </tr>
   </tbody>
 </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1875,12 +1875,12 @@ en:
             summary: Tell the applicant why the fee is incorrect
       fee_items:
         fee_item_table:
-          description: Description
           detail: Detail
           exempt: Exempt
           fee_paid: Fee Paid
           item: Item
           payment_reference: Payment Reference
+          session_id: Session ID
         proposal_details_table:
           related_questions: Related questions and answers from PlanX
         validate:

--- a/spec/system/planning_applications/validating/fee_items_validation_spec.rb
+++ b/spec/system/planning_applications/validating/fee_items_validation_spec.rb
@@ -63,11 +63,6 @@ RSpec.describe "FeeItemsValidation", type: :system do
       table = find_all(".govuk-table").first
 
       within(table) do
-        within(".govuk-table__head") do
-          expect(page).to have_content("Item")
-          expect(page).to have_content("Detail")
-        end
-
         within(".govuk-table__body") do
           rows = page.all(".govuk-table__row")
 
@@ -82,8 +77,8 @@ RSpec.describe "FeeItemsValidation", type: :system do
           end
 
           within(rows[2]) do
-            expect(page).to have_content("Description")
-            expect(page).to have_content(planning_application.description)
+            expect(page).to have_content("Session ID")
+            expect(page).to have_content("21161b70-0e29-40e6-9a38-c42f61f25ab9")
           end
         end
       end
@@ -182,14 +177,6 @@ RSpec.describe "FeeItemsValidation", type: :system do
       expect(page).to have_content("Request other validation change (fee)")
       expect(page).to have_content("Application number: #{planning_application.reference}")
 
-      # Display fee item table
-      within(".govuk-table") do
-        within(".govuk-table__head") do
-          expect(page).to have_content("Item")
-          expect(page).to have_content("Detail")
-        end
-      end
-
       within(".govuk-details__summary") do
         expect(page).to have_content(
           "View guidance on supporting documents"
@@ -269,12 +256,7 @@ RSpec.describe "FeeItemsValidation", type: :system do
         expect(page).to have_content("Application number: #{planning_application.reference}")
 
         # Display fee item table
-        within(".govuk-table") do
-          within(".govuk-table__head") do
-            expect(page).to have_content("Item")
-            expect(page).to have_content("Detail")
-          end
-        end
+        expect(page).to have_css(".fee-table")
 
         fill_in(
           "Tell the applicant why the fee is incorrect",


### PR DESCRIPTION
### Description of change

Add session ID to check fee page
- This enables better fee reconciliation between PlanX and BOPS

### Story Link

https://trello.com/c/bPwMdB10/68-add-planx-session-id-to-bops-application

### Screenshots

<img width="680" alt="Screenshot 2024-12-10 at 13 36 56" src="https://github.com/user-attachments/assets/d26ae86a-8500-4d7b-a2fc-1f40fba9f4e4">
