### PR TITLE
Only write published_at when 'make_public' is set

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -255,13 +255,11 @@ class PlanningApplicationsController < AuthenticationController
       town
       uprn
       longitude
-      latitude]
+      latitude
+      make_public]
     # rubocop:enable Naming/VariableNumber
-    permitted_params = params.require(:planning_application).permit permitted_keys
 
-    permitted_params[:published_at] = (params[:planning_application][:make_public] == "true") ? Time.zone.now : nil
-
-    permitted_params
+    params.require(:planning_application).permit(*permitted_keys)
   end
 
   def determination_date_params

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -914,7 +914,12 @@ class PlanningApplication < ApplicationRecord
   alias_method :make_public, :make_public?
 
   def make_public=(value)
-    self[:published_at] = value ? Time.zone.now : nil
+    case value
+    when true, "true"
+      self.published_at ||= Time.zone.now
+    when false, "false"
+      self.published_at = nil
+    end
   end
 
   def documents_for_publication

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -2435,4 +2435,180 @@ RSpec.describe PlanningApplication do
       end
     end
   end
+
+  describe "#make_public=" do
+    subject { described_class.new(published_at: published_at) }
+
+    around do |example|
+      travel_to("2025-03-25T12:00:00Z") { example.run }
+    end
+
+    context "when the value is true" do
+      let(:value) { true }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "sets the value" do
+          expect {
+            subject.make_public = value
+          }.to change {
+            subject.published_at
+          }.from(nil).to("2025-03-25T12:00:00Z".in_time_zone)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone)
+        end
+      end
+    end
+
+    context "when the value is 'true'" do
+      let(:value) { "true" }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "sets the value" do
+          expect {
+            subject.make_public = value
+          }.to change {
+            subject.published_at
+          }.from(nil).to("2025-03-25T12:00:00Z".in_time_zone)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone)
+        end
+      end
+    end
+
+    context "when the value is false" do
+      let(:value) { false }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from(nil)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "sets the value" do
+          expect {
+            subject.make_public = value
+          }.to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone).to(nil)
+        end
+      end
+    end
+
+    context "when the value is 'false'" do
+      let(:value) { "false" }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from(nil)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "sets the value" do
+          expect {
+            subject.make_public = value
+          }.to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone).to(nil)
+        end
+      end
+    end
+
+    context "when the value is nil" do
+      let(:value) { nil }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from(nil)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone)
+        end
+      end
+    end
+
+    context "when the value is something else" do
+      let(:value) { "1" }
+
+      context "and published_at is blank" do
+        let(:published_at) { nil }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from(nil)
+        end
+      end
+
+      context "and published_at is present" do
+        let(:published_at) { "2025-03-25T10:00:00Z" }
+
+        it "doesn't change the value" do
+          expect {
+            subject.make_public = value
+          }.not_to change {
+            subject.published_at
+          }.from("2025-03-25T10:00:00Z".in_time_zone)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Previously we were setting `published_at` to nil if `make_public` wasn't in the params hash.

### Story Link

https://trello.com/c/trL4QYIb
