### PR TITLE
Don't inherit matches? method

### DIFF
--- a/engines/bops_core/lib/bops_core/routing.rb
+++ b/engines/bops_core/lib/bops_core/routing.rb
@@ -19,8 +19,13 @@ module BopsCore
       end
     end
 
-    class ApplicantsDomain < BopsDomain
+    class ApplicantsDomain
       class << self
+        def matches?(request)
+          tld_length = [1, request.subdomains.size].max
+          domain.starts_with?(request.domain(tld_length))
+        end
+
         private
 
         def domain


### PR DESCRIPTION
It seemed to point at the original domain method in the subclass even though it was tested.
