### PR TITLE
Update form text etc to match new (non-approval) workflow

### DIFF
--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -84,9 +84,12 @@ module PlanningApplications
         @validation_request.user = current_user
 
         if @validation_request.save
+          i18n_key = ".#{@validation_request.type.underscore}.success"
+          i18n_key << "_autoapproved" if @validation_request.type == "DescriptionChangeValidationRequest" && !@planning_application.application_type.description_change_requires_validation?
+
           redirect_to(
             create_request_redirect_url,
-            notice: t(".#{@validation_request.type.underscore}.success")
+            notice: t(i18n_key)
           )
         else
           if @validation_request.type == "ReplacementDocumentValidationRequest"

--- a/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
@@ -16,13 +16,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-margin-top-3">
-      Suggest a new description to the applicant
-    </h2>
-
     <% if @planning_application.application_type.description_change_requires_validation? %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-3">
+        Suggest a new description to the applicant
+      </h2>
+
       <p class="govuk-body">
         This will be sent to the applicant immediately. If the applicant does not respond within 5 days, the amended description will be automatically accepted.
+      </p>
+    <% else %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-3">
+        Update description
+      </h2>
+
+      <p class="govuk-body">
+        This will be applied immediately.
       </p>
     <% end %>
 
@@ -51,7 +59,7 @@
       <% end %>
       <%= form.hidden_field(:type, value: "DescriptionChangeValidationRequest") %>
       <%= form.govuk_text_area :proposed_description,
-            label: {size: "s", text: "Enter an amended description to send to the applicant"},
+            label: {size: "s", text: "Enter an amended description" + (@planning_application.application_type.description_change_requires_validation? ? " to send to the applicant" : "")},
             rows: 5 %>
       <% if @planning_application.not_started? %>
         <%= form.hidden_field(:return_to, value: planning_application_validation_tasks_path(@planning_application)) %>
@@ -59,7 +67,7 @@
         <%= form.hidden_field(:return_to, value: @back_path) %>
       <% end %>
       <div class="govuk-button-group">
-        <%= form.govuk_submit "Send request" %>
+        <%= form.govuk_submit @planning_application.application_type.description_change_requires_validation? ? "Send request" : "Save and mark as complete" %>
         <%= back_link %>
       </div>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1962,6 +1962,7 @@ en:
             success: Additional document request successfully created.
           description_change_validation_request:
             success: Description change request successfully sent.
+            success_autoapproved: Description updated.
           fee_change_validation_request:
             success: Fee change request successfully created.
           other_change_validation_request:

--- a/spec/system/planning_applications/validating/description_changes_validation_spec.rb
+++ b/spec/system/planning_applications/validating/description_changes_validation_spec.rb
@@ -212,13 +212,13 @@ RSpec.describe "DescriptionChangesValidation" do
       expect(page).to have_content("Application number: #{planning_application.reference}")
 
       fill_in(
-        "Enter an amended description to send to the applicant",
+        "Enter an amended description",
         with: "My better description"
       )
 
-      click_button "Send request"
+      click_button "Save and mark as complete"
 
-      expect(page).to have_content("Description change request successfully sent.")
+      expect(page).to have_content("Description updated.")
 
       within("#check-description-task") do
         expect(page).to have_content("Completed")


### PR DESCRIPTION
### Description of change

In #2129 description change requests were updated to potentially skip the approval step; however the form text etc seems to suggest that the applicant will still need to approve the change. Updated so it's clearer.

### Story Link

https://trello.com/c/7tE9MC0c/280-change-the-description-without-sending-validation-request-to-applicants
