### PR TITLE
Add check enforcement report details page & mark case urgent

### DIFF
--- a/app/controllers/enforcements/check_details_controller.rb
+++ b/app/controllers/enforcements/check_details_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class Enforcements::CheckDetailsController < AuthenticationController
+  before_action :set_enforcement
+  before_action :set_proposal_details
+
+  def show
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  private
+
+  def set_enforcement
+    @enforcement = current_local_authority
+      .enforcements
+      .joins(:case_record)
+      .find_by!(case_record: {id: params[:enforcement_id]})
+  end
+
+  def set_proposal_details
+    @proposal_details = @enforcement.proposal_details
+  end
+end

--- a/app/controllers/enforcements/reports_controller.rb
+++ b/app/controllers/enforcements/reports_controller.rb
@@ -9,6 +9,17 @@ class Enforcements::ReportsController < AuthenticationController
     end
   end
 
+  def update
+    respond_to do |format|
+      format.html
+    end
+    if @enforcement.update(enforcement_params)
+      redirect_to enforcement_report_path(@enforcement), notice: "Enforcement case updated"
+    else
+      render :show, notice: "Unable to update enforcement case"
+    end
+  end
+
   private
 
   def set_enforcement
@@ -16,5 +27,9 @@ class Enforcements::ReportsController < AuthenticationController
       .enforcements
       .joins(:case_record)
       .find_by!(case_record: {id: params[:enforcement_id]})
+  end
+
+  def enforcement_params
+    params.require(:enforcement).permit(:urgent)
   end
 end

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -21,4 +21,10 @@ class Enforcement < ApplicationRecord
   def status
     :unknown
   end
+
+  def proposal_details
+    Array(super).each_with_index.map do |hash, index|
+      ProposalDetail.new(hash, index)
+    end
+  end
 end

--- a/app/views/enforcements/check_details/show.html.erb
+++ b/app/views/enforcements/check_details/show.html.erb
@@ -1,0 +1,52 @@
+<%= render "enforcements/enforcement", title: "Check report details" %>
+
+<%= govuk_accordion do |accordion| %>
+    <%= accordion.with_section(heading_text: "Breach report") do %>
+      <% @proposal_details.each do |proposal_detail| %>
+        <%= render(
+              ProposalDetails::SummaryComponent.new(proposal_detail: proposal_detail)
+            ) %>
+      <% end %>
+    <% end %>
+
+    <%= accordion.with_section(heading_text: "Complainant details") { tag.p("Content") } %>
+    <%= accordion.with_section(heading_text: "Site owner and interested parties") { tag.p("Content") } %>
+    <%= accordion.with_section(heading_text: "Documents") { tag.p("Content") } %>
+    <%= accordion.with_section(heading_text: "Photos") { tag.p("Content") } %>
+<% end %>
+
+<div id="quick-close-case">
+  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Quick close </h2>
+  <p class="govuk-body">
+    If you believe this case can be closed without an investigation you can
+    <%= govuk_link_to "close the case.", class: "govuk-body", no_visited_state: true %>
+    This decision will <strong>not</strong> be reviewed.
+  </p>
+</div>
+
+<div id="quick-recommendation">
+  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Quick recommendation </h2>
+  <p class="govuk-body">
+    If you believe this case is not expedient to enforce you can
+    <%= govuk_link_to "make a recommendation.", class: "govuk-body", no_visited_state: true %>
+    This decision will be reviewed by a manager.
+  </p>
+</div>
+
+<div id="urgent-tag">
+  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Is this case urgent? </h2>
+  <%= form_with model: @enforcement, url: enforcement_report_path(@enforcement), method: :patch do |form| %>
+    <div>
+      <%= form.govuk_check_box :urgent, 1, 0, label: {text: "Select here if the case is urgent"}, multiple: false %>
+    </div>
+
+    <div id="quick-recommendation">
+      <h2 class="govuk-heading-m govuk-!-margin-top-5"> Check description </h2>
+      <p class="govuk-body govuk-!-margin-bottom-1"> <%= @enforcement.description %></p>
+      <%= govuk_link_to "Edit desciption", class: "govuk-body-small govuk-!-margin-top-1", no_visited_state: true %>
+    </div>
+    <%= form.govuk_submit "Save and mark complete", class: "govuk-!-margin-top-5" do %>
+      <%= govuk_button_link_to "Back", enforcement_report_path(@enforcement), secondary: true %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/enforcements/reports/show.html.erb
+++ b/app/views/enforcements/reports/show.html.erb
@@ -1,7 +1,7 @@
 <%= render "enforcements/enforcement", title: "Check breach report" %>
 
 <%= govuk_task_list(id_prefix: "breach-report") do |task_list|
