### PR TITLE
Show correct permitted development right assessment

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -41,13 +41,13 @@
     <p class="govuk-body"><%= review_immunity_detail.summary %></p>
   </section>
 <% end %>
-<% if permitted_development_right %>
+<% if permitted_development_right.persisted? %>
   <section id="permitted-development-rights-section" class="govuk-!-margin-bottom-7">
     <h3 class="govuk-heading-m"><%= t(".have_the_permitted_development_rights") %></h3>
     <% if permitted_development_right.removed %>
       <p class="govuk-body"><strong>Yes</strong></p>
       <%= render(FormattedContentComponent.new(text: permitted_development_right.removed_reason)) %>
-    <% else %>
+    <% elsif permitted_development_right.removed == false %>
       <p class="govuk-body"><strong>No</strong></p>
     <% end %>
   </section>

--- a/app/views/planning_applications/assessment/permitted_development_rights/_form.html.erb
+++ b/app/views/planning_applications/assessment/permitted_development_rights/_form.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <%= form.govuk_radio_button(
-          :removed, false, checked: !@permitted_development_right.removed, label: {text: "No"}
+          :removed, false, checked: @permitted_development_right.removed == false, label: {text: "No"}
         ) %>
   <% end %>
 

--- a/app/views/planning_applications/review/permitted_development_rights/_summary.html.erb
+++ b/app/views/planning_applications/review/permitted_development_rights/_summary.html.erb
@@ -7,9 +7,13 @@
       <%= @permitted_development_right.removed_reason %>
     </p>
   </div>
-<% else %>
+<% elsif @permitted_development_right.removed == false %>
   <p class="govuk-body">
     The permitted development rights have not been removed.
+  </p>
+<% else %>
+  <p class="govuk-body">
+    There was no assessment for permitted development rights
   </p>
 <% end %>
 


### PR DESCRIPTION
### Description of change

Show correct permitted development right assessment

### Story Link

https://trello.com/c/BlcdKdY3/254-permitted-development-rights-appearing-on-all-assessment-reports

