### PR TITLE
Send pre-app report to applicants

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -238,4 +238,15 @@ class PlanningApplicationMailer < ApplicationMailer
       reply_to_id: @planning_application.local_authority.email_reply_to_id
     )
   end
+
+  def report_mail(planning_application, email)
+    @planning_application = planning_application
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:report_mail, council_name: @planning_application.local_authority.council_name),
+      to: email,
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
+    )
+  end
 end

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -110,6 +110,7 @@ class Audit < ApplicationRecord
     neighbour_response_uploaded
     neighbour_response_edited
     legislation_checked
+    pre_application_report_sent
     press_notice
     press_notice_mail
     site_notice_created

--- a/app/models/concerns/planning_application/notification.rb
+++ b/app/models/concerns/planning_application/notification.rb
@@ -26,6 +26,16 @@ class PlanningApplication < ApplicationRecord
       end
     end
 
+    def send_report_mail
+      return unless applicant_and_agent_email.any?
+
+      downcase_and_unique(applicant_and_agent_email).each do |email|
+        PlanningApplicationMailer
+          .report_mail(self, email)
+          .deliver_later
+      end
+    end
+
     def send_invalidation_notice_mail
       PlanningApplicationMailer
         .invalidation_notice_mail(self)

--- a/app/views/planning_application_mailer/report_mail.text.erb
+++ b/app/views/planning_application_mailer/report_mail.text.erb
@@ -1,0 +1,17 @@
+Subject: <%= @planning_application.local_authority.council_name %> pre-application advice
+
+Dear <%= @planning_application.applicant_name %>,
+
+<%= @planning_application.reference %>
+
+Your case officer has completed their review of the information you submitted to us about the proposed development at <%= @planning_application.full_address %>.
+
+You can view the case officer’s advice here: <%= @planning_application.report_link %>
+
+Please note that this advice is based on the information you gave us. If you choose to make a full application, this will be subject to a statutory consultation process. It is only then that a final decision can be made.
+
+If you have any questions, please contact <%= mail_to @planning_application.local_authority.email_address %>. We can offer clarifications but we cannot offer any further advice at this stage.
+
+Regards,
+
+<%= @planning_application.local_authority.council_name %> Pre-application Services

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -570,6 +570,7 @@ en:
       ownership_certificate_validation_request_received: 'Received: request for change (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_sent: 'Sent: request for change (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_sent_post_validation: 'Sent: request for change (ownership certificate validation#%{args})'
+      pre_application_report_sent: Pre-application report sent
       pre_commencement_condition_validation_request_added: 'Added: validation request for pre-commencement condition #%{args}'
       pre_commencement_condition_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (pre-commencement condition)'
@@ -816,6 +817,7 @@ en:
       press_notice_confirmation_request_mail: Request for confirmation of a press notice for %{reference}
       press_notice_mail: Request for press notice
       receipt_notice_mail: "%{application_type_name} application received"
+      report_mail: "%{council_name} Pre-application advice"
       site_notice_confirmation_request_mail: Request for confirmation of a site notice for %{reference}
       site_notice_mail: Display site notice for your application %{reference}
       update_notification_mail: BOPS case %{reference} has a new update

--- a/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
+++ b/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
@@ -29,6 +29,10 @@ module BopsCore
         bops_consultees.planning_application_url(
           reference: planning_application.reference, sgid:, subdomain:
         )
+      when PlanningApplication
+        bops_reports.planning_application_url(
+          reference: planning_application.reference, sgid:, subdomain:
+        )
       else
         main_app.root_url
       end

--- a/engines/bops_reports/app/controllers/bops_reports/planning_applications/base_controller.rb
+++ b/engines/bops_reports/app/controllers/bops_reports/planning_applications/base_controller.rb
@@ -10,6 +10,7 @@ module BopsReports
       before_action :set_site_description
       before_action :set_constraints
       before_action :set_recommendation
+      before_action :set_considerations
 
       delegate :pre_application?, to: :@planning_application
 
@@ -56,6 +57,10 @@ module BopsReports
 
       def set_recommendation
         @recommendation = build_or_find_recommendation
+      end
+
+      def set_considerations
+        @considerations = @planning_application.considerations.active
       end
 
       def build_or_find_recommendation

--- a/engines/bops_reports/app/controllers/bops_reports/planning_applications_controller.rb
+++ b/engines/bops_reports/app/controllers/bops_reports/planning_applications_controller.rb
@@ -2,6 +2,10 @@
 
 module BopsReports
   class PlanningApplicationsController < PlanningApplications::BaseController
+    include BopsCore::MagicLinkAuthenticatable
+
+    before_action :authenticate_with_sgid!, only: :show, unless: :user_signed_in?
+
     def show
       respond_to do |format|
         format.html

--- a/engines/bops_reports/app/jobs/concerns/bops_reports/application_job.rb
+++ b/engines/bops_reports/app/jobs/concerns/bops_reports/application_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module BopsReports
+  class ApplicationJob < ActiveJob::Base
+  end
+end

--- a/engines/bops_reports/app/jobs/concerns/bops_reports/send_report_email_job.rb
+++ b/engines/bops_reports/app/jobs/concerns/bops_reports/send_report_email_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module BopsReports
+  class SendReportEmailJob < ApplicationJob
+    queue_as :low_priority
+
+    def perform(planning_application, user)
+      return unless planning_application.pre_application?
+
+      ApplicationRecord.transaction do
+        planning_application.send_report_mail
+
+        planning_application.audits.create!(
+          user: user,
+          activity_type: "pre_application_report_sent",
+          audit_comment: "Pre-application report was sent"
+        )
+      end
+    end
+  end
+end

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
@@ -9,11 +9,11 @@
       <div class="govuk-summary-card__content">
         <dl class="govuk-summary-list">
           <% values.each do |value| %>
-              <div class="govuk-summary-list__row">
-                <dd class="govuk-summary-list__value">
-                  <%= value.type.humanize %>
-                </dd>
-              </div>
+            <div class="govuk-summary-list__row">
+              <dd class="govuk-summary-list__value">
+                <%= value.type.humanize %>
+              </dd>
+            </div>
           <% end %>
         </dl>
       </div>

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
@@ -14,20 +14,20 @@
       </div>
       <div class="govuk-summary-card__content">
         <dl class="govuk-summary-list">
-              <div class="govuk-summary-list__row">
-                <dd class="govuk-summary-list__value">
-                  <strong>Description: </strong><%= site_history.description %>
-                  <div class="govuk-!-margin-top-2">
-                    <% if site_history.comment %>
-                    <strong>Officer comment:</strong> <%= site_history.comment %>
-                    <% else %>
-                      <p class="govuk-body govuk-!-font-size-16  govuk-secondary-text-colour">
-                        No comment added
-                      </p>
-                    <% end %>
-                  </div>
-                </dd>
+          <div class="govuk-summary-list__row">
+            <dd class="govuk-summary-list__value">
+              <strong>Description: </strong><%= site_history.description %>
+              <div class="govuk-!-margin-top-2">
+                <% if site_history.comment %>
+                <strong>Officer comment:</strong> <%= site_history.comment %>
+                <% else %>
+                  <p class="govuk-body govuk-!-font-size-16  govuk-secondary-text-colour">
+                    No comment added
+                  </p>
+                <% end %>
               </div>
+            </dd>
+          </div>
         </dl>
       </div>
     </div>

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -2,9 +2,12 @@
   Pre-application report - <%= t("page_title") %>
 <% end %>
 
-<% add_parent_breadcrumb_link "Home", main_app.root_path %>
-<% add_parent_breadcrumb_link "Application", main_app.planning_application_path(@planning_application) %>
-<% add_parent_breadcrumb_link "Review pre-application", main_app.planning_application_review_root_path(@planning_application) %>
+<% if current_user %>
+  <% add_parent_breadcrumb_link "Home", main_app.root_path %>
+  <% add_parent_breadcrumb_link "Application", main_app.planning_application_path(@planning_application) %>
+  <% add_parent_breadcrumb_link "Review pre-application", main_app.planning_application_review_root_path(@planning_application) %>
+<% end %>
+
 <% content_for :title, "Pre-application report" %>
 
 <% if current_user && current_user.reviewer? %>
@@ -27,7 +30,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="planning-application-details">
-    <span class="govuk-caption-m">Preview and submit</span>
+    <% if current_user %>
+      <p class="govuk-caption-m">Preview and submit</p>
+    <% end %>
     <h1 class="govuk-heading-l">Pre-application report</h1>
     <p class="govuk-body">
       This report gives clear guidance on your proposal, helping you to
@@ -38,8 +43,10 @@
       <strong><%= @planning_application.full_address %></strong><br>
       Pre-application number: <strong><%= @planning_application.reference %></strong><br>
       Case officer: <strong><%= @planning_application.user&.name || "Unassigned" %></strong><br>
-      Date of report: <strong><%= @planning_application.determined_at&.to_date&.to_fs %></strong><br>
-      </p>
+      <% if @planning_application.determined_at %>
+        Date of report: <strong><%= @planning_application.determined_at.to_date.to_fs %></strong><br>
+      <% end %>
+    </p>
   </div>
 </div>
 
@@ -65,17 +72,19 @@
 <section id="pre-application-outcome">
   <div class="flex-between govuk-!-margin-bottom-2">
     <h2 class="govuk-heading-m">Pre-application outcome</h2>
-    <p class="govuk-body-m">
-      <% if @summary_of_advice&.summary_tag %>
-        <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
-              @planning_application, @summary_of_advice, category: "summary_of_advice", return_to: "report"
-            ) %>
-      <% else %>
-        <%= govuk_link_to "Add outcome", main_app.new_planning_application_assessment_assessment_detail_path(
-              @planning_application, category: "summary_of_advice", return_to: "report"
-            ) %>
-      <% end %>
-    </p>
+    <% if current_user %>
+      <p class="govuk-body-m">
+        <% if @summary_of_advice&.summary_tag %>
+          <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
+                @planning_application, @summary_of_advice, category: "summary_of_advice", return_to: "report"
+              ) %>
+        <% else %>
+          <%= govuk_link_to "Add outcome", main_app.new_planning_application_assessment_assessment_detail_path(
+                @planning_application, category: "summary_of_advice", return_to: "report"
+              ) %>
+        <% end %>
+      </p>
+    <% end %>
   </div>
 
   <% if @summary_of_advice&.summary_tag %>
