### PR TITLE
Fix flaky system specs

### DIFF
--- a/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
+++ b/app/views/planning_applications/assessment/pre_commencement_conditions/index.html.erb
@@ -41,9 +41,8 @@
               remove_record_url: planning_application_assessment_pre_commencement_condition_path(@planning_application, condition)
             )) %>
       <% end %>
-
-      <p class="govuk-body"><%= t(".drag_and_drop") %></p>
     </ol>
+    <p class="govuk-body"><%= t(".drag_and_drop") %></p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/planning_applications/assessment/terms/index.html.erb
+++ b/app/views/planning_applications/assessment/terms/index.html.erb
@@ -32,8 +32,8 @@
             )) %>
       <% end %>
 
-      <p class="govuk-body"><%= t(".drag_and_drop") %></p>
     </ol>
+    <p class="govuk-body"><%= t(".drag_and_drop") %></p>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/engines/bops_admin/spec/system/tokens_spec.rb
+++ b/engines/bops_admin/spec/system/tokens_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe "API Tokens", :capybara do
       fill_in "Service", with: "Service Name"
 
       click_button "Save"
+      expect(page).to have_current_path("/admin/tokens")
       expect(page).to have_selector("h1", text: "API token generated")
       expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
 
@@ -164,6 +165,7 @@ RSpec.describe "API Tokens", :capybara do
       end
 
       click_button "Save"
+      expect(page).to have_current_path("/admin/tokens")
       expect(page).to have_selector("h1", text: "API token generated")
       expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
 
@@ -208,6 +210,7 @@ RSpec.describe "API Tokens", :capybara do
       end
 
       click_button "Save"
+      expect(page).to have_current_path("/admin/tokens")
       expect(page).to have_selector("h1", text: "API token generated")
       expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
 
@@ -254,6 +257,7 @@ RSpec.describe "API Tokens", :capybara do
       end
 
       click_button "Save"
+      expect(page).to have_current_path("/admin/tokens")
       expect(page).to have_selector("h1", text: "API token generated")
       expect(page).to have_selector("div.govuk-panel__body strong", text: /\Abops_[a-zA-Z0-9]{36}[-_a-zA-Z0-9]{6}\z/)
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -13,6 +13,20 @@ Capybara.add_selector(:planning_applications_status_tab) do
   xpath { "//*[@class='govuk-tabs__list']" }
 end
 
+Capybara.add_selector(:open_accordion) do
+  xpath { "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']" }
+end
+
+Capybara.add_selector(:open_review_task) do
+  xpath do
+    [
+      "//*[@class='bops-task-accordion__section bops-task-accordion__section--expanded']",
+      "/div[@class='bops-task-accordion__section-header']",
+      "/button/h3[@class='bops-task-accordion__section-heading']"
+    ].join
+  end
+end
+
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = Selenium::WebDriver::Chrome::Options.new

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -27,6 +27,12 @@ Capybara.add_selector(:open_review_task) do
   end
 end
 
+Capybara.add_selector(:autoselect_option) do
+  xpath do |from, value|
+    "//ul[@id='#{from.delete_prefix("#")}__listbox']/li[@role='option' and normalize-space(.)='#{value}']"
+  end
+end
+
 Capybara.register_driver :chrome_headless do |app|
   Capybara::Selenium::Driver.load_selenium
   browser_options = Selenium::WebDriver::Chrome::Options.new

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -17,10 +17,6 @@ module SystemSpecHelpers
     find(".govuk-checkboxes__item ##{id}")
   end
 
-  def open_accordion_section
-    find(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']")
-  end
-
   def expand_span_item(text)
     find("span", text:).click
   end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -24,8 +24,19 @@ module SystemSpecHelpers
   def pick(value, from:)
     listbox = "ul[@id='#{from.delete_prefix("#")}__listbox']"
     option = "li[@role='option' and normalize-space(.)='#{value}']"
+    retries = 0
 
-    find(:xpath, "//#{listbox}/#{option}").click
+    begin
+      find(:xpath, "//#{listbox}/#{option}").click
+    rescue => error
+      if retries < 3
+        retries += 1
+        sleep 0.1
+        retry
+      else
+        raise error
+      end
+    end
 
     # The autocomplete javascript has some setTimeout handlers
     # to work around bugs with event order so we need to wait

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -51,6 +51,6 @@ module SystemSpecHelpers
   end
 
   def toggle(summary)
-    find(:xpath, "//details/summary[contains(., '#{summary}')]").click
+    find(:xpath, ".//details/summary[contains(., '#{summary}')]").click
   end
 end

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -21,21 +21,28 @@ module SystemSpecHelpers
     find("span", text:).click
   end
 
-  def pick(value, from:)
-    listbox = "ul[@id='#{from.delete_prefix("#")}__listbox']"
-    option = "li[@role='option' and normalize-space(.)='#{value}']"
+  def with_retry(delay: 0.1, count: 3)
     retries = 0
 
     begin
-      find(:xpath, "//#{listbox}/#{option}").click
+      yield
     rescue => error
-      if retries < 3
+      if retries < count
         retries += 1
-        sleep 0.1
+        sleep delay
         retry
       else
         raise error
       end
+    end
+  end
+
+  def pick(value, from:)
+    listbox = "ul[@id='#{from.delete_prefix("#")}__listbox']"
+    option = "li[@role='option' and normalize-space(.)='#{value}']"
+
+    with_retry do
+      find(:xpath, "//#{listbox}/#{option}").click
     end
 
     # The autocomplete javascript has some setTimeout handlers

--- a/spec/system/filter_spec.rb
+++ b/spec/system/filter_spec.rb
@@ -107,113 +107,164 @@ RSpec.describe "filtering planning applications", type: :system, capybara: true 
         visit "/"
       end
 
-      it "allows user to filter by different statuses" do
-        within(selected_govuk_tab) do
-          expect(page).to have_content("Your live applications")
-          expect(page).to have_content(not_started_planning_application.reference)
-          expect(page).to have_content(invalid_planning_application.reference)
-          expect(page).to have_content(in_assessment_planning_application.reference)
-          expect(page).to have_content(awaiting_determination_planning_application.reference)
-          expect(page).to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
-          expect(page).not_to have_content(other_closed_planning_application.reference)
-
-          click_button("Filter")
-          uncheck("Invalid")
-          uncheck("In assessment")
-          uncheck("Awaiting determination")
-          uncheck("To be reviewed")
-
-          click_button("Apply filters")
-
-          expect(page).to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
-
-          check("Invalid")
-          uncheck("Not started")
-          uncheck("In assessment")
-          uncheck("Awaiting determination")
-          uncheck("To be reviewed")
-
-          click_button("Apply filters")
-
-          expect(page).to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
-
-          check("In assessment")
-          uncheck("Not started")
-          uncheck("Invalid")
-          uncheck("Awaiting determination")
-          uncheck("To be reviewed")
-
-          click_button("Apply filters")
-
-          expect(page).to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
-
-          check("Awaiting determination")
-          uncheck("Not started")
-          uncheck("Invalid")
-          uncheck("In assessment")
-          uncheck("To be reviewed")
-
-          click_button("Apply filters")
-
-          expect(page).to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
-
-          check("To be reviewed")
-          uncheck("Not started")
-          uncheck("Invalid")
-          uncheck("In assessment")
-          uncheck("Awaiting determination")
-
-          click_button("Apply filters")
-
-          expect(page).to have_content(to_be_reviewed_planning_application.reference)
-          expect(page).not_to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(closed_planning_application.reference)
+      describe "filtering by different statuses" do
+        before do
+          within(selected_govuk_tab) do
+            expect(page).to have_content("Your live applications")
+            expect(page).to have_content(not_started_planning_application.reference)
+            expect(page).to have_content(invalid_planning_application.reference)
+            expect(page).to have_content(in_assessment_planning_application.reference)
+            expect(page).to have_content(awaiting_determination_planning_application.reference)
+            expect(page).to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+            expect(page).not_to have_content(other_closed_planning_application.reference)
+          end
         end
 
-        click_link("Closed")
+        it "allows viewing 'Not started' applications" do
+          within(selected_govuk_tab) do
+            click_button("Filter")
+            check("Not started")
+            uncheck("Invalid")
+            uncheck("In assessment")
+            uncheck("Awaiting determination")
+            uncheck("To be reviewed")
 
-        within(selected_govuk_tab) do
-          expect(page).to have_content(closed_planning_application.reference)
-          expect(page).not_to have_content(other_closed_planning_application.reference)
-          expect(page).not_to have_content(not_started_planning_application.reference)
-          expect(page).not_to have_content(invalid_planning_application.reference)
-          expect(page).not_to have_content(in_assessment_planning_application.reference)
-          expect(page).not_to have_content(awaiting_determination_planning_application.reference)
-          expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            click_button("Apply filters")
+            expect(page).to have_current_path("/planning_applications", ignore_query: true)
+
+            expect(page).to have_content(not_started_planning_application.reference)
+            expect(page).not_to have_content(invalid_planning_application.reference)
+            expect(page).not_to have_content(in_assessment_planning_application.reference)
+            expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+            expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+          end
+        end
+
+        it "allows viewing 'Invalid' applications" do
+          within(selected_govuk_tab) do
+            click_button("Filter")
+            uncheck("Not started")
+            check("Invalid")
+            uncheck("In assessment")
+            uncheck("Awaiting determination")
+            uncheck("To be reviewed")
+
+            click_button("Apply filters")
+            expect(page).to have_current_path("/planning_applications", ignore_query: true)
+
+            expect(page).not_to have_content(not_started_planning_application.reference)
+            expect(page).to have_content(invalid_planning_application.reference)
+            expect(page).not_to have_content(in_assessment_planning_application.reference)
+            expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+            expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+          end
+        end
+
+        it "allows viewing 'In assessment' applications" do
+          within(selected_govuk_tab) do
+            click_button("Filter")
+            uncheck("Not started")
+            uncheck("Invalid")
+            check("In assessment")
+            uncheck("Awaiting determination")
+            uncheck("To be reviewed")
+
+            click_button("Apply filters")
+            expect(page).to have_current_path("/planning_applications", ignore_query: true)
+
+            expect(page).not_to have_content(not_started_planning_application.reference)
+            expect(page).not_to have_content(invalid_planning_application.reference)
+            expect(page).to have_content(in_assessment_planning_application.reference)
+            expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+            expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+          end
+        end
+
+        it "allows viewing 'Awaiting determination' applications" do
+          within(selected_govuk_tab) do
+            click_button("Filter")
+            uncheck("Not started")
+            uncheck("Invalid")
+            uncheck("In assessment")
+            check("Awaiting determination")
+            uncheck("To be reviewed")
+
+            click_button("Apply filters")
+            expect(page).to have_current_path("/planning_applications", ignore_query: true)
+
+            expect(page).not_to have_content(not_started_planning_application.reference)
+            expect(page).not_to have_content(invalid_planning_application.reference)
+            expect(page).not_to have_content(in_assessment_planning_application.reference)
+            expect(page).to have_content(awaiting_determination_planning_application.reference)
+            expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+          end
+        end
+
+        it "allows viewing 'To be reviewed' applications" do
+          within(selected_govuk_tab) do
+            click_button("Filter")
+            uncheck("Not started")
+            uncheck("Invalid")
+            uncheck("In assessment")
+            uncheck("Awaiting determination")
+            check("To be reviewed")
+
+            click_button("Apply filters")
+            expect(page).to have_current_path("/planning_applications", ignore_query: true)
+
+            expect(page).not_to have_content(not_started_planning_application.reference)
+            expect(page).not_to have_content(invalid_planning_application.reference)
+            expect(page).not_to have_content(in_assessment_planning_application.reference)
+            expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+            expect(page).to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).not_to have_content(closed_planning_application.reference)
+          end
+        end
+
+        it "allows viewing 'Closed' applications" do
+          click_link("Closed")
+
+          within(selected_govuk_tab) do
+            expect(page).not_to have_content(other_closed_planning_application.reference)
+            expect(page).not_to have_content(not_started_planning_application.reference)
+            expect(page).not_to have_content(invalid_planning_application.reference)
+            expect(page).not_to have_content(in_assessment_planning_application.reference)
+            expect(page).not_to have_content(awaiting_determination_planning_application.reference)
+            expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
+            expect(page).to have_content(closed_planning_application.reference)
+          end
         end
       end
 
       it "allows user to filter by many different statuses" do
         within(selected_govuk_tab) do
           click_button("Filter")
