### PR TITLE
Add comments to site history

### DIFF
--- a/app/controllers/planning_applications/assessment/site_histories_controller.rb
+++ b/app/controllers/planning_applications/assessment/site_histories_controller.rb
@@ -87,7 +87,7 @@ module PlanningApplications
       end
 
       def planning_history_params
-        params.require(:site_history).permit(:reference, :description, :decision, :other_decision, :date)
+        params.require(:site_history).permit(:reference, :description, :decision, :other_decision, :date, :comment)
       end
     end
   end

--- a/app/views/planning_applications/assessment/site_histories/_form.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_form.html.erb
@@ -18,6 +18,8 @@
 
       <%= form.govuk_date_field :date, legend: {text: "Decision received on", size: "s", tag: nil} %>
 
+      <%= form.govuk_text_area :comment, rows: 4, label: {text: "Relevance to proposal"} %>
+
       <% if model.persisted? %>
         <%= form.govuk_submit "Update site history", class: "govuk-!-margin-bottom-2" do %>
           <%= govuk_button_link_to "Back", planning_application_assessment_site_histories_path(@planning_application), secondary: true %>

--- a/app/views/planning_applications/assessment/site_histories/_table.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_table.html.erb
@@ -6,10 +6,11 @@
   <%= govuk_table(classes: "planning-history-table") do |table| %>
     <% table.with_head do |head| %>
       <% head.with_row do |row| %>
-        <% row.with_cell(text: "Date") %>
         <% row.with_cell(text: "Application number") %>
-        <% row.with_cell(text: "Description") %>
         <% row.with_cell(text: "Decision") %>
+        <% row.with_cell(text: "Description") %>
+        <% row.with_cell(text: "Relevance to proposal") %>
+        <% row.with_cell(text: "Date") %>
         <% if show_action %>
           <% row.with_cell(text: "Action") %>
         <% end %>
@@ -19,21 +20,24 @@
     <% table.with_body do |body| %>
       <% site_histories.each do |site_history| %>
         <% body.with_row do |row| %>
-          <% row.with_cell(text: site_history.date? ? site_history.date.to_fs(:day_month_year_slashes) : "–") %>
           <% row.with_cell(text: site_history.reference) %>
-          <% row.with_cell(text: site_history.description) %>
           <% row.with_cell do %>
             <%= govuk_tag(text: site_history.decision_label, colour: t(site_history.decision_type, scope: :planning_application_tags)) %>
           <% end %>
-          <% row.with_cell do %>
-              <%= govuk_link_to "Edit",
-                    edit_planning_application_assessment_site_history_path(@planning_application, site_history),
-                    class: "govuk-!-display-inline-block" %>
+          <% row.with_cell(text: site_history.description) %>
+          <% row.with_cell(text: site_history.comment) %>
+          <% row.with_cell(text: site_history.date? ? site_history.date.to_fs(:day_month_year_slashes) : "–") %>
+          <% if show_action %>
+            <% row.with_cell do %>
+                <%= govuk_link_to "Edit",
+                      edit_planning_application_assessment_site_history_path(@planning_application, site_history),
+                      class: "govuk-!-display-inline-block" %>
 
-              <%= govuk_link_to "Remove",
-                    planning_application_assessment_site_history_path(@planning_application, site_history),
-                    method: :delete, class: "govuk-!-display-inline-block govuk-!-margin-left-1",
-                    data: {confirm: "This action cannot be undone.\nAre you sure you want to remove this site history?"} %>
+                <%= govuk_link_to "Remove",
+                      planning_application_assessment_site_history_path(@planning_application, site_history),
+                      method: :delete, class: "govuk-!-display-inline-block govuk-!-margin-left-1",
+                      data: {confirm: "This action cannot be undone.\nAre you sure you want to remove this site history?"} %>
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/db/migrate/20250130165912_add_comment_to_site_history.rb
+++ b/db/migrate/20250130165912_add_comment_to_site_history.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCommentToSiteHistory < ActiveRecord::Migration[7.2]
+  def change
+    add_column :site_histories, :comment, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_30_115103) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_30_165912) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -993,6 +993,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_115103) do
     t.bigint "planning_application_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "comment"
     t.index ["planning_application_id"], name: "ix_site_histories_on_planning_application_id"
   end
 

