### PR TITLE
Allow 'Heads of Terms' to be disabled per-application type

### DIFF
--- a/app/controllers/planning_applications/assessment/terms_controller.rb
+++ b/app/controllers/planning_applications/assessment/terms_controller.rb
@@ -3,9 +3,9 @@
 module PlanningApplications
   module Assessment
     class TermsController < BaseController
+      before_action :redirect_to_assessment_tasks, unless: :heads_of_terms_enabled?
       before_action :set_heads_of_term
       before_action :set_term
-      before_action :ensure_planning_application_is_not_preapp
 
       def index
         respond_to do |format|
@@ -71,6 +71,14 @@ module PlanningApplications
       end
 
       private
+
+      def redirect_to_assessment_tasks
+        redirect_to planning_application_assessment_tasks_path(@planning_application)
+      end
+
+      def heads_of_terms_enabled?
+        @planning_application.heads_of_terms?
+      end
 
       def set_heads_of_term
         @heads_of_term = @planning_application.heads_of_term

--- a/app/controllers/planning_applications/review/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/review/heads_of_terms_controller.rb
@@ -3,6 +3,8 @@
 module PlanningApplications
   module Review
     class HeadsOfTermsController < BaseController
+      before_action :redirect_to_review_tasks, unless: :heads_of_terms_enabled?
+
       def update
         respond_to do |format|
           format.html do
@@ -18,6 +20,14 @@ module PlanningApplications
       end
 
       private
+
+      def redirect_to_review_tasks
+        redirect_to planning_application_review_tasks_path(@planning_application)
+      end
+
+      def heads_of_terms_enabled?
+        @planning_application.heads_of_terms?
+      end
 
       def heads_of_term
         @planning_application.heads_of_term

--- a/app/models/application_type/config.rb
+++ b/app/models/application_type/config.rb
@@ -97,6 +97,7 @@ class ApplicationType < ApplicationRecord
       delegate :consultations_skip_bank_holidays?
       delegate :description_change_requires_validation?
       delegate :eia?
+      delegate :heads_of_terms?
       delegate :informatives?
       delegate :legislative_requirements?
       delegate :ownership_details?

--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -11,6 +11,7 @@ class ApplicationTypeFeature
   attribute :consultations_skip_bank_holidays, :boolean, default: false
   attribute :description_change_requires_validation, :boolean, default: true
   attribute :eia, :boolean, default: true
+  attribute :heads_of_terms, default: true
   attribute :informatives, :boolean, default: false
   attribute :legislative_requirements, :boolean, default: true
   attribute :ownership_details, :boolean, default: true

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -106,6 +106,7 @@ class PlanningApplication < ApplicationRecord
     delegate :site_visits?
     delegate :ownership_details?
     delegate :planning_conditions?
+    delegate :heads_of_terms?
     delegate :informatives?
     delegate :publishable?, allow_nil: true
   end

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -70,8 +70,7 @@
         </div>
       </li>
     <% end %>
-    <!-- >Only show if it's a minor application<!-->
-    <% unless @planning_application.pre_application? %>
+    <% if @planning_application.heads_of_terms? %>
       <li class="app-task-list__item" id="add-heads-of-terms">
         <span class="app-task-list__task-name">
           <%= govuk_link_to "Add heads of terms", planning_application_assessment_terms_path(@planning_application) %>

--- a/db/migrate/20250428083500_exclude_heads_of_terms_from_pre_app_and_ldcs.rb
+++ b/db/migrate/20250428083500_exclude_heads_of_terms_from_pre_app_and_ldcs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ExcludeHeadsOfTermsFromPreAppAndLdcs < ActiveRecord::Migration[7.2]
+  class ApplicationTypeConfig < ActiveRecord::Base; end
+
+  def change
+    reversible do |dir|
+      dir.up do
+        ApplicationTypeConfig.find_each do |config|
+          case config.code
+          when /\ApreApp\z/, /\Aldc\./
+            config.update!(features: config.features.merge("heads_of_terms" => false))
+          else
+            config.update!(features: config.features.merge("heads_of_terms" => true))
+          end
+        end
+      end
+
+      dir.down do
+        ApplicationTypeConfig.find_each do |config|
+          features = config.features.except("heads_of_terms")
+          config.update!(features: features)
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_24_091602) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_28_083500) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"

--- a/spec/factories/application_type_config.rb
+++ b/spec/factories/application_type_config.rb
@@ -15,7 +15,8 @@ FactoryBot.define do
 
       features {
         {
-          assess_against_policies: true
+          assess_against_policies: true,
+          heads_of_terms: false
         }
       }
 
@@ -89,6 +90,7 @@ FactoryBot.define do
       features {
         {
           "assess_against_policies" => true,
+          "heads_of_terms" => false,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []
@@ -107,6 +109,7 @@ FactoryBot.define do
       features {
         {
           "assess_against_policies" => true,
+          "heads_of_terms" => false,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []
@@ -533,6 +536,17 @@ FactoryBot.define do
       reporting_types { %w[Q13 Q14 Q15 Q16 Q17 Q18] }
 
       legislation { association :legislation, :tcpa_1990 }
+
+      features {
+        {
+          "considerations" => true,
+          "informatives" => true,
+          "planning_conditions" => true,
+          "permitted_development_rights" => false,
+          "site_visits" => true,
+          "consultation_steps" => ["neighbour", "publicity", "consultee"]
+        }
+      }
     end
 
     trait :major do
@@ -543,6 +557,17 @@ FactoryBot.define do
       reporting_types { %w[Q01 Q02 Q03 Q04 Q05 Q06] }
 
       legislation { association :legislation, :tcpa_1990 }
+
+      features {
+        {
+          "considerations" => true,
+          "informatives" => true,
+          "planning_conditions" => true,
+          "permitted_development_rights" => false,
+          "site_visits" => true,
+          "consultation_steps" => ["neighbour", "publicity", "consultee"]
+        }
+      }
     end
 
     trait :listed do
@@ -565,6 +590,7 @@ FactoryBot.define do
           "cil" => false,
           "description_change_requires_validation" => false,
           "eia" => false,
+          "heads_of_terms" => false,
           "informatives" => false,
           "legislative_requirements" => false,
           "consultation_steps" => ["consultee"],

--- a/spec/system/planning_applications/review/heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/review/heads_of_terms_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Reviewing heads of terms", type: :system, capybara: true do
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
   let!(:planning_application) do
-    create(:planning_application, :with_heads_of_terms, :awaiting_determination, :with_recommendation, local_authority: default_local_authority)
+    create(:planning_application, :planning_permission, :with_heads_of_terms, :awaiting_determination, :with_recommendation, local_authority: default_local_authority)
   end
 
   context "when signed in as a reviewer" do


### PR DESCRIPTION
### Description of change

There are certain types of applications that don't need the 'Heads of Terms' feature so add a feature flag for these types.

### Story Link

https://trello.com/c/bXqUeHK5
