### PR TITLE
Add pre-application details to report

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -296,7 +296,7 @@ $govuk-page-width: 1100px;
   }
 }
 
-.proposal-details-sub-heading {
+.flex-between {
   display: flex;
   justify-content: space-between;
 }

--- a/app/components/proposal_details/group_component.html.erb
+++ b/app/components/proposal_details/group_component.html.erb
@@ -4,7 +4,7 @@
         show_hide_target: ("toggleable" if auto_answered?)
       }
     ) do %>
-  <div class="proposal-details-sub-heading">
+  <div class="flex-between">
     <h4 class="govuk-heading-s" id="<%= id %>"><%= title %></h4>
     <div>
       <%= render(

--- a/app/controllers/concerns/return_to_report.rb
+++ b/app/controllers/concerns/return_to_report.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ReturnToReport
+  extend ActiveSupport::Concern
+
+  private
+
+  def store_return_to_report_path
+    return unless params[:return_to] == "report"
+    return unless @planning_application.pre_application?
+
+    session[:return_to_report_paths] ||= {}
+    session[:return_to_report_paths][@planning_application.reference] = true
+  end
+
+  def report_path_or(default_path)
+    if session.dig(:return_to_report_paths, @planning_application.reference)
+      session[:return_to_report_paths].delete(@planning_application.reference)
+      planning_application_review_report_path(@planning_application)
+    else
+      default_path
+    end
+  end
+end

--- a/app/controllers/planning_applications/assessment/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment/assessment_details_controller.rb
@@ -3,11 +3,14 @@
 module PlanningApplications
   module Assessment
     class AssessmentDetailsController < BaseController
+      include ReturnToReport
+
       before_action :set_assessment_detail, only: %i[show edit update]
       before_action :set_category, :set_rejected_assessment_detail, only: %i[new create edit update show]
       before_action :set_consultation, if: :has_consultation_and_summary?
       before_action :set_neighbour_responses, if: :neighbour_summary?
       before_action :set_site_and_press_notices, if: :check_publicity?
+      before_action :store_return_to_report_path, only: [:edit]
 
       def show
         respond_to do |format|
@@ -146,11 +149,13 @@ module PlanningApplications
       end
 
       def redirect_path
-        if current_user.reviewer?
+        path = if current_user.reviewer?
           planning_application_review_tasks_path(@planning_application)
         else
           planning_application_assessment_tasks_path(@planning_application)
         end
+
+        report_path_or(path)
       end
     end
   end

--- a/app/controllers/planning_applications/assessment/meetings_controller.rb
+++ b/app/controllers/planning_applications/assessment/meetings_controller.rb
@@ -3,8 +3,11 @@
 module PlanningApplications
   module Assessment
     class MeetingsController < AuthenticationController
+      include ReturnToReport
+
       before_action :set_planning_application
       before_action :build_meeting, only: %i[new create index]
+      before_action :store_return_to_report_path, only: [:index]
 
       def index
         @meetings = @planning_application.meetings.by_occurred_at_desc.includes(:created_by)
@@ -29,7 +32,7 @@ module PlanningApplications
         respond_to do |format|
           if @meeting.update(meeting_params)
             format.html do
-              redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+              redirect_to redirect_path, notice: t(".success")
             end
           else
             format.html { render :new }
@@ -47,6 +50,10 @@ module PlanningApplications
 
       def build_meeting
         @meeting = @planning_application.meetings.new
+      end
+
+      def redirect_path
+        report_path_or(planning_application_assessment_tasks_path(@planning_application))
       end
     end
   end

--- a/app/controllers/planning_applications/review/reports_controller.rb
+++ b/app/controllers/planning_applications/review/reports_controller.rb
@@ -3,16 +3,15 @@
 module PlanningApplications
   module Review
     class ReportsController < BaseController
+      skip_before_action :ensure_user_is_reviewer
+
       def show
         redirect_to planning_application_path(@planning_application) unless @planning_application.pre_application?
 
-        summary_tags = @planning_application.assessment_details.map(&:summary_tag)
-        @outcome_status = if summary_tags.any?(:does_not_comply)
-          :does_not_comply
-        elsif summary_tags.present? && summary_tags.all?(:complies)
-          :complies
-        else
-          :needs_changes
+        @summary_of_advice = @planning_application.assessment_details.summary_of_advice.last
+
+        respond_to do |format|
+          format.html
         end
       end
     end

--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -3,6 +3,8 @@
 module PlanningApplications
   module Validation
     class ValidationRequestsController < BaseController
+      include ReturnToReport
+
       rescue_from Notifications::Client::NotFoundError, with: :validation_notice_request_error
       rescue_from Notifications::Client::ServerError, with: :validation_notice_request_error
       rescue_from Notifications::Client::RequestError, with: :validation_notice_request_error
@@ -17,6 +19,7 @@ module PlanningApplications
       before_action :ensure_planning_application_not_validated, only: %i[new create edit update]
       before_action :ensure_planning_application_not_invalidated, only: :edit
       before_action :ensure_planning_application_is_not_closed_or_cancelled, only: %i[new create]
+      before_action :store_return_to_report_path, only: %i[new]
 
       def index
         validation_requests = @planning_application.requests_excluding_time_extension.where(post_validation: false)

--- a/app/javascript/controllers/edit_form_controller.js
+++ b/app/javascript/controllers/edit_form_controller.js
@@ -5,7 +5,7 @@ export default class extends Controller {
     event.preventDefault()
 
     event.currentTarget.parentElement.parentElement.classList.remove(
-      "proposal-details-sub-heading",
+      "flex-between",
     )
     event.currentTarget.parentElement.parentElement
       .querySelector(".govuk-body")

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -114,7 +114,10 @@ class PlanningApplication < ApplicationRecord
     delegate :required?, to: :environment_impact_assessment
     delegate :suffix, to: :application_type
     delegate :rejected_review?, to: :committee_decision
+    delegate :visited_at, to: :site_visit
+    delegate :occurred_at, to: :meeting
   end
+
   with_options to: :planx_planning_data, allow_nil: true do
     delegate :params_v1
     delegate :params_v2
@@ -914,6 +917,10 @@ class PlanningApplication < ApplicationRecord
 
   def site_visit
     site_visits.first
+  end
+
+  def meeting
+    meetings.first
   end
 
   def make_public?

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -45,6 +45,7 @@ class ValidationRequest < ApplicationRecord
 
   scope :closed, -> { where(state: "closed") }
   scope :active, -> { where.not(state: "cancelled") }
+  scope :approved, -> { where(approved: true) }
   scope :cancelled, -> { where(state: "cancelled") }
   scope :pending, -> { where(state: "pending") }
   scope :not_cancelled, -> { where(cancelled_at: nil) }

--- a/app/views/planning_applications/neighbour_letter_batches/index.html.erb
+++ b/app/views/planning_applications/neighbour_letter_batches/index.html.erb
@@ -28,7 +28,7 @@
           Date sent: <%= batch.created_at.to_date.to_fs %>
         <% end %>
         <% section.with_footer do %>
-          <div class="display-flex" style="justify-content: space-between">
+          <div class="flex-between">
             <p class="govuk-body">
               Response period: <%= @planning_application.consultation.consultee_response_period %> days
             </p>

--- a/app/views/planning_applications/neighbours/_selected_list.html.erb
+++ b/app/views/planning_applications/neighbours/_selected_list.html.erb
@@ -4,7 +4,7 @@
       <% accordion.with_section(heading_text: "Neighours already selected") do %>
         <% @consultation.neighbours.select(&:persisted?).sort_by(&:id).each do |neighbour| %>
         <hr>
-        <div class="proposal-details-sub-heading" data-controller="edit-form">
+        <div class="flex-between" data-controller="edit-form">
           <div class="govuk-!-width-three-quarters govuk-!-margin-top-1">
             <p class="govuk-body">
               <%= neighbour.address %>

--- a/app/views/planning_applications/review/reports/show.html.erb
+++ b/app/views/planning_applications/review/reports/show.html.erb
@@ -25,30 +25,108 @@
   </div>
 </div>
 
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
 <%= render BopsCore::TableOfContentsComponent.new(items: [
-      ## a section with no heading
-      # {links: [
-      #  ["foo", "#"]  # links are arrays containing two items, text and href
-      # ]},
-      ## sections with headings
-      # {title: "first", links: [
-      #  ["foo", "#"]
-      # ]},
-      # {title: "second", links: [
-      #  ["bar", "#"]
-      # ]}
+      {links: [
+        ["Pre-application outcome", "#pre-application-outcome"],
+        ["Your pre-application details", "#pre-application-details"]
+      ]}
     ]) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m govuk-!-margin-top-5">
-        Pre-application outcome
-      </h2>
+<section id="pre-application-outcome">
+  <div class="govuk-grid-row">
+    <div class="flex-between govuk-!-margin-bottom-2">
+      <h2 class="govuk-heading-m">Pre-application outcome</h2>
+      <%= govuk_link_to "Edit", edit_planning_application_assessment_assessment_detail_path(
+            @planning_application, @summary_of_advice, category: "summary_of_advice", return_to: "report"
+          ) %>
+    </div>
 
+    <% if @summary_of_advice.summary_tag %>
+      <% content = summary_advice_content(@summary_of_advice.summary_tag) %>
       <%= bops_notification_banner(
             title: "Outcome",
-            **summary_advice_content(@outcome_status)
+            **content
           ) %>
-    <%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>
+    <% else %>
+      <p class="govuk-body">The pre-application outcome has not been set.</p>
+    <% end %>
   </div>
-</div>
+</section>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<section id="pre-application-details">
+  <h2 class="govuk-heading-m">
+    Your pre-application details
+  </h2>
+
+  <%= govuk_table(id: "pre-application-details-table") do |table| %>
+    <% table.with_caption(size: "s", text: "This section summarises your proposal and key dates in the pre-application process.") %>
+
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% row.with_cell(text: "Event") %>
+        <% row.with_cell(text: "Date") %>
+        <% row.with_cell(text: "Action") %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: "Date made valid") %>
+        <% row.with_cell(text: time_tag(@planning_application.validated_at)) %>
+        <% row.with_cell(text: "-") %>
+      <% end %>
+
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: "Site visit") %>
+        <% if @planning_application.site_visit_visited_at %>
+          <% row.with_cell(text: time_tag(@planning_application.site_visit_visited_at)) %>
+        <% else %>
+          <% row.with_cell(text: "-") %>
+        <% end %>
+        <% row.with_cell do %>
+          <%= govuk_link_to "Edit", planning_application_assessment_site_visits_path(@planning_application, return_to: "report") %>
+        <% end %>
+      <% end %>
+
+      <% body.with_row do |row| %>
+        <% row.with_cell(text: "Meeting") %>
+        <% if @planning_application.meeting_occurred_at %>
+          <% row.with_cell(text: time_tag(@planning_application.meeting_occurred_at)) %>
+        <% else %>
+          <% row.with_cell(text: "-") %>
+        <% end %>
+          <% row.with_cell do %>
+            <%= govuk_link_to "Edit", planning_application_assessment_meetings_path(@planning_application, return_to: "report") %>
+          <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <div id="proposal-description">
+    <div class="display-flex justify-between govuk-!-margin-bottom-2">
+      <h3 class="govuk-heading-s">Description of your proposal</h3>
+      <%= govuk_link_to "Edit", new_planning_application_validation_validation_request_path(
+            @planning_application,
+            type: "description_change",
+            return_to: "report"
+          ) %>
+    </div>
+    <p class="govuk-body"><%= @planning_application.description %></p>
+
+    <% if @planning_application.description_change_validation_requests.approved.any? %>
+      <%= govuk_inset_text do %>
+        <p>
+          <strong>Note:</strong> The case officer has updated the description to accurately reflect the proposed development.
+        </p>
+      <% end %>
+    <% end %>
+  </div>
+</section>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>

