### PR TITLE
Add pre-application outcomes summary

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -9,6 +9,7 @@ $govuk-page-width: 1100px;
 @import "@x-govuk/govuk-prototype-components/x-govuk/components/sub-navigation/sub-navigation";
 
 // Imports from engines
+@import "bops_core/components/notification_banner";
 @import "bops_core/components/side_navigation";
 @import "bops_core/components/task_accordion";
 @import "bops_core/components/ticket_panel";

--- a/app/controllers/planning_applications/assessment/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment/assessment_details_controller.rb
@@ -106,7 +106,7 @@ module PlanningApplications
       def assessment_details_params
         params
           .require(:assessment_detail)
-          .permit(:entry, :category, NeighbourResponse::TAGS, :untagged)
+          .permit(:entry, :category, NeighbourResponse::TAGS, :untagged, :summary_tag)
           .merge(assessment_status:)
       end
 

--- a/app/helpers/assessment_detail_helper.rb
+++ b/app/helpers/assessment_detail_helper.rb
@@ -20,4 +20,8 @@ module AssessmentDetailHelper
 
     t(:neighbour_responses_by_summary_tag, tag: "neighbour response", count:)
   end
+
+  def summary_advice_content(summary_tag)
+    I18n.t("summary_advice.#{summary_tag}")
+  end
 end

--- a/app/models/application_type/config.rb
+++ b/app/models/application_type/config.rb
@@ -140,20 +140,6 @@ class ApplicationType < ApplicationRecord
       end
     end
 
-    before_update unless: :assessment_details? do
-      self.assessment_details =
-        case name
-        when "lawfulness_certificate"
-          %w[summary_of_work site_description consultation_summary additional_evidence]
-        when "prior_approval"
-          %w[summary_of_work site_description additional_evidence neighbour_summary amenity check_publicity]
-        when "planning_permission"
-          %w[summary_of_work site_description additional_evidence consultation_summary neighbour_summary check_publicity]
-        else
-          %w[summary_of_work site_description additional_evidence consultation_summary neighbour_summary check_publicity]
-        end
-    end
-
     before_update unless: :consistency_checklist? do
       self.consistency_checklist =
         case name

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -14,6 +14,7 @@ class AssessmentDetail < ApplicationRecord
     consultation_summary
     neighbour_summary
     amenity
+    summary_of_advice
     check_publicity
   ].freeze
 
@@ -35,15 +36,19 @@ class AssessmentDetail < ApplicationRecord
     additional_evidence
     neighbour_summary
     amenity
+    summary_of_advice
     check_publicity
   ].index_with(&:to_s)
 
   CATEGORIES = defined_enums["category"].keys.map(&:to_sym).freeze
 
+  enum :summary_tag, %i[complies needs_changes does_not_comply].index_with(&:to_s)
+
   before_validation :set_user
 
   validates :assessment_status, presence: true
   validates :entry, presence: true, if: :validate_entry_presence?
+  validates :summary_tag, presence: true, if: :summary_of_advice?
   validate :tagged_entry, if: :neighbour_summary?
   validates :reviewer_verdict, presence: true, if: :review_complete?
 
@@ -86,7 +91,7 @@ class AssessmentDetail < ApplicationRecord
     return false if accepted? || rejected?
 
     summary_of_work? ||
-      site_description? || amenity? || any_neighbour_responses? ||
+      site_description? || amenity? || summary_of_advice? || any_neighbour_responses? ||
       (assessment_complete? && consultation_summary?)
   end
 

--- a/app/models/consideration_set.rb
+++ b/app/models/consideration_set.rb
@@ -23,6 +23,13 @@ class ConsiderationSet < ApplicationRecord
     end
   end
 
+  def suggested_outcome
+    return "does_not_comply" if considerations.exists?(summary_tag: "does_not_comply")
+    return "needs_changes" if considerations.exists?(summary_tag: "needs_changes")
+
+    "complies"
+  end
+
   private
 
   def mark_as_complete(params)

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -99,7 +99,7 @@ class PlanningApplication < ApplicationRecord
     delegate :planning_permission?
     delegate :work_status
   end
