### PR TITLE
Fix requirements only visible for pre-app

### DIFF
--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -55,20 +55,22 @@
             )
           ) %>
     <% end %>
+    <% if @planning_application.pre_application? %>
+      <li class="app-task-list__item" id="check-add-requirements">
+        <span class="app-task-list__task-name">
+          <%= govuk_link_to "Check and add requirements", planning_application_assessment_requirements_path(@planning_application) %>
+        </span>
+        <div class="govuk-task-list__status app-task-list__task-tag">
+        <%= render(
+              StatusTags::RequirementsComponent.new(
+                planning_application: @planning_application,
+                requirements: @planning_application.requirements
+              )
+            ) %>
+        </div>
+      </li>
+    <% end %>
     <!-- >Only show if it's a minor application<!-->
-    <li class="app-task-list__item" id="check-add-requirements">
-      <span class="app-task-list__task-name">
-        <%= govuk_link_to "Check and add requirements", planning_application_assessment_requirements_path(@planning_application) %>
-      </span>
-      <div class="govuk-task-list__status app-task-list__task-tag">
-      <%= render(
-            StatusTags::RequirementsComponent.new(
-              planning_application: @planning_application,
-              requirements: @planning_application.requirements
-            )
-          ) %>
-      </div>
-    </li>
     <% unless @planning_application.pre_application? %>
       <li class="app-task-list__item" id="add-heads-of-terms">
         <span class="app-task-list__task-name">

--- a/spec/system/planning_applications/assessing/adding_requirements_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_requirements_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Add requirements", type: :system, capybara: true do
   let!(:requirement4) { create(:local_authority_requirement, local_authority:, category: "other", description: "Other") }
 
   let(:planning_application) do
-    create(:planning_application, :in_assessment, local_authority: local_authority)
+    create(:planning_application, :in_assessment, :pre_application, local_authority: local_authority)
   end
 
   let(:reference) { planning_application.reference }

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe "Assessment tasks", type: :system do
             expect(page).to have_link("Review documents for recommendation")
             expect(page).to have_link("Make draft recommendation")
             expect(page).to have_content("Review and submit recommendation")
+            expect(page).not_to have_content("Check and add requirements")
           end
         end
       end


### PR DESCRIPTION
### Description of change

Check and add Requirements task list item should only be visible for pre-applications, currently it's rendering for all application types. I've wrapped it in a conditional to check if a pre-application. Scoping requirements are not required as they would only ever be relevant for Pre-Apps and no other application types.

### Story Link

https://trello.com/c/7AvEtVuK/624-requirements-showing-for-all-application-types

