### PR TITLE
Remove GOV.UK from the page title

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1022,7 +1022,7 @@ en:
   no_consultees_component:
     no_consultees_yet: No consultees have been added to the consultation yet.
   not_required: Not required
-  page_title: BETA BOPs - GOV.UK
+  page_title: BETA BOPS
   permitted_development_rights:
     already_accepted: The assessment of permitted development rights has been accepted - contact the reviewer to ask them to reject your assessment so you can amend it.
     review_assessment_error: You agreed with the assessor recommendation, to request any change you must change your decision on the Sign-off recommendation screen


### PR DESCRIPTION
https://trello.com/c/fnZ8ghS2/670-update-title-tag-to-not-use-govuk