### PR TITLE
Add sections to pre-app final report

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -397,6 +397,14 @@ body {
   padding: 2rem;
 }
 
+.grey-border-box {
+  background-color: govuk-colour("light-grey");
+  border: 1px solid govuk-colour("mid-grey");
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  padding: 2rem;
+}
+
 .background-light-grey {
   background-color: govuk-colour("light-grey");
 }

--- a/app/controllers/planning_applications/assessment/consistency_checklists_controller.rb
+++ b/app/controllers/planning_applications/assessment/consistency_checklists_controller.rb
@@ -3,8 +3,11 @@
 module PlanningApplications
   module Assessment
     class ConsistencyChecklistsController < BaseController
+      include ReturnToReport
+
       before_action :set_consistency_checklist, except: %i[new create]
       before_action :redirect_to_reference_url
+      before_action :store_return_to_report_path, only: %i[edit create]
 
       def show
       end
@@ -37,10 +40,8 @@ module PlanningApplications
         if @consistency_checklist.update(consistency_checklist_params.except(:proposal_measurement))
           update_proposal_measurements
 
-          redirect_to(
-            planning_application_assessment_tasks_path(@planning_application),
-            notice: t(".successfully_updated_application")
-          )
+          redirect_to redirect_path, notice: t(".successfully_updated_application")
+
         else
           render :new
         end
@@ -98,6 +99,10 @@ module PlanningApplications
             eaves height: #{@planning_application.proposal_measurement.eaves_height}m,
             depth: #{@planning_application.proposal_measurement.depth}m"
         )
+      end
+
+      def redirect_path
+        report_path_or(planning_application_assessment_tasks_path(@planning_application))
       end
     end
   end

--- a/app/controllers/planning_applications/assessment/site_histories_controller.rb
+++ b/app/controllers/planning_applications/assessment/site_histories_controller.rb
@@ -3,8 +3,11 @@
 module PlanningApplications
   module Assessment
     class SiteHistoriesController < BaseController
+      include ReturnToReport
+
       before_action :set_site_histories
       before_action :set_site_history, except: %i[confirm]
+      before_action :store_return_to_report_path, only: %i[index edit update destroy]
 
       def index
         respond_to do |format|
@@ -17,7 +20,7 @@ module PlanningApplications
 
         respond_to do |format|
           format.html do
-            redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
+            redirect_to redirect_path, notice: t(".success")
           end
         end
       end
@@ -88,6 +91,10 @@ module PlanningApplications
 
       def planning_history_params
         params.require(:site_history).permit(:reference, :description, :decision, :other_decision, :date, :comment)
+      end
+
+      def redirect_path
+        report_path_or(planning_application_assessment_tasks_path(@planning_application))
       end
     end
   end

--- a/app/controllers/planning_applications/validation/constraints_controller.rb
+++ b/app/controllers/planning_applications/validation/constraints_controller.rb
@@ -3,9 +3,12 @@
 module PlanningApplications
   module Validation
     class ConstraintsController < BaseController
+      include ReturnToReport
+
       before_action :ensure_constraint_edits_unlocked, only: %i[index update]
       before_action :set_planning_application_constraints, only: %i[update index create]
       before_action :set_other_constraints, only: %i[index]
+      before_action :store_return_to_report_path, only: %i[index create destroy update]
 
       def index
         respond_to do |format|
@@ -41,8 +44,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @planning_application.constraints_checked!
-              redirect_to planning_application_validation_tasks_path(@planning_application),
-                notice: t(".success")
+              redirect_to redirect_path, notice: t(".success")
             else
               redirect_to planning_application_validation_tasks_path(@planning_application),
                 alert: t(".failure")
@@ -70,6 +72,10 @@ module PlanningApplications
 
       def search_param
         params.fetch(:q, "")
+      end
+
+      def redirect_path
+        report_path_or(planning_application_validation_tasks_path(@planning_application))
       end
     end
   end

