### PR TITLE
Don't prepopulate comment field with last comment text

### DIFF
--- a/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/assessment/policy_areas/policy_classes/edit.html.erb
@@ -39,9 +39,25 @@
               <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
               <%= render(FormattedContentComponent.new(text: pa_policy_section&.description || policy_section.description)) %>
 
+              <% if pa_policy_section&.last_comment&.text.present? %>
+                <% comment = pa_policy_section.last_comment %>
+                <div id="planning_application_policy_section-<%= policy_section.id %>-current-comment">
+                  <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-1">
+                    <%= existing_policy_comment_label(comment) %>
+                  </p>
+                  <p class="govuk-body"><%= comment.created_at.to_fs %></p>
+                  <p class="govuk-body"><%= simple_format(comment.text) %></p>
+                  <% if comment.deleted? %>
+                    <p class="govuk-body govuk-!-font-weight-bold">
+                      <%= t(".comment_deleted", time: comment.deleted_at) %>
+                    </p>
+                  <% end %>
+                </div>
+              <% end %>
+
               <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.id}][comments_attributes][0][text]",
                     label: {text: "Add comment", class: "govuk-label govuk-label--s"},
-                    value: pa_policy_section&.last_comment&.text,
+                    value: "",
                     class: "govuk-textarea govuk-!-margin-bottom-2",
                     rows: 2 %>
 

--- a/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_against_legislation_spec.rb
@@ -167,11 +167,11 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
               expect(page).to have_content("description for section 1a")
               expect(page).not_to have_content("A new description")
 
-              expect(page).to have_field("Add comment", with: "My first comment")
+              expect(page).to have_content("My first comment")
               fill_in("Add comment", with: "Updated first comment")
             end
             within("#policy-section-#{policy_section1b.id}") do
-              expect(page).to have_field("Add comment", with: "My second comment")
+              expect(page).to have_content("My second comment")
               fill_in("Add comment", with: "Updated second comment")
             end
 
@@ -185,13 +185,13 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
 
             click_link("Part 1, Class A")
             within("#policy-section-#{policy_section1a.id}") do
-              expect(page).to have_field("Add comment", with: "Updated first comment")
+              expect(page).to have_content("Updated first comment")
               find("span", text: "Previous comments").click
               expect(page).to have_content("Comment added on 1 September 2022 by Alice Smith")
               expect(page).to have_content("My first comment")
             end
             within("#policy-section-#{policy_section1b.id}") do
-              expect(page).to have_field("Add comment", with: "Updated second comment")
+              expect(page).to have_content("Updated second comment")
               find("span", text: "Previous comments").click
               expect(page).to have_content("Comment added on 1 September 2022 by Alice Smith")
               expect(page).to have_content("My second comment")
@@ -226,7 +226,7 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
               click_link("Part 1, Class A")
 
               within("#policy-section-#{policy_section1a.id}") do
-                expect(page).to have_field("Add comment", with: "Current comment")
+                expect(page).to have_content("Current comment")
                 find("span", text: "Previous comments").click
 
                 within("#comment_#{comment1.id}") do
@@ -247,8 +247,8 @@ RSpec.describe "assessment against legislation", type: :system, capybara: true d
               click_button("Save and come back later")
               click_link("Part 1, Class A")
 
-              within("#policy-section-#{policy_section1a.id}") do
-                expect(page).to have_field("Add comment", with: "Current comment")
+              within("#planning_application_policy_section-#{policy_section1a.id}-current-comment") do
+                expect(page).to have_content("Current comment")
               end
               expect(planning_application_policy_section.comments.length).to eq(3)
             end


### PR DESCRIPTION
### Description of change

This was misleading as the comment isn't being edited; rather, a new comment is created. In turn this means that blanking the field won't delete the comment; it'll simply be ignored.

### Story Link

<https://trello.com/c/ghVF20VP/625-comment-updates-not-persisting-on-policy-references>
