### PR TITLE
Link PlanningApplication to CaseRecord

### DIFF
--- a/app/models/case_record.rb
+++ b/app/models/case_record.rb
@@ -3,7 +3,7 @@
 require "securerandom"
 
 class CaseRecord < ApplicationRecord
-  delegated_type :caseable, types: %w[Enforcement], dependent: :destroy
+  delegated_type :caseable, types: %w[Enforcement PlanningApplication], dependent: :destroy
 
   belongs_to :local_authority
   belongs_to :user, optional: true

--- a/app/models/concerns/caseable.rb
+++ b/app/models/concerns/caseable.rb
@@ -6,6 +6,7 @@ module Caseable
   included do
     has_one :case_record, as: :caseable, touch: true, dependent: :destroy
     delegate :local_authority, to: :case_record
+    delegate :submission, to: :case_record
     delegate :user, to: :case_record
   end
 end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -9,6 +9,8 @@ class PlanningApplication < ApplicationRecord
 
   include Auditable
 
+  include Caseable
+
   include Discard::Model
 
   include PlanningApplicationDecorator
@@ -565,7 +567,7 @@ class PlanningApplication < ApplicationRecord
 
   def assign!(user)
     transaction do
-      update!(user:)
+      case_record.update!(user:)
       audit!(activity_type: "assigned", activity_information: user&.name)
 
       if application_type_name == "prior_approval"

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -23,7 +23,7 @@ class PlanningApplication < ApplicationRecord
 
   self.discard_column = :deleted_at
 
-  self.ignored_columns += %i[work_status make_public reporting_type]
+  self.ignored_columns += %i[work_status make_public reporting_type submission_id]
 
   DAYS_TO_EXPIRE = 56
   DAYS_TO_EXPIRE_EIA = 112

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -4,9 +4,16 @@ class Submission < ApplicationRecord
   include AASM
 
   belongs_to :local_authority
-  has_one :planning_application, dependent: :nullify
+  has_one :planning_application, dependent: :nullify # TODO: migrate this to through: case_record
   has_one :case_record, dependent: :nullify
   has_many :documents, dependent: :destroy
+
+  with_options through: :case_record, source: :caseable, dependent: :nullify do
+    has_one :enforcement, source_type: "Enforcement"
+
+    # TODO: this needs to migrate from the original reference
+    # has_one :planning_application, source_type: "PlanningApplication"
+  end
 
   validates :external_uuid, uniqueness: true, allow_nil: true
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -4,15 +4,12 @@ class Submission < ApplicationRecord
   include AASM
 
   belongs_to :local_authority
-  has_one :planning_application, dependent: :nullify # TODO: migrate this to through: case_record
   has_one :case_record, dependent: :nullify
   has_many :documents, dependent: :destroy
 
   with_options through: :case_record, source: :caseable, dependent: :nullify do
     has_one :enforcement, source_type: "Enforcement"
-
-    # TODO: this needs to migrate from the original reference
-    # has_one :planning_application, source_type: "PlanningApplication"
+    has_one :planning_application, source_type: "PlanningApplication"
   end
 
   validates :external_uuid, uniqueness: true, allow_nil: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   include EmailConfirmable
 
   has_many :case_records, dependent: :nullify
-  has_many :planning_applications, -> { kept }, dependent: :nullify
+  has_many :planning_applications, -> { kept }, through: :case_record, dependent: :nullify
   has_many :audits, dependent: :nullify
   has_many :comments, dependent: :nullify
   belongs_to :local_authority, optional: true

--- a/app/services/planning_applications_creation.rb
+++ b/app/services/planning_applications_creation.rb
@@ -60,7 +60,8 @@ class PlanningApplicationsCreation
 
   def importer
     pa = PlanningApplication.find_or_initialize_by(reference: reference)
-    pa.update!(**planning_application_attributes)
+    pa.update!(case_record: CaseRecord.new(local_authority: planning_application_attributes[:local_authority]),
+               **planning_application_attributes)
     pa
   rescue => e
     Rails.logger.debug { "[IMPORT ERROR] #{e.class}: #{e.message}" }

--- a/db/migrate/20250714195355_create_planning_application_case_records.rb
+++ b/db/migrate/20250714195355_create_planning_application_case_records.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePlanningApplicationCaseRecords < ActiveRecord::Migration[7.2]
+  def change
+    up_only do
+      PlanningApplication.all.find_each do |pa|
+        CaseRecord.find_or_create_by!(
+          caseable_id: pa.id,
+          caseable_type: "PlanningApplication"
+        ) do |record|
+          record.local_authority_id = pa.attributes["local_authority_id"]
+          record.user_id = pa.attributes["user_id"]
+          record.submission_id = pa.attributes["submission_id"]
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_07_11_090552) do
+ActiveRecord::Schema[7.2].define(version: 2025_07_14_195355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"

--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -30,6 +30,7 @@ module BopsApi
         PlanningApplication.new(planning_application_params).tap do |pa|
           pa.api_user_id = user.id
           pa.local_authority_id = local_authority.id
+          pa.case_record = CaseRecord.new(local_authority:)
         end
       end
 

--- a/engines/bops_reports/spec/system/pre_application_report_spec.rb
+++ b/engines/bops_reports/spec/system/pre_application_report_spec.rb
@@ -32,13 +32,14 @@ RSpec.describe "Pre-application report" do
     }.to_json
   end
 
