### PR TITLE
Store application's previous references

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1133,16 +1133,18 @@ class PlanningApplication < ApplicationRecord
     old_application_type = ApplicationType.find(changes["application_type_id"].first)
     old_reference = reference
 
-    set_application_number
-    set_reference
+    transaction do
+      set_reference
+      previous_references << old_reference
 
-    audit!(
-      activity_type: "updated",
-      activity_information: "Application type",
-      audit_comment:
-        "Application type changed from: #{old_application_type.full_name} / Changed to: #{application_type.full_name},
+      audit!(
+        activity_type: "updated",
+        activity_information: "Application type",
+        audit_comment:
+          "Application type changed from: #{old_application_type.full_name} / Changed to: #{application_type.full_name},
          Reference changed from #{old_reference} to #{reference}"
-    )
+      )
+    end
   end
 
   def determination_date_is_not_in_the_future

--- a/app/views/shared/_proposal_header.html.erb
+++ b/app/views/shared/_proposal_header.html.erb
@@ -11,38 +11,41 @@
         <strong><%= @planning_application.full_address %></strong>
         <br>
         <%= t(".application_number") %> <strong><%= @planning_application.reference %></strong>
+        <% if @planning_application.previous_references.any? %>
+          (<%= t(".previously") %>: <strong><%= @planning_application.previous_references.join(", ") %></strong>)
+        <% end %>
       </p>
     <% else %>
-      <span class="govuk-caption-l"><%= t(".application_number") %> <%= @planning_application.reference %></span>
+      <span class="govuk-caption-l"><%= t(".application_number") %><%= @planning_application.reference %></span>
       <h1 class="govuk-heading-l"><%= @planning_application.full_address %></h1>
     <% end %>
 
-  <div id="planning-application-statuses-tags">
-    <p class="govuk-body">
-      <% if @planning_application.appeal&.persisted? %>
-        <%= @planning_application.appeal_status_tag %>
-      <% end %>
-      <%= @planning_application.status_tag %>
-      <% if @planning_application.in_progress? %>
-        <span class="govuk-!-margin-left-1">
-          <%= @planning_application.days_status_tag %>
-        </span>
-      <% end %>
+    <div id="planning-application-statuses-tags">
+      <p class="govuk-body">
+        <% if @planning_application.appeal&.persisted? %>
+          <%= @planning_application.appeal_status_tag %>
+        <% end %>
+        <%= @planning_application.status_tag %>
+        <% if @planning_application.in_progress? %>
+          <span class="govuk-!-margin-left-1">
+            <%= @planning_application.days_status_tag %>
+          </span>
+        <% end %>
 
-      <% if @planning_application.environment_impact_assessment_required? %>
-        <span class="govuk-!-margin-left-1">
-          <span class="govuk-tag govuk-tag--yellow">EIA</span>
-        </span>
-      <% end %>
+        <% if @planning_application.environment_impact_assessment_required? %>
+          <span class="govuk-!-margin-left-1">
+            <span class="govuk-tag govuk-tag--yellow">EIA</span>
+          </span>
+        <% end %>
 
-      <% if @planning_application.appeals? && controller_path == "planning_applications" %>
-        <% translation_key, link_path = appeal_link_and_translation(@planning_application) %>
-        <span class="govuk-!-margin-left-1">
-          <%= govuk_link_to t(translation_key), link_path %>
-        </span>
-      <% end %>
-    </p>
-  </div>
+        <% if @planning_application.appeals? && controller_path == "planning_applications" %>
+          <% translation_key, link_path = appeal_link_and_translation(@planning_application) %>
+          <span class="govuk-!-margin-left-1">
+            <%= govuk_link_to t(translation_key), link_path %>
+          </span>
+        <% end %>
+      </p>
+    </div>
 
     <% if @planning_application.closed? %>
       <p class="govuk-body">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2132,6 +2132,7 @@ en:
     proposal_header:
       application_number: 'Application number:'
       mark_for_appeal: Mark for appeal
+      previously: Previously
       update_appeal: Update appeal
     review_task_breadcrumbs:
       application: Application