+          expect(page).to have_selector(:open_accordion, text: "Filters")
+
           uncheck("Awaiting determination")
           uncheck("To be reviewed")
 
+          query = %w[
+            query=
+            application_type%5B%5D=
+            application_type%5B%5D=prior_approval
+            application_type%5B%5D=planning_permission
+            application_type%5B%5D=lawfulness_certificate
+            application_type%5B%5D=pre_application
+            application_type%5B%5D=other
+            status%5B%5D=
+            status%5B%5D=not_started
+            status%5B%5D=invalidated
+            status%5B%5D=in_assessment
+          ].join("&")
+
           click_button("Apply filters")
+          expect(page).to have_current_path("/planning_applications?#{query}")
 
           expect(page).to have_content(not_started_planning_application.reference)
           expect(page).to have_content(invalid_planning_application.reference)
@@ -227,7 +278,26 @@ RSpec.describe "filtering planning applications", type: :system, capybara: true 
       it "allows user to filter on searched results" do
         within(selected_govuk_tab) do
           fill_in("Find an application", with: "Chimney")
+
+          query = %w[
+            query=Chimney
+            submit=search
+            application_type%5B%5D=
+            application_type%5B%5D=prior_approval
+            application_type%5B%5D=planning_permission
+            application_type%5B%5D=lawfulness_certificate
+            application_type%5B%5D=pre_application
+            application_type%5B%5D=other
+            status%5B%5D=
+            status%5B%5D=not_started
+            status%5B%5D=invalidated
+            status%5B%5D=in_assessment
+            status%5B%5D=awaiting_determination
+            status%5B%5D=to_be_reviewed
+          ].join("&")
+
           click_button("Search")
+          expect(page).to have_current_path("/planning_applications?#{query}")
 
           expect(page).to have_content(not_started_planning_application.reference)
           expect(page).to have_content(invalid_planning_application.reference)
@@ -236,11 +306,45 @@ RSpec.describe "filtering planning applications", type: :system, capybara: true 
           expect(page).not_to have_content(to_be_reviewed_planning_application.reference)
           expect(page).not_to have_content(closed_planning_application.reference)
 
+          query = %w[
+            query=Chimney
+            submit=search
+            application_type%5B%5D=
+            application_type%5B%5D=prior_approval
+            application_type%5B%5D=planning_permission
+            application_type%5B%5D=lawfulness_certificate
+            application_type%5B%5D=pre_application
+            application_type%5B%5D=other
+            status%5B%5D=
+            status%5B%5D=not_started
+            status%5B%5D=invalidated
+            status%5B%5D=in_assessment
+            status%5B%5D=awaiting_determination
+            status%5B%5D=to_be_reviewed
+          ].join("&")
+
           click_button("Filter")
+          expect(page).to have_current_path("/planning_applications?#{query}")
+
           uncheck("Invalidated")
           uncheck("To be reviewed")
 
+          query = %w[
+            query=Chimney
+            application_type%5B%5D=
+            application_type%5B%5D=prior_approval
+            application_type%5B%5D=planning_permission
+            application_type%5B%5D=lawfulness_certificate
+            application_type%5B%5D=pre_application
+            application_type%5B%5D=other
+            status%5B%5D=
+            status%5B%5D=not_started
+            status%5B%5D=in_assessment
+            status%5B%5D=awaiting_determination
+          ].join("&")
+
           click_button("Apply filters")
+          expect(page).to have_current_path("/planning_applications?#{query}")
 
           expect(page).to have_content(not_started_planning_application.reference)
           expect(page).not_to have_content(invalid_planning_application.reference)

--- a/spec/system/planning_applications/assessing/adding_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_conditions_spec.rb
@@ -11,41 +11,56 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
     create(:planning_application, :planning_permission, :in_assessment, :with_condition_set, local_authority: default_local_authority, api_user:, decision: "granted")
   end
 
+  let(:reference) { planning_application.reference }
+
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.reference}"
+    visit "/planning_applications/#{reference}"
     click_link "Check and assess"
   end
 
   context "when planning application is planning permission" do
     it "you can add conditions" do
       click_link "Add conditions"
-
       expect(page).to have_content("Add conditions")
 
       toggle "Add condition"
 
       fill_in "Enter condition", with: "New condition"
       fill_in "Enter a reason for this condition", with: "No reason"
+
       click_button "Add condition to list"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/conditions")
+      expect(page).to have_content("Conditions successfully updated")
 
       toggle "Add condition"
+
       fill_in "Enter condition", with: "Custom condition 1"
       fill_in "Enter a reason for this condition", with: "Custom reason 1"
+
       click_button "Add condition to list"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/conditions")
+      expect(page).to have_content("Conditions successfully updated")
 
       toggle "Add condition"
+
       fill_in "Enter condition", with: "Custom condition 2"
       fill_in "Enter a reason for this condition", with: "Custom reason 2"
+
       click_button "Add condition to list"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/conditions")
+      expect(page).to have_content("Conditions successfully updated")
 
       toggle "Add condition"
+
       fill_in "Enter condition", with: "Custom condition 3"
       fill_in "Enter a reason for this condition", with: "Custom reason 3"
       # n.b. form not submitted here
       toggle "Add condition"
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+      expect(page).to have_content("Conditions successfully updated")
 
       within("#add-conditions") do
         expect(page).to have_content "Completed"
@@ -68,7 +83,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
     it "you can edit conditions" do
       create(:condition, condition_set: planning_application.condition_set, standard: false, title: "", text: "You must do this", reason: "For this reason")
 
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
 
       click_link "Add conditions"
@@ -97,7 +112,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
     end
 
     it "you can delete conditions" do
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
 
       click_link "Add conditions"
@@ -165,7 +180,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       create(:recommendation, :assessment_in_progress, planning_application:)
       create(:condition, condition_set: planning_application.condition_set, standard: true)
 
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
       click_link "Review and submit recommendation"
 
@@ -182,7 +197,7 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
       end
 
       it "doesn't break" do
-        visit "/planning_applications/#{planning_application.reference}"
+        visit "/planning_applications/#{reference}"
         click_link "Check and assess"
 
         click_link "Add conditions"
@@ -206,11 +221,12 @@ RSpec.describe "Add conditions", type: :system, capybara: true do
   end
 
   context "when planning application is not planning permission" do
