### PR TITLE
Able to download all documents with duplicates

### DIFF
--- a/app/javascript/controllers/download_controller.js
+++ b/app/javascript/controllers/download_controller.js
@@ -13,17 +13,27 @@ export default class extends Controller {
     event.preventDefault()
     this.clearError()
     this.showLoadingSpinner()
+
     const applicationReference = this.element.dataset.applicationReferenceValue
     const documents = this.documentsElementTarget.querySelectorAll("li")
     const zip = new JSZip()
+    const fileNameMap = new Map()
 
     try {
       documents.forEach((document) => {
         const imageDownload = document.dataset.documentUrlValue
         const file = fetch(imageDownload).then((r) => r.blob())
 
-        const fileName = document.dataset.documentTitleValue
+        const originalFileName = document.dataset.documentTitleValue
+        let fileName = originalFileName
+        const nameCounter = fileNameMap.get(fileName) || 0
 
+        if (nameCounter > 0) {
+          const splitFileName = fileName.slice(0, fileName.lastIndexOf("."))
+          const fileExtension = fileName.slice(fileName.lastIndexOf("."))
+          fileName = `${splitFileName} (${nameCounter})${fileExtension}`
+        }
+        fileNameMap.set(originalFileName, nameCounter + 1)
         zip.file(fileName, file)
       })
 
@@ -56,7 +66,8 @@ export default class extends Controller {
     errorMessage.innerText =
       "Unable to complete download, please contact support"
     errorMessage.className = "govuk-error-message"
-    this.buttonTarget.prepend(errorMessage)
+    errorMessage.classList.add("govuk-!-padding-left-5")
+    this.buttonTarget.append(errorMessage)
   }
 
   clearError() {

--- a/spec/system/planning_applications/download_documents_spec.rb
+++ b/spec/system/planning_applications/download_documents_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe "Downloading planning application documents", type: :system, js: 
   let!(:doc1) { create(:document, :floorplan_tags, file: file1, planning_application:) }
   let!(:doc2) { create(:document, file: file2, planning_application:) }
   let!(:doc3) { create(:document, file: file3, planning_application:) }
+  let!(:doc4) { create(:document, file: file3, planning_application:) }
 
   let(:download_path) { Rails.root.join("tmp/downloads", "#{planning_application.reference}.zip") }
 
@@ -50,7 +51,8 @@ RSpec.describe "Downloading planning application documents", type: :system, js: 
       expect(zip_files).to include(
         "existing-floorplan.png",
         "proposed-floorplan.png",
-        "existing-floorplan-redacted.png"
+        "existing-floorplan-redacted.png",
+        "existing-floorplan-redacted (1).png"
       )
     end
   end


### PR DESCRIPTION
### Description of change

Change download all document feature to be able to hand duplicate named documents. Each subsequent document has a number appended to filename e.g. file.pdf, file (1).pdf

### Story Link

https://trello.com/c/xTb4RJU9/675-able-to-bulk-download-all-documents

