### PR TITLE
Update public search endpoint to use Postsubmission pagination DSNPI-1262

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/consultee_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/consultee_responses_controller.rb
@@ -12,7 +12,7 @@ module BopsApi
           end
           @consultee_responses = @consultation.consultee_responses.redacted
 
-          @total_responses = @consultee_responses.count
+          @total_available_items = @consultee_responses.count
           @total_consulted = @consultation.consultees.count
 
           @response_summary = @consultee_responses.group(:summary_tag)

--- a/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
@@ -17,7 +17,7 @@ module BopsApi
             pagination_params
           ).call
 
-          @total_responses = @neighbour_responses.count
+          @total_available_items = @neighbour_responses.count
           @response_summary = @neighbour_responses.group(:summary_tag).count
           @response_summary = {
             supportive: @response_summary["supportive"] || 0,

--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -5,7 +5,10 @@ module BopsApi
     module Public
       class PlanningApplicationsController < PublicController
         def search
-          @pagy, @planning_applications = search_service(planning_applications_scope.by_latest_published).call
+          @total_available_items = planning_applications_scope.by_latest_published.count
+
+          @pagy, @planning_applications = BopsApi::Postsubmission::PlanningApplicationsSearchService
+            .new(planning_applications_scope.by_latest_published, pagination_params).call
 
           respond_to do |format|
             format.json
@@ -18,6 +21,12 @@ module BopsApi
           respond_to do |format|
             format.json
           end
+        end
+
+        private
+
+        def pagination_params
+          params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :q, :page, :format, :reference, :description, :postcode, :publishedAtFrom, :publishedAtTo, :receivedAtFrom, :receivedAtTo, :validatedAtFrom, :validatedAtTo, :consultationEndDateFrom, :consultationEndDateTo, applicationType: [])
         end
       end
     end

