### PR TITLE
Allow deactivation and reactivation of users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,10 @@
 
 class User < ApplicationRecord
   include BopsCore::AuditableModel
+  include Discard::Model
 
   self.audit_attributes = %w[id name role]
+  self.discard_column = :deactivated_at
 
   enum :role, {assessor: 0, reviewer: 1, administrator: 2, global_administrator: 3}
   enum :otp_delivery_method, {sms: 0, email: 1}
@@ -32,8 +34,8 @@ class User < ApplicationRecord
 
   scope :non_administrator, -> { where.not(role: "administrator") }
   scope :global_administrator, -> { where(local_authority_id: nil, role: "global_administrator") }
-  scope :confirmed, -> { where.not(confirmed_at: nil) }
-  scope :unconfirmed, -> { where(confirmed_at: nil) }
+  scope :confirmed, -> { kept.where.not(confirmed_at: nil) }
+  scope :unconfirmed, -> { kept.where(confirmed_at: nil) }
 
   class << self
     def menu(scope = User.all)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,10 +54,10 @@ class User < ApplicationRecord
     email = tainted_conditions[:email]
 
     if subdomain == "config"
-      User.global_administrator.find_first_by_auth_conditions(email:)
+      User.kept.global_administrator.find_first_by_auth_conditions(email:)
     else
       local_authority = LocalAuthority.find_by!(subdomain:)
-      local_authority.users.find_first_by_auth_conditions(email:)
+      local_authority.users.kept.find_first_by_auth_conditions(email:)
     end
   end
 

--- a/db/migrate/20241219161821_add_deactivated_at_to_users.rb
+++ b/db/migrate/20241219161821_add_deactivated_at_to_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddDeactivatedAtToUsers < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_column :users, :deactivated_at, :datetime
+    add_index :users, :deactivated_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_16_141746) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_19_161821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -1058,7 +1058,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_16_141746) do
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
     t.string "persistence_token"
+    t.datetime "deactivated_at"
     t.index ["confirmation_token"], name: "ix_users_on_confirmation_token", unique: true
+    t.index ["deactivated_at"], name: "ix_users_on_deactivated_at"
     t.index ["email", "local_authority_id"], name: "index_users_on_email_and_local_authority_id", unique: true
     t.index ["encrypted_otp_secret"], name: "ix_users_on_encrypted_otp_secret", unique: true
     t.index ["local_authority_id"], name: "index_users_on_local_authority_id"

--- a/engines/bops_admin/app/controllers/bops_admin/users_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/users_controller.rb
@@ -4,7 +4,7 @@ module BopsAdmin
   class UsersController < ApplicationController
     before_action :set_users, only: %i[index]
     before_action :build_user, only: %i[new create]
-    before_action :set_user, only: %i[edit update resend_invite]
+    before_action :set_user, only: %i[edit update resend_invite destroy reactivate]
 
     def index
       respond_to do |format|
@@ -41,6 +41,30 @@ module BopsAdmin
         if @user.update(user_params)
           format.html do
             redirect_to users_path, notice: t(".user_successfully_updated")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        if @user.discard
+          format.html do
+            redirect_to users_path, notice: t(".success")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def reactivate
+      respond_to do |format|
+        if @user.undiscard
+          format.html do
+            redirect_to users_path, notice: t(".success")
           end
         else
           format.html { render :edit }

--- a/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
@@ -23,5 +23,16 @@
   <div class="govuk-button-group">
     <%= form.govuk_submit(t(".submit")) %>
     <%= back_link %>
+    <% if @user.persisted? %>
+      <% if @user.discarded? %>
+        <%= govuk_button_link_to("Reactivate user", reactivate_user_path(@user),
+              warning: true,
+              method: :patch, data: {confirm: "Are you sure?"}) %>
+      <% else %>
+        <%= govuk_button_link_to("Deactivate user", user_path(@user),
+              warning: true,
+              method: :delete, data: {confirm: "Are you sure?"}) %>
+      <% end %>
+    <% end %>
   </div>
 <% end %>

--- a/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
@@ -23,7 +23,7 @@
   <div class="govuk-button-group">
     <%= form.govuk_submit(t(".submit")) %>
     <%= back_link %>