--- a/app/views/planning_applications/site_notices/_status.html.erb
+++ b/app/views/planning_applications/site_notices/_status.html.erb
@@ -1,5 +1,5 @@
 <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-top-7">
-<div class="proposal-details-sub-heading govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-controller="pdf">
+<div class="flex-between govuk-!-margin-top-3 govuk-!-margin-bottom-3" data-controller="pdf">
   <p class="govuk-body govuk-!-margin-top-1">
     <%= @planning_application.last_site_notice_audit&.audit_comment %><br>
     <%= govuk_link_to "Download site notice PDF", "#",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1858,6 +1858,7 @@ en:
           neighbour_summary: Summary of neighbour responses
           return: Return with comments
           site_description: Site description
+          summary_of_advice: Summary of advice
           summary_of_consultee: Summary of consultee responses
           summary_of_work: Summary of works
           update_additional_evidence: Update additional evidence

--- a/spec/system/planning_applications/pre_application_report_spec.rb
+++ b/spec/system/planning_applications/pre_application_report_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Pre-application report" do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:reviewer) { create(:user, :reviewer, local_authority:) }
+
+  let(:planning_application) do
+    create(
+      :planning_application,
+      :pre_application,
+      :in_assessment,
+      user: reviewer,
+      local_authority:,
+      validated_at: Time.zone.local(2024, 6, 1),
+      determined_at: Time.zone.local(2024, 6, 20),
+      description: "Single-storey rear extension"
+    )
+  end
+  let!(:site_visit) do
+    create(:site_visit, planning_application:, visited_at: Time.zone.local(2024, 6, 10))
+  end
+  let!(:meeting) do
+    create(:meeting, planning_application:, occurred_at: Time.zone.local(2024, 6, 15))
+  end
+
+  let!(:assessment_detail) { create(:assessment_detail, planning_application:) }
+
+  let!(:summary_of_advice) do
+    create(:assessment_detail, planning_application:, category: "summary_of_advice", summary_tag: "complies", entry: "Looks good")
+  end
+
+  let(:report_url) { "/planning_applications/#{planning_application.reference}/review/report" }
+
+  before do
+    sign_in reviewer
+    visit "/planning_applications/#{planning_application.reference}"
+    click_link "Check and assess"
+    click_link "Review and submit pre-application"
+  end
+
+  it "shows the report content and table of contents" do
+    expect(page).to have_content("Pre-application report")
+    expect(page).to have_content("This report gives clear guidance on your proposal")
+    expect(page).to have_content(planning_application.full_address)
+    expect(page).to have_content("Pre-application number: #{planning_application.reference}")
+    expect(page).to have_content("Case officer: #{reviewer.name}")
+    expect(page).to have_content("Date of report: #{planning_application.determined_at.to_date.to_fs}")
+
+    within(".bops-table-of-contents") do
+      expect(page).to have_link("Pre-application outcome", href: "#pre-application-outcome")
+      expect(page).to have_link("Your pre-application details", href: "#pre-application-details")
+    end
+  end
+
+  it "displays the summary of advice outcome section" do
+    within("#pre-application-outcome") do
+      expect(page).to have_content("Pre-application outcome")
+      expect(page).to have_link("Edit", href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{summary_of_advice.id}/edit?category=summary_of_advice&return_to=report")
+      expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--green")
+      expect(page).to have_content("Likely to be supported")
+    end
+  end
+
+  it "displays pre-application details table" do
+    within("#pre-application-details-table") do
+      rows = all("tbody tr")
+
+      within(rows[0]) do
+        expect(page).to have_content("Date made valid")
+        expect(page).to have_content(planning_application.validated_at.to_date.to_fs)
+        expect(page).not_to have_link("Edit")
+      end
+
+      within(rows[1]) do
+        expect(page).to have_content("Site visit")
+        expect(page).to have_content(planning_application.site_visit_visited_at.to_date.to_fs)
+        expect(page).to have_link("Edit", href: "/planning_applications/#{planning_application.reference}/assessment/site_visits?return_to=report")
+      end
+
+      within(rows[2]) do
+        expect(page).to have_content("Meeting")
+        expect(page).to have_content(planning_application.meeting_occurred_at.to_date.to_fs)
+        expect(page).to have_link("Edit", href: "/planning_applications/#{planning_application.reference}/assessment/meetings?return_to=report")
+      end
+    end
+  end
+
+  it "displays the proposal description" do
+    expect(page).to have_content("Description of your proposal")
+    expect(page).to have_content("Single-storey rear extension")
+  end
+
+  it "has a back link to the application page" do
+    expect(page).to have_link("Back", href: "/planning_applications/#{planning_application.reference}")
+  end
+
+  it "returns to the report page after editing summary of advice" do
+    within("#pre-application-outcome") do
+      click_link "Edit"
+    end
+
+    fill_in "Enter summary of planning considerations and advice", with: "Updated advice."
+    choose "Likely to be supported with changes"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/report")
+    expect(page).to have_content("Likely to be supported with changes")
+    expect(page).to have_css(".govuk-notification-banner.bops-notification-banner--orange")
+  end
+
+  it "returns to the report page after adding a new meeting" do
+    within("#pre-application-details-table") do
+      click_link "Edit", href: "/planning_applications/#{planning_application.reference}/assessment/meetings?return_to=report"
+    end
+
+    toggle "Add a new meeting"
+    fill_in "Day", with: "2"
+    fill_in "Month", with: "4"
+    fill_in "Year", with: "2025"
+    fill_in "Add notes (optional)", with: "Discussed next steps"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/report")
+    within("#pre-application-details-table") do
+      rows = all("tbody tr")
+
+      within(rows[2]) do
+        expect(page).to have_content("2 April 2025")
+      end
+    end
+  end
+
+  it "returns to the report page after viewing site visits" do
+    within("#pre-application-details-table") do
+      click_link "Edit", href: "/planning_applications/#{planning_application.reference}/assessment/site_visits?return_to=report"
+    end
+
+    click_link "Back"
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/report")
+  end
+
+  it "returns to the report page after editing proposal description" do
+    within("#proposal-description") do
+      expect(page).to have_content("Single-storey rear extension")
+      click_link "Edit"
+    end
+
+    fill_in "Enter an amended description", with: "This is the amended description for the proposal"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/report")
+    within("#proposal-description") do
+      expect(page).to have_content("This is the amended description for the proposal")
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add pre-application details to report

- Allow editing and returning back to report of individual items

### Story Link

https://trello.com/c/S0EOTvIB/443-pre-app-preview-and-submit-final-report-your-application-details

### Screenshots

![Screenshot 2025-04-02 at 15 51 05](https://github.com/user-attachments/assets/3f62bd03-c23a-4c0b-8bcc-258399c5ceb8)
