### PR TITLE
Fix dashboard pagination

### DIFF
--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -30,7 +30,21 @@ module PlanningApplications
     def pagination
       return unless @pagy.pages > 1
 
-      govuk_pagination(pagy: @pagy)
+      page_data = @pagy.series.map { |i|
+        {href: pagination_url(page: i), number: i, current: i.to_i == @pagy.page}
+      }
+
+      govuk_pagination do |p|
+        p.with_previous_page(href: pagination_url(page: @pagy.prev)) if @pagy.page > 1
+
+        p.with_items page_data
+
+        p.with_next_page(href: pagination_url(page: @pagy.next)) if @pagy.page < @pagy.last
+      end
+    end
+
+    def pagination_url(page:)
+      pagy_url_for(@pagy, page) + "##{type}"
     end
 
     def title

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -13,9 +13,7 @@ module PlanningApplications
     attr_reader :type, :search
 
     def before_render
-      if type == :all
-        @pagy, @paginated_applications = pagy(@planning_applications)
-      end
+      @pagy, @paginated_applications = pagy(@planning_applications)
     end
 
     def planning_applications


### PR DESCRIPTION
### Description of change

Pagy by default does not include the fragment (`#whatever`) in pagination urls (because they're not passed through to the server at all) but we're using them to select a tab so they're needed; add them back in by deriving it from the panel type.

Also enable pagination for the other tabs: previously it was special-cased for the 'all' tab but that might not make sense any more. (Pagination is skipped if there's only one page anyway.)

### Story Link

https://trello.com/c/ikiMZDQP/570-differentiate-between-new-cases-and-assigned-cases-on-dashboard
