### PR TITLE
Update constraints table element

### DIFF
--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
@@ -8,7 +8,7 @@
         <%= bops_status_detail(
               id: "consideration-#{consideration.id}"
             ) do |component| %>
-          <% component.with_title { consideration.policy_area } %>
+          <% component.with_title { "#{consideration.policy_area}: #{consideration.proposal}" } %>
           <% component.with_body { consideration.policy_references.map(&:code_and_description).join("; ") } %>
           <% component.with_status do %>
             <% case consideration.summary_tag %>

--- a/spec/factories/consideration.rb
+++ b/spec/factories/consideration.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     advice { Faker::Lorem.paragraph }
     proposal { Faker::Lorem.sentence }
 
+    trait :design_consideration do
+      policy_area { "Design" }
+      proposal { "Roof lights" }
+    end
+
     consideration_set
 
     after(:create) do |consideration|

--- a/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
+++ b/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
@@ -28,12 +28,17 @@ RSpec.describe "Summary of Advice", type: :system, capybara: true do
   end
 
   it "displays considerations, consultee and constraints tabs" do
+    create(:consideration, :design_consideration, consideration_set:, summary_tag: "does_not_comply")
     click_link "Summary of advice"
 
     within(".govuk-tabs") do
       expect(page).to have_css("#considerations")
       expect(page).to have_css("#consultees")
       expect(page).to have_css("#constraints")
+    end
+
+    within "#considerations" do
+      expect(page).to have_content("Design: Roof lights")
     end
   end
 


### PR DESCRIPTION
### Description of change

Updated constraints table on summary of advice to show element as opposed to topic.

### Story Link

https://trello.com/c/f5b3KEMt/620-in-summary-of-advice-show-summary-by-element-eg-rooflight-instead-of-topic-eg-amenity

Design discussed with Jean:
<img width="931" alt="image" src="https://github.com/user-attachments/assets/b1c696b0-8671-49e5-9acc-d3c31cbc409a" />
