### PR TITLE
Redirect to anchor not top of page when updating review

### DIFF
--- a/app/controllers/planning_applications/review/base_controller.rb
+++ b/app/controllers/planning_applications/review/base_controller.rb
@@ -39,6 +39,10 @@ module PlanningApplications
         redirect_to planning_application_review_tasks_path(@planning_application), alert: Array.wrap(error).to_sentence
       end
 
+      def redirect_to_review_tasks
+        redirect_to planning_application_review_tasks_path(@planning_application)
+      end
+
       def render_review_tasks
         set_planning_application_constraints
         set_neighbour_review

--- a/app/controllers/planning_applications/review/cil_liability_controller.rb
+++ b/app/controllers/planning_applications/review/cil_liability_controller.rb
@@ -9,7 +9,7 @@ module PlanningApplications
         @previous_decision = @planning_application.cil_liable
         if @planning_application.update(cil_liability_params)
           record_audit_for_cil_liability!
-          redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+          redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-cil"), notice: t(".success")
         else
           render :edit
         end

--- a/app/controllers/planning_applications/review/cil_liability_controller.rb
+++ b/app/controllers/planning_applications/review/cil_liability_controller.rb
@@ -47,10 +47,6 @@ module PlanningApplications
         end
       end
 
-      def redirect_to_review_tasks
-        redirect_to planning_application_review_tasks_path(@planning_application)
-      end
-
       def cil_feature?
         @planning_application.application_type.cil?
       end

--- a/app/controllers/planning_applications/review/cil_liability_controller.rb
+++ b/app/controllers/planning_applications/review/cil_liability_controller.rb
@@ -9,7 +9,7 @@ module PlanningApplications
         @previous_decision = @planning_application.cil_liable
         if @planning_application.update(cil_liability_params)
           record_audit_for_cil_liability!
-          redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-cil"), notice: t(".success")
+          redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-cil-liability"), notice: t(".success")
         else
           render :edit
         end

--- a/app/controllers/planning_applications/review/committee_decisions_controller.rb
+++ b/app/controllers/planning_applications/review/committee_decisions_controller.rb
@@ -15,7 +15,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @committee_decision.update(committee_decision_params)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "recommendation_to_committee_section"), notice: t(".success")
             else
               flash.now[:alert] = @committee_decision.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/controllers/planning_applications/review/conditions_controller.rb
+++ b/app/controllers/planning_applications/review/conditions_controller.rb
@@ -9,7 +9,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @condition_set.update(condition_set_review_params)
-              redirect_to planning_application_review_tasks_path(@planning_application),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-conditions"),
                 notice: I18n.t("review.conditions.update.success")
             else
               flash.now[:alert] = @condition_set.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/considerations/items_controller.rb
+++ b/app/controllers/planning_applications/review/considerations/items_controller.rb
@@ -17,7 +17,7 @@ module PlanningApplications
           respond_to do |format|
             format.html do
               if @consideration.update(consideration_params)
-                redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+                redirect_to planning_application_review_tasks_path(@planning_application, anchor: "considerations_section"), notice: t(".success")
               else
                 render :edit
               end

--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -45,10 +45,6 @@ module PlanningApplications
           .permit(:action, :comment, :review_status)
           .merge(reviewer: current_user, reviewed_at: Time.current)
       end
-
-      def redirect_to_review_tasks
-        redirect_to planning_application_review_tasks_path(@planning_application)
-      end
     end
   end
 end

--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -17,7 +17,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-considerations"), notice: t(".success")
             else
               flash.now[:alert] = @review.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/controllers/planning_applications/review/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/review/heads_of_terms_controller.rb
@@ -7,7 +7,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if heads_of_term.update(review_params)
-              redirect_to planning_application_review_tasks_path(@planning_application),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-heads-of-terms"),
                 notice: I18n.t("review.heads_of_terms.update.success")
             else
               flash.now[:alert] = heads_of_term.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/immunity_details_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_details_controller.rb
