### PR TITLE
Reset the map when the accordion is expanded

### DIFF
--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -53,9 +53,22 @@
       document.querySelector("[id^='<%= locals[:geojson_field] %>']").value = JSON.stringify(geoJSON["EPSG:3857"]);
     });
   <% end %>
+
   <% if locals[:in_accordion] == true %>
-    function accordion_expanded() {
-      window.dispatchEvent(new Event("resize"));
+    const map = document.querySelector("my-map");
+    const section = map.closest(".govuk-accordion__section");
+
+    if (section) {
+      const callback = (mutationList, observer) => {
+        if (section.classList.contains("govuk-accordion__section--expanded")) {
+          setTimeout(() => {
+            map.shadowRoot.querySelector("button[title='Reset map view']").click();
+          }, 100);
+        }
+      }
+
+      const observer = new MutationObserver(callback);
+      observer.observe(section, { attributes: true });
     }
   <% end %>
 <% end %>


### PR DESCRIPTION
### Description of change

The site map inside an accordion fails to zoom to the extents of the GeoJSON on first render so dispatch a `click` event to the reset button when it is expanded.

### Story Link

https://trello.com/c/hsCckTE9

### Known issues

This is trying to work around limitations of the GOV.UK accordion and the OSL map component. The former doesn't appear to send any kind of callback event when the accordion is expanded so we have to use the `MutationObserver` API to be notified when it happens by tracking the `classList` attribute. That's just the start of our problems - the OSL map doesn't provide a way to reset the map from JavaScript so we have to reach into the shadow DOM of the custom `my-map` element to find the reset button by the title and click it.

🤮 