+  let(:case_record) { build(:case_record, user: reviewer, local_authority:) }
   let(:planning_application) do
     create(
       :planning_application,
       :pre_application,
       :in_assessment,
       :with_preapp_assessment,
-      user: reviewer,
+      case_record:,
       local_authority:,
       boundary_geojson:,
       consideration_set:,
@@ -134,7 +135,7 @@ RSpec.describe "Pre-application report" do
   end
 
   it "allows the user to assign case officer if not set" do
-    planning_application.update(user: nil)
+    planning_application.case_record.update(user: nil)
     visit "/reports/planning_applications/#{reference}"
 
     within("#contact-details") do

--- a/engines/bops_reports/spec/system/recommendation_spec.rb
+++ b/engines/bops_reports/spec/system/recommendation_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Recommending and submitting a pre-application report" do
   let(:assessor) { create(:user, :assessor, local_authority:, name: "Jane Smith") }
   let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Alan Jones") }
 
+  let(:case_record) { build(:case_record, user: assessor, local_authority:) }
   let(:planning_application) do
     create(
       :planning_application,
@@ -14,7 +15,7 @@ RSpec.describe "Recommending and submitting a pre-application report" do
       :in_assessment,
       :with_preapp_assessment,
       local_authority:,
-      user: assessor
+      case_record:
     )
   end
 
@@ -97,7 +98,7 @@ RSpec.describe "Recommending and submitting a pre-application report" do
   end
 
   it "requires an assigned case officer before you can submit the recommendation" do
-    planning_application.update(user: nil)
+    planning_application.case_record.update(user: nil)
 
     sign_in(assessor)
 

--- a/engines/bops_submissions/app/services/bops_submissions/application/creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/application/creation_service.rb
@@ -33,8 +33,7 @@ module BopsSubmissions
 
       def build_planning_application
         PlanningApplication.new(planning_application_params).tap do |pa|
-          pa.case_record = CaseRecord.new(local_authority:)
-          pa.submission_id = submission.id
+          pa.case_record = CaseRecord.new(local_authority:, submission:)
           pa.local_authority_id = local_authority.id
         end
       end

--- a/engines/bops_submissions/app/services/bops_submissions/application/creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/application/creation_service.rb
@@ -33,6 +33,7 @@ module BopsSubmissions
 
       def build_planning_application
         PlanningApplication.new(planning_application_params).tap do |pa|
+          pa.case_record = CaseRecord.new(local_authority:)
           pa.submission_id = submission.id
           pa.local_authority_id = local_authority.id
         end

--- a/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
+++ b/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
 
         pa = PlanningApplication.last
         expect(pa).to be_present
-        expect(pa.submission_id).to eq(submission.id)
+        expect(pa.case_record.submission_id).to eq(submission.id)
         expect(pa.local_authority_id).to eq(submission.local_authority_id)
       end
     end

--- a/spec/factories/application_type.rb
+++ b/spec/factories/application_type.rb
@@ -41,6 +41,6 @@ FactoryBot.define do
       end
     end
 
-    initialize_with { local_authority.application_types.find_or_create_by(code:) }
+    initialize_with { local_authority.application_types.find_or_initialize_by(code:) }
   end
 end

--- a/spec/factories/case_record.rb
+++ b/spec/factories/case_record.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :case_record do
-    local_authority { create(:local_authority, :default) }
+    local_authority { create(:local_authority) }
   end
 end

--- a/spec/factories/local_authorities.rb
+++ b/spec/factories/local_authorities.rb
@@ -82,7 +82,7 @@ FactoryBot.define do
 
     trait :with_api_user do
       after(:create) do |local_authority|
-        local_authority.api_users.find_or_create_by!(name: local_authority.subdomain, permissions: %w[validation_request:read])
+        local_authority.api_users.find_or_initialize_by(name: local_authority.subdomain, permissions: %w[validation_request:read])
       end
     end
 
@@ -90,6 +90,6 @@ FactoryBot.define do
       planning_history_enabled { true }
     end
 
-    initialize_with { LocalAuthority.find_or_create_by(subdomain:) }
+    initialize_with { LocalAuthority.find_or_initialize_by(subdomain:) }
   end
 end

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -7,6 +7,8 @@ FactoryBot.define do
     local_authority do
       LocalAuthority.find_by(subdomain: "buckinghamshire") || create(:local_authority)
     end
+    user { nil }
+    case_record { association :case_record, local_authority:, user:, strategy: :build }
     description { Faker::Lorem.unique.sentence }
     status { :in_assessment }
     in_assessment_at { Time.zone.now }

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     context "when there is an assigned officer to the case" do
       before do
-        planning_application.user = assessor
+        planning_application.case_record.user = assessor
       end
 
       it "includes the information about the validation request being auto accepted" do
@@ -491,7 +491,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     context "when there is an assigned officer to the case" do
       before do
-        planning_application.user = assessor
+        planning_application.case_record.user = assessor
       end
 
       it "includes the information about the validation request being auto accepted" do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -1156,13 +1156,13 @@ RSpec.describe PlanningApplication do
 
     context "when an ActiveRecord error is raised" do
       before do
-        allow(planning_application).to receive(:update!).and_raise(ActiveRecord::ActiveRecordError)
+        allow(planning_application.case_record).to receive(:update!).and_raise(ActiveRecord::ActiveRecordError)
       end
 
       it "raises an error and does not create an audit" do
         expect { planning_application.assign!(user) }
           .to raise_error(ActiveRecord::ActiveRecordError)
-          .and not_change(planning_application, :user_id)
+          .and not_change(planning_application.case_record, :user_id)
           .and not_change(Audit, :count)
       end
     end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe Submission do
 
   describe "associations" do
     let(:local_authority) { create(:local_authority) }
-    let(:submission) { create(:submission, local_authority: local_authority) }
-    let!(:planning_application) { create(:planning_application, submission: submission) }
+    let(:submission) { create(:submission, local_authority:) }
+    let(:case_record) { build(:case_record, local_authority:, submission:) }
+    let!(:planning_application) { create(:planning_application, case_record:) }
 
     describe "#local_authority" do
       it "returns the associated local authority" do
@@ -47,9 +48,9 @@ RSpec.describe Submission do
         expect { submission.destroy }.not_to change(PlanningApplication, :count)
       end
 
-      it "nullifies the planning application's submission_id" do
+      it "nullifies the case record's submission_id" do
         submission.destroy
-        expect(planning_application.reload.submission_id).to be_nil
+        expect(case_record.reload.submission_id).to be_nil
       end
     end
   end

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -5,8 +5,8 @@ require "openapi3_parser"
 
 RSpec.describe "The Open API Specification document" do
   let!(:document) { Openapi3Parser.load_file(Rails.public_path.join("api/docs/v1/swagger_doc.yaml")) }
-  let!(:default_local_authority) { create(:local_authority, :default) }
-  let!(:api_user) { create(:api_user, permissions: %w[validation_request:read planning_application:read], local_authority: default_local_authority) }
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:api_user) { create(:api_user, permissions: %w[validation_request:read planning_application:read], local_authority:) }
   let!(:application_type) { create(:application_type, :ldc_proposed) }
   let(:result) { PlanningApplication.last }
 
