### PR TITLE
Resend magic link for consultees

### DIFF
--- a/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
@@ -2,12 +2,25 @@
 
 module BopsConsultees
   class PlanningApplicationsController < ApplicationController
-    before_action :authenticate_with_sgid!
-    before_action :set_planning_application, only: :show
+    before_action :authenticate_with_sgid!, only: :show
+    before_action :set_planning_application, only: %i[show resend_link]
+    before_action :set_consultee, only: :resend_link
 
     def show
       respond_to do |format|
         format.html
+      end
+    end
+
+    def resend_link
+      BopsCore::MagicLinkMailerJob.perform_later(
+        resource: @consultee,
+        subdomain: @current_local_authority.subdomain,
+        planning_application: @planning_application.presented
+      )
+
+      respond_to do |format|
+        format.html { redirect_to root_url, notice: "A magic link has been sent to: #{@consultee.email_address}" }
       end
     end
 
@@ -16,6 +29,13 @@ module BopsConsultees
     def set_planning_application
       planning_application = planning_applications_scope.find_by!(reference:)
       @planning_application = PlanningApplicationPresenter.new(view_context, planning_application)
+    rescue ActiveRecord::RecordNotFound
+      render_not_found
+    end
+
+    def set_consultee
+      expired_resource = BopsCore::SgidAuthenticationService.new(sgid).expired_resource
+      @consultee = @planning_application.consultation.consultees.find(expired_resource.id)
     rescue ActiveRecord::RecordNotFound
       render_not_found
     end

--- a/engines/bops_consultees/app/presenters/bops_consultees/planning_application_presenter.rb
+++ b/engines/bops_consultees/app/presenters/bops_consultees/planning_application_presenter.rb
@@ -2,11 +2,12 @@
 
 module BopsConsultees
   class PlanningApplicationPresenter
-    include Presentable
+    include BopsCore::Presentable
 
     presents :planning_application
 
     include BopsCore::StatusPresenter
+    include ActionView::Helpers::SanitizeHelper
 
     def initialize(template, planning_application)
       @template = template

--- a/engines/bops_consultees/app/views/bops_consultees/dashboards/show.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/dashboards/show.html.erb
@@ -5,11 +5,21 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">
-      Consultees
+      BOPS Consultees
     </h1>
 
-    <% if @resend_link %>
-      <p class="govuk-body">Your magic link has expired. Click resend to generate another link.</p>
+    <% if @expired_resource %>
+      <p class="govuk-body"><strong>Your magic link has expired</strong></p>
+
+      <p class="govuk-body">
+        Contact
+        <%= tag.a href: "mailto:#{current_local_authority.feedback_email}", class: "govuk-link" do %>
+          <% current_local_authority.feedback_email %>
+        <% end %>
+        if you think there's a problem.
+      </p>
+
+      <%= govuk_button_to "Send a new magic link", resend_link_planning_application_path(params[:reference], sgid: params[:sgid]) %>
     <% end %>
   </div>
 </div>

--- a/engines/bops_consultees/config/routes.rb
+++ b/engines/bops_consultees/config/routes.rb
@@ -4,5 +4,7 @@ BopsConsultees::Engine.routes.draw do
   root to: redirect("dashboard")
 
   resource :dashboard, only: %i[show]
-  resources :planning_applications, param: :reference, only: %i[show]
+  resources :planning_applications, param: :reference, only: %i[show] do
+    post :resend_link, on: :member
+  end
 end

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -24,13 +24,25 @@ RSpec.describe "Planning applications", type: :system do
 
   context "with expired magic link" do
     let!(:sgid) { consultee.sgid(expires_in: 1.minute, for: "magic_link") }
+    let(:mail) { ActionMailer::Base.deliveries }
 
     it "I can see that the link has expired" do
       travel 2.minutes
       visit "/consultees/planning_applications/#{reference}?sgid=#{sgid}"
       expect(page).not_to have_content(planning_application.full_address)
       expect(page).not_to have_content(reference)
-      expect(page).to have_content("Your magic link has expired. Click resend to generate another link.")
+      expect(page).to have_content("Your magic link has expired")
+      expect(page).to have_content("Contact #{local_authority.feedback_email} if you think there's a problem.")
+
+      delivered_emails = mail.count
+      click_button("Send a new magic link")
+      expect(page).to have_content("A magic link has been sent to: #{consultee.email_address}")
+      perform_enqueued_jobs
+      expect(mail.count).to eql(delivered_emails + 1)
+
+      url = mail.last.body.raw_source.match(/href="(?<url>.+?)">/)[:url]
+      visit url
+      expect(page).to have_content(reference)
     end
   end
 

--- a/engines/bops_core/app/controllers/concerns/bops_core/magic_link_authenticatable.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/magic_link_authenticatable.rb
@@ -27,8 +27,7 @@ module BopsCore
     end
 
     def handle_expired_or_invalid_sgid
-      if (resource = sgid_authentication_service.expired_resource)
-        @resend_link = resource.sgid
+      if (@expired_resource = sgid_authentication_service.expired_resource)
         render_expired
       else
         render_not_found

--- a/engines/bops_core/app/jobs/concerns/bops_core/application_job.rb
+++ b/engines/bops_core/app/jobs/concerns/bops_core/application_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module BopsCore
+  class ApplicationJob < ActiveJob::Base
+  end
+end

--- a/engines/bops_core/app/jobs/concerns/bops_core/magic_link_mailer_job.rb
+++ b/engines/bops_core/app/jobs/concerns/bops_core/magic_link_mailer_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module BopsCore
+  class MagicLinkMailerJob < ApplicationJob
+    queue_as :low_priority
+
+    def perform(resource:, planning_application:, subdomain:)
+      MagicLinkMailer.magic_link_mail(
+        resource: resource,
+        planning_application: planning_application,
+        subdomain: subdomain
+      ).deliver_now
+    end
+  end
+end

