### PR TITLE
Define defaults for PlanningApplicationDependencyJob parameters to simplify calling it on its own

### DIFF
--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -19,9 +19,11 @@ module BopsApi
       @document_checklist_items ||= params.dig(:metadata, :service, :files)
     end
 
-    def perform(planning_application:, user:, files:, params:, email_sending_permitted:)
-      @user = user
-      @params = params
+    def perform(planning_application:, user: nil, files: nil, params: nil, email_sending_permitted: false)
+      @user = user || planning_application.api_user
+      @params = params || planning_application.params_v2.with_indifferent_access
+
+      files ||= @params.fetch(:files)
 
       Application::AnonymisationService.new(planning_application:).call! if planning_application.from_production?
       process_document_checklist_items(planning_application)

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -5,7 +5,10 @@ module BopsApi
     class CreationService
       def initialize(local_authority: nil, user: nil, params: nil, planning_application: nil, email_sending_permitted: false)
         if planning_application
-          initialize_from_planning_application(planning_application)
+          @params = planning_application.params_v2.with_indifferent_access
+          @local_authority = planning_application.local_authority
+          @user = planning_application.api_user
+          @email_sending_permitted = false
         else
           @local_authority = local_authority
           @user = user
@@ -82,13 +85,6 @@ module BopsApi
         PostApplicationToStagingJob.perform_later(local_authority, planning_application) if Bops.env.production?
 
         planning_application
-      end
-
-      def initialize_from_planning_application(planning_application)
-        @params = planning_application.params_v2.with_indifferent_access
-        @local_authority = planning_application.local_authority
-        @user = planning_application.api_user
-        @email_sending_permitted = false
       end
 
       def raise_not_permitted_in_production_error


### PR DESCRIPTION
### Description of change

If we need to rerun the PlanningApplicationDependencyJob due to failure, it's necessary to reconstruct all the parameters it wants from the CreationService. But in fact, all of those parameters are taken from the PlanningApplication record directly, so if a record is being passed they could be optional and derived in the job's initialize method instead.

They're still needed in the service too, but this should make it possible to call the job as `PlanningApplicationDependencyJob.perform_now(planning_application: some_app)`.
