### PR TITLE
 Pre populate application type requirements for pre-applications

### DIFF
--- a/app/components/status_tags/base_component.rb
+++ b/app/components/status_tags/base_component.rb
@@ -35,6 +35,8 @@ module StatusTags
         "yellow"
       when :refused, :removed, :invalid, :rejected, :objection, :failed, :refused_legal_agreement, :cancelled, :does_not_comply
         "red"
+      when :cannot_start_yet
+        "grey"
       end
     end
   end

--- a/app/components/status_tags/requirements_component.rb
+++ b/app/components/status_tags/requirements_component.rb
@@ -15,6 +15,8 @@ module StatusTags
     def status
       if @requirements.any?
         :complete
+      elsif @planning_application.recommended_application_type.blank?
+        :cannot_start_yet
       else
         :not_started
       end

--- a/app/controllers/planning_applications/assessment/requirements_controller.rb
+++ b/app/controllers/planning_applications/assessment/requirements_controller.rb
@@ -12,6 +12,10 @@ module PlanningApplications
       def index
         @categories = LocalAuthority::Requirement.categories
         @existing_requirements = @planning_application.requirements.pluck(:description)
+        @application_type_requirements = ApplicationTypeRequirement.includes(:local_authority_requirement).where(
+          local_authority_requirement: {local_authority_id: @planning_application.local_authority.id},
+          application_type_id: @planning_application.recommended_application_type_id
+        ).pluck(:description)
         respond_to do |format|
           format.html
         end

--- a/app/views/planning_applications/assessment/requirements/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/requirements/_tabs.html.erb
@@ -1,14 +1,21 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <p class="govuk-body">
-      This section is to select requirements to add to the list.
+       The recommended application type is:
+        <strong> <%= @planning_application.recommended_application_type.description %>. </strong>
+      <% if @application_type_requirements.any? && !@existing_requirements.any? %>
+        Any pre-configured requirements for <%= @planning_application.recommended_application_type.description %> have been pre-selected.
+      <% end %>
+    </p>
+    <p class="govuk-body">
+      This section is to select requirements for any subsequent application.
     </p>
     <div class="govuk-tabs" data-module="govuk-tabs">
     <%= form_with method: :post, url: planning_application_assessment_requirements_path do |form| %>
       <%= govuk_tabs do |tabs| %>
         <% @categories.each do |category| %>
           <% tabs.with_tab(label: category.humanize) do %>
-            <% if @requirements.where(category: category).length > 0 %>
+            <% if @requirements.where(category: category).length > 0 && @application_type_requirements.any? %>
                 <div class="govuk-checkboxes govuk-checkboxes--small">
                   <%= form.collection_check_boxes :requirement_ids,
                         @requirements.where(category: category),
@@ -17,10 +24,18 @@
                         legend: {text: category.humanize},
                         small: true do |b| %>
                     <div class="govuk-checkboxes__item">
-                      <% requirement_added = @existing_requirements.include?(b.object.description) %>
-                      <%= b.check_box(class: "govuk-checkboxes__input", checked: requirement_added, disabled: requirement_added) %>
-                      <%= b.label(class: "govuk-label govuk-checkboxes__label") do %>
-                      <%= b.object.description %>
+                      <% if @existing_requirements.any? %>
+                          <% requirement_added = @existing_requirements.include?(b.object.description) %>
+                          <%= b.check_box(class: "govuk-checkboxes__input", checked: requirement_added, disabled: requirement_added) %>
+                          <%= b.label(class: "govuk-label govuk-checkboxes__label") do %>
+                          <%= b.object.description %>
+                        <% end %>
+                      <% else %>
+                        <% application_type_requirement = @application_type_requirements.include?(b.object.description) %>
+                        <%= b.check_box(class: "govuk-checkboxes__input", checked: application_type_requirement) %>
+                        <%= b.label(class: "govuk-label govuk-checkboxes__label") do %>
+                        <%= b.object.description %>
+                      <% end %>
                     <% end %>
                     </div>
                   <% end %>
@@ -32,7 +47,11 @@
         <% end %>
       <% end %>
       <div class="govuk-!-margin-top-4">