-    it "you cannot add conditions" do
-      type = create(:application_type)
-      planning_application.update(application_type: type)
+    let(:planning_application) do
+      create(:planning_application, :ldc_proposed, :in_assessment, local_authority: default_local_authority, api_user:, decision: "granted")
+    end
 
-      visit "/planning_applications/#{planning_application.reference}"
+    it "you cannot add conditions" do
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
 
       expect(page).not_to have_content("Add conditions")

--- a/spec/system/planning_applications/assessing/adding_informatives_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_informatives_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Add informatives", type: :system do
   let(:default_local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, name: "PlanX", local_authority: default_local_authority) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let(:reference) { planning_application.reference }
 
   shared_examples "an application type that supports informatives" do
     before do
@@ -31,8 +32,13 @@ RSpec.describe "Add informatives", type: :system do
       pick "Section 106", from: "#informative-title-field"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
+
       expect(page).to have_content "Must do 106"
       expect(page).to have_no_selector("details[open]")
 
@@ -42,8 +48,13 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "Consider the trees"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
+
       expect(page).to have_content "Consider the trees"
       expect(page).to have_no_selector("details[open]")
 
@@ -53,6 +64,7 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "Consider the park"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
       expect(page).to have_content "Consider the park"
       expect(page).to have_no_selector("details[open]")
@@ -68,6 +80,7 @@ RSpec.describe "Add informatives", type: :system do
       expect(page).to have_no_selector("details[open]")
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
 
       within("#add-informatives") do
         expect(page).to have_content "Completed"
@@ -90,10 +103,16 @@ RSpec.describe "Add informatives", type: :system do
       expect(page).to have_field "Enter details of the informative", with: "Must do 106"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
 
       click_button "Save and come back later"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+      expect(page).to have_content("Informatives were successfully saved")
 
       within("#add-informatives") do
         expect(page).to have_content "In progress"
@@ -109,12 +128,18 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "Consider the trees"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
+
       expect(page).to have_content "Consider the trees"
       expect(page).to have_no_selector("details[open]")
 
       click_button "Save and come back later"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
 
       within("#add-informatives") do
         expect(page).to have_content "In progress"
@@ -122,6 +147,7 @@ RSpec.describe "Add informatives", type: :system do
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
 
       within("#add-informatives") do
         expect(page).to have_content "Completed"
@@ -145,6 +171,7 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "informative-text-field", with: "The new detail"
 
       click_button "Save informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
       expect(page).to have_content "Informative was successfully saved"
 
@@ -291,8 +318,13 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "The new detail"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
+
       expect(page).to have_content "The new detail"
 
       click_link "Edit"
@@ -303,6 +335,7 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: ""
 
       click_button "Save informative"
+      expect(page).to have_current_path(%r{^/planning_applications/#{reference}/assessment/informatives/items/\d+})
 
       expect(page).to have_content "Fill in the title of the informative"
       expect(page).to have_content "Fill in the text of the informative"
@@ -311,6 +344,7 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "The newer detail"
 
       click_button "Save informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
       expect(page).to have_content "Informative was successfully saved"
       expect(page).to have_content "The newer detail"
@@ -319,6 +353,7 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "The newer detail"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives")
 
       expect(page).to have_content("There is already an informative with this title")
     end
@@ -329,6 +364,7 @@ RSpec.describe "Add informatives", type: :system do
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
 
       within("#add-informatives") do
         expect(page).to have_content "Complete"
@@ -357,8 +393,13 @@ RSpec.describe "Add informatives", type: :system do
       fill_in "Enter details of the informative", with: "Consider the trees"
 
       click_button "Add informative"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/informatives/edit")
 
-      expect(page).to have_content "Informative was successfully added"
+      # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
+      with_retry do
+        expect(page).to have_content "Informative was successfully added"
+      end
+
       expect(page).to have_content "Informative 1"
       expect(page).to have_content "Consider the trees"
       expect(page).to have_no_selector("details[open]")

--- a/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_pre_commencement_conditions_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
     create(:planning_application, :planning_permission, :in_assessment, :with_condition_set, local_authority: default_local_authority, api_user:, decision: "granted")
   end
 
+  let(:reference) { planning_application.reference }
+
   def pre_commencement_conditions
     Condition.joins(:condition_set).where(condition_set: {pre_commencement: true})
   end
@@ -19,7 +21,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
     Current.user = assessor
     travel_to(Time.zone.local(2024, 4, 17, 12, 30))
     sign_in assessor
-    visit "/planning_applications/#{planning_application.reference}"
+    visit "/planning_applications/#{reference}"
     click_link "Check and assess"
   end
 
@@ -193,7 +195,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       create(:review, owner: condition2.condition_set)
 
       travel_to(Time.zone.local(2024, 4, 17, 14, 30))
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
       click_link "Add pre-commencement conditions"
 
@@ -203,7 +205,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
         expect(page).to have_selector("p", text: "Sent on: 17 April 2024 13:30")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions/#{condition1.id}/edit"
+          href: "/planning_applications/#{reference}/assessment/pre_commencement_conditions/#{condition1.id}/edit"
         )
       end
 
@@ -211,7 +213,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
         expect(page).to have_selector(".govuk-tag", text: "Accepted")
         expect(page).to have_link(
           "Edit",
-          href: "/planning_applications/#{planning_application.reference}/assessment/pre_commencement_conditions/#{condition2.id}/edit"
+          href: "/planning_applications/#{reference}/assessment/pre_commencement_conditions/#{condition2.id}/edit"
         )
       end
 
@@ -244,7 +246,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       end
       create(:review, owner: condition1.condition_set)
 
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
       click_link "Add pre-commencement conditions"
 
@@ -273,9 +275,12 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       fill_in "Enter title", with: "Title 1"
       fill_in "Enter condition", with: "Custom condition 1"
       fill_in "Enter reason", with: "Custom reason 1"
-      click_button "Add pre-commencement condition"
 
-      within("#condition_#{Condition.last.id}") do
+      click_button "Add pre-commencement condition"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/pre_commencement_conditions")
+      expect(page).to have_content("Pre-commencement condition has been successfully added")
+
+      within("#conditions-list li:last-child") do
         expect(page).to have_selector("h2", text: "Title 1")
 
         accept_confirm(text: "Are you sure?") do
@@ -283,6 +288,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
         end
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/pre_commencement_conditions")
       expect(page).to have_selector("[role=alert] p", text: "Pre-commencement condition was successfully removed")
       expect(page).not_to have_selector("h2", text: "Title 1")
 
@@ -291,12 +297,17 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       fill_in "Enter title", with: "Another title"
       fill_in "Enter condition", with: "Another condition"
       fill_in "Enter reason", with: "Another reason"
+
       click_button "Add pre-commencement condition"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/pre_commencement_conditions")
+      expect(page).to have_content("Pre-commencement condition has been successfully added")
+
       click_button "Confirm and send to applicant"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/pre_commencement_conditions")
+      expect(page).to have_content("Pre-commencement conditions have been confirmed and sent to the applicant")
 
-      within("#condition_#{Condition.last.id}") do
+      within("#conditions-list li:last-child") do
         expect(page).to have_selector("h2", text: "Another title")
-
         expect(page).not_to have_link("Remove")
       end
     end
@@ -306,7 +317,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       condition = create(:condition, :other, condition_set: planning_application.pre_commencement_condition_set, title: "title 1")
       create(:pre_commencement_condition_validation_request, owner: condition, approved: true, state: "closed")
 
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
       click_link "Review and submit recommendation"
 
@@ -335,7 +346,7 @@ RSpec.describe "Add pre-commencement conditions", type: :system, capybara: true 
       type = create(:application_type)
       planning_application.update(application_type: type)
 
-      visit "/planning_applications/#{planning_application.reference}"
+      visit "/planning_applications/#{reference}"
       click_link "Check and assess"
 
       expect(page).not_to have_content("Add conditions")

--- a/spec/system/planning_applications/assessing/adding_requirements_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_requirements_spec.rb
@@ -14,9 +14,11 @@ RSpec.describe "Add requirements", type: :system, capybara: true do
     create(:planning_application, :in_assessment, local_authority: local_authority)
   end
 
+  let(:reference) { planning_application.reference }
+
   before do
     sign_in assessor
-    visit "/planning_applications/#{planning_application.reference}"
+    visit "/planning_applications/#{reference}"
     click_link("Check and assess")
     click_link("Check and add requirements")
   end
@@ -61,13 +63,15 @@ RSpec.describe "Add requirements", type: :system, capybara: true do
     end
 
     it "allows me to add further requirements" do
-      find("span", text: "Add another requirement").click
+      toggle "Add another requirement"
+
       click_link("Drawings")
       check "Floor plans – existing"
 
       click_button "Add requirements"
-
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/requirements")
       expect(page).to have_content("Requirements successfully added")
+
       within("#drawings-card") do
         expect(page).to have_content("Floor plans – existing")
       end

--- a/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
@@ -11,34 +11,45 @@ RSpec.describe "Evidence of immunity", type: :system do
     create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
   end
 
+  let(:reference) { planning_application.reference }
+
   context "when signed in as an assessor", :capybara do
     before do
-      create(:evidence_group, :with_document, tag: "utilityBill", immunity_detail: planning_application.immunity_detail)
-      create(:evidence_group, :with_document, tag: "buildingControlCertificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
+      create(
+        :evidence_group,
+        :with_document,
+        start_date: "2016-02-02",
+        end_date: "2020-02-02",
+        tag: "utilityBill",
+        immunity_detail: planning_application.immunity_detail
+      )
+
+      create(
+        :evidence_group,
+        :with_document,
+        tag: "buildingControlCertificate",
+        start_date: "2012-02-10",
+        end_date: nil,
+        immunity_detail: planning_application.immunity_detail
+      )
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.reference}"
+
+      visit "/planning_applications/#{reference}"
+      expect(page).to have_selector("h1", text: "Application")
     end
 
     context "when planning application is in assessment" do
       it "I can view the information on the evidence of immunity page" do
         click_link "Check and assess"
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Not started")
 
-        expect(page).to have_list_item_for(
-          "Evidence of immunity",
-          with: "Not started"
-        )
+        click_link "Evidence of immunity"
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/immunity_details/new")
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
 
-        click_link("Evidence of immunity")
-
-        expect(page).to have_current_path(
-          "/planning_applications/#{planning_application.reference}/assessment/immunity_details/new"
-        )
-
-        within(".govuk-heading-l") do
-          expect(page).to have_content("Evidence of immunity")
-        end
-        expect(page).to have_content("Application number: #{planning_application.reference}")
+        expect(page).to have_content("Application number: #{reference}")
         expect(page).to have_content(planning_application.full_address)
 
         expect(page).to have_content("Were the works carried out more than 4 years ago? Yes")
@@ -48,30 +59,34 @@ RSpec.describe "Evidence of immunity", type: :system do
         expect(page).to have_content("Has enforcement action been taken about these changes? No")
 
         click_button "Utility bills (1)"
-        utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utilityBill").first
 
         within(:open_accordion) do
           within_fieldset("Starts from") do
-            expect(page).to have_field("Day", with: utility_bill_group.start_date.strftime("%-d"))
-            expect(page).to have_field("Month", with: utility_bill_group.start_date.strftime("%-m"))
-            expect(page).to have_field("Year", with: utility_bill_group.start_date.strftime("%Y"))
+            expect(page).to have_field("Day", with: "2")
+            expect(page).to have_field("Month", with: "2")
+            expect(page).to have_field("Year", with: "2016")
           end
 
           within_fieldset("Runs until") do
-            expect(page).to have_field("Day", with: utility_bill_group.end_date.strftime("%-d"))
-            expect(page).to have_field("Month", with: utility_bill_group.end_date.strftime("%-m"))
-            expect(page).to have_field("Year", with: utility_bill_group.end_date.strftime("%Y"))
+            expect(page).to have_field("Day", with: "2")
+            expect(page).to have_field("Month", with: "2")
+            expect(page).to have_field("Year", with: "2020")
           end
 
           expect(page).to have_content("This is my proof")
-
-          expect(page).to have_content(utility_bill_group.documents.first.numbers)
         end
       end
 
       it "I can save and come back later when adding or editing the immunity evidence" do
         click_link "Check and assess"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Not started")
+
         click_link "Evidence of immunity"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/immunity_details/new")
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
 
         click_button "Utility bills (1)"
 
@@ -87,14 +102,14 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Save and come back later"
 
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
         expect(page).to have_content("Evidence of immunity successfully updated")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "In progress")
 
