### PR TITLE
Add condition for blank site description

### DIFF
--- a/app/controllers/planning_applications/assessment/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment/assessment_details_controller.rb
@@ -10,7 +10,7 @@ module PlanningApplications
       before_action :set_consultation, if: :has_consultation_and_summary?
       before_action :set_neighbour_responses, if: :neighbour_summary?
       before_action :set_site_and_press_notices, if: :check_publicity?
-      before_action :store_return_to_report_path, only: %i[new edit]
+      before_action :store_return_to_report_path, only: %i[new create edit]
 
       def show
         respond_to do |format|
@@ -38,10 +38,7 @@ module PlanningApplications
         respond_to do |format|
           if @assessment_detail.save
             format.html do
-              redirect_to(
-                planning_application_assessment_tasks_path(@planning_application),
-                notice: created_notice
-              )
+              redirect_to redirect_path, notice: created_notice
             end
           else
             @category = @assessment_detail.category
@@ -149,7 +146,7 @@ module PlanningApplications
       end
 
       def redirect_path
-        path = if current_user.reviewer?
+        path = if current_user.reviewer? && @category == "site_description"
           planning_application_review_tasks_path(@planning_application)
         else
           planning_application_assessment_tasks_path(@planning_application)

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -241,15 +241,27 @@
 <section id="site-and-surroundings">
   <div class="flex-between govuk-!-margin-bottom-2">
     <h2 class="govuk-heading-m">Site and surroundings</h2>
-    <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
-          @planning_application, @site_description,
-          category: "site_description",
-          return_to: "report"
-        ) %>
-  </div>
-  <p class="govuk-body">
-    <%= @site_description.entry %>
-  </p>
+    <% if @site_description %>
+      <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
+            @planning_application, @site_description,
+            category: "site_description",
+            return_to: "report"
+          ) %>
+      </div>
+      <p class="govuk-body">
+        <%= @site_description.entry %>
+      </p>
+    <% else %>
+      <%= govuk_link_to "Edit", main_app.new_planning_application_assessment_assessment_detail_path(
+            @planning_application,
+            category: "site_description",
+            return_to: "report"
+          ) %>
+      </div>
+      <p class="govuk-body">
+        No site description set.
+      </p>
+    <% end %>
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 </section>
 


### PR DESCRIPTION
### Description of change

Add a condition to render a placeholder message when site description is blank and allow user to add site description from report.
