### PR TITLE
Use strings for nested model factory class names

### DIFF
--- a/spec/factories/local_authority_informative.rb
+++ b/spec/factories/local_authority_informative.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :local_authority_informative, class: LocalAuthority::Informative do
+  factory :local_authority_informative, class: "LocalAuthority::Informative" do
     local_authority
     title { Faker::Lorem.sentence }
     text { Faker::Lorem.paragraph }

--- a/spec/factories/local_authority_policy_area.rb
+++ b/spec/factories/local_authority_policy_area.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :local_authority_policy_area, class: LocalAuthority::PolicyArea do
+  factory :local_authority_policy_area, class: "LocalAuthority::PolicyArea" do
     local_authority
     description { Faker::Lorem.unique.sentence }
   end

--- a/spec/factories/local_authority_policy_guidance.rb
+++ b/spec/factories/local_authority_policy_guidance.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :local_authority_policy_guidance, class: LocalAuthority::PolicyGuidance do
+  factory :local_authority_policy_guidance, class: "LocalAuthority::PolicyGuidance" do
     local_authority
     description { Faker::Lorem.unique.sentence }
   end

--- a/spec/factories/local_authority_policy_reference.rb
+++ b/spec/factories/local_authority_policy_reference.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :local_authority_policy_reference, class: LocalAuthority::PolicyReference do
+  factory :local_authority_policy_reference, class: "LocalAuthority::PolicyReference" do
     local_authority
     code { Faker::IDNumber.unique.ssn_valid }
     description { Faker::Lorem.unique.sentence }


### PR DESCRIPTION
Using the actual class name triggers the model to load in situations where this is undesirable such as when creating the database during CI runs.
