### PR TITLE
Add appeals to BOPS endpoints in PostsubmissionSchema format (DSNPI-1008)

### DIFF
--- a/engines/bops_api/app/helpers/bops_api/postsubmission_application_schema_helper.rb
+++ b/engines/bops_api/app/helpers/bops_api/postsubmission_application_schema_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module PostsubmissionApplicationSchemaHelper
+    # Formats a given date in 'YYYY-MM-DD' format.
+    # Use this when formatting dates stored as datetimes in the database to date strings until they can be converted
+    #
+    # @param date [DateTime, Time, nil] the date to be formatted
+    # @return [String, nil] the formatted date string or nil if the date is nil
+    #
+    # Note: This method converts the given date to a Date object, which removes the time component,
+    # and then converts it to a string in 'YYYY-MM-DD' format. This method does not account for time zones
+    # as it only deals with the date part so data could be lost if the time zone is important.
+    def format_postsubmission_date(date)
+      date&.to_date&.to_s
+    end
+
+    # Formats a given date as UTC and returns it in ISO 8601 format.
+    #
+    # @param date [DateTime, Time, nil] the date to be formatted
+    # @return [String, nil] the formatted date string or nil if the date is nil
+    def format_postsubmission_datetime(date)
+      date&.utc&.iso8601
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
@@ -3,5 +3,6 @@
 json.partial! "bops_api/v2/shared/metadata"
 
 json.data @planning_applications do |planning_application|
-  json.partial! "bops_api/v2/public/shared/show", planning_application:
+  json.partial! "bops_api/v2/public/shared/show", planning_application: planning_application
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/postsubmissionApplication", planning_application: planning_application
 end

