### PR TITLE
Apply govuk-body to <p> tags by default for bops-applicants

### DIFF
--- a/engines/bops_applicants/app/assets/stylesheets/bops_applicants/application.scss
+++ b/engines/bops_applicants/app/assets/stylesheets/bops_applicants/application.scss
@@ -10,6 +10,10 @@ $govuk-font-family: open-sans, sans-serif;
 @import "notifications";
 @import "consultation";
 
+p {
+  @extend .govuk-body;
+}
+
 .autocomplete__input {
   font-family: $govuk-font-family;
 


### PR DESCRIPTION
PR #2398 removed the class attributes but didn't add the `@extend` for the applicants.css.
