### PR TITLE
Move LA lookup and user scoping to middleware

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -60,6 +60,15 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:7.0
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/app/controllers/concerns/authenticate_with_otp_two_factor.rb
+++ b/app/controllers/concerns/authenticate_with_otp_two_factor.rb
@@ -73,18 +73,14 @@ module AuthenticateWithOtpTwoFactor
 
   def find_user
     if session[:otp_user_id]
-      users_scope.find(session[:otp_user_id])
+      user_scope.find(session[:otp_user_id])
     elsif user_params[:email]
-      users_scope.find_for_authentication(email: user_params[:email])
+      user_scope.find_for_authentication(email: user_params[:email])
     end
   end
 
-  def users_scope
-    if request.subdomain == "config"
-      User.global_administrator
-    else
-      current_local_authority.users
-    end
+  def user_scope
+    request.env["bops.user_scope"]
   end
 
   def mobile_number_needed?(user)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -57,7 +57,7 @@ module Users
     end
 
     def find_otp_user
-      @user = users_scope.find_by(id: session[:otp_user_id])
+      @user = user_scope.find_by(id: session[:otp_user_id])
 
       redirect_to root_path unless @user
     end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,24 +1,7 @@
 # frozen_string_literal: true
 
 class Current < ActiveSupport::CurrentAttributes
-  GLOBAL_SUBDOMAINS = %w[config].freeze
-
-  attribute :subdomain
   attribute :user
   attribute :api_user
   attribute :local_authority
-
-  def global_subdomain?
-    GLOBAL_SUBDOMAINS.include?(subdomain)
-  end
-
-  def user_scope
-    if global_subdomain?
-      User.global.kept
-    elsif local_authority
-      local_authority.users.kept
-    else
-      User.none
-    end
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,7 @@ class User < ApplicationRecord
     end
 
     def find_for_authentication(tainted_conditions)
-      Current.user_scope.find_first_by_auth_conditions(tainted_conditions)
+      find_first_by_auth_conditions(tainted_conditions)
     end
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -57,6 +57,12 @@ module Bops
     # Use Rails 7.0 digest class
     config.active_record.encryption.hash_digest_class = OpenSSL::Digest::SHA256
 
+    # Ensure the correct local_authority is loaded
+    config.middleware.use BopsCore::Middleware::LocalAuthority
+
+    # Ensure the correct user scope is used for authentication
+    config.middleware.use BopsCore::Middleware::User, global_subdomains: %w[config]
+
     # Load config from application.yml
     config_for(:application).each do |key, value|
       config.send(:"#{key}=", value)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # Scope the lookup to the local authority when restoring the user from the session
   config.warden do |manager|
     manager.serialize_from_session(:user) do |((id), salt)|
-      user = Current.user_scope.find_by(id:)
+      user = env["bops.user_scope"].find_by(id:)
       user if user && user.authenticatable_salt == salt
     end
   end

--- a/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/planning_applications_controller_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe BopsApi::V2::PlanningApplicationsController, type: :controller do
     request.set_header("HTTP_HOST", "southwark.bops.test")
     request.set_header("HTTP_AUTHORIZATION", "Bearer #{token}")
 
+    request.set_header("bops.local_authority", southwark)
+    request.set_header("bops.user_scope", southwark.users.kept)
+
     expect(BopsApi::Application::CreationService).to receive(:new).and_return(creation_service)
     expect(creation_service).to receive(:call!).and_return(planning_application)
   end

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -197,24 +197,6 @@ RSpec.describe "BOPS API" do
         run_test!
       end
 
-      response "404", "when a local authority isn't found" do
-        before do
-          allow(LocalAuthority).to receive(:find_by).and_return(nil)
-        end
-
-        schema "$ref" => "#/components/schemas/NotFoundError"
-
-        example "application/json", :default, {
-          error: {
-            code: 404,
-            message: "Not Found",
-            detail: "Local authority not found"
-          }
-        }
-
-        run_test!
-      end
-
       response "422", "when an application is invalid" do
         schema "$ref" => "#/components/schemas/UnprocessableEntityError"
 

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -19879,8 +19879,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt: 
-                      decision: 
+                      determinedAt:
+                      decision:
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -19894,7 +19894,7 @@ paths:
                       - value: sections.proposed
                         description: Sections - proposed
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -19904,7 +19904,7 @@ paths:
                       - value: internal.siteNotice
                         description: Site Notice
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -19953,8 +19953,8 @@ paths:
                     links:
                       first: http://planx.example.com/api/v2/neighbour_responses?page=1
                       last: http://planx.example.com/api/v2/neighbour_responses?page=1
