### PR TITLE
Include discarded applications when calculating the number

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1154,7 +1154,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def set_application_number
-    max_application_number = local_authority.planning_applications.maximum(:application_number)
+    max_application_number = local_authority.planning_applications.with_discarded.maximum(:application_number)
 
     self.application_number = max_application_number ? max_application_number + 1 : 100
   end

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -220,6 +220,24 @@ RSpec.describe PlanningApplication do
         end
       end
 
+      context "when a planning application is discarded" do
+        let(:local_authority) { create(:local_authority) }
+        let(:planning_application1) { create(:planning_application, local_authority:) }
+        let(:planning_application2) { create(:planning_application, local_authority:) }
+        let(:planning_application3) { create(:planning_application, local_authority:) }
+        let(:planning_application4) { create(:planning_application, local_authority:) }
+
+        it "updates the application number incrementing after the existing maximum application number" do
+          expect(planning_application1.application_number).to eq("00100")
+          expect(planning_application2.application_number).to eq("00101")
+          expect(planning_application3.application_number).to eq("00102")
+
+          planning_application3.discard
+
+          expect(planning_application4.application_number).to eq("00103")
+        end
+      end
+
       describe "#reference" do
         let(:planning_application) do
           build(:planning_application, :ldc_proposed)


### PR DESCRIPTION
Because we look at the `maximum`, i.e., the highest numerically, if the very last one is marked as discarded (and therefore excluded from the scope) it won't be included in the calculation; it'll therefore try to use the ID below, add 1, and end up with the same ID as the discarded one, causing a unique key violation.
