### PR TITLE
Fix policy section comment bug

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -181,20 +181,20 @@
   <section id="policy-classes-section" class="govuk-!-margin-bottom-7">
     <h3 class="govuk-heading-m"><%= t(".assessment_against_legislation") %></h3>
 
-    <% policy_classes.each do |policy_class| %>
-      <p class="govuk-body"><%= govuk_link_to policy_class.description, policy_class.url %></p>
+    <% planning_application_policy_classes.each do |pa_policy_class| %>
+      <p class="govuk-body"><%= govuk_link_to pa_policy_class.description, pa_policy_class.url %></p>
 
       <dl class="bops-assessment-list">
-        <% policy_class.policy_sections.each do |policy_section| %>
+        <% pa_policy_class.planning_application_policy_sections.each do |pa_policy_section| %>
           <div class="bops-assessment-list__row">
             <dt class="bops-assessment-list__section">
-              <%= policy_section.section %>
+              <%= pa_policy_section.section %>
             </dt>
             <dd class="bops-assessment-list__description">
               <p class="govuk-body">
-                <%= policy_section.description %>
+                <%= pa_policy_section.description %>
               </p>
-              <% if comment = policy_section.last_comment %>
+              <% if comment = pa_policy_section.last_comment %>
                 <%= bops_ticket_panel(colour: "yellow") do |ticket| %>
                   <% ticket.with_body { comment.text } %>
                   <% ticket.with_footer { comment.information } %>
@@ -202,14 +202,14 @@
               <% end %>
             </dd>
             <dd class="bops-assessment-list__status">
-              <%= render(StatusTags::BaseComponent.new(status: policy_section.status)) %>
+              <%= render(StatusTags::BaseComponent.new(status: pa_policy_section.status)) %>
             </dd>
           </div>
         <% end %>
       </dl>
       <% if show_edit_links && current_user.assessor? %>
         <p class="govuk-body-s">
-          <%= govuk_link_to("Edit assessment", edit_planning_application_assessment_policy_areas_policy_class_path(@planning_application, policy_class)) %>
+          <%= govuk_link_to("Edit assessment", edit_planning_application_assessment_policy_areas_policy_class_path(@planning_application, pa_policy_class)) %>
         </p>
       <% end %>
     <% end %>

--- a/app/components/planning_applications/assessment/assessment_report_component.rb
+++ b/app/components/planning_applications/assessment/assessment_report_component.rb
@@ -44,10 +44,6 @@ module PlanningApplications
         planning_application.documents_for_decision_notice
       end
 
-      def policy_classes
-        planning_application_policy_classes
-      end
-
       def current_user
         Current.user
       end

--- a/app/form_models/policy_section_form.rb
+++ b/app/form_models/policy_section_form.rb
@@ -8,21 +8,11 @@ class PolicySectionForm
   def initialize(planning_application:, policy_class:)
     @planning_application = planning_application
     @policy_class = policy_class
-    @planning_application_policy_sections = build_planning_application_policy_sections
-  end
-
-  def build_planning_application_policy_sections
-    policy_class.policy_sections.map do |policy_section|
-      PlanningApplicationPolicySection.find_or_initialize_by(
-        planning_application: @planning_application.presented,
-        policy_section: policy_section
-      )
-    end.index_by(&:policy_section_id)
   end
 
   def update(params)
     params.each do |policy_section_id, section_params|