-
+  delegate :consultee_responses, to: :consultation, allow_nil: true
   delegate :reviewer_group_email, to: :local_authority
   with_options prefix: true, allow_nil: true do
     delegate :email, to: :user

--- a/app/views/planning_applications/assessment/assessment_details/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/edit.html.erb
@@ -13,4 +13,6 @@
 <%= render template: "planning_applications/assessment/assessment_details/site_description/edit" %>
 <% when "summary_of_work" %>
 <%= render template: "planning_applications/assessment/assessment_details/summary_of_work/edit" %>
+<% when "summary_of_advice" %>
+<%= render template: "planning_applications/assessment/assessment_details/summary_of_advice/edit" %>
 <% end %>

--- a/app/views/planning_applications/assessment/assessment_details/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/new.html.erb
@@ -13,4 +13,6 @@
 <%= render template: "planning_applications/assessment/assessment_details/site_description/new" %>
 <% when "summary_of_work" %>
 <%= render template: "planning_applications/assessment/assessment_details/summary_of_work/new" %>
+<% when "summary_of_advice" %>
+<%= render template: "planning_applications/assessment/assessment_details/summary_of_advice/new" %>
 <% end %>

--- a/app/views/planning_applications/assessment/assessment_details/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/show.html.erb
@@ -13,4 +13,6 @@
 <%= render template: "planning_applications/assessment/assessment_details/site_description/show" %>
 <% when "summary_of_work" %>
 <%= render template: "planning_applications/assessment/assessment_details/summary_of_work/show" %>
+<% when "summary_of_advice" %>
+<%= render template: "planning_applications/assessment/assessment_details/summary_of_advice/show" %>
 <% end %>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_form.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_form.html.erb
