### PR TITLE
Retry PlanningApplicationDependencyJob after a minute

### DIFF
--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -7,11 +7,11 @@ module BopsApi
   class PlanningApplicationDependencyJob < ApplicationJob
     queue_as :submissions
 
-    retry_on(StandardError, attempts: 5, wait: 2.minutes, jitter: 0) do |_, error|
+    retry_on(StandardError, attempts: 5, wait: 1.minute, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 
-    retry_on(Faraday::TimeoutError, attempts: 5, wait: 2.minutes, jitter: 0) do |_, error|
+    retry_on(Faraday::TimeoutError, attempts: 5, wait: 1.minute, jitter: 0) do |_, error|
       Appsignal.report_error(error)
     end
 


### PR DESCRIPTION
- 2 minutes is on the longer side, we only need about a minute max if the first time fails

