### PR TITLE
Add application details to assessment report

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -1,3 +1,25 @@
+<section id="application-details-section" class="govuk-!-margin-bottom-7">
+  <h3 class="govuk-heading-m"><%= t(".application_details") %></h3>
+
+  <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list|
+        {
+          "Applicant" => planning_application.applicant_name,
+          "Application number" => planning_application.reference,
+          "Application type" => planning_application.application_type.description,
+          "Decision date" => planning_application.determination_date&.to_fs || "TBD",
+          "Site address" => planning_application.full_address,
+          "Use/development" => planning_application.description,
+          "Assigned officer" => planning_application.user&.name || "Unassigned",
+          "Recommendation agreed by" => planning_application.recommendation.reviewer&.name || "TBD"
+        }.each do |pair|
+          summary_list.with_row do |row|
+            row.with_key { pair[0] }
+            row.with_value { pair[1] }
+          end
+        end
+      end %>
+</section>
+
 <section id="constraints-section" class="govuk-!-margin-bottom-7">
   <h3 class="govuk-heading-m"><%= t(".constraints_including_article") %></h3>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1174,6 +1174,7 @@ en:
             success: Summary of works was successfully updated.
       assessment_report_component:
         additional_evidence: Summary of additional evidence
+        application_details: Application details
         assessment_against_policies_and_guidance: Policies and guidance
         constraints_including_article: Constraints including Article 4 direction(s)
         consultation_documents: Consultation documents

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "viewing assessment report", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: local_authority) }
+  let!(:assessor) { create(:user, :assessor, local_authority:) }
 
   let!(:assessor) do
     create(
@@ -22,7 +23,8 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
       :with_constraints,
       local_authority:,
       decision: :granted,
-      api_user:
+      api_user:,
+      user: assessor
     )
   end
 
@@ -98,6 +100,14 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
     visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
     click_link("Review and submit recommendation")
     click_button("Assessment report details")
+
+    within("#application-details-section") do
+      expect(page).to have_content(planning_application.applicant_name)
+      expect(page).to have_content(planning_application.reference)
+      expect(page).to have_content(planning_application.application_type.description)
+      expect(page).to have_content(planning_application.determination_date.to_fs)
+      expect(page).to have_content(planning_application.user.name)
+    end
 
     expect(page).to have_content("Conservation area")
     expect(page).to have_content("22-00999-LDCP")


### PR DESCRIPTION
### Description of change

Add application details to assessment report

### Story Link

https://trello.com/c/LSRsIeUF/259-add-additional-data-to-assessment-reports-for-context