@@ -99,14 +108,13 @@
   <%= govuk_inset_text do %>
     <% if @planning_application.user %>
       <p><strong>Case officer:</strong> <%= @planning_application.user.name %></p>
-      <p><strong>Email:</strong> <%= mail_to @planning_application.user.email %></p>
-      <% if mobile_number = @planning_application.user.mobile_number %>
-        <p><strong>Phone:</strong> <%= mobile_number %></p>
-      <% end %>
     <% else %>
-      <p>No case officer has been assigned yet.</p>
-      <%= govuk_link_to "Assign case officer", main_app.planning_application_assign_users_path(@planning_application, return_to: "report") %>
+      <% if current_user %>
+        <p>No case officer has been assigned yet.</p>
+        <%= govuk_link_to "Assign case officer", main_app.planning_application_assign_users_path(@planning_application, return_to: "report") %>
+      <% end %>
     <% end %>
+    <p><strong>Email:</strong> <%= mail_to @current_local_authority.email_address %></p>
   <% end %>
 </section>
 
@@ -124,7 +132,7 @@
       <% head.with_row do |row| %>
         <% row.with_cell(text: "Event") %>
         <% row.with_cell(text: "Date") %>
-        <% row.with_cell(classes: %w[govuk-!-text-align-right], text: "Action") %>
+        <% row.with_cell(classes: %w[govuk-!-text-align-right], text: "Action") if current_user %>
       <% end %>
     <% end %>
 