@@ -1,0 +1,21 @@
+<%= form_with model: [@planning_application, :assessment, @assessment_detail] do |form| %>
+  <%= form.govuk_error_summary %>
+  <% outcome = @planning_application.consideration_set.suggested_outcome %>
+
+<%= form.govuk_radio_buttons_fieldset :summary_tag, legend: {text: "Select pre-application outcome", size: "s"}, small: true do %>
+  <% AssessmentDetail.summary_tags.each do |label, value| %>
+    <% key = (value == outcome) ? "#{label}_recommended_html" : label %>
+    <% label_text = t(".#{key}") %>
+    <%= form.govuk_radio_button :summary_tag, value, label: {text: label_text} %>
+  <% end %>
+<% end %>
+
+  <h3 class="govuk-heading-s">
+    Add summary of advice
+  </h3>
+
+  <%= form.govuk_text_area(:entry, label: {text: t(".label")}, rows: 10) %>
+  <%= form.hidden_field(:category, value: @category) %>
+
+  <%= render(partial: "shared/submit_buttons", locals: {form: form}) %>
+<% end %>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
@@ -1,0 +1,74 @@
+<%= govuk_tabs do |tabs| %>
+  <% tabs.with_tab(label: "Considerations") do %>
+    <h2 class="govuk-heading-m">Considerations</h2>
+    <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+    <div class="govuk-!-margin-bottom-5">
+      <% @planning_application.consideration_set.considerations.active.each do |consideration| %>
+        <%= bops_status_detail(
+              id: "consideration-#{consideration.id}"
+            ) do |component| %>
+          <% component.with_title { consideration.policy_area } %>
+          <% component.with_body { consideration.policy_references.map(&:code_and_description).join("; ") } %>
+          <% component.with_status do %>
+            <% case consideration.summary_tag %>
+            <% when "needs_changes" %>
+              <%= tag.span(t(".needs_changes"), class: "govuk-tag govuk-tag--yellow") %>
+            <% when "does_not_comply" %>
+              <%= tag.span(t(".does_not_comply"), class: "govuk-tag govuk-tag--red") %>
+            <% when "complies" %>
+              <%= tag.span(t(".complies"), class: "govuk-tag govuk-tag--green") %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <%= govuk_link_to "View considerations", planning_application_assessment_consideration_guidances_path(@planning_application), new_tab: true %>
+  <% end %>
+
+  <% tabs.with_tab(label: "Consultees") do %>
+    <h2 class="govuk-heading-m">Consultees</h2>
+    <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+    <div class="govuk-!-margin-bottom-5">
+      <% @planning_application.consultee_responses.each do |consultee_response| %>
+        <%= bops_status_detail(
+              id: "consultee-response-#{consultee_response.id}"
+            ) do |component| %>
+          <% component.with_title { consultee_response.name } %>
+          <% component.with_body { consultee_response.comment } %>
+          <% component.with_status do %>
+            <% case consultee_response.summary_tag %>
+            <% when "amendments_needed" %>
+              <%= tag.span(t(".amendments_needed"), class: "govuk-tag govuk-tag--yellow") %>
+            <% when "objected" %>
+              <%= tag.span(t(".objected"), class: "govuk-tag govuk-tag--red") %>
+            <% when "approved" %>
+              <%= tag.span(t(".approved"), class: "govuk-tag govuk-tag--green") %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <%= govuk_link_to "View consultee responses", planning_application_consultees_responses_path(@planning_application), new_tab: true %>
+  <% end %>
+
+  <% tabs.with_tab(label: "Constraints") do %>
+    <h2 class="govuk-heading-m">Constraints</h2>
+    <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+
+    <%= render(
+          partial: "planning_applications/validation/constraints/table",
+          locals: {
+            title: "Identified constraints",
+            identifier: "identified",
+            planning_application_constraints: @planning_application.planning_application_constraints,
+            show_source: true,
+            show_entity: true,
+            show_action: false
+          }
+        ) %>
+  <% end %>
+<% end %>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/edit.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% content_for :title, t(".breadcrumb") %>
+
+<%= render(partial: "shared/assessment_task_breadcrumbs", locals: {planning_application: @planning_application}) %>
+<%= render(partial: "shared/proposal_header", locals: {heading: t(".title")}) %>
+
+<div class="govuk-grid-row">
+  <%= render "planning_applications/assessment/assessment_details/summary_of_advice/tabs" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "planning_applications/assessment/assessment_details/summary_of_advice/form" %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/new.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% content_for :title, t(".breadcrumb") %>
+
+<%= render(partial: "shared/assessment_task_breadcrumbs", locals: {planning_application: @planning_application}) %>
+<%= render(partial: "shared/proposal_header", locals: {heading: t(".title")}) %>
+
+<div class="govuk-grid-row">
+  <%= render "planning_applications/assessment/assessment_details/summary_of_advice/tabs" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Check pre-application outcome</h2>
+    <p class="govuk-body">This is a suggested outcome based on your assessment. If you'd like to change it, you can select the outcome.</p>
+
+    <%= render "planning_applications/assessment/assessment_details/summary_of_advice/form" %>
+  </div>
+</div>

--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/show.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/show.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title do %>
+  <%= t(".title") %> - <%= t("page_title") %>
+<% end %>
+
+<% content_for :title, t(".breadcrumb") %>
+
+<%= render(partial: "shared/assessment_task_breadcrumbs", locals: {planning_application: @planning_application}) %>
+<%= render(partial: "shared/proposal_header", locals: {heading: t(".title")}) %>
+
+<div class="govuk-grid-row">
+  <%= render "planning_applications/assessment/assessment_details/summary_of_advice/tabs" %>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @assessment_detail.summary_tag %>
+      <% content = summary_advice_content(@assessment_detail.summary_tag) %>
+      <%= bops_notification_banner(
+            title: "Outcome",
+            **content
+          ) %>
+    <% end %>
+
+    <p class="govuk-body">
+      <%= render(FormattedContentComponent.new(text: @assessment_detail.entry)) %>
+    </p>
+
+    <div class="govuk-button-group">
+      <%= back_link %>
+      <%= govuk_link_to t(".edit"), [:edit, @planning_application, :assessment, @assessment_detail, category: @category] %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1184,6 +1184,36 @@ en:
             warning: This information WILL be made publicly available.
           updated:
             success: Site description was successfully updated.
