### PR TITLE
Add additional expectations around non-delivery of messages

### DIFF
--- a/engines/bops_reports/config/locales/en.yml
+++ b/engines/bops_reports/config/locales/en.yml
@@ -35,11 +35,6 @@ en:
           withdrawal_failed: Failed to withdraw pre-application report - please contact support
           withdrawal_not_allowed: Withdrawing the pre-application report is no longer allowed
           withdrawn: Pre-application report withdrawn
-        publish:
-          not_assigned: Pre-application report must be assigned to a case officer before it can be submitted to the applicant
-          not_reviewer: Pre-application reports can only be published by a manager
-          publish_failed: Failed to publish pre-application report - please contact support
-          published: Pre-application report has been sent to the applicant
         update:
           challenged: Pre-application report has been sent back to the case officer for amendments
           not_assigned: Pre-application report must be assigned to a case officer before it can be submitted to the applicant

--- a/engines/bops_reports/config/routes.rb
+++ b/engines/bops_reports/config/routes.rb
@@ -7,9 +7,7 @@ BopsReports::Engine.routes.draw do
 
   resources :planning_applications, param: :reference, only: %i[show] do
     scope module: "planning_applications" do
-      resource :recommendation, only: %i[create update destroy] do
-        post :publish, on: :member
-      end
+      resource :recommendation, only: %i[create update destroy]
     end
   end
 end

--- a/engines/bops_reports/spec/system/recommendation_spec.rb
+++ b/engines/bops_reports/spec/system/recommendation_spec.rb
@@ -117,6 +117,32 @@ RSpec.describe "Recommending and submitting a pre-application report" do
     click_button "Confirm and submit recommendation"
     expect(page).to have_selector("[role=alert] p", text: "Pre-application report submitted for review")
 
+    expect(BopsReports::SendReportEmailJob).not_to have_been_enqueued
+
+    click_link "Review and submit pre-application"
+    expect(page).to have_button("Confirm and submit pre-application report")
+
+    within_fieldset "Do you agree with the advice?" do
+      choose "No (return the case for assessment)"
+      fill_in "Reviewer comment", with: "Not good enough"
+    end
+
+    click_button "Confirm and submit pre-application report"
+    expect(page).to have_selector("[role=alert] p", text: "Pre-application report has been sent back to the case officer for amendments")
+
+    expect(BopsReports::SendReportEmailJob).not_to have_been_enqueued
+
+    click_link "Check and assess"
+    expect(page).to have_selector("h1", text: "Assess the application")
+
+    click_link "Review and submit pre-application"
+    expect(page).to have_button("Confirm and submit recommendation")
+
+    fill_in "Assessor comment", with: "It is now"
+
+    click_button "Confirm and submit recommendation"
+    expect(page).to have_selector("[role=alert] p", text: "Pre-application report submitted for review")
+
     click_link "Review and submit pre-application"
     expect(page).to have_button("Confirm and submit pre-application report")
 


### PR DESCRIPTION
There was a report that a report email was sent after submitting a recommendation. It was not possible to replicate this so extra expectations were added to the self assess and review flow to ensure it's only sent after being determined.

Also removes the publish action added in #2350 as it's no longer required.

https://trello.com/c/S5BFbxsJ#comment-6878b2aaddfc0b3256710cc5