### PR TITLE
Remove add informative option for pre-app

### DIFF
--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -48,7 +48,7 @@
             )
           ) %>
     <% end %>
-    <% if @planning_application.informatives? %>
+    <% if @planning_application.informatives?  && !@planning_application.pre_application? %>
       <%= render(
             TaskListItems::Assessment::InformativesComponent.new(
               planning_application: @planning_application


### PR DESCRIPTION
### Description of change

Remove option to 'add informatives' for pre-app assessment. Missed from PR 2234: https://github.com/unboxed/bops/pull/2234

### Story Link

https://trello.com/c/9QqhJ2av

### Screenshots

<img width="882" alt="image" src="https://github.com/user-attachments/assets/0721ff57-f45e-46ef-b12f-be3135c25b18" />