-        <%= form.govuk_submit("Add requirements") %>
+        <% if @existing_requirements.any? %>
+          <%= form.govuk_submit("Add requirements", class: "govuk-button--secondary") %>
+        <% else %>
+          <%= form.govuk_submit("Add requirements") %>
+        <% end %>
         <%= govuk_button_link_to t("back"), planning_application_assessment_requirements_path, secondary: true %>
       </div>
     <% end %>

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -58,7 +58,14 @@
     <% if @planning_application.pre_application? %>
       <li class="app-task-list__item" id="check-add-requirements">
         <span class="app-task-list__task-name">
-          <%= govuk_link_to "Check and add requirements", planning_application_assessment_requirements_path(@planning_application) %>
+          <%= link_to_if(
+                @planning_application.recommended_application_type.present?,
+                "Check and add requirements",
+                planning_application_assessment_requirements_path(@planning_application),
+                class: "govuk-link"
+              ) do %>
+              Check and add requirements
+          <% end %>
         </span>
         <div class="govuk-task-list__status app-task-list__task-tag">
         <%= render(

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2258,6 +2258,7 @@ en:
     awaiting_response: Awaiting response
     awaiting_responses: Awaiting responses
     cancelled: Cancelled
+    cannot_start_yet: Cannot start yet
     complete: Completed
     complies: Complies
     does_not_comply: Does not comply

--- a/spec/factories/application_type_requirement.rb
+++ b/spec/factories/application_type_requirement.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :application_type_requirement, class: "ApplicationTypeRequirement" do
+    local_authority_requirement
+    application_type
+  end
+end

--- a/spec/system/planning_applications/assessing/adding_requirements_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_requirements_spec.rb
@@ -9,9 +9,17 @@ RSpec.describe "Add requirements", type: :system, capybara: true do
   let!(:requirement2) { create(:local_authority_requirement, local_authority:, category: "supporting_documents", description: "Parking plan") }
   let!(:requirement3) { create(:local_authority_requirement, local_authority:, category: "evidence", description: "Design statement") }
   let!(:requirement4) { create(:local_authority_requirement, local_authority:, category: "other", description: "Other") }
+  let!(:recommended_application_type) { create(:application_type, :householder) }
+  let!(:application_type_requirement) { create(:application_type_requirement, local_authority_requirement: requirement, application_type: recommended_application_type) }
 
   let(:planning_application) do
-    create(:planning_application, :in_assessment, :pre_application, local_authority: local_authority)
+    create(
+      :planning_application,
+      :in_assessment,
+      :pre_application,
+      local_authority: local_authority,
+      recommended_application_type: recommended_application_type
+    )
   end
 
   let(:reference) { planning_application.reference }
@@ -31,10 +39,18 @@ RSpec.describe "Add requirements", type: :system, capybara: true do
       expect(page).to have_content("Floor plans – existing")
       expect(page).not_to have_element(".govuk-summary-card")
     end
+
+    it "shows pre-configured application type requirements" do
+      expect(page).to have_content("The recommended application type is: #{recommended_application_type.description}")
+      expect(page).to have_content("Any pre-configured requirements for #{recommended_application_type.description} have been pre-selected.")
+      expect(page).to have_field("Floor plans – existing", type: "checkbox", checked: true)
+    end
   end
 
   describe "adding a list of requirements" do
     before do
+      click_link("Drawings")
+      uncheck "Floor plans – existing"
       click_link("Evidence")
       check "Design statement"
       click_link("Supporting documents")


### PR DESCRIPTION
### Description of change

Application type requirements pre-populate in the checklist for 'Check and add requirements' step for pre-app assessment when they are configured in local admin.

Included minor bug fix to change button colour.

### Story Link

https://trello.com/c/nsgJdCmY/639-application-type-requirements-pre-populate-for-pre-apps
also: https://trello.com/c/npl4wqyk/559-change-colour-of-the-add-requirements-button-to-grey-and-remove-back-button-inside

### Screenshots

![image](https://github.com/user-attachments/assets/b3ae12b5-2916-421e-994c-e4ab14748d51)
