### PR TITLE
Fix pluralisation on controller name

### DIFF
--- a/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
@@ -35,7 +35,7 @@ module BopsAdmin
         "profile"
       when "informatives"
         "informatives"
-      when "policy_areas", "policy_guidance", "policy_references"
+      when "policy_areas", "policy_guidances", "policy_references"
         "policy"
       else
         "dashboard"


### PR DESCRIPTION
The pluralisation of the policy guidance is incorrect which means the dashboard is show as the current item in the primary navigation.