@@ -132,7 +140,7 @@
       <% body.with_row do |row| %>
         <% row.with_cell(text: "Date made valid") %>
         <% row.with_cell(text: time_tag(@planning_application.validated_at)) %>
-        <% row.with_cell(classes: %w[govuk-!-text-align-right], text: "-") %>
+        <% row.with_cell(classes: %w[govuk-!-text-align-right], text: "-") if current_user %>
       <% end %>
 
       <% body.with_row do |row| %>
@@ -143,7 +151,7 @@
           <% row.with_cell(text: "-") %>
         <% end %>
         <% row.with_cell(classes: %w[govuk-!-text-align-right]) do %>
-          <%= govuk_link_to "Edit", main_app.planning_application_assessment_site_visits_path(@planning_application, return_to: "report") %>
+          <%= govuk_link_to "Edit", main_app.planning_application_assessment_site_visits_path(@planning_application, return_to: "report") if current_user %>
         <% end %>
       <% end %>
 
@@ -155,7 +163,7 @@
           <% row.with_cell(text: "-") %>
         <% end %>
           <% row.with_cell(classes: %w[govuk-!-text-align-right]) do %>
-            <%= govuk_link_to "Edit", main_app.planning_application_assessment_meetings_path(@planning_application, return_to: "report") %>
+            <%= govuk_link_to "Edit", main_app.planning_application_assessment_meetings_path(@planning_application, return_to: "report") if current_user %>
           <% end %>
       <% end %>
     <% end %>
