### PR TITLE
Redirect review informatives to accordion header on page after submission

### DIFF
--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -19,7 +19,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-informatives"), notice: t(".success")
+              redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-informatives-section"), notice: t(".success")
             else
               flash.now[:alert] = @review.errors.messages.values.flatten.join(", ")
               render_review_tasks

--- a/app/views/planning_applications/review/tasks/_review_informatives.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_informatives.html.erb
@@ -1,4 +1,4 @@
-<%= accordion.with_section(id: "informatives_section", expanded: current_review.errors.any?) do |section| %>
+<%= accordion.with_section(id: "review-informatives-section", expanded: current_review.errors.any?) do |section| %>
   <%= section.with_heading(text: "Review informatives") %>
 
   <%= section.with_status do %>

--- a/spec/system/planning_applications/review/informatives_spec.rb
+++ b/spec/system/planning_applications/review/informatives_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Reviewing informatives", js: true do
           expect(page).to have_current_path("/planning_applications/#{reference}/review/informatives")
           expect(page).to have_selector("[role=alert] li", text: "Select an option")
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             within(".bops-task-accordion__section-header") do
               expect(find("button")[:"aria-expanded"]).to eq("true")
             end
@@ -77,7 +77,7 @@ RSpec.describe "Reviewing informatives", js: true do
           expect(page).to have_current_path("/planning_applications/#{reference}/review/informatives")
           expect(page).to have_selector("[role=alert] li", text: "Explain to the case officer why")
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             within(".bops-task-accordion__section-header") do
               expect(find("button")[:"aria-expanded"]).to eq("true")
             end
@@ -90,7 +90,7 @@ RSpec.describe "Reviewing informatives", js: true do
         it "I can accept the planning officer's decision" do
           click_button "Review informatives"
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Not started")
             informative1 = Informative.first
             informative2 = Informative.second
@@ -148,7 +148,7 @@ RSpec.describe "Reviewing informatives", js: true do
             expect(page).to have_content("Review of informatives updated successfully")
           end
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Completed")
           end
 
@@ -189,7 +189,7 @@ RSpec.describe "Reviewing informatives", js: true do
             expect(page).to have_content("Review of informatives updated successfully")
           end
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Completed")
           end
 
@@ -217,7 +217,7 @@ RSpec.describe "Reviewing informatives", js: true do
             expect(page).to have_content("Review of informatives updated successfully")
           end
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Awaiting changes")
           end
 
@@ -262,7 +262,7 @@ RSpec.describe "Reviewing informatives", js: true do
           sign_in(reviewer)
 
           visit "/planning_applications/#{reference}/review/tasks"
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Updated")
           end
 
@@ -280,7 +280,7 @@ RSpec.describe "Reviewing informatives", js: true do
             expect(page).to have_content("Review of informatives updated successfully")
           end
 
-          within("#informatives_section") do
+          within("#review-informatives-section") do
             expect(find(".govuk-tag")).to have_content("Completed")
           end
 


### PR DESCRIPTION
### Description of change

Redirect review informatives to accordion header on page after submission

### Story Link

https://trello.com/c/LoBPOcDR