### PR TITLE
Include selected document tags in default list of checkboxes

### DIFF
--- a/app/models/application_type_document_tags.rb
+++ b/app/models/application_type_document_tags.rb
@@ -54,9 +54,19 @@ class ApplicationTypeDocumentTags
     TAG_GROUPS.map(&method(:build_tag_group))
   end
 
+  def tag_groups_for_document(document)
+    TAG_GROUPS.map { |name| build_tag_group_for_document(name, document.tags) }
+  end
+
   private
 
   def build_tag_group(name)
     TagGroup.new(name, attributes[name], Document.tags(name))
+  end
+
+  def build_tag_group_for_document(name, document_tags)
+    all = Document.tags(name)
+    selected = (attributes[name] + (document_tags & all)).uniq
+    TagGroup.new(name, selected, all)
   end
 end

--- a/app/views/documents/form_partials/_tags.html.erb
+++ b/app/views/documents/form_partials/_tags.html.erb
@@ -9,7 +9,7 @@
     </legend>
 
     <%= govuk_tabs do |tabs| %>
-      <% document_tags.tag_groups.each do |group| %>
+      <% document_tags.tag_groups_for_document(@document).each do |group| %>
         <% tabs.with_tab(label: t(".groups.#{group}"), id: "#{group}-tags") do %>
           <%= form.govuk_check_boxes_fieldset :tags, legend: {text: t(".groups.#{group}")}, hint: {text: t(".hints.#{group}")}, small: true do %>
             <div data-controller="show-hide">

--- a/spec/models/application_type_document_tags_spec.rb
+++ b/spec/models/application_type_document_tags_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationTypeDocumentTags, type: :model do
+  describe "#tag_groups_for_document" do
+    let(:document) { instance_double("Document", tags: document_tags) }
+    let(:document_tags) { ["floorPlan.proposed", "bankStatement"] }
+
+    subject(:groups) { described_class.new(attributes).tag_groups_for_document(document) }
+
+    context "when no attributes are pre-selected" do
+      let(:attributes) do
+        {
+          drawings: [],
+          evidence: [],
+          supporting_documents: []
+        }
+      end
+
+      it "includes only the document’s tags in each group" do
+        drawing_group = groups.find { |g| g.name == "drawings" }
+        evidence_group = groups.find { |g| g.name == "evidence" }
+        supporting_group = groups.find { |g| g.name == "supporting_documents" }
+
+        expect(drawing_group.selected_tags).to contain_exactly("floorPlan.proposed")
+        expect(evidence_group.selected_tags).to contain_exactly("bankStatement")
+        expect(supporting_group.selected_tags).to be_empty
+      end
+    end
+
+    context "when attributes have pre-selected values" do
+      let(:attributes) do
+        {
+          drawings: ["roofPlan.existing"],
+          evidence: ["councilTaxBill"],
+          supporting_documents: []
+        }
+      end
+
+      it "merges form-selected and document tags into each group" do
+        drawing_group = groups.find { |g| g.name == "drawings" }
+        evidence_group = groups.find { |g| g.name == "evidence" }
+
+        expect(drawing_group.selected_tags).to match_array(
+          ["roofPlan.existing", "floorPlan.proposed"]
+        )
+        expect(evidence_group.selected_tags).to match_array(
+          ["councilTaxBill", "bankStatement"]
+        )
+      end
+    end
+  end
+end

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -38,6 +38,37 @@ RSpec.describe "Edit document", type: :system do
       expect(page).to have_content(planning_application.reference)
     end
 
+    context "when viewing the document tags", js: true do
+      let!(:document) do
+        create(
+          :document,
+          :with_file,
+          planning_application: planning_application,
+          tags: ["floorPlan.existing", "locationPlan"]
+        )
+      end
+
+      it "only shows selected tags and hides the rest until 'Show all' is clicked" do
+        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
+
+        within "#drawings-tags" do
+          expect(page).to have_checked_field("Floor plan - existing")
+          expect(page).to have_checked_field("Location plan")
+
+          expect(page).to have_css(".document-tags", visible: false)
+          expect(page).to have_unchecked_field("Elevations - existing", visible: false)
+          expect(page).to have_unchecked_field("Elevations - proposed", visible: false)
+
+          count = Document.tags("drawings").size - 2
+          click_link "Show all (#{count})"
+          expect(page).to have_css(".document-tags", visible: true)
+
+          expect(page).to have_unchecked_field("Elevations - existing")
+          expect(page).to have_unchecked_field("Elevations - proposed")
+        end
+      end
+    end
+
     it "archives and replaces existing document when new file is uploaded" do
       visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
 


### PR DESCRIPTION
### Description of change

Include selected document tags in default list of checkboxes

### Story Link

https://trello.com/c/EMgN9foF/671-tags-selected-in-planx-are-hidden-behind-show-all-on-every-document-page

