### PR TITLE
Able to add additional consultee comments when reconsulted

### DIFF
--- a/app/components/consultee_response_list_component.html.erb
+++ b/app/components/consultee_response_list_component.html.erb
@@ -2,8 +2,7 @@
   <h2 class="govuk-heading-m">
     <%= t(".heading") %>
   </h2>
-
   <% responses.reverse_each do |response| %>
-    <%= render ConsulteeResponseComponent.new(response: response, redact_and_publish: true) %>
+    <%= render ConsulteeResponseComponent.new(response: response, redact_and_publish: redact_and_publish) %>
   <% end %>
 </div>

--- a/app/components/consultee_response_list_component.rb
+++ b/app/components/consultee_response_list_component.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class ConsulteeResponseListComponent < ViewComponent::Base
-  def initialize(responses:)
-    @responses = responses
+  def initialize(responses:, redact_and_publish:)
+    @responses = responses.select(&:persisted?)
+    @redact_and_publish = redact_and_publish
   end
 
   private
 
-  attr_reader :responses
+  attr_reader :responses, :redact_and_publish
 end

--- a/app/views/planning_applications/consultees/show.html.erb
+++ b/app/views/planning_applications/consultees/show.html.erb
@@ -16,7 +16,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render ConsulteeSummaryComponent.new(consultee: @consultee) %>
-    <%= render ConsulteeResponseListComponent.new(responses: @consultee.responses) %>
+    <%= render ConsulteeResponseListComponent.new(responses: @consultee.responses, redact_and_publish: true) %>
 
     <div class="govuk-button-group govuk-!-margin-top-5">
       <%= govuk_button_link_to "Back", planning_application_consultees_responses_path(@planning_application), secondary: true %>

--- a/engines/bops_consultees/app/controllers/bops_consultees/consultee_responses_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/consultee_responses_controller.rb
@@ -6,8 +6,9 @@ module BopsConsultees
     before_action :set_consultee
     before_action :set_consultee_response
 
-    def update
-      if @consultee_response.update(consultee_response_params.merge(received_at: Time.zone.now))
+    def create
+      @consultee_response.assign_attributes(consultee_response_params.merge(received_at: Time.zone.now))
+      if @consultee_response.save
         redirect_to planning_application_path(@planning_application, sgid: params[:sgid]),
           notice: "Your response has been updated."
       else
@@ -25,7 +26,7 @@ module BopsConsultees
     end
 
     def set_consultee_response
-      @consultee_response = @consultee.responses.first_or_initialize
+      @consultee_response = @consultee.responses.new
     end
 
     def consultee_response_params

--- a/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
@@ -35,7 +35,7 @@ module BopsConsultees
     end
 
     def set_consultee_response
-      @consultee_response = @consultee.responses.first_or_initialize
+      @consultee_response = @consultee.responses.new
     end
 
     def render_expired

--- a/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
@@ -2,7 +2,7 @@
       scope: :consultee_response,
       model: consultee_response,
       url: planning_application_consultee_response_path(planning_application, sgid: params[:sgid]),
-      method: :patch,
+      method: :post,
       class: "govuk-!-margin-top-5"
     ) do |form| %>
 

--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/show.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/show.html.erb
@@ -16,14 +16,13 @@
       <%= @planning_application.status_tag %>
       <%= @planning_application.days_status_tag %>
     </p>
-
-    <% unless @consultee_response.persisted? %>
       <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
         <div class="govuk-notification-banner__header">
           <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
             Important
           </h2>
         </div>
+      <% unless @planning_application.consultation.complete? %>
         <div class="govuk-notification-banner__content">
           <p class="govuk-notification-banner__heading">
             Submit your comments by
@@ -35,7 +34,17 @@
           </p>
         </div>
       </div>
-    <% end %>
+      <% else %>
+        <div class="govuk-notification-banner__content">
+          <p class="govuk-notification-banner__heading">
+            Consulation for this planning application has ended
+          </p>
+          <p class="gov-uk-body">
+            Please contact the planning officer if you have further comments.
+          </p>
+        </div>
+      </div>
+      <% end %>
   </div>
   <div class="govuk-grid-column-full">
     <% if @planning_application.boundary_geojson.present? %>