-        expect(page).to have_list_item_for(
-          "Evidence of immunity",
-          with: "In progress"
-        )
+        click_link "Evidence of immunity"
 
-        click_link("Evidence of immunity")
+        expect(page).to have_current_path(%r{^/planning_applications/#{reference}/assessment/immunity_details/\d+/edit})
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
 
         click_button "Utility bills (1)"
 
@@ -105,19 +120,27 @@ RSpec.describe "Evidence of immunity", type: :system do
             expect(page).to have_field("Year", with: "2021")
           end
 
-          find("span", text: "Previous comments").click
-
+          toggle "Previous comments"
           expect(page).to have_content("This is my comment")
         end
 
-        click_link("Application")
+        click_link "Application"
 
+        expect(page).to have_current_path("/planning_applications/#{reference}")
+        expect(page).to have_selector("h1", text: "Application")
         expect(list_item("Check and assess")).to have_content("In progress")
       end
 
       it "I can save and mark as complete the evidence of immunity" do
         click_link "Check and assess"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Not started")
+
         click_link "Evidence of immunity"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/immunity_details/new")
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
 
         click_button "Utility bills (1)"
 
@@ -137,25 +160,23 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Save and mark as complete"
 
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
         expect(page).to have_content("Evidence of immunity successfully updated")
-
-        expect(page).to have_list_item_for(
-          "Evidence of immunity",
-          with: "Completed"
-        )
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Completed")
 
         click_link "Evidence of immunity"
 
+        expect(page).to have_current_path(%r{^/planning_applications/#{reference}/assessment/immunity_details/\d+})
         expect(page).to have_content("Edit evidence of immunity")
         expect(page).not_to have_content("Save and mark as complete")
 
         click_button "Utility bills (1)"
 
-        within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
+        within(:open_accordion) do
           expect(page).to have_field("List all the gap(s) in time", with: "May 2019", disabled: true)
           expect(page).to have_css(".govuk-warning-text__icon")
 
-          find("span", text: "Previous comments").click
+          toggle "Previous comments"
           expect(page).to have_content("Not good enough")
         end
 
@@ -163,8 +184,8 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Building control certificates (1)"
 
-        within(:xpath, "//*[@class='govuk-accordion__section govuk-accordion__section--expanded']") do
-          find("span", text: "Previous comments").click
+        within(:open_accordion) do
+          toggle "Previous comments"
           expect(page).to have_content("This proves it")
         end
       end
@@ -178,12 +199,16 @@ RSpec.describe "Evidence of immunity", type: :system do
 
     it "does not allow me to visit the page" do
       sign_in assessor
-      visit "/planning_applications/#{planning_application.reference}"
 
+      visit "/planning_applications/#{reference}"
+
+      expect(page).to have_current_path("/planning_applications/#{reference}")
+      expect(page).to have_content("Application")
       expect(page).not_to have_link("Evidence of immunity")
 
-      visit "/planning_applications/#{planning_application.reference}/assessment/immunity_details/new"
+      visit "/planning_applications/#{reference}/assessment/immunity_details/new"
 
+      expect(page).to have_current_path("/planning_applications/#{reference}")
       expect(page).to have_content("The planning application must be validated before assessment can begin")
     end
   end

--- a/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Evidence of immunity", type: :system do
         click_button "Utility bills (1)"
         utility_bill_group = planning_application.immunity_detail.evidence_groups.where(tag: "utilityBill").first
 
-        within(open_accordion_section) do
+        within(:open_accordion) do
           within_fieldset("Starts from") do
             expect(page).to have_field("Day", with: utility_bill_group.start_date.strftime("%-d"))
             expect(page).to have_field("Month", with: utility_bill_group.start_date.strftime("%-m"))
@@ -75,7 +75,7 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Utility bills (1)"
 
-        within(open_accordion_section) do
+        within(:open_accordion) do
           within_fieldset("Runs until") do
             fill_in "Day", with: "03"
             fill_in "Month", with: "12"
@@ -98,7 +98,7 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Utility bills (1)"
 
-        within(open_accordion_section) do
+        within(:open_accordion) do
           within_fieldset("Runs until") do
             expect(page).to have_field("Day", with: "3")
             expect(page).to have_field("Month", with: "12")
@@ -121,7 +121,7 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Utility bills (1)"
 
-        within(open_accordion_section) do
+        within(:open_accordion) do
           check "Missing evidence (gap in time)"
           fill_in "List all the gap(s) in time", with: "May 2019"
           fill_in "Add comment", with: "Not good enough"
@@ -131,7 +131,7 @@ RSpec.describe "Evidence of immunity", type: :system do
 
         click_button "Building control certificates (1)"
 
-        within(open_accordion_section) do
+        within(:open_accordion) do
           fill_in "Add comment", with: "This proves it"
         end
 

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -10,11 +10,13 @@ RSpec.describe "Immunity", type: :system do
   context "when not immune" do
     before do
       sign_in assessor
+
       visit "/planning_applications/#{planning_application.reference}"
+      expect(page).to have_selector("h1", text: "Application")
     end
 
     let(:planning_application) do
-      create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+      create(:planning_application, :in_assessment, local_authority: default_local_authority)
     end
 
     it "returns false from possibly_immune?" do
@@ -28,13 +30,14 @@ RSpec.describe "Immunity", type: :system do
 
   context "when immune" do
     let(:planning_application) do
-      create(:planning_application, :invalidated, validated_at: nil, local_authority: default_local_authority)
+      create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
     end
 
     before do
-      allow_any_instance_of(PlanningApplication).to receive(:possibly_immune?).and_return(true)
       sign_in assessor
+
       visit "/planning_applications/#{planning_application.reference}"
+      expect(page).to have_selector("h1", text: "Application")
     end
 
     it "returns true from possibly_immune?" do
@@ -52,73 +55,102 @@ RSpec.describe "Immunity", type: :system do
     end
 
     let!(:immunity_detail) { create(:immunity_detail, planning_application:) }
+    let!(:reference) { planning_application.reference }
 
     before do
-      create(:evidence_group, :with_document, tag: "utilityBill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: planning_application.immunity_detail)
+      create(:evidence_group, :with_document, tag: "utilityBill", missing_evidence: true, missing_evidence_entry: "gaps everywhere", immunity_detail: immunity_detail)
       create(:decision, :ldc_granted)
       create(:decision, :ldc_refused)
 
       sign_in assessor
-      visit "/planning_applications/#{planning_application.reference}"
+
+      visit "/planning_applications/#{reference}"
+      expect(page).to have_selector("h1", text: "Application")
     end
 
     it "shows the assessment and review stages for immunity", :capybara do
-      click_link("Check and assess")
+      click_link "Check and assess"
       expect(page).to have_content("Note: application may be immune from enforcement")
 
-      click_link("Evidence of immunity")
+      click_link "Evidence of immunity"
+      expect(page).to have_selector("h1", text: "Evidence of immunity")
+
       click_button "Utility bills (1)"
 
-      within(open_accordion_section) do
+      within(:open_accordion) do
+        expect(page).to have_content("Applicant comment: This is my proof")
+
         check "Missing evidence (gap in time)"
         fill_in "List all the gap(s) in time", with: "May 2020"
         fill_in "Add comment", with: "Not good enough"
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Evidence of immunity successfully updated")
 
-      click_link("Immunity/permitted development rights")
+      click_link "Immunity/permitted development rights"
+      expect(page).to have_selector("h1", text: "Immunity/permitted development rights")
 
       within("#assess-immunity-detail-section") do
         choose "Yes"
-
-        within(".govuk-radios") do
-          choose "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse"
-        end
-
+        choose "no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse"
         fill_in "Immunity from enforcement summary", with: "A summary"
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Immunity/permitted development rights response was successfully created")
 
       click_link "Make draft recommendation"
+      expect(page).to have_selector("h1", text: "Make draft recommendation")
+
       within_fieldset("What is your recommendation?") do
         choose "Granted"
       end
+
       fill_in "State the reasons for your recommendation.", with: "A public comment"
       fill_in "Provide supporting information for your manager.", with: "A private comment"
+
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+      expect(page).to have_selector("h1", text: "Assess the application")
 
-      click_on("Review and submit recommendation")
-      click_on("Submit recommendation")
+      within("#make-draft-recommendation") do
+        expect(page).to have_selector("strong", text: "Completed")
+      end
 
+      click_link "Review and submit recommendation"
+      expect(page).to have_selector("h1", text: "Review and submit recommendation")
+
+      click_button "Submit recommendation"
+      expect(page).to have_current_path("/planning_applications/#{reference}")
+      expect(page).to have_content("Recommendation was successfully submitted")
+
+      sign_out(assessor)
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.reference}"
+
+      visit "/planning_applications/#{reference}"
+      expect(page).to have_selector("h1", text: "Application")
+
       click_link "Review and sign-off"
+      expect(page).to have_selector("h1", text: "Review and sign-off")
 
       click_button "Review evidence of immunity"
+      expect(page).to have_selector(:open_review_task, text: "Review evidence of immunity")
 
       within("#review-immunity-details") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Please re-assess the evidence of immunity"
+
         click_button "Save and mark as complete"
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review immunity details was successfully updated")
 
       click_button "Review assessment of immunity"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment of immunity")
 
       within("#review-immunity-enforcements") do
         expect(page).to have_content("Assessor decision: Yes")
@@ -129,15 +161,24 @@ RSpec.describe "Immunity", type: :system do
       within("#review-immunity-enforcements-form") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Please re-assess immunity enforcement response"
+
         click_button "Save and mark as complete"
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
+      sign_out(reviewer)
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.reference}"
-      click_link("Check and assess")
-      click_link("Evidence of immunity")
+
+      visit "/planning_applications/#{reference}"
+      expect(page).to have_selector("h1", text: "Application")
+
+      click_link "Check and assess"
+      expect(page).to have_selector("h1", text: "Assess the application")
+
+      click_link "Evidence of immunity"
+      expect(page).to have_selector("h1", text: "Evidence of immunity")
 
       # Fill in evidence of immunity again
       expect(page).to have_content("Reviewer comment")
@@ -146,21 +187,23 @@ RSpec.describe "Immunity", type: :system do
       # Modify evidence group input
       click_button "Utility bills (1)"
 
-      within(open_accordion_section) do
+      within(:open_accordion) do
         check "Missing evidence (gap in time)"
         fill_in "List all the gap(s) in time", with: "June 2020"
         fill_in "Add comment", with: "Never good enough"
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Evidence of immunity successfully updated")
 
       within("#immunity-permitted-development-rights") do
         expect(page).to have_content("To be reviewed")
-        click_link("Immunity/permitted development rights")
+        click_link "Immunity/permitted development rights"
       end
 
-      expand_span_item("See previous review immunity detail responses")
+      toggle "See previous review immunity detail responses"
+
       expect(page).to have_content("Assessor decision: Yes")
       expect(page).to have_content("Reason: no action is taken within 4 years for an unauthorised change of use to a single dwellinghouse")
       expect(page).to have_content("Summary: A summary")
@@ -180,21 +223,31 @@ RSpec.describe "Immunity", type: :system do
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Immunity/permitted development rights response was successfully created")
 
+      sign_out(assessor)
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.reference}"
+
+      visit "/planning_applications/#{reference}"
+      expect(page).to have_selector("h1", text: "Application")
+
       click_link "Review and sign-off"
+      expect(page).to have_selector("h1", text: "Review and sign-off")
 
       click_button "Review evidence of immunity"
+      expect(page).to have_selector(:open_review_task, text: "Review evidence of immunity")
 
       within("#review-immunity-details") do
         choose "Agree"
         click_button "Save and mark as complete"
       end
+
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review immunity details was successfully updated")
 
       click_button "Review assessment of immunity"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment of immunity")
 
       within("#review-immunity-enforcements") do
         expect(page).to have_content("Assessor decision: No")
@@ -203,10 +256,14 @@ RSpec.describe "Immunity", type: :system do
         choose("Agree", match: :first)
         click_button "Save and mark as complete"
       end
+
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review immunity details was successfully updated for enforcement")
 
       within("#review-permitted-development-rights") do
         click_button "Review permitted development rights"
+        expect(page).to have_selector(:open_review_task, text: "Review permitted development rights")
+
         expect(page).to have_content("The permitted development rights have been removed for the following reason")
         expect(page).to have_content("A reason")
 
@@ -214,6 +271,7 @@ RSpec.describe "Immunity", type: :system do
         click_button "Save and mark as complete"
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Permitted development rights response was successfully updated")
 
       expect(immunity_detail.current_evidence_review_immunity_detail.accepted?).to be(true)

--- a/spec/system/planning_applications/publicity/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/create_site_notice_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe "Create a site notice", js: true do
       user: assessor)
   end
 
+  let(:reference) { planning_application.reference }
+
   around do |example|
     travel_to("2023-02-01") { example.run }
   end
@@ -46,11 +48,10 @@ RSpec.describe "Create a site notice", js: true do
 
     click_button "Create site notice", visible: true
 
-    expect(page).to have_content "Site notice was successfully created"
-    expect(page).to have_link(
-      "Download site notice PDF",
-      href: "#"
-    )
+    expect(page).to have_current_path("/planning_applications/#{reference}/site_notices/new")
+    expect(page).to have_content("Site notice was successfully created")
+    expect(page).to have_link("Download site notice PDF", href: "#")
+
     expect(planning_application.site_notice.content).not_to include "This application is subject to an Environmental Impact Assessment (EIA)."
   end
 
@@ -65,15 +66,14 @@ RSpec.describe "Create a site notice", js: true do
     choose "Send it by email to applicant"
 
     click_button "Email site notice and mark as complete"
+    expect(page).to have_current_path("/planning_applications/#{reference}/consultation")
+    expect(page).to have_content("Site notice was successfully emailed")
 
     perform_enqueued_jobs
     email_notification = ActionMailer::Base.deliveries.last
 
     expect(email_notification.to).to contain_exactly(planning_application.agent_email)
-
     expect(email_notification.subject).to eq("Display site notice for your application 23-00100-PA1A")
-
-    expect(page).to have_content "Site notice was successfully emailed"
   end
 
   it "sends it to the applicant if agent email is not present" do
@@ -86,15 +86,14 @@ RSpec.describe "Create a site notice", js: true do
     choose "Send it by email to applicant"
 
     click_button "Email site notice and mark as complete"
+    expect(page).to have_current_path("/planning_applications/#{reference}/consultation")
+    expect(page).to have_content("Site notice was successfully emailed")
 
     perform_enqueued_jobs
     email_notification = ActionMailer::Base.deliveries.last
 
     expect(email_notification.to).to contain_exactly(planning_application.applicant_email)
-
     expect(email_notification.subject).to eq("Display site notice for your application 23-00100-PA1A")
-
-    expect(page).to have_content "Site notice was successfully emailed"
   end
 
   it "allows officers to create a site notice and email it to the internal team" do
@@ -113,16 +112,16 @@ RSpec.describe "Create a site notice", js: true do
 
     choose "Send it by email to internal team to post"
     fill_in "Internal team email", with: "internal@email.com"
+
     click_button "Email site notice and mark as complete"
+    expect(page).to have_current_path("/planning_applications/#{reference}/consultation")
+    expect(page).to have_content("Site notice was successfully emailed")
 
     perform_enqueued_jobs
     email_notification = ActionMailer::Base.deliveries.last
 
     expect(email_notification.to).to contain_exactly("internal@email.com")
-
     expect(email_notification.subject).to eq("Site notice for application number 23-00100-PA1A")
-
-    expect(page).to have_content "Site notice was successfully emailed"
   end
 
   it "allows officers to confirm site notice is not needed" do
@@ -131,8 +130,8 @@ RSpec.describe "Create a site notice", js: true do
     choose "No"
 
     click_button "Save and mark as complete", visible: true
-
-    expect(page).not_to have_content "Confirm site notice is in place"
+    expect(page).to have_current_path("/planning_applications/#{reference}/consultation")
+    expect(page).not_to have_content("Confirm site notice is in place")
   end
 
   context "when it's an EIA application" do
@@ -154,12 +153,9 @@ RSpec.describe "Create a site notice", js: true do
       fill_in "Year", with: "2023"
 
       click_button "Create site notice", visible: true
-
-      expect(page).to have_content "Site notice was successfully created"
-      expect(page).to have_link(
-        "Download site notice PDF",
-        href: "#"
-      )
+      expect(page).to have_current_path("/planning_applications/#{reference}/site_notices/new")
+      expect(page).to have_content("Site notice was successfully created")
+      expect(page).to have_link("Download site notice PDF", href: "#")
 
       expect(planning_application.site_notice.content).to include "This application is subject to an Environmental Impact Assessment (EIA)."
       expect(planning_application.site_notice.content).not_to include "View a hard copy of the Environment Statement"
@@ -180,12 +176,9 @@ RSpec.describe "Create a site notice", js: true do
       fill_in "Year", with: "2023"
 
       click_button "Create site notice", visible: true
-
-      expect(page).to have_content "Site notice was successfully created"
-      expect(page).to have_link(
-        "Download site notice PDF",
-        href: "#"
-      )
+      expect(page).to have_current_path("/planning_applications/#{reference}/site_notices/new")
+      expect(page).to have_content("Site notice was successfully created")
+      expect(page).to have_link("Download site notice PDF", href: "#")
 
       expect(planning_application.site_notice.content).to include "This application is subject to an Environmental Impact Assessment (EIA)."
       expect(planning_application.site_notice.content).to include "You can request a hard copy for a fee of £19 by emailing planner@council.com or in person at 123 street."

--- a/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
@@ -31,23 +31,41 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       click_link "Assess against policies and guidance"
       expect(page).to have_selector("h1", text: "Assess against policies and guidance")
 
-      fill_in "Enter policy area", with: "Design"
-      pick "Design", from: "#consideration-policy-area-field"
+      within_fieldset("Add a new consideration") do
+        with_retry do
+          fill_in "Enter policy area", with: "Design"
+          expect(page).to have_selector(:autoselect_option, ["#consideration-policy-area-field", "Design"])
 
-      fill_in "Enter policy references", with: "Wall"
-      pick "PP100 - Wall materials", from: "#policyReferencesAutoComplete"
+          pick "Design", from: "#consideration-policy-area-field"
+        end
 
-      fill_in "Enter policy references", with: "Roofing"
-      pick "PP101 - Roofing materials", from: "#policyReferencesAutoComplete"
+        with_retry do
+          fill_in "Enter policy references", with: "Wall"
+          expect(page).to have_selector(:autoselect_option, ["#policyReferencesAutoComplete", "PP100 - Wall materials"])
 
-      fill_in "Enter policy guidance", with: "Design"
-      pick "Design Guidance", from: "#policyGuidanceAutoComplete"
+          pick "PP100 - Wall materials", from: "#policyReferencesAutoComplete"
+        end
 
-      fill_in "Enter assessment", with: "Uses red brick with grey slates"
-      fill_in "Enter conclusion", with: "Complies with design guidance policies"
+        with_retry do
+          fill_in "Enter policy references", with: "Roofing"
+          expect(page).to have_selector(:autoselect_option, ["#policyReferencesAutoComplete", "PP101 - Roofing materials"])
+
+          pick "PP101 - Roofing materials", from: "#policyReferencesAutoComplete"
+        end
+
+        with_retry do
+          fill_in "Enter policy guidance", with: "Design"
+          expect(page).to have_selector(:autoselect_option, ["#policyGuidanceAutoComplete", "Design Guidance"])
+
+          pick "Design Guidance", from: "#policyGuidanceAutoComplete"
+        end
+
+        fill_in "Enter assessment", with: "Uses red brick with grey slates"
+        fill_in "Enter conclusion", with: "Complies with design guidance policies"
+      end
 
       click_button "Add consideration"
-
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/considerations/edit")
       expect(page).to have_content("Consideration was successfully added")
 
       within "main ol" do
@@ -57,6 +75,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       end
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Assessment against local policies was successfully saved")
 
       sign_in(reviewer)

--- a/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
     create(:planning_application, :planning_permission, :awaiting_determination, :with_recommendation, local_authority:)
   end
 
+  let(:reference) { planning_application.reference }
+
   before do
     create(:local_authority_policy_area, local_authority:, description: "Design")
     create(:local_authority_policy_reference, local_authority:, code: "PP100", description: "Wall materials")
@@ -26,7 +28,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       travel_to Time.zone.local(2024, 7, 23, 11)
 
       sign_in(assessor)
-      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+      visit "/planning_applications/#{reference}/assessment/tasks"
 
       click_link "Assess against policies and guidance"
       expect(page).to have_selector("h1", text: "Assess against policies and guidance")
@@ -79,7 +81,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       expect(page).to have_content("Assessment against local policies was successfully saved")
 
       sign_in(reviewer)
-      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+      visit "/planning_applications/#{reference}/review/tasks"
     end
 
     it "shows validation errors" do
@@ -129,7 +131,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
             expect(page).to have_selector("h2", text: "Design")
             expect(page).to have_link(
               "Edit to accept",
-              href: "/planning_applications/#{planning_application.reference}/review/considerations/items/#{consideration.id}/edit"
+              href: "/planning_applications/#{reference}/review/considerations/items/#{consideration.id}/edit"
             )
             expect(page).to have_selector("p", text: "Uses red brick with grey slates", visible: false)
             expect(page).to have_selector("p", text: "Complies with design guidance policies", visible: false)
@@ -145,7 +147,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
 
           expect(page).to have_link(
             "Edit list position",
-            href: "/planning_applications/#{planning_application.reference}/review/considerations/edit"
+            href: "/planning_applications/#{reference}/review/considerations/edit"
           )
         end
 
@@ -216,6 +218,8 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
 
     it "I can return to the planning officer with a comment" do
       click_button "Review assessment against policies and guidance"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment against policies and guidance")
+
       within("#considerations_footer") do
         choose "Return with comments"
         fill_in "Add a comment", with: "Please provide more details about the design of the property"
@@ -225,7 +229,9 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
         click_button "Save and mark as complete"
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review of assessment against policy and guidance updated successfully")
+
       within("#considerations_section") do
         expect(find(".govuk-tag")).to have_content("Awaiting changes")
       end
@@ -233,6 +239,8 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       expect(current_review.reload).to have_attributes(action: "rejected", review_status: "review_complete", comment: "Please provide more details about the design of the property")
 
       click_button "Review assessment against policies and guidance"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment against policies and guidance")
+
       within("#considerations_block") do
         click_link("Edit list position")
       end
@@ -243,7 +251,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       travel_to Time.zone.local(2024, 7, 23, 12)
       sign_in(assessor)
 
-      visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+      visit "/planning_applications/#{reference}/assessment/tasks"
       expect(page).to have_list_item_for("Assess against policies and guidance", with: "To be reviewed")
 
       click_link "Assess against policies and guidance"
@@ -258,17 +266,22 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
       fill_in "Enter assessment", with: "Uses yellow brick with grey slates"
 
       click_button "Save consideration"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/considerations/edit")
       expect(page).to have_content("Consideration was successfully saved")
 
       click_button "Save and mark as complete"
+      expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
       expect(page).to have_content("Assessment against local policies was successfully saved")
       expect(page).to have_list_item_for("Assess against policies and guidance", with: "Updated")
 
       travel_to Time.zone.local(2024, 7, 23, 13)
       sign_in(reviewer)
 
-      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+      visit "/planning_applications/#{reference}/review/tasks"
+
       click_button "Review assessment against policies and guidance"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment against policies and guidance")
+
       within("#considerations_section") do
         expect(find(".govuk-tag")).to have_content("Updated")
       end
@@ -278,15 +291,20 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
         click_button "Save and mark as complete"
       end
 
+      expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
       expect(page).to have_content("Review of assessment against policy and guidance updated successfully")
+
       within("#considerations_section") do
         expect(find(".govuk-tag")).to have_content("Completed")
       end
 
       click_button "Review assessment against policies and guidance"
+      expect(page).to have_selector(:open_review_task, text: "Review assessment against policies and guidance")
+
       within("#considerations_block") do
         click_link("Edit list position")
       end
+
       expect(page).to have_content("Assessment accepted by Ray Reviewer, 23 July 2024")
     end
   end

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
   end
   let!(:recommendation) { create(:recommendation, planning_application:) }
   let!(:consultation) { planning_application.consultation }
+  let!(:reference) { planning_application.reference }
 
   before do
     allow(Current).to receive(:user).and_return(reviewer)
@@ -28,7 +29,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
       expect(page).to have_content("Review and sign-off")
 
-      expect(page).not_to have_content "Check neighbour notifications"
+      expect(page).not_to have_content("Check neighbour notifications")
     end
   end
 
@@ -42,7 +43,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can accept that the assessor has notified the correct people" do
-        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        visit "/planning_applications/#{reference}/review/tasks"
 
         within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
@@ -65,7 +66,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can send it back for assessment", :capybara do
-        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        visit "/planning_applications/#{reference}/review/tasks"
 
         within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
@@ -73,6 +74,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
         end
 
         click_button "Check neighbour notifications"
+        expect(page).to have_selector(:open_review_task, text: "Check neighbour notifications")
 
         within "#review-neighbour-responses" do
           choose "Return with comments"
@@ -81,6 +83,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
           click_button "Save and mark as complete"
         end
 
+        expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
         expect(page).to have_content("Review of neighbour responses successfully added")
 
         within("#review-neighbour-responses") do
@@ -90,7 +93,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         click_link "Sign off recommendation"
 
-        expect(page).to have_content "You have suggested changes to be made by the officer."
+        expect(page).to have_content("You have suggested changes to be made by the officer.")
 
         choose "No (return the case for assessment)"
 
@@ -98,7 +101,9 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         click_button "Save and mark as complete"
 
-        expect(page).to have_content "To be reviewed"
+        expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
+        expect(page).to have_content("Recommendation was successfully reviewed")
+        expect(page).to have_content("To be reviewed")
 
         click_link "Application"
 
@@ -116,9 +121,11 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
         click_link "Send letters to neighbours"
 
-        expect(page).to have_content "Notify more people"
+        expect(page).to have_content("Notify more people")
 
         click_button "Confirm and send letters"
+        expect(page).to have_current_path("/planning_applications/#{reference}/consultation/neighbour_letters")
+        expect(page).to have_content("Letters have been sent to neighbours")
 
         click_link "Consultation"
 
@@ -129,7 +136,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "shows errors" do
-        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        visit "/planning_applications/#{reference}/review/tasks"
 
         within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
@@ -168,7 +175,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
 
     context "when the consultation has not been started" do
       it "you can accept that the assessor has notified the correct people" do
-        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        visit "/planning_applications/#{reference}/review/tasks"
 
         within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")
@@ -202,7 +209,7 @@ RSpec.describe "Check neighbour notifications", type: :system do
       end
 
       it "you can't accept or reject the officer's work" do
-        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        visit "/planning_applications/#{reference}/review/tasks"
 
         within("#review-neighbour-responses") do
           expect(page).to have_content("Check neighbour notifications")

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -27,10 +27,12 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
     )
   end
 
