### PR TITLE
Don't wrap consideration advice in FormattedContentComponent

### DIFF
--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -386,7 +386,7 @@
         </div>
 
         <p class="govuk-body">
-          <%= render(FormattedContentComponent.new(text: consideration.advice)) %>
+          <%= consideration.advice %>
         </p>
       <% end %>
     <% end %>


### PR DESCRIPTION
https://trello.com/c/k3nsqJB7/610-when-uploading-an-image-in-the-rich-text-in-planning-consideration-and-advice-and-submitted-the-pre-application-it-leads-to-the