### PR TITLE
Remove neighbour tab in pre-app report overview

### DIFF
--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -67,4 +67,16 @@ module PlanningApplicationHelper
       [".mark_for_appeal", new_planning_application_appeal_path(planning_application)]
     end
   end
+
+  def consultation_task_title(planning_application)
+    if planning_application.neighbour_consultation_feature? && planning_application.publishable?
+      "Consultees, neighbours and publicity"
+    elsif planning_application.publishable?
+      "Consultees and publicity"
+    elsif planning_application.neighbour_consultation_feature?
+      "Consultees and neighbours"
+    else
+      "Consultees"
+    end
+  end
 end

--- a/app/views/planning_applications/steps/_consultation.html.erb
+++ b/app/views/planning_applications/steps/_consultation.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-9 application-step-heading">Consultation</h2>
 <%= govuk_task_list(id_prefix: "consultation-section", html_attributes: {id: "consultation-section"}) do |task_list|
-      task_list.with_item(title: "Consultees, neighbours and publicity",
+      task_list.with_item(title: consultation_task_title(@planning_application),
         href: planning_application_consultation_path(@planning_application),
         status: render(StatusTags::BaseComponent.new(status: @planning_application.consultation.status)))
     end %>

--- a/app/views/shared/_overview_tabs.html.erb
+++ b/app/views/shared/_overview_tabs.html.erb
@@ -103,9 +103,11 @@
         ) %>
   <% end %>
   <% if @planning_application.application_type.consultation? %>
-    <% tabs.with_tab(label: (@planning_application.consultation.neighbours&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbours.count})" : "Neighbours (0)", id: "neighbours")  do %>
-      <h2 class="govuk-heading-m"><%= (@planning_application.consultation.neighbours&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbours.count})" : "Neighbours (0)" %></h2>
-      <%= render "shared/neighbours_table", planning_application: @planning_application, neighbours: @planning_application.consultation.neighbours %>
+    <% if @planning_application.neighbour_consultation_feature? %>
+      <% tabs.with_tab(label: (@planning_application.consultation.neighbours&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbours.count})" : "Neighbours (0)", id: "neighbours")  do %>
+        <h2 class="govuk-heading-m"><%= (@planning_application.consultation.neighbours&.count.to_i > 0) ? "Neighbours (#{@planning_application.consultation.neighbours.count})" : "Neighbours (0)" %></h2>
+        <%= render "shared/neighbours_table", planning_application: @planning_application, neighbours: @planning_application.consultation.neighbours %>
+      <% end %>
     <% end %>
     <% tabs.with_tab(label: (@planning_application.consultation&.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)", id: "consultees")  do %>
       <h2 class="govuk-heading-m"><%= (@planning_application.consultation&.consultees&.count.to_i > 0) ? "Consultees (#{@planning_application.consultation.consultees.count})" : "Consultees (0)" %></h2>

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe "Consultation" do
     }
 
     it "does not show the neighbour section" do
-      click_link "Consultees, neighbours and publicity"
+      click_link "Consultees and publicity"
 
       expect(page).to have_css("#consultee-tasks")
       expect(page).to have_css("#publicity-tasks")

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -601,11 +601,11 @@ RSpec.describe "Consultation", type: :system, js: true do
       expect(page).not_to have_text("Public on BOPS Public Portal")
 
       within "#consultation-section" do
-        expect(page).to have_selector("li:first-child a", text: "Consultees, neighbours and publicity")
+        expect(page).to have_selector("li:first-child a", text: "Consultees")
         expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
       end
 
-      click_link "Consultees, neighbours and publicity"
+      click_link "Consultees"
       expect(page).to have_selector("h1", text: "Consultation")
 
       within "#consultation-end-date" do


### PR DESCRIPTION
### Description of change

Remove neighbours tab from the reviewer summary on pre-app report.

### Story Link
https://trello.com/c/fktFb6tn/614-remove-neighbours-tab-from-the-overview-table-in-review-landing-page-and-update-consultation-description-on-the-application-land

### Screenshots

![image](https://github.com/user-attachments/assets/4fe84b1e-cd6c-4dd2-9ee5-c55358e2ec2a)