--- a/spec/system/planning_applications/assessing/planning_history_show_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_history_show_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe "Planning History" do
           reference: record["reference"],
           date: record["decision_issued_at"],
           description: record["description"],
-          decision: record["decision"]
+          decision: record["decision"],
+          comment: "A comment that is relevant to the proposal"
         )
       end
 
@@ -35,10 +36,11 @@ RSpec.describe "Planning History" do
       within(".planning-history-table") do
         within(".govuk-table__head") do
           within(all(".govuk-table__row").first) do
-            expect(page).to have_content("Date")
             expect(page).to have_content("Application number")
-            expect(page).to have_content("Description")
             expect(page).to have_content("Decision")
+            expect(page).to have_content("Description")
+            expect(page).to have_content("Relevance to proposal")
+            expect(page).to have_content("Date")
             expect(page).to have_content("Action")
           end
         end
@@ -50,18 +52,21 @@ RSpec.describe "Planning History" do
             cells = page.all(".govuk-table__cell")
 
             within(cells[0]) do
-              expect(page).to have_content("16/09/2022")
+              expect(page).to have_content("22/06601/FUL")
             end
             within(cells[1]) do
-              expect(page).to have_content("22/06601/FUL")
+              expect(page).to have_content("Application Refused")
             end
             within(cells[2]) do
               expect(page).to have_content("Householder application for construction of detached two storey double garage with external staircase")
             end
             within(cells[3]) do
-              expect(page).to have_content("Application Refused")
+              expect(page).to have_content("A comment that is relevant to the proposal")
             end
             within(cells[4]) do
+              expect(page).to have_content("16/09/2022")
+            end
+            within(cells[5]) do
               expect(page).to have_link("Edit")
               expect(page).to have_link("Remove")
             end
@@ -71,18 +76,21 @@ RSpec.describe "Planning History" do
             cells = page.all(".govuk-table__cell")
 
             within(cells[0]) do
-              expect(page).to have_content("16/09/2022")
+              expect(page).to have_content("PL/22/2428/SA")
             end
             within(cells[1]) do
-              expect(page).to have_content("PL/22/2428/SA")
+              expect(page).to have_content("Cert of law for proposed dev/use refused")
             end
             within(cells[2]) do
               expect(page).to have_content("Certificate of lawfulness for proposed loft conversion including hip to gable roof extensions to both sides, rear dormer window, 3 front and 1 rear rooflights and 4 side windows")
             end
             within(cells[3]) do
-              expect(page).to have_content("Cert of law for proposed dev/use refused")
+              expect(page).to have_content("A comment that is relevant to the proposal")
             end
             within(cells[4]) do
+              expect(page).to have_content("16/09/2022")
+            end
+            within(cells[5]) do
               expect(page).to have_link("Edit")
               expect(page).to have_link("Remove")
             end
@@ -92,18 +100,21 @@ RSpec.describe "Planning History" do
             cells = page.all(".govuk-table__cell")
 
             within(cells[0]) do
-              expect(page).to have_content("16/09/2022")
+              expect(page).to have_content("PL/22/2883/KA")
             end
             within(cells[1]) do
-              expect(page).to have_content("PL/22/2883/KA")
+              expect(page).to have_content("TPO shall not be made")
             end
             within(cells[2]) do
               expect(page).to have_content("T1 English oak - crown reduction by approx 4.5m, T2 sycamore - crown reduction by approx 2.5m (Chesham Bois Conservation Area)")
             end
             within(cells[3]) do
-              expect(page).to have_content("TPO shall not be made")
+              expect(page).to have_content("A comment that is relevant to the proposal")
             end
             within(cells[4]) do
+              expect(page).to have_content("16/09/2022")
+            end
+            within(cells[5]) do
               expect(page).to have_link("Edit")
               expect(page).to have_link("Remove")
             end


### PR DESCRIPTION
### Description of change

- Add and update site history entries with a comment

### Story Link

https://trello.com/c/YLcWxXPX/316-able-to-add-comment-to-each-site-history-record