-                      prev: 
-                      next: 
+                      prev:
+                      next:
                     responses:
                     - receivedAt: '2024-10-21T11:30:00.000+01:00'
                       text: I like it *****
@@ -20060,8 +20060,8 @@ paths:
                     links:
                       first: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
                       last: http://southwark.bops.localhost:3000/api/v2/planning_applications/24-00593-HAPP/validation_requests?page=1
-                      prev: 
-                      next: 
+                      prev:
+                      next:
                     data:
                     - type: FeeChangeValidationRequest
                       state: open
@@ -20070,12 +20070,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.073+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         suggestion: test change
                     - type: AdditionalDocumentValidationRequest
@@ -20085,12 +20085,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.081+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         document_request_type: test
                     - type: OtherChangeValidationRequest
@@ -20100,12 +20100,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.090+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         suggestion: test change
                     - type: DescriptionChangeValidationRequest
@@ -20113,13 +20113,13 @@ paths:
                       post_validation: false
                       created_at: '2024-04-23T15:17:00.174+01:00'
                       notified_at: '2024-04-23T15:17:00.290+01:00'
-                      reason: 
+                      reason:
                       response_due: '2024-04-30'
-                      response: 
-                      rejection_reason: 
+                      response:
+                      rejection_reason:
                       approved: true
-                      cancel_reason: 
-                      cancelled_at: 
+                      cancel_reason:
+                      cancelled_at:
                       closed_at: '2024-04-23T15:19:38.912+01:00'
                       specific_attributes:
                         previous_description: Roof extension to the rear of the property,
@@ -20133,12 +20133,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.058+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
+                      response:
+                      rejection_reason:
                       approved: true
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         new_geojson:
                           type: FeatureCollection
@@ -20157,7 +20157,7 @@ paths:
                                   - 51.4655038504508
                                 - - -0.11835515499115692
                                   - 51.465546460366994
-                            properties: 
+                            properties:
                         original_geojson:
                           type: Feature
                           geometry:
@@ -20173,7 +20173,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties: 
+                          properties:
         '401':
           description: with missing or invalid credentials
           content:
@@ -20302,19 +20302,6 @@ paths:
                         not permitted in production
               schema:
                 "$ref": "#/components/schemas/ForbiddenError"
-        '404':
-          description: when a local authority isn't found
-          content:
-            application/json:
-              examples:
-                default:
-                  value:
-                    error:
-                      code: 404
-                      message: Not Found
-                      detail: Local authority not found
-              schema:
-                "$ref": "#/components/schemas/NotFoundError"
         '422':
           description: when an application is invalid
           content:
@@ -21830,7 +21817,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -21989,7 +21976,7 @@ paths:
                                 - 51.69954799782576
                               - - -0.7085376977920632
                                 - 51.699564621757816
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.299367
                           squareMetres: 2993.67
@@ -22793,7 +22780,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -22896,7 +22883,7 @@ paths:
                                 - 51.61561499701554
                               - - -0.646633654832832
                                 - 51.61556919642334
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.141826
                           squareMetres: 1418.26
@@ -24843,7 +24830,7 @@ paths:
                                 - 51.512609937924225
                               - - -0.5202563671906586
                                 - 51.51349326091676
-                          properties: 
+                          properties:
                         area:
                           hectares: 6.1751949999999995
                           squareMetres: 61751.95
@@ -25949,7 +25936,7 @@ paths:
                                 - 52.00027971842326
                               - - -0.8271436393261123
                                 - 52.00047292273189
-                          properties: 
+                          properties:
                         area:
                           hectares: 0.069395
                           squareMetres: 693.95
@@ -31940,10 +31927,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -31957,11 +31944,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -31982,12 +31969,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude: 
-                        longitude: 
+                        latitude:
+                        longitude:
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -32003,28 +31990,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role: 
-                      awaiting_determination_at: 
-                      to_be_reviewed_at: 
+                      user_role:
+                      awaiting_determination_at:
+                      to_be_reviewed_at:
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at: 
+                      in_assessment_at:
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag: 
-                      result_heading: 
-                      result_description: 
-                      result_override: 
-                      returned_at: 
-                      started_at: 
+                      result_flag:
+                      result_heading:
+                      result_description:
+                      result_override:
+                      returned_at:
+                      started_at:
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -32041,14 +32028,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties: 
+                        properties:
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2: 
-                        county: 
+                        address_2:
+                        county:
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -32059,7 +32046,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date: 
+                        end_date:
                       make_public: false
                 ids:
                   value:
