### PR TITLE
Bug fix for requirements not showing

### DIFF
--- a/app/views/planning_applications/assessment/requirements/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/requirements/_tabs.html.erb
@@ -15,7 +15,7 @@
       <%= govuk_tabs do |tabs| %>
         <% @categories.each do |category| %>
           <% tabs.with_tab(label: category.humanize) do %>
-            <% if @requirements.where(category: category).length > 0 && @application_type_requirements.any? %>
+            <% if @requirements.where(category: category).length > 0 %>
                 <div class="govuk-checkboxes govuk-checkboxes--small">
                   <%= form.collection_check_boxes :requirement_ids,
                         @requirements.where(category: category),


### PR DESCRIPTION
### Description of change

Requriements not showing on pre-apps when configured on local admin. Erroneous additional condition of checking for application type requirements to show requirements in the list, i.e. if there were local admin requirements, but no requirements for the specific application type selected they were not showing.

### Story Link

https://trello.com/b/mNGcYJoX/bops-delivery

