### PR TITLE
Update structure of public specialist (consultee) summary

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/consultee_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/consultee_responses_controller.rb
@@ -19,9 +19,9 @@ module BopsApi
             .unscope(:order) # Remove default ORDER BY clause
             .count
           @response_summary = {
-            supportive: @response_summary["approved"] || 0,
-            objection: @response_summary["objected"] || 0,
-            neutral: @response_summary["amendments_needed"] || 0
+            approved: @response_summary["approved"] || 0,
+            objected: @response_summary["objected"] || 0,
+            amendments_needed: @response_summary["amendments_needed"] || 0
           }
 
           @pagy, @comments = BopsApi::Postsubmission::CommentsSpecialistService.new(

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist.json.jbuilder
@@ -3,16 +3,7 @@
 # DprComment
 
 json.id comment.id
-json.sentiment case comment.summary_tag
-when "supportive"
-  "approved"
-when "objected"
-  "objection"
-when "amendments_needed"
-  "neutral"
-else
-  "neutral" # Fallback for unexpected values
-end
+json.sentiment comment.summary_tag.camelize(:lower)
 json.comment comment.redacted_response
 json.receivedAt format_postsubmission_datetime(comment.received_at)
 

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist_summary.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/comments/_comment_specialist_summary.json.jbuilder
@@ -1,4 +1,11 @@
 # frozen_string_literal: true
 
-json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public_summary", total_responses: total_responses, response_summary: response_summary
 json.totalConsulted total_consulted
+json.totalComments total_responses
+if response_summary.present?
+  json.sentiment do
+    json.approved response_summary[:approved]
+    json.amendmentsNeeded response_summary[:amendments_needed]
+    json.objected response_summary[:objected]
+  end
+end

--- a/engines/bops_api/schemas/odp/v0.7.3/comments_specialist.json
+++ b/engines/bops_api/schemas/odp/v0.7.3/comments_specialist.json
@@ -17,13 +17,13 @@
         "sentiment": {
           "type": "object",
           "properties": {
-            "supportive": {
+            "approved": {
               "type": "integer"
             },
-            "objection": {
+            "amendmentsNeeded": {
               "type": "integer"
             },
-            "neutral": {
+            "objected": {
               "type": "integer"
             }
           }
@@ -41,7 +41,7 @@
               "type": "integer"
             },
             "sentiment": {
-              "enum": ["objection", "neutral", "approved"],
+              "enum": ["approved", "amendmentsNeeded", "objected"],
               "type": "string"
             },
             "comment": {

--- a/engines/bops_api/schemas/odp/v0.7.4/comments_specialist.json
+++ b/engines/bops_api/schemas/odp/v0.7.4/comments_specialist.json
@@ -17,13 +17,13 @@
         "sentiment": {
           "type": "object",
           "properties": {
-            "supportive": {
+            "approved": {
               "type": "integer"
             },
-            "objection": {
+            "amendmentsNeeded": {
               "type": "integer"
             },
-            "neutral": {
+            "objected": {
               "type": "integer"
             }
           }
@@ -41,7 +41,7 @@
               "type": "integer"
             },
             "sentiment": {
-              "enum": ["objection", "neutral", "approved"],
+              "enum": ["approved", "amendmentsNeeded", "objected"],
               "type": "string"
             },
             "comment": {

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_specialist.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.3/public/comments_specialist.json
@@ -6,36 +6,36 @@
     "totalItems": 4
   },
   "summary": {
+    "totalConsulted": 4,
     "totalComments": 4,
     "sentiment": {
-      "supportive": 4,
-      "objection": 0,
-      "neutral": 0
-    },
-    "totalConsulted": 4
+      "approved": 4,
+      "amendmentsNeeded": 0,
+      "objected": 0
+    }
   },
   "comments": [
     {
       "id": 1,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Qui eos impedit. In nostrum nam. Qui odit non.",
       "receivedAt": "2025-03-13T10:49:10Z"
     },
     {
       "id": 2,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Etiam porta sem malesuada magna mollis euismod.",
       "receivedAt": "2025-03-13T10:49:22Z"
     },
     {
       "id": 3,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Cras mattis consectetur purus sit amet fermentum.",
       "receivedAt": "2025-03-13T10:49:24Z"
     },
     {
       "id": 4,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Nullam id dolor id nibh ultricies vehicula ut id elit.",
       "receivedAt": "2025-03-13T10:49:25Z"
     }

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.4/public/comments_specialist.json
@@ -6,36 +6,36 @@
     "totalItems": 4
   },
   "summary": {
+    "totalConsulted": 4,
     "totalComments": 4,
     "sentiment": {
-      "supportive": 4,
-      "objection": 0,
-      "neutral": 0
-    },
-    "totalConsulted": 4
+      "approved": 4,
+      "amendmentsNeeded": 0,
+      "objected": 0
+    }
   },
   "comments": [
     {
       "id": 1,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Qui eos impedit. In nostrum nam. Qui odit non.",
       "receivedAt": "2025-03-13T10:49:10Z"
     },
     {
       "id": 2,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Etiam porta sem malesuada magna mollis euismod.",
       "receivedAt": "2025-03-13T10:49:22Z"
     },
     {
       "id": 3,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Cras mattis consectetur purus sit amet fermentum.",
       "receivedAt": "2025-03-13T10:49:24Z"
     },
     {
       "id": 4,
-      "sentiment": "supportive",
+      "sentiment": "approved",
       "comment": "Nullam id dolor id nibh ultricies vehicula ut id elit.",
       "receivedAt": "2025-03-13T10:49:25Z"
     }

--- a/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
@@ -74,16 +74,16 @@ RSpec.describe "BOPS public API Specialist comments" do
       def validate_comment_summary(data)
         expect(data["summary"]["totalComments"]).to eq(50)
         expect(data["summary"]["totalConsulted"]).to eq(100)
-        expect(data["summary"]["sentiment"]["supportive"]).to eq(50)
-        expect(data["summary"]["sentiment"]["objection"]).to eq(0)
-        expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+        expect(data["summary"]["sentiment"]["approved"]).to eq(50)
+        expect(data["summary"]["sentiment"]["amendmentsNeeded"]).to eq(0)
+        expect(data["summary"]["sentiment"]["objected"]).to eq(0)
       end
 
       def validate_comments(data, count:, total_items:)
         expect(data["comments"].count).to eq(count)
         data["comments"].each do |comment|
           expect(comment["id"]).to be_a(Integer)
-          expect(comment["sentiment"]).to be_in(["supportive", "objection", "neutral"])
+          expect(comment["sentiment"]).to be_in(["approved", "amendmentsNeeded", "objected"])
           expect(comment["comment"]).to include("*****")
           expect { DateTime.iso8601(comment["receivedAt"]) }.not_to raise_error
         end
@@ -144,9 +144,9 @@ RSpec.describe "BOPS public API Specialist comments" do
 
           # comment summary
           expect(data["summary"]["totalComments"]).to eq(51)
-          expect(data["summary"]["sentiment"]["supportive"]).to eq(51)
-          expect(data["summary"]["sentiment"]["objection"]).to eq(0)
-          expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
+          expect(data["summary"]["sentiment"]["approved"]).to eq(51)
+          expect(data["summary"]["sentiment"]["amendmentsNeeded"]).to eq(0)
+          expect(data["summary"]["sentiment"]["objected"]).to eq(0)
 
           # comments
           validate_comments(data, count: 1, total_items: 1)

--- a/engines/bops_api/spec/services/postsubmission/comments_specialist_service_spec.rb
+++ b/engines/bops_api/spec/services/postsubmission/comments_specialist_service_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe BopsApi::Postsubmission::CommentsSpecialistService, type: :servic
     end
 
     context "when a query parameter is provided" do
-      let(:params) { {query: "supportive"} }
+      let(:params) { {query: "approved"} }
 
       it "filters the scope by the query" do
-        filtered_scope = scope.where("redacted_response ILIKE ?", "%supportive%")
-        allow(scope).to receive(:where).with("redacted_response ILIKE ?", "%supportive%").and_return(filtered_scope)
+        filtered_scope = scope.where("redacted_response ILIKE ?", "%approved%")
+        allow(scope).to receive(:where).with("redacted_response ILIKE ?", "%approved%").and_return(filtered_scope)
         allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
 
         _, result = service.call

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -21688,11 +21688,11 @@ components:
             sentiment:
               type: object
               properties:
-                supportive:
+                approved:
                   type: integer
-                objection:
+                amendmentsNeeded:
                   type: integer
-                neutral:
+                objected:
                   type: integer
           required:
           - totalComments
@@ -21707,9 +21707,9 @@ components:
                 type: integer
               sentiment:
                 enum:
-                - objection
-                - neutral
                 - approved
+                - amendmentsNeeded
+                - objected
                 type: string
               comment:
                 type: string
@@ -35303,27 +35303,27 @@ paths:
                       totalPages: 1
                       totalItems: 4
                     summary:
+                      totalConsulted: 4
                       totalComments: 4
                       sentiment:
-                        supportive: 4
-                        objection: 0
-                        neutral: 0
-                      totalConsulted: 4
+                        approved: 4
+                        amendmentsNeeded: 0
+                        objected: 0
                     comments:
                     - id: 1
-                      sentiment: supportive
+                      sentiment: approved
                       comment: Qui eos impedit. In nostrum nam. Qui odit non.
                       receivedAt: '2025-03-13T10:49:10Z'
                     - id: 2
-                      sentiment: supportive
+                      sentiment: approved
                       comment: Etiam porta sem malesuada magna mollis euismod.
                       receivedAt: '2025-03-13T10:49:22Z'
                     - id: 3
-                      sentiment: supportive
+                      sentiment: approved
                       comment: Cras mattis consectetur purus sit amet fermentum.
                       receivedAt: '2025-03-13T10:49:24Z'
                     - id: 4
-                      sentiment: supportive
+                      sentiment: approved
                       comment: Nullam id dolor id nibh ultricies vehicula ut id elit.
                       receivedAt: '2025-03-13T10:49:25Z'
               schema:


### PR DESCRIPTION
### Description of change

Updates the current endpoint to use the latest schema for specialist sentiment. 

From  `supportive, objection, neutral` to  `approved, amendmentsNeeded, objected`


