### PR TITLE
Remove requirement for pre-app to be public to contact consultees

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -85,8 +85,8 @@ class Consultation < ApplicationRecord
     validate do
       errors.add(:planning_application, :invalidated) if planning_application.invalidated?
       errors.add(:planning_application, :not_started) if planning_application.not_started?
-      errors.add(:planning_application, :not_public) unless planning_application.make_public?
       errors.add(:consultees, :blank) if consultees.none_selected?
+      errors.add(:planning_application, :not_public) unless planning_application.make_public? || planning_application.pre_application?
 
       unknown_placeholders(consultee_message_subject) do |placeholder|
         errors.add(:consultee_message_subject, :invalid, placeholder: placeholder)

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -36,9 +36,11 @@
       </p>
     <% end %>
 
-    <p class="govuk-body">
-      Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
-    </p>
+    <% unless @planning_application.pre_application? %>
+      <p class="govuk-body">
+        Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
+      </p>
+    <% end %>
 
     <p class="govuk-body">
       Application type: <strong><%= @planning_application.application_type.description %></strong>

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -555,6 +555,9 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
       end
 
       context "when application type is preApp" do
+        before do
+          stub_os_places_api_request_for_radius(53.5020957, -1.0205473)
+        end
         let(:params) { json_fixture("v2/preApplication.json").with_indifferent_access }
         let(:planning_application) { create_planning_application }
         let(:service) { described_class.new(local_authority:, user:, params:, planning_application:) }

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -5,8 +5,7 @@ require "rails_helper"
 RSpec.describe "Planning applications", type: :system do
   let!(:local_authority) { create(:local_authority, :default) }
   let!(:planning_application) { create(:planning_application, :pre_application, local_authority:, user:, documents:) }
-  let!(:consultation) { create(:consultation, :started, planning_application:) }
-  let(:consultee) { create(:consultee, consultation:) }
+  let(:consultee) { create(:consultee, consultation: planning_application.consultation) }
   let(:sgid) { consultee.sgid(expires_in: 1.day, for: "magic_link") }
   let(:reference) { planning_application.reference }
   let(:user) { create(:user) }
@@ -17,6 +16,7 @@ RSpec.describe "Planning applications", type: :system do
   end
 
   before do
+    planning_application.consultation.start_deadline
     visit "/consultees/planning_applications/#{reference}?sgid=#{sgid}"
   end
 

--- a/spec/factories/application_type_config.rb
+++ b/spec/factories/application_type_config.rb
@@ -558,13 +558,15 @@ FactoryBot.define do
     trait :pre_application do
       code { "preApp" }
       suffix { "PRE" }
+      steps { %w[validation consultation assessment review] }
 
       features {
         {
           "cil" => false,
           "description_change_requires_validation" => false,
           "eia" => false,
-          "legislative_requirements" => false
+          "legislative_requirements" => false,
+          "consultation_steps" => ["consultee"]
         }
       }
     end

--- a/spec/system/planning_applications/assessing/planning_considerations_and_advice_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_considerations_and_advice_spec.rb
@@ -7,9 +7,8 @@ RSpec.describe "Add planning considerations and advice", type: :system, capybara
   let!(:assessor) { create(:user, :assessor, local_authority:) }
 
   let(:planning_application) do
-    create(:planning_application, :pre_application, :in_assessment, local_authority:, consultation:)
+    create(:planning_application, :pre_application, :in_assessment, local_authority:)
   end
-  let(:consultation) { create(:consultation) }
   let!(:consultee) { create(:consultee, consultation: planning_application.consultation) }
 
   let!(:consultee_response_approved) do


### PR DESCRIPTION

### Description of change

Remove requirement for pre-app to be public to contact consultees. Also removed task from planning application tasklist if application is a pre-app. 

### Story Link

https://trello.com/c/PUlgglHX/473-bug-when-sending-consultation-that-application-needs-to-be-made-public

### Screenshots

![image](https://github.com/user-attachments/assets/acbcb45b-331a-4beb-a8db-8c64f99d27df)