+        summary_of_advice:
+          created:
+            success: Summary of advice was successfully created.
+          edit:
+            breadcrumb: Summary of advice
+            title: Edit summary of advice
+          form:
+            complies: Likely to be supported_html
+            complies_recommended_html: Likely to be supported <strong>(recommended based on considerations)</strong>
+            does_not_comply: Unlikely to be supported
+            does_not_comply_recommended_html: Unlikely to be supported <strong>(recommended based on considerations)</strong>
+            label: Enter summary of planning considerations and advice. This should summarise any changes the applicant needs to make before they make an application.
+            needs_changes: Likely to be supported with changes
+            needs_changes_recommended_html: Likely to be supported with changes <strong>(recommended based on considerations)</strong>
+          new:
+            breadcrumb: Summary of advice
+            title: Add summary of advice
+          show:
+            breadcrumb: Summary of advice
+            edit: Edit summary of advice
+            title: Summary of advice
+          tabs:
+            amendments_needed: Amendments Needed
+            approved: Approved
+            complies: Complies
+            does_not_comply: Does not comply
+            needs_changes: Needs changes
+            objected: Objected
+          updated:
+            success: Summary of advice was successfully updated.
         summary_of_work:
           created:
             success: Summary of works was successfully created.
@@ -2271,6 +2301,19 @@ en:
     returned: Returned
     to_be_reviewed: Corrections requested
     withdrawn: Withdrawn
+  summary_advice:
+    complies:
+      colour: green
+      message: Your proposal is likely to be supported based on the information you have provided.
+      subheading: Likely to be supported
+    does_not_comply:
+      colour: red
+      message: Your proposal includes elements that do not comply with current planning policy.
+      subheading: Unlikely to be supported
+    needs_changes:
+      colour: orange
+      message: Your proposal is generally acceptable, provided you address the recommended changes in this report.
+      subheading: Likely to be supported with changes
   task_list_items:
     additional_document_component:
       check_missing_documents: Check and request documents
@@ -2284,6 +2327,7 @@ en:
         consultation_summary: Summary of consultation
         neighbour_summary: Summary of neighbour responses
         site_description: Site description
+        summary_of_advice: Summary of advice
         summary_of_work: Summary of works
       considerations_component:
         link_text: Assess against policies and guidance

--- a/db/migrate/20250324155402_add_summary_of_advice_to_assessment_details.rb
+++ b/db/migrate/20250324155402_add_summary_of_advice_to_assessment_details.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddSummaryOfAdviceToAssessmentDetails < ActiveRecord::Migration[7.2]
+  def up
+    ApplicationType::Config.find_by(code: "preApp").try(:tap) do |pre_app|
+      pre_app.assessment_details << "summary_of_advice"
+      pre_app.save
+    end
+  end
+
+  def down
+    ApplicationType::Config.find_by(code: "preApp").try(:tap) do |pre_app|
+      pre_app.assessment_details.delete("summary_of_advice")
+      pre_app.save
+    end
+  end
+end

--- a/db/migrate/20250325115851_add_summary_tag_to_assessment_details.rb
+++ b/db/migrate/20250325115851_add_summary_tag_to_assessment_details.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSummaryTagToAssessmentDetails < ActiveRecord::Migration[7.2]
+  def change
+    add_column :assessment_details, :summary_tag, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -160,6 +160,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_26_120937) do
     t.string "category", null: false
     t.string "reviewer_verdict"
     t.string "review_status"
+    t.string "summary_tag"
     t.index ["planning_application_id"], name: "ix_assessment_details_on_planning_application_id"
     t.index ["user_id"], name: "ix_assessment_details_on_user_id"
   end

