### PR TITLE
Add reused link_to_document helper to Bops Core

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -33,25 +33,6 @@ module DocumentHelper
     document.numbers.presence || document.name
   end
 
-  def link_to_document(link_text, document, **args)
-    new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
-
-    govuk_link_to(
-      link_text,
-      url_for_document(document),
-      new_tab:,
-      **args
-    )
-  end
-
-  def url_for_document(document)
-    if document.published?
-      api_v1_planning_application_document_url(document.planning_application, document)
-    else
-      uploaded_file_url(document.blob)
-    end
-  end
-
   def document_thumbnail_link(document, thumbnail_args: {}, image_args: {})
     image = if document.representable?
       image_tag(document.representation_url(**thumbnail_args) || "", **image_args)

--- a/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/application_helper.rb
@@ -71,16 +71,5 @@ module BopsAdmin
         {text: "Settings", href: profile_path, active: active_page_key?("settings")}
       ]
     end
-
-    def link_to_document(link_text, document, **args)
-      new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
-
-      govuk_link_to(
-        link_text,
-        main_app.uploaded_file_url(document.blob),
-        new_tab:,
-        **args
-      )
-    end
   end
 end

--- a/engines/bops_consultees/app/helpers/bops_consultees/application_helper.rb
+++ b/engines/bops_consultees/app/helpers/bops_consultees/application_helper.rb
@@ -12,16 +12,5 @@ module BopsConsultees
     def home_path
       root_path
     end
-
-    def link_to_document(link_text, document, **args)
-      new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
-
-      govuk_link_to(
-        link_text,
-        main_app.uploaded_file_url(document.blob),
-        new_tab:,
-        **args
-      )
-    end
   end
 end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -39,5 +39,24 @@ module BopsCore
 
       super
     end
+
+    def link_to_document(link_text, document, **args)
+      new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
+
+      govuk_link_to(
+        link_text,
+        url_for_document(document),
+        new_tab:,
+        **args
+      )
+    end
+
+    def url_for_document(document)
+      if document.published?
+        main_app.api_v1_planning_application_document_url(document.planning_application, document)
+      else
+        main_app.uploaded_file_url(document.blob)
+      end
+    end
   end
 end

--- a/engines/bops_core/spec/helpers/bops_core/application_helper_spec.rb
+++ b/engines/bops_core/spec/helpers/bops_core/application_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe(BopsCore::ApplicationHelper, type: :helper) do
+  describe "#link_to_document" do
+    include GovukVisuallyHiddenHelper
+    include GovukLinkHelper
+
+    let(:document) { create(:document) }
+
+    it "adds view in new tab text" do
+      link = link_to_document("hello world", document)
+      expect(link).to match(/hello world \(opens in new tab\)/)
+    end
+
+    it "does not repeat view in new tab text" do
+      link = link_to_document("View document in new window", document)
+      expect(link).to match(/View document in new window/)
+      expect(link).not_to match(/\(opens in new tab\)/)
+    end
+  end
+end

--- a/engines/bops_reports/app/helpers/bops_reports/application_helper.rb
+++ b/engines/bops_reports/app/helpers/bops_reports/application_helper.rb
@@ -21,24 +21,5 @@ module BopsReports
     def map_link(full_address)
       "https://google.co.uk/maps/place/#{CGI.escape(full_address)}"
     end
-
-    def link_to_document(link_text, document, **args)
-      new_tab = /(new (window|tab)|<img\b)/.match?(link_text) ? "" : true
-
-      govuk_link_to(
-        link_text,
-        url_for_document(document),
-        new_tab:,
-        **args
-      )
-    end
-
-    def url_for_document(document)
-      if document.published?
-        main_app.api_v1_planning_application_document_url(document.planning_application, document)
-      else
-        main_app.uploaded_file_url(document.blob)
-      end
-    end
   end
 end

--- a/spec/helpers/document_helper_spec.rb
+++ b/spec/helpers/document_helper_spec.rb
@@ -17,22 +17,4 @@ RSpec.describe DocumentHelper do
       expect(reference_or_file_name(document)).to eq "proposed-floorplan.png"
     end
   end
-
-  describe "#link_to_document" do
-    include GovukVisuallyHiddenHelper
-    include GovukLinkHelper
-
-    let(:document) { create(:document) }
-
-    it "adds view in new tab text" do
-      link = link_to_document("hello world", document)
-      expect(link).to match(/hello world \(opens in new tab\)/)
-    end
-
-    it "does not repeat view in new tab text" do
-      link = link_to_document("View document in new window", document)
-      expect(link).to match(/View document in new window/)
-      expect(link).not_to match(/\(opens in new tab\)/)
-    end
-  end
 end


### PR DESCRIPTION
### Description of change

Probably shouldn't have the same method 4 times..