--- a/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module Postsubmission
+    class PlanningApplicationsSearchService
+      POSTCODE_REGEX = /^(GIR\s?0AA|[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2})$/i
+      DATE_FIELDS = %i[receivedAt validatedAt publishedAt consultationEndDate].freeze
+
+      def initialize(scope, params)
+        @scope = scope
+        @params = params
+      end
+      attr_reader :scope, :params
+
+      def call
+        scoped = filter_by(scope)
+        scoped = apply_date_filters(scoped)
+        scoped = sort_results(scoped)
+        paginate(scoped)
+      end
+
+      private
+
+      def filter_by(scope)
+        types_param = params[:applicationType]
+        if types_param.present?
+          codes = Array(types_param)
+            .flat_map { |c| c.to_s.split(",") }
+            .map(&:presence)
+            .compact
+            .uniq
+
+          scope = scope.for_application_type_codes(codes)
+        end
+
+        search_param = (params[:query] || params[:q]).presence
+        if search_param.present?
+          normalised_query = search_param.downcase.strip
+
+          reference_matches = scope.where(
+            "LOWER(reference) LIKE ?",
+            "%#{normalised_query}%"
+          )
+          return reference_matches if reference_matches.exists?
+
+          if normalised_query.match?(POSTCODE_REGEX)
+            compacted_postcode = normalised_query.delete(" ")
+            postcode_matches = scope.where(
+              "LOWER(replace(postcode,' ','')) = ?",
+              compacted_postcode
+            )
+            return postcode_matches if postcode_matches.exists?
+          end
+
+          address_query_ts = normalised_query.split.join(" & ")
+          address_matches = scope.where(
+            "address_search @@ to_tsquery('simple', ?)",
+            address_query_ts
+          )
+          return address_matches if address_matches.exists?
+
+          description_query_ts = normalised_query.split.join(" | ")
+          return scope.where(
+            "to_tsvector('english', description) @@ to_tsquery('english', ?)",
+            description_query_ts
+          )
+        end
+
+        if params[:reference].present?
+          scope = scope.where(
+            "LOWER(reference) LIKE ?",
+            "%#{params[:reference].downcase}%"
+          )
+        end
+
+        if params[:description].present?
+          scope = scope.where(
+            "LOWER(description) LIKE ?",
+            "%#{params[:description].downcase}%"
+          )
+        end
+
+        if params[:postcode].present?
+          scope = scope.where(
+            "LOWER(postcode) LIKE ?",
+            "%#{params[:postcode].downcase}%"
+          )
+        end
+
+        scope
+      end
+
+      def apply_date_filters(current_scope)
+        DATE_FIELDS.reduce(current_scope) do |scope, prefix|
+          from_key = :"#{prefix}From"
+          to_key = :"#{prefix}To"
+
+          if params[from_key].present? || params[to_key].present?
+            from_time = parse_date(params[from_key])&.beginning_of_day || Time.zone.at(0)
+            to_time = parse_date(params[to_key])&.end_of_day || Time.zone.now.end_of_day
+
+            scope_method = "#{prefix.to_s.underscore}_between"
+            scope.public_send(scope_method, from_time, to_time)
+          else
+            scope
+          end
+        end
+      end
+
+      def parse_date(date_string)
+        return if date_string.blank?
+        Date.iso8601(date_string)
+      rescue ArgumentError
+        nil
+      end
+
+      def allowed_sort_fields
+        {
+          "publishedAt" => {column: "published_at", default_order: "desc"},
+          "receivedAt" => {column: "received_at", default_order: "desc"}
+        }
+      end
+
+      def allowed_order_values
+        %w[asc desc]
+      end
+
+      def default_sort_by
+        "publishedAt"
+      end
+
+      def sort_results(scope)
+        sort_by = params[:sortBy].present? ? params[:sortBy].camelize(:lower) : default_sort_by
+        unless allowed_sort_fields.key?(sort_by)
+          raise ArgumentError, "Invalid sortBy field: #{params[:sortBy]}"
+        end
+        order_by = (params[:orderBy].present? && allowed_order_values.include?(params[:orderBy])) ? params[:orderBy] : allowed_sort_fields[sort_by][:default_order]
+        scope.reorder("#{allowed_sort_fields[sort_by][:column]} #{order_by}")
+      end
+
+      def paginate(scope)
+        BopsApi::Postsubmission::PostsubmissionPagination
+          .new(scope: scope, params: params)
+          .call
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/consultee_responses/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/consultee_responses/index.json.jbuilder
@@ -3,7 +3,7 @@
 json.partial! "bops_api/v2/shared/postsubmissionApplication/pagination"
 
 json.summary do
-  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_specialist_summary", total_responses: @total_responses, total_consulted: @total_consulted, response_summary: @response_summary
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_specialist_summary", total_responses: @total_available_items, total_consulted: @total_consulted, response_summary: @response_summary
 end
 
 json.comments @comments do |comment|

--- a/engines/bops_api/app/views/bops_api/v2/public/neighbour_responses/index.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/neighbour_responses/index.json.jbuilder
@@ -3,7 +3,7 @@
 json.partial! "bops_api/v2/shared/postsubmissionApplication/pagination"
 
 json.summary do
-  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public_summary", total_responses: @total_responses, response_summary: @response_summary
+  json.partial! "bops_api/v2/shared/postsubmissionApplication/comments/comment_public_summary", total_responses: @total_available_items, response_summary: @response_summary
 end
 
 json.comments @comments do |comment|

--- a/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/search.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.partial! "bops_api/v2/shared/metadata"
+json.partial! "bops_api/v2/shared/postsubmissionApplication/pagination"
 
 json.data @planning_applications do |planning_application|
   json.partial! "bops_api/v2/public/shared/show", planning_application: planning_application

--- a/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/shared/postsubmissionApplication/_pagination.json.jbuilder
@@ -5,8 +5,8 @@ json.pagination do
   json.currentPage @pagy.page
   json.totalPages @pagy.pages
   json.totalResults @pagy.count
-  if @total_responses.present?
-    json.totalAvailableItems @total_responses
+  if @total_available_items.present?
+    json.totalAvailableItems @total_available_items
   end
 end
 