@@ -164,13 +172,15 @@
   <div id="proposal-description">
     <div class="flex-between govuk-!-margin-bottom-2">
       <h3 class="govuk-heading-s">Description of your proposal</h3>
-      <p class="govuk-body-m">
-        <%= govuk_link_to "Edit", main_app.new_planning_application_validation_validation_request_path(
-              @planning_application,
-              type: "description_change",
-              return_to: "report"
-            ) %>
-      </p>
+      <% if current_user %>
+        <p class="govuk-body-m">
+          <%= govuk_link_to "Edit", main_app.new_planning_application_validation_validation_request_path(
+                @planning_application,
+                type: "description_change",
+                return_to: "report"
+              ) %>
+        </p>
+      <% end %>
     </div>
     <p class="govuk-body"><%= @planning_application.description %></p>
 
@@ -207,13 +217,15 @@
         <h3 class="govuk-heading-s">
           Officer comments
         </h3>
-        <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_consistency_checklist_path(
-              @planning_application,
-              anchor: "site-map-title-field",
-              return_to: "report"
-            ) %>
+        <% if current_user %>
+          <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_consistency_checklist_path(
+                @planning_application,
+                anchor: "site-map-title-field",
+                return_to: "report"
+              ) %>
+        <% end %>
       </div>
-      <% if @planning_application.consistency_checklist.site_map_correct == "no" %>
+      <% if @planning_application.consistency_checklist&.site_map_correct == "no" %>
         <p class="govuk-body">
           <%= @planning_application.consistency_checklist.site_map_correct_comment %>
         </p>
@@ -229,10 +241,12 @@
 <section id="site-constraints">
   <div class="flex-between govuk-!-margin-bottom-2">
     <h2 class="govuk-heading-m">Relevant site constraints</h2>
-    <%= govuk_link_to "Edit", main_app.planning_application_validation_constraints_path(
-          @planning_application,
-          return_to: "report"
-        ) %>
+    <% if current_user %>
+      <%= govuk_link_to "Edit", main_app.planning_application_validation_constraints_path(
+            @planning_application,
+            return_to: "report"
+          ) %>
+    <% end %>
   </div>
   <p class="govuk-body">
     Site constraints are factors that could affect the development, such as zoning, environmental protections, or nearby conservation areas.
@@ -244,11 +258,13 @@
 
 <section id="site-history">
   <div class="flex-between govuk-!-margin-bottom-2">
-    <h2 class="govuk-heading-m"> Relevant site history </h2>
-    <%= govuk_link_to "Edit", main_app.planning_application_assessment_site_histories_path(
-          @planning_application,
-          return_to: "report"
-        ) %>
+    <h2 class="govuk-heading-m">Relevant site history</h2>
+    <% if current_user %>
+      <%= govuk_link_to "Edit", main_app.planning_application_assessment_site_histories_path(
+            @planning_application,
+            return_to: "report"
+          ) %>
+    <% end %>
   </div>
   <p class="govuk-body">
     Past applications for this site or relevant nearby locations
@@ -262,21 +278,25 @@
   <div class="flex-between govuk-!-margin-bottom-2">
     <h2 class="govuk-heading-m">Site and surroundings</h2>
     <% if @site_description %>
-      <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
-            @planning_application, @site_description,
-            category: "site_description",
-            return_to: "report"
-          ) %>
-      </div>
-      <p class="govuk-body">
-        <%= @site_description.entry %>
-      </p>
+      <% if current_user %>
+        <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
+              @planning_application, @site_description,
+              category: "site_description",
+              return_to: "report"
+            ) %>
+        </div>
+        <p class="govuk-body">
+          <%= @site_description.entry %>
+        </p>
+      <% end %>
     <% else %>