@@ -46,7 +46,8 @@ RSpec.describe "The Open API Specification document" do
       planning_application = PlanningApplication.create! planning_application_hash.except("reference", "reference_in_full", "status",
         "received_date", "documents", "site", "constraints", "work_status",
         "application_type").merge(
-          local_authority: default_local_authority,
+          case_record: CaseRecord.create(local_authority:),
+          local_authority:,
           application_type_id: ApplicationType.first.id,
           status: "in_assessment",
           validated_at: Time.zone.now

--- a/spec/system/enforcements/show_spec.rb
+++ b/spec/system/enforcements/show_spec.rb
@@ -3,8 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Enforcement show page", type: :system do
-  let(:enforcement) { create(:enforcement) }
-  let(:user) { create(:user, local_authority: enforcement.case_record.local_authority) }
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:case_record) { build(:case_record, local_authority:) }
+  let(:enforcement) { create(:enforcement, case_record:) }
+  let(:user) { create(:user, local_authority:) }
 
   before { sign_in user }
 

--- a/spec/system/planning_applications/create_spec.rb
+++ b/spec/system/planning_applications/create_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe "Creating a planning application", type: :system do
   let!(:ldc_proposed) { create(:application_type, :ldc_proposed, local_authority: local_authority) }
 
   let!(:subdomain) { local_authority.subdomain }
+  let!(:case_record) { build(:case_record, local_authority:) }
   let!(:planning_applications) { local_authority.planning_applications }
-  let!(:planning_application) { planning_applications.new }
+  let!(:planning_application) { planning_applications.new(case_record:) }
 
   let(:reference) { planning_application.reference }
 


### PR DESCRIPTION
Bare minimum to add a case record to planning applications.

Mainly this involves mapping the user and local authority attributes to the case record, since that's what's already on there. Other fields have not yet been migrated/delegated, in the interests of getting this done and doing it incrementally.