@@ -32079,10 +32066,10 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2024-02-06T17:23:44.428+00:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-09-08T11:24:29.682+01:00'
                       description: Add a chimney stack
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 49
                       invalidated_at: '2023-09-08T17:04:37.705+01:00'
@@ -32096,11 +32083,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: awaiting_determination
                       target_date: '2023-10-16'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -32121,12 +32108,12 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
-                        latitude: 
-                        longitude: 
+                        latitude:
+                        longitude:
                       received_date: '2023-09-08T11:24:29.682+01:00'
                       constraints:
                       - Conservation area
@@ -32142,28 +32129,28 @@ paths:
                       agent_email: ziggy@example.com
                       applicant_first_name: David
                       applicant_last_name: Bowie
-                      user_role: 
-                      awaiting_determination_at: 
-                      to_be_reviewed_at: 
+                      user_role:
+                      awaiting_determination_at:
+                      to_be_reviewed_at:
                       created_at: '2024-01-03T16:28:37.986+00:00'
                       description: Roof extension to the rear of the property, incorporating
                         starship launchpad.
-                      determined_at: 
+                      determined_at:
                       determination_date: '2024-03-06'
                       id: 98
                       invalidated_at: '2024-01-04T22:30:31.634+00:00'
-                      in_assessment_at: 
+                      in_assessment_at:
                       payment_reference: sandbox-ref-456
                       payment_amount: '206.0'
-                      result_flag: 
-                      result_heading: 
-                      result_description: 
-                      result_override: 
-                      returned_at: 
-                      started_at: 
+                      result_flag:
+                      result_heading:
+                      result_description:
+                      result_override:
+                      returned_at:
+                      started_at:
                       status: invalidated
                       target_date: '2024-02-07'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: Feature
@@ -32180,14 +32167,14 @@ paths:
                               - 51.4655038504508
                             - - -0.1186569035053321
                               - 51.465703531871384
-                        properties: 
+                        properties:
                       application_type: planning_permission
                       reference: 24-00173-HAPP
                       reference_in_full: SWK-24-00173-HAPP
                       site:
                         address_1: 40, STANSFIELD ROAD
-                        address_2: 
-                        county: 
+                        address_2:
+                        county:
                         town: LONDON
                         postcode: SW9 9RZ
                         uprn: '100021892955'
@@ -32198,7 +32185,7 @@ paths:
                       published_comments: []
                       consultee_comments: []
                       consultation:
-                        end_date: 
+                        end_date:
                       make_public: false
         '401':
           description: with missing or invalid credentials
@@ -32262,13 +32249,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at: 
+                      invalidated_at:
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -32279,11 +32266,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -32302,7 +32289,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties: 
+                          properties:
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -32339,7 +32326,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -32394,13 +32381,13 @@ paths:
                       applicant_last_name: Manteras
                       user_role: agent
                       awaiting_determination_at: '2023-08-04T13:24:17.885+01:00'
-                      to_be_reviewed_at: 
+                      to_be_reviewed_at:
                       created_at: '2023-06-06T16:50:37.821+01:00'
                       description: Add a chimney stack
                       determined_at: '2023-11-03T08:59:02.345+00:00'
                       determination_date: '2023-11-03T00:00:00.000+00:00'
                       id: 9
-                      invalidated_at: 
+                      invalidated_at:
                       in_assessment_at: '2023-08-04T13:24:06.829+01:00'
                       payment_reference: PAY1
                       payment_amount: '0.0'
@@ -32411,11 +32398,11 @@ paths:
                         we do not think this is eligible for a Lawful Development
                         Certificate
                       result_override: This was my reason for rejecting the result
-                      returned_at: 
-                      started_at: 
+                      returned_at:
+                      started_at:
                       status: determined
                       target_date: '2023-07-11'
-                      withdrawn_at: 
+                      withdrawn_at:
                       work_status: proposed
                       boundary_geojson:
                         type: FeatureCollection
