### PR TITLE
DSNPI-1251 update PostSubmissionPagination to return totalResults & totalItems (if present)

### DIFF
--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
@@ -6,7 +6,7 @@ json.pagination do
   json.totalPages @pagy.pages
   json.totalResults @pagy.count
   if @total_responses.present?
-    json.totalItems @total_responses
+    json.totalAvailableItems @total_responses
   end
 end
 

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
@@ -4,7 +4,10 @@ json.pagination do
   json.resultsPerPage @pagy.limit
   json.currentPage @pagy.page
   json.totalPages @pagy.pages
-  json.totalItems @pagy.count
+  json.totalResults @pagy.count
+  if @total_responses.present?
+    json.totalItems @total_responses
+  end
 end
 
 # json.links pagy_jsonapi_links(@pagy, absolute: true)

--- a/engines/bops_api/schemas/odp/v0.7.3/shared/definitions.json
+++ b/engines/bops_api/schemas/odp/v0.7.3/shared/definitions.json
@@ -154,6 +154,9 @@
         "totalPages": {
           "type": "integer"
         },
+        "totalResults": {
+          "type": "integer"
+        },
         "totalItems": {
           "type": "integer"
         }

--- a/engines/bops_api/schemas/odp/v0.7.4/shared/definitions.json
+++ b/engines/bops_api/schemas/odp/v0.7.4/shared/definitions.json
@@ -154,6 +154,9 @@
         "totalPages": {
           "type": "integer"
         },
+        "totalResults": {
+          "type": "integer"
+        },
         "totalItems": {
           "type": "integer"
         }

--- a/engines/bops_api/schemas/odp/v0.7.4/shared/definitions.json
+++ b/engines/bops_api/schemas/odp/v0.7.4/shared/definitions.json
@@ -157,11 +157,16 @@
         "totalResults": {
           "type": "integer"
         },
-        "totalItems": {
+        "totalAvailableItems": {
           "type": "integer"
         }
       },
-      "required": ["resultsPerPage", "currentPage", "totalPages", "totalItems"]
+      "required": [
+        "resultsPerPage",
+        "currentPage",
+        "totalPages",
+        "totalAvailableItems"
+      ]
     }
   }
 }

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_public.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_public.json
@@ -3,6 +3,7 @@
     "resultsPerPage": 10,
     "currentPage": 1,
     "totalPages": 1,
+    "totalResults": 4,
     "totalItems": 4
   },
   "summary": {

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_public.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_public.json
@@ -4,7 +4,7 @@
     "currentPage": 1,
     "totalPages": 1,
     "totalResults": 4,
-    "totalItems": 4
+    "totalAvailableItems": 4
   },
   "summary": {
     "totalComments": 4,

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
@@ -3,6 +3,7 @@
     "resultsPerPage": 10,
     "currentPage": 1,
     "totalPages": 1,
+    "totalResults": 4,
     "totalItems": 4
   },
   "summary": {

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
@@ -4,7 +4,7 @@
     "currentPage": 1,
     "totalPages": 1,
     "totalResults": 4,
-    "totalItems": 4
+    "totalAvailableItems": 4
   },
   "summary": {
     "totalComments": 4,

--- a/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
@@ -64,12 +64,12 @@ RSpec.describe "BOPS public API Specialist comments" do
         description: "Search by redacted comment content"
       }, required: false
 
-      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_items:)
+      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
         expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
         expect(data["pagination"]["currentPage"]).to eq(current_page)
         expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
         expect(data["pagination"]["totalResults"]).to eq(total_results)
-        expect(data["pagination"]["totalItems"]).to eq(total_items)
+        expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
       end
 
       def validate_comment_summary(data)
@@ -100,7 +100,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_items: 50)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -119,7 +119,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_items: 50)
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -141,7 +141,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_items: 51)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
 
           # comment summary
           expect(data["summary"]["totalComments"]).to eq(51)

--- a/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
@@ -64,10 +64,11 @@ RSpec.describe "BOPS public API Specialist comments" do
         description: "Search by redacted comment content"
       }, required: false
 
-      def validate_pagination(data, results_per_page:, current_page:, total_items:)
+      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_items:)
         expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
         expect(data["pagination"]["currentPage"]).to eq(current_page)
