### PR TITLE
Use `travel_to` to avoid date-sensitive expected values

### DIFF
--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe "BOPS public API" do
   let(:document) { create(:document, :with_tags, validated: true, publishable: true) }
   let(:planning_application) { create(:planning_application, :published, :with_boundary_geojson, :determined, documents: [document], local_authority:, application_type:) }
 
+  around do |example|
+    travel_to("2024-10-22T10:30:00Z") { example.run }
+  end
+
   path "/api/v2/public/planning_applications/{reference}/documents" do
     get "Retrieves documents for a planning application" do
       tags "Planning applications"

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1513,13 +1513,14 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
   end
 
   describe "#send_committee_decision_mail" do
-    let!(:local_authority) do
+    let(:local_authority) do
       create(
         :local_authority,
         :default
       )
     end
-    let!(:committee_decision) do
+
+    let(:committee_decision) do
       create(
         :committee_decision,
         planning_application:,
@@ -1540,7 +1541,13 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
     let(:mail_body) { send_committee_decision_mail.body.encoded }
 
     before do
+      travel_to("2024-10-22") do
+        planning_application.touch
+      end
+
+      committee_decision.touch
       planning_application.update(decision: "granted")
+      send_committee_decision_mail
     end
 
     it "emails the applicant" do


### PR DESCRIPTION
These specs would break again in January 2026 if we just changed the reference.