--- a/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
+++ b/app/views/planning_applications/assessment/consistency_checklists/_site_map_correct.html.erb
@@ -1,6 +1,6 @@
 <%= form.govuk_radio_buttons_fieldset(
       :site_map_correct,
-      legend: {text: t(".is_the_red"), size: "s"}
+      legend: {text: t(".is_the_red"), size: "s", id: "site-map-title-field"}
     ) do %>
     <%= render "shared/location_map", locals: {in_accordion: true, geojson: @planning_application.boundary_geojson} %>
     <br>

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -1,6 +1,6 @@
 <my-map
   style="width: 100%; height: 600px;"
-  osProxyEndpoint="<%= os_proxy_url %>"
+  osProxyEndpoint="<%= main_app.os_proxy_url %>"
   showScale
   useScaleBarStyle
   showNorthArrow

--- a/engines/bops_reports/app/controllers/bops_reports/planning_applications_controller.rb
+++ b/engines/bops_reports/app/controllers/bops_reports/planning_applications_controller.rb
@@ -9,6 +9,10 @@ module BopsReports
 
       @summary_of_advice = @planning_application.assessment_details.summary_of_advice.last
 
+      @site_description = @planning_application.site_description
+
+      @constraints = @planning_application.constraints.group_by(&:category)
+
       respond_to do |format|
         format.html
       end

--- a/engines/bops_reports/app/helpers/bops_reports/planning_application_helper.rb
+++ b/engines/bops_reports/app/helpers/bops_reports/planning_application_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BopsReports
+  module PlanningApplicationHelper
+    def show_map_pin?(planning_application, data)
+      (data[:geojson].blank? || data[:invalid_red_line_boundary].present?) && planning_application.lonlat.present?
+    end
+  end
+end

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
@@ -1,0 +1,22 @@
+<% if constraints.any? %>
+  <% constraints.each do |category, values| %>
+    <div class="govuk-summary-card" id="site-constraints-<%= category %>">
+      <div class="govuk-summary-card__title-wrapper">
+        <h2 class="govuk-summary-card__title">
+          <%= category.humanize %>
+        </h2>
+      </div>
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+          <% values.each do |value| %>
+              <div class="govuk-summary-list__row">
+                <dd class="govuk-summary-list__value">
+                  <%= value.type.humanize %>
+                </dd>
+              </div>
+          <% end %>
+        </dl>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
@@ -1,0 +1,35 @@
+<% if @planning_application.site_histories.any? %>
+  <% @planning_application.site_histories.each do |site_history| %>
+    <div class="govuk-summary-card">
+      <div class="govuk-summary-card__title-wrapper">
+        <div class="display-flex govuk-!-padding-bottom-2">
+          <h2 class="govuk-summary-card__title">
+            <%= site_history.application_number %>
+          </h2>
+          <%= govuk_tag(text: site_history.decision_label, colour: t(site_history.decision_type, scope: :planning_application_tags), html_attributes: {class: "govuk-!-padding-top-2"}) %>
+        </div>
+        <p class="govuk-body govuk-!-font-size-16  govuk-secondary-text-colour">
+          Decided on <%= site_history.date %>
+        </p>
+      </div>
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+              <div class="govuk-summary-list__row">
+                <dd class="govuk-summary-list__value">
+                  <strong>Description: </strong><%= site_history.description %>
+                  <div class="govuk-!-margin-top-2">
+                    <% if site_history.comment %>
+                    <strong>Officer comment:</strong> <%= site_history.comment %>
+                    <% else %>
+                      <p class="govuk-body govuk-!-font-size-16  govuk-secondary-text-colour">
+                        No comment added
+                      </p>
+                    <% end %>
+                  </div>
+                </dd>
+              </div>
+        </dl>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -31,6 +31,11 @@
       {links: [
         ["Pre-application outcome", "#pre-application-outcome"],
         ["Your pre-application details", "#pre-application-details"],
+        ["Site map", "#site-map"],
+        ["Site constraints", "#site-constraints"],
+        ["Site history", "#site-history"],
+        ["Site and surroundings", "#site-and-surroundings"],
+        ["Your pre-application details", "#pre-application-details"],
         ["Next steps", "#next-steps"],
         ["Disclaimer", "#disclaimer"]
       ]}