--- a/db/migrate/20250203121426_add_previous_references_to_planning_applications.rb
+++ b/db/migrate/20250203121426_add_previous_references_to_planning_applications.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPreviousReferencesToPlanningApplications < ActiveRecord::Migration[7.2]
+  def change
+    add_column :planning_applications, :previous_references, :string, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_30_165912) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_03_121426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -830,6 +830,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_165912) do
     t.boolean "site_history_checked", default: false, null: false
     t.virtual "address_search", type: :tsvector, as: "to_tsvector('simple'::regconfig, (((((((((COALESCE(address_1, ''::character varying))::text || ' '::text) || (COALESCE(address_2, ''::character varying))::text) || ' '::text) || (COALESCE(town, ''::character varying))::text) || ' '::text) || (COALESCE(county, ''::character varying))::text) || ' '::text) || (COALESCE(postcode, ''::character varying))::text))", stored: true
     t.datetime "deleted_at"
+    t.string "previous_references", default: [], array: true
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "lower(replace((postcode)::text, ' '::text, ''::text))", name: "ix_planning_applications_on_LOWER_replace_postcode"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -399,16 +399,16 @@ RSpec.describe PlanningApplication do
               ldc_planning_application.update!(application_type_id: ApplicationType.find_by(name: "prior_approval").id)
             end.to change(Audit, :count)
               .by(1)
-              .and change(ldc_planning_application, :application_number)
-              .from("00101").to("00102")
               .and change(ldc_planning_application, :reference)
-              .from("23-00101-LDCP").to("23-00102-PA1A")
+              .from("23-00101-LDCP").to("23-00101-PA1A")
+              .and change(ldc_planning_application, :previous_references)
+              .from([]).to(["23-00101-LDCP"])
 
             expect(Audit.last).to have_attributes(
               planning_application_id: ldc_planning_application.id,
               activity_type: "updated",
               activity_information: "Application type",
-              audit_comment: "Application type changed from: Lawfulness certificate / Changed to: Prior approval,\n         Reference changed from 23-00101-LDCP to 23-00102-PA1A",
+              audit_comment: "Application type changed from: Lawfulness certificate / Changed to: Prior approval,\n         Reference changed from 23-00101-LDCP to 23-00101-PA1A",
               user: assessor
             )
           end

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "editing planning application" do
     find("span", text: "Application information")
     click_link("Edit details")
 
-    expect(page).to have_content("Application number: 23-00101-PA1A")
+    expect(page).to have_content("Application number: 23-00100-PA1A")
     expect(page).to have_select("planning-application-application-type-id-field", selected: "Prior Approval - Larger extension to a house")
     fill_in("Address 1", with: "125 High Street")
     click_button("Save")
@@ -88,7 +88,7 @@ RSpec.describe "editing planning application" do
     within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(
-        "Application type changed from: Lawfulness certificate / Changed to: Prior approval, Reference changed from 23-00100-LDCP to 23-00101-PA1A"
+        "Application type changed from: Lawfulness certificate / Changed to: Prior approval, Reference changed from 23-00100-LDCP to 23-00100-PA1A"
       )
       expect(page).to have_content(assessor.name)
       expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))

--- a/spec/system/planning_applications/show_spec.rb
+++ b/spec/system/planning_applications/show_spec.rb
@@ -105,6 +105,19 @@ RSpec.describe "Planning Application show page" do
         expect(page).to have_content("#{planning_application.created_at.year % 100}-00100-HAPP")
       end
     end
+
+    context "when application type has been changed" do
+      before do
+        planning_application.update!(application_type: create(:application_type, :ldc_existing))
+        visit "/planning_applications/#{planning_application.reference}"
+      end
+
+      it "Displays previous application reference numbers" do
+        expect(page).to have_text(
+          "Application number: #{planning_application.created_at.year % 100}-00100-LDCE (Previously: #{planning_application.created_at.year % 100}-00100-LDCP)"
+        )
+      end
+    end
   end
 
   context "as an assessor when target date is within a week" do


### PR DESCRIPTION
### Description of change

Store application's previous references

- When changing application type for a planning application, we update the reference number to include the new application type suffix. We want to store previous versions of the reference number for transparency

### Story Link

https://trello.com/c/dFLkk4Jw/373-changing-application-type-changes-reference-number-and-the-public-status

