### PR TITLE
Remove check for document being representable

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,6 @@ class DocumentsController < AuthenticationController
   before_action :set_planning_application
   before_action :set_document, only: %i[edit update archive confirm_archive unarchive]
   before_action :ensure_document_edits_unlocked, only: %i[new edit update archive unarchive]
-  before_action :ensure_blob_is_representable, only: %i[edit update archive unarchive]
   before_action :validate_document?, only: %i[edit update]
   before_action :replacement_document_validation_request, only: %i[edit update]
   before_action :set_return_to_session, only: %i[update]
@@ -155,10 +154,6 @@ class DocumentsController < AuthenticationController
     else
       planning_application_documents_path(@planning_application)
     end
-  end
-
-  def ensure_blob_is_representable
-    render plain: "forbidden", status: :forbidden and return unless @document.representable?
   end
 
   def set_return_to_session

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -229,21 +229,4 @@ RSpec.describe "Documents index page" do
       expect(page).to have_content("Cannot archive document with an open or pending validation request")
     end
   end
-
-  context "when a document has been removed due to a security issue" do
-    let!(:document) do
-      create(:document, planning_application:)
-    end
-
-    before do
-      sign_in assessor
-      allow_any_instance_of(Document).to receive(:representable?).and_return(false)
-    end
-
-    it "cannot archive" do
-      visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
-
-      expect(page).to have_content("forbidden")
-    end
-  end
 end

--- a/spec/system/documents/edit_documents_spec.rb
+++ b/spec/system/documents/edit_documents_spec.rb
@@ -160,22 +160,6 @@ RSpec.describe "Edit document", type: :system do
       expect(page).not_to have_css("#validate-document")
     end
 
-    context "when a document has been removed due to a security issue" do
-      let!(:document) do
-        create(:document, planning_application:)
-      end
-
-      before do
-        allow_any_instance_of(Document).to receive(:representable?).and_return(false)
-      end
-
-      it "cannot edit" do
-        visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"
-
-        expect(page).to have_content("forbidden")
-      end
-    end
-
     context "when editing/archiving document from the documents accordian section" do
       it "can edit document and return back to the planning applications index page" do
         visit "/planning_applications/#{planning_application.reference}/documents/#{document.id}/edit"


### PR DESCRIPTION
### Description of change

Not sure this is the right strategy to render a forbidden page document is not representable. We need to handle this case better but for now this is leading to confusion so remove this check.