@@ -139,6 +144,93 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
+<section id="site-map">
+  <h2 class="govuk-heading-m">
+    Site map
+  </h2>
+  <p class="govuk-body">
+    This map shows the area of the proposed development. It has been checked by the case officer.
+  </p>
+  <%= render(
+        partial: "shared/location_map",
+        locals: {
+          locals: {
+            geojson: @planning_application.boundary_geojson
+          }
+        }
+      ) %>
+  <div class="govuk-!-margin-bottom-2 govuk-!-margin-top-5">
+    <div class="grey-border-box" id="officer-map-comments">
+      <div class="flex-between">
+        <h3 class="govuk-heading-s">
+          Officer comments
+        </h3>
+        <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_consistency_checklist_path(
+              @planning_application,
+              anchor: "site-map-title-field",
+              return_to: "report"
+            ) %>
+      </div>
+      <% if @planning_application.consistency_checklist.site_map_correct == "no" %>
+        <p class="govuk-body">
+          <%= @planning_application.consistency_checklist.site_map_correct_comment %>
+        </p>
+      <% else %>
+        <p class="govuk-body">The site map was marked as correct.</p>
+      <% end %>
+    </div>
+  </div>
+</section>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<section id="site-constraints">
+  <div class="flex-between govuk-!-margin-bottom-2">
+    <h2 class="govuk-heading-m">Relevant site constraints</h2>
+    <%= govuk_link_to "Edit", main_app.planning_application_validation_constraints_path(
+          @planning_application,
+          return_to: "report"
+        ) %>
+  </div>
+  <p class="govuk-body">
+    Site constraints are factors that could affect the development, such as zoning, environmental protections, or nearby conservation areas.
+  </p>
+  <%= render("constraints_table", constraints: @constraints) %>
+</section>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<section id="site-history">
+  <div class="flex-between govuk-!-margin-bottom-2">
+    <h2 class="govuk-heading-m"> Relevant site history </h2>
+    <%= govuk_link_to "Edit", main_app.planning_application_assessment_site_histories_path(
+          @planning_application,
+          return_to: "report"
+        ) %>
+  </div>
+  <p class="govuk-body">
+    Past applications for this site or relevant nearby locations
+  </p>
+  <%= render "site_history_table" %>
+</section>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<section id="site-and-surroundings">
+  <div class="flex-between govuk-!-margin-bottom-2">
+    <h2 class="govuk-heading-m">Site and surroundings</h2>
+    <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
+          @planning_application, @site_description,
+          category: "site_description",
+          return_to: "report"
+        ) %>
+  </div>
+  <p class="govuk-body">
+    <%= @site_description.entry %>
+  </p>
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+</section>
+
 <section id="next-steps">
   <h3 class="govuk-heading-s"><%= t(".next_steps_heading") %></h3>
 
@@ -171,7 +263,5 @@
     <%= @planning_application.disclaimer || t(".disclaimer_content") %>
   <% end %>
 </section>
-
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <%= govuk_button_link_to "Back", main_app.planning_application_path(@planning_application), secondary: true %>

--- a/engines/bops_reports/spec/system/pre_application_report_spec.rb
+++ b/engines/bops_reports/spec/system/pre_application_report_spec.rb
@@ -6,6 +6,24 @@ RSpec.describe "Pre-application report" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:reviewer) { create(:user, :reviewer, local_authority:) }
 
+  let(:boundary_geojson) do
+    {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [-0.054597, 51.537331],
+            [-0.054588, 51.537287],
+            [-0.054453, 51.537313],
+            [-0.054597, 51.537331]
+          ]
+        ]
+      }
+    }.to_json
+  end
+
   let(:planning_application) do
     create(
       :planning_application,
@@ -13,12 +31,14 @@ RSpec.describe "Pre-application report" do
       :in_assessment,
       user: reviewer,
       local_authority:,
+      boundary_geojson:,
       validated_at: Time.zone.local(2024, 6, 1),
       determined_at: Time.zone.local(2024, 6, 20),
       description: "Single-storey rear extension",
       recommended_application_type: create(:application_type, :householder)
     )
   end