+  let(:reference) { planning_application.reference }
+
   context "when there's not an evidence of immunity" do
     before do
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+      visit "/planning_applications/#{reference}/review/tasks"
     end
 
     it "I cannot view the link of Review evidence of immunity page" do
@@ -45,7 +47,7 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
       create(:evidence_group, :with_document, tag: "buildingControlCertificate", end_date: nil, immunity_detail: planning_application.immunity_detail)
 
       sign_in reviewer
-      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+      visit "/planning_applications/#{reference}/review/tasks"
     end
 
     context "when planning application is awaiting determination", :capybara do
@@ -97,6 +99,9 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
 
           click_button "Save and mark as complete"
         end
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
+        expect(page).to have_content("Review immunity details was successfully updated")
 
         click_link "Application"
         click_link "Check and assess"

--- a/spec/system/planning_applications/review/sign_off_spec.rb
+++ b/spec/system/planning_applications/review/sign_off_spec.rb
@@ -266,8 +266,8 @@ RSpec.describe "Reviewing sign-off", type: :system do
 
       fill_in "This information will appear on the decision notice.", with: "This text will appear on the decision notice."
       click_button "Save"
-      expect(page).to have_content("The information appearing on the decision notice was successfully updated.")
       expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/tasks")
+      expect(page).to have_content("The information appearing on the decision notice was successfully updated.")
 
       click_link "Sign off recommendation"
 

