### PR TITLE
Import task for planning applications csv

### DIFF
--- a/app/services/planning_applications_import_service.rb
+++ b/app/services/planning_applications_import_service.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "csv"
+
+class PlanningApplicationsImportService
+  VALIDATION_REPORT_PATH = Rails.root.join("tmp/validation_report.csv")
+  IMPORT_REPORT_PATH = Rails.root.join("tmp/import_results.csv")
+
+  REQUIRED_COLUMNS = [
+    "address_1", "agent_first_name", "agent_last_name", "applicant_first_name", "applicant_last_name",
+    "assessment_in_progress_at", "awaiting_determination_at", "cil_liable", "decision", "description",
+    "determination_date", "determined_at", "expiry_date", "invalidated_at", "valid_ownership_certificate",
+    "parish_name", "payment_amount", "postcode", "previous_references", "received_at", "reference",
+    "reporting_type_code", "returned_at", "target_date", "town", "uprn", "valid_description",
+    "in_committee_at", "ownership_certificate_checked", "regulation_3", "regulation_4", "valid_fee",
+    "valid_red_line_boundary", "validated_at", "ward", "withdrawn_at", "application_type"
+  ].freeze
+
+  attr_reader :csv_path, :authority_id
+
+  def initialize(csv_path:, authority_id:, application_type:)
+    @csv_path = Rails.root.join(csv_path)
+    @authority_id = authority_id
+    @application_type = application_type
+    @import_report_rows = []
+  end
+
+  def broadcast(message)
+    Rails.logger.debug message
+    Rails.logger&.info(message)
+  end
+
+  def run
+    validate
+    import
+    report
+  end
+
+  def validate
+    broadcast "Validating CSV at #{csv_path}..."
+
+    csv = CSV.read(csv_path, headers: true)
+    headers = csv.headers
+
+    missing_columns = REQUIRED_COLUMNS.reject { |col| headers.include?(col) }
+    blank_columns = headers.select do |header|
+      csv.map { |row| row[header].to_s.strip }.all?(&:empty?)
+    end
+
+    issues = []
+
+    unless missing_columns.empty?
+      issues << "Missing required columns: #{missing_columns.join(", ")}"
+    end
+
+    unless blank_columns.empty?
+      issues << "Columns with no data: #{blank_columns.join(", ")}"
+    end
+
+    CSV.open(VALIDATION_REPORT_PATH, "w") do |output|
+      output << ["row_number", "previous_references", "blank_fields"]
+      csv.each_with_index do |row, index|
+        blank_fields = row.headers.select { |field| row[field].to_s.strip.empty? }
+
+        if blank_fields.any?
+          output << [
+            index + 2, # 1-based row index + header
+            row["previous_references"].to_s.strip.presence || "(none)",
+            blank_fields.join(", ")
+          ]
+        end
+      end
+    end
+
+    broadcast "Validation report written to: #{VALIDATION_REPORT_PATH}"
+
+    if issues.any?
+      issues.each { |msg| broadcast msg }
+      broadcast "CSV validation completed with issues, continuing import."
+    else
+      broadcast "CSV validation passed — all required fields present and populated."
+    end
+  end
+
+  def import
+    broadcast "Importing PlanningApplications from #{csv_path} with local_authority_id #{authority_id}..."
+
+    CSV.foreach(csv_path, headers: true) do |row|
+      attrs = row.to_h
+      # Temporary solution until application_type is populated
+      attrs.delete("application_type")
+
+      # Transform decision values
+      case attrs["decision"]&.strip&.upcase
+      when "GRANT"
+        attrs["decision"] = "granted"
+      when "REFUSED"
+        attrs["decision"] = "refused"
+      when "NOT REQUIRED"
+        attrs["decision"] = "not_required"
+      end
+
+      app = PlanningApplication.create!(
+        attrs.merge(
+          local_authority_id: authority_id,
+          application_type_id: @application_type.id,
+          regulation_3: "pending",
+          regulation_4: "pending",
+          applicant_email: attrs["applicant_email"].presence || "admin@example.com",
+          ownership_certificate_checked: attrs["ownership_certificate_checked"].presence || false
+        )
+      )
+
+      @import_report_rows << [row["previous_references"], app.reference]
+    end
+
+    broadcast "Import complete."
+  end
+
+  def report
+    CSV.open(IMPORT_REPORT_PATH, "w") do |output|
+      output << ["previous_references", "new_reference"]
+      @import_report_rows.each { |r| output << r }
+    end
+    broadcast "Import results written to: #{IMPORT_REPORT_PATH}"
+  end
+end

