### PR TITLE
Fix application type consultations mismatch

### DIFF
--- a/app/models/application_type.rb
+++ b/app/models/application_type.rb
@@ -88,7 +88,6 @@ class ApplicationType < ApplicationRecord
     delegate :assess_against_policies?
     delegate :cil?
     delegate :considerations?
-    delegate :consultation_steps
     delegate :consultations_skip_bank_holidays?
     delegate :description_change_requires_validation?
     delegate :eia?
@@ -268,7 +267,13 @@ class ApplicationType < ApplicationRecord
   end
 
   def consultation?
-    consultation_steps.any?
+    steps.include?("consultation")
+  end
+
+  def consultation_steps
+    return [] unless consultation?
+
+    features.consultation_steps
   end
 
   Consultation::STEPS.each do |feature|

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -510,6 +510,7 @@ RSpec.describe "Application Types", type: :system, capybara: true do
   it "allows editing of the features" do
     application_type = create(
       :application_type, :configured, :ldc_proposed,
+      steps: %w[validation consultation assessment review],
       features: {
         "informatives" => true,
         "planning_conditions" => true,


### PR DESCRIPTION
### Description of change

If the steps contain 'consultation' but there are no consultation steps defined, this method will return false. This means that a consultation record will not be created for an application of this type. However, when iterating over the steps, it will include 'consultation' and thus try to render those tasks, which will fail.

So, these should behave consistently, it should not be possible to have application types with consultations but no consultation steps or vice versa.

### Known issues [OPTIONAL]

It would be nice if we could use validations to ensure this would never actually happen anyway. Right now it seems like it would be possible to create a broken configuration, but (with this fix) just have it silently ignored, which is better than breaking but not as good as giving feedback to the (global admin) user.