-      planning_application_policy_section = planning_application_policy_sections[policy_section_id.to_i]
+      planning_application_policy_section = PlanningApplicationPolicySection.find_by(planning_application: @planning_application.presented, policy_section_id:)
 
       update_attributes = {
         status: section_params[:status],

--- a/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
@@ -32,8 +32,8 @@
       <% end %>
 
       <% table.with_body do |body| %>
-        <% @planning_application_policy_class.policy_class.policy_sections.each do |policy_section| %>
-          <% pa_policy_section = policy_section.planning_application_policy_section %>
+        <% @planning_application_policy_class.planning_application_policy_sections.each do |pa_policy_section| %>
+          <% policy_section = pa_policy_section.policy_section %>
           <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
             <% row.with_cell do %>
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
@@ -58,7 +58,7 @@
                   <%= form.govuk_radio_button(
                         "planning_application_policy_sections[#{policy_section.id}][status]",
                         status,
-                        checked: @form.planning_application_policy_sections[policy_section.id].status == status,
+                        checked: pa_policy_section.status == status,
                         label: {hidden: true},
                         class: "govuk-radios__input"
                       ) %>

--- a/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
@@ -22,8 +22,8 @@
       <% end %>
 
       <% table.with_body do |body| %>
-        <% @planning_application_policy_class.policy_class.policy_sections.each do |policy_section| %>
-          <% pa_policy_section = policy_section.planning_application_policy_section %>
+        <% @planning_application_policy_class.planning_application_policy_sections.each do |pa_policy_section| %>
+          <% policy_section = pa_policy_section.policy_section %>
           <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
             <% row.with_cell do %>
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
@@ -48,7 +48,7 @@
                   <%= form.govuk_radio_button(
                         "planning_application_policy_sections[#{policy_section.id}][status]",
                         status,
-                        checked: @form.planning_application_policy_sections[policy_section.id].status == status,
+                        checked: pa_policy_section.status == status,
                         label: {hidden: true},
                         disabled: true,
                         class: "govuk-radios__input"

--- a/spec/factories/planning_application_policy_section.rb
+++ b/spec/factories/planning_application_policy_section.rb
@@ -18,5 +18,7 @@ FactoryBot.define do
         create(:comment, text: "A comment", commentable: planning_application_policy_section, commentable_type: "PlanningApplicationPolicySection")
       end
     end
+
+    initialize_with { PlanningApplicationPolicySection.find_or_create_by(planning_application:, policy_section:) }
   end
 end

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
             let(:comment1) { create(:comment, text: "Original comment") }
             let(:comment2) { create(:comment, text: "Updated comment") }
             let(:comment3) { create(:comment, text: "Current comment") }
-            let(:planning_application_policy_section) { create(:planning_application_policy_section, policy_section: policy_section1a, planning_application:) }
+            let(:planning_application_policy_section) { policy_section1a.planning_application_policy_sections.find_or_create_by(planning_application:) }
 
             before do
               Current.user = assessor

--- a/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
+++ b/spec/system/planning_applications/assessing/viewing_assessment_report_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
       expect(page).to have_link(policy_class.description, href: policy_class.url)
 
       within ".bops-assessment-list" do
-        within ".bops-assessment-list__row:nth-of-type(1)" do
+        within ".bops-assessment-list__row:nth-of-type(4)" do
           expect(page).to have_selector(".bops-assessment-list__section", text: "A")
 
           within ".bops-assessment-list__description" do
@@ -240,7 +240,7 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
           end
         end
 
-        within ".bops-assessment-list__row:nth-of-type(2)" do
+        within ".bops-assessment-list__row:nth-of-type(1)" do
           expect(page).to have_selector(".bops-assessment-list__section", text: "1a")
 
           within ".bops-assessment-list__description" do
@@ -257,7 +257,7 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
           end
         end
 
-        within ".bops-assessment-list__row:nth-of-type(3)" do
+        within ".bops-assessment-list__row:nth-of-type(2)" do
           expect(page).to have_selector(".bops-assessment-list__section", text: "1b")
 
           within ".bops-assessment-list__description" do
@@ -274,7 +274,7 @@ RSpec.describe "viewing assessment report", type: :system, capybara: true do
           end
         end
 
-        within ".bops-assessment-list__row:nth-of-type(4)" do
+        within ".bops-assessment-list__row:nth-of-type(3)" do
           expect(page).to have_selector(".bops-assessment-list__section", text: "1c")
 
           within ".bops-assessment-list__description" do


### PR DESCRIPTION
### Description of change

Previously, the comment lookup traversed the multiple steps of references incorrectly, so that for the planning application policy class in question, it was looking up the global policy class, and then from there all the planning application policy sections for that policy class. This was then used to prepopulate the form field for a particular comment, but instead of being the most recent comment on the given planning-application-policy-section, it would be the most recent comment on the instance of a section for any other planning application, potentially at a different local authority.

This PR corrects the traversal so it looks only for related policy classes/sections and the comments on them.

(The way the comments are looked up causes some less critical but still counter-intuitive behaviour, which was initially reported as a bug and will be addressed separately — actually, fixing the initial bug first seems like it might have masked this one, either way I couldn't get my head around the initial one until this was out of the way.)

### Story Link

https://trello.com/c/ghVF20VP/625-comment-updates-not-persisting-on-policy-references