--- a/engines/bops_api/schemas/odp/v0.7.5/public/search.json
+++ b/engines/bops_api/schemas/odp/v0.7.5/public/search.json
@@ -2,54 +2,28 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "metadata": {
+    "pagination": {
       "type": "object",
       "properties": {
-        "page": {
+        "currentPage": {
           "type": "integer"
         },
-        "results": {
+        "resultsPerPage": {
           "type": "integer"
         },
-        "from": {
+        "totalPages": {
           "type": "integer"
         },
-        "to": {
-          "type": "integer"
-        },
-        "total_pages": {
-          "type": "integer"
-        },
-        "total_results": {
+        "totalResults": {
           "type": "integer"
         }
       },
       "required": [
-        "page",
-        "results",
-        "from",
-        "to",
-        "total_pages",
-        "total_results"
+        "currentPage",
+        "resultsPerPage",
+        "totalPages",
+        "totalResults"
       ]
-    },
-    "links": {
-      "type": "object",
-      "properties": {
-        "first": {
-          "type": "string"
-        },
-        "last": {
-          "type": "string"
-        },
-        "prev": {
-          "type": ["string", "null"]
-        },
-        "next": {
-          "type": ["string", "null"]
-        }
-      },
-      "required": ["first", "last", "prev", "next"]
     },
     "data": {
       "type": "array",
@@ -322,5 +296,5 @@
       ]
     }
   },
-  "required": ["metadata", "links", "data"]
+  "required": ["pagination", "data"]
 }

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/public/search.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/public/search.json
@@ -1,17 +1,10 @@
 {
-  "metadata": {
-    "page": 2,
-    "results": 2,
-    "from": 3,
-    "to": 4,
-    "total_pages": 5,
-    "total_results": 10
-  },
-  "links": {
-    "first": "/api/v2/public/planning_applications/search?page=1&maxresults=2",
-    "last": "/api/v2/public/planning_applications/search?page=5&maxresults=2",
-    "prev": "/api/v2/public/planning_applications/search?page=1&maxresults=2",
-    "next": "/api/v2/public/planning_applications/search?page=3&maxresults=2"
+  "pagination": {
+    "currentPage": 2,
+    "resultsPerPage": 2,
+    "totalPages": 5,
+    "totalResults": 10,
+    "totalAvailableItems": 10
   },
   "data": [
     {

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -5,17 +5,53 @@ require_relative "../../../swagger_helper"
 RSpec.describe "BOPS public API" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:application_type) { create(:application_type, :householder) }
-  let!(:planning_applications) { create_list(:planning_application, 6, :published, :with_boundary_geojson, :with_press_notice, local_authority:, application_type:, user: create(:user)) }
+  let!(:planning_applications) do
+    create_list(
+      :planning_application, 6,
+      :published,
+      :with_boundary_geojson,
+      :with_press_notice,
+      local_authority: local_authority,
+      application_type: application_type,
+      user: create(:user)
+    )
+  end
+
   let(:page) { 1 }
-  let(:maxresults) { 5 }
+  let(:resultsPerPage) { 5 }
   let(:invalidated) { create(:planning_application, :with_boundary_geojson_features, :published, local_authority:, application_type:, description: "This is not valid even if marked as published", status: :invalidated) }
   let("applicationType[]") { [] }
   let(:orderBy) { "desc" }
   let(:sortBy) { "publishedAt" }
 
+  let(:invalidated) do
+    create(
+      :planning_application,
+      :with_boundary_geojson_features,
+      :published,
+      local_authority: local_authority,
+      application_type: application_type,
+      description: "This is not valid even if marked as published",
+      status: :invalidated
+    )
+  end
+
   before do
-    create_list(:planning_application, 2, :with_boundary_geojson_features, :published, local_authority:, application_type:)
-    create_list(:planning_application, 2, :with_boundary_geojson_features, :published, local_authority:, application_type:, description: "I want to build a roof extension.")
+    create_list(
+      :planning_application, 2,
+      :with_boundary_geojson_features,
+      :published,
+      local_authority: local_authority,
+      application_type: application_type
+    )
+    create_list(
+      :planning_application, 2,
+      :with_boundary_geojson_features,
+      :published,
+      local_authority: local_authority,
+      application_type: application_type,
+      description: "I want to build a roof extension."
+    )
   end
 
   path "/api/v2/public/planning_applications/search" do
@@ -25,33 +61,68 @@ RSpec.describe "BOPS public API" do
 
       with_search_and_filter_params
 
-      response "200", "returns planning applications when searching by the reference" do
-        schema "$ref" => "#/components/schemas/Search"
+      parameter name: :resultsPerPage, in: :query, schema: {
+        type: :integer,
+        default: 5,
+        minimum: 1,
+        maximum: BopsApi::Postsubmission::PostsubmissionPagination::MAXRESULTS_LIMIT
+      }, required: false
 
-        let(:page) { 1 }
-        let(:q) { planning_applications.first.reference }
+      parameter name: :query, in: :query, schema: {
+        type: :string,
+        description: "Search by reference or description"
+      }, required: false
+
+      parameter name: "applicationType[]", in: :query, style: :form, explode: true, schema: {
+        type: :array,
+        items: {
+          type: :string
+        },
+        description: "Filter by one or more application type codes"
+      }
+
+      parameter name: :orderBy, in: :query, schema: {
+        type: :string,
+        description: "Sort by ascending or descending order",
+        enum: ["asc", "desc"],
+        default: "desc"
+      }
+
+      parameter name: :sortBy, in: :query, schema: {
+        type: :string,
+        description: "Sort by field",
+        enum: ["publishedAt", "receivedAt"],
+        default: "receivedAt"
+      }
+
+      response "200", "returns planning applications when searching by the reference" do
+        schema "$ref" => "#/components/schemas/PublicSearch"
+
+        let(:query) { planning_applications.first.reference }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 1,
-              "results" => 5,
-              "from" => 1,
-              "to" => 1,
-              "total_pages" => 1,
-              "total_results" => 1
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => 5,
+            "currentPage" => 1,
+            "totalPages" => 1,
+            "totalResults" => 1,
+            "totalAvailableItems" => 10
           )
 
-          expect(data["data"].first["application"]["fullReference"]).to eq("PlanX-#{planning_applications.first.reference}")
+          expect(
+            data["data"].first["application"]["fullReference"]
+          ).to eq("PlanX-#{planning_applications.first.reference}")
         end
       end
 
       it "validates successfully against the example search json" do
-        resolved_schema = load_and_resolve_schema(name: "search", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+        resolved_schema = load_and_resolve_schema(
+          name: "search",
+          version: BopsApi::Schemas::DEFAULT_ODP_VERSION
+        )
         schemer = JSONSchemer.schema(resolved_schema)
         example_json = example_fixture("public/search.json")
 
@@ -59,51 +130,45 @@ RSpec.describe "BOPS public API" do
       end
 
       response "200", "returns planning applications when searching by the description" do
-        schema "$ref" => "#/components/schemas/Search"
+        schema "$ref" => "#/components/schemas/PublicSearch"
 
-        let(:page) { 1 }
-        let(:q) { "roof extension" }
+        let(:query) { "roof extension" }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 1,
-              "results" => 5,
-              "from" => 1,
-              "to" => 2,
-              "total_pages" => 1,
-              "total_results" => 2
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => 5,
+            "currentPage" => 1,
+            "totalPages" => 1,
+            "totalResults" => 2,
+            "totalAvailableItems" => 10
           )
 
           data["data"].each do |application|
-            expect(application["proposal"]["description"]).to include("roof extension")
+            expect(
+              application["proposal"]["description"]
+            ).to include("roof extension")
           end
         end
       end
 
       response "200", "does not return 'private' applications" do
-        schema "$ref" => "#/components/schemas/Search"
+        schema "$ref" => "#/components/schemas/PublicSearch"
 
-        let(:page) { 1 }
-        let(:q) { invalidated.reference }
+        let(:query) { invalidated.reference }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 1,
-              "results" => 5,
-              "from" => 0,
-              "to" => 0,
-              "total_pages" => 1,
-              "total_results" => 0
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => 5,
+            "currentPage" => 1,
+            "totalPages" => 1,
+            "totalResults" => 0,
+            "totalAvailableItems" => 10
           )
 
           expect(data["data"]).to eq([])
@@ -111,74 +176,64 @@ RSpec.describe "BOPS public API" do
       end
 
       response "200", "returns empty array when no results from search" do
-        schema "$ref" => "#/components/schemas/Search"
+        schema "$ref" => "#/components/schemas/PublicSearch"
 
-        let(:page) { 1 }
-        let(:q) { "no results found" }
+        let(:query) { "no results found" }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 1,
-              "results" => 5,
-              "from" => 0,
-              "to" => 0,
-              "total_pages" => 1,
-              "total_results" => 0
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => 5,
+            "currentPage" => 1,
+            "totalPages" => 1,
+            "totalResults" => 0,
+            "totalAvailableItems" => 10
           )
 
           expect(data["data"]).to eq([])
         end
       end
 
-      response "200", "returns planning applications when searching by an out of range page and maxresults" do
-        schema "$ref" => "#/components/schemas/Search"
+      response "200", "returns planning applications when searching by an out of range page and resultsPerPage" do
+        schema "$ref" => "#/components/schemas/PublicSearch"
 
         let(:page) { 0 }
-        let(:max_results) { 100000 }
+        let(:resultsPerPage) { 100_000 }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 1,
-              "results" => 5,
-              "from" => 1,
-              "to" => 5,
-              "total_pages" => 2,
-              "total_results" => 10
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => BopsApi::Postsubmission::PostsubmissionPagination::MAXRESULTS_LIMIT,
+            "currentPage" => 1,
+            "totalPages" => 1,
+            "totalResults" => 10,
+            "totalAvailableItems" => 10
           )
         end
       end
 
       response "200", "returns planning applications when searching by a reference or description" do
-        schema "$ref" => "#/components/schemas/Search"
+        schema "$ref" => "#/components/schemas/PublicSearch"
         example "application/json", :default, example_fixture("public/search.json")
 
         let(:page) { 2 }
-        let(:maxresults) { 2 }
-        let(:q) { "HAPP" }
+        let(:resultsPerPage) { 2 }
+        let(:query) { "HAPP" }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          metadata = data["metadata"]
+          pagination = data["pagination"]
 
-          expect(metadata).to eq(
-            {
-              "page" => 2,
-              "results" => 2,
-              "from" => 3,
-              "to" => 4,
-              "total_pages" => 5,
-              "total_results" => 10
-            }
+          expect(pagination).to eq(
+            "resultsPerPage" => 2,
+            "currentPage" => page,
+            "totalPages" => 5,
+            "totalResults" => 10,
+            "totalAvailableItems" => 10
           )
         end
       end

--- a/engines/bops_api/spec/services/postsubmission/planning_applications_search_service_spec.rb
+++ b/engines/bops_api/spec/services/postsubmission/planning_applications_search_service_spec.rb
@@ -1,0 +1,263 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::Postsubmission::PlanningApplicationsSearchService do
+  let(:scope) { PlanningApplication.all }
+  let(:params) { {} }
+  let(:service) { described_class.new(scope, params) }
+  let(:pagy_and_results) { service.call }
+  let(:pagy) { pagy_and_results.first }
+  let(:results) { pagy_and_results.last }
+
+  describe "#call" do
+    context "when page and resultsPerPage are provided" do
+      before { create_list(:planning_application, 25) }
+      let(:params) { {page: 2, resultsPerPage: 5} }
+
+      it "returns a Pagy object and results slice" do
+        expect(pagy).to be_a(Pagy)
+        expect(results.size).to eq(5)
+      end
+
+      context "when exceeding the resultsPerPage limit" do
+        let(:params) { {resultsPerPage: 50} }
+
+        it "limits the results to MAXRESULTS_LIMIT" do
+          expect(pagy.limit).to eq(
+            BopsApi::Postsubmission::PostsubmissionPagination::MAXRESULTS_LIMIT
+          )
+        end
+      end
+    end
+
+    context "when performing a search" do
+      let!(:matching_reference) do
+        create(:planning_application)
+      end
+      let!(:matching_description) do
+        create(:planning_application,
+          description: "This is a unique description")
+      end
+      let!(:matching_address) do
+        create(:planning_application,
+          address_1: "123 Unique Road",
+          county: "Greater London",
+          town: "Unique Town",
+          postcode: "SE21 7DN")
+      end
+
+      context "when searching by reference" do
+        let(:params) { {query: matching_reference.reference} }
+
+        it "returns applications matching the reference" do
+          expect(results).to include(matching_reference)
+          expect(results).not_to include(matching_description, matching_address)
+        end
+      end
+
+      context "when searching by description" do
+        let(:params) { {query: "unique description"} }
+
+        it "returns applications matching the description" do
+          expect(results).to include(matching_description)
+          expect(results).not_to include(matching_reference, matching_address)
+        end
+      end
+
+      context "when searching by address" do
+        context "with address lines" do
+          let(:params) { {query: "123 unique Road Unique town"} }
+
+          it "returns applications matching the address" do
+            expect(results).to include(matching_address)
+            expect(results).not_to include(matching_reference, matching_description)
+          end
+        end
+
+        context "with postcode" do
+          context "with exact postcode query" do
+            let(:params) { {query: "SE21 7DN"} }
+
+            it "returns applications matching the postcode" do
+              expect(results).to include(matching_address)
+              expect(results).not_to include(matching_reference, matching_description)
+            end
+          end
+
+          context "with postcode query" do
+            let(:params) { {query: "se217Dn"} }
+
+            it "returns applications matching the postcode" do
+              expect(results).to include(matching_address)
+              expect(results).not_to include(matching_reference, matching_description)
+            end
+          end
+        end
+      end
+
+      context "when no search term matches" do
+        let(:params) { {query: "noresults"} }
+
+        it "returns no results" do
+          expect(results).to be_empty
+        end
+      end
+    end
+
+    context "when filtering by date ranges" do
+      let!(:old) do
+        create(:planning_application,
+          :planning_permission, :consulting,
+          received_at: 10.days.ago,
+          validated_at: 8.days.ago,
+          published_at: 6.days.ago)
+      end
+      let!(:mid) do
+        create(:planning_application,
+          :planning_permission, :consulting,
+          received_at: 5.days.ago,
+          validated_at: 4.days.ago,
+          published_at: 3.days.ago)
+      end
+      let!(:newer) do
+        create(:planning_application,
+          :planning_permission, :consulting,
+          received_at: 1.day.ago,
+          validated_at: 1.day.ago,
+          published_at: 1.day.ago)
+      end
+
+      before do
+        old.consultation.update(end_date: 12.days.ago)
+        mid.consultation.update(end_date: 5.days.ago)
+        newer.consultation.update(end_date: 1.day.ago)
+      end
+
+      context "receivedAtFrom only" do
+        let(:params) { {receivedAtFrom: 3.days.ago.to_date.iso8601} }
+
+        it "returns applications received on or after the given date" do
+          expect(results).to match_array([newer])
+        end
+      end
+
+      context "receivedAtTo only" do
+        let(:params) { {receivedAtTo: 6.days.ago.to_date.iso8601} }
+
+        it "returns applications received on or before the given date" do
+          expect(results).to match_array([old])
+        end
+      end
+
+      context "receivedAtFrom and receivedAtTo" do
+        let(:params) do
+          {
+            receivedAtFrom: 7.days.ago.to_date.iso8601,
+            receivedAtTo: 2.days.ago.to_date.iso8601
+          }
+        end
+
+        it "returns applications within the received date range" do
+          expect(results).to match_array([mid])
+        end
+      end
+
+      context "validatedAt range" do
+        let(:params) do
+          {
+            validatedAtFrom: 5.days.ago.to_date.iso8601,
+            validatedAtTo: 2.days.ago.to_date.iso8601
+          }
+        end
+
+        it "returns applications within the validated date range" do
+          expect(results).to match_array([mid])
+        end
+      end
+
+      context "publishedAt range" do
+        let(:params) do
+          {
+            publishedAtFrom: "2020-01-01",
+            publishedAtTo: "2020-01-10"
+          }
+        end
+
+        before do
+          old.update!(published_at: "2020-01-01")
+          mid.update!(published_at: "2020-01-05")
+          newer.update!(published_at: "2020-02-01")
+        end
+
+        it "returns applications within the published date range" do
+          expect(results).to match_array([old, mid])
+        end
+      end
+
+      context "consultationEndDate range" do
+        let(:params) do
+          {
+            consultationEndDateFrom: 6.days.ago.to_date.iso8601,
+            consultationEndDateTo: 2.days.ago.to_date.iso8601
+          }
+        end
+
+        it "returns applications with consultation end date in range" do
+          expect(results).to match_array([mid])
+        end
+      end
+    end
+
+    context "when chaining multiple filters: date + search" do
+      let!(:roof_a) do
+        create(:planning_application,
+          received_at: 5.days.ago,
+          published_at: 5.days.ago,
+          description: "A roof extension")
+      end
+      let!(:roof_b) do
+        create(:planning_application,
+          received_at: 3.days.ago,
+          published_at: 3.days.ago,
+          description: "A roof extension")
+      end
+      let!(:loft) do
+        create(:planning_application,
+          received_at: 3.days.ago,
+          published_at: 3.days.ago,
+          description: "A loft extension")
+      end
+
+      let(:params) do
+        {
+          receivedAtFrom: 4.days.ago.to_date.iso8601,
+          publishedAtTo: 2.days.ago.to_date.iso8601,
+          q: "roof"
+        }
+      end
+
+      it "returns only applications matching both date filters and search" do
+        expect(results).to match_array([roof_b])
+      end
+    end
+
+    context "when chaining date + sortBy" do
+      let!(:old_app) { create(:planning_application, published_at: 5.days.ago) }
+      let!(:mid_app) { create(:planning_application, published_at: 3.days.ago) }
+      let!(:new_app) { create(:planning_application, published_at: 1.day.ago) }
+
+      let(:params) do
+        {
+          publishedAtFrom: 3.days.ago.to_date.iso8601,
+          sortBy: "publishedAt",
+          orderBy: "asc"
+        }
+      end
+
+      it "returns filtered and sorted results" do
+        expect(results).to eq([mid_app, new_app])
+      end
+    end
+  end
+end

--- a/engines/bops_api/spec/swagger_helper.rb
+++ b/engines/bops_api/spec/swagger_helper.rb
@@ -13,6 +13,7 @@ RSpec.configure do |config|
   version = BopsApi::Schemas::DEFAULT_ODP_VERSION
   submission_json = BopsApi::Schemas.find!("submission", version:).value
   search_json = BopsApi::Schemas.find!("search", version:).value
+  public_search_json = BopsApi::Schemas.find!("public/search", version:).value
   application_submission_json = BopsApi::Schemas.find!("applicationSubmission", version:).value
   documents_json = BopsApi::Schemas.find!("documents", version:).value
   neighbour_responses_json = BopsApi::Schemas.find!("neighbourResponses", version:).value
@@ -41,6 +42,8 @@ RSpec.configure do |config|
   submission = submission_json.slice(*keys).deep_transform_values(&transformer)
 
   search = search_json.slice(*keys).deep_transform_values(&transformer)
+
+  public_search = public_search_json.slice(*keys).deep_transform_values(&transformer)
 
   application_submission = application_submission_json.slice(*keys).deep_transform_values(&transformer)
 
@@ -88,6 +91,8 @@ RSpec.configure do |config|
           },
 
           Search: search,
+
+          PublicSearch: public_search,
 
           ApplicationSubmission: application_submission,
 

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -21140,45 +21140,21 @@ components:
         metadata:
           type: object
           properties:
-            page:
+            resultsPerPage:
               type: integer
-            results:
+            currentPage:
               type: integer
-            from:
+            totalPages:
               type: integer
-            to:
+            totalResults:
               type: integer
-            total_pages:
-              type: integer
-            total_results:
+            totalAvailableItems:
               type: integer
           required:
-          - page
-          - results
-          - from
-          - to
-          - total_pages
-          - total_results
-        links:
-          type: object
-          properties:
-            first:
-              type: string
-            last:
-              type: string
-            prev:
-              type:
-              - string
-              - 'null'
-            next:
-              type:
-              - string
-              - 'null'
-          required:
-          - first
-          - last
-          - prev
-          - next
+          - resultsPerPage
+          - currentPage
+          - totalPages
+          - totalAvailableItems
         data:
           type: array
           items:
@@ -21369,7 +21345,6 @@ components:
           - "$ref": "#/components/definitions/ApplicationFeeNotApplicable"
       required:
       - metadata
-      - links
       - data
       type: object
     ApplicationSubmission:
@@ -35102,13 +35077,13 @@ paths:
           type: integer
           default: 1
         required: false
-      - name: maxresults
+      - name: resultsPerPage
         in: query
         schema:
           type: integer
           default: 10
         required: false
-      - name: q
+      - name: query
         in: query
         description: Search by reference, address or description
         required: false
@@ -35209,17 +35184,15 @@ paths:
                 default:
                   value:
                     metadata:
-                      page: 2
-                      results: 2
-                      from: 3
-                      to: 4
-                      total_pages: 5
-                      total_results: 10
+                      resultsPerPage: 2
+                      currentPage: 2
+                      totalPages: 5
+                      totalAvailableItems: 10
                     links:
-                      first: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&maxresults=2
-                      last: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=5&maxresults=2
-                      prev: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&maxresults=2
-                      next: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=3&maxresults=2
+                      first: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&resultsPerPage=2
+                      last: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=5&resultsPerPage=2
+                      prev: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=1&resultsPerPage=2
+                      next: https://southwark.bops-staging.services/api/v2/public/planning_applications/search?page=3&resultsPerPage=2
                     data:
                     - application:
                         type:
@@ -35671,13 +35644,13 @@ paths:
           type: integer
           default: 1
         required: false
-      - name: maxresults
+      - name: resultsPerPage
         in: query
         schema:
           type: integer
           default: 10
         required: false
-      - name: q
+      - name: query
         in: query
         description: Search by reference, address or description
         required: false
@@ -35780,17 +35753,11 @@ paths:
                 default:
                   value:
                     metadata:
-                      page: 2
-                      results: 2
-                      from: 3
-                      to: 4
-                      total_pages: 5
-                      total_results: 10
-                    links:
-                      first: "/api/v2/public/planning_applications/search?page=1&maxresults=2"
-                      last: "/api/v2/public/planning_applications/search?page=5&maxresults=2"
-                      prev: "/api/v2/public/planning_applications/search?page=1&maxresults=2"
-                      next: "/api/v2/public/planning_applications/search?page=3&maxresults=2"
+                      resultsPerPage: 2
+                      currentPage: 2
+                      totalPages: 5
+                      totalResults: 10
+                      totalAvailableItems: 10
                     data:
                     - application:
                         type:


### PR DESCRIPTION
I'm making this PR on behalf of @madz-lw as she's away at the moment! ☀️

### Description of change

This PR brings the public endpoint `/api/v2/public/planning_applications/search` into alignment with the [Postsubmission schema pagination](https://github.com/theopensystemslab/digital-planning-data-schemas/blob/main/IMPLEMENTATION.md), it doesn't touch any of the returned data, just what its wrapped in and what filters it accepts. 

It adds in these query params and uses the `PostsubmissionPagination` service. 

- `query`
- `resultsPerPage`
- `page`
- `sortBy`
- `orderBy`
- `reference`
- `description`
- `postcode`
- `publishedAtFrom`
- `publishedAtTo`

There are some example tests to check in the original PR [here](https://github.com/tpximpact/bops/pull/12#pullrequestreview-2957856645).