--- a/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
+++ b/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
@@ -2,10 +2,11 @@
 
 module BopsCore
   class MagicLinkMailer < ApplicationMailer
-    def magic_link_mail(resource:, subdomain:, subject: "Your magic link")
+    def magic_link_mail(resource:, subdomain:, planning_application:, subject: "Your BOPS magic link")
       @resource = resource
       @sgid = resource.sgid
       @subdomain = subdomain
+      @planning_application = planning_application
       @url = magic_link_url
 
       mail(
@@ -16,12 +17,14 @@ module BopsCore
 
     private
 
-    attr_reader :resource, :sgid, :subdomain
+    attr_reader :resource, :sgid, :subdomain, :planning_application
 
     def magic_link_url
       case resource
       when Consultee
-        bops_consultees.dashboard_url(sgid:, subdomain:)
+        bops_consultees.planning_application_url(
+          reference: planning_application.reference, sgid:, subdomain:
+        )
       else
         main_app.root_url
       end

--- a/engines/bops_core/app/presenters/bops_core/presentable.rb
+++ b/engines/bops_core/app/presenters/bops_core/presentable.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Presentable
+    extend ActiveSupport::Concern
+    include Rails.application.routes.url_helpers
+
+    attr_reader :template, :planning_application
+
+    delegate :tag, :concat, :link_to, :truncate, :link_to_if, to: :template
+    delegate :to_param, to: :presented
+
+    class_methods do
+      def presents(presented)
+        define_method(:presented) do
+          @presented ||= send(presented)
+        end
+      end
+    end
+
+    private
+
+    def method_missing(method_name, *, **kwargs, &)
+      if presented.respond_to?(method_name)
+        kwargs.any? ? presented.send(method_name, **kwargs, &) : presented.send(method_name, *, &)
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(method_name, *args)
+      presented.respond_to?(method_name) || super
+    end
+  end
+end

--- a/engines/bops_core/app/views/bops_core/magic_link_mailer/magic_link_mail.text.erb
+++ b/engines/bops_core/app/views/bops_core/magic_link_mailer/magic_link_mail.text.erb
@@ -1,7 +1,7 @@
 Hello <%= @resource.name %>
 
-Click the link below to access your dashboard:
+This is your magic link.
 
-<%= link_to "Access Dashboard", @url %>
+<%= link_to "View BOPS application: #{@planning_application.reference_in_full}", @url %>
 
 This link will expire in 48 hours.

--- a/engines/bops_core/spec/jobs/bops_core/magic_link_mailer_job_spec.rb
+++ b/engines/bops_core/spec/jobs/bops_core/magic_link_mailer_job_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe BopsCore::MagicLinkMailerJob, type: :job do
+  let(:consultation) { create(:consultation) }
+  let(:consultee) { create(:consultee, consultation:) }
+  let(:planning_application) { create(:planning_application, consultation:) }
+
+  it "enqueues the job" do
+    expect {
+      BopsCore::MagicLinkMailerJob.perform_later(resource: consultee, planning_application:, subdomain: "southwark")
+    }.to have_enqueued_job(BopsCore::MagicLinkMailerJob).with(resource: consultee, planning_application:, subdomain: "southwark")
+  end
+
+  it "sends the email" do
+    expect {
+      perform_enqueued_jobs do
+        BopsCore::MagicLinkMailerJob.perform_now(resource: consultee, planning_application:, subdomain: "southwark")
+      end
+    }.to change { ActionMailer::Base.deliveries.count }.by(1)
+  end
+end

--- a/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
+++ b/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe BopsCore::MagicLinkMailer, type: :mailer do
+  describe "magic_link_mail" do
+    let(:consultation) { create(:consultation) }
+    let(:consultee) { create(:consultee, consultation:, email_address: "consultee@example.com", name: "Bops Consultee") }
+    let(:planning_application) { consultation.planning_application }
+    let(:mail) { described_class.magic_link_mail(resource: consultee, planning_application:, subdomain: "southwark", subject: "Your magic link") }
+
+    before do
+      allow(consultee).to receive(:sgid).and_return("123456789")
+    end
+
+    it "renders the subject" do
+      expect(mail.subject).to eq("Your magic link")
+    end
+
+    it "sends to the correct email address" do
+      expect(mail.to).to eq([consultee.email_address])
+    end
+
+    it "assigns the correct magic link URL" do
+      expect(mail.body.encoded).to include("http://southwark.bops.services/consultees/planning_applications/25-00100-LDCE?sgid=123456789")
+    end
+
+    it "includes the planning application reference in the email body" do
+      expect(mail.body.encoded).to include("View BOPS application: #{planning_application.reference_in_full}")
+    end
+
+    it "includes the link expiration information" do
+      expect(mail.body.encoded).to include("This link will expire in 48 hours.")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Resend magic link for consultees

### Story Link

https://trello.com/c/ZKP18eFC/361-as-a-consultee-i-need-to-see-the-planning-application-information-after-i-navigate-to-bops-via-a-magic-link

<img width="758" alt="Screenshot 2025-01-24 at 09 55 56" src="https://github.com/user-attachments/assets/fe73ea36-be24-4fed-8405-6d31414377d6" />

<img width="716" alt="Screenshot 2025-01-24 at 09 57 54" src="https://github.com/user-attachments/assets/0b2dd3ef-d130-48ad-a824-472543e88d8a" />