--- a/engines/bops_core/app/assets/stylesheets/bops_core/components/_notification_banner.scss
+++ b/engines/bops_core/app/assets/stylesheets/bops_core/components/_notification_banner.scss
@@ -1,0 +1,30 @@
+@use "sass:map";
+
+.bops-notification-banner {
+  $notification_colours: (
+    "green": (
+      "background-color": govuk-colour("green"),
+      "border-color": govuk-colour("green")
+    ),
+    "orange": (
+      "background-color": govuk-colour("orange"),
+      "border-color": govuk-colour("orange")
+    ),
+    "red": (
+      "background-color": govuk-colour("red"),
+      "border-color": govuk-colour("red")
+    )
+  );
+
+  $default_colour: map.get($notification_colours, "green");
+
+  background-color: map.get($default_colour, "background-color");
+  border: 5px solid map.get($default_colour, "border-color");
+
+  @each $name, $attributes in $notification_colours {
+    &--#{$name} {
+      background-color: map.get($attributes, "background-color");
+      border-color: map.get($attributes, "border-color");
+    }
+  }
+}

--- a/engines/bops_core/app/components/bops_core/notification_banner_component.rb
+++ b/engines/bops_core/app/components/bops_core/notification_banner_component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module BopsCore
+  class NotificationBannerComponent < GovukComponent::Base
+    attr_reader :title, :colour, :subheading, :message
+
+    def initialize(title:, colour:, subheading:, message:, classes: [], html_attributes: {})
+      @title = title
+      @colour = colour
+      @subheading = subheading
+      @message = message
+
+      super(classes:, html_attributes:)
+    end
+
+    def call
+      tag.div(**default_attributes) do
+        safe_join([header_content, body_content])
+      end
+    end
+
+    private
+
+    def header_content
+      tag.div(class: "govuk-notification-banner__header") do
+        tag.h2(title, class: "govuk-notification-banner__title", id: "govuk-notification-banner-title")
+      end
+    end
+
+    def body_content
+      tag.div(class: "govuk-notification-banner__content") do
+        safe_join([tag.h2(subheading), tag.p(message)])
+      end
+    end
+
+    def default_attributes
+      {
+        role: "region",
+        "aria-labelledby": "govuk-notification-banner-title",
+        "data-module": "govuk-notification-banner",
+        "data-govuk-notification-banner-init": "",
+        class: ["govuk-notification-banner", colour_class]
+      }
+    end
+
+    def colour_class
+      "bops-notification-banner--#{colour}"
+    end
+  end
+end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -10,7 +10,8 @@ module BopsCore
       bops_sub_navigation: "BopsCore::SubNavigationComponent",
       bops_task_accordion: "BopsCore::TaskAccordionComponent",
       bops_ticket_panel: "BopsCore::TicketPanelComponent",
-      bops_status_detail: "BopsCore::StatusDetailComponent"
+      bops_status_detail: "BopsCore::StatusDetailComponent",
+      bops_notification_banner: "BopsCore::NotificationBannerComponent"
     }.each do |name, klass|
       define_method(name) do |*args, **kwargs, &block|
         capture do