--- a/spec/system/planning_applications/time_extension_validation_request_spec.rb
+++ b/spec/system/planning_applications/time_extension_validation_request_spec.rb
@@ -5,33 +5,37 @@ require "rails_helper"
 RSpec.describe "Requesting time extension to a planning application", type: :system, capybara: true do
   let!(:default_local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:api_user) { create(:api_user, name: "Api Wizard") }
 
   let(:planning_application) do
     create(:planning_application, :in_assessment, local_authority: default_local_authority)
   end
 
-  let!(:api_user) { create(:api_user, name: "Api Wizard") }
+  let(:reference) { planning_application.reference }
 
   before do
     travel_to Time.zone.local(2024, 1, 1)
     sign_in assessor
-    visit "/planning_applications/#{planning_application.reference}"
+    visit "/planning_applications/#{reference}"
   end
 
   it "displays the planning application address and reference" do
-    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+    visit "/planning_applications/#{reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
     expect(page).to have_content(planning_application.full_address)
-    expect(page).to have_content(planning_application.reference)
+    expect(page).to have_content(reference)
   end
 
   it "lets user create and cancel request" do
-    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
-    click_button("Application information")
-    click_link("Request extension")
+    visit "/planning_applications/#{reference}/assessment/tasks"
+    expect(page).to have_selector("h1", text: "Assess the application")
 
