### PR TITLE
Don't allow local admins to create global admins

### DIFF
--- a/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/users/_form.html.erb
@@ -13,7 +13,7 @@
     <% unless form.object == current_user %>
       <%= form.govuk_collection_select(
             :role,
-            User.roles.keys,
+            User.local_roles,
             :itself,
             :capitalize
           ) %>

--- a/engines/bops_config/spec/controllers/bops_config/application_types_controller_spec.rb
+++ b/engines/bops_config/spec/controllers/bops_config/application_types_controller_spec.rb
@@ -3,7 +3,7 @@
 require "bops_config_helper"
 
 RSpec.describe BopsConfig::ApplicationTypesController, type: :controller do
-  let(:user) { create(:user, :global_administrator) }
+  let(:user) { create(:user, :global_administrator, local_authority: nil) }
 
   before do
     sign_in(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -127,6 +127,47 @@ RSpec.describe User do
         expect(user.valid?).to be(true)
       end
     end
+
+    context "when local_authority is present" do
+      let(:user) { build(:user, role: role) }
+
+      context "with a valid local role" do
+        let(:role) { :assessor }
+
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+
+      context "with an invalid global role" do
+        let(:role) { :global_administrator }
+
+        it "is not valid" do
+          expect(user).to be_invalid
+          expect(user.errors[:role]).to include("is not included in the list")
+        end
+      end
+    end
+
+    context "when local_authority is not present" do
+      let(:user) { build(:user, role: role, local_authority: nil) }
+
+      context "with a global role" do
+        let(:role) { :global_administrator }
+
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+
+      context "with a local role" do
+        let(:role) { :assessor }
+
+        it "is valid" do
+          expect(user).to be_valid
+        end
+      end
+    end
   end
 
   describe "#send_otp_by_sms?" do


### PR DESCRIPTION
### Description of change

Don't allow local admins to create global admins

### Story Link

https://trello.com/c/YUAg3Ixr