--- a/engines/bops_core/spec/components/bops_core/notification_banner_component_spec.rb
+++ b/engines/bops_core/spec/components/bops_core/notification_banner_component_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe(BopsCore::NotificationBannerComponent, type: :component) do
+  context "with default attributes" do
+    subject! do
+      render_inline(described_class.new(
+        title: "Outcome",
+        colour: "green",
+        subheading: "Likely to be supported",
+        message: "Your proposal is likely to be supported based on the information you have provided."
+      ))
+    end
+
+    it "renders the notification banner component" do
+      expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--green")
+      within ".govuk-notification-banner__header" do
+        expect(page).to have_css(".govuk-notification-banner__title", text: "Outcome")
+      end
+      within ".govuk-notification-banner__content" do
+        expect(page).to have_css("h2", text: "Likely to be supported")
+        expect(page).to have_css("p", text: "Your proposal is likely to be supported based on the information you have provided.")
+      end
+    end
+  end
+
+  context "with different colours" do
+    %w[green orange red grey].each do |colour|
+      context "with the colour: #{colour}" do
+        subject! do
+          render_inline(described_class.new(
+            title: "Outcome",
+            colour: colour,
+            subheading: "Test Subheading",
+            message: "Test Message"
+          ))
+        end
+
+        it "renders the notification banner with the correct colour class" do
+          expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--#{colour}")
+        end
+      end
+    end
+  end
+
+  context "with HTML content in the message" do
+    subject! do
+      render_inline(described_class.new(
+        title: "Outcome",
+        colour: "blue",
+        subheading: "Additional Information",
+        message: <<~HTML.html_safe
+          <p>This is a detailed explanation of the outcome.</p>
+          <p>More details can be found <a href='https://example.com'>here</a>.</p>
+        HTML
+      ))
+    end
+
+    it "renders the message with HTML content" do
+      within ".govuk-notification-banner__content" do
+        expect(page).to have_css("p", text: "This is a detailed explanation of the outcome.")
+        expect(page).to have_link("here", href: "https://example.com")
+      end
+    end
+  end
+end

--- a/spec/factories/application_type_config.rb
+++ b/spec/factories/application_type_config.rb
@@ -569,6 +569,16 @@ FactoryBot.define do
           "consultation_steps" => ["consultee"]
         }
       }
+
+      assessment_details do
+        %w[
+          summary_of_work
+          summary_of_advice
+          site_description
+          consultation_summary
+          additional_evidence
+        ]
+      end
     end
 
     trait :without_consultation do

--- a/spec/factories/assessment_detail.rb
+++ b/spec/factories/assessment_detail.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
     entry { "This is a description about the summary of works" }
 
     AssessmentDetail.categories.each_key do |category|
+      if category == "summary_of_advice"
+        summary_tag { :needs_changes }
+      end
+
       trait category do
         category { category }
       end

--- a/spec/models/assessment_detail_spec.rb
+++ b/spec/models/assessment_detail_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe AssessmentDetail do
       end
     end
 
+    describe "#summary_tag" do
+      it "validates presence of summary_tag" do
+        assessment_detail = build(:assessment_detail, category: :summary_of_advice, summary_tag: nil)
+
+        expect(assessment_detail.valid?).to be(false)
+        expect(assessment_detail.errors[:summary_tag]).to include("can't be blank")
+      end
+    end
+
     described_class.categories.each_key do |category_type|
       let(:category) { described_class.new(category: category_type) }
 

--- a/spec/models/consideration_set_spec.rb
+++ b/spec/models/consideration_set_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ConsiderationSet, type: :model do
+  describe "#suggested_outcome" do
+    let(:consideration_set) { create(:consideration_set) }
+
+    context "when a consideration has 'does_not_comply' tag" do
+      before do
+        create(:consideration, consideration_set:, summary_tag: "does_not_comply")
+      end
+
+      it "returns 'does_not_comply'" do
+        expect(consideration_set.suggested_outcome).to eq("does_not_comply")
+      end
+    end
+
+    context "when no consideration has 'does_not_comply' but at least one has 'needs_changes' tag" do
+      before do
+        create(:consideration, consideration_set:, summary_tag: "needs_changes")
+      end
+
+      it "returns 'needs_changes'" do
+        expect(consideration_set.suggested_outcome).to eq("needs_changes")
+      end
+    end
+
+    context "when all considerations have 'complies' tag" do
+      before do
+        create(:consideration, consideration_set:, summary_tag: "complies")
+        create(:consideration, consideration_set:, summary_tag: "complies")
+      end
+
+      it "returns 'complies'" do
+        expect(consideration_set.suggested_outcome).to eq("complies")
+      end
+    end
+
+    context "when there are no considerations" do
+      it "returns 'complies' by default" do
+        expect(consideration_set.suggested_outcome).to eq("complies")
+      end
+    end
+  end
+end

