### PR TITLE
Use HashWithIndifferentAccess not ActionController::Parameters

### DIFF
--- a/engines/bops_api/spec/services/application/parsers/address_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/address_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::AddressParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:property][:address]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:property][:address]
       }
 
       it "returns a correctly formatted address hash" do

--- a/engines/bops_api/spec/services/application/parsers/agent_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/agent_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::AgentParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:applicant][:agent]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:applicant][:agent]
       }
 
       it "returns a correctly formatted agent hash" do

--- a/engines/bops_api/spec/services/application/parsers/applicant_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/applicant_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::ApplicantParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:applicant]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:applicant]
       }
 
       it "returns a correctly formatted applicant hash" do

--- a/engines/bops_api/spec/services/application/parsers/application_type_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/application_type_parser_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe BopsApi::Application::Parsers::ApplicationTypeParser do
 
     context "when application type is LDCE" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_lawful_development_certificate_existing.json").read)
-        )[:data][:application][:type]
+        JSON.parse(file_fixture("v2/valid_lawful_development_certificate_existing.json").read).with_indifferent_access[:data][:application][:type]
       }
 
       it "returns the correct application type" do
@@ -29,9 +27,7 @@ RSpec.describe BopsApi::Application::Parsers::ApplicationTypeParser do
 
     context "when application type is LDCP" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_lawful_development_certificate_proposed.json").read)
-        )[:data][:application][:type]
+        JSON.parse(file_fixture("v2/valid_lawful_development_certificate_proposed.json").read).with_indifferent_access[:data][:application][:type]
       }
 
       it "returns the correct application type" do
@@ -51,9 +47,7 @@ RSpec.describe BopsApi::Application::Parsers::ApplicationTypeParser do
 
     context "when application type is planning permission full householder" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:application][:type]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:application][:type]
       }
 
       it "returns the correct application type" do

--- a/engines/bops_api/spec/services/application/parsers/fee_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/fee_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::FeeParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:application][:fee]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:application][:fee]
       }
 
       it "returns a correctly formatted applicant hash" do

--- a/engines/bops_api/spec/services/application/parsers/pre_assessment_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/pre_assessment_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::PreAssessmentParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_prior_approval.json").read)
-        )[:preAssessment]
+        JSON.parse(file_fixture("v2/valid_prior_approval.json").read).with_indifferent_access[:preAssessment]
       }
 
       it "returns a correctly formatted applicant hash" do

--- a/engines/bops_api/spec/services/application/parsers/proposal_details_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/proposal_details_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::ProposalDetailsParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:responses]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:responses]
       }
 
       it "returns a correctly formatted proposal_details hash" do

--- a/engines/bops_api/spec/services/application/parsers/proposal_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/proposal_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::ProposalParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )[:data][:proposal]
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access[:data][:proposal]
       }
 
       it "returns a correctly formatted proposal hash" do

--- a/engines/bops_api/spec/services/application/parsers/submission_parser_spec.rb
+++ b/engines/bops_api/spec/services/application/parsers/submission_parser_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe BopsApi::Application::Parsers::SubmissionParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(
-          JSON.parse(file_fixture("v2/valid_planning_permission.json").read)
-        )
+        JSON.parse(file_fixture("v2/valid_planning_permission.json").read).with_indifferent_access
       }
 
       it "returns a correctly formatted submission hash" do

--- a/engines/bops_submissions/app/services/bops_submissions/parsers/base_parser.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/parsers/base_parser.rb
@@ -6,7 +6,7 @@ module BopsSubmissions
       attr_reader :params, :local_authority
 
       def initialize(params, local_authority:)
-        @params = params
+        @params = params&.with_indifferent_access
         @local_authority = local_authority
       end
     end

--- a/engines/bops_submissions/spec/requests/v2/submissions_spec.rb
+++ b/engines/bops_submissions/spec/requests/v2/submissions_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "BOPS Submissions API", type: :request do
         let(:event) { valid_submission_event }
 
         before do
-          stub_request(:get, event[:documentLinks].first[:documentLink])
+          stub_request(:get, event["documentLinks"].first["documentLink"])
             .to_return(
               status: 200,
               body: zip_fixture("applications/PT-10087984.zip"),

--- a/engines/bops_submissions/spec/services/application/parsers/address_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/address_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BopsSubmissions::Parsers::AddressParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(json_fixture("files/applications/PT-10087984.json"))[:applicationData][:siteLocation]
+        json_fixture("files/applications/PT-10087984.json")["applicationData"]["siteLocation"]
       }
 
       it "returns a correctly formatted address hash" do

