### PR TITLE
Fix GPDO routing and add description to planning application policy ssections

### DIFF
--- a/app/models/planning_application_policy_section.rb
+++ b/app/models/planning_application_policy_section.rb
@@ -17,7 +17,9 @@ class PlanningApplicationPolicySection < ApplicationRecord
     reject_if: :reject_comment?
   )
 
-  validates :status, presence: true
+  validates :status, :description, presence: true
+
+  before_validation :set_description, on: :create
 
   enum(
     status: {
@@ -27,6 +29,10 @@ class PlanningApplicationPolicySection < ApplicationRecord
     },
     _default: :to_be_determined
   )
+
+  def set_description
+    self.description ||= policy_section.description
+  end
 
   def last_comment
     @last_comment ||= persisted_comments.last

--- a/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
@@ -37,7 +37,7 @@
           <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
             <% row.with_cell do %>
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
-              <%= render(FormattedContentComponent.new(text: policy_section.description)) %>
+              <%= render(FormattedContentComponent.new(text: pa_policy_section&.description || policy_section.description)) %>
 
               <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.id}][comments_attributes][0][text]",
                     label: {text: "Add comment", class: "govuk-label govuk-label--s"},

--- a/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
@@ -27,7 +27,7 @@
           <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
             <% row.with_cell do %>
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
-              <%= render(FormattedContentComponent.new(text: policy_section.description)) %>
+              <%= render(FormattedContentComponent.new(text: pa_policy_section&.description || policy_section.description)) %>
 
               <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.id}][comments_attributes][0][text]",
                     label: {text: "Add comment", class: "govuk-label govuk-label--s"},

--- a/db/migrate/20241217112749_add_description_to_planning_application_policy_sections.rb
+++ b/db/migrate/20241217112749_add_description_to_planning_application_policy_sections.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddDescriptionToPlanningApplicationPolicySections < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      add_column :planning_application_policy_sections, :description, :text
+
+      up_only do
+        execute <<~SQL
+          UPDATE planning_application_policy_sections
+          SET description = policy_sections.description
+          FROM policy_sections
+          WHERE policy_sections.id = planning_application_policy_sections.policy_section_id
+        SQL
+
+        change_column_null :planning_application_policy_sections, :description, false
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -735,6 +735,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_19_161821) do
     t.bigint "policy_section_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description", null: false
     t.index ["planning_application_id"], name: "ix_planning_application_policy_sections_on_planning_application"
     t.index ["policy_section_id"], name: "ix_planning_application_policy_sections_on_policy_section_id"
   end

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -35,7 +35,7 @@ BopsConfig::Engine.routes.draw do
       resources :policy_schedules, param: :number, path: "schedule" do
         resources :policy_parts, param: :number, path: "part" do
           resources :policy_class, param: :section, path: "class" do
-            resources :policy_sections, param: :section, path: "section"
+            resources :policy_sections, param: :section, path: "section", constraints: {section: /.*/}
           end
         end
       end

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -158,8 +158,15 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
             expect(page).to have_content("Policy class was successfully updated")
             expect(page).to have_list_item_for("Part 1, Class A", with: "In progress")
 
+            # Updating policy section description
+            policy_section1a.update!(description: "A new description")
+
             click_link("Part 1, Class A")
             within("#policy-section-#{policy_section1a.id}") do
+              # Description at time of assessment should be present
+              expect(page).to have_content("description for section 1a")
+              expect(page).not_to have_content("A new description")
+
               expect(page).to have_field("Add comment", with: "My first comment")
               fill_in("Add comment", with: "Updated first comment")
             end

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Reviewing Policy Class", type: :system do
 
       let!(:policy_section1a) { create(:policy_section, section: "1a", description: "description for section 1a", new_policy_class: policy_classA) }
       let!(:policy_section1b) { create(:policy_section, section: "1b", description: "description for section 1b", new_policy_class: policy_classA) }
-      let!(:policy_section2bii) { create(:policy_section, section: "2b(ii)", description: "description for section 2ab(ii)", new_policy_class: policy_classA) }
+      let!(:policy_section2bii) { create(:policy_section, section: "2b(ii)", description: "description for section 2bb(ii)", new_policy_class: policy_classA) }
 
       let!(:pa_policy_section1a) { create(:planning_application_policy_section, :complies, policy_section: policy_section1a, planning_application:) }
       let!(:pa_policy_section1b) { create(:planning_application_policy_section, :complies, policy_section: policy_section1b, planning_application:) }
@@ -122,6 +122,9 @@ RSpec.describe "Reviewing Policy Class", type: :system do
 
         expect(list_item("Part 1, Class A")).to have_content("To be reviewed")
 
+        # Updating policy section description
+        policy_section2bii.update!(description: "A new description")
+
         click_link("Part 1, Class A")
         within("#reviewer_comment") do
           expect(page).to have_content("Reviewer comment:")
@@ -129,6 +132,10 @@ RSpec.describe "Reviewing Policy Class", type: :system do
         end
 
         within("#policy-section-#{policy_section2bii.id}") do
+          # Description at time of assessment should be present
+          expect(page).to have_content("description for section 2bb(ii)")
+          expect(page).not_to have_content("A new description")
+
           choose(option: "complies")
         end
         click_button("Save and mark as complete")


### PR DESCRIPTION
### Description of change

Fix GPDO routing and add description to planning application policy ssections
- allow dots in the route by specifying constraints
- add text description column and backfill policy section description. We want to keep a record of what the description was at the time when this record is created so it isn't affected by future edits of the policy section description

### Story Link

https://trello.com/c/WV4zF3Rt/48-gpdo-admin-cannot-edit-remove-policy-sections-if-it-is-the-only-section-added

