### PR TITLE
Allow empty dates for site histories

### DIFF
--- a/app/models/site_history.rb
+++ b/app/models/site_history.rb
@@ -7,10 +7,8 @@ class SiteHistory < ApplicationRecord
 
   alias_attribute :reference, :application_number
 
-  with_options presence: true do
-    validates :reference, :description, :decision
-    validates :date, date: {before: :current}
-  end
+  validates :reference, :description, :decision, presence: true
+  validates :date, date: {on_or_before: :current}
 
   def decision_label
     other_decision? ? decision : I18n.t(decision)

--- a/app/views/planning_applications/assessment/site_histories/_table.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_table.html.erb
@@ -19,7 +19,7 @@
     <% table.with_body do |body| %>
       <% site_histories.each do |site_history| %>
         <% body.with_row do |row| %>
-          <% row.with_cell(text: site_history.date.to_fs(:day_month_year_slashes)) %>
+          <% row.with_cell(text: site_history.date? ? site_history.date.to_fs(:day_month_year_slashes) : "–") %>
           <% row.with_cell(text: site_history.reference) %>
           <% row.with_cell(text: site_history.description) %>
           <% row.with_cell do %>

--- a/spec/models/site_history_spec.rb
+++ b/spec/models/site_history_spec.rb
@@ -20,12 +20,20 @@ RSpec.describe SiteHistory do
       expect(build(:site_history, decision: nil)).to be_invalid
     end
 
-    it "validates the presence of a date" do
-      expect(build(:site_history, date: nil)).to be_invalid
+    it "doesn't validate the presence of a date" do
+      expect(build(:site_history, date: nil)).to be_valid
     end
 
-    it "validates the date is in the past" do
-      expect(build(:site_history, date: Date.current)).to be_invalid
+    it "allows dates in the past" do
+      expect(build(:site_history, date: Date.yesterday)).to be_valid
+    end
+
+    it "allows today's date" do
+      expect(build(:site_history, date: Date.current)).to be_valid
+    end
+
+    it "doesn't allow dates in the future" do
+      expect(build(:site_history, date: Date.tomorrow)).to be_invalid
     end
   end
 


### PR DESCRIPTION
### Description of change

Removes the presence validation on the date field and allows today's date.

### Story Link

https://trello.com/c/nbhQcVPp

