### PR TITLE
Add disclaimer to local admin

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -61,10 +61,4 @@ module ApplicationHelper
   def nav_items
     []
   end
-
-  def markdown(text)
-    return if text.blank?
-
-    CommonMarker.render_html(text).html_safe
-  end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -88,6 +88,7 @@ class PlanningApplication < ApplicationRecord
     delegate :appeals?
     delegate :assess_against_policies?
     delegate :consultation?
+    delegate :disclaimer
     delegate :neighbour_consultation_feature?
     delegate :consultee_consultation_feature?
     delegate :publicity_consultation_feature?

--- a/db/migrate/20250318164438_add_disclaimer_to_application_type.rb
+++ b/db/migrate/20250318164438_add_disclaimer_to_application_type.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddDisclaimerToApplicationType < ActiveRecord::Migration[7.2]
+  def change
+    add_column :application_type_configs, :disclaimer, :string
+    add_column :application_types, :disclaimer, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,6 +103,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_075646) do
     t.string "category"
     t.string "reporting_types", default: [], null: false, array: true
     t.string "decisions", default: [], null: false, array: true
+    t.string "disclaimer"
     t.index ["code"], name: "ix_application_type_configs_on_code", unique: true, where: "((status)::text <> 'retired'::text)"
     t.index ["legislation_id"], name: "ix_application_type_configs_on_legislation_id"
     t.index ["suffix"], name: "ix_application_type_configs_on_suffix", unique: true
@@ -130,6 +131,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_20_075646) do
     t.string "decisions", default: [], null: false, array: true
     t.bigint "config_id"
     t.bigint "local_authority_id"
+    t.string "disclaimer"
     t.index ["config_id"], name: "ix_application_types_on_config_id"
     t.index ["legislation_id"], name: "ix_application_types_on_legislation_id"
     t.index ["local_authority_id", "code"], name: "ix_application_types_on_local_authority_id__code", unique: true, where: "((status)::text <> 'retired'::text)"

--- a/engines/bops_admin/app/controllers/bops_admin/application_types/disclaimers_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/application_types/disclaimers_controller.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  module ApplicationTypes
+    class DisclaimersController < ApplicationController
+      before_action :set_application_type
+
+      def edit
+        respond_to do |format|
+          format.html
+        end
+      end
+
+      def update
+        respond_to do |format|
+          if @application_type.update(application_type_params, :disclaimer)
+            format.html do
+              redirect_to @application_type, notice: t(".success")
+            end
+          else
+            format.html { render :edit }
+          end
+        end
+      end
+
+      private
+
+      def application_type_params
+        params.require(:application_type).permit(:disclaimer)
+      end
+
+      def set_application_type
+        @application_type = current_local_authority.application_types.find(application_type_id)
+      end
+
+      def application_type_id
+        Integer(params[:application_type_id])
+      end
+    end
+  end
+end

--- a/engines/bops_admin/app/views/bops_admin/application_types/disclaimers/_side_navigation.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/application_types/disclaimers/_side_navigation.html.erb
@@ -1,0 +1,8 @@
+<%= bops_side_navigation(title: "Settings") do |nav| %>
+  <% nav.with_section(title: "Profile", index: 2) do |section| %>
+    <% section.with_navigation_item(text: "Manage profile", href: profile_path) %>
+  <% end %>
+  <% nav.with_section(title: "Application Types", index: 2) do |section| %>
+    <% section.with_navigation_item(text: "Manage application types", href: application_types_path, current: true) %>
+  <% end %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/application_types/disclaimers/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/application_types/disclaimers/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title do %>
+  <%= t(".disclaimer") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application Types", application_types_path %>
+
+<% content_for :title, t(".disclaimer") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "side_navigation" %>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+    <%= form_with model: @application_type, url: [@application_type, :disclaimer] do |form| %>
+      <%= form.govuk_error_summary %>
+
+      <%= form.govuk_text_area :disclaimer,
+            label: {text: t(".set_disclaimer_html", description: @application_type.description)},
+            hint: {text: t(".hint")} %>
+
+      <%= form.govuk_submit(t(".continue")) do %>
+        <%= govuk_button_link_to t("back"), @application_type, secondary: true %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/application_types/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/application_types/show.html.erb
@@ -49,6 +49,12 @@
           end
 
           summary_list.with_row do |row|