--- a/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
+++ b/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Summary of Advice", type: :system, capybara: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let!(:assessor) { create(:user, :assessor, local_authority:) }
+
+  let(:planning_application) do
+    create(:planning_application, :pre_application, :in_assessment, local_authority:)
+  end
+  let!(:consultee) { create(:consultee, consultation: planning_application.consultation) }
+
+  let!(:consultee_response_approved) do
+    create(:consultee_response, name: "Heritage Officer", summary_tag: "approved", response: "No objections.", received_at: 2.days.ago, consultee:)
+  end
+
+  let!(:consultee_response_objected) do
+    create(:consultee_response, name: "Environmental Agency", summary_tag: "objected", response: "Significant flooding risks identified.", received_at: 3.days.ago, consultee:)
+  end
+
+  let!(:consideration_set) { create(:consideration_set, planning_application:) }
+
+  before do
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.reference}"
+    click_link "Check and assess"
+  end
+
+  it "displays considerations, consultee and constraints tabs" do
+    click_link "Summary of advice"
+
+    within(".govuk-tabs") do
+      expect(page).to have_css("#considerations")
+      expect(page).to have_css("#consultees")
+      expect(page).to have_css("#constraints")
+    end
+  end
+
+  context "when displaying the summary of advice" do
+    it "shows the outcome based on considerations" do
+      create(:consideration, consideration_set:, summary_tag: "does_not_comply")
+
+      click_link "Summary of advice"
+      expect(page).to have_content("Unlikely to be supported (recommended based on considerations)")
+    end
+
+    it "shows needs_changes when no does_not_comply exists" do
+      create(:consideration, consideration_set:, summary_tag: "needs_changes")
+
+      click_link "Summary of advice"
+      expect(page).to have_content("Likely to be supported with changes (recommended based on considerations)")
+    end
+
+    it "shows complies when all considerations comply" do
+      create(:consideration, consideration_set:, summary_tag: "complies")
+
+      click_link "Summary of advice"
+      expect(page).to have_content("Likely to be supported (recommended based on considerations)")
+    end
+  end
+
+  context "when adding summary of advice" do
+    it "allows adding a new summary of advice" do
+      within("#assessment-information-tasks") do
+        expect(page).to have_content("Not started")
+        click_link "Summary of advice"
+      end
+
+      choose "Likely to be supported (recommended based on considerations)"
+      fill_in "Enter summary of planning considerations and advice. This should summarise any changes the applicant needs to make before they make an application.", with: "This proposal complies with all planning regulations."
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Summary of advice was successfully created.")
+      within("#assessment-information-tasks") do
+        expect(page).to have_content("Completed")
+        click_link "Summary of advice"
+      end
+      expect(page).to have_content("This proposal complies with all planning regulations.")
+      expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--green")
+
+      click_link "Edit summary of advice"
+      fill_in "Enter summary of planning considerations and advice. This should summarise any changes the applicant needs to make before they make an application.", with: "Updated summary of advice."
+      choose "Likely to be supported with changes"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Summary of advice was successfully updated")
+      click_link "Summary of advice"
+      expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--orange")
+
+      click_link "Edit summary of advice"
+      choose "Unlikely to be supported"
+      click_button "Save and mark as complete"
+      click_link "Summary of advice"
+      expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--red")
+    end
+
+    it "shows validation errors when no summary tag is selected" do
+      click_link "Summary of advice"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Summary tag can't be blank")
+      expect(page).to have_content("Entry can't be blank")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add pre-application outcomes summary 
- View suggested outcome based on response to considerations
- Enable officer to manually choose an outcome
- Add and edit the outcome and summary of advice

### Story Link

https://trello.com/c/W5CJSjtM/426-add-pre-application-outcomes-summary

### Screenshots
<img width="729" alt="Screenshot 2025-03-28 at 12 34 05" src="https://github.com/user-attachments/assets/8279f2e3-b5ef-4158-80d5-b4b1e8ab6a87" />

--------------------

<img width="767" alt="Screenshot 2025-03-28 at 12 34 28" src="https://github.com/user-attachments/assets/e8c15beb-945b-445b-b913-17af3526a1d1" />