+    click_button("Application information")
+    expect(page).to have_selector(:open_accordion, text: "Application information")
+
+    click_link("Request extension")
     expect(page).to have_content(planning_application.full_address)
 
     fill_in "Day", with: "03"
@@ -41,29 +45,24 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
     fill_in "Enter a reason for the request", with: "This is taking longer than I thought"
 
     click_button "Send request"
-
+    expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
     expect(page).to have_text("Time extension request successfully sent.")
 
-    expect(page).to have_current_path(
-      "/planning_applications/#{planning_application.reference}/assessment/tasks"
-    )
-
     click_link("Extension requested")
-
     expect(page).to have_content("Review time extension request")
 
     click_link("Cancel request")
-
     expect(page).to have_content("You requested an extension")
 
     fill_in "Explain to the applicant why this request is being cancelled", with: "We need more time"
-    click_button "Confirm cancellation"
 
+    click_button "Confirm cancellation"
+    expect(page).to have_current_path("/planning_applications/#{reference}")
     expect(page).to have_content("Time extension request successfully cancelled.")
   end
 
   it "displays the expected error message when there is a time extension request already open" do
-    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+    visit "/planning_applications/#{reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -78,7 +77,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   end
 
   it "displays the expected error message when the time extension is earlier than the current expiry" do
-    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+    visit "/planning_applications/#{reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -95,7 +94,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   it "displays the previously created time extension request on the edit page" do
     create(:time_extension_validation_request, :closed, planning_application: planning_application, reason: "Took too long")
 
-    visit "/planning_applications/#{planning_application.reference}/assessment/tasks"
+    visit "/planning_applications/#{reference}/assessment/tasks"
     click_button("Application information")
     click_link("Request extension")
 
@@ -106,7 +105,7 @@ RSpec.describe "Requesting time extension to a planning application", type: :sys
   it "displays the rejection reason when applicant rejects the request" do
     rejected_request = create(:time_extension_validation_request, :closed, approved: false, planning_application: planning_application, reason: "Took too long", rejection_reason: "I can't wait any longer")
 
-    visit "/planning_applications/#{planning_application.reference}/validation/validation_requests/#{rejected_request.id}"
+    visit "/planning_applications/#{reference}/validation/validation_requests/#{rejected_request.id}"
 
     expect(page).to have_content("Rejected")
     expect(page).to have_content("I can't wait any longer")

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -84,8 +84,10 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
         expect(page).not_to have_content(planning_application3.reference)
-        click_button("Search")
       end
+
+      click_button("Search")
+      expect(page).to have_current_path(%r{^/planning_applications\?query=&submit=search})
 
       within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
@@ -95,10 +97,10 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).not_to have_content(planning_application3.reference)
       end
 
-      within(govuk_tab_all) do
-        fill_in("Find an application", with: "00100")
-        click_button("Search")
-      end
+      fill_in("Find an application", with: "00100")
+
+      click_button("Search")
+      expect(page).to have_current_path(%r{^/planning_applications\?query=00100&submit=search})
 
       within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
@@ -119,10 +121,8 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).not_to have_content(planning_application3.reference)
       end
 
-      within(govuk_tab_all) do
-        click_link("Clear search")
-        expect(find_field("Find an application").value).to eq("")
-      end
+      click_link("Clear search")
+      expect(page).to have_field("Find an application", with: "")
 
       within(govuk_tab_all) do
         expect(page).to have_content("Your live applications")
@@ -163,74 +163,150 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
       end
     end
 
-    it "allows the user to search for planning applications with an address" do
-      click_link "View all applications"
+    describe "searching for applications using an address" do
+      context "when using: '11 Abbey Gardens'" do
+        it "returns the correct results" do
+          click_link "View all applications"
 
-      within(govuk_tab_all) do
-        fill_in("Find an application", with: "11 Abbey Gardens")
-        click_button("Search")
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "11 Abbey Gardens")
 
-        expect(page).to have_content(planning_application1.reference)
-        expect(page).not_to have_content(planning_application2.reference)
-        expect(page).not_to have_content(planning_application3.reference)
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=11\+Abbey\+Gardens})
 