+
   let!(:site_visit) do
     create(:site_visit, planning_application:, visited_at: Time.zone.local(2024, 6, 10))
   end
@@ -31,6 +51,29 @@ RSpec.describe "Pre-application report" do
   let!(:summary_of_advice) do
     create(:assessment_detail, planning_application:, category: "summary_of_advice", summary_tag: "complies", entry: "Looks good")
   end
+
+  let(:report_url) { "/reports/planning_applications/#{planning_application.reference}" }
+  let!(:site_history) { create(:site_history, planning_application:) }
+
+  let!(:site_description) do
+    create(:assessment_detail, planning_application:, category: "site_description", entry: "A double storey detached house adjacent to greenbelt.")
+  end
+
+  let!(:consistency_checklist) do
+    create(:consistency_checklist, :site_map_incorrect, planning_application:)
+  end
+
+  let!(:designated_conservation_area) do
+    create(:planning_application_constraint, planning_application:)
+  end
+
+  let!(:tpo) { create(:constraint, :tpo) }
+
+  let!(:planning_application_constraint) do
+    create(:planning_application_constraint, constraint: tpo, planning_application:)
+  end
+
+  let(:report_url) { "/planning_applications/#{planning_application.reference}" }
 
   before do
     sign_in reviewer
@@ -50,6 +93,10 @@ RSpec.describe "Pre-application report" do
     within(".bops-table-of-contents") do
       expect(page).to have_link("Pre-application outcome", href: "#pre-application-outcome")
       expect(page).to have_link("Your pre-application details", href: "#pre-application-details")
+      expect(page).to have_link("Site map", href: "#site-map")
+      expect(page).to have_link("Site constraints", href: "#site-constraints")
+      expect(page).to have_link("Site history", href: "#site-history")
+      expect(page).to have_link("Site and surroundings", href: "#site-and-surroundings")
     end
   end
 
@@ -153,6 +200,140 @@ RSpec.describe "Pre-application report" do
     expect(page).to have_current_path("/reports/planning_applications/#{planning_application.reference}")
     within("#proposal-description") do
       expect(page).to have_content("This is the amended description for the proposal")