+            row.with_key { t(".disclaimer") }
+            row.with_value { markdown @application_type.disclaimer }
+            row.with_action(text: t(".change"), href: url_for([:edit, @application_type, :disclaimer]), visually_hidden_text: t(".disclaimer"))
+          end
+
+          summary_list.with_row do |row|
             row.with_key { t(".features") }
             row.with_value { %>
               <p class="govuk-body"><strong>Application details</strong></p>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -24,6 +24,20 @@ en:
             </h1>
         update:
           success: Determination period successfully updated
+      disclaimers:
+        edit:
+          continue: Continue
+          disclaimer: Disclaimer
+          hint: Set the legal disclaimer that will be displayed for this type of application.
+          set_disclaimer_html: |
+            <h1 class="govuk-heading-l govuk-!-margin-bottom-3">
+              <span class="govuk-caption-l govuk-!-margin-bottom-2">
+                %{description}
+              </span>
+              Set disclaimer
+            </h1>
+        update:
+          success: Disclaimer successfully updated
       index:
         create_new_application_type: Create new application type
         outstanding_count:
@@ -60,6 +74,7 @@ en:
         determination_period_including_bank_holidays:
           one: 1 day - bank holidays included
           other: "%{count} days - bank holidays included"
+        disclaimer: Disclaimer
         edit: Edit
         features: Features
         groups:

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -12,6 +12,7 @@ BopsAdmin::Engine.routes.draw do
     scope module: "application_types" do
       with_options only: %i[edit update] do
         resource :determination_period
+        resource :disclaimer
       end
     end
   end

--- a/engines/bops_admin/spec/system/application_types_spec.rb
+++ b/engines/bops_admin/spec/system/application_types_spec.rb
@@ -184,4 +184,39 @@ RSpec.describe "Profile", type: :system do
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(6) dd", text: "25 days - bank holidays included")
   end
+
+  it "allows the administrator to edit the disclaimer" do
+    application_type = create(:application_type, :configured, :pre_application, local_authority:)
+
+    visit "/admin/application_types/#{application_type.id}"
+
+    within "dl div:nth-child(7)" do
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Set disclaimer")
+    expect(page).to have_selector("h1 > span", text: "Pre-application Advice")
+
+    # Set determination period
+    expect(page).to have_selector(".govuk-label", text: "Set disclaimer")
+    expect(page).to have_selector("div.govuk-hint", text: "Set the legal disclaimer that will be displayed for this type of application.")
+
+    fill_in "Set disclaimer", with: "hello world!"
+    click_button "Continue"
+
+    expect(page).to have_content("Disclaimer successfully updated")
+    expect(page).to have_content("hello world!")
+
+    within "dl div:nth-child(7)" do
+      click_link "Change"
+    end
+
+    fill_in "Set disclaimer", with: ""
+    click_button "Continue"
+
+    expect(page).to have_content("Disclaimer successfully updated")
+    expect(page).not_to have_content("hello world!")
+
+    expect(page).to have_selector("h1", text: "Review the application type")
+  end
 end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -24,5 +24,11 @@ module BopsCore
     def active_page_key?(page_key)
       active_page_key == page_key
     end
+
+    def markdown(text)
+      return if text.blank?
+
+      CommonMarker.render_html(text).html_safe
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Pre-application reports need a disclaimer, so we need to be able to store and edit that in order to (later) display it.

### Story Link

https://trello.com/c/anY0pEYT/444-add-disclaimer

### Known issues [OPTIONAL]

This can be configured for any application type but might only ever be relevant for preapps, so we may want to limit it on the show/edit form. Do we want an application type feature for example?