### PR TITLE
Redirect to review documents after adding reference

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -9,6 +9,7 @@ class DocumentsController < AuthenticationController
   before_action :ensure_blob_is_representable, only: %i[edit update archive unarchive]
   before_action :validate_document?, only: %i[edit update]
   before_action :replacement_document_validation_request, only: %i[edit update]
+  before_action :set_return_to_session, only: %i[update]
 
   def index
     @documents = @planning_application.documents.default.with_file_attachment
@@ -149,6 +150,8 @@ class DocumentsController < AuthenticationController
       supply_documents_planning_application_path(@planning_application)
     elsif session[:return_to]
       return_to_session
+    elsif request.referer&.include?("route=review")
+      planning_application_review_documents_path(@planning_application)
     else
       planning_application_documents_path(@planning_application)
     end

--- a/app/views/documents/_edit_and_upload.html.erb
+++ b/app/views/documents/_edit_and_upload.html.erb
@@ -1,5 +1,6 @@
 <%= form_with model: [@planning_application, @document], class: "document" do |form| %>
   <%= form.govuk_error_summary %>
+  <%= form.hidden_field :redirect_to, value: request.referer %>
   <%= render partial: "documents/form_partials/upload", locals: {form: form} unless @validate_document %>
   <div class="govuk-form-group">
     <%= render partial: "documents/form_partials/received_at", locals: {form: form} unless @validate_document %>

--- a/app/views/planning_applications/review/documents/index.html.erb
+++ b/app/views/planning_applications/review/documents/index.html.erb
@@ -63,7 +63,7 @@
                   </td>
                 <% else %>
                   <td class="govuk-table__cell text-align-centre" colspan="2">
-                    <%= govuk_link_to "Add document reference", edit_planning_application_document_path(@planning_application, document) %>
+                    <%= govuk_link_to "Add document reference", edit_planning_application_document_path(@planning_application, document, route: "review") %>
                   </td>
                 <% end %>
               <% end %>

--- a/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
+++ b/spec/system/planning_applications/assessing/review_documents_for_recommendation_spec.rb
@@ -189,19 +189,40 @@ RSpec.describe "Review documents for recommendation" do
       expect(document_with_reference_and_tags__publishable_checkbox).to be_checked
     end
 
-    it "I see a link to add a document reference when a reference hasn't been set" do
-      click_link "Check and assess"
-      expect(page).to have_selector("h1", text: "Assess the application")
+    context "when a reference hasn't been set", capybara: true do
+      it "shows me the link to add a reference" do
+        click_link "Check and assess"
+        expect(page).to have_selector("h1", text: "Assess the application")
 
-      click_link "Review documents for recommendation"
-      expect(page).to have_selector("h1", text: "Review documents for recommendation")
+        click_link "Review documents for recommendation"
+        expect(page).to have_selector("h1", text: "Review documents for recommendation")
 
-      within("#document_#{document_without_reference.id}") do
-        expect(page).to have_link(
-          "Add document reference",
-          href: edit_planning_application_document_path(planning_application, document_without_reference)
-        )
-        expect(page).not_to have_css("govuk-checkboxes")
+        within("#document_#{document_without_reference.id}") do
+          expect(page).to have_link(
+            "Add document reference",
+            href: edit_planning_application_document_path(planning_application, document_without_reference, route: "review")
+          )
+          expect(page).not_to have_css("govuk-checkboxes")
+        end
+      end
+
+      it "navigates back to the document review page" do
+        click_link "Check and assess"
+        click_link "Review documents for recommendation"
+        within("#document_#{document_without_reference.id}") do
+          click_link(
+            "Add document reference",
+            href: edit_planning_application_document_path(planning_application, document_without_reference, route: "review")
+          )
+        end
+
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/documents/#{document_without_reference.id}/edit?route=review")
+
+        expect(page).to have_content("Document reference(s)")
+        fill_in "Document reference(s)", with: "DOC-REF-01"
+        click_button "Save"
+
+        expect(page).to have_current_path("/planning_applications/#{planning_application.reference}/review/documents")
       end
     end
 


### PR DESCRIPTION
### Description of change

Currently when reviewing documents there is a link back to the edit document page in oder to add a reference and change the publish documents information. When you save this page it re-routes you back to the documents index page whereas it should return to the document review page, this PR corrects that.

### Story Link

https://trello.com/c/nqYT2pS7/767-able-to-navigate-back-from-the-add-drawing-reference-journey