### PR TITLE
Make PlanningApplication#reporting_type a reference

### DIFF
--- a/app/controllers/planning_applications/validation/reporting_types_controller.rb
+++ b/app/controllers/planning_applications/validation/reporting_types_controller.rb
@@ -32,7 +32,7 @@ module PlanningApplications
 
       def reporting_type_params
         (params[:planning_application] ? params.require(:planning_application) : params)
-          .permit(:reporting_type_code, :regulation).to_h.merge(regulation_3:, regulation_4:)
+          .permit(:reporting_type_id, :regulation).to_h.merge(regulation_3:, regulation_4:)
       end
 
       def regulation_3

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -118,12 +118,15 @@ class PlanningApplication < ApplicationRecord
 
   delegate :lodged?, :validated?, :started?, :determined?, :display_status, to: :appeal, allow_nil: true, prefix: true
 
+  delegate :code, to: :reporting_type, prefix: true
+
   belongs_to :user, optional: true
   belongs_to :api_user, optional: true
   belongs_to :boundary_created_by, class_name: "User", optional: true
   belongs_to :local_authority
   belongs_to :application_type
   belongs_to :recommended_application_type, class_name: "ApplicationType", optional: true
+  belongs_to :reporting_type, optional: true
 
   scope :by_created_at_desc, -> { order(created_at: :desc) }
   scope :by_determined_at_desc, -> { order(determined_at: :desc) }
@@ -232,7 +235,7 @@ class PlanningApplication < ApplicationRecord
 
   with_options on: :reporting_types do
     validate :regulation_present, if: :regulation?
-    validates :reporting_type_code, presence: true, if: :selected_reporting_types?
+    validates :reporting_type_id, presence: true, if: :selected_reporting_types?
   end
 
   with_options on: :recommended_application_type do
@@ -849,7 +852,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def reporting_type_status
-    reporting_type_code.blank? ? :not_started : :complete
+    reporting_type.nil? ? :not_started : :complete
   end
 
   def updated_neighbour_boundary_geojson
@@ -919,10 +922,6 @@ class PlanningApplication < ApplicationRecord
 
   def documents_for_publication
     documents.active.for_publication.or(site_notice_documents_for_publication)
-  end
-
-  def reporting_type_detail
-    @reporting_type_detail ||= application_type.selected_reporting_types.find_by(code: reporting_type_code)
   end
 
   def to_param

--- a/app/models/reporting_type.rb
+++ b/app/models/reporting_type.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReportingType < ApplicationRecord
+  has_many :planning_applications, dependent: :nullify
+
   with_options presence: true do
     validates :code, uniqueness: true
     validates :categories, :description

--- a/app/views/planning_applications/validation/reporting_types/_form.html.erb
+++ b/app/views/planning_applications/validation/reporting_types/_form.html.erb
@@ -4,7 +4,7 @@
   <%= form.govuk_radio_buttons_fieldset(:reporting_type, legend: {size: "m"}) do %>
     <% if @planning_application.application_type.selected_reporting_types? %>
       <% @planning_application.application_type.selected_reporting_types.each do |reporting_type| %>
-        <%= form.govuk_radio_button(:reporting_type_code, reporting_type.code, label: {text: reporting_type.full_description}, disabled: action_name == "show") do %>
+        <%= form.govuk_radio_button(:reporting_type_id, reporting_type.id, label: {text: reporting_type.full_description}, disabled: action_name == "show") do %>
           <% if reporting_type.guidance? %>
             <%= render FormattedContentComponent.new(text: reporting_type.guidance, classname: "govuk-hint") %>
             <% if reporting_type.guidance_link? %>

--- a/app/workflows/validation/reporting_details_task.rb
+++ b/app/workflows/validation/reporting_details_task.rb
@@ -7,7 +7,7 @@ module Validation
     end
 
     def task_list_link
-      if planning_application.reporting_type_code.present?
+      if planning_application.reporting_type.present?
         planning_application_validation_reporting_type_path(planning_application)
       else
         edit_planning_application_validation_reporting_type_path(planning_application)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -335,7 +335,7 @@ en:
               not_a_number: Payment amount must be a number not exceeding 2 decimal places
             public_comment:
               blank: Please state the reasons for your recommendation
-            reporting_type_code:
+            reporting_type_id:
               blank: Please select a development type for reporting
             review_documents_for_recommendation_status:
               inclusion: "%{attribute} must be Not started, In progress or Complete"

