### PR TITLE
Use a custom serialize_from_session handler

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -75,7 +75,7 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:otp_attempt, :subdomain])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:otp_attempt])
   end
 
   private

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -2,7 +2,6 @@
 
 class AuthenticationController < ApplicationController
   before_action :authenticate_user!
-  before_action :reset_session_and_redirect, unless: :session_domain_matches?
 
   rescue_from ActionController::InvalidAuthenticityToken, with: :reset_session_and_redirect
 

--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -4,6 +4,7 @@ module AuthenticateWithOtpTwoFactor
   extend ActiveSupport::Concern
 
   def authenticate_with_otp_two_factor
+    return unless otp_two_factor_enabled?
     return unless valid_mobile_number?
 
     user = self.resource = find_user
@@ -74,7 +75,7 @@ module AuthenticateWithOtpTwoFactor
     if session[:otp_user_id]
       users_scope.find(session[:otp_user_id])
     elsif user_params[:email]
-      users_scope.find_for_authentication(email: user_params[:email], subdomain: request.subdomain)
+      users_scope.find_for_authentication(email: user_params[:email])
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -10,12 +10,17 @@ module Users
 
     include AuthenticateWithOtpTwoFactor
 
-    prepend_before_action :authenticate_with_otp_two_factor, if: :otp_two_factor_enabled?, only: :create
-    before_action :find_otp_user, only: %i[setup two_factor resend_code]
     skip_before_action :enforce_user_permissions
+
+    before_action :authenticate_with_otp_two_factor, only: %i[create]
+    before_action :find_otp_user, only: %i[setup two_factor resend_code]
     before_action :set_mobile_number_form, only: %i[setup two_factor]
 
     protect_from_forgery with: :exception, prepend: true, except: :destroy
+
+    def create
+      super
+    end
 
     def setup
       render "devise/sessions/new" if @user.mobile_number?

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,7 +1,24 @@
 # frozen_string_literal: true
 
 class Current < ActiveSupport::CurrentAttributes
+  GLOBAL_SUBDOMAINS = %w[config].freeze
+
+  attribute :subdomain
   attribute :user
   attribute :api_user
   attribute :local_authority
+
+  def global_subdomain?
+    GLOBAL_SUBDOMAINS.include?(subdomain)
+  end
+
+  def user_scope
+    if global_subdomain?
+      User.global.kept
+    elsif local_authority
+      local_authority.users.kept
+    else
+      User.none
+    end
+  end
 end

--- a/app/models/planning_application_policy_section.rb
+++ b/app/models/planning_application_policy_section.rb
@@ -21,14 +21,9 @@ class PlanningApplicationPolicySection < ApplicationRecord
 
   before_validation :set_description, on: :create
 
-  enum(
-    status: {
-      complies: "complies",
-      does_not_comply: "does_not_comply",
-      to_be_determined: "to_be_determined"
-    },
-    _default: :to_be_determined
-  )
+  enum :status,
+    %i[complies does_not_comply to_be_determined].index_with(&:to_s),
+    default: :to_be_determined
 
   def set_description
     self.description ||= policy_section.description

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -42,6 +42,15 @@ Devise.setup do |config|
   config.otp_allowed_drift = 300
 
   # ==> Warden configuration
+
+  # Scope the lookup to the local authority when restoring the user from the session
+  config.warden do |manager|
+    manager.serialize_from_session(:user) do |((id), salt)|
+      user = Current.user_scope.find_by(id:)
+      user if user && user.authenticatable_salt == salt
+    end
+  end
+
   # Reset the token after logging in so that other sessions are logged out
   Warden::Manager.after_set_user except: :fetch do |user, warden, options|
     if warden.authenticated?(:user)

--- a/engines/bops_admin/app/controllers/bops_admin/application_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/application_controller.rb
@@ -7,7 +7,6 @@ module BopsAdmin
     before_action :require_local_authority!
     before_action :authenticate_user!
     before_action :require_administrator!
-    before_action :reset_session_and_redirect, unless: :session_domain_matches?
     before_action :set_back_path
 
     layout "application"

--- a/engines/bops_config/spec/bops_config_helper.rb
+++ b/engines/bops_config/spec/bops_config_helper.rb
@@ -5,6 +5,10 @@ require "rails_helper"
 Dir[BopsCore::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
+  config.before type: :controller do |example|
+    request.set_header("HTTP_HOST", "config.bops.services")
+  end
+
   config.before type: :system do |example|
     Capybara.app_host = "http://config.bops.services"
   end

--- a/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
@@ -59,6 +59,7 @@ module BopsCore
     end
 
     def set_current
+      Current.subdomain = request.subdomain
       Current.local_authority = current_local_authority
       Current.user = current_user
       Current.api_user = current_api_user
@@ -85,10 +86,6 @@ module BopsCore
     def set_back_path
       session[:back_path] = request.referer if request.get?
       @back_path = session[:back_path]
-    end
-
-    def session_domain_matches?
-      Current.user.nil? || Current.user.local_authority == Current.local_authority
     end
 
     def reset_session_and_redirect(_exception = nil)

--- a/spec/requests/contacts_spec.rb
+++ b/spec/requests/contacts_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Searching for contacts" do
   subject { JSON.parse(response.body) }
 
   before do
-    login_as(assessor)
+    sign_in(assessor)
   end
 
   describe "searching for consultees" do

--- a/spec/requests/informatives_spec.rb
+++ b/spec/requests/informatives_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Searching for informatives" do
   subject { JSON.parse(response.body) }
 
   before do
-    login_as(assessor)
+    sign_in(assessor)
   end
 
   before do

--- a/spec/requests/policy_guidance_spec.rb
+++ b/spec/requests/policy_guidance_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Searching for policy guidance" do
   subject { JSON.parse(response.body) }
 
   before do
-    login_as(assessor)
+    sign_in(assessor)
   end
 
   before do

--- a/spec/requests/policy_references_spec.rb
+++ b/spec/requests/policy_references_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Searching for policy references" do
   subject { JSON.parse(response.body) }
 
   before do
-    login_as(assessor)
+    sign_in(assessor)
   end
 
   before do

--- a/spec/requests/requirements_spec.rb
+++ b/spec/requests/requirements_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Searching for requirements" do
   subject { JSON.parse(response.body) }
 
   before do
-    login_as(assessor)
+    sign_in(assessor)
   end
 
   before do

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -299,9 +299,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -333,7 +333,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 
@@ -414,9 +414,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -448,7 +448,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 
@@ -530,9 +530,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -564,7 +564,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 
@@ -648,9 +648,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -683,7 +683,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 
@@ -764,9 +764,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -798,7 +798,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 
@@ -879,9 +879,9 @@ RSpec.describe "Reviewing assessment summaries" do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
 
-        click_link("Log out")
-        sign_in(assessor)
+        sign_out(reviewer)
         travel 1.day
+        sign_in(assessor)
         visit "/planning_applications/#{planning_application.reference}"
 
         expect(page).to have_list_item_for(
@@ -913,7 +913,7 @@ RSpec.describe "Reviewing assessment summaries" do
         click_button("Update assessment")
         click_link("Review and submit recommendation")
         click_button("Submit recommendation")
-        click_link("Log out")
+        sign_out(assessor)
         sign_in(reviewer)
         visit "/planning_applications/#{planning_application.reference}"
 


### PR DESCRIPTION
We need to scope restoring the user from the session to the current local authority otherwise you can reuse session cookies across subdomains.
