### PR TITLE
Fix routing on production

### DIFF
--- a/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/application_controller.rb
@@ -22,7 +22,7 @@ module BopsCore
 
     def require_local_authority!
       unless devise_controller? || current_local_authority
-        raise ActiveRecord::RecordNotFound, "Couldn't find LocalAuthority with 'subdomain'=#{request.subdomain}"
+        raise ActiveRecord::RecordNotFound, "Couldn't find LocalAuthority with 'subdomain'=#{request.subdomains.first}"
       end
     end
 

--- a/engines/bops_core/lib/bops_core/middleware/local_authority.rb
+++ b/engines/bops_core/lib/bops_core/middleware/local_authority.rb
@@ -9,7 +9,7 @@ module BopsCore
 
       def call(env)
         request = ActionDispatch::Request.new(env)
-        env["bops.local_authority"] = ::LocalAuthority.find_by(subdomain: request.subdomain)
+        env["bops.local_authority"] = ::LocalAuthority.find_by(subdomain: request.subdomains.first)
 
         @app.call(env)
       end

--- a/engines/bops_core/lib/bops_core/middleware/user.rb
+++ b/engines/bops_core/lib/bops_core/middleware/user.rb
@@ -10,7 +10,7 @@ module BopsCore
 
       def call(env)
         request = ActionDispatch::Request.new(env)
-        env["bops.user_scope"] = user_scope(request.subdomain, env["bops.local_authority"])
+        env["bops.user_scope"] = user_scope(request.subdomains.first, env["bops.local_authority"])
 
         @app.call(env)
       end

--- a/engines/bops_core/spec/requests/bops_core/routing_spec.rb
+++ b/engines/bops_core/spec/requests/bops_core/routing_spec.rb
@@ -1,0 +1,404 @@
+# frozen_string_literal: true
+
+require "bops_core_helper"
+
+RSpec.describe BopsCore::Routing, show_exceptions: true do
+  with_routing do |set|
+    set.draw do
+      extend BopsCore::Routing
+
+      bops_domain do
+        public_subdomain do
+          get "/public", to: proc { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+        end
+
+        local_authority_subdomain do
+          get "/la-bops", to: proc { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+        end
+
+        config_subdomain do
+          get "/config", to: proc { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+        end
+
+        devise_subdomain do
+          get "/login", to: proc { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+        end
+      end
+
+      applicants_domain do
+        local_authority_subdomain do
+          get "/la-applicants", to: proc { [200, {"Content-Type" => "text/plain"}, %w[OK]] }
+        end
+      end
+    end
+  end
+
+  context "when in development" do
+    let!(:local_authority) { create(:local_authority, :default) }
+
+    before do
+      allow(Rails.application.config).to receive(:domain).and_return("bops.localhost:3000")
+      allow(Rails.application.config).to receive(:applicants_domain).and_return("bops-applicants.localhost:3000")
+    end
+
+    context "and making a request on the bops domain" do
+      before do
+        host! "planx.bops.localhost:3000"
+      end
+
+      it "routes correctly" do
+        get "/public"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-bops"
+        expect(response).to have_http_status(:ok)
+
+        get "/login"
+        expect(response).to have_http_status(:ok)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context "and making a request on the config subdomain" do
+        before do
+          host! "config.bops.localhost:3000"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:ok)
+
+          get "/config"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on the public subdomain" do
+        before do
+          host! "www.bops.localhost:3000"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on no subdomain" do
+        before do
+          host! "bops.localhost:3000"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "and making a request on the applicants domain" do
+      before do
+        host! "planx.bops-applicants.localhost:3000"
+      end
+
+      it "routes correctly" do
+        get "/public"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-bops"
+        expect(response).to have_http_status(:not_found)
+
+        get "/login"
+        expect(response).to have_http_status(:not_found)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when on staging" do
+    let!(:local_authority) { create(:local_authority, :default) }
+
+    before do
+      allow(Rails.application.config).to receive(:domain).and_return("bops-staging.services")
+      allow(Rails.application.config).to receive(:applicants_domain).and_return("bops-applicants-staging.services")
+    end
+
+    context "and making a request on the bops domain" do
+      before do
+        host! "planx.bops-staging.services"
+      end
+
+      it "routes correctly" do
+        get "/la-bops"
+        expect(response).to have_http_status(:ok)
+
+        get "/login"
+        expect(response).to have_http_status(:ok)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context "and making a request on the config subdomain" do
+        before do
+          host! "config.bops-staging.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:ok)
+
+          get "/config"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on the public subdomain" do
+        before do
+          host! "www.bops-staging.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on no subdomain" do
+        before do
+          host! "bops-staging.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "and making a request on the applicants domain" do
+      before do
+        host! "planx.bops-applicants-staging.services"
+      end
+
+      it "routes correctly" do
+        get "/public"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-bops"
+        expect(response).to have_http_status(:not_found)
+
+        get "/login"
+        expect(response).to have_http_status(:not_found)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+
+  context "when on production" do
+    let!(:local_authority) { create(:local_authority, :default) }
+
+    before do
+      allow(Rails.application.config).to receive(:domain).and_return("bops.services")
+      allow(Rails.application.config).to receive(:applicants_domain).and_return("applicants.bops.services")
+    end
+
+    context "and making a request on the bops domain" do
+      before do
+        host! "planx.bops.services"
+      end
+
+      it "routes correctly" do
+        get "/public"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-bops"
+        expect(response).to have_http_status(:ok)
+
+        get "/login"
+        expect(response).to have_http_status(:ok)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      context "and making a request on the config subdomain" do
+        before do
+          host! "config.bops.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:ok)
+
+          get "/config"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on the public subdomain" do
+        before do
+          host! "www.bops.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+
+      context "and making a request on no subdomain" do
+        before do
+          host! "bops.services"
+        end
+
+        it "routes correctly" do
+          get "/public"
+          expect(response).to have_http_status(:ok)
+
+          get "/la-bops"
+          expect(response).to have_http_status(:not_found)
+
+          get "/login"
+          expect(response).to have_http_status(:not_found)
+
+          get "/config"
+          expect(response).to have_http_status(:not_found)
+
+          get "/la-applicants"
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+
+    context "and making a request on the applicants domain" do
+      before do
+        host! "planx.applicants.bops.services"
+      end
+
+      it "routes correctly" do
+        get "/public"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-bops"
+        expect(response).to have_http_status(:not_found)
+
+        get "/login"
+        expect(response).to have_http_status(:not_found)
+
+        get "/config"
+        expect(response).to have_http_status(:not_found)
+
+        get "/la-applicants"
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Applicants requests on production use an applicants subdomain, e.g.

  https://southwark.applicants.bops.services

In this case `request.subdomain` returns `southwark.applicants` which will not find a local authority so switch to using `request.subdomains`.