-    <% if @user.persisted? %>
+    <% if @user.persisted? && @user != current_user %>
       <% if @user.discarded? %>
         <%= govuk_button_link_to("Reactivate user", reactivate_user_path(@user),
               warning: true,

--- a/engines/bops_admin/app/views/bops_admin/users/_table.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_table.html.erb
@@ -4,6 +4,9 @@
     <th scope="col" class="govuk-table__header">User details</th>
     <th scope="col" class="govuk-table__header">2FA set up</th>
     <th scope="col" class="govuk-table__header">2FA method</th>
+    <% if local_assigns[:deactivated] %>
+      <th scope="col" class="govuk-table__header">Deactivation date</th>
+    <% end %>
   </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -26,6 +29,11 @@
       <td class="govuk-table__cell">
         <%= t(".#{user.otp_delivery_method}") %>
       </td>
+      <% if local_assigns[:deactivated] %>
+        <td class="govuk-table__cell">
+          Deactivated at <%= user.deactivated_at.to_fs %>
+        </td>
+      <% end %>
     </tr>
   <% end %>
   </tbody>

--- a/engines/bops_admin/app/views/bops_admin/users/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for :title, t(".users") %>
 
 <% if @users.any?(&:unconfirmed?) %>
-  <%= render("status_prompt", users: @users.select(&:unconfirmed?)) %>
+  <%= render("status_prompt", users: @users.unconfirmed) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -29,10 +29,10 @@
         </li>
       </ul>
       <div class="govuk-tabs__panel govuk-tabs__panel" id="confirmed">
-        <%= render("table", users: @users.select(&:confirmed?)) %>
+        <%= render("table", users: @users.confirmed) %>
       </div>
       <div class="govuk-tabs__panel govuk-tabs__panel" id="unconfirmed">
-        <%= render("table", users: @users.select(&:unconfirmed?)) %>
+        <%= render("table", users: @users.unconfirmed) %>
       </div>
     </div>
     <div class="govuk-button-group">

--- a/engines/bops_admin/app/views/bops_admin/users/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/index.html.erb
@@ -27,12 +27,20 @@
             Unconfirmed
           </a>
         </li>
+        <li class="govuk-tabs__list-item">
+          <a class="govuk-tabs__tab" href="#deactivated">
+            Deactivated
+          </a>
+        </li>
       </ul>
       <div class="govuk-tabs__panel govuk-tabs__panel" id="confirmed">
         <%= render("table", users: @users.confirmed) %>
       </div>
       <div class="govuk-tabs__panel govuk-tabs__panel" id="unconfirmed">
         <%= render("table", users: @users.unconfirmed) %>
+      </div>
+      <div class="govuk-tabs__panel govuk-tabs__panel" id="deactivated">
+        <%= render("table", users: @users.discarded, deactivated: true) %>
       </div>
     </div>
     <div class="govuk-button-group">

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -333,6 +333,8 @@ en:
     users:
       create:
         user_successfully_created: User successfully created
+      destroy:
+        success: User successfully deactivated
       edit:
         edit_user: Edit user
       form:
@@ -344,6 +346,8 @@ en:
         users: Manage users
       new:
         add_user: Add a new user
+      reactivate:
+        success: User successfully reactivated
       resend_invite:
         confirmation_failed_to_resend: Unable to send a reminder email - please contact support
         confirmation_resent: User will receive a reminder email

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -26,7 +26,8 @@ BopsAdmin::Engine.routes.draw do
 
   resources :tokens, except: %i[show]
 
-  resources :users, except: %i[show destroy] do
+  resources :users, except: %i[show] do
     get :resend_invite, on: :member
+    patch :reactivate, on: :member
   end
 end

--- a/engines/bops_admin/spec/system/users_spec.rb
+++ b/engines/bops_admin/spec/system/users_spec.rb
@@ -170,6 +170,23 @@ RSpec.describe "Users" do
     end
   end
 
+  it "allows deactivation of an existing user", capybara: true do
+    create(:user, :reviewer, local_authority:, name: "Bella Jones", otp_delivery_method: :email)
+
+    visit "/admin/users"
+
+    within("#confirmed tbody tr:nth-child(1)") do
+      expect(page).to have_content("Bella Jones")
+      click_link("Edit user")
+    end
+
+    accept_confirm do
+      click_link "Deactivate user"
+    end
+
+    expect(page).to have_text("User successfully deactivated")
+  end
+
   context "when users are unconfirmed" do
     before do
       2.times do
@@ -228,6 +245,44 @@ RSpec.describe "Users" do
       expect(page).to have_content("User will receive a reminder email")
       expect(last_email.subject).to eq("Set password instructions")
       expect(last_email.body).to include("Welcome to the Back-office Planning System")
+    end
+  end
+
+  context "when there are deactivated users", :capybara do
+    before do
+      create(:user, :reviewer, local_authority:, name: "Dieter Waldbeck")
+      create(:user, :assessor, local_authority:, name: "Andrea Khan", deactivated_at: 1.day.ago)
+    end
+
+    it "lists the deactivated users" do
+      visit "/admin/users"
+
+      click_link "Deactivated"
+
+      within("#deactivated table.govuk-table") do
+        expect(page).to have_selector("tr:nth-child(1)", text: "Andrea Khan")
+        # only testing for the date, not the time, to avoid a race condition if the minute ticks over
+        expect(page).to have_selector("tr:nth-child(1)", text: "Deactivated at #{1.day.ago.to_date.to_fs}")
+      end
+    end
+
+    it "allows reactivating the deactivated users" do
+      visit "/admin/users"
+
+      click_link "Deactivated"
+
+      within("#deactivated table.govuk-table") do
+        click_on "Edit user"
+      end
+
+      accept_confirm do
+        click_on "Reactivate"
+      end
+
+      expect(page).to have_text("User successfully reactivated")
+      within("#confirmed table.govuk-table") do
+        expect(page).to have_selector("tr:nth-child(1)", text: "Andrea Khan")
+      end
     end
   end
 end

--- a/engines/bops_admin/spec/system/users_spec.rb
+++ b/engines/bops_admin/spec/system/users_spec.rb
@@ -285,4 +285,22 @@ RSpec.describe "Users" do
       end
     end
   end
+
+  context "when user account is deactivated", :capybara do
+    let(:deactivated_user) { create(:user, :assessor, local_authority:, deactivated_at: 1.day.ago) }
+
+    before do
+      sign_out(user)
+    end
+
+    it "can't sign in" do
+      visit "/"
+      fill_in("user[email]", with: deactivated_user.email)
+      fill_in("user[password]", with: deactivated_user.password)
+      click_button("Log in")
+
+      expect(page).to have_text("Invalid Email or password.")
+      expect(page).not_to have_text("Signed in successfully.")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Allow marking a user as deactivated and reactivating them.

### Story Link

https://trello.com/c/Be3PE2h7/226-able-to-manage-users-in-bops