### PR TITLE
Pass SGID when linking to documents

### DIFF
--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
@@ -27,7 +27,9 @@
           </p>
 
           <p class="govuk-body">
-            <%= govuk_link_to "Download", planning_application_document_path(@planning_application, document, sgid: params[:sgid]) %>
+            <%= govuk_link_to "Download",
+                  planning_application_document_path(@planning_application, document, sgid: params[:sgid]),
+                  new_tab: "" %>
           </p>
         </td>
       </tr>

--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
@@ -27,7 +27,7 @@
           </p>
 
           <p class="govuk-body">
-            <%= govuk_link_to "Download", planning_application_document_path(@planning_application, document) %>
+            <%= govuk_link_to "Download", planning_application_document_path(@planning_application, document, sgid: params[:sgid]) %>
           </p>
         </td>
       </tr>

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -37,9 +37,12 @@ RSpec.describe "Planning applications", type: :system do
 
     it "includes documents on planning application overview" do
       expect(page).to have_content(documents.first.name)
-      expect(page).to have_link "Download", href: "/consultees/planning_applications/#{reference}/documents/#{documents.first.id}"
+      expect(page).to have_link "Download", href: %r{^/consultees/planning_applications/#{reference}/documents/#{documents.first.id}\?sgid=}
       expect(page).to have_content(documents.last.name)
-      expect(page).to have_link "Download", href: "/consultees/planning_applications/#{reference}/documents/#{documents.last.id}"
+      expect(page).to have_link "Download", href: %r{^/consultees/planning_applications/#{reference}/documents/#{documents.last.id}\?sgid=}
+
+      find_all("a", text: "Download").first.click
+      expect(page.status_code).to be < 400
     end
 
     it "successfully submits and disables the form" do


### PR DESCRIPTION
Pass magic link ID to documents controller. Add test to confirm it's working.