### PR TITLE
Rely on new_tab parameter to add new tab annotation to link text

### DIFF
--- a/app/views/planning_applications/assessment/considerations/edit.html.erb
+++ b/app/views/planning_applications/assessment/considerations/edit.html.erb
@@ -16,9 +16,9 @@
 
 <% if @planning_application.local_authority.planning_policy_and_guidance? %>
   <p class="govuk-body govuk-!-margin-bottom-7">
-    <%= govuk_link_to @planning_application.local_authority.planning_policy_and_guidance, new_tab: "" do %>
-      Check your local policies and guidance (in a new tab)
-    <% end %>
+  <%= govuk_link_to "Check your local policies and guidance",
+        @planning_application.local_authority.planning_policy_and_guidance,
+        new_tab: true %>
   </p>
 <% end %>
 
@@ -128,7 +128,7 @@
 
 <% if @planning_application.decision? %>
   <p class="govuk-body govuk-!-margin-bottom-9">
-    <%= govuk_link_to "View draft decision notice (in a new tab)", decision_notice_planning_application_path(@planning_application), new_tab: "" %>
+    <%= govuk_link_to "View draft decision notice", decision_notice_planning_application_path(@planning_application), new_tab: true %>
   </p>
 <% end %>
 

--- a/app/views/planning_applications/assessment/considerations/show.html.erb
+++ b/app/views/planning_applications/assessment/considerations/show.html.erb
@@ -16,9 +16,9 @@
 
 <% if @planning_application.local_authority.planning_policy_and_guidance? %>
   <p class="govuk-body govuk-!-margin-bottom-7">
-    <%= govuk_link_to @planning_application.local_authority.planning_policy_and_guidance, new_tab: "" do %>
-      Check your local policies and guidance (in a new tab)
-    <% end %>
+  <%= govuk_link_to "Check your local policies and guidance",
+        @planning_application.local_authority.planning_policy_and_guidance,
+        new_tab: true %>
   </p>
 <% end %>
 
@@ -80,7 +80,7 @@
 
     <% if @planning_application.decision? %>
       <p class="govuk-body govuk-!-margin-bottom-9">
-        <%= govuk_link_to "View draft decision notice (in a new tab)", decision_notice_planning_application_path(@planning_application), new_tab: "" %>
+        <%= govuk_link_to "View draft decision notice", decision_notice_planning_application_path(@planning_application), new_tab: true %>
       </p>
     <% end %>
 

--- a/app/views/planning_applications/review/considerations/edit.html.erb
+++ b/app/views/planning_applications/review/considerations/edit.html.erb
@@ -16,9 +16,9 @@
 
 <% if @planning_application.local_authority.planning_policy_and_guidance? %>
   <p class="govuk-body govuk-!-margin-bottom-7">
-    <%= govuk_link_to @planning_application.local_authority.planning_policy_and_guidance, new_tab: "" do %>
-      Check your local policies and guidance (in a new tab)
-    <% end %>
+  <%= govuk_link_to "Check your local policies and guidance",
+        @planning_application.local_authority.planning_policy_and_guidance,
+        new_tab: true %>
   </p>
 <% end %>
 

--- a/app/views/planning_applications/review/tasks/_review_considerations.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_considerations.html.erb
@@ -11,9 +11,9 @@
   <% section.with_block(id: "considerations_block") do %>
     <% if @planning_application.local_authority.planning_policy_and_guidance? %>
       <p class="govuk-body govuk-!-margin-bottom-7">
-        <%= govuk_link_to @planning_application.local_authority.planning_policy_and_guidance, new_tab: "" do %>
-          Check your local policies and guidance (in a new tab)
-        <% end %>
+      <%= govuk_link_to "Check your local policies and guidance",
+            @planning_application.local_authority.planning_policy_and_guidance,
+            new_tab: true %>
       </p>
     <% end %>
 

