### PR TITLE
Enable site histories per local authority

### DIFF
--- a/app/controllers/planning_applications/assessment/site_histories_controller.rb
+++ b/app/controllers/planning_applications/assessment/site_histories_controller.rb
@@ -7,7 +7,7 @@ module PlanningApplications
       before_action :set_site_history, except: %i[confirm]
 
       def index
-        if @planning_application.planning_history_enabled?
+        if current_local_authority.planning_history_enabled?
           @site_histories += Apis::Paapi::Query.new.fetch(@planning_application.uprn)
         end
 

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -560,10 +560,6 @@ class PlanningApplication < ApplicationRecord
     policy_classes.pluck(:section).include?(section)
   end
 
-  def planning_history_enabled?
-    Rails.configuration.planning_history_enabled
-  end
-
   def rejected_assessment_detail(category:)
     assessment_details.where(
       category:,

--- a/config/application.yml
+++ b/config/application.yml
@@ -6,7 +6,6 @@ shared:
   notify_letter_api_key: <%= ENV["NOTIFY_LETTER_API_KEY"] %>
   otp_secret_encryption_key: <%= ENV["OTP_SECRET_ENCRYPTION_KEY"] %>
   paapi_url: <%= ENV.fetch("PAAPI_URL", "https://staging.paapi.services/api/v1") %>
-  planning_history_enabled: <%= ENV["PLANNING_HISTORY_ENABLED"] == "true" %>
   planx_file_api_key: <%= ENV["PLANX_FILE_API_KEY"] %>
   planx_file_production_api_key: <%= ENV["PLANX_FILE_PRODUCTION_API_KEY"] %>
   staging_api_bearer: <%= ENV["STAGING_API_BEARER"] %>

--- a/db/migrate/20241213114148_add_planning_history_enabled_to_local_authority.rb
+++ b/db/migrate/20241213114148_add_planning_history_enabled_to_local_authority.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddPlanningHistoryEnabledToLocalAuthority < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      add_column :local_authorities, :planning_history_enabled, :boolean
+
+      up_only do
+        execute <<~SQL
+          UPDATE local_authorities
+          SET planning_history_enabled = CASE
+          WHEN subdomain = 'buckinghamshire' THEN TRUE
+          WHEN subdomain = 'lambeth' THEN TRUE
+          ELSE FALSE
+          END
+        SQL
+
+        change_column_default :local_authorities, :planning_history_enabled, false
+        change_column_null :local_authorities, :planning_history_enabled, false
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_10_163303) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_13_114148) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -496,6 +496,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_10_163303) do
     t.string "document_checklist"
     t.string "planning_policy_and_guidance"
     t.string "notify_error_status"
+    t.boolean "planning_history_enabled", default: false, null: false
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
   end
 

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -62,5 +62,9 @@ FactoryBot.define do
         local_authority.api_users.find_or_create_by!(name: local_authority.subdomain)
       end
     end
+
+    trait :planning_history do
+      planning_history_enabled { true }
+    end
   end
 end

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Assessment tasks", type: :system do
 
   before do
     sign_in assessor
-    Rails.configuration.planning_history_enabled = true
+
     visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
   end
 

--- a/spec/system/planning_applications/assessing/planning_history_show_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_history_show_spec.rb
@@ -3,13 +3,11 @@
 require "rails_helper"
 
 RSpec.describe "Planning History" do
-  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:default_local_authority) { create(:local_authority, :default, :planning_history) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
   before do
     sign_in assessor
-
-    Rails.configuration.planning_history_enabled = true
   end
 
   context "when planning application's property uprn has planning history" do


### PR DESCRIPTION
### Description of change

Only a limited number of local authorities have imported data into PAAPI so only enable it for those.

### Story Link

https://trello.com/c/NmkvSLHe
