### PR TITLE
Show a link to document validation request where appropriate

### DIFF
--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -27,7 +27,11 @@
                 <p class="govuk-body govuk-!-margin-right-2 govuk-!-text-align-right">
                   <%= govuk_link_to "Edit", edit_planning_application_document_path(@planning_application, document) %><br>
                   <%= govuk_link_to "Archive", planning_application_document_archive_path(document_id: document.id) %><br>
-                  <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: @planning_application.reference, document: document, type: "replacement_document") %>
+                  <% if document.replacement_document_validation_request %>
+                    <%= govuk_link_to "Cancel replacement request", show_validation_request_url(@planning_application, document.replacement_document_validation_request) %>
+                  <% else %>
+                    <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: @planning_application.reference, document: document, type: "replacement_document") %>
+                  <% end %>
                 </p>
               <% end %>
             <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -11,7 +11,11 @@
       <%= govuk_link_to t(".archive"), planning_application_document_archive_path(planning_application, document) %>
     </p>
     <p class="govuk-body">
-      <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: planning_application.reference, document: document, type: "replacement_document") %>
+      <% if document.replacement_document_validation_request %>
+        <%= govuk_link_to "Cancel replacement request", show_validation_request_url(planning_application, document.replacement_document_validation_request) %>
+      <% else %>
+        <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: planning_application.reference, document: document, type: "replacement_document") %>
+      <% end %>
     </p>
   <% end %>
 <% else %>

--- a/app/views/planning_applications/assessment/consistency_checklists/_additional_document_validation_request.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_additional_document_validation_request.html.erb
@@ -19,4 +19,7 @@
         planning_application,
         anchor: dom_id(request)
       ) %>
+  <% if request.can_cancel? %>
+    <%= govuk_link_to "Cancel request", cancel_confirmation_planning_application_validation_validation_request_path(@planning_application, request), class: "govuk-!-display-block" %>
+  <% end %>
 <% end %>

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -608,7 +608,6 @@ RSpec.describe "checking consistency" do
       "Additional document requests must be closed or cancelled"
     )
 
-    click_link("View and edit request")
     click_link("Cancel request")
 
     fill_in(

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -136,6 +136,12 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       click_button "Update request"
       expect(page).to have_content("Replacement document request successfully updated")
 
+      click_link "Application"
+      within "#documents-content" do
+        expect(page).to have_content "Cancel replacement request"
+      end
+      click_link "Check and validate"
+
       click_link "Tag and validate supplied documents"
 
       # Delete the request


### PR DESCRIPTION
### Description of change

Currently we're always showing a link to request a replacement even if one is already in the process of being requested. This also makes it hard to cancel requests after the validation stage (when the validation request view isn't so easily accessible). Linking to the management page for an existing request when one exists seems reasonable.

### Story Link

https://trello.com/c/hSnZOHGB/471-be-able-to-cancel-validation-requests-at-any-stage-where-appropriate

### Screenshots

<img width="1138" alt="Screenshot 2025-03-24 at 15 14 05" src="https://github.com/user-attachments/assets/1022caae-6da6-4bc3-8284-e80d830d1565" />

<img width="1134" alt="Screenshot 2025-03-24 at 15 04 31" src="https://github.com/user-attachments/assets/7395f68f-3953-476a-9c29-a8a6d211d872" />