### PR TITLE
Import historic users

### DIFF
--- a/app/services/users_creation.rb
+++ b/app/services/users_creation.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class UsersCreation
+  ATTRIBUTES = %i[
+    name
+    role
+    email
+    deactivated_at
+    local_authority
+  ].freeze
+
+  def initialize(**params)
+    ATTRIBUTES.each do |attribute|
+      value = params[attribute]
+      value = value.is_a?(String) ? value.strip : value
+      instance_variable_set(:"@#{attribute}", value)
+    end
+  end
+
+  def perform
+    importer
+  end
+
+  private
+
+  attr_reader(*ATTRIBUTES)
+
+  def importer
+    normalized_email = normalize_email(email)
+    return nil if User.exists?(email: normalized_email)
+
+    user = User.new(**user_attributes.merge(email: normalized_email))
+
+    user.skip_confirmation_notification! if user.deactivated_at.present?
+
+    user.save!
+  rescue => e
+    Rails.logger.debug { "[IMPORT ERROR] #{e.class}: #{e.message}" }
+    Rails.logger.debug e.record&.errors&.full_messages&.join(", ")
+    raise
+  end
+
+  def normalize_email(value)
+    value.to_s.unicode_normalize(:nfkc).gsub(/[[:space:]]+/, "").downcase
+  end
+
+  def user_attributes
+    {
+      name:,
+      role:,
+      deactivated_at:,
+      local_authority:
+    }
+  end
+end

--- a/lib/tasks/import_site_history.rake
+++ b/lib/tasks/import_site_history.rake
@@ -15,4 +15,19 @@ namespace :import do
       create_class_name: "PlanningApplicationsCreation"
     )
   end
+
+  desc "Import users"
+  task planning_applications: :environment do
+    local_authority = ENV["AUTHORITY"]
+    if local_authority.nil?
+      puts "Usage: rake import:users AUTHORITY=Buckinghamshire"
+      exit 1
+    end
+
+    puts "Enqueuing ImportSiteHistoryJob for UsersCreation"
+    ImportSiteHistoryJob.perform_now(
+      local_authority_name: local_authority,
+      create_class_name: "UsersCreation"
+    )
+  end
 end

--- a/spec/services/users_creation_spec.rb
+++ b/spec/services/users_creation_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# rubocop:disable Layout/ArgumentAlignment, Layout/FirstArgumentIndentation, Layout/MultilineOperationIndentation
+RSpec.describe UsersCreation do
+  let(:local_authority) { create(:local_authority) }
+
+  context "with a user that is active" do
+    let(:params) do
+      {
+        name: "Alice Planner",
+        email: "alice.planner@example.com",
+        role: "assessor",
+        local_authority: local_authority
+      }
+    end
+
+    it "creates a new User with the correct attributes" do
+      expect {
+        described_class.new(**params).perform
+      }.to change(User, :count).by(1)
+
+      u = User.find_by(email: "alice.planner@example.com")
+      expect(u).to have_attributes(
+                      name: "Alice Planner",
+                      email: "alice.planner@example.com",
+                      role: "assessor",
+                      local_authority: local_authority
+                    )
+    end
+  end
+
+  context "with a user that has been deactivated" do
+    deactivated_at_date = Time.zone.parse("2025-05-27 10:38:35.469341000 +0100")
+
+    let(:params) do
+      {
+        name: "Bob Planner",
+        email: "bob.planner@example.com",
+        role: "reviewer",
+        deactivated_at: deactivated_at_date,
+        local_authority: local_authority
+      }
+    end
+
+    it "creates a new User with the correct attributes" do
+      expect {
+        described_class.new(**params).perform
+      }.to change(User, :count).by(1)
+
+      u = User.find_by(email: "bob.planner@example.com")
+      expect(u).to have_attributes(
+                      name: "Bob Planner",
+                      email: "bob.planner@example.com",
+                      role: "reviewer",
+                      deactivated_at: deactivated_at_date,
+                      local_authority: local_authority
+                    )
+    end
+  end
+end
+# rubocop:enable Layout/ArgumentAlignment, Layout/FirstArgumentIndentation, Layout/MultilineOperationIndentation


### PR DESCRIPTION
### Description of change

This adds a creation class for the User object when it's batch-imported via CSV from the S3 bucket. It skips sending out the Devise confirmation email when the user has already been deactivated.

### Story Link

https://trello.com/c/iwXsaEEH/801-create-a-parser-in-bops-for-the-users-csv