--- a/lib/tasks/import_planning_applications.rake
+++ b/lib/tasks/import_planning_applications.rake
@@ -1,125 +1,19 @@
 # frozen_string_literal: true
 
-require "csv"
-
-VALIDATION_REPORT_PATH = Rails.root.join("lib/assets/data/validation_report.csv")
-IMPORT_REPORT_PATH = Rails.root.join("lib/assets/data/import_results.csv")
-REQUIRED_COLUMNS = ["address_1", "agent_first_name", "agent_last_name", "applicant_first_name", "applicant_last_name", "assessment_in_progress_at", "awaiting_determination_at", "cil_liable", "decision", "description", "determination_date", "determined_at", "expiry_date", "invalidated_at", "valid_ownership_certificate", "parish_name", "payment_amount", "postcode", "previous_references", "received_at", "reference", "reporting_type_code", "returned_at", "target_date", "town", "uprn", "valid_description", "in_committee_at", "ownership_certificate_checked", "regulation_3", "regulation_4", "valid_fee", "valid_red_line_boundary", "validated_at", "ward", "withdrawn_at", "payment_amount", "application_type"].freeze
-
 namespace :import do
-  def broadcast(message)
-    puts message
-    Rails.logger&.info(message)
-  end
-
-  desc "Pre-validate planning application CSV"
-  task prevalidate: :environment do
-    # We need to update this to work with Google Sheets API so we can work with PII within safe area
-    csv_path = ENV["CSV"]
-    unless csv_path
-      broadcast "Usage: rake import:prevalidate CSV=path/to/file.csv"
-      exit 1
-    end
-
-    broadcast "Validating CSV at #{csv_path}..."
-
-    csv = CSV.read(Rails.root.join(csv_path), headers: true)
-    headers = csv.headers
-
-    missing_columns = REQUIRED_COLUMNS.reject { |col| headers.include?(col) }
-    blank_columns = headers.select do |header|
-      csv.map { |row| row[header].to_s.strip }.all?(&:empty?)
-    end
-
-    issues = []
-
-    unless missing_columns.empty?
-      issues << "Missing required columns: #{missing_columns.join(", ")}"
-    end
-
-    unless blank_columns.empty?
-      issues << "Columns with no data: #{blank_columns.join(", ")}"
-    end
-
-    CSV.open(VALIDATION_REPORT_PATH, "w") do |output|
-      output << ["row_number", "previous_references", "blank_fields"]
-
-      csv.each_with_index do |row, index|
-        blank_fields = row.headers.select { |field| row[field].to_s.strip.empty? }
-
-        if blank_fields.any?
-          output << [
-            index + 2, # account for 1-based row numbering, +1 for headers
-            row["previous_references"].to_s.strip.presence || "(none)",
-            blank_fields.join(", ")
-          ]
-        end
-      end
-    end
-
-    broadcast "Validation report written to: #{VALIDATION_REPORT_PATH}"
-
-    if issues.any?
-      issues.each { |msg| broadcast msg }
-      broadcast "CSV validation completed with issues, but continuing import."
-    else
-      broadcast "CSV validation passed — all required fields present and populated."
-    end
-  end
-
-  # Need to add logic to halt import if the validation doesn't pass. Also need to tidy up agent name and company
-
   desc "Import planning applications from CSV with local_authority_id"
   task planning_applications: :environment do
     csv_path = ENV["CSV"]
     authority_id = ENV["AUTHORITY_ID"]
 
     unless csv_path && authority_id
-      broadcast "Usage: rake import:planning_applications CSV=path/to/file.csv AUTHORITY_ID=123"
+      puts "Usage: rake import:planning_applications CSV=path/to/file.csv AUTHORITY_ID=123"
       exit 1
     end
 
