### PR TITLE
Remove unnecessary usually-hidden text from login page

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -12,10 +12,6 @@
       <% end %>
     </h1>
 
-    <h2 class="govuk-tabs__title">
-      Log in
-    </h2>
-
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
       <div class="govuk-form-group">
         <div class="field">


### PR DESCRIPTION
This only appears on mobile, is not correctly styled, and is not used or needed.