### PR TITLE
Normalize docker dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   linters:
     name: Linters
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         task:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -44,7 +44,7 @@ on:
 jobs:
   tests:
     name: ${{ inputs.name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -2,7 +2,7 @@
 
 # Make sure RUBY_VERSION matches the Ruby version in .ruby-version and Gemfile
 ARG RUBY_VERSION=3.4.1
-FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base
+FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim-bookworm AS base
 
 # Rails app lives here
 WORKDIR /rails
@@ -15,11 +15,11 @@ ENV RAILS_ENV="production" \
 
 
 # Throw-away build stage to reduce size of final image
-FROM base as build
+FROM base AS build
 
 # Install packages needed to build gems and node modules
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libvips node-gyp pkg-config python-is-python3
+    apt-get install --no-install-recommends -y build-essential curl git libpq-dev libyaml-dev libvips node-gyp pkg-config python-is-python3
 
 # Install JavaScript dependencies
 ARG NODE_VERSION=20.11.0
@@ -99,7 +99,6 @@ ARG DATABASE_URL=postgres://localhost:5432/bops_web
 ARG RAILS_LOG_TO_STDOUT=true
 ARG RAILS_SERVE_STATIC_FILES=true
 ARG PORT=80
-ARG SECRET_KEY_BASE=notasecret
 
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000

--- a/docker/dnsmasq/Dockerfile
+++ b/docker/dnsmasq/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 # Run security updates and install packages
 RUN bash -c "export DEBIAN_FRONTEND=noninteractive && \

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:14-bullseye
+FROM postgres:14-bookworm
 
 ENV POSTGIS_MAJOR 3
 

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUBY_VERSION=3.4.1
 
-FROM ruby:$RUBY_VERSION-bullseye
+FROM ruby:$RUBY_VERSION-bookworm
 
 ENV BUNDLE_PATH=/home/rails/bundle
 
@@ -15,7 +15,7 @@ RUN bash -c "export DEBIAN_FRONTEND=noninteractive && \
 RUN bash -c "apt-get install -y --no-install-recommends libvips-dev poppler-utils"
 
 # Install PostgreSQL client
-RUN bash -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' \
+RUN bash -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' \
     > /etc/apt/sources.list.d/pgdg.list && \
     wget -q -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc \
     | apt-key add - && apt-get update && \


### PR DESCRIPTION
Use Debian Bookworm/Ubuntu 24.04 and Ruby 3.4.1 everywhere.