--- a/engines/bops_submissions/spec/services/application/parsers/agent_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/agent_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BopsSubmissions::Parsers::AgentParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(json_fixture("files/applications/PT-10087984.json"))[:applicationData][:agent]
+        json_fixture("files/applications/PT-10087984.json")["applicationData"]["agent"]
       }
 
       it "returns a correctly formatted agent hash" do

--- a/engines/bops_submissions/spec/services/application/parsers/applicant_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/applicant_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BopsSubmissions::Parsers::ApplicantParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(json_fixture("files/applications/PT-10087984.json"))[:applicationData][:applicant]
+        json_fixture("files/applications/PT-10087984.json")["applicationData"]["applicant"]
       }
 
       it "returns a correctly formatted applicant hash" do

--- a/engines/bops_submissions/spec/services/application/parsers/fee_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/fee_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BopsSubmissions::Parsers::FeeParser do
 
     context "with valid params" do
       let(:params) {
-        ActionController::Parameters.new(json_fixture("files/applications/PT-10087984.json"))[:feeCalculationSummary]
+        json_fixture("files/applications/PT-10087984.json")["feeCalculationSummary"]
       }
 
       it "returns a correctly formatted fee hash" do

--- a/engines/bops_submissions/spec/services/application/parsers/proposal_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/proposal_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BopsSubmissions::Parsers::ProposalParser do
 
     context "with valid params" do
       let(:params) {
-        json_fixture("files/applications/PT-10087984.json").with_indifferent_access
+        json_fixture("files/applications/PT-10087984.json")
       }
 
       it "returns a correctly formatted proposal hash" do
@@ -45,7 +45,7 @@ RSpec.describe BopsSubmissions::Parsers::ProposalParser do
 
     context "with missing polygon" do
       let(:params) do
-        fixture = ActionController::Parameters.new(json_fixture("files/applications/PT-10087984.json")).deep_dup
+        fixture = json_fixture("files/applications/PT-10087984.json").deep_dup
         fixture["polygon"] = nil
         fixture
       end

--- a/engines/bops_submissions/spec/services/application/parsers/proposal_parser_spec.rb
+++ b/engines/bops_submissions/spec/services/application/parsers/proposal_parser_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe BopsSubmissions::Parsers::ProposalParser do
 
     context "with missing polygon" do
       let(:params) do
-        fixture = json_fixture("files/applications/PT-10087984.json").deep_dup
+        fixture = json_fixture("files/applications/PT-10087984.json")
         fixture["polygon"] = nil
         fixture
       end

--- a/engines/bops_submissions/spec/support/fixture_helper.rb
+++ b/engines/bops_submissions/spec/support/fixture_helper.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |config|
   helpers = Module.new do
     def json_fixture(name, **opts)
-      JSON.parse(BopsSubmissions::Engine.root.join("spec", "fixtures", name).read, symbolize_names: true, **opts)
+      JSON.parse(BopsSubmissions::Engine.root.join("spec", "fixtures", name).read, **opts)
     end
 
     def zip_fixture(name)

--- a/spec/support/json_helpers.rb
+++ b/spec/support/json_helpers.rb
@@ -3,7 +3,7 @@
 RSpec.configure do |config|
   helpers = Module.new do
     def json_fixture(name, **)
-      JSON.parse(Rails.root.join("spec", "fixtures", "files", name).read, **)
+      JSON.parse(Rails.root.join("spec", "fixtures", "files", name).read, **).with_indifferent_access
     end
 
     def api_json_fixture(name, **)


### PR DESCRIPTION
### Description of change

In a few places in the tests we're using ActionController::Parameters to allow accessing hash parameters as either strings or symbols.

I think this has arisen as a result of a couple of things:

- hashes from the api come in with string keys
- but the test fixture was creating hashes with symbol keys
- we then added another layer in the tests to allow the code that expects strings to read the hashes from the fixture

I've changed the fixture so it's more consistent but also added `.with_indifferent_access` in the BaseParser constructor so that the production code can also use either (which matches what we've done in other places, I believe).