--- a/db/migrate/20250320155026_add_reporting_type_reference_to_planning_applications.rb
+++ b/db/migrate/20250320155026_add_reporting_type_reference_to_planning_applications.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AddReportingTypeReferenceToPlanningApplications < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    safety_assured do
+      remove_column :planning_applications, :reporting_type, :string
+    end
+
+    add_reference :planning_applications, :reporting_type, null: true, index: {algorithm: :concurrently}
+
+    up_only do
+      PlanningApplication.where.not(reporting_type_code: nil).find_each do |planning_application|
+        planning_application.reporting_type_id = ReportingType.find_by(code: planning_application.reporting_type_code).id
+      end
+    end
+  end
+end

--- a/db/migrate/20250320155126_add_reporting_type_reference_foreign_key.rb
+++ b/db/migrate/20250320155126_add_reporting_type_reference_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddReportingTypeReferenceForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    add_foreign_key :planning_applications, :reporting_types, column: :reporting_type_id, validate: false
+  end
+end

--- a/db/migrate/20250320155303_enable_reporting_type_reference_foreign_key.rb
+++ b/db/migrate/20250320155303_enable_reporting_type_reference_foreign_key.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class EnableReportingTypeReferenceForeignKey < ActiveRecord::Migration[7.2]
+  def change
+    validate_foreign_key :planning_applications, :reporting_types, column: :reporting_type_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -904,7 +904,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_121622) do
     t.datetime "not_started_at"
     t.boolean "valid_ownership_certificate"
     t.boolean "valid_description"
-    t.string "reporting_type"
     t.geography "neighbour_boundary_geojson", limit: {srid: 4326, type: "geometry_collection", geographic: true}
     t.string "documents_status", default: "not_started", null: false
     t.datetime "in_committee_at"
@@ -918,6 +917,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_121622) do
     t.string "previous_references", default: [], array: true
     t.string "reporting_type_code"
     t.bigint "recommended_application_type_id"
+    t.bigint "reporting_type_id"
     t.index "lower((reference)::text)", name: "ix_planning_applications_on_lower_reference"
     t.index "lower(replace((postcode)::text, ' '::text, ''::text))", name: "ix_planning_applications_on_LOWER_replace_postcode"
     t.index "to_tsvector('english'::regconfig, description)", name: "index_planning_applications_on_description", using: :gin
@@ -931,6 +931,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_121622) do
     t.index ["lonlat"], name: "ix_planning_applications_on_lonlat", using: :gist
     t.index ["recommended_application_type_id"], name: "ix_planning_applications_on_recommended_application_type_id"
     t.index ["reference", "local_authority_id"], name: "ix_planning_applications_on_reference__local_authority_id", unique: true
+    t.index ["reporting_type_id"], name: "ix_planning_applications_on_reporting_type_id"
     t.index ["status", "application_type_id"], name: "ix_planning_applications_on_status__application_type_id"
     t.index ["status"], name: "ix_planning_applications_on_status"
     t.index ["user_id"], name: "index_planning_applications_on_user_id"
@@ -1255,6 +1256,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_21_121622) do
   add_foreign_key "planning_applications", "application_types"
   add_foreign_key "planning_applications", "application_types", column: "recommended_application_type_id"
   add_foreign_key "planning_applications", "local_authorities"
+  add_foreign_key "planning_applications", "reporting_types"
   add_foreign_key "planning_applications", "users"
   add_foreign_key "planning_applications", "users", column: "boundary_created_by_id"
   add_foreign_key "planx_planning_data", "planning_applications"

--- a/engines/bops_api/app/views/bops_api/v2/public/shared/_show.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/shared/_show.json.jbuilder
@@ -20,10 +20,10 @@ json.property do
 end
 json.proposal do
   json.description planning_application.description
-  if planning_application.reporting_type_detail.present?
+  if planning_application.reporting_type.present?
     json.reportingType do
-      json.code planning_application.reporting_type_detail.code
-      json.description planning_application.reporting_type_detail.description
+      json.code planning_application.reporting_type.code
+      json.description planning_application.reporting_type.description
     end
   else
     json.reportingType nil


### PR DESCRIPTION
### Description of change

Following on from #2215, add `reporting_type` as a reference on PlanningApplication so the original string column isn't needed

### Story Link

https://trello.com/c/GTvuVy6x/144-make-reportingtype-a-direct-association-rather-than-a-string