@@ -32434,7 +32421,7 @@ paths:
                                 - 51.49453137017866
                               - - -0.06490596313800803
                                 - 51.48755549852538
-                          properties: 
+                          properties:
                       site_notice_content: |-
                         <div style="font-size: 10px; padding-left: 20px; padding-right: 20px; letter-spacing: 0.02px;">
                         <div style="width: 420px; text-align: center">
@@ -32471,7 +32458,7 @@ paths:
                       site:
                         address_1: 11 Abbey Gardens
                         address_2: Southwark
-                        county: 
+                        county:
                         town: London
                         postcode: SE16 3RQ
                         uprn: '100081043511'
@@ -32540,19 +32527,19 @@ paths:
                     applicant_first_name: Albert
                     applicant_last_name: Manteras
                     user_role: agent
-                    awaiting_determination_at: 
-                    to_be_reviewed_at: 
+                    awaiting_determination_at:
+                    to_be_reviewed_at:
                     created_at: '2023-05-23T09:39:04.197+01:00'
                     description: This is a long winded description, bla bla bla a
                       single storey ground floor rear extension; replacement of existing
                       garage door with brick infill and a new window; replacement
                       of the existing windows with double glazed windows, installation
                       of rooflight
-                    determined_at: 
+                    determined_at:
                     determination_date: '2024-03-06'
                     id: 2
-                    invalidated_at: 
-                    in_assessment_at: 
+                    invalidated_at:
+                    in_assessment_at:
                     payment_reference: PAY1
                     payment_amount: '0.0'
                     result_flag: Planning permission / Permission needed
@@ -32561,11 +32548,11 @@ paths:
                     result_description: Based on the information you have provided,
                       we do not think this is eligible for a Lawful Development Certificate
                     result_override: This was my reason for rejecting the result
-                    returned_at: 
-                    started_at: 
+                    returned_at:
+                    started_at:
                     status: not_started
                     target_date: '2023-06-27'
-                    withdrawn_at: 
+                    withdrawn_at:
                     work_status: proposed
                     boundary_geojson:
                       type: Feature
@@ -32648,10 +32635,10 @@ paths:
                       targetDate: '2024-05-15'
                       receivedAt: '2024-04-17T00:00:00.000+01:00'
                       validAt: '2024-04-12T00:00:00.000+01:00'
-                      publishedAt: 
-                      determinedAt: 
+                      publishedAt:
+                      determinedAt:
                       status: in_assessment
-                      decision: 
+                      decision:
                       consultation:
                         startDate: '2024-04-15'
                         endDate: '2024-05-07'
@@ -32731,7 +32718,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties: 
+                              properties:
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -32831,7 +32818,7 @@ paths:
                                     - 51.4655038504508
                                   - - -0.1186569035053321
                                     - 51.465703531871384
-                              properties: 
+                              properties:
                             area:
                               hectares: 0.012592
                               squareMetres: 125.92
@@ -33066,9 +33053,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt: 
-                        determinedAt: 
-                        decision: 
+                        publishedAt:
+                        determinedAt:
+                        decision:
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -33175,10 +33162,10 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties: 
+                            properties:
                       proposal:
                         description: Build a roof extension.
-                        reportingType: 
+                        reportingType:
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
@@ -33240,8 +33227,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt: 
-                      decision: 
+                      determinedAt:
+                      decision:
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -33255,7 +33242,7 @@ paths:
                       - value: sections.proposed
                         description: Sections - proposed
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -33265,7 +33252,7 @@ paths:
                       - value: internal.siteNotice
                         description: Site Notice
                       createdAt: '2024-06-12T15:56:29.803+01:00'
-                      applicantDescription: 
+                      applicantDescription:
                       metadata:
                         byteSize: 144212
                         contentType: application/pdf
@@ -33334,9 +33321,9 @@ paths:
                         targetDate: '2024-05-15'
                         receivedAt: '2024-04-17T00:00:00.000+01:00'
                         validAt: '2024-04-12T00:00:00.000+01:00'
-                        publishedAt: 
-                        determinedAt: 
-                        decision: 
+                        publishedAt:
+                        determinedAt:
+                        decision:
                         status: in_assessment
                         consultation:
                           startDate: '2024-04-15'
@@ -33443,10 +33430,10 @@ paths:
                                   - 51.537313
                                 - - -0.054597
                                   - 51.537331
