### PR TITLE
Add local authority show pages to global admin

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -93,6 +93,42 @@ class LocalAuthority < ApplicationRecord
     onboarded? ? "Completed" : onboarding_progress
   end
 
+  ACTIVE_ATTRIBUTES = %w[email_address
+    email_reply_to_id
+    enquiries_paragraph
+    feedback_email
+    letter_template_id
+    notify_api_key
+    press_notice_email
+    reviewer_group_email
+    signatory_job_title
+    signatory_name].freeze
+
+  CREATION_ATTRIBUTES = %w[subdomain
+    council_code
+    council_name
+    short_name
+    applicants_url].freeze
+
+  ONBOARDED_ATTRIBUTES = (CREATION_ATTRIBUTES + ACTIVE_ATTRIBUTES).freeze
+
+  REDACTED_INFO = %w[notify_api_key
+    reviewer_group_email
+    applicants_url
+    email_address].freeze
+
+  def redacted?(onboarded_attribute)
+    REDACTED_INFO.include?(onboarded_attribute)
+  end
+
+  def onboarded_attributes_list
+    ONBOARDED_ATTRIBUTES
+  end
+
+  def to_param
+    subdomain
+  end
+
   private
 
   def council_code_exists
@@ -121,29 +157,6 @@ class LocalAuthority < ApplicationRecord
   def active_attributes?
     attributes.select { |k, v| ACTIVE_ATTRIBUTES.include?(k) }.each_value.all?(&:present?)
   end
-
-  ACTIVE_ATTRIBUTES = %w[
-    email_address
-    email_reply_to_id
-    enquiries_paragraph
-    feedback_email
-    letter_template_id
-    notify_api_key
-    press_notice_email
-    reviewer_group_email
-    signatory_job_title
-    signatory_name
-  ].freeze
-
-  CREATION_ATTRIBUTES = %w[
-    subdomain
-    council_code
-    council_name
-    short_name
-    applicants_url
-  ].freeze
-
-  ONBOARDED_ATTRIBUTES = (ACTIVE_ATTRIBUTES + CREATION_ATTRIBUTES).freeze
 
   def onboarded_attributes
     @onboarded_attributes ||= attributes.select(&method(:onboarded_attribute?))

--- a/engines/bops_config/app/controllers/bops_config/local_authorities_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/local_authorities_controller.rb
@@ -2,18 +2,18 @@
 
 module BopsConfig
   class LocalAuthoritiesController < ApplicationController
-    before_action :set_local_authorities, only: %i[index]
-
     def index
+      @local_authorities = LocalAuthority.all.order(short_name: :asc)
       respond_to do |format|
         format.html
       end
     end
 
-    private
-
-    def set_local_authorities
-      @local_authorities = LocalAuthority.all.order(short_name: :asc)
+    def show
+      @local_authority = LocalAuthority.find_by(subdomain: params[:name])
+      respond_to do |format|
+        format.html
+      end
     end
   end
 end

--- a/engines/bops_config/app/views/bops_config/local_authorities/_table.html.erb
+++ b/engines/bops_config/app/views/bops_config/local_authorities/_table.html.erb
@@ -14,7 +14,7 @@
     <% local_authorities.each do |local_authority| %>
         <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-                <%= govuk_link_to local_authority.short_name %>
+                <%= govuk_link_to local_authority.short_name, local_authority_path(local_authority) %>
             </td>
             <td class="govuk-table__cell">
                 <%= local_authority.council_code %>

--- a/engines/bops_config/app/views/bops_config/local_authorities/index.html.erb
+++ b/engines/bops_config/app/views/bops_config/local_authorities/index.html.erb
@@ -1,3 +1,10 @@
+
+<% content_for :page_title do %>
+  <%= t(".local_authorities") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">

--- a/engines/bops_config/app/views/bops_config/local_authorities/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/local_authorities/show.html.erb
@@ -1,0 +1,61 @@
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Local authorities", local_authorities_path %>
+
+<div class="govuk-width-container">
+    <h1 class="govuk-heading-l govuk-!-margin-bottom-4">
+        <%= @local_authority.short_name %> onboarding progress
+    </h1>
+    <h3 class="govuk-heading-m">
+        <% if  @local_authority.onboarding_status != "Completed" %>
+            <strong class="govuk-tag govuk-tag--grey">
+                <%= @local_authority.onboarding_status %> steps completed
+            </strong>
+        <% else %>
+            <strong class="govuk-tag govuk-tag--green">
+                Onboarding complete
+            </strong>
+        <% end %>
+    </h3>
+
+    <table class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Required field</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Value</th>
+        <th scope="col" class="govuk-table__header">Status</th>
+        </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+        <% @local_authority.onboarded_attributes_list.each do |onboarded_attribute| %>
+                <% next if onboarded_attribute == "subdomain" %>
+                <tr class="govuk-table__row">
+                    <th scope="row" class="govuk-table__cell">
+                        <%= onboarded_attribute.humanize %>
+                    </th>
+                    <td class="govuk-table__cell">
+                        <% if @local_authority[onboarded_attribute].nil? %>
+                            -
+                        <% elsif @local_authority.redacted?(onboarded_attribute) %>
+                            Redacted
+                        <% else %>
+                            <%= @local_authority[onboarded_attribute] %>
+                        <% end %>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <% if @local_authority[onboarded_attribute] %>
+                            Completed
+                        <% else %>
+                            <strong class="govuk-tag govuk-tag--blue">
+                                Not started
+                            </strong>
+                        <% end %>
+                    </td>
+                </tr>
+        <% end %>
+    </tbody>
+    </table>
+    <div class="govuk-button-group">
+        <%= back_link %>
+    </div>
+</div>

--- a/engines/bops_config/config/routes.rb
+++ b/engines/bops_config/config/routes.rb
@@ -47,5 +47,5 @@ BopsConfig::Engine.routes.draw do
     patch :reactivate, on: :member
   end
 
-  resources :local_authorities, except: %i[destroy]
+  resources :local_authorities, param: :name, except: %i[destroy]
 end

--- a/engines/bops_config/spec/system/local_authorities_spec.rb
+++ b/engines/bops_config/spec/system/local_authorities_spec.rb
@@ -78,4 +78,16 @@ RSpec.describe "Local Authorities", type: :system, capybara: true do
       expect(page).to have_content("Lambeth")
     end
   end
+
+  it "visits the local authorities show page" do
+    click_link("Active")
+    within("#active table.govuk-table") do
+      click_link(local_authority3.short_name)
+    end
+
+    expect(page).to have_content("Buckinghamshire")
+    expect(page).to have_content("press@buckinghamshire.gov.uk")
+    expect(page).not_to have_content("Not started")
+    expect(page).not_to have_content("digitalplanning@lambeth.gov.uk")
+  end
 end


### PR DESCRIPTION
### Description of change

Add Local Authority onboarding page to global admin to allow tracking of individual LA onboarding.

### Story Link

https://trello.com/c/9FgCGguT/392-as-a-global-admin-i-can-view-individual-la-show-pages

### Screenshots
<img width="794" alt="image" src="https://github.com/user-attachments/assets/748e599b-6374-4d45-8f93-4d5e597a2fd4" />
<img width="841" alt="image" src="https://github.com/user-attachments/assets/9a2e4215-2707-493c-b0ff-6bde53578e93" />