@@ -16,7 +16,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review_immunity_detail.update(review_immunity_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-evidence"),
                 notice: I18n.t("planning_applications.review..immunity_details.successfully_updated")
             else
               flash.now[:alert] = @review_immunity_detail.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/immunity_details_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_details_controller.rb
@@ -16,7 +16,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review_immunity_detail.update(review_immunity_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-evidence"),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-immunity-details"),
                 notice: I18n.t("planning_applications.review..immunity_details.successfully_updated")
             else
               flash.now[:alert] = @review_immunity_detail.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
@@ -13,7 +13,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review_immunity_detail.update(review_immunity_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-enforcement"),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-immunity-enforcements"),
                 notice: I18n.t("review_immunity_enforcements.successfully_updated")
             else
               flash.now[:alert] = @review_immunity_detail.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
+++ b/app/controllers/planning_applications/review/immunity_enforcements_controller.rb
@@ -13,7 +13,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review_immunity_detail.update(review_immunity_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-enforcement"),
                 notice: I18n.t("review_immunity_enforcements.successfully_updated")
             else
               flash.now[:alert] = @review_immunity_detail.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/informatives/items_controller.rb
+++ b/app/controllers/planning_applications/review/informatives/items_controller.rb
@@ -17,7 +17,7 @@ module PlanningApplications
           respond_to do |format|
             format.html do
               if @informative.update(informative_params)
-                redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+                redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-informatives"), notice: t(".success")
               else
                 render :edit
               end

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -48,10 +48,6 @@ module PlanningApplications
           .merge(reviewer: current_user, reviewed_at: Time.current)
       end
 
-      def redirect_to_review_tasks
-        redirect_to planning_application_review_tasks_path(@planning_application)
-      end
-
       def informatives_not_started?
         @review.not_started?
       end

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -19,7 +19,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-informatives"), notice: t(".success")
             else
               flash.now[:alert] = @review.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -12,7 +12,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @neighbour_review.update(review_params) && @consultation.update(status: consultation_status)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-neighbour-notifications"), notice: t(".success")
             else
               error = @neighbour_review.errors.group_by_attribute.transform_values { |errors| errors.map(&:full_message) }.values.flatten
               redirect_failed_create_error(error)
@@ -27,7 +27,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @neighbour_review.save && @consultation.update(status: consultation_status)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-neighbour-notifications"), notice: t(".success")
             else
               error = @neighbour_review.errors.group_by_attribute.transform_values { |errors| errors.map(&:full_message) }.values.flatten
               redirect_failed_create_error(error)

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -12,7 +12,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @neighbour_review.update(review_params) && @consultation.update(status: consultation_status)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-neighbour-notifications"), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-neighbour-responses"), notice: t(".success")
             else
               error = @neighbour_review.errors.group_by_attribute.transform_values { |errors| errors.map(&:full_message) }.values.flatten
               redirect_failed_create_error(error)
@@ -27,7 +27,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @neighbour_review.save && @consultation.update(status: consultation_status)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-neighbour-notifications"), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-neighbour-responses"), notice: t(".success")
             else
               error = @neighbour_review.errors.group_by_attribute.transform_values { |errors| errors.map(&:full_message) }.values.flatten
               redirect_failed_create_error(error)

--- a/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/review/permitted_development_rights_controller.rb
@@ -14,7 +14,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @permitted_development_right.update(permitted_development_right_params)
-              redirect_to planning_application_review_tasks_path(@planning_application),
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-permitted-development-rights"),
                 notice: I18n.t("permitted_development_rights.successfully_updated")
             else
               flash.now[:alert] = @permitted_development_right.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -30,7 +30,7 @@ module PlanningApplications
           @form.update(policy_section_status_params)
 
           if @planning_application_policy_class.update_review(review_params)
-            redirect_to planning_application_review_policy_areas_policy_classes_path(@planning_application), notice: t(".success")
+            redirect_to planning_application_review_policy_areas_policy_classes_path(@planning_application, anchor: "review-legislation"), notice: t(".success")
           else
             render :edit
           end

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -30,7 +30,7 @@ module PlanningApplications
           @form.update(policy_section_status_params)
 
           if @planning_application_policy_class.update_review(review_params)
