### PR TITLE
Add aarch64-linux platform to the lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -271,6 +271,7 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.17.1)
+    ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -405,6 +406,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.18.4)
       mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.18.4-aarch64-linux-gnu)
       racc (~> 1.4)
     nokogiri (1.18.4-arm64-darwin)
       racc (~> 1.4)
@@ -658,6 +661,7 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin
   ruby
   x86_64-darwin


### PR DESCRIPTION
Don't build gems when running in Docker.
