### PR TITLE
Remove site and press notice rows in application summary for pre-app

### DIFF
--- a/app/views/shared/_overview_tabs.html.erb
+++ b/app/views/shared/_overview_tabs.html.erb
@@ -67,22 +67,24 @@
             <% end %>
           </td>
         </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <strong><%= t(".press_notice_date") %></strong>
-          </td>
-          <td class="govuk-table__cell">
-            <%= @planning_application.press_notice&.published_at.present? ? time_tag(@planning_application.press_notice.published_at) : "-" %>
-          </td>
-        </tr>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <strong><%= t(".site_notice_date") %></strong>
-          </td>
-          <td class="govuk-table__cell">
-            <%= @planning_application.site_notices.last&.displayed_at.present? ? time_tag(@planning_application.site_notices.last.displayed_at) : "-" %>
-          </td>
-        </tr>
+        <% unless @planning_application.pre_application? %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= t(".press_notice_date") %></strong>
+            </td>
+            <td class="govuk-table__cell">
+              <%= @planning_application.press_notice&.published_at.present? ? time_tag(@planning_application.press_notice.published_at) : "-" %>
+            </td>
+          </tr>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= t(".site_notice_date") %></strong>
+            </td>
+            <td class="govuk-table__cell">
+              <%= @planning_application.site_notices.last&.displayed_at.present? ? time_tag(@planning_application.site_notices.last.displayed_at) : "-" %>
+            </td>
+          </tr>
+        <% end %>
       </tbody>
     </table>
   <% end %>


### PR DESCRIPTION
### Description of change

When reviewing the final pre app report site and press notice rows were present in the table under the application details tab. These are not relevant for Pre-applications so I conditionally removed them for this application type.

### Story Link

https://trello.com/c/rymMe7zl/633-site-and-press-notices-show-in-preview-and-review-tabs-for-pre-app

### Screenshots

![image](https://github.com/user-attachments/assets/43862bbd-9c5a-4f1c-8182-edda04087642)