+    end
+  end
+
+  it "displays site map" do
+    within("#site-map") do
+      expect(page).to have_content("Site map")
+      expect(page).to have_content("This map shows the area of the proposed development. It has been checked by the case officer.")
+
+      within("#officer-map-comments") do
+        expect(page).to have_content("Officer comments")
+        expect(page).to have_content("Site map is of neighbours property")
+      end
+    end
+  end
+
+  it "returns to report after editing site map comment" do
+    within("#officer-map-comments") do
+      click_link "Edit"
+    end
+
+    fill_in "consistency-checklist-site-map-correct-comment-field", with: "Site map is of neighbours property, this comment has been updated."
+
+    click_button "Save and mark as complete"
+    expect(page).to have_content("Successfully updated application checklist")
+    expect(page).to have_current_path("/reports/planning_applications/#{planning_application.reference}")
+
+    within("#officer-map-comments") do
+      expect(page).to have_content("Site map is of neighbours property, this comment has been updated.")
+    end
+  end
+
+  it "displays site constraints" do
+    within("#site-constraints") do
+      expect(page).to have_content("Relevant site constraints")
+      expect(page).to have_content("Site constraints are factors that could affect the development, such as zoning, environmental protections, or nearby conservation areas.")
+
+      within("#site-constraints-heritage_and_conservation") do
+        expect(page).to have_content("Heritage and conservation")
+        expect(page).to have_content("Designated conservationarea")
+      end
+
+      within("#site-constraints-trees") do
+        expect(page).to have_content("Trees")
+        expect(page).to have_content("Tpo")
+      end
+    end
+  end
+
+  it "returns to report after editing site constraints" do
+    within("#site-constraints") do
+      click_link "Edit"
+    end
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/validation/constraints?return_to=report")
+    expect(page).to have_content("Check the constraints")
+
+    within(".identified-constraints-table") do
+      expect(page).to have_text("Conservation area")
+      within(row_with_content("Tree preservation zone")) do
+        click_link "Remove"
+      end
+    end
+    expect(page).to have_content("Constraint was successfully removed")
+
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/reports/planning_applications/#{planning_application.reference}")
+    expect(page).to have_content("Constraints were successfully checked")
+
+    within("#site-constraints") do
+      expect(page).not_to have_content("Trees")
+    end
+  end
+
+  it "displays site history" do
+    within("#site-history") do
+      expect(page).to have_content("Relevant site history")
+      expect(page).to have_content("Past applications for this site or relevant nearby locations")
+
+      within(".govuk-summary-card") do
+        expect(page).to have_content("REF123")
+        expect(page).to have_content("An entry for planning history")
+      end
+    end
+  end
+
+  it "returns to report page after editing site history" do
+    within("#site-history") do
+      click_link "Edit"
+    end
+
+    expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/assessment/site_histories?return_to=report")
+
+    within(".planning-history-table") do
+      within(row_with_content("REF123")) do
+        click_link "Edit"
+      end
+    end
+
+    fill_in "site-history-comment-field", with: "An amended entry for planning history"
+
+    click_button "Update site history"
+
+    expect(page).to have_content("Site history was successfully updated")
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/reports/planning_applications/#{planning_application.reference}")
+    expect(page).to have_content("Site history has been confirmed")
+
+    within("#site-history") do
+      expect(page).to have_content("Officer comment: An amended entry for planning history")
+    end
+  end
+
+  it "displays site and surroundings" do
+    within("#site-and-surroundings") do
+      expect(page).to have_content("Site and surroundings")
+      expect(page).to have_content("A double storey detached house adjacent to greenbelt.")
+    end
+  end
+
+  it "returns to report page after editing site and surroundings" do
+    within("#site-and-surroundings") do
+      click_link "Edit"
+    end
+
+    expect(page).to have_content("Edit site description")
+
+    fill_in "assessment_detail[entry]", with: "This is the amended description of site and surroundings"
+    click_button "Save and mark as complete"
+
+    expect(page).to have_current_path("/reports/planning_applications/#{planning_application.reference}")
+    within("#site-and-surroundings") do
+      expect(page).to have_content("This is the amended description of site and surroundings")
     end
   end
 

--- a/spec/factories/consistency_checklist.rb
+++ b/spec/factories/consistency_checklist.rb
@@ -19,5 +19,14 @@ FactoryBot.define do
       site_map_correct { :yes }
       proposal_measurements_match_documents { :yes }
     end
+
+    trait :site_map_incorrect do
+      description_matches_documents { :yes }
+      documents_consistent { :yes }
+      proposal_details_match_documents { :yes }
+      site_map_correct { :no }
+      site_map_correct_comment { "Site map is of neighbours property" }
+      proposal_measurements_match_documents { :yes }
+    end
   end
 end


### PR DESCRIPTION
### Description of change

Added following sections to officer report for reviewer:
- Site map
- Relevant site constraints
- Relevant site history
- Site and surroundings

### Story Link

https://trello.com/c/pP9PIcu7/548-pre-app-preview-and-submit-final-report-about-their-application

### Screenshots
<img width="855" alt="image" src="https://github.com/user-attachments/assets/b604415b-6bd0-4542-8154-9f291b05ce7c" />
<img width="857" alt="image" src="https://github.com/user-attachments/assets/1a31880b-d916-46b7-b4ab-0030f7e7c6ea" />
<img width="850" alt="image" src="https://github.com/user-attachments/assets/2214888b-438b-475a-99fe-e8955133e4f7" />