-      task_list.with_item(title: "Check report details", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
+      task_list.with_item(title: "Check report details", href: enforcement_report_check_details_path(@enforcement), status: govuk_tag(text: "Incomplete", colour: "blue"))
       task_list.with_item(title: "Check site location", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
       task_list.with_item(title: "Review constraints", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))
       task_list.with_item(title: "Review site history", href: "#", status: govuk_tag(text: "Incomplete", colour: "blue"))

--- a/config/routes/bops.rb
+++ b/config/routes/bops.rb
@@ -352,7 +352,9 @@ local_authority_subdomain do
 
   resources :enforcements, only: %i[show] do
     scope module: :enforcements do
-      resource :report, only: :show
+      resource :report, only: %i[show update] do
+        resource :check_details, only: :show
+      end
     end
   end
 

--- a/engines/bops_submissions/spec/services/enforcement/creation_service_spec.rb
+++ b/engines/bops_submissions/spec/services/enforcement/creation_service_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe BopsSubmissions::Enforcement::CreationService, type: :service do
       )
     end
     let(:service) { described_class.new(submission: submission) }
+    let!(:expected_proposal_details) do
+      submission.request_body["responses"]
+    end
     let(:parsed_enforcement_data) do
       factory = RGeo::Geographic.spherical_factory(srid: 4326)
       {
@@ -24,8 +27,7 @@ RSpec.describe BopsSubmissions::Enforcement::CreationService, type: :service do
         postcode: "ME1 1EW",
         uprn: "000044009430",
         boundary_geojson: nil,
-        lonlat: factory.point(0.506217, 51.3873264),
-        proposal_details: submission.request_body["responses"]
+        lonlat: factory.point(0.506217, 51.3873264)
       }
     end
 
@@ -41,6 +43,9 @@ RSpec.describe BopsSubmissions::Enforcement::CreationService, type: :service do
       expect(enforcement).to have_attributes(
         **parsed_enforcement_data
       )
+
+      expect(enforcement.proposal_details).to all(be_a(ProposalDetail))
+      expect(enforcement.proposal_details.size).to eq(expected_proposal_details.size)
     end
 
     context "when saving Enforcement fails" do

--- a/spec/system/enforcements/check_report_details_spec.rb
+++ b/spec/system/enforcements/check_report_details_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check breach report", type: :system, capybara: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:case_record) { build(:case_record, local_authority:) }
+  let(:enforcement) { create(:enforcement, case_record:) }
+  let(:user) { create(:user, local_authority:) }
+
+  before do
+    sign_in user
+    visit "/enforcements/#{enforcement.case_record.id}/report"
+  end
+
+  it "shows the relevant report details" do
+    click_link "Check report details"
+
+    expect(page).to have_content("Check report details")
+    expect(page).to have_content("Quick close")
+    expect(page).to have_content("Is this case urgent?")
+  end
+
+  it "allows me to mark a case as urgent" do
+    expect(page).not_to have_content("urgent")
+    click_link "Check report details"
+    check "Select here if the case is urgent"
+
+    click_button "Save and mark complete"
+    expect(page).to have_content("Enforcement case updated")
+    expect(page).to have_content("urgent")
+  end
+end


### PR DESCRIPTION
### Description of change

Add the page to check report details, and mark the case as urgent. Other links are disabled at this time (edit description, close case, make recommendation) and are handled by later tickets.

### Story Link
https://trello.com/c/ij63yttL/758-check-report-details-page and https://trello.com/c/bVPeucse/892-able-to-mark-a-case-as-urgent-check-report-details-page


### Screenshots

<img width="566" height="747" alt="image" src="https://github.com/user-attachments/assets/895cfca4-8e56-48e0-9f83-6e72dde934a4" />