-                            properties: 
+                            properties:
                       proposal:
                         description: Build a roof extension.
-                        reportingType: 
+                        reportingType:
                         ownerIsPlanningAuthority: false
                       applicant:
                         type: individual
@@ -33505,8 +33492,8 @@ paths:
                       receivedAt: '2024-06-12T15:56:29.830+01:00'
                       validAt: '2024-06-12T00:00:00.000+01:00'
                       publishedAt: '2024-06-12T15:56:29.828+01:00'
-                      determinedAt: 
-                      decision: 
+                      determinedAt:
+                      decision:
                       status: determined
                       consultation:
                         startDate: '2024-04-15'
@@ -33630,8 +33617,8 @@ paths:
                     links:
                       first: http://southwark.bops.localhost:3000/api/v2/validation_requests?page=1
                       last: http://southwark.bops.localhost:3000/api/v2/validation_requests?page=1
-                      prev: 
-                      next: 
+                      prev:
+                      next:
                     data:
                     - planning_application:
                         reference: 24-00593-HAPP
@@ -33642,12 +33629,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.073+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         suggestion: test change
                     - planning_application:
@@ -33659,12 +33646,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.081+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         document_request_type: test
                     - planning_application:
@@ -33676,12 +33663,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.090+01:00'
                       reason: test change
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
-                      approved: 
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      response:
+                      rejection_reason:
+                      approved:
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         suggestion: test change
                     - planning_application:
@@ -33691,13 +33678,13 @@ paths:
                       post_validation: false
                       created_at: '2024-04-23T15:17:00.174+01:00'
                       notified_at: '2024-04-23T15:17:00.290+01:00'
-                      reason: 
+                      reason:
                       response_due: '2024-04-30'
-                      response: 
-                      rejection_reason: 
+                      response:
+                      rejection_reason:
                       approved: true
-                      cancel_reason: 
-                      cancelled_at: 
+                      cancel_reason:
+                      cancelled_at:
                       closed_at: '2024-04-23T15:19:38.912+01:00'
                       specific_attributes:
                         previous_description: Roof extension to the rear of the property,
@@ -33713,12 +33700,12 @@ paths:
                       notified_at: '2024-04-23T15:17:50.058+01:00'
                       reason: test
                       response_due: '2024-05-15'
-                      response: 
-                      rejection_reason: 
+                      response:
+                      rejection_reason:
                       approved: true
-                      cancel_reason: 
-                      cancelled_at: 
-                      closed_at: 
+                      cancel_reason:
+                      cancelled_at:
+                      closed_at:
                       specific_attributes:
                         new_geojson:
                           type: FeatureCollection
@@ -33737,7 +33724,7 @@ paths:
                                   - 51.4655038504508
                                 - - -0.11835515499115692
                                   - 51.465546460366994
-                            properties: 
+                            properties:
                         original_geojson:
                           type: Feature
                           geometry:
@@ -33753,7 +33740,7 @@ paths:
                                 - 51.4655038504508
                               - - -0.1186569035053321
                                 - 51.465703531871384
-                          properties: 
+                          properties:
               schema:
                 "$ref": "#/components/schemas/ValidationRequests"
         '401':