-      <%= govuk_link_to "Edit", main_app.new_planning_application_assessment_assessment_detail_path(
-            @planning_application,
-            category: "site_description",
-            return_to: "report"
-          ) %>
+      <% if current_user %>
+        <%= govuk_link_to "Edit", main_app.new_planning_application_assessment_assessment_detail_path(
+              @planning_application,
+              category: "site_description",
+              return_to: "report"
+            ) %>
+      <% end %>
       </div>
       <p class="govuk-body">
         No site description set.
@@ -288,11 +308,13 @@
 
 <section id="considerations-advice">
   <div class="flex-between govuk-!-margin-bottom-2">
-     <h2 class="govuk-heading-m">Planning considerations and advice</h2>
-     <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_considerations_path(
-           @planning_application,
-           return_to: "report"
-         ) %>
+    <h2 class="govuk-heading-m">Planning considerations and advice</h2>
+    <% if current_user %>
+      <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_considerations_path(
+            @planning_application,
+            return_to: "report"
+          ) %>
+    <% end %>
   </div>
 
   <p class="govuk-body"> This section includes the case officer's assessment of your proposal against relevant policy and guidance. The elements of the proposal are grouped by how acceptable they are:</p>
@@ -323,7 +345,7 @@
          end
        end %>
     <% table.with_body do |body|
-         @planning_application.considerations.each do |consideration|
+         @considerations.each do |consideration|
            body.with_row do |row|
              row.with_cell(text: consideration.policy_area)
              row.with_cell(text: consideration.proposal)
@@ -333,15 +355,17 @@
        end %>
   <% end %>
 
-  <% @planning_application.considerations.group_by(&:policy_area).each do |policy_area, considerations| %>
+  <% @considerations.group_by(&:policy_area).each do |policy_area, considerations| %>
     <%= govuk_summary_card(title: policy_area) do %>
       <% considerations.each do |consideration| %>
         <div class="flex-between">
           <strong class="govuk-heading-s"><%= consideration.proposal %></strong>
-          <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_considerations_path(
-                @planning_application,
-                return_to: "report"
-              ) %>
+          <% if current_user %>
+            <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_considerations_path(
+                  @planning_application,
+                  return_to: "report"
+                ) %>
+          <% end %>
         </div>
 
         <%= render StatusTags::PreappComponent.new(status: consideration.summary_tag) %><br>
@@ -375,9 +399,11 @@
   <section id="summary-advice">
     <div class="flex-between">
       <h2 class="govuk-heading-m">Summary</h2>
-      <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
-            @planning_application, @summary_of_advice, category: "summary_of_advice", return_to: "report"
-          ) %>
+      <% if current_user %>
+        <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_assessment_detail_path(
+              @planning_application, @summary_of_advice, category: "summary_of_advice", return_to: "report"
+            ) %>
+      <% end %>
     </div>
 
     <p class="govuk-body">This is the case officer's summary of the conclusions and advice.</p>
@@ -393,7 +419,7 @@
   <h2 class="govuk-heading-m">List of relevant policies and guidance</h2>
   <p class="govuk-body">You can view all relevant planning policy and guidance at <%= govuk_link_to @planning_application.local_authority.submission_guidance_url, @planning_application.local_authority.submission_guidance_url %>.</p>
 
-  <% @planning_application.considerations.group_by(&:policy_area).each do |policy_area, considerations| %>
+  <% @considerations.group_by(&:policy_area).each do |policy_area, considerations| %>
     <% references = considerations.map(&:policy_references).flatten %>
     <p class="govuk-body"><strong><%= policy_area.humanize %></strong></p>
     <ul class="govuk-list">
@@ -409,7 +435,9 @@
 <section id="requirements">
   <div class="flex-between">
     <h2 class="govuk-heading-m">Requirements</h2>
-    <%= govuk_link_to "Edit", main_app.planning_application_assessment_requirements_path(@planning_application, return_to: "report") %>
+    <% if current_user %>
+      <%= govuk_link_to "Edit", main_app.planning_application_assessment_requirements_path(@planning_application, return_to: "report") %>
+    <% end %>
   </div>
 
   <p class="govuk-body">Should you wish to submit an application, the following requirements are needed:</p>
@@ -450,9 +478,11 @@
           ) %>
     </p>
   <% else %>
-    <p class="govuk-body">
-      You must set the submission guidance url in local authority settings before displaying next steps.
-    </p>
+    <% if current_user %>
+      <p class="govuk-body">
+        You must set the submission guidance url in local authority settings before displaying next steps.
+      </p>
+    <% end %>
   <% end %>
 </section>
 

