### PR TITLE
Start consultation when application is made public

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -982,6 +982,9 @@ class PlanningApplication < ApplicationRecord
     case value
     when true, "true"
       self.published_at ||= Time.zone.now
+      if consultation
+        consultation.start_deadline unless consultation.start_date
+      end
     when false, "false"
       self.published_at = nil
     end

--- a/spec/system/planning_applications/make_public_spec.rb
+++ b/spec/system/planning_applications/make_public_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "making planning application public" do
   let!(:local_authority) { create(:local_authority, :default) }
   let!(:assessor) { create(:user, :assessor, local_authority:) }
-  let!(:planning_application) { create(:planning_application, local_authority:) }
+  let!(:planning_application) { create(:planning_application, :planning_permission, local_authority:) }
   let!(:reference) { planning_application.reference }
 
   around do |example|
@@ -30,8 +30,8 @@ RSpec.describe "making planning application public" do
       click_button "Update application"
       expect(page).to have_content("Public on BOPS Public Portal: Yes")
     }.to change {
-      planning_application.reload.published_at
-    }.from(nil).to("2022-01-01".in_time_zone)
+      [planning_application.reload.published_at, planning_application.consultation.start_date]
+    }.from([nil, nil]).to(["2022-01-01".in_time_zone, "2022-01-01".in_time_zone])
 
     expect {
       visit "/planning_applications/#{reference}/make_public"


### PR DESCRIPTION
### Description of change

Start consultation when application is made public

### Story Link

https://trello.com/c/9FwphjbU/685-possible-to-make-a-planning-application-public-in-the-api-when-a-consultation-hasnt-been-started

