### PR TITLE
Add report view for preapps

### DIFF
--- a/app/controllers/planning_applications/review/reports_controller.rb
+++ b/app/controllers/planning_applications/review/reports_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PlanningApplications
+  module Review
+    class ReportsController < BaseController
+      def show
+        redirect_to planning_application_path(@planning_application) unless @planning_application.pre_application?
+
+        summary_tags = @planning_application.assessment_details.map(&:summary_tag)
+        @outcome_status = if summary_tags.any?(:does_not_comply)
+          :does_not_comply
+        elsif summary_tags.present? && summary_tags.all?(:complies)
+          :complies
+        else
+          :needs_changes
+        end
+      end
+    end
+  end
+end

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -83,7 +83,13 @@
         </div>
       </li>
     <% end %>
-    <% unless @planning_application.pre_application? %>
+    <% if @planning_application.pre_application? %>
+      <li class="app-task-list__item">
+        <span class="app-task-list__task-name">
+          <%= govuk_link_to "Review and submit pre-application", planning_application_review_report_path(@planning_application), aria: {describedby: "submit_preapplication-completed"} %>
+        </span>
+      </li>
+    <% else %>
       <li class="app-task-list__item">
         <span class="app-task-list__task-name">
           <% if @planning_application.can_submit_recommendation? %>

--- a/app/views/planning_applications/review/reports/show.html.erb
+++ b/app/views/planning_applications/review/reports/show.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title do %>
+  Pre-application report - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+<% add_parent_breadcrumb_link "Review pre-application", planning_application_review_root_path(@planning_application) %>
+<% content_for :title, "Pre-application report" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds" id="planning-application-details">
+    <p class="govuk-caption-m">Preview and submit</p>
+    <h1 class="govuk-heading-l">Pre-application report</h1>
+    <p class="govuk-body">
+      This report gives clear guidance on your proposal, helping you to
+      understand what to expect when submitting your formal planning
+      application.
+    </p>
+    <p class="govuk-body">
+      <strong><%= @planning_application.full_address %></strong><br>
+      Pre-application number: <strong><%= @planning_application.reference %></strong><br>
+      Case officer: <strong><%= @planning_application.user&.name || "Unassigned" %></strong><br>
+      Date of report: <strong><%= @planning_application.determined_at&.to_date&.to_fs %></strong><br>
+      </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m govuk-!-margin-top-5">
+        Pre-application outcome
+      </h2>
+
+      <%= bops_notification_banner(
+            title: "Outcome",
+            **summary_advice_content(@outcome_status)
+          ) %>
+    <%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,8 @@ Rails.application.routes.draw do
           resources :recommendations, only: %i[new create update edit]
 
           resource :pre_commencement_conditions, only: %i[edit update show]
+
+          resource :report, only: %i[show]
         end
       end
     end


### PR DESCRIPTION
### Description of change

Add a skeleton page for the preapp report with a status header, ready for filling in subcategory details.

### Story Link

https://trello.com/c/Vqz7SsJd/554-pre-app-final-advice-report-skeleton

### Screenshots

<img width="786" alt="Screenshot 2025-03-31 at 10 11 54" src="https://github.com/user-attachments/assets/9a7f7cf6-fd92-4e7c-acdb-5106b156bbd0" />
