### PR TITLE
Sign out via delete and get

### DIFF
--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -28,7 +28,8 @@
                   t(".log_out"),
                   main_app.destroy_user_session_path,
                   method: :delete,
-                  class: "govuk-header__link"
+                  class: "govuk-header__link",
+                  rel: "nofollow"
                 ) %>
           </div>
         </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -37,7 +37,7 @@ Devise.setup do |config|
 
   config.reset_password_within = 6.hours
 
-  config.sign_out_via = :delete
+  config.sign_out_via = [:delete, :get]
 
   config.otp_allowed_drift = 300
 


### PR DESCRIPTION
### Description of change

- Avoid 404 error when navigating directly to sign_out url

### Story Link

https://trello.com/c/BJ0fBbXS/143-error-when-logging-out