@@ -92,11 +101,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full" id="comments-form">
-    <% unless @consultee_response.persisted? %>
+    <% unless @planning_application.consultation.complete? %>
       <%= render "bops_consultees/consultee_responses/form", planning_application: @planning_application, consultee_response: @consultee_response, sgid: params[:sgid] %>
-    <% else %>
-      <h2 class="govuk-heading-m">Response</h2>
-      <%= render ConsulteeResponseComponent.new(response: @consultee_response, redact_and_publish: false) %>
+      <hr class="govuk-!-margin-top-5 govuk-!-margin-bottom-5">
+      <%= render ConsulteeResponseListComponent.new(responses: @consultee.responses, redact_and_publish: false) %>
     <% end %>
   </div>
 </div>

--- a/engines/bops_consultees/config/routes.rb
+++ b/engines/bops_consultees/config/routes.rb
@@ -5,7 +5,7 @@ BopsConsultees::Engine.routes.draw do
 
   resource :dashboard, only: %i[show]
   resources :planning_applications, param: :reference, only: %i[show] do
-    resource :consultee_response, only: :update
+    resource :consultee_response, only: :create
     post :resend_link, on: :member
   end
 end

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Planning applications", type: :system do
         expect(page.status_code).to be < 400
       end
 
-      it "successfully submits and disables the form" do
+      it "successfully submits two comments" do
         choose "Approved"
 
         click_button "Submit Response"
@@ -68,7 +68,18 @@ RSpec.describe "Planning applications", type: :system do
             expect(page).to have_selector("p", text: "We are happy for this application to proceed")
           end
 
-          expect(page).not_to have_content(planning_application.consultation.end_date.to_fs(:day_month_year_slashes))
+          choose "Amendments needed"
+
+          fill_in "Response", with: "On further reflection we believe the applicant should reduce the size and scale of the proposed development"
+
+          click_button "Submit Response"
+
+          within ".consultee-response:first-of-type" do
+            expect(page).to have_selector("p time", text: "Received on #{today.to_fs}")
+            expect(page).to have_selector("p span", text: "Amendments needed")
+            expect(page).to have_selector("p span", text: "Private")
+            expect(page).to have_selector("p", text: "On further reflection we believe the applicant should reduce the size and scale of the proposed development")
+          end
         end
       end
     end

--- a/engines/bops_core/app/models/concerns/bops_core/magic_linkable.rb
+++ b/engines/bops_core/app/models/concerns/bops_core/magic_linkable.rb
@@ -5,7 +5,7 @@ module BopsCore
     extend ActiveSupport::Concern
     include GlobalID::Identification
 
-    def sgid(expires_in: 48.hours, for: "magic_link")
+    def sgid(expires_in: 7.days, for: "magic_link")
       to_sgid(expires_in:, for:).to_s
     end
   end

--- a/engines/bops_core/app/views/bops_core/magic_link_mailer/magic_link_mail.text.erb
+++ b/engines/bops_core/app/views/bops_core/magic_link_mailer/magic_link_mail.text.erb
@@ -5,5 +5,3 @@ This is your magic link to view BOPS application: <%= @planning_application.refe
 To view the application, visit:
 
 <%= @url %>
-
-This link will expire in 48 hours.

--- a/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
+++ b/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
@@ -28,9 +28,5 @@ RSpec.describe BopsCore::MagicLinkMailer, type: :mailer do
     it "includes the planning application reference in the email body" do
       expect(mail.body.encoded).to include("This is your magic link to view BOPS application: #{planning_application.reference_in_full}")
     end
-
-    it "includes the link expiration information" do
-      expect(mail.body.encoded).to include("This link will expire in 48 hours.")
-    end
   end
 end


### PR DESCRIPTION
### Description of change

Currently professional consultees are only able to make one comment, despite the ability to be reconsulted. This change allows consultees to be able to submit additional comments if they are reconsulted.

### Story Link

https://trello.com/c/PSVEBsjS/705-consultees-cant-submit-a-comment-when-reconsulted-or-submit-more-than-one-comment

### Screenshots

![image](https://github.com/user-attachments/assets/b81e73a5-6fde-4c6a-a87a-12d93e32937b)
