### PR TITLE
Mark consultation as starting immediately but retain existing end date calculation

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -210,10 +210,6 @@ class Consultation < ApplicationRecord
     end
   end
 
-  def end_date_from_now
-    end_date_from(Time.zone.today)
-  end
-
   def letter_closing_date
     end_date_from(Time.next_immediate_business_day(Time.zone.now).to_date)
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -194,22 +194,6 @@ class Consultation < ApplicationRecord
     update!(end_date: new_date)
   end
 
-  def end_date_from(now = Time.zone.today)
-    # Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday)
-    # Second class letters are delivered 2 days after they’re dispatched.
-    # Royal Mail delivers from Monday to Saturday, excluding bank holidays.
-
-    effective_period_days = [consultee_response_period.days, period_days].max
-
-    from_date = 1.business_day.since(now)
-
-    if planning_application.application_type.consultations_skip_bank_holidays?
-      Bops::Holidays.days_after_plus_holidays(from_date: from_date, count: effective_period_days)
-    else
-      from_date + effective_period_days
-    end
-  end
-
   def letter_closing_date
     end_date_from(Time.next_immediate_business_day(Time.zone.now).to_date)
   end
@@ -524,5 +508,21 @@ class Consultation < ApplicationRecord
 
   def neighbour_exists?(new_neighbour)
     neighbours.find_by(address: new_neighbour[:address]).present?
+  end
+
+  def end_date_from(now = Time.zone.today)
+    # Letters are printed at 5:30pm and dispatched the next working day (Monday to Friday)
+    # Second class letters are delivered 2 days after they’re dispatched.
+    # Royal Mail delivers from Monday to Saturday, excluding bank holidays.
+
+    effective_period_days = [consultee_response_period.days, period_days].max
+
+    from_date = 1.business_day.since(now)
+
+    if planning_application.application_type.consultations_skip_bank_holidays?
+      Bops::Holidays.days_after_plus_holidays(from_date: from_date, count: effective_period_days)
+    else
+      from_date + effective_period_days
+    end
   end
 end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -182,7 +182,8 @@ class Consultation < ApplicationRecord
     )
   end
 
-  def start_deadline(now = Time.zone.today)
+  def start_deadline
+    now = Time.zone.today
     update!(end_date: [end_date, end_date_from(now)].compact.max, start_date: start_date || now)
   end
 

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -77,12 +77,11 @@ RSpec.describe Consultation do
     end
   end
 
-  describe "#end_date_from_now" do
+  describe "#end_date_from" do
     let(:consultation) { create(:consultation) }
 
     before do
       create(:environment_impact_assessment, planning_application: consultation.planning_application, required: false)
-      travel_to date
     end
 
     context "when tomorrow is not a working day" do
@@ -91,7 +90,7 @@ RSpec.describe Consultation do
         let(:date) { Time.zone.local(2023, 9, 23, 13) }
 
         it "returns the day 21 days after the next working day" do
-          expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 17).to_date)
+          expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 17).to_date)
         end
       end
 
@@ -100,7 +99,7 @@ RSpec.describe Consultation do
         let(:date) { Time.zone.local(2023, 9, 24, 13) }
 
         it "returns the day 21 days after the next working day" do
-          expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 17).to_date)
+          expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 17).to_date)
         end
       end
     end
@@ -110,7 +109,7 @@ RSpec.describe Consultation do
       let(:date) { Time.zone.local(2023, 9, 20, 13) }
 
       it "returns the day 21 days after the next working day" do
-        expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 12).to_date)
+        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 12).to_date)
       end
     end
 
@@ -123,7 +122,7 @@ RSpec.describe Consultation do
       end
 
       it "sets the end date to 30 days instead of 21" do
-        expect(consultation.end_date_from_now).to eq(Time.zone.local(2023, 10, 21).to_date)
+        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 21).to_date)
       end
     end
 
@@ -135,7 +134,7 @@ RSpec.describe Consultation do
       let(:date) { Time.zone.local(2023, 12, 18, 13) }
 
       it "returns the day 21 days after the next working day" do
-        expect(consultation.end_date_from_now).to eq(Time.zone.local(2024, 1, 12).to_date)
+        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2024, 1, 12).to_date)
       end
     end
   end

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe Consultation do
 
   describe "#end_date_from" do
     let(:consultation) { create(:consultation) }
