### PR TITLE
Enable reviewers to directly publish report to applicants

### DIFF
--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_assessment_actions.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_assessment_actions.html.erb
@@ -13,7 +13,9 @@
     <% end %>
   <% end %>
 <% else %>
-  <div class="govuk-button-group">
-    <%= govuk_button_link_to("Back", main_app.planning_application_path(@planning_application), secondary: true) %>
-  </div>
+  <%= form_with(model: @recommendation, url: publish_planning_application_recommendation_path(@planning_application), id: "recommendation-review-form") do |form| %>
+    <%= form.govuk_submit("Confirm and submit pre-application report") do %>
+      <%= govuk_button_link_to("Back", main_app.planning_application_path(@planning_application), secondary: true) %>
+    <% end %>
+  <% end %>
 <% end %>

--- a/engines/bops_reports/config/locales/en.yml
+++ b/engines/bops_reports/config/locales/en.yml
@@ -33,9 +33,13 @@ en:
           withdrawal_failed: Failed to withdraw pre-application report - please contact support
           withdrawal_not_allowed: Withdrawing the pre-application report is no longer allowed
           withdrawn: Pre-application report withdrawn
+        publish:
+          not_assigned: Pre-application report must be assigned to a case officer before it can be submitted to the applicant
+          publish_failed: Failed to publish pre-application report - please contact support
+          published: Pre-application report has been sent to the applicant
         update:
           challenged: Pre-application report has been sent back to the case officer for amendments
-          not_assigned: Pre-application report must be assigned to a case officer before it can be submitted for review
+          not_assigned: Pre-application report must be assigned to a case officer before it can be submitted to the applicant
           not_challenged: Pre-application report has been sent to the applicant
           review_failed_html: Review submission failed – <a href="#recommendation-review-form" class="govuk-link govuk-link--no-visited-state">check the form for errors</a>
       review_actions:

--- a/engines/bops_reports/config/routes.rb
+++ b/engines/bops_reports/config/routes.rb
@@ -7,7 +7,9 @@ BopsReports::Engine.routes.draw do
 
   resources :planning_applications, param: :reference, only: %i[show] do
     scope module: "planning_applications" do
-      resource :recommendation, only: %i[create update destroy]
+      resource :recommendation, only: %i[create update destroy] do
+        post :publish, on: :member
+      end
     end
   end
 end

--- a/engines/bops_reports/spec/system/recommendation_spec.rb
+++ b/engines/bops_reports/spec/system/recommendation_spec.rb
@@ -106,4 +106,23 @@ RSpec.describe "Recommending and submitting a pre-application report" do
     click_button "Confirm and submit recommendation"
     expect(page).to have_selector("[role=alert] p", text: "Pre-application report must be assigned to a case officer before it can be submitted for review")
   end
+
+  context "when a reviewer skips assessment and publishes directly" do
+    before do
+      sign_in(reviewer)
+      visit "/reports/planning_applications/#{reference}"
+    end
+
+    it "allows them to send the report to the applicant" do
+      click_button "Confirm and submit pre-application report"
+
+      expect(BopsReports::SendReportEmailJob).to have_been_enqueued.with(
+        planning_application,
+        reviewer
+      ).once
+
+      expect(page).to have_selector("[role=alert] p",
+        text: "Pre-application report has been sent to the applicant")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Enable reviewers to directly publish report to applicants without needing assessor to submit first

### Story Link

https://trello.com/c/cKpXYwmb/688-allow-reviewers-to-complete-assessment-steps-in-pre-app-currently-appears-as-only-assessor-role-can-complete-assessment

