### PR TITLE
Add "check breach report" page with placeholder task list

### DIFF
--- a/app/controllers/enforcements/reports_controller.rb
+++ b/app/controllers/enforcements/reports_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class EnforcementsController < AuthenticationController
+class Enforcements::ReportsController < AuthenticationController
+  before_action -> { view_context_class.prefix_partial_path_with_controller_namespace = false }
+
   before_action :set_enforcement
 
   def show
@@ -15,6 +17,6 @@ class EnforcementsController < AuthenticationController
     @enforcement = current_local_authority
       .enforcements
       .joins(:case_record)
-      .find_by!(case_record: {id: params[:id]})
+      .find_by!(case_record: {id: params[:enforcement_id]})
   end
 end

--- a/app/views/enforcements/_enforcement.html.erb
+++ b/app/views/enforcements/_enforcement.html.erb
@@ -1,6 +1,8 @@
+<%# locals: (title: "Enforcement case", with_dates: false, with_assignment: false, enforcement:) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="planning-application-details">
-    <h1 class="govuk-heading-l">Enforcement case</h1>
+    <h1 class="govuk-heading-l"><%= title %></h1>
     <p class="govuk-body">
       <strong><%= @enforcement.address %></strong>
       <br>

--- a/app/views/enforcements/reports/show.html.erb
+++ b/app/views/enforcements/reports/show.html.erb
@@ -1,0 +1,16 @@
+<%= render @enforcement, title: "Check breach report" %>
+
+<%= govuk_task_list(id_prefix: "breach-report") do |task_list|
+      task_list.with_item(title: "Check report details", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Check site location", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Review constraints", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Review site history", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Review documents", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Start investigation", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+    end %>
+
+<%= form_with model: @enforcement, url: "#", local: true do |form| %>
+  <%= form.govuk_submit "Close the case" do %>
+    <%= govuk_button_link_to "Back", enforcement_path(@enforcement), secondary: true %>
+  <% end %>
+<% end %>

--- a/app/views/enforcements/show.html.erb
+++ b/app/views/enforcements/show.html.erb
@@ -11,3 +11,7 @@
 
       accordion.with_section(heading_text: "Photos") { tag.p("Content") }
     end %>
+
+<%= govuk_task_list(id_prefix: "enforcement") do |task_list|
+      task_list.with_item(title: "Check breach report", href: enforcement_report_path(@enforcement), status: govuk_tag(text: "Incomplete", colour: "blue"))
+    end %>

--- a/config/routes/bops.rb
+++ b/config/routes/bops.rb
@@ -350,7 +350,11 @@ local_authority_subdomain do
     end
   end
 
-  resources :enforcements, only: %i[show]
+  resources :enforcements, only: %i[show] do
+    scope module: :enforcements do
+      resource :report, only: :show
+    end
+  end
 
   namespace :public, path: "/" do
     scope "/planning_guides" do

--- a/spec/system/enforcements/show_spec.rb
+++ b/spec/system/enforcements/show_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe "Enforcement show page", type: :system do
     expect(page).to have_content(enforcement.address)
   end
 
+  it "has a link to the breach report page" do
+    visit "/enforcements/#{enforcement.case_record.id}/"
+    click_link "Check breach report"
+    expect(page).to have_selector("h1", text: "Check breach report")
+  end
+
   context "when assigned to an officer" do
     before { enforcement.case_record.update!(user:) }
 


### PR DESCRIPTION
### Description of change

Add a placeholder task list for the 'check breach report', that we can update with the real links as we go.

### Story Link

<https://trello.com/c/cZP41SCh/896-check-breach-report-show-page-landing-page>

### Screenshots
<img width="893" height="906" alt="Screenshot 2025-07-10 at 16 50 46" src="https://github.com/user-attachments/assets/ec2f2716-66c9-496e-a64b-4d138da917c3" />
<img width="2200" height="1424" alt="Screen Shot 2025-07-10 at 16 51 05" src="https://github.com/user-attachments/assets/355df462-e0d2-41cd-b809-10027af75cf1" />