-        fill_in("Find an application", with: "20 Abbey Gardens")
-        click_button("Search")
+            expect(page).to have_content(planning_application1.reference)
+            expect(page).not_to have_content(planning_application2.reference)
+            expect(page).not_to have_content(planning_application3.reference)
+          end
+        end
+      end
 
-        expect(page).not_to have_content(planning_application1.reference)
-        expect(page).not_to have_content(planning_application2.reference)
-        expect(page).not_to have_content(planning_application3.reference)
+      context "when using: '20 Abbey Gardens'" do
+        it "returns the correct results" do
+          click_link "View all applications"
 
-        fill_in("Find an application", with: "GARDENS")
-        click_button("Search")
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "20 Abbey Gardens")
 
-        expect(page).to have_content(planning_application1.reference)
-        expect(page).not_to have_content(planning_application2.reference)
-        expect(page).to have_content(planning_application3.reference)
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=20\+Abbey\+Gardens})
 
-        fill_in("Find an application", with: "140 woodwarde")
-        click_button("Search")
+            expect(page).not_to have_content(planning_application1.reference)
+            expect(page).not_to have_content(planning_application2.reference)
+            expect(page).not_to have_content(planning_application3.reference)
+          end
+        end
+      end
 
-        expect(page).not_to have_content(planning_application1.reference)
-        expect(page).to have_content(planning_application2.reference)
-        expect(page).not_to have_content(planning_application3.reference)
+      context "when using: 'GARDENS'" do
+        it "returns the correct results" do
+          click_link "View all applications"
 
-        fill_in("Find an application", with: "london")
-        click_button("Search")
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "GARDENS")
 
-        expect(page).to have_content(planning_application1.reference)
-        expect(page).to have_content(planning_application2.reference)
-        expect(page).to have_content(planning_application3.reference)
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=GARDENS})
 
-        fill_in("Find an application", with: "southwark")
-        click_button("Search")
+            expect(page).to have_content(planning_application1.reference)
+            expect(page).not_to have_content(planning_application2.reference)
+            expect(page).to have_content(planning_application3.reference)
+          end
+        end
+      end
 
-        expect(page).to have_content(planning_application1.reference)
-        expect(page).not_to have_content(planning_application2.reference)
-        expect(page).to have_content(planning_application3.reference)
+      context "when using: '140 woodwarde'" do
+        it "returns the correct results" do
+          click_link "View all applications"
 
-        fill_in("Find an application", with: "se22 8UR")
-        click_button("Search")
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "140 woodwarde")
 
-        expect(page).not_to have_content(planning_application1.reference)
-        expect(page).to have_content(planning_application2.reference)
-        expect(page).not_to have_content(planning_application3.reference)
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=140\+woodwarde})
 
-        fill_in("Find an application", with: "sE228uR")
-        click_button("Search")
+            expect(page).not_to have_content(planning_application1.reference)
+            expect(page).to have_content(planning_application2.reference)
+            expect(page).not_to have_content(planning_application3.reference)
+          end
+        end
+      end
 
-        expect(page).not_to have_content(planning_application1.reference)
-        expect(page).to have_content(planning_application2.reference)
-        expect(page).not_to have_content(planning_application3.reference)
+      context "when using: 'london'" do
+        it "returns the correct results" do
+          click_link "View all applications"
+
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "london")
+
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=london})
+
+            expect(page).to have_content(planning_application1.reference)
+            expect(page).to have_content(planning_application2.reference)
+            expect(page).to have_content(planning_application3.reference)
+          end
+        end
+      end
+
+      context "when using: 'southwark'" do
+        it "returns the correct results" do
+          click_link "View all applications"
+
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "southwark")
+
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=southwark})
+
+            expect(page).to have_content(planning_application1.reference)
+            expect(page).not_to have_content(planning_application2.reference)
+            expect(page).to have_content(planning_application3.reference)
+          end
+        end
+      end
+
+      context "when using: 'se22 8UR'" do
+        it "returns the correct results" do
+          click_link "View all applications"
+
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "se22 8UR")
+
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=se22\+8UR})
+
+            expect(page).not_to have_content(planning_application1.reference)
+            expect(page).to have_content(planning_application2.reference)
+            expect(page).not_to have_content(planning_application3.reference)
+          end
+        end
+      end
+
+      context "when using: 'se22 8UR'" do
+        it "returns the correct results" do
+          click_link "View all applications"
+
+          within(govuk_tab_all) do
+            fill_in("Find an application", with: "sE228uR")
+
+            click_button("Search")
+            expect(page).to have_current_path(%r{^/planning_applications\?query=sE228uR})
+
+            expect(page).not_to have_content(planning_application1.reference)
+            expect(page).to have_content(planning_application2.reference)
+            expect(page).not_to have_content(planning_application3.reference)
+          end
+        end
       end
     end
 
     it "allows user to clear form without submitting it" do
       within(govuk_tab_all) do
         fill_in("Find an application", with: "abc")
-        click_link("Clear search")
 
-        expect(find_field("Find an application").value).to eq("")
+        click_link("Clear search")
+        expect(page).to have_field("Find an application", with: "")
 
         expect(page).to have_content("Your live applications")
         expect(page).to have_content(planning_application1.reference)
@@ -261,18 +337,44 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
   end
 
   context "when user views all planning applications" do
+    let(:empty_query) {
+      %w[
+        query=
+        view=all
+        submit=search
+        application_type%5B%5D=
+        application_type%5B%5D=prior_approval
+        application_type%5B%5D=planning_permission
+        application_type%5B%5D=lawfulness_certificate
+        application_type%5B%5D=pre_application
+        application_type%5B%5D=other
+        status%5B%5D=
+        status%5B%5D=not_started
+        status%5B%5D=invalidated
+        status%5B%5D=in_assessment
+        status%5B%5D=awaiting_determination
+        status%5B%5D=to_be_reviewed
+      ].join("&")
+    }
+
     let(:query) {
-      {
-        query: "00100",
-        view: "all",
-        submit: "search",
-        application_type: %w[
-          prior_approval planning_permission lawfulness_certificate
-        ],
-        status: %w[
-          not_started invalidated in_assessment awaiting_determination to_be_reviewed
-        ]
-      }.to_query
+      %w[
+        query=00100
+        view=all
+        submit=search
+        application_type%5B%5D=
+        application_type%5B%5D=prior_approval
+        application_type%5B%5D=planning_permission
+        application_type%5B%5D=lawfulness_certificate
+        application_type%5B%5D=pre_application
+        application_type%5B%5D=other
+        status%5B%5D=
+        status%5B%5D=not_started
+        status%5B%5D=invalidated
+        status%5B%5D=in_assessment
+        status%5B%5D=awaiting_determination
+        status%5B%5D=to_be_reviewed
+      ].join("&")
     }
 
     before do
@@ -281,6 +383,7 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
 
       within(govuk_tab_all) do
         click_link("Clear search")
+        expect(page).to have_field("Find an application", with: "")
       end
     end
 
@@ -293,6 +396,7 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).to have_content(planning_application3.reference)
 
         click_button("Search")
+        expect(page).to have_current_path("/planning_applications?#{empty_query}")
 
         expect(page).to have_content("Live applications")
         expect(page).to have_content("Query can't be blank")
@@ -301,7 +405,9 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).to have_content(planning_application3.reference)
 
         fill_in("Find an application", with: "00100")
+
         click_button("Search")
+        expect(page).to have_current_path("/planning_applications?#{query}")
 
         expect(page).to have_content("Live applications")
         expect(page).not_to have_content("Query can't be blank")
@@ -321,8 +427,7 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
         expect(page).not_to have_content(planning_application3.reference)
 
         click_link("Clear search")
-
-        expect(find_field("Find an application").value).to eq("")
+        expect(page).to have_field("Find an application", with: "")
 
         expect(page).to have_content("Live applications")
         expect(page).to have_content(planning_application1.reference)
@@ -334,7 +439,9 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
     it "allows user to search planning applications by description" do
       within(govuk_tab_all) do
         fill_in("Find an application", with: "chimney")
+
         click_button("Search")
+        expect(page).to have_current_path(%r{^/planning_applications\?query=chimney})
 
         expect(page).to have_content(planning_application1.reference)
         expect(page).not_to have_content(planning_application2.reference)
@@ -369,9 +476,10 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
     it "allows user to clear form without submitting it" do
       within(govuk_tab_all) do
         fill_in("Find an application", with: "abc")
-        click_link("Clear search")
 
-        expect(find_field("Find an application").value).to eq("")
+        click_link("Clear search")
+        expect(page).to have_field("Find an application", with: "")
+
         expect(page).to have_content("Live applications")
         expect(page).to have_content(planning_application1.reference)
         expect(page).to have_content(planning_application2.reference)
@@ -382,8 +490,10 @@ RSpec.describe "searching planning applications", type: :system, capybara: true 
     it "shows message when there are no search results" do
       within(govuk_tab_all) do
         fill_in("Find an application", with: "something else entirely")
+
         click_button("Search")
 
+        expect(page).to have_current_path(%r{^/planning_applications\?query=something\+else\+entirely})
         expect(page).to have_content("No planning applications match your search")
       end
     end


### PR DESCRIPTION
A collection of system specs that don't follow the standard pattern:

Trigger action (click link, etc.) => Expect on response (page.has_content?, etc.)

Failure to do this results in the spec racing ahead of the browser state.