### PR TITLE
Raise error when neighbor comments sent to invalid application type

### DIFF
--- a/app/controllers/api/v1/neighbour_responses_controller.rb
+++ b/app/controllers/api/v1/neighbour_responses_controller.rb
@@ -9,6 +9,10 @@ module Api
       skip_before_action :authenticate_api_user!
 
       def create
+        unless @planning_application.application_type.consultation_steps.include? "neighbour"
+          raise NeighbourResponseCreationService::CreateError, "This application type cannot accept neighbour responses"
+        end
+
         @neighbour_response = NeighbourResponseCreationService.new(
           params:, planning_application: @planning_application
         ).call

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -42,4 +42,23 @@ RSpec.describe "Creating a planning application via the API" do
     expect(response).not_to be_successful
     expect(response).to have_http_status :bad_request
   end
+
+  context "when the application type doesn't include neighbour consultation" do
+    let(:application_type) { create(:application_type, :without_consultation) }
+    let!(:planning_application) { create(:planning_application, :planning_permission, local_authority: default_local_authority, application_type:) }
+    it "successfully creates a new neighbour response" do
+      json = {
+        name: "Keira Walsh",
+        response: "This is good",
+        address: "123 street, AAA111",
+        summary_tag: "supportive",
+        files: [""]
+      }.to_json
+
+      post(path, params: json, headers:)
+
+      expect(response).not_to be_successful
+      expect(JSON.parse(response.body)["message"]).to eq("This application type cannot accept neighbour responses")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

If neighbour comments are sent to an application of a type that doesn't support them, the creation fails with a `NoMethodError`. Instead we should explicitly reject them and return an intentional error.

### Story Link

https://trello.com/c/NKZ1z9tn/60-neighbour-responses-to-an-application-without-a-consultation-are-handled-badly
