### PR TITLE
Remove unused code path

### DIFF
--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -3,18 +3,11 @@
 module BopsApi
   module Application
     class CreationService
-      def initialize(local_authority: nil, user: nil, params: nil, planning_application: nil, email_sending_permitted: false)
-        if planning_application
-          @params = planning_application.params_v2.with_indifferent_access
-          @local_authority = planning_application.local_authority
-          @user = planning_application.api_user
-          @email_sending_permitted = false
-        else
-          @local_authority = local_authority
-          @user = user
-          @params = params
-          @email_sending_permitted = email_sending_permitted
-        end
+      def initialize(local_authority: nil, user: nil, params: nil, email_sending_permitted: false)
+        @local_authority = local_authority
+        @user = user
+        @params = params
+        @email_sending_permitted = email_sending_permitted
       end
 
       def call!

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -559,11 +559,9 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           stub_os_places_api_request_for_radius(53.5020957, -1.0205473)
         end
         let(:params) { json_fixture("v2/preApplication.json").with_indifferent_access }
-        let(:planning_application) { create_planning_application }
-        let(:service) { described_class.new(local_authority:, user:, params:, planning_application:) }
 
         it "creates a planning application with pre-application services" do
-          service.call!
+          create_planning_application
           perform_enqueued_jobs
           expect(planning_application.additional_services).to be_present
         end


### PR DESCRIPTION
This was only used to support the application cloning feature, which has been removed; and was incidentally also used by one test, which didn't actually need it.