### PR TITLE
Allow officers to put in future dates for press notices

### DIFF
--- a/app/models/press_notice.rb
+++ b/app/models/press_notice.rb
@@ -32,7 +32,7 @@ class PressNotice < ApplicationRecord
   with_options on: :confirmation do
     validates :published_at, presence: true,
       date: {
-        on_or_before: :current,
+        on_or_before: :consultation_end_date,
         on_or_after: :consultation_start_date
       }
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -378,7 +378,7 @@ en:
               date_blank: Provide the date when the press notice was published
               date_invalid: The date the press notice was published must be a valid date
               date_not_on_or_after: The date the press notice was published must be on or after the consultation start date
-              date_not_on_or_before: The date the press notice was published must be on or before today
+              date_not_on_or_before: The date the press notice was published must be on or before the consultation end date
             reasons:
               blank: Provide a reason for the press notice
             required:

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -505,7 +505,7 @@ RSpec.describe "Press notice" do
         end
 
         click_button "Save"
-        expect(page).to have_content("The date the press notice was published must be on or before today")
+        expect(page).to have_content("The date the press notice was published must be on or before the consultation end date")
 
         within("#published-at-field") do
           fill_in "Day", with: "29"


### PR DESCRIPTION
### Description of change

Officers may put in the date of publication ahead of time and then go back and add the press notice evidence at a later date.

### Story Link

https://trello.com/c/26yRO6fE
