### PR TITLE
Look up CIL liability in correct place in PlanX data

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -406,7 +406,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def cil_liability_details
-    planx_planning_data&.params_v2&.dig(:data, :CIL)
+    planx_planning_data&.params_v2&.dig(:data, :application, :CIL)
   end
 
   def cil_liability_details?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -417,6 +417,10 @@ class PlanningApplication < ApplicationRecord
     cil_liability_details&.fetch(:result) == "liable"
   end
 
+  def likely_cil_exempt?
+    cil_liability_details&.fetch(:result)&.start_with? "exempt."
+  end
+
   def secure_change_url
     params = {planning_application_id: id, change_access_id:}
     "#{local_authority.applicants_url}/validation_requests?#{params.to_query}"

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -414,7 +414,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def likely_cil_liable?
-    cil_liability_details&.fetch(:result) != "notLiable"
+    cil_liability_details&.fetch(:result) == "liable"
   end
 
   def secure_change_url

--- a/app/views/planning_applications/validation/cil_liability/edit.html.erb
+++ b/app/views/planning_applications/validation/cil_liability/edit.html.erb
@@ -26,11 +26,14 @@
           <br>
           This might mean that
         <% end %>
-          the application is
-          <% unless @planning_application.likely_cil_liable? %>
-            not
-          <% end %>
-          liable for CIL.
+        the application is
+        <% if @planning_application.likely_cil_exempt? %>
+          exempt from CIL.
+        <% elsif @planning_application.likely_cil_liable? %>
+            liable for CIL.
+        <% else %>
+          not liable for CIL.
+        <% end %>
       <% else %>
         No information on potential CIL liability from PlanX.
       <% end %>

--- a/spec/system/planning_applications/validating/cil_liability_spec.rb
+++ b/spec/system/planning_applications/validating/cil_liability_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe "Community Infrastructure Levy (CIL)", type: :system do
   context "when there is liability information from planx" do
     before do
       planx_planning_data = instance_double(PlanxPlanningData)
-      params_v2 = {data: {CIL: {result: planx_response, proposedTotalArea: {squareMetres: planx_size}}}}
+      params_v2 = {data: {application: {CIL: {result: planx_response, proposedTotalArea: {squareMetres: planx_size}}}}}
       allow(planx_planning_data).to receive(:params_v2).and_return(params_v2)
       allow_any_instance_of(PlanningApplication).to receive(:planx_planning_data).and_return(planx_planning_data)
     end


### PR DESCRIPTION
### Description of change

This was looking in `data.CIL` when it should have been `data.application.CIL`.

Also don't mark `exempt` applications as `liable`: categorise them under `not liable`, but also show the details to the user.

### Story Link

<https://trello.com/c/zozJc7uw/564-information-provided-about-cil-from-planx-out-of-date>
