### PR TITLE
Add neighbour_responses api endpoint

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -23,8 +23,11 @@ class LocalAuthority < ApplicationRecord
 
   with_options through: :planning_applications do
     has_many :audits
+    has_many :consultations
     has_many :validation_requests
   end
+
+  has_many :neighbour_responses, through: :consultations
 
   with_options presence: true do
     validates :council_code, :subdomain

--- a/engines/bops_api/app/controllers/bops_api/v2/neighbour_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/neighbour_responses_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module V2
+    class NeighbourResponsesController < AuthenticatedController
+      def index
+        @pagy, @responses = Pagination.new(scope: response_scope, params: query_params).paginate
+
+        respond_to do |format|
+          format.json
+        end
+      end
+
+      private
+
+      def response_scope
+        current_local_authority.neighbour_responses
+      end
+
+      def query_params
+        params.permit(:page, :maxresults)
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/neighbour_responses/_neighbour_response.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/neighbour_responses/_neighbour_response.json.jbuilder
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+json.extract! response,
+  :received_at
+
+json.text response.redacted_response.presence
+json.sentiment response.summary_tag
+
+json.respondent do
+  json.postcode response.neighbour.address.split(/, */).last
+end
+
+json.application do
+  json.extract! response.neighbour.consultation.planning_application,
+    :reference,
+    :address
+end

--- a/engines/bops_api/app/views/bops_api/v2/neighbour_responses/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/neighbour_responses/index.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+json.partial! "bops_api/v2/shared/metadata"
+
+json.responses @responses do |response|
+  json.partial! "neighbour_response", response:
+end

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -13,6 +13,8 @@ BopsApi::Engine.routes.draw do
       get "/ping", to: "ping#index"
       get "/docs", to: redirect("docs/index.html?urls.primaryName=API%20V2%20Docs", status: 302)
 
+      resources :neighbour_responses, only: [:index]
+
       resources :planning_applications, only: [:index, :show, :create] do
         get :determined, on: :collection
         get :submission, on: :member

--- a/engines/bops_api/schemas/odp/v0.7.1/neighbourResponses.json
+++ b/engines/bops_api/schemas/odp/v0.7.1/neighbourResponses.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "results": {
+          "type": "integer"
+        },
+        "totalResults": {
+          "type": "integer"
+        }
+      },
+      "required": ["results", "totalResults"]
+    },
+    "responses": {
+      "type": "array",
+      "items": [
+        {
+          "type": "object",
+          "properties": {
+            "application": {
+              "type": "object",
+              "properties": {
+                "reference": {
+                  "type": ["string", "null"]
+                },
+                "address": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["reference", "address"]
+            },
+            "receivedAt": {
+              "format": "datetime",
+              "type": ["string", "null"]
+            },
+            "respondent": {
+              "type": "object",
+              "properties": {
+                "postcode": {
+                  "type": ["string", "null"]
+                }
+              },
+              "required": ["postcode"]
+            },
+            "sentiment": {
+              "type": ["string", "null"]
+            },
+            "text": {
+              "type": ["string", "null"]
+            }
+          },
+          "required": [
+            "application",
+            "receivedAt",
+            "respondent",
+            "sentiment",
+            "text"
+          ]
+        }
+      ]
+    }
+  },
+  "required": ["metadata", "responses"]
+}

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.1/neighbourResponses.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.1/neighbourResponses.json
@@ -1,0 +1,28 @@
+{
+  "metadata": {
+    "page": 1,
+    "results": 10,
+    "from": 1,
+    "to": 1,
+    "totalPages": 1,
+    "totalResults": 1
+  },
+  "links": {
+    "first": "http://planx.example.com/api/v2/neighbour_responses?page=1",
+    "last": "http://planx.example.com/api/v2/neighbour_responses?page=1",
+    "prev": null,
+    "next": null
+  },
+  "responses": [
+    {
+      "receivedAt": "2024-10-21T11:30:00.000+01:00",
+      "text": "I like it *****",
+      "sentiment": "supportive",
+      "respondent": { "postcode": "PE35 6AB" },
+      "application": {
+        "reference": "24-00100-HAPP",
+        "address": "1 The Mall, London, SW1A 1AA"
+      }
+    }
+  ]
+}