--- a/app/views/planning_applications/validation/documents/edit.html.erb
+++ b/app/views/planning_applications/validation/documents/edit.html.erb
@@ -24,8 +24,8 @@
     <% if @planning_application.local_authority.document_checklist? %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <p class="govuk-body-m">
-        <%= govuk_link_to(@planning_application.local_authority.document_checklist, new_tab: "") do %>
-          Checklist for <%= @planning_application.application_type.name.humanize.downcase %> (opens in a new tab)
+        <%= govuk_link_to(@planning_application.local_authority.document_checklist, new_tab: true) do %>
+          Checklist for <%= @planning_application.application_type.name.humanize.downcase %>
         <% end %>
       </p>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/shared/_planning_guides_link.html.erb
+++ b/app/views/shared/_planning_guides_link.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
-  <%= govuk_link_to "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
-        public_planning_guides_path, new_tab: "" %>
+  <%= govuk_link_to "Applicants will be able to see this advice about how to prepare plans",
+        public_planning_guides_path, new_tab: true %>
 </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2008,7 +2008,7 @@ en:
         form:
           legislation: Legislation
           no_applicable_reporting_types: No applicable reporting types. Please configure them for the application type if they are required.
-          read_more: Read more guidance on GOV.UK (opens in a new tab)
+          read_more: Read more guidance on GOV.UK
         update:
           failure: Please select a development type for reporting
           success: Planning application's reporting details were successfully updated.

--- a/spec/system/planning_applications/additional_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/additional_document_validation_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
     expect(page).to have_content("This request will be sent to the applicant immediately.")
 
     expect(page).to have_link(
-      "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
+      "Applicants will be able to see this advice about how to prepare plans (opens in new tab)",
       href: public_planning_guides_path
     )
 
@@ -267,7 +267,7 @@ RSpec.describe "Requesting a new document for a planning application", type: :sy
       expect(page).to have_content("Request a new document")
 
       expect(page).to have_link(
-        "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
+        "Applicants will be able to see this advice about how to prepare plans (opens in new tab)",
         href: public_planning_guides_path
       )
       expect(page).to have_content(

--- a/spec/system/planning_applications/replacement_document_validation_request_spec.rb
+++ b/spec/system/planning_applications/replacement_document_validation_request_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
         "This request will be added to the application. The requests will not be sent until the application is marked as invalid."
       )
       expect(page).to have_link(
-        "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
+        "Applicants will be able to see this advice about how to prepare plans (opens in new tab)",
         href: public_planning_guides_path
       )
       expect(page).to have_link("Back")
@@ -287,7 +287,7 @@ RSpec.describe "Requesting document changes to a planning application", type: :s
       expect(page).to have_content("Request a replacement document")
       expect(page).to have_content("This request will be sent to the applicant immediately.")
       expect(page).to have_link(
-        "Applicants will be able to see this advice about how to prepare plans (Opens in a new window or tab)",
+        "Applicants will be able to see this advice about how to prepare plans (opens in new tab)",
         href: public_planning_guides_path
       )
 

--- a/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", type: :syst
         expect(find(".govuk-tag")).to have_content("Not started")
 
         within("#considerations_block") do
-          expect(page).to have_link("Check your local policies and guidance (in a new tab)")
+          expect(page).to have_link("Check your local policies and guidance (opens in new tab)")
 
           consideration = Consideration.last
           within("#consideration_#{consideration.id}") do


### PR DESCRIPTION
The `new_tab` parameter to `govuk_link_to` will add a suffix to the link text if enabled to make it clear that the link opens in a new tab. However in a few places we're suppressing that (`new_tab: ""`) and then adding our own, which seems unnecessary.

See the [docs](https://govuk-components.netlify.app/helpers/link/#links-that-open-in-a-new-tab).

There are a few other places where we could change it but it'd be more invasive (like `View in new window` -> `View (opens in new tab)` or similar), so I've skipped those at least for the time being.