### PR TITLE
Fix routing issue when signed in reviewer site description

### DIFF
--- a/app/controllers/planning_applications/assessment/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/assessment/assessment_details_controller.rb
@@ -146,13 +146,11 @@ module PlanningApplications
       end
 
       def redirect_path
-        path = if current_user.reviewer? && @category == "site_description"
-          planning_application_review_tasks_path(@planning_application)
+        if current_user.reviewer? && @category == "site_description" && !@planning_application.pre_application?
+          report_path_or planning_application_review_tasks_path(@planning_application)
         else
-          planning_application_assessment_tasks_path(@planning_application)
+          report_path_or planning_application_assessment_tasks_path(@planning_application)
         end
-
-        report_path_or(path)
       end
     end
   end


### PR DESCRIPTION
### Description of change

When logged in as a reviewer the user was being directed to the report page after creating or editing a site description, even when they had navigated from the assessment tasklist. There is a separate url error that is being triggered related to a blank summary of advice but regardless this is not the desired behaviour.

### Story Link

https://trello.com/c/2Tbjh2Q1/651-error-when-completing-site-description-for-pre-app