--- a/engines/bops_api/spec/requests/v2/neighbour_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/neighbour_responses_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "swagger_helper"
+
+RSpec.describe "BOPS public API" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:application_type) { create(:application_type, :householder) }
+  let(:document) { create(:document, :with_tags, validated: true, publishable: true) }
+
+  let(:token) { "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }
+  let!(:api_user) { create(:api_user, token:, local_authority:) }
+  let!(:Authorization) { "Bearer #{token}" }
+
+  around do |example|
+    travel_to("2024-10-22T10:30:00Z") { example.run }
+  end
+
+  path "/api/v2/neighbour_responses" do
+    get "Retrieves neighbour responses for a planning application" do
+      tags "Planning applications"
+      security [bearerAuth: []]
+      produces "application/json"
+
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
+
+      response "200", "returns a planning application's neighbour responses and decision notice given a reference" do
+        example "application/json", :default, example_fixture("neighbourResponses.json")
+        schema "$ref" => "#/components/schemas/NeighbourResponses"
+
+        let(:reference) { planning_application.reference }
+        let(:planning_application) { create(:planning_application, :published, local_authority:, application_type:) }
+        before do
+          create(:neighbour_response, neighbour: create(:neighbour, consultation: planning_application.consultation))
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["responses"]).not_to be_empty
+        end
+      end
+
+      it "validates successfully against the example neighbour responses json" do
+        resolved_schema = load_and_resolve_schema(name: "neighbourResponses", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+        schemer = JSONSchemer.schema(resolved_schema)
+        example_json = example_fixture("neighbourResponses.json")
+
+        expect(schemer.valid?(example_json)).to eq(true)
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -15,6 +15,7 @@ RSpec.configure do |config|
   search_json = BopsApi::Schemas.find!("search", version:).value
   application_submission_json = BopsApi::Schemas.find!("applicationSubmission", version:).value
   documents_json = BopsApi::Schemas.find!("documents", version:).value
+  neighbour_responses_json = BopsApi::Schemas.find!("neighbourResponses", version:).value
   validation_requests_json = BopsApi::Schemas.find!("validationRequests", version:).value
   shared_definitions_json = BopsApi::Schemas.find!("shared/definitions", version:).value
 
@@ -42,6 +43,8 @@ RSpec.configure do |config|
   application_submission = application_submission_json.slice(*keys).deep_transform_values(&transformer)
 
   documents = documents_json.slice(*keys).deep_transform_values(&transformer)
+
+  neighbour_responses = neighbour_responses_json.slice(*keys).deep_transform_values(&transformer)
 
   validation_requests = validation_requests_json.slice(*keys).deep_transform_values(&transformer)
 
@@ -83,6 +86,8 @@ RSpec.configure do |config|
           ApplicationSubmission: application_submission,
 
           Documents: documents,
+
+          NeighbourResponses: neighbour_responses,
 
           ValidationRequests: validation_requests,
 

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -17849,6 +17849,69 @@ components:
       - application
       - files
       type: object
+    NeighbourResponses:
+      properties:
+        metadata:
+          type: object
+          properties:
+            results:
+              type: integer
+            totalResults:
+              type: integer
+          required:
+          - results
+          - totalResults
+        responses:
+          type: array
+          items:
+          - type: object
+            properties:
+              application:
+                type: object
+                properties:
+                  reference:
+                    type:
+                    - string
+                    - 'null'
+                  address:
+                    type:
+                    - string
+                    - 'null'
+                required:
+                - reference
+                - address
+              receivedAt:
+                format: datetime
+                type:
+                - string
+                - 'null'
+              respondent:
+                type: object
+                properties:
+                  postcode:
+                    type:
+                    - string
+                    - 'null'
+                required:
+                - postcode
+              sentiment:
+                type:
+                - string
+                - 'null'
+              text:
+                type:
+                - string
+                - 'null'
+            required:
+            - application
+            - receivedAt
+            - respondent
+            - sentiment
+            - text
+      required:
+      - metadata
+      - responses
+      type: object
     ValidationRequests:
       properties:
         metadata:
@@ -18097,6 +18160,50 @@ components:
       required:
       - error
 paths:
+  "/api/v2/neighbour_responses":
+    get:
+      summary: Retrieves neighbour responses for a planning application
+      tags:
+      - Planning applications
+      parameters:
+      - name: reference
+        in: path
+        schema:
+          type: string
+          description: The planning application reference
+        required: true
+      responses:
+        '200':
+          description: returns a planning application's neighbour responses and decision
+            notice given a reference
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    metadata:
+                      page: 1
+                      results: 10
+                      from: 1
+                      to: 1
+                      totalPages: 1
+                      totalResults: 1
+                    links:
+                      first: http://planx.example.com/api/v2/neighbour_responses?page=1
+                      last: http://planx.example.com/api/v2/neighbour_responses?page=1
+                      prev:
+                      next:
+                    responses:
+                    - receivedAt: '2024-10-21T11:30:00.000+01:00'
+                      text: I like it *****
+                      sentiment: supportive
+                      respondent:
+                        postcode: PE35 6AB
+                      application:
+                        reference: 24-00100-HAPP
+                        address: 1 The Mall, London, SW1A 1AA
+              schema:
+                "$ref": "#/components/schemas/NeighbourResponses"
   "/api/v2/ping":
     get:
       summary: Returns a healthcheck


### PR DESCRIPTION
### Description of change

Add an authenticated-only API endpoint showing neighbour responses and the associated postcode.

### Story Link

https://trello.com/c/1RipCDEF/228-api-for-neighbour-comments