-    # Run pre-validation but do not block import
-    Rake::Task["import:prevalidate"].invoke
-
-    broadcast "Importing PlanningApplications from #{csv_path} with local_authority_id #{authority_id}..."
-
-    import_report_rows = []
-
-    CSV.foreach(Rails.root.join(csv_path), headers: true) do |row|
-      attrs = row.to_h
-
-      # Transform known decision values
-      case attrs["decision"]&.strip&.upcase
-      when "GRANT"
-        attrs["decision"] = "granted"
-      when "REFUSED"
-        attrs["decision"] = "refused"
-      when "NOT REQUIRED"
-        attrs["decision"] = "not_required"
-      end
-
-      # Added email, regulation_3, regulation_4 and application_type as a placeholder just to see if the import works
-      app = PlanningApplication.create!(
-        attrs.merge(
-          local_authority_id: authority_id,
-          application_type_id: 872,
-          regulation_3: "pending",
-          regulation_4: "pending",
-          applicant_email: attrs["applicant_email"].presence || "admin@example.com",
-          ownership_certificate_checked: attrs["ownership_certificate_checked"].presence || false
-        )
-      )
-
-      import_report_rows << [row["previous_references"], app.reference]
-    end
-
-    CSV.open(IMPORT_REPORT_PATH, "w") do |output|
-      output << ["previous_references", "new_reference"]
-      import_report_rows.each { |r| output << r }
-    end
-
-    broadcast "Import complete."
-    broadcast "Import results written to: #{IMPORT_REPORT_PATH}"
+    PlanningApplicationsImportService.new(
+      csv_path: csv_path,
+      authority_id: authority_id
+    ).run
   end
 end

--- a/spec/services/planning_applications_import_service_spec.rb
+++ b/spec/services/planning_applications_import_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PlanningApplicationsImportService, type: :service do
+  let(:csv_path) { "tmp/test_import.csv" }
+
+  let(:local_authority) { create(:local_authority) }
+  let(:application_type) { create(:application_type, local_authority_id: local_authority.id) }
+  let(:authority_id) { local_authority.id }
+
+  subject(:service) do
+    described_class.new(
+      csv_path: csv_path,
+      authority_id: authority_id,
+      application_type: application_type
+    )
+  end
+
+  let(:valid_headers) do
+    described_class::REQUIRED_COLUMNS
+  end
+
+  let(:valid_row) do
+    valid_headers.map { |h| [h, "value for #{h}"] }.to_h.merge(
+      "decision" => "GRANT",
+      "previous_references" => "PP-HH-123"
+    )
+  end
+
+  before do
+    # Write test CSV with headers and one valid row
+    CSV.open(csv_path, "w") do |csv|
+      csv << valid_headers
+      csv << valid_headers.map { |h| valid_row[h] }
+    end
+  end
+
+  after do
+    [csv_path, described_class::VALIDATION_REPORT_PATH, described_class::IMPORT_REPORT_PATH].each do |path|
+      File.delete(path) if File.exist?(path)
+    end
+  end
+
+  describe "#validate" do
+    it "creates a validation report file with no critical issues" do
+      service.validate
+      expect(File).to exist(described_class::VALIDATION_REPORT_PATH)
+
+      rows = CSV.read(described_class::VALIDATION_REPORT_PATH, headers: true)
+      expect(rows.headers).to include("row_number", "previous_references", "blank_fields")
+    end
+  end
+
+  describe "#import" do
+    it "creates a PlanningApplication with transformed decision" do
+      expect {
+        service.import
+      }.to change(PlanningApplication, :count).by(1)
+
+      expect(PlanningApplication.last.decision).to eq("granted")
+    end
+
+    it "adds local_authority_id and application_type_id" do
+      service.import
+      app = PlanningApplication.last
+
+      expect(app.local_authority_id).to eq(authority_id)
+      expect(app.application_type_id).to eq(application_type.id)
+    end
+  end
+
+  describe "#report" do
+    it "writes a mapping of previous_references to new references" do
+      service.import
+      service.report
+
+      report_rows = CSV.read(described_class::IMPORT_REPORT_PATH, headers: true)
+      expect(report_rows.length).to eq(1)
+      expect(report_rows[0]["previous_references"]).to eq("PP-HH-123")
+      expect(report_rows[0]["new_reference"]).to eq(PlanningApplication.last.reference)
+    end
+  end
+
+  describe "#run" do
+    it "runs validation, import, and report" do
+      expect {
+        service.run
+      }.to change(PlanningApplication, :count).by(1)
+
+      expect(File).to exist(described_class::VALIDATION_REPORT_PATH)
+      expect(File).to exist(described_class::IMPORT_REPORT_PATH)
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add Rake task and service to import legacy `planning_applications` data into BOPS. This is work in progress. It can be tested with the `edited_planning_applications.csv` as the original version has some incorrect headings.

This will be iterated as we get more data and eventually the placeholders will disappear.

### Story Link

https://trello.com/c/i8lSEmrt/100-create-a-parser-in-bops-for-the-planning-applications-csv