-            redirect_to planning_application_review_policy_areas_policy_classes_path(@planning_application, anchor: "review-legislation"), notice: t(".success")
+            redirect_to planning_application_review_policy_areas_policy_classes_path(@planning_application, anchor: "review-policy-classes"), notice: t(".success")
           else
             render :edit
           end

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -14,7 +14,7 @@ module PlanningApplications::Review
       respond_to do |format|
         format.html do
           if @pre_commencement_condition_set.update(review_params)
-            redirect_to planning_application_review_tasks_path(@planning_application),
+            redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-pre-commencement-conditions"),
               notice: I18n.t("review.conditions.update.success")
           else
             flash.now[:alert] = @pre_commencement_condition_set.errors.messages.values.flatten.join(", ")

--- a/app/controllers/planning_applications/review/publicities_controller.rb
+++ b/app/controllers/planning_applications/review/publicities_controller.rb
@@ -12,7 +12,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @assessment_detail.update(assessment_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-publicity"), notice: t(".success")
             else
               flash.now[:alert] = @assessment_detail.errors.messages.values.flatten.join(", ")
               render_review_tasks
@@ -27,7 +27,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @assessment_detail.save
-              redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-publicity"), notice: t(".success")
             else
               flash.now[:alert] = @assessment_detail.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/controllers/planning_applications/review/publicities_controller.rb
+++ b/app/controllers/planning_applications/review/publicities_controller.rb
@@ -12,7 +12,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @assessment_detail.update(assessment_detail_params)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-publicity"), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-publicities"), notice: t(".success")
             else
               flash.now[:alert] = @assessment_detail.errors.messages.values.flatten.join(", ")
               render_review_tasks
@@ -27,7 +27,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @assessment_detail.save
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "check-publicity"), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-publicities"), notice: t(".success")
             else
               flash.now[:alert] = @assessment_detail.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/controllers/planning_applications/review/recommendations_controller.rb
+++ b/app/controllers/planning_applications/review/recommendations_controller.rb
@@ -28,7 +28,7 @@ module PlanningApplications
         )
 
         if @recommendation.save_and_submit(recommendation_form_params)
-          redirect_to planning_application_review_tasks_path(@planning_application), notice: t(".success")
+          redirect_to planning_application_review_tasks_path(@planning_application, anchor: "recommendation_to_committee_section"), notice: t(".success")
         else
           render :new
         end

--- a/app/views/planning_applications/review/policy_areas/policy_classes/index.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/index.html.erb
@@ -14,7 +14,7 @@
 
 <%= render "shared/dates_and_assignment_header" %>
 
-<ul class="app-task-list__items" id="review-legislation">
+<ul class="app-task-list__items" id="review-policy-classes">
   <% @planning_application.planning_application_policy_classes.order(:policy_class_id).each do |policy_class| %>
     <% next if policy_class.current_review.not_started? || policy_class.current_review.in_progress? %>
 

--- a/app/views/planning_applications/review/tasks/_review_assessment.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment.html.erb
@@ -2,7 +2,7 @@
   <% accordion.with_heading(text: "Review assessment") %>
 
   <% if @planning_application.application_type.cil? %>
