### PR TITLE
Add 'publishable' feature flag

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -3,6 +3,7 @@
 class PlanningApplicationsController < AuthenticationController
   before_action :set_planning_application, except: %i[new create index]
   before_action :build_planning_application, only: %i[new create]
+  before_action :ensure_planning_application_is_publishable, only: %i[make_public]
   before_action :ensure_user_is_reviewer_checking_assessment, only: %i[edit_public_comment]
   before_action :ensure_no_open_post_validation_requests, only: %i[submit]
   before_action :ensure_draft_recommendation_complete, only: :update
@@ -182,9 +183,15 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def publish
+    respond_to do |format|
+      format.html
+    end
   end
 
   def make_public
+    respond_to do |format|
+      format.html
+    end
   end
 
   def determine
@@ -292,6 +299,13 @@ class PlanningApplicationsController < AuthenticationController
 
   def after_update_url
     params.dig(:planning_application, :return_to) || @planning_application
+  end
+
+  def ensure_planning_application_is_publishable
+    return if @planning_application.publishable?
+
+    redirect_to planning_application_assessment_tasks_path(@planning_application),
+      alert: t(".not_publishable", application_type: @planning_application.application_type.description)
   end
 
   def ensure_no_open_post_validation_requests

--- a/app/models/application_type/config.rb
+++ b/app/models/application_type/config.rb
@@ -102,6 +102,7 @@ class ApplicationType < ApplicationRecord
       delegate :ownership_details?
       delegate :permitted_development_rights?
       delegate :planning_conditions?
+      delegate :publishable?
       delegate :site_visits?
     end
 

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -16,6 +16,7 @@ class ApplicationTypeFeature
   attribute :ownership_details, :boolean, default: true
   attribute :permitted_development_rights, :boolean, default: true
   attribute :planning_conditions, :boolean, default: false
+  attribute :publishable, :boolean, default: true
   attribute :site_visits, :boolean, default: true
 
   validate :consultation_steps_are_valid

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -103,6 +103,7 @@ class PlanningApplication < ApplicationRecord
     delegate :ownership_details?
     delegate :planning_conditions?
     delegate :informatives?
+    delegate :publishable?, allow_nil: true
   end
   delegate :consultee_responses, to: :consultation, allow_nil: true
   delegate :reviewer_group_email, to: :local_authority
@@ -152,6 +153,7 @@ class PlanningApplication < ApplicationRecord
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create
+  before_validation :reset_published_at, unless: :publishable?
   before_create :set_received_at
   before_create :set_key_dates
   before_create :set_change_access_id
@@ -169,7 +171,6 @@ class PlanningApplication < ApplicationRecord
                 }, if: :valid_fee?
   before_update :audit_update_application_type!, if: :application_type_id_changed?
   before_update :create_proposal_measurement, if: :changed_to_prior_approval?
-
   after_update :audit_updated!
   after_update :update_constraints
   after_update :address_or_boundary_geojson_updated?
@@ -984,6 +985,10 @@ class PlanningApplication < ApplicationRecord
       max_height: max_height_extension.to_f,
       eaves_height: eave_height_extension.to_f
     )
+  end
+
+  def reset_published_at
+    self.published_at = nil
   end
 
   def set_reference

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -36,7 +36,7 @@
       </p>
     <% end %>
 
-    <% unless @planning_application.pre_application? %>
+    <% if @planning_application.publishable? %>
       <p class="govuk-body">
         Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
       </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1560,6 +1560,8 @@ en:
     invalidate:
       failure: Please create at least one validation request before invalidating
       success: Application has been invalidated and email has been sent
+    make_public:
+      not_publishable: You can’t publish %{application_type} on the public portal
     neighbour_letters:
       create:
         failure: 'Error adding neighbour addresses with message: %{message}'

--- a/engines/bops_admin/app/helpers/bops_admin/application_type_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_type_helper.rb
@@ -25,6 +25,7 @@ module BopsAdmin
         ownership_details
         site_visits
         description_change_requires_validation
+        publishable
       ]
     end
   end

--- a/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/application_types/features_controller.rb
@@ -43,6 +43,7 @@ module BopsConfig
           :ownership_details,
           :permitted_development_rights,
           :planning_conditions,
+          :publishable,
           :site_visits,
           {consultation_steps: []}
         ]

--- a/engines/bops_config/app/helpers/bops_config/application_type_helper.rb
+++ b/engines/bops_config/app/helpers/bops_config/application_type_helper.rb
@@ -25,6 +25,7 @@ module BopsConfig
         ownership_details
         site_visits
         description_change_requires_validation
+        publishable
       ]
     end
   end

--- a/engines/bops_config/config/locales/application_type_features.yml
+++ b/engines/bops_config/config/locales/application_type_features.yml
@@ -13,6 +13,7 @@ en:
       ownership_details: "Ownership details"
       planning_conditions: "Check planning conditions"
       permitted_development_rights: "Check permitted development rights"
+      publishable: "Allow applications to be made public"
       site_visits: "Site visits"
       consultation_steps:
         neighbour: Neighbours consultation

--- a/spec/factories/application_type_config.rb
+++ b/spec/factories/application_type_config.rb
@@ -569,7 +569,8 @@ FactoryBot.define do
           "legislative_requirements" => false,
           "consultation_steps" => ["consultee"],
           "ownership_details" => false,
-          "permitted_development_rights" => false
+          "permitted_development_rights" => false,
+          "publishable" => false
         }
       }
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -163,6 +163,38 @@ RSpec.describe PlanningApplication do
   end
 
   describe "callbacks" do
+    describe "::before_validation #reset_published_at" do
+      let(:published_at) { Time.zone.now }
+
+      around do |example|
+        freeze_time { example.run }
+      end
+
+      context "when the application type is householder" do
+        let(:planning_application) { build(:planning_application, :planning_permission, published_at:) }
+
+        it "doesn't reset the published_at timestamp" do
+          expect {
+            planning_application.validate!(:create)
+          }.not_to change {
+            planning_application.published_at
+          }.from(published_at)
+        end
+      end
+
+      context "when the application type is pre-application" do
+        let(:planning_application) { build(:planning_application, :pre_application, published_at:) }
+
+        it "resets the published_at timestamp" do
+          expect {
+            planning_application.validate!(:create)
+          }.to change {
+            planning_application.published_at
+          }.from(published_at).to(nil)
+        end
+      end
+    end
+
     describe "::before_create #set_application_number" do
       context "when an application number for a given local authority already exists" do
         let(:local_authority) { create(:local_authority) }

--- a/spec/system/planning_applications/assessing/planning_considerations_and_advice_spec.rb
+++ b/spec/system/planning_applications/assessing/planning_considerations_and_advice_spec.rb
@@ -102,9 +102,9 @@ RSpec.describe "Add planning considerations and advice", type: :system, capybara
 
       click_button "Add consideration"
 
-      expect(considerations.last.draft).to eq(true)
-      expect(page).to have_css(".govuk-summary-card__title", text: "Transport")
       expect(page).to have_content("Consideration was successfully added")
+      expect(page).to have_css(".govuk-summary-card__title", text: "Transport")
+      expect(considerations.last.draft).to eq(true)
 
       toggle "Add advice"
       fill_in "Enter element of proposal", with: "A proposal"


### PR DESCRIPTION
This is primarily so we can toggle things off where they need to be private for pre-applications such as documents, etc.

### Story Link

https://trello.com/c/CqX4cIgV