--- a/engines/bops_config/spec/bops_config_helper.rb
+++ b/engines/bops_config/spec/bops_config_helper.rb
@@ -7,6 +7,8 @@ Dir[BopsCore::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 RSpec.configure do |config|
   config.before type: :controller do |example|
     request.set_header("HTTP_HOST", "config.bops.services")
+    request.set_header("bops.local_authority", nil)
+    request.set_header("bops.user_scope", ::User.global.kept)
   end
 
   config.before type: :system do |example|

--- a/engines/bops_config/spec/system/sidekiq_spec.rb
+++ b/engines/bops_config/spec/system/sidekiq_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "bops_config_helper"
+
+RSpec.describe "Sidekiq", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+
+  before do
+    visit "/sidekiq"
+    fill_in "Email", with: user.email
+    fill_in "Password", with: user.password
+    click_button "Log in"
+  end
+
+  context "when the user is an assessor" do
+    let(:user) { create(:user, :assessor, local_authority:) }
+
+    it "doesn't allow access to the Sidekiq control panel" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is a reviewer" do
+    let(:user) { create(:user, :reviewer, local_authority:) }
+
+    it "doesn't allow access to the Sidekiq control panel" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is an administrator for a local authority" do
+    let(:user) { create(:user, :administrator, local_authority:) }
+
+    it "doesn't allow access to the Sidekiq control panel" do
+      expect(page).to have_current_path("/users/sign_in")
+      expect(page).to have_content("Invalid Email or password.")
+    end
+  end
+
+  context "when the user is a global administrator" do
+    let(:user) { create(:user, :global_administrator, otp_required_for_login: false, local_authority: nil, name: "Gordon Global Administrator") }
+
+    it "shows the Sidekiq control panel" do
+      expect(page).to have_current_path("/sidekiq/")
+      expect(page).to have_content("Sidekiq")
+      expect(page).to have_link("Metrics", href: "/sidekiq/metrics")
+    end
+  end
+end

--- a/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
@@ -17,7 +17,7 @@ module BopsCore
 
     def current_local_authority
       return @current_local_authority if defined?(@current_local_authority)
-      @current_local_authority = LocalAuthority.find_by(subdomain: request.subdomain)
+      @current_local_authority = request.env["bops.local_authority"]
     end
 
     def require_local_authority!
@@ -59,7 +59,6 @@ module BopsCore
     end
 
     def set_current
-      Current.subdomain = request.subdomain
       Current.local_authority = current_local_authority
       Current.user = current_user
       Current.api_user = current_api_user

--- a/engines/bops_core/lib/bops_core.rb
+++ b/engines/bops_core/lib/bops_core.rb
@@ -2,6 +2,7 @@
 
 require "bops_core/engine"
 require "bops_core/routing"
+require "bops_core/middleware"
 
 module BopsCore
   class << self

--- a/engines/bops_core/lib/bops_core/middleware.rb
+++ b/engines/bops_core/lib/bops_core/middleware.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Middleware
+    autoload :LocalAuthority, "bops_core/middleware/local_authority"
+    autoload :User, "bops_core/middleware/user"
+  end
+end

--- a/engines/bops_core/lib/bops_core/middleware/local_authority.rb
+++ b/engines/bops_core/lib/bops_core/middleware/local_authority.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Middleware
+    class LocalAuthority
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+        env["bops.local_authority"] = ::LocalAuthority.find_by(subdomain: request.subdomain)
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/engines/bops_core/lib/bops_core/middleware/user.rb
+++ b/engines/bops_core/lib/bops_core/middleware/user.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Middleware
+    class User
+      def initialize(app, global_subdomains: %w[])
+        @app = app
+        @global_subdomains = global_subdomains
+      end
+
+      def call(env)
+        request = ActionDispatch::Request.new(env)
+        env["bops.user_scope"] = user_scope(request.subdomain, env["bops.local_authority"])
+
+        @app.call(env)
+      end
+
+      private
+
+      def user_scope(subdomain, local_authority)
+        if global?(subdomain)
+          ::User.global.kept
+        elsif local_authority.present?
+          local_authority.users.kept
+        else
+          ::User.none
+        end
+      end
+
+      def global?(subdomain)
+        @global_subdomains.include?(subdomain)
+      end
+    end
+  end
+end

--- a/engines/bops_core/lib/bops_core/routing.rb
+++ b/engines/bops_core/lib/bops_core/routing.rb
@@ -7,7 +7,8 @@ module BopsCore
     class LocalAuthoritySubdomain
       class << self
         def matches?(request)
-          LocalAuthority.pluck(:subdomain).include?(request.subdomain)
+          local_authority = request.env["bops.local_authority"]
+          local_authority && local_authority.subdomain == request.subdomain
         end
       end
     end

--- a/engines/bops_core/spec/controllers/bops_core/application_controller_spec.rb
+++ b/engines/bops_core/spec/controllers/bops_core/application_controller_spec.rb
@@ -19,9 +19,14 @@ RSpec.describe BopsCore::ApplicationController, type: :controller do
   let(:user) { create(:user, :assessor, local_authority:) }
   let(:api_user) { create(:api_user, local_authority:) }
 
+  before do
+    request.env["HTTP_HOST"] = "#{local_authority.subdomain}.bops.services"
+    request.env["bops.local_authority"] = local_authority
+    request.env["bops.user_scope"] = local_authority.users.kept
+  end
+
   describe "#set_current" do
     before do
-      request.env["HTTP_HOST"] = "#{local_authority.subdomain}.bops.services"
     end
 
     it "sets the current local authority" do
@@ -58,8 +63,6 @@ RSpec.describe BopsCore::ApplicationController, type: :controller do
   describe "#set_appsignal_tags" do
     before do
       allow(Appsignal).to receive(:add_tags)
-
-      request.env["HTTP_HOST"] = "#{local_authority.subdomain}.bops.services"
     end
 
     context "for an API request" do

--- a/engines/bops_core/spec/lib/bops_core/middleware/local_authority_spec.rb
+++ b/engines/bops_core/spec/lib/bops_core/middleware/local_authority_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe BopsCore::Middleware::LocalAuthority do
+  let(:local_authority) { create(:local_authority, subdomain: "royston") }
+  let(:response) { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+  let(:app) { double(call: response) }
+
+  subject { described_class.new(app) }
+
+  describe "#call" do
+    context "when on a global subdomain" do
+      let(:env) { {"HTTP_HOST" => "config.bops.services"} }
+
+      it "sets the local authority in the request hash to nil" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.local_authority")
+        }.from(false).to(true)
+
+        expect(env["bops.local_authority"]).to be_nil
+      end
+    end
+
+    context "when on a local authority subdomain" do
+      let(:env) { {"HTTP_HOST" => "#{local_authority.subdomain}.bops.services"} }
+
+      it "sets the local authority in the request hash" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.local_authority")
+        }.from(false).to(true)
+
+        expect(env["bops.local_authority"]).to eq(local_authority)
+      end
+    end
+
+    context "when on an unknown subdomain" do
+      let(:env) { {"HTTP_HOST" => "other.bops.services"} }
+
+      it "sets the local authority in the request hash to nil" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.local_authority")
+        }.from(false).to(true)
+
+        expect(env["bops.local_authority"]).to be_nil
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/lib/bops_core/middleware/user_spec.rb
+++ b/engines/bops_core/spec/lib/bops_core/middleware/user_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe BopsCore::Middleware::User do
+  let(:local_authority) { create(:local_authority, subdomain: "royston") }
+  let(:response) { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+  let(:app) { double(call: response) }
+
+  let(:global_scope) { ::User.global.kept.to_sql }
+  let(:local_authority_scope) { local_authority.users.kept.to_sql }
+  let(:null_scope) { ::User.none.to_sql }
+
+  subject { described_class.new(app, global_subdomains: %w[config]) }
+
+  describe "#call" do
+    context "when the request is on a global subdomain" do
+      let(:env) do
+        {
+          "HTTP_HOST" => "config.bops.services",
+          "bops.local_authority" => nil
+        }
+      end
+
+      it "sets the user scope in the request hash to the global scope" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.user_scope")
+        }.from(false).to(true)
+
+        expect(env["bops.user_scope"].to_sql).to eq(global_scope)
+      end
+    end
+
+    context "when the request is on a local authority subdomain" do
+      let(:env) do
+        {
+          "HTTP_HOST" => "#{local_authority.subdomain}.bops.services",
+          "bops.local_authority" => local_authority
+        }
+      end
+
+      it "sets the user scope in the request hash to the local authority scope" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.user_scope")
+        }.from(false).to(true)
+
+        expect(env["bops.user_scope"].to_sql).to eq(local_authority_scope)
+      end
+    end
+
+    context "when the request is on a unknown subdomain" do
+      let(:env) do
+        {
+          "HTTP_HOST" => "other.bops.services",
+          "bops.local_authority" => nil
+        }
+      end
+
+      it "sets the user scope in the request hash to the null scope" do
+        expect {
+          expect(subject.call(env)).to eq(response)
+        }.to change {
+          env.has_key?("bops.user_scope")
+        }.from(false).to(true)
+
+        expect(env["bops.user_scope"].to_sql).to eq(null_scope)
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/support/sidekiq.rb
+++ b/engines/bops_core/spec/support/sidekiq.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  # Sidekiq logs on connecting to redis so redirect STDOUT whilst it
+  # connects to prevent an ugly message in the middle of our green dots
+  config.before(:suite) do
+    stdout, $stdout = $stdout, StringIO.new
+    Sidekiq::Stats.new
+  ensure
+    $stdout = stdout
+  end
+end


### PR DESCRIPTION
Because we need to use it to protect Rack-based apps such as the Sidekiq control panel which don't support controller callbacks.