+    let(:consultation_end_date) { consultation.send(:end_date_from, date).to_date }
 
     before do
       create(:environment_impact_assessment, planning_application: consultation.planning_application, required: false)
@@ -90,7 +91,7 @@ RSpec.describe Consultation do
         let(:date) { Time.zone.local(2023, 9, 23, 13) }
 
         it "returns the day 21 days after the next working day" do
-          expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 17).to_date)
+          expect(consultation_end_date).to eq(Time.zone.local(2023, 10, 17).to_date)
         end
       end
 
@@ -99,7 +100,7 @@ RSpec.describe Consultation do
         let(:date) { Time.zone.local(2023, 9, 24, 13) }
 
         it "returns the day 21 days after the next working day" do
-          expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 17).to_date)
+          expect(consultation_end_date).to eq(Time.zone.local(2023, 10, 17).to_date)
         end
       end
     end
@@ -109,7 +110,7 @@ RSpec.describe Consultation do
       let(:date) { Time.zone.local(2023, 9, 20, 13) }
 
       it "returns the day 21 days after the next working day" do
-        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 12).to_date)
+        expect(consultation_end_date).to eq(Time.zone.local(2023, 10, 12).to_date)
       end
     end
 
@@ -122,7 +123,7 @@ RSpec.describe Consultation do
       end
 
       it "sets the end date to 30 days instead of 21" do
-        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2023, 10, 21).to_date)
+        expect(consultation_end_date).to eq(Time.zone.local(2023, 10, 21).to_date)
       end
     end
 
@@ -134,7 +135,7 @@ RSpec.describe Consultation do
       let(:date) { Time.zone.local(2023, 12, 18, 13) }
 
       it "returns the day 21 days after the next working day" do
-        expect(consultation.end_date_from(date).to_date).to eq(Time.zone.local(2024, 1, 12).to_date)
+        expect(consultation_end_date).to eq(Time.zone.local(2024, 1, 12).to_date)
       end
     end
   end

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Consultation do
       end
 
       it "sets the start date to tomorrow" do
-        expect(consultation.start_date).to eq(Time.zone.local(2023, 9, 21).to_date)
+        expect(consultation.start_date).to eq(Time.zone.local(2023, 9, 20).to_date)
       end
 
       it "sets the end date to the future" do

--- a/spec/models/site_notice_spec.rb
+++ b/spec/models/site_notice_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe SiteNotice do
 
       before do
         site_notice.planning_application = planning_application
-        planning_application.consultation.start_deadline(1.day.from_now)
+        travel_to 1.day.from_now do
+          planning_application.consultation.start_deadline
+        end
       end
 
       it "validates date is not in future" do

--- a/spec/services/letter_sending_service_spec.rb
+++ b/spec/services/letter_sending_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe LetterSendingService do
           expect(letter.id).not_to be_nil
           expect(letter.status).not_to be_nil
           expect(neighbour.consultation.end_date).to eq(Time.utc(2023, 1, 27).to_date)
-          expect(neighbour.consultation.start_date).to eq(Time.utc(2023, 1, 6).to_date)
+          expect(neighbour.consultation.start_date).to eq(Time.utc(2023, 1, 5).to_date)
           expect(letter.text).to include(letter_content)
         end
       end

--- a/spec/system/planning_applications/publicity/press_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/press_notice_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Press notice" do
   let!(:assessor) { create(:user, :assessor, local_authority:) }
 
   let!(:planning_application) do
-    create(:planning_application, :prior_approval, local_authority:)
+    create(:planning_application, :prior_approval, local_authority:, postcode: "")
   end
 
   before do
@@ -412,11 +412,11 @@ RSpec.describe "Press notice" do
   describe "confirming a press notice" do
     let(:consultation) { planning_application.consultation }
 
-    before do
-      consultation.start_deadline("2023-09-20".in_time_zone)
-    end
-
     around do |example|
+      travel_to "2023-09-20" do
+        consultation.start_deadline
+      end
+
       travel_to "2023-10-31" do
         example.run
       end


### PR DESCRIPTION
### Description of change

We want the consultation start date, as presented in the API etc, to be the actual date on which the planning application is made public; however, we need the end date to remain calculated, as currently, from the next business day. This means the old start date gets retained internally for the end date calculation, but the new start date is just immediate.

### Story Link

https://trello.com/c/3lHvT7rJ/557-consultation-start-date-doesnt-align-with-dpr-statuses