### PR TITLE
Remove publish to bops portal for pre-apps

### DIFF
--- a/app/views/planning_applications/confirm_validation.html.erb
+++ b/app/views/planning_applications/confirm_validation.html.erb
@@ -23,9 +23,13 @@
       <div class="govuk-hint" id="planning-application-validated-at-hint">
         Will be marked as valid from <%= @planning_application.valid_from_date.to_date.to_fs %>
       </div>
-      <%= form.govuk_radio_buttons_fieldset :make_public, legend: {text: "Publish application on BOPS Public Portal?"} do %>
-        <%= form.govuk_radio_button :make_public, true, label: {text: "Yes"} %>
-        <%= form.govuk_radio_button :make_public, false, label: {text: "No"} %>
+      <% if @planning_application.publishable? %>
+        <%= form.govuk_radio_buttons_fieldset :make_public, legend: {text: "Publish application on BOPS Public Portal?"} do %>
+          <%= form.govuk_radio_button :make_public, true, label: {text: "Yes"}, class: "govuk-!-display-none hidden-content" %>
+          <%= form.govuk_radio_button :make_public, false, label: {text: "No"} %>
+        <% end %>
+      <% else %>
+        <%= form.hidden_field :make_public, value: false %>
       <% end %>
       <div class="govuk-button-group">
         <%= form.submit "Mark the application as valid", class: "govuk-button", data: {module: "govuk-button"} %>


### PR DESCRIPTION
### Description of change

PreApps are not required to be published, this PR removes the question to ask if the application should be published as well as hiding the item in the dates and assignment header.

### Story Link

https://trello.com/c/sStA0KFC/698-skip-publish-application-on-bops-public-portal-for-pre-apps

### Screenshots

![image](https://github.com/user-attachments/assets/300ab631-36de-4662-b63b-66676a7d00fd)
