### PR TITLE
Fix dashboard pagination

### DIFF
--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -13,7 +13,7 @@ module PlanningApplications
     attr_reader :type, :search
 
     def before_render
-      @pagy, @paginated_applications = pagy(@planning_applications)
+      @pagy, @paginated_applications = pagy(@planning_applications, overflow: :last_page)
     end
 
     def planning_applications
@@ -28,7 +28,21 @@ module PlanningApplications
     def pagination
       return unless @pagy.pages > 1
 
-      govuk_pagination(pagy: @pagy)
+      page_data = @pagy.series.map { |i|
+        {href: pagination_url(page: i), number: i, current: i.is_a?(String)}
+      }
+
+      govuk_pagination do |p|
+        p.with_previous_page(href: pagination_url(page: @pagy.prev)) if @pagy.page > 1
+
+        p.with_items page_data
+
+        p.with_next_page(href: pagination_url(page: @pagy.next)) if @pagy.page < @pagy.last
+      end
+    end
+
+    def pagination_url(page:)
+      pagy_url_for(@pagy, page) + "##{type}"
     end
 
     def title

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -13,9 +13,7 @@ module PlanningApplications
     attr_reader :type, :search
 
     def before_render
-      if type == :all
-        @pagy, @paginated_applications = pagy(@planning_applications)
-      end
+      @pagy, @paginated_applications = pagy(@planning_applications)
     end
 
     def planning_applications


### PR DESCRIPTION
Reapplying #2385, which was reverterd in #2390, plus a bugfix for the unhandled symbol in pagy.series — pagy returns a an integer page number for most pages, but a string page number for the current (!?) and then a symbol to indicate gaps, but the test data doesn't have enough pages to need a gap in the pagination, so it was missed.

Also addresses an issue with having several paginated tables on the same page (in each different tab) causing the `page` parameter to be reused for each: an exception would be raised when going past the end of the _smallest_ table even if other tables were larger.