### PR TITLE
Sitemap corrects bug

### DIFF
--- a/app/models/consistency_checklist.rb
+++ b/app/models/consistency_checklist.rb
@@ -48,6 +48,8 @@ class ConsistencyChecklist < ApplicationRecord
     end
   end
 
+  before_validation :reset_site_map_correct_comment_if_needed
+
   private
 
   CHECKS.each do |check|
@@ -72,5 +74,9 @@ class ConsistencyChecklist < ApplicationRecord
         planning_application.send(:"#{request_type}_validation_requests").open
       )
     end
+  end
+
+  def reset_site_map_correct_comment_if_needed
+    self.site_map_correct_comment = nil if site_map_correct == "yes"
   end
 end

--- a/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
@@ -31,7 +31,7 @@
     <%= form.govuk_radio_button(
           :site_map_correct,
           consistency_checklist.site_map_correct,
-          label: {text: t(".#{consistency_checklist.documents_consistent}")},
+          label: {text: t(".#{consistency_checklist.site_map_correct}")},
           disabled: true
         ) %>
   <% end %>


### PR DESCRIPTION
### Description of change

- Their was a bug where the label for `site_map_correct` was the value of `documents_consistent`.
- Also added a validation where is setting `site_map_correct_comment` to `nil` when the user has selected `site_map_correct` to Yes

### Story Link

https://trello.com/c/1lvMCnq6