--- a/engines/bops_reports/config/locales/en.yml
+++ b/engines/bops_reports/config/locales/en.yml
@@ -26,6 +26,7 @@ en:
         submitted_recommendation: Submitted recommendation
       recommendations:
         create:
+          not_assigned: Pre-application report must be assigned to a case officer before it can be submitted for review
           submit_failed: Failed to submit pre-application report for review - please contact support
           submitted: Pre-application report submitted for review
         destroy:

--- a/engines/bops_reports/spec/jobs/send_report_email_job_spec.rb
+++ b/engines/bops_reports/spec/jobs/send_report_email_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsReports::SendReportEmailJob, type: :job do
+  let!(:planning_application) { create(:planning_application, :pre_application, user:) }
+  let(:user) { create(:user) }
+
+  it "enqueues the job" do
+    expect {
+      described_class.perform_later(planning_application, user)
+    }.to have_enqueued_job(described_class).with(planning_application, user)
+  end
+
+  context "when the planning application is a pre-application" do
+    it "sends the report email" do
+      expect {
+        perform_enqueued_jobs do
+          described_class.perform_now(planning_application, user)
+        end
+      }.to change { ActionMailer::Base.deliveries.count }.by(2) # Sends to both applicant / agent emails
+    end
+
+    it "creates an audit record" do
+      perform_enqueued_jobs do
+        described_class.perform_now(planning_application, user)
+      end
+
+      audit = planning_application.audits.last
+      expect(audit.user).to eq(user)
+      expect(audit.activity_type).to eq("pre_application_report_sent")
+      expect(audit.audit_comment).to eq("Pre-application report was sent")
+    end
+  end
+
+  context "when the planning application is not a pre-application" do
+    let(:planning_application) { create(:planning_application, user:) }
+
+    it "does not send the report email" do
+      expect {
+        perform_enqueued_jobs do
+          described_class.perform_now(planning_application, user)
+        end
+      }.not_to change { ActionMailer::Base.deliveries.count }
+    end
+
+    it "does not create an audit record" do
+      expect {
+        perform_enqueued_jobs do
+          described_class.perform_now(planning_application, user)
+        end
+      }.not_to change { planning_application.audits.count }
+    end
+  end
+end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1589,4 +1589,47 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
   end
+
+  describe "#report_mail" do
+    let(:report_mail) do
+      described_class.report_mail(
+        planning_application,
+        planning_application.agent_email
+      )
+    end
+
+    let(:mail_body) { report_mail.body.encoded }
+
+    before do
+      travel_to("2024-10-22") do
+        planning_application.user = reviewer
+      end
+    end
+
+    it "sets the subject" do
+      expect(report_mail.subject).to eq("PlanX Council Pre-application advice")
+    end
+
+    it "sets the recipient" do
+      expect(report_mail.to).to contain_exactly("cookie_crackers@example.com")
+    end
+
+    it "includes the reference" do
+      expect(mail_body).to include(
+        "24-00100-LDCP"
+      )
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include(
+        "123 High Street, Big City, AB3 4EF"
+      )
+    end
+
+    it "includes the report content" do
+      expect(mail_body).to include(
+        "Your case officer has completed their review of the information you submitted to us about the proposed development"
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Send pre-app report to applicants
- Use magic link with sgid to construct secure link for applicants to review report
- Remove edit actions for applicants
- Send email when reviewer submits the report

### Story Link

https://trello.com/c/dRAbOFY7/555-applicants-receive-the-report


![Screenshot 2025-04-14 at 12 15 01](https://github.com/user-attachments/assets/798c379a-c373-41c7-8f66-019603c9e0e8)
![Screenshot 2025-04-14 at 12 15 08](https://github.com/user-attachments/assets/4217e14d-422c-4e54-930a-5f73e8a066ba)
![Screenshot 2025-04-14 at 12 15 15](https://github.com/user-attachments/assets/f5d65cfc-4759-46f7-aefa-3fadd2a06083)
![Screenshot 2025-04-14 at 12 15 22](https://github.com/user-attachments/assets/58ed4042-63f1-4ba9-a5f0-9daa8d78146d)
![Screenshot 2025-04-14 at 12 15 29](https://github.com/user-attachments/assets/e460b261-bf76-4072-b2ea-9ef69425d681)

