### PR TITLE
Enable authentication on NeighbourResponsesController

### DIFF
--- a/app/controllers/api/v1/neighbour_responses_controller.rb
+++ b/app/controllers/api/v1/neighbour_responses_controller.rb
@@ -6,8 +6,6 @@ module Api
       before_action :set_cors_headers, if: :json_request?
       before_action :set_application
 
-      skip_before_action :authenticate_api_user!
-
       def create
         unless @planning_application.application_type.consultation_steps.include? "neighbour"
           raise NeighbourResponseCreationService::CreateError, "This application type cannot accept neighbour responses"

--- a/spec/requests/api/neighbour_response_request_post_spec.rb
+++ b/spec/requests/api/neighbour_response_request_post_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe "Creating a planning application via the API" do
   let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:api_user) { create(:api_user, :validation_requests_rw, local_authority: default_local_authority) }
+  let!(:api_user) { create(:api_user, permissions: %w[comment:write], local_authority: default_local_authority) }
   let!(:planning_application) { create(:planning_application, :planning_permission, local_authority: default_local_authority) }
 
   let(:path) do


### PR DESCRIPTION
### Description of change

It was noticed during testing of #2325 that we weren't actually requiring authentication for this controller, which makes having the `comment:write` permission useless. DPR have confirmed that they're sending authentication anyway so there should be no problem with enabling this.

### Story Link

<https://trello.com/c/U1wsSee0/779-enable-authentication-for-comments-endpoint>