--- a/engines/bops_api/app/views/bops_api/v2/public/show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/show.json.jbuilder
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 json.partial! "bops_api/v2/shared/show", planning_application: @planning_application
+json.partial! "bops_api/v2/shared/postsubmissionApplication/postsubmissionApplication", planning_application: @planning_application

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_appeal.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_appeal.json.jbuilder
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# This contains the structure for the data.appeals section of the Postsubmission Application schema
+if planning_application.appeal
+  json.appeal do
+    json.reason planning_application.appeal.reason.camelize(:lower) if planning_application.appeal.reason
+
+    json.lodgedDate format_postsubmission_date(planning_application.appeal.lodged_at) if planning_application.appeal.lodged_at
+    json.validatedDate format_postsubmission_date(planning_application.appeal.validated_at) if planning_application.appeal.validated_at
+    json.startedDate format_postsubmission_date(planning_application.appeal.started_at) if planning_application.appeal.started_at
+
+    json.decisionDate format_postsubmission_date(planning_application.appeal.determined_at) if planning_application.appeal.determined_at
+    json.decision planning_application.appeal.decision if planning_application.appeal.decision
+
+    if planning_application.appeal.documents
+      json.files planning_application.appeal.documents do |document|
+        json.partial! "bops_api/v2/shared/document", planning_application: planning_application, document:
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_postsubmissionApplication.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_postsubmissionApplication.json.jbuilder
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# This file is the starting point for building the data in the Postsubmission Application schema
+json.data do
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/appeal", planning_application: planning_application
+end

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/search.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/search.json
@@ -1,0 +1,322 @@
+{
+  "metadata": {
+    "page": 2,
+    "results": 2,
+    "from": 3,
+    "to": 4,
+    "total_pages": 5,
+    "total_results": 10
+  },
+  "links": {
+    "first": "https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&maxresults=2",
+    "last": "https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=5&maxresults=2",
+    "prev": "https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&maxresults=2",
+    "next": "https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=3&maxresults=2"
+  },
+  "data": [
+    {
+      "application": {
+        "type": {
+          "value": "pp.full.householder",
+          "description": "planning_permission"
+        },
+        "reference": "24-00107-HAPP",
+        "fullReference": "PlanX-24-00107-HAPP",
+        "targetDate": "2024-05-15",
+        "receivedAt": "2024-04-17T00:00:00.000+01:00",
+        "validAt": "2024-04-12T00:00:00.000+01:00",
+        "publishedAt": null,
+        "determinedAt": null,
+        "decision": null,
+        "status": "in_assessment",
+        "consultation": {
+          "startDate": "2024-04-15",
+          "endDate": "2024-05-07"
+        }
+      },
+      "property": {
+        "address": {
+          "latitude": 84.3630530473182,
+          "longitude": -105.7502386387352,
+          "title": "511 German Village",
+          "singleLine": "511 German Village, West Rod, 66983",
+          "uprn": "00565512",
+          "town": "West Rod",
+          "postcode": "66983"
+        },
+        "boundary": {
+          "site": {
+            "type": "FeatureCollection",
+            "features": [
+              {
+                "type": "Feature",
+                "geometry": {
+                  "type": "Polygon",
+                  "coordinates": [
+                    [
+                      [-0.07739927369747812, 51.501345554406896],
+                      [-0.0778893839394212, 51.501002280754676],
+                      [-0.07690508968054104, 51.50102474569704],
+                      [-0.07676672973966252, 51.50128963605792],
+                      [-0.07739927369747812, 51.501345554406896]
+                    ]
+                  ]
+                },
+                "properties": {
+                  "color": "#d870fc"
+                }
+              },
+              {
+                "type": "Feature",
+                "geometry": {
+                  "type": "Polygon",
+                  "coordinates": [
+                    [
+                      [30, 10],
+                      [40, 40],
+                      [30, 10]
+                    ]
+                  ]
+                },
+                "properties": {}
+              }
+            ]
+          }
+        }
+      },
+      "proposal": {
+        "description": "householder extension",
+        "reportingType": {
+          "code": "A123",
+          "description": "fake reporting type"
+        },
+        "ownerIsPlanningAuthority": false
+      },
+      "applicant": {
+        "type": "individual",
+        "address": {
+          "sameAsSiteAddress": true
+        },
+        "ownership": {
+          "interest": "owner.sole",
+          "certificate": "a",
+          "agriculturalTenants": false,
+          "declaration": {
+            "accurate": true
+          }
+        },
+        "agent": {
+          "address": {
+            "line1": "40 Stansfield Road",
+            "line2": "Brixton",
+            "town": "London",
+            "county": "Greater London",
+            "postcode": "SW9 9RZ",
+            "country": "UK"
+          }
+        }
+      }
+    },
+    {
+      "application": {
+        "type": {
+          "value": "pp.full.householder",
+          "description": "planning_permission"
+        },
+        "reference": "24-00106-HAPP",
+        "fullReference": "PlanX-24-00106-HAPP",
+        "receivedAt": "2024-04-18T00:00:00.000+01:00",
+        "validAt": "2024-04-19T00:00:00.000+01:00",
+        "published_at": "2024-04-19T00:00:00.000+01:00",
+        "determinedAt": "2024-04-20T00:00:00.000+01:00",
+        "status": "determined",
+        "decision": "granted",
+        "consultation": {
+          "startDate": "2024-03-12",
+          "endDate": "2024-04-02"
+        }
+      },
+      "property": {
+        "address": {
+          "latitude": -37.54605786072338,
+          "longitude": -149.12320338972793,
+          "title": "41874 Dare Parks",
+          "singleLine": "41874 Dare Parks, Rosetteside, 23463-4689",
+          "uprn": "00595249",
+          "town": "Rosetteside",
+          "postcode": "23463-4689"
+        },
+        "boundary": {
+          "site": {
+            "type": "Feature",
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [-0.054597, 51.537331],
+                  [-0.054588, 51.537287],
+                  [-0.054453, 51.537313],
+                  [-0.054597, 51.537331]
+                ]
+              ]
+            },
+            "properties": null
+          }
+        }
+      },
+      "proposal": {
+        "description": "Build a roof extension.",
+        "reportingType": null,
+        "ownerIsPlanningAuthority": false
+      },
+      "applicant": {
+        "type": "individual",
+        "address": {
+          "sameAsSiteAddress": true
+        },
+        "siteContact": {
+          "role": "applicant"
+        },
+        "ownership": {
+          "interest": "occupier",
+          "owners": [
+            {
+              "interest": "owner",
+              "name": "Matilda Wormwood",
+              "address": {
+                "town": "Reading",
+                "line1": "9, Library Way",
+                "line2": "",
+                "county": "",
+                "country": "UK",
+                "postcode": "L1T3R8Y"
+              },
+              "noticeGiven": true
+            }
+          ]
+        },
+        "agent": {
+          "address": {
+            "line1": "The Tree",
+            "line2": "One Tree Hill",
+            "town": "Great Tunnelling",
+            "county": "",
+            "postcode": "F0XH0L3",
+            "country": ""
+          }
+        }
+      }
+    },
+    {
+      "application": {
+        "type": { "value": "pa.part1.classA", "description": "prior_approval" },
+        "reference": "25-00240-PA1A",
+        "fullReference": "SWK-25-00240-PA1A",
+        "targetDate": "2025-04-08",
+        "expiryDate": "2025-03-25",
+        "receivedAt": "2025-03-04T14:36:32.999+00:00",
+        "validAt": "2025-03-04T00:00:00.000+00:00",
+        "publishedAt": "2025-03-06T14:22:12.293+00:00",
+        "determinedAt": null,
+        "decision": null,
+        "status": "Appeal allowed",
+        "consultation": {
+          "startDate": null,
+          "endDate": null,
+          "publicUrl": "https://southwark.bops-applicants.localhost:3001/planning_applications/25-00240-PA1A",
+          "publishedComments": [],
+          "consulteeComments": []
+        },
+        "pressNotice": null
+      },
+      "property": {
+        "address": {
+          "latitude": 22.87483014329466,
+          "longitude": 105.04327269762632,
+          "title": "7796 Sherie Mountain",
+          "singleLine": "7796 Sherie Mountain, Bashirianland, 78923",
+          "uprn": "00254420",
+          "town": "Bashirianland",
+          "postcode": "78923"
+        },
+        "boundary": { "site": null }
+      },
+      "proposal": {
+        "description": "Non voluptatum quo et.",
+        "reportingType": null,
+        "ownerIsPlanningAuthority": false
+      },
+      "applicant": {
+        "type": null,
+        "address": null,
+        "ownership": null,
+        "agent": { "address": null }
+      },
+      "officer": { "name": "Zena Spinka" },
+      "data": {
+        "appeal": {
+          "reason": "too slow!",
+          "lodgedDate": "2025-02-26",
+          "validatedDate": "2025-02-27",
+          "startedDate": "2025-02-28",
+          "decisionDate": "2025-03-02",
+          "decision": "allowed",
+          "files": [
+            {
+              "name": "01.png",
+              "url": "http://uploads.bops.localhost:3000/b48as3tuafybda00zffy1h8ym0mu",
+              "type": [
+                {
+                  "value": "internal.appealDecision",
+                  "description": "Appeal Decision"
+                }
+              ],
+              "createdAt": "2025-03-06T20:42:18.299+00:00",
+              "applicantDescription": null,
+              "metadata": { "byteSize": 312599, "contentType": "image/png" }
+            },
+            {
+              "name": "03.png",
+              "url": "http://uploads.bops.localhost:3000/93dj4n9hw8px6q1wgnm7hqwjwyu7",
+              "type": [
+                {
+                  "value": "internal.appealDecision",
+                  "description": "Appeal Decision"
+                }
+              ],
+              "createdAt": "2025-03-06T20:42:18.400+00:00",
+              "applicantDescription": null,
+              "metadata": { "byteSize": 338776, "contentType": "image/png" }
+            },
+            {
+              "name": "02.png",
+              "url": "http://uploads.bops.localhost:3000/n2jd2xor3sl8514m49a4rn8rf3p4",
+              "type": [
+                {
+                  "value": "internal.appealDecision",
+                  "description": "Appeal Decision"
+                }
+              ],
+              "createdAt": "2025-03-06T20:42:18.415+00:00",
+              "applicantDescription": null,
+              "metadata": { "byteSize": 890308, "contentType": "image/png" }
+            },
+            {
+              "name": "04.png",
+              "url": "http://uploads.bops.localhost:3000/gd21huup5zg82wl4qy38gia2tapx",
+              "type": [
+                {
+                  "value": "internal.appealDecision",
+                  "description": "Appeal Decision"
+                }
+              ],
+              "createdAt": "2025-03-06T20:42:18.428+00:00",
+              "applicantDescription": null,
+              "metadata": { "byteSize": 258315, "contentType": "image/png" }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/show.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/show.json
@@ -1,0 +1,122 @@
+{
+  "application": {
+    "type": { "value": "pa.part1.classA", "description": "prior_approval" },
+    "reference": "25-00240-PA1A",
+    "fullReference": "SWK-25-00240-PA1A",
+    "targetDate": "2025-04-08",
+    "expiryDate": "2025-03-25",
+    "receivedAt": "2025-03-04T14:36:32.999+00:00",
+    "validAt": "2025-03-04T00:00:00.000+00:00",
+    "publishedAt": "2025-03-06T14:22:12.293+00:00",
+    "determinedAt": null,
+    "decision": null,
+    "status": "Appeal allowed",
+    "consultation": {
+      "startDate": null,
+      "endDate": null,
+      "publicUrl": "https://southwark.bops-applicants.localhost:3001/planning_applications/25-00240-PA1A",
+      "publishedComments": [],
+      "consulteeComments": []
+    },
+    "pressNotice": null
+  },
+  "property": {
+    "address": {
+      "latitude": 22.87483014329466,
+      "longitude": 105.04327269762632,
+      "title": "7796 Sherie Mountain",
+      "singleLine": "7796 Sherie Mountain, Bashirianland, 78923",
+      "uprn": "00254420",
+      "town": "Bashirianland",
+      "postcode": "78923"
+    },
+    "boundary": { "site": null }
+  },
+  "proposal": {
+    "description": "Non voluptatum quo et.",
+    "reportingType": null,
+    "ownerIsPlanningAuthority": false
+  },
+  "applicant": {
+    "type": null,
+    "address": null,
+    "ownership": null,
+    "agent": { "address": null }
+  },
+  "officer": { "name": "Zena Spinka" },
+  "applicationFee": {
+    "id": 144,
+    "planning_application_id": 144,
+    "total_fee": null,
+    "payable_fee": null,
+    "requested_fee": null,
+    "exemptions": [],
+    "reductions": [],
+    "created_at": "2025-03-04T14:36:33.003+00:00",
+    "updated_at": "2025-03-04T14:36:33.003+00:00"
+  },
+  "data": {
+    "appeal": {
+      "reason": "too slow!",
+      "lodgedDate": "2025-02-26",
+      "validatedDate": "2025-02-27",
+      "startedDate": "2025-02-28",
+      "decisionDate": "2025-03-02",
+      "decision": "allowed",
+      "files": [
+        {
+          "name": "01_decision_type_counts.png",
+          "url": "http://uploads.bops.localhost:3000/b48as3tuafybda00zffy1h8ym0mu",
+          "type": [
+            {
+              "value": "internal.appealDecision",
+              "description": "Appeal Decision"
+            }
+          ],
+          "createdAt": "2025-03-06T20:42:18.299+00:00",
+          "applicantDescription": null,
+          "metadata": { "byteSize": 312599, "contentType": "image/png" }
+        },
+        {
+          "name": "03_average_days_to_decision.png",
+          "url": "http://uploads.bops.localhost:3000/93dj4n9hw8px6q1wgnm7hqwjwyu7",
+          "type": [
+            {
+              "value": "internal.appealDecision",
+              "description": "Appeal Decision"
+            }
+          ],
+          "createdAt": "2025-03-06T20:42:18.400+00:00",
+          "applicantDescription": null,
+          "metadata": { "byteSize": 338776, "contentType": "image/png" }
+        },
+        {
+          "name": "02_decision_by_app_type.png",
+          "url": "http://uploads.bops.localhost:3000/n2jd2xor3sl8514m49a4rn8rf3p4",
+          "type": [
+            {
+              "value": "internal.appealDecision",
+              "description": "Appeal Decision"
+            }
+          ],
+          "createdAt": "2025-03-06T20:42:18.415+00:00",
+          "applicantDescription": null,
+          "metadata": { "byteSize": 890308, "contentType": "image/png" }
+        },
+        {
+          "name": "04_applications_without_decision.png",
+          "url": "http://uploads.bops.localhost:3000/gd21huup5zg82wl4qy38gia2tapx",
+          "type": [
+            {
+              "value": "internal.appealDecision",
+              "description": "Appeal Decision"
+            }
+          ],
+          "createdAt": "2025-03-06T20:42:18.428+00:00",
+          "applicantDescription": null,
+          "metadata": { "byteSize": 258315, "contentType": "image/png" }
+        }
+      ]
+    }
+  }
+}

--- a/engines/bops_api/spec/helpers/postsubmission_application_schema_helper_spec.rb
+++ b/engines/bops_api/spec/helpers/postsubmission_application_schema_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::PostsubmissionApplicationSchemaHelper, type: :helper do
+  include BopsApi::PostsubmissionApplicationSchemaHelper
+
+  describe "#format_postsubmission_date" do
+    it "formats a DateTime object in YYYY-MM-DD format" do
+      date = DateTime.new(2025, 3, 6, 12, 0, 0)
+      expect(format_postsubmission_date(date)).to eq("2025-03-06")
+    end
+
+    it "formats a Date object in YYYY-MM-DD format" do
+      date = Date.new(2025, 3, 6)
+      expect(format_postsubmission_date(date)).to eq("2025-03-06")
+    end
+
+    it "returns nil if the date is nil" do
+      expect(format_postsubmission_date(nil)).to be_nil
+    end
+  end
+
+  describe "#format_postsubmission_datetime" do
+    it "formats a DateTime object to UTC and returns it in ISO 8601 format" do
+      date = DateTime.new(2025, 3, 6, 12, 0, 0)
+      expect(format_postsubmission_datetime(date)).to eq("2025-03-06T12:00:00Z")
+    end
+
+    it "returns nil if the date is nil" do
+      expect(format_postsubmission_datetime(nil)).to be_nil
+    end
+  end
+end

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "BOPS public API" do
       it "validates successfully against the example search json" do
         resolved_schema = load_and_resolve_schema(name: "search", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
         schemer = JSONSchemer.schema(resolved_schema)
-        example_json = example_fixture("search.json")
+        example_json = example_fixture("public/search.json")
 
         expect(schemer.valid?(example_json)).to eq(true)
       end
@@ -170,7 +170,7 @@ RSpec.describe "BOPS public API" do
 
       response "200", "returns planning applications when searching by a reference or description" do
         schema "$ref" => "#/components/schemas/Search"
-        example "application/json", :default, example_fixture("search.json")
+        example "application/json", :default, example_fixture("public/search.json")
 
         let(:page) { 2 }
         let(:maxresults) { 2 }
@@ -206,7 +206,7 @@ RSpec.describe "BOPS public API" do
       }
 
       response "200", "returns a planning application given a reference" do
-        example "application/json", :default, example_fixture("show.json")
+        example "application/json", :default, example_fixture("public/show.json")
 
         let!(:planning_application) { planning_applications.first }
         let!(:appeal) { create(:appeal, planning_application:) }
@@ -216,6 +216,8 @@ RSpec.describe "BOPS public API" do
           data = JSON.parse(response.body)
           expect(data["application"]["reference"]).to eq(planning_application.reference)
           expect(data["application"]["status"]).to eq("Appeal lodged")
+          expect(data["data"]["appeal"]["reason"]).not_to be_empty
+          expect(data["data"]["appeal"]["lodgedDate"]).to match(/\d{4}-\d{2}-\d{2}/)
 
           expect(data["officer"]["name"]).to eq(planning_application.user.name)
 

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -35237,6 +35237,99 @@ paths:
                             county: ''
                             postcode: F0XH0L3
                             country: ''
+                    - application:
+                        type:
+                          value: pa.part1.classA
+                          description: prior_approval
+                        reference: 25-00240-PA1A
+                        fullReference: SWK-25-00240-PA1A
+                        targetDate: '2025-04-08'
+                        expiryDate: '2025-03-25'
+                        receivedAt: '2025-03-04T14:36:32.999+00:00'
+                        validAt: '2025-03-04T00:00:00.000+00:00'
+                        publishedAt: '2025-03-06T14:22:12.293+00:00'
+                        determinedAt:
+                        decision:
+                        status: Appeal allowed
+                        consultation:
+                          startDate:
+                          endDate:
+                          publicUrl: https://southwark.bops-applicants.localhost:3001/planning_applications/25-00240-PA1A
+                          publishedComments: []
+                          consulteeComments: []
+                        pressNotice:
+                      property:
+                        address:
+                          latitude: 22.87483014329466
+                          longitude: 105.04327269762632
+                          title: 7796 Sherie Mountain
+                          singleLine: 7796 Sherie Mountain, Bashirianland, 78923
+                          uprn: '00254420'
+                          town: Bashirianland
+                          postcode: '78923'
+                        boundary:
+                          site:
+                      proposal:
+                        description: Non voluptatum quo et.
+                        reportingType:
+                        ownerIsPlanningAuthority: false
+                      applicant:
+                        type:
+                        address:
+                        ownership:
+                        agent:
+                          address:
+                      officer:
+                        name: Zena Spinka
+                      data:
+                        appeal:
+                          reason: too slow!
+                          lodgedDate: '2025-02-26'
+                          validatedDate: '2025-02-27'
+                          startedDate: '2025-02-28'
+                          decisionDate: '2025-03-02'
+                          decision: allowed
+                          files:
+                          - name: 01.png
+                            url: http://uploads.bops.localhost:3000/b48as3tuafybda00zffy1h8ym0mu
+                            type:
+                            - value: internal.appealDecision
+                              description: Appeal Decision
+                            createdAt: '2025-03-06T20:42:18.299+00:00'
+                            applicantDescription:
+                            metadata:
+                              byteSize: 312599
+                              contentType: image/png
+                          - name: 03.png
+                            url: http://uploads.bops.localhost:3000/93dj4n9hw8px6q1wgnm7hqwjwyu7
+                            type:
+                            - value: internal.appealDecision
+                              description: Appeal Decision
+                            createdAt: '2025-03-06T20:42:18.400+00:00'
+                            applicantDescription:
+                            metadata:
+                              byteSize: 338776
+                              contentType: image/png
+                          - name: 02.png
+                            url: http://uploads.bops.localhost:3000/n2jd2xor3sl8514m49a4rn8rf3p4
+                            type:
+                            - value: internal.appealDecision
+                              description: Appeal Decision
+                            createdAt: '2025-03-06T20:42:18.415+00:00'
+                            applicantDescription:
+                            metadata:
+                              byteSize: 890308
+                              contentType: image/png
+                          - name: 04.png
+                            url: http://uploads.bops.localhost:3000/gd21huup5zg82wl4qy38gia2tapx
+                            type:
+                            - value: internal.appealDecision
+                              description: Appeal Decision
+                            createdAt: '2025-03-06T20:42:18.428+00:00'
+                            applicantDescription:
+                            metadata:
+                              byteSize: 258315
+                              contentType: image/png
   "/api/v2/public/planning_applications/{reference}":
     get:
       summary: Retrieves a planning application
@@ -35259,69 +35352,107 @@ paths:
                   value:
                     application:
                       type:
-                        value: pp.full.householder
-                        description: planning_permission
-                      reference: 24-00100-HAPP
-                      fullReference: PlanX-24-00100-HAPP
-                      targetDate: '2024-05-15'
-                      receivedAt: '2024-06-12T15:56:29.830+01:00'
-                      validAt: '2024-06-12T00:00:00.000+01:00'
-                      publishedAt: '2024-06-12T15:56:29.828+01:00'
+                        value: pa.part1.classA
+                        description: prior_approval
+                      reference: 25-00240-PA1A
+                      fullReference: SWK-25-00240-PA1A
+                      targetDate: '2025-04-08'
+                      expiryDate: '2025-03-25'
+                      receivedAt: '2025-03-04T14:36:32.999+00:00'
+                      validAt: '2025-03-04T00:00:00.000+00:00'
+                      publishedAt: '2025-03-06T14:22:12.293+00:00'
                       determinedAt:
                       decision:
-                      status: determined
+                      status: Appeal allowed
                       consultation:
-                        startDate: '2024-04-15'
-                        endDate: '2024-05-07'
-                        publishedComments:
-                        - comment: I'm worried about construction noise.
-                          receivedAt: '2024-04-19T00:00:00.000+00:00'
-                          summaryTag: objection
-                        consulteeComments:
-                        - comment: Accepted
-                          receivedAt: '2024-04-19T00:00:00.000+00:00'
-                      property:
+                        startDate:
+                        endDate:
+                        publicUrl: https://southwark.bops-applicants.localhost:3001/planning_applications/25-00240-PA1A
+                        publishedComments: []
+                        consulteeComments: []
+                      pressNotice:
+                    property:
+                      address:
+                        latitude: 22.87483014329466
+                        longitude: 105.04327269762632
+                        title: 7796 Sherie Mountain
+                        singleLine: 7796 Sherie Mountain, Bashirianland, 78923
+                        uprn: '00254420'
+                        town: Bashirianland
+                        postcode: '78923'
+                      boundary:
+                        site:
+                    proposal:
+                      description: Non voluptatum quo et.
+                      reportingType:
+                      ownerIsPlanningAuthority: false
+                    applicant:
+                      type:
+                      address:
+                      ownership:
+                      agent:
                         address:
-                          latitude: 84.3630530473182
-                          longitude: -105.7502386387352
-                          title: 511 German Village
-                          singleLine: 511 German Village, West Rod, 66983
-                          uprn: '00565512'
-                          town: West Rod
-                          postcode: '66983'
-                        boundary:
-                          site:
-                            type: FeatureCollection
-                            features:
-                            - type: Feature
-                              geometry:
-                                type: Polygon
-                                coordinates:
-                                - - - -0.07739927369747812
-                                    - 51.501345554406896
-                                  - - -0.0778893839394212
-                                    - 51.501002280754676
-                                  - - -0.07690508968054104
-                                    - 51.50102474569704
-                                  - - -0.07676672973966252
-                                    - 51.50128963605792
-                                  - - -0.07739927369747812
-                                    - 51.501345554406896
-                              properties:
-                                color: "#d870fc"
-                            - type: Feature
-                              geometry:
-                                type: Polygon
-                                coordinates:
-                                - - - 30
-                                    - 10
-                                  - - 40
-                                    - 40
-                                  - - 30
-                                    - 10
-                              properties: {}
-                      proposal:
-                        description: householder extension
+                    officer:
+                      name: Zena Spinka
+                    applicationFee:
+                      id: 144
+                      planning_application_id: 144
+                      total_fee:
+                      payable_fee:
+                      requested_fee:
+                      exemptions: []
+                      reductions: []
+                      created_at: '2025-03-04T14:36:33.003+00:00'
+                      updated_at: '2025-03-04T14:36:33.003+00:00'
+                    data:
+                      appeal:
+                        reason: too slow!
+                        lodgedDate: '2025-02-26'
+                        validatedDate: '2025-02-27'
+                        startedDate: '2025-02-28'
+                        decisionDate: '2025-03-02'
+                        decision: allowed
+                        files:
+                        - name: 01_decision_type_counts.png
+                          url: http://uploads.bops.localhost:3000/b48as3tuafybda00zffy1h8ym0mu
+                          type:
+                          - value: internal.appealDecision
+                            description: Appeal Decision
+                          createdAt: '2025-03-06T20:42:18.299+00:00'
+                          applicantDescription:
+                          metadata:
+                            byteSize: 312599
+                            contentType: image/png
+                        - name: 03_average_days_to_decision.png
+                          url: http://uploads.bops.localhost:3000/93dj4n9hw8px6q1wgnm7hqwjwyu7
+                          type:
+                          - value: internal.appealDecision
+                            description: Appeal Decision
+                          createdAt: '2025-03-06T20:42:18.400+00:00'
+                          applicantDescription:
+                          metadata:
+                            byteSize: 338776
+                            contentType: image/png
+                        - name: 02_decision_by_app_type.png
+                          url: http://uploads.bops.localhost:3000/n2jd2xor3sl8514m49a4rn8rf3p4
+                          type:
+                          - value: internal.appealDecision
+                            description: Appeal Decision
+                          createdAt: '2025-03-06T20:42:18.415+00:00'
+                          applicantDescription:
+                          metadata:
+                            byteSize: 890308
+                            contentType: image/png
+                        - name: 04_applications_without_decision.png
+                          url: http://uploads.bops.localhost:3000/gd21huup5zg82wl4qy38gia2tapx
+                          type:
+                          - value: internal.appealDecision
+                            description: Appeal Decision
+                          createdAt: '2025-03-06T20:42:18.428+00:00'
+                          applicantDescription:
+                          metadata:
+                            byteSize: 258315
+                            contentType: image/png
   "/api/v2/validation_requests":
     get:
       summary: Retrieves a paginated list of notified validation requests for an LPA


### PR DESCRIPTION
Hey!

We will slowly be submitting PR's to convert the public endpoints to the ODP schema for the DPR, this one is for the appeals section. 

### Description of change

This PR makes a change to the `v2 public search` and `v2 public show` endpoints to return appeals in the structure we've put in the PostsubmissionApplication schema and the DPR. 

### Decisions 

- I have purposely put files in `engines/bops_api/app/views/bops_api/v2/shared/` and not public as the intention is in the future to add a new `PublishedSubmission` schema which is a subset of the `Postsubmission` and this would require moving and renaming all sorts of files down the line when currently everything we're doing applies at this top level. 
- I have created a new helper `PostsubmissionApplicationSchemaHelper` as a starting point for Post submission specific formatting
- I have placed the appeals data inside of a data object in the returned json all on its lonesome for now so that we can keep adding to it as we migrate to the new schema.


### Known issues 

I haven't updated the `swagger_doc.yml` as I was having trouble validating it in the swagger editor - hoping to get some tips on this from this PR!

I have also kept the tests fairly minimal, I have some [example's documented](https://github.com/theopensystemslab/digital-planning-data-schemas/tree/main/types/schemas/postSubmissionApplication#test-cases-in-the-examples) in the ODP schema repo which might be good to build tests against as we build up the new schema but I felt adding all that was a little beyond the scope of this PR - something to discuss in our next call?