-        expect(data["pagination"]["totalPages"]).to eq((total_items.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalResults"]).to eq(total_results)
         expect(data["pagination"]["totalItems"]).to eq(total_items)
       end
 
@@ -99,7 +100,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_items: 50)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -118,7 +119,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: 2, current_page: 2, total_items: 50)
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -140,7 +141,7 @@ RSpec.describe "BOPS public API Specialist comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_items: 1)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_items: 51)
 
           # comment summary
           expect(data["summary"]["totalComments"]).to eq(51)

--- a/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
@@ -55,12 +55,12 @@ RSpec.describe "BOPS public API Public comments" do
         description: "Search by redacted comment content"
       }, required: false
 
-      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_items:)
+      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
         expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
         expect(data["pagination"]["currentPage"]).to eq(current_page)
         expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
         expect(data["pagination"]["totalResults"]).to eq(total_results)
-        expect(data["pagination"]["totalItems"]).to eq(total_items)
+        expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
       end
 
       def validate_comment_summary(data)
@@ -90,7 +90,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_items: 50)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -109,7 +109,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_items: 50)
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -131,7 +131,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_items: 51)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
 
           # comment summary
           expect(data["summary"]["totalComments"]).to eq(51)

--- a/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
@@ -55,10 +55,11 @@ RSpec.describe "BOPS public API Public comments" do
         description: "Search by redacted comment content"
       }, required: false
 
-      def validate_pagination(data, results_per_page:, current_page:, total_items:)
+      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_items:)
         expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
         expect(data["pagination"]["currentPage"]).to eq(current_page)
-        expect(data["pagination"]["totalPages"]).to eq((total_items.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
+        expect(data["pagination"]["totalResults"]).to eq(total_results)
         expect(data["pagination"]["totalItems"]).to eq(total_items)
       end
 
@@ -89,7 +90,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_items: 50)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -108,7 +109,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: 2, current_page: 2, total_items: 50)
+          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_items: 50)
 
           # comment summary
           validate_comment_summary(data)
@@ -130,7 +131,7 @@ RSpec.describe "BOPS public API Public comments" do
           data = JSON.parse(response.body)
 
           # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_items: 1)
+          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_items: 51)
 
           # comment summary
           expect(data["summary"]["totalComments"]).to eq(51)

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -21044,13 +21044,13 @@ components:
           type: integer
         totalResults:
           type: integer
-        totalItems:
+        totalAvailableItems:
           type: integer
       required:
       - resultsPerPage
       - currentPage
       - totalPages
-      - totalItems
+      - totalAvailableItems
   schemas:
     Submission:
       additionalProperties: false
@@ -35304,7 +35304,7 @@ paths:
                       currentPage: 1
                       totalPages: 1
                       totalResults: 4
-                      totalItems: 4
+                      totalAvailableItems: 4
                     summary:
                       totalComments: 4
                       sentiment:
@@ -35466,7 +35466,7 @@ paths:
                       currentPage: 1
                       totalPages: 1
                       totalResults: 4
-                      totalItems: 4
+                      totalAvailableItems: 4
                     summary:
                       totalComments: 4
                       sentiment:

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -21042,6 +21042,8 @@ components:
           type: integer
         totalPages:
           type: integer
+        totalResults:
+          type: integer
         totalItems:
           type: integer
       required:
@@ -35301,6 +35303,7 @@ paths:
                       resultsPerPage: 10
                       currentPage: 1
                       totalPages: 1
+                      totalResults: 4
                       totalItems: 4
                     summary:
                       totalComments: 4
@@ -35462,6 +35465,7 @@ paths:
                       resultsPerPage: 10
                       currentPage: 1
                       totalPages: 1
+                      totalResults: 4
                       totalItems: 4
                     summary:
                       totalComments: 4


### PR DESCRIPTION
[DSNPI-1251](https://tpximpact.atlassian.net/browse/DSNPI-1251)

### Description of change

This PR goes along with this change to the ODP schema [here](https://github.com/theopensystemslab/digital-planning-data-schemas/pull/346)

It updates the Post-submission pagination view to return `totalResults` and `totalItems` (if `totalItems` is set in the controller)

* `totalResults` is the total number of results for this request 
* `totalItems` is the total number of items regardless of filtering. 

The `totalItems` field is optional since it could be a bit of an overhead for some endpoints to provide, but in the case of comments we're already calculating `totalItems` for the commentSummary. 

