### PR TITLE
Use the validated_at timestamp directly when showing valid from

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -477,7 +477,7 @@ class PlanningApplication < ApplicationRecord
   def valid_from
     return nil unless validated?
 
-    valid_from_date
+    validated_at || valid_from_date
   end
 
   def valid_from_date

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -650,6 +650,18 @@ RSpec.describe PlanningApplication do
     end
 
     context "when the application is valid" do
+      let(:planning_application) { create(:valid_planning_application) }
+
+      it "is validated at" do
+        expect(planning_application.valid_from).to eq(planning_application.validated_at)
+      end
+    end
+  end
+
+  describe "#valid_from_date" do
+    let(:planning_application) { create(:not_started_planning_application) }
+
+    context "when the application is valid" do
       context "when there have been validation requests" do
         before do
           travel_to(DateTime.new(2022, 8, 17))
@@ -672,7 +684,7 @@ RSpec.describe PlanningApplication do
         end
 
         it "is the time of the last successfully closed request" do
-          expect(planning_application.valid_from).to eq Time.next_immediate_business_day(1.day.ago)
+          expect(planning_application.valid_from_date).to eq Time.next_immediate_business_day(1.day.ago)
         end
       end
 
@@ -680,7 +692,7 @@ RSpec.describe PlanningApplication do
         before { planning_application.start! }
 
         it "returns the received_at value" do
-          expect(planning_application.valid_from).to eq planning_application.received_at
+          expect(planning_application.valid_from_date).to eq planning_application.received_at
         end
       end
     end

--- a/spec/system/planning_applications/review/tasks_index_spec.rb
+++ b/spec/system/planning_applications/review/tasks_index_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Reviewing Tasks Index" do
         expect(page).to have_row_for("Application type:", with: "Planning Permission - Full householder")
         expect(page).to have_row_for("Site address:", with: "123 Long Lane, Big City, AB34EF")
         expect(page).to have_row_for("Location:", with: "View site on Google Maps (opens in new tab)")
-        expect(page).to have_row_for("Valid from:", with: "11 November 2022")
+        expect(page).to have_row_for("Valid from:", with: "12 November 2022")
         expect(page).to have_row_for("Expiry date:", with: "7 January 2023")
         expect(page).to have_row_for("Consultation end:", with: "Not yet started")
         expect(page).to have_row_for("Press notice:", with: "-")


### PR DESCRIPTION
Use the validated_at timestamp directly when displaying when the application was valid from.
Keep the valid_from_date method as this will determine what this date should be when confirming the validation date