-    <% accordion.with_section(id: "check-cil", expanded: false) do |section| %>
+    <% accordion.with_section(id: "review-cil-liability", expanded: false) do |section| %>
       <%= section.with_heading(text: "Check Community Infrastructure Levy (CIL)") %>
       <%= section.with_status do %>
         <%= render(

--- a/app/views/planning_applications/review/tasks/_review_conditions.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_conditions.html.erb
@@ -30,7 +30,7 @@
   <% end %>
 
   <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.evidence.any? %>
-    <%= accordion.with_section(id: "review-evidence", expanded: @planning_application.immunity_detail.current_evidence_review_immunity_detail.errors.any?) do |section| %>
+    <%= accordion.with_section(id: "review-immunity-details", expanded: @planning_application.immunity_detail.current_evidence_review_immunity_detail.errors.any?) do |section| %>
       <% section.with_heading(text: "Review evidence of immunity") %>
 
       <% section.with_status do %>
@@ -47,14 +47,14 @@
         <%= govuk_link_to "Show evidence", planning_application_review_immunity_detail_path(@planning_application, @planning_application.immunity_detail.current_evidence_review_immunity_detail) %>
       <% end %>
 
-      <% section.with_footer(id: "review-evidence-form") do %>
+      <% section.with_footer(id: "review-immunity-details-form") do %>
         <%= render(partial: "planning_applications/review/immunity_details/form") %>
       <% end %>
     <% end %>
   <% end %>
 
   <% if @planning_application.possibly_immune? && @planning_application.immunity_detail.reviews.enforcement.any? %>
-    <%= accordion.with_section(id: "review-enforcement", expanded: @planning_application.immunity_detail.current_enforcement_review_immunity_detail.errors.any?) do |section| %>
+    <%= accordion.with_section(id: "review-immunity-enforcements", expanded: @planning_application.immunity_detail.current_enforcement_review_immunity_detail.errors.any?) do |section| %>
       <% section.with_heading(text: "Review assessment of immunity") %>
 
       <% section.with_status do %>
@@ -69,7 +69,7 @@
         <%= render(partial: "planning_applications/review/immunity_enforcements/details") %>
       <% end %>
 
-      <% section.with_footer(id: "review-enforcement-form") do %>
+      <% section.with_footer(id: "review-immunity-enforcements-form") do %>
         <%= render(partial: "planning_applications/review/immunity_enforcements/form") %>
       <% end %>
     <% end %>
@@ -167,7 +167,7 @@
 
 <ul class="app-task-list__items">
   <% if @planning_application.application_type.assess_against_policies? %>
-    <li class="app-task-list__item" id="review-legislation">
+    <li class="app-task-list__item" id="review-policy-classes">
       <span class="app-task-list__task-name">
         <%= govuk_link_to "Review assessment against legislation", planning_application_review_policy_areas_policy_classes_path(@planning_application) %>
       </span>

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -1,6 +1,6 @@
 <%= bops_task_accordion(id: "review-consultation") do |accordion| %>
   <% accordion.with_heading(text: "Review consultation") %>
-  <%= accordion.with_section(id: "check-neighbour-notifications", expanded: @neighbour_review.errors.any?) do |section| %>
+  <%= accordion.with_section(id: "review-neighbour-responses", expanded: @neighbour_review.errors.any?) do |section| %>
     <% section.with_heading(text: "Check neighbour notifications") %>
 
     <% section.with_status do %>
@@ -19,7 +19,7 @@
     <% end %>
   <% end %>
 
-  <%= accordion.with_section(id: "check-publicity", expanded: @planning_application.existing_or_new_check_publicity.errors.any?) do |section| %>
+  <%= accordion.with_section(id: "review-publicities", expanded: @planning_application.existing_or_new_check_publicity.errors.any?) do |section| %>
     <% section.with_heading(text: "Check publicity") %>
     <% section.with_status do %>
       <%= render(
@@ -37,7 +37,7 @@
       <%= render(partial: "planning_applications/review/publicities/press_notice") %>
     <% end %>
 
-    <% section.with_footer(id: "check-publicity-form") do %>
+    <% section.with_footer(id: "review-publicities-form") do %>
       <%= render(partial: "planning_applications/review/publicities/form") %>
     <% end %>
   <% end %>

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Immunity", type: :system do
 
       click_button "Review evidence of immunity"
 
-      within("#review-evidence") do
+      within("#review-immunity-details") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Please re-assess the evidence of immunity"
         click_button "Save and mark as complete"
@@ -120,13 +120,13 @@ RSpec.describe "Immunity", type: :system do
 
       click_button "Review assessment of immunity"
 
-      within("#review-enforcement") do
+      within("#review-immunity-enforcements") do
         expect(page).to have_content("Assessor decision: Yes")
         expect(page).to have_content("Reason: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
         expect(page).to have_content("Summary: A summary")
       end
 
-      within("#review-enforcement-form") do
+      within("#review-immunity-enforcements-form") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Please re-assess immunity enforcement response"
         click_button "Save and mark as complete"
@@ -188,7 +188,7 @@ RSpec.describe "Immunity", type: :system do
 
       click_button "Review evidence of immunity"
 
-      within("#review-evidence") do
+      within("#review-immunity-details") do
         choose "Agree"
         click_button "Save and mark as complete"
       end
@@ -196,7 +196,7 @@ RSpec.describe "Immunity", type: :system do
 
       click_button "Review assessment of immunity"
 
-      within("#review-enforcement") do
+      within("#review-immunity-enforcements") do
         expect(page).to have_content("Assessor decision: No")
         expect(page).to have_content("Reason: Application is not immune")
 

--- a/spec/system/planning_applications/review/check_cil_liability_spec.rb
+++ b/spec/system/planning_applications/review/check_cil_liability_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "checking publicity" do
     it "the reviewer can mark it as not needing confirmation" do
       visit "planning_applications/#{planning_application.id}/review/tasks"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Not started"
       end
 
@@ -39,13 +39,13 @@ RSpec.describe "checking publicity" do
 
       expect(page).to have_content "The validation officer did not confirm whether the application is liable for CIL."
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         click_button "Save and mark as complete"
       end
 
       expect(page).to have_content "Review of CIL liability successfully updated"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Completed"
       end
 
@@ -58,7 +58,7 @@ RSpec.describe "checking publicity" do
     it "the reviewer can update it" do
       visit "planning_applications/#{planning_application.id}/review/tasks"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Not started"
       end
 
@@ -68,13 +68,13 @@ RSpec.describe "checking publicity" do
 
       choose "Yes"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         click_button "Save and mark as complete"
       end
 
       expect(page).to have_content "Review of CIL liability successfully updated"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Completed"
       end
 
@@ -93,7 +93,7 @@ RSpec.describe "checking publicity" do
     it "the reviewer can mark it as correct" do
       visit "planning_applications/#{planning_application.id}/review/tasks"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Not started"
       end
 
@@ -101,13 +101,13 @@ RSpec.describe "checking publicity" do
 
       expect(page).to have_content "The validation officer marked this application as liable for CIL"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         click_button "Save and mark as complete"
       end
 
       expect(page).to have_content "Review of CIL liability successfully updated"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Completed"
       end
 
@@ -120,7 +120,7 @@ RSpec.describe "checking publicity" do
     it "the reviewer can change it" do
       visit "planning_applications/#{planning_application.id}/review/tasks"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Not started"
       end
 
@@ -130,13 +130,13 @@ RSpec.describe "checking publicity" do
 
       choose "No"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         click_button "Save and mark as complete"
       end
 
       expect(page).to have_content "Review of CIL liability successfully updated"
 
-      within "#check-cil" do
+      within "#review-cil-liability" do
         expect(page).to have_content "Completed"
       end
 
@@ -155,7 +155,7 @@ RSpec.describe "checking publicity" do
     it "does not have a section to review CIL" do
       visit "planning_applications/#{planning_application.reference}/review/tasks"
 
-      expect(page).not_to have_css("#check-cil")
+      expect(page).not_to have_css("#review-cil-liability")
       expect(page).not_to have_content("Check Community Infrastructure Levy (CIL)")
     end
   end

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
       it "you can accept that the assessor has notified the correct people" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#check-neighbour-notifications" do
+        within "#review-neighbour-responses" do
           choose "Agree"
 
           click_button "Save and mark as complete"
@@ -59,7 +59,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Completed")
         end
       end
@@ -67,14 +67,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
       it "you can send it back for assessment", :capybara do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#check-neighbour-notifications" do
+        within "#review-neighbour-responses" do
           choose "Return with comments"
           fill_in "Add a comment", with: "Notify more people"
 
@@ -83,7 +83,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Awaiting changes")
         end
@@ -131,14 +131,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
       it "shows errors" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#check-neighbour-notifications" do
+        within "#review-neighbour-responses" do
           click_button "Save and mark as complete"
         end
 
@@ -147,14 +147,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
           expect(page).to have_content("Select an option")
         end
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           choose "Return with comments"
           click_button "Save and mark as complete"
         end
@@ -170,14 +170,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
       it "you can accept that the assessor has notified the correct people" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#check-neighbour-notifications" do
+        within "#review-neighbour-responses" do
           choose "Return with comments"
           fill_in "Add a comment", with: "People need to be consulted"
 
@@ -186,7 +186,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Awaiting changes")
         end
@@ -204,14 +204,14 @@ RSpec.describe "Check neighbour notifications", type: :system do
       it "you can't accept or reject the officer's work" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-neighbour-notifications") do
+        within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#check-neighbour-notifications" do
+        within "#review-neighbour-responses" do
           choose "Agree"
           click_button "Save and mark as complete"
         end

--- a/spec/system/planning_applications/review/check_publicity_spec.rb
+++ b/spec/system/planning_applications/review/check_publicity_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "checking publicity" do
       it "allows a reviewer to mark the publicity check as complete" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Not started")
         end
@@ -114,14 +114,14 @@ RSpec.describe "checking publicity" do
           expect(page).to have_content("File name: press-notice.jpg")
         end
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           choose "Agree"
           click_button "Save and mark as complete"
         end
 
         expect(page).to have_selector("[role=alert] p", text: "Review of publicity successfully added.")
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Completed")
         end
@@ -130,14 +130,14 @@ RSpec.describe "checking publicity" do
       it "allows a reviewer to return the application to the assessor" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check publicity"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           choose "Return with comments"
           fill_in "Add a comment", with: "Check this"
           click_button "Save and mark as complete"
@@ -145,7 +145,7 @@ RSpec.describe "checking publicity" do
 
         expect(page).to have_selector("[role=alert] p", text: "Review of publicity successfully added.")
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Awaiting changes")
         end
@@ -193,7 +193,7 @@ RSpec.describe "checking publicity" do
 
         click_link "Review and sign-off"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Not started")
         end
@@ -202,21 +202,21 @@ RSpec.describe "checking publicity" do
       it "shows errors" do
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           expect(page).to have_content("Check publicity")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check publicity"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           click_button "Save and mark as complete"
         end
 
         expect(page).to have_content "Determine whether this is correct"
         expect(page).not_to have_content "You must add a comment"
 
-        within("#check-publicity") do
+        within("#review-publicities") do
           choose "Return with comments"
           click_button "Save and mark as complete"
         end
@@ -275,7 +275,7 @@ RSpec.describe "checking publicity" do
     it "the reviewer can accept" do
       visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Not started")
       end
@@ -313,13 +313,13 @@ RSpec.describe "checking publicity" do
         expect(page).to have_content("File name: press-notice.jpg")
       end
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         choose "Agree"
         click_button "Save and mark as complete"
       end
       expect(page).to have_selector("[role=alert] p", text: "Review of publicity successfully added.")
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Completed")
       end
@@ -328,14 +328,14 @@ RSpec.describe "checking publicity" do
     it "allows a reviewer to return the application to the assessor" do
       visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Not started")
       end
 
       click_button "Check publicity"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Check this"
         click_button "Save and mark as complete"
@@ -343,7 +343,7 @@ RSpec.describe "checking publicity" do
 
       expect(page).to have_selector("[role=alert] p", text: "Review of publicity successfully added.")
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Awaiting changes")
       end
@@ -392,7 +392,7 @@ RSpec.describe "checking publicity" do
 
       click_link "Review and sign-off"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Not started")
       end
@@ -401,21 +401,21 @@ RSpec.describe "checking publicity" do
     it "shows errors" do
       visit "/planning_applications/#{planning_application.reference}/review/tasks"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         expect(page).to have_content("Check publicity")
         expect(page).to have_content("Not started")
       end
 
       click_button "Check publicity"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         click_button "Save and mark as complete"
       end
 
       expect(page).to have_content "Determine whether this is correct"
       expect(page).not_to have_content "You must add a comment"
 
-      within("#check-publicity") do
+      within("#review-publicities") do
         choose "Return with comments"
         click_button "Save and mark as complete"
       end

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -50,14 +50,14 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
 
     context "when planning application is awaiting determination", :capybara do
       it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
-        within("#review-evidence") do
+        within("#review-immunity-details") do
           expect(page).to have_content("Review evidence of immunity")
           expect(page).to have_content("Not started")
         end
 
         click_button "Review evidence of immunity"
 
-        within("#review-evidence") do
+        within("#review-immunity-details") do
           expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
           expect(page).to have_content("Have the works been completed? Yes")
           expect(page).to have_content("When were the works completed? 01/02/2015")
@@ -70,21 +70,21 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
 
         expect(page).to have_content("Review immunity details was successfully updated")
 
-        within("#review-evidence") do
+        within("#review-immunity-details") do
           expect(page).to have_content("Review evidence of immunity")
           expect(page).to have_content("Completed")
         end
       end
 
       it "when I return it with comments, they can see my comments" do
-        within("#review-evidence") do
+        within("#review-immunity-details") do
           expect(page).to have_content("Review evidence of immunity")
           expect(page).to have_content("Not started")
         end
 
         click_button "Review evidence of immunity"
 
-        within("#review-evidence") do
+        within("#review-immunity-details") do
           expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
           expect(page).to have_content("Have the works been completed? Yes")
           expect(page).to have_content("When were the works completed? 01/02/2015")

--- a/spec/system/planning_applications/review/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/review/immunity_enforcement_spec.rb
@@ -48,27 +48,27 @@ RSpec.describe "Reviewing immunity enforcement" do
 
     context "when planning application is awaiting determination" do
       it "I can save and mark as complete when adding my review to accept the review evidence of immunity response" do
-        within("#review-enforcement") do
+        within("#review-immunity-enforcements") do
           expect(page).to have_content("Review assessment of immunity")
           expect(page).to have_content("Not started")
         end
 
         click_button "Review assessment of immunity"
 
-        within("#review-enforcement") do
+        within("#review-immunity-enforcements") do
           expect(page).not_to have_content("Immunity from enforcement summary")
           expect(page).to have_content("Assessor decision: Yes")
           expect(page).to have_content("Reason: it looks immune to me")
           expect(page).to have_content("Summary: they have enough bills to show it's immune")
         end
 
-        within("#review-enforcement-form") do
+        within("#review-immunity-enforcements-form") do
           choose "Agree"
 
           click_button "Save and mark as complete"
         end
 
-        within("#review-enforcement") do
+        within("#review-immunity-enforcements") do
           expect(page).to have_content("Review assessment of immunity")
           expect(page).to have_content("Completed")
         end
@@ -77,7 +77,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       it "when I return it with comments, they can see my comments" do
         click_button "Review assessment of immunity"
 
-        within("#review-enforcement-form") do
+        within("#review-immunity-enforcements-form") do
           choose "Return with comments"
 
           fill_in "Add a comment", with: "Please re-assess"
@@ -85,7 +85,7 @@ RSpec.describe "Reviewing immunity enforcement" do
           click_button "Save and mark as complete"
         end
 
-        within("#review-enforcement") do
+        within("#review-immunity-enforcements") do
           expect(page).to have_content("Review assessment of immunity")
           expect(page).to have_content("Awaiting changes")
         end


### PR DESCRIPTION
### Description of change

Redirect links from review task controllers should go to anchors, not to the top of the page, for a smoother experience when submitting the form and continuing on to the next task.

### Story Link

https://trello.com/c/YR50G29L/262-scrolling-review-page-for-each-task-saved-is-distracting-and-catches-the-map