### PR TITLE
Enable YJIT in production

### DIFF
--- a/config/initializers/yjit.rb
+++ b/config/initializers/yjit.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+if defined? RubyVM::YJIT.enable
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable unless Rails.env.local?
+  end
+end


### PR DESCRIPTION
Rails 7.2 [enabled this by default in new applications](https://github.com/rails/rails/blob/f010edc6eb0b863fa72eff1ddf01155c72596870/guides/source/7_2_release_notes.md?plain=1#L241) but we didn't add the initializer for it. Rails 8 [appears to change this to only in production](https://github.com/rails/rails/blob/f010edc6eb0b863fa72eff1ddf01155c72596870/railties/CHANGELOG.md?plain=1#L41) (because there's little benefit in dev/test) so we might as well just go straight to that setting ourselves.