### PR TITLE
Change table on la onboarding show page

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -122,12 +122,19 @@ class LocalAuthority < ApplicationRecord
     applicants_url
     email_address].freeze
 
+  HIDDEN_ATTRS = %W[email_reply_to_id
+    letter_template_id].freeze
+
   def redacted?(onboarded_attribute)
     REDACTED_INFO.include?(onboarded_attribute)
   end
 
   def onboarded_attributes_list
     ONBOARDED_ATTRIBUTES
+  end
+
+  def hidden?(onboarded_attribute)
+    HIDDEN_ATTRS.include?(onboarded_attribute)
   end
 
   def to_param

--- a/engines/bops_config/app/views/bops_config/local_authorities/show.html.erb
+++ b/engines/bops_config/app/views/bops_config/local_authorities/show.html.erb
@@ -38,6 +38,8 @@
                             -
                         <% elsif @local_authority.redacted?(onboarded_attribute) %>
                             Redacted
+                        <% elsif @local_authority.hidden?(onboarded_attribute) %>
+                            Completed
                         <% else %>
                             <%= @local_authority[onboarded_attribute] %>
                         <% end %>


### PR DESCRIPTION

### Description of change

Update letter template id and email reply to id on la onboarding show page to simply show 'completed' if present as opposed to showing the actual id.

### Story Link

https://trello.com/c/9FgCGguT/392-as-a-global-admin-i-can-view-individual-la-show-pages

### Screenshots



