### PR TITLE
Use reference not id in links to bops-applicants

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -6,7 +6,7 @@ class PlanningApplicationMailer < ApplicationMailer
 
   def decision_notice_mail(planning_application, host, user)
     @planning_application = planning_application
-    @decision_notice_url = decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.id, format: "pdf", host: host)
+    @decision_notice_url = decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.reference, format: "pdf", host: host)
 
     view_mail(
       NOTIFY_TEMPLATE_ID,

--- a/app/models/committee_decision.rb
+++ b/app/models/committee_decision.rb
@@ -101,7 +101,7 @@ class CommitteeDecision < ApplicationRecord
   end
 
   def application_link
-    "#{planning_application.local_authority.applicants_url}/planning_applications/#{planning_application.id}"
+    "#{planning_application.local_authority.applicants_url}/planning_applications/#{planning_application.reference}"
   end
 
   def review_complete?

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -383,7 +383,7 @@ class Consultation < ApplicationRecord
   end
 
   def application_link
-    "#{local_authority.applicants_url}/planning_applications/#{planning_application.id}"
+    "#{local_authority.applicants_url}/planning_applications/#{planning_application.reference}"
   end
 
   def period_days

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -431,7 +431,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def site_notice_link
-    "#{local_authority.applicants_url}/planning_applications/#{id}/site_notices/download"
+    "#{local_authority.applicants_url}/planning_applications/#{reference}/site_notices/download"
   end
 
   def last_site_notice_audit

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -83,11 +83,7 @@ class SiteNotice < ApplicationRecord
   private
 
   def application_link
-    if Bops.env.production?
-      "https://planningapplications.#{planning_application.local_authority.subdomain}.gov.uk/planning_applications/#{planning_application.id}"
-    else
-      "https://#{planning_application.local_authority.subdomain}.bops-applicants.services/planning_applications/#{planning_application.id}"
-    end
+    "#{planning_application.local_authority.applicants_url}/planning_applications/#{planning_application.reference}"
   end
 
   def eia_statement

--- a/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/documents/show.json.jbuilder
@@ -15,6 +15,6 @@ end
 if @planning_application.decision
   json.decisionNotice do
     json.name "decision-notice-#{@planning_application.reference_in_full}.pdf"
-    json.url main_app.decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.id, format: "pdf")
+    json.url main_app.decision_notice_api_v1_planning_application_url(@planning_application, id: @planning_application.reference, format: "pdf")
   end
 end

--- a/engines/bops_api/spec/requests/v2/public/documents_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/documents_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "BOPS public API" do
           expect(data["application"]["reference"]).to eq(planning_application.reference)
           expect(data["files"]).not_to be_empty
           expect(data["decisionNotice"]["name"]).to eq("decision-notice-PlanX-24-00100-HAPP.pdf")
-          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf")
+          expect(data["decisionNotice"]["url"]).to eq("http://planx.example.com/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf")
         end
       end
 

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes a link to the decision notice" do
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
+        "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
       )
     end
 
@@ -130,7 +130,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "includes a link to the decision notice" do
         expect(mail_body).to include(
-          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.id}/decision_notice.pdf"
+          "https://planx.bops-applicants.services/api/v1/planning_applications/#{planning_application.reference}/decision_notice.pdf"
         )
       end
 
@@ -968,7 +968,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "A prior approval application has been made for the development described below:"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}"
       )
     end
 
@@ -1056,7 +1056,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "As part of the application process"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
       )
     end
   end
@@ -1126,7 +1126,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "The site notice for this application is ready for display"
       )
       expect(mail_body).to include(
-        "https://planx.bops-applicants.services/planning_applications/#{planning_application.id}/site_notices/download"
+        "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notices/download"
       )
     end
   end


### PR DESCRIPTION
### Description of change

Switch over to reference-based routes in bops-applicants now that it supports them.

### Story Link

https://trello.com/c/1xlU7eZa/221-change-email-and-letter-content-so-that-bops-applicants-urls-use-planning-applications-reference-and-not-id-same-as-bops
