### PR TITLE
Only display list of application types of the same type when updating

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -183,7 +183,8 @@ class ApplicationType < ApplicationRecord
       end
     end
 
-    def menu(scope = by_name)
+    def menu(scope = by_name, type: nil)
+      scope = scope.where(name: type) if type
       scope.active.order(code: :asc).map do |application_type|
         [application_type.description, application_type.id]
       end

--- a/app/views/planning_applications/_form.html.erb
+++ b/app/views/planning_applications/_form.html.erb
@@ -24,7 +24,7 @@
         <% end %>
       </p>
 
-      <%= form.govuk_select(:application_type_id, ApplicationType.menu, label: {text: "Application type"}) %>
+      <%= form.govuk_select(:application_type_id, ApplicationType.menu(type: @planning_application.application_type.name), label: {text: "Application type"}) %>
     <% end %>
   </div>
   <div class="govuk-form-group govuk-!-margin-top-8">

--- a/spec/models/application_type_spec.rb
+++ b/spec/models/application_type_spec.rb
@@ -194,6 +194,40 @@ RSpec.describe ApplicationType do
           ]
         )
       end
+
+      context "when provided an application type name" do
+        let!(:ldc_proposed) { create(:application_type, :ldc_proposed) }
+        let!(:prior_approval_part_14) { create(:application_type, :pa_part_14_class_j) }
+        let!(:householder) { create(:application_type, :householder) }
+        let!(:householder_retrospective) { create(:application_type, :householder_retrospective) }
+
+        it "returns an array of application type names and ids for ldcs only" do
+          expect(described_class.menu(type: lawfulness_certificate.name)).to eq(
+            [
+              ["Lawful Development Certificate - Existing use", lawfulness_certificate.id],
+              ["Lawful Development Certificate - Proposed use", ldc_proposed.id]
+            ]
+          )
+        end
+
+        it "returns an array of application type names and ids for prior approvals only" do
+          expect(described_class.menu(type: prior_approval.name)).to eq(
+            [
+              ["Prior Approval - Install or change solar panels", prior_approval_part_14.id],
+              ["Prior Approval - Larger extension to a house", prior_approval.id]
+            ]
+          )
+        end
+
+        it "returns an array of application type names and ids for householder only" do
+          expect(described_class.menu(type: householder.name)).to eq(
+            [
+              ["Planning Permission - Full householder", householder.id],
+              ["Planning Permission - Full householder retrospective", householder_retrospective.id]
+            ]
+          )
+        end
+      end
     end
   end
 

--- a/spec/system/planning_applications/editing_planning_application_spec.rb
+++ b/spec/system/planning_applications/editing_planning_application_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "editing planning application" do
     travel_to(DateTime.new(2023, 1, 1))
     sign_in(assessor)
     create(:application_type, :prior_approval)
+    create(:application_type, :ldc_existing)
     visit "/planning_applications/#{planning_application.reference}"
   end
 
@@ -41,7 +42,7 @@ RSpec.describe "editing planning application" do
 
     expect(page).to have_content("An applicant or agent email is required.")
 
-    select("Prior Approval - Larger extension to a house")
+    select("Lawful Development Certificate - Existing use")
 
     within(find(:fieldset, text: "Agent information")) do
       fill_in("Email address", with: "alice@example.com")
@@ -69,8 +70,8 @@ RSpec.describe "editing planning application" do
     find("span", text: "Application information")
     click_link("Edit details")
 
-    expect(page).to have_content("Application number: 23-00100-PA1A")
-    expect(page).to have_select("planning-application-application-type-id-field", selected: "Prior Approval - Larger extension to a house")
+    expect(page).to have_content("Application number: 23-00100-LDCE (Previously: 23-00100-LDCP)")
+    expect(page).to have_select("planning-application-application-type-id-field", selected: "Lawful Development Certificate - Existing use")
     fill_in("Address 1", with: "125 High Street")
     click_button("Save")
     planning_application.reload
@@ -88,7 +89,7 @@ RSpec.describe "editing planning application" do
     within("#audit_#{Audit.find_by(activity_information: "Application type").id}") do
       expect(page).to have_content("Application type updated")
       expect(page).to have_content(
-        "Application type changed from: Lawfulness certificate / Changed to: Prior approval, Reference changed from 23-00100-LDCP to 23-00100-PA1A"
+        "Application type changed from: Lawfulness certificate / Changed to: Lawfulness certificate, Reference changed from 23-00100-LDCP to 23-00100-LDCE"
       )
       expect(page).to have_content(assessor.name)
       expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))


### PR DESCRIPTION
### Description of change

Only display list of application types of the same type when updating

Allowing an update to any application type runs the risk of the settings being widely different between the application types. For example, some application types do not support having a consultation so if we switch from an application type that has this to one without, we will run into issues. 
This selective list only displays the application types with the same name/type. This should limit any issues with big variances in the application type settings.

### Story Link

https://trello.com/c/dFLkk4Jw/373-changing-application-type-changes-reference-number-and-the-public-status

