### PR TITLE
Add enforcement index page

### DIFF
--- a/app/components/enforcements/panel_component.html.erb
+++ b/app/components/enforcements/panel_component.html.erb
@@ -1,0 +1,41 @@
+<h2 class="govuk-heading-m"><%= title %></h2>
+
+<%= render(
+      Enforcements::SearchComponent.new(
+        panel_type: type,
+        search: @search
+      )
+    ) %>
+
+<% if enforcements.empty? %>
+  <p><%= t(".no_enforcements") %></p>
+<% else %>
+  <%= govuk_table(id: "enforcements") do |table| %>
+    <% table.with_head do |head| %>
+      <% head.with_row do |row| %>
+        <% default_attributes.each do |attribute| %>
+          <% if attribute == :full_address %>
+            <% row.with_cell(text: t(".#{attribute}"), width: "three-quarters") %>
+          <% else %>
+            <% row.with_cell(text: t(".#{attribute}")) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <% table.with_body do |body| %>
+      <% enforcements.each do |enforcement| %>
+        <% body.with_row do |row| %>
+          <% default_attributes.each do |attribute| %>
+            <%= row.with_cell do %>
+              <%= render_attribute(enforcement, attribute) %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+  <% if type == :all %>
+    <%= pagination %>
+  <% end %>
+<% end %>

--- a/app/components/enforcements/panel_component.rb
+++ b/app/components/enforcements/panel_component.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Enforcements
+  class PanelComponent < ViewComponent::Base
+    include Pagy::Backend
+
+    def initialize(enforcements:, type:, attributes:, search:)
+      @enforcements = enforcements
+      @type = type
+      @search = search
+      @attributes = attributes
+    end
+
+    attr_reader :type, :search
+
+    def before_render
+      @pagy, @paginated_enforcements = pagy(@enforcements, overflow: :last_page)
+    end
+
+    def enforcements
+      case type
+      when :all
+        @paginated_enforcements
+      else
+        @enforcements
+      end
+    end
+
+    TAG_MAPPINGS = {
+      urgent: ->(e, h) { e.urgent? ? h.govuk_tag(text: "Urgent", colour: "red") : nil },
+      days_status_tag: ->(e, h) { h.govuk_tag(text: "#{e.days_from} days received", colour: "orange") },
+      status_tag: ->(e, h) { h.govuk_tag(text: e.status.to_s, colour: e.status_tag_colour) },
+      to_param: ->(e, h) { h.govuk_link_to(e.case_record.id, h.enforcement_path(e)) }
+    }.freeze
+
+    def render_attribute(enforcement, attribute)
+      if TAG_MAPPINGS.key?(attribute)
+        TAG_MAPPINGS[attribute].call(enforcement, helpers)
+      else
+        enforcement.send(attribute)
+      end
+    end
+
+    def pagination
+      return unless @pagy.pages > 1
+
+      page_data = @pagy.series.map { |i|
+        {href: pagination_url(page: i), number: (i == :gap) ? "…" : i, current: i.is_a?(String)}
+      }
+
+      govuk_pagination do |p|
+        p.with_previous_page(href: pagination_url(page: @pagy.prev)) if @pagy.page > 1
+
+        p.with_items page_data
+
+        p.with_next_page(href: pagination_url(page: @pagy.next)) if @pagy.page < @pagy.last
+      end
+    end
+
+    def pagination_url(page:)
+      pagy_url_for(@pagy, page) + "##{type}"
+    end
+
+    def attributes
+      default_attributes
+    end
+
+    def title
+      t(".#{type}")
+    end
+
+    def default_attributes
+      %i[
+        to_param
+        to_s
+        days_status_tag
+        urgent
+        status_tag
+      ]
+    end
+  end
+end

--- a/app/components/enforcements/search_component.html.erb
+++ b/app/components/enforcements/search_component.html.erb
@@ -1,0 +1,44 @@
+<%= form_with(
+      model: search,
+      scope: "",
+      method: :get,
+      url: enforcements_path
+    ) do |form| %>
+  <%# add in error summary with search %>
+  <div class="search-form-inputs">
+    <%= form.govuk_fieldset(legend: {text: nil}) do %>
+      <%= form.govuk_text_field(
+            :query,
+            class: "govuk-input--width-30",
+            label: {text: t(".find_a_case")},
+            hint: {text: t(".you_can_search")}
+          ) %>
+    <% end %>
+    <%= form.govuk_submit t(".search"), name: "submit", value: "search" %>
+    <%= govuk_button_link_to(
+          t(".clear_search"),
+          clear_search_url,
+          secondary: true
+        ) %>
+  </div>
+
+  <%= govuk_accordion do |accordion| %>
+    <% accordion.with_section(heading_text: "Filters") do %>
+      <div class="govuk-accordion__section-content govuk-!-padding-bottom-0">
+        <p><strong>Priority</strong></p>
+        <%= form.govuk_check_box(:urgent, "Urgent", small: true, legend: nil, class: "display-flex") %>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      </div>
+
+      <div class="govuk-accordion__section-content govuk-!-padding-bottom-0">
+        <p><strong>Status</strong></p>
+        <%= form.govuk_check_box(:status, "status", small: true, legend: nil, class: "display-flex") %>
+        <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      </div>
+      <div class="govuk-accordion__section-content govuk-!-padding-bottom-3">
+        <%= form.govuk_submit "Apply filters", class: "govuk-button govuk-button--secondary" %>
+      </div>
+    <% end %>
+    <%# will need to change to collection_check_boxes once status' are re-added %>
+  <% end %>
+<% end %>

--- a/app/components/enforcements/search_component.rb
+++ b/app/components/enforcements/search_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Enforcements
+  class SearchComponent < ViewComponent::Base
+    def initialize(panel_type:, search:)
+      @panel_type = panel_type
+      @search = search
+    end
+
+    private
+
+    attr_reader :search, :panel_type
+
+    def clear_search_url
+      enforcements_path
+    end
+  end
+end

--- a/app/controllers/enforcements_controller.rb
+++ b/app/controllers/enforcements_controller.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
 class EnforcementsController < AuthenticationController
-  before_action :set_enforcement
+  before_action :set_enforcement, only: %i[show]
+  before_action :set_enforcements, only: %i[index]
+
+  def index
+    respond_to do |format|
+      format.html
+    end
+  end
 
   def show
     respond_to do |format|
@@ -10,6 +17,13 @@ class EnforcementsController < AuthenticationController
   end
 
   private
+
+  def set_enforcements
+    @enforcements = current_local_authority
+      .enforcements
+      .joins(:case_record)
+      .by_received_at_desc
+  end
 
   def set_enforcement
     @enforcement = current_local_authority

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,7 +58,23 @@ module ApplicationHelper
     end
   end
 
+  def active_page_key
+    page_keys = {
+      "planning_applications" => "planning_applications",
+      "enforcements" => "enforcements"
+    }
+
+    page_keys.fetch(controller_name, "dashboard")
+  end
+
+  def active_page_key?(page_key)
+    active_page_key == page_key
+  end
+
   def nav_items
-    []
+    [
+      {text: "Planning", href: root_path, active: active_page_key?("planning_applications")},
+      {text: "Enforcement", href: enforcements_path, active: active_page_key?("enforcements")}
+    ]
   end
 end

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -14,6 +14,9 @@ class Enforcement < ApplicationRecord
 
   after_initialize -> { self.received_at ||= Time.zone.now }
 
+  scope :by_received_at_desc, -> { order(received_at: :desc) }
+  delegate :to_s, to: :address
+
   def to_param
     case_record.id
   end
@@ -26,5 +29,13 @@ class Enforcement < ApplicationRecord
     Array(super).each_with_index.map do |hash, index|
       ProposalDetail.new(hash, index)
     end
+  end
+
+  def status_tag_colour
+    "grey"
+  end
+
+  def days_from
+    created_at.to_date.business_days_until(Time.previous_business_day(Date.current))
   end
 end

--- a/app/presenters/enforcement_presenter.rb
+++ b/app/presenters/enforcement_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class EnforcementPresenter
+  def initialize(enforcement)
+    @enforcement = enforcement
+  end
+
+  def status_tag_colour
+    "orange"
+  end
+
+  def status_tag
+    classes = ["govuk-tag govuk-tag--#{status_tag_colour}"]
+
+    tag.span class: classes do
+      "unknown"
+      # status' to be added later
+    end
+  end
+
+  def days_status_tag
+    classes = ["govuk-tag", "govuk-tag--orange"]
+
+    tag.span class: classes.join(" ") do
+      I18n.t("enforcement.days_from", count: days_from)
+    end
+  end
+end

--- a/app/views/enforcements/index.html.erb
+++ b/app/views/enforcements/index.html.erb
@@ -1,0 +1,47 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Enforcement cases
+    </h1>
+    <p class="govuk-body-m">
+      <strong><%= current_user.name %>,</strong> <%= role_name %>
+    </p>
+  </div>
+</div>
+
+<div class="status-bar-container status-bar-container--colored">
+  <div class="status-bar govuk-!-margin-bottom-4 govuk-!-padding-bottom-4">
+    <div class="status-panel" id="follow-up-cases">
+      <h3 class="govuk-heading-m"><%= t ".follow_ups", count: 1 %></h3>
+      <%= govuk_link_to enforcements_path, class: "status-filter-link" do %>
+        <p class="govuk-heading-s"><%= t ".follow_ups.title" %></p>
+      <% end %>
+    </div>
+    <div class="status-panel" id="returned-cases">
+      <h3 class="govuk-heading-m"><%= t ".returned_cases", count: 1 %></h3>
+      <%= govuk_link_to enforcements_path, class: "status-filter-link" do %>
+        <p class="govuk-heading-s"><%= t ".returned_cases.title" %></p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div class="govuk-tabs" data-module="govuk-tabs">
+      <h2 class="govuk-tabs__title">
+        Contents
+      </h2>
+      <%= govuk_tabs do |tabs|
+            tabs.with_tab(label: "All cases", id: "all") {
+              render Enforcements::PanelComponent.new(
+                enforcements: @enforcements,
+                type: :all,
+                search: @search,
+                attributes: @attributes
+              )
+            }
+          end %>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -893,6 +893,37 @@ en:
       validation_notice_mail: Your application for a %{application_type_name}
       validation_request_closure_mail: Changes to your %{application_type_name} application
       validation_request_mail: "%{application_type_name} application - further changes needed"
+  enforcements:
+    index:
+      follow_ups:
+        one: "%{count}"
+        other: "%{count}"
+        title: Cases with actions to follow-up
+      returned_cases:
+        one: "%{count}"
+        other: "%{count}"
+        title: Cases returned after review
+    panel_component:
+      all: All enforcement cases
+      closed: Closed
+      days_status_tag: Days received
+      description: Description
+      formatted_expiry_date: Expiry date
+      mine: My applications
+      no_enforcements: No enforcement cases
+      not_started_and_invalid: Not started
+      outcome: Outcome
+      status_tag: Status
+      to_param: Case reference
+      to_s: Address
+      unassigned: Unassigned applications
+      urgent: Priority
+      user_name: Planning officer
+    search_component:
+      clear_search: Clear search
+      find_a_case: Find a case
+      search: Search
+      you_can_search: You can search by case number or description
   environment_impact_assessment:
     guidance_link: https://www.gov.uk/government/publications/environmental-impact-assessment-screening-checklist
   errors:

--- a/config/routes/bops.rb
+++ b/config/routes/bops.rb
@@ -350,7 +350,7 @@ local_authority_subdomain do
     end
   end
 
-  resources :enforcements, only: %i[show] do
+  resources :enforcements, only: %i[index show] do
     scope module: :enforcements do
       resource :report, only: %i[show update] do
         resource :check_details, only: :show

--- a/spec/system/enforcements/index_spec.rb
+++ b/spec/system/enforcements/index_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Enforcement index page", type: :system do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:case_record) { build(:case_record, local_authority:) }
+  let!(:case_record_1) { build(:case_record, local_authority:) }
+  let!(:enforcement) { create(:enforcement, case_record: case_record, received_at: 1.day.ago) }
+  let!(:enforcement_1) { create(:enforcement, case_record: case_record_1, received_at: 3.days.ago) }
+  let(:user) { create(:user, local_authority:) }
+
+  before do
+    sign_in user
+    visit "/"
+  end
+
+  it "allows me to navigate to the enforcement index" do
+    expect(page).to have_selector("h1", text: "Planning applications")
+    click_link("Enforcement")
+    expect(page).to have_current_path("/enforcements")
+    expect(page).to have_selector("h1", text: "Enforcement cases")
+  end
+
+  it "displays all planning applications" do
+    visit "/enforcements"
+    click_link "All cases"
+
+    within("#all") do
+      expect(page).to have_selector("h2", text: "All enforcement cases")
+
+      within(".govuk-table") do
+        within(".govuk-table__head") do
+          within(all(".govuk-table__row").first) do
+            expect(page).to have_content("Case reference")
+            expect(page).to have_content("Address")
+            expect(page).to have_content("Days received")
+            expect(page).to have_content("Status")
+            expect(page).to have_content("Priority")
+          end
+        end
+
+        within(".govuk-table__body") do
+          rows = page.all(".govuk-table__row")
+
+          within(rows[0]) do
+            cells = page.all(".govuk-table__cell")
+            within(cells[0]) do
+              expect(page).to have_content(case_record.id)
+            end
+            within(cells[1]) do
+              expect(page).to have_content(enforcement.to_s)
+            end
+            within(cells[2]) do
+              expect(page).to have_content("0 days received")
+            end
+          end
+
+          within(rows[1]) do
+            cells = page.all(".govuk-table__cell")
+            within(cells[0]) do
+              expect(page).to have_content(case_record_1.id)
+            end
+            within(cells[1]) do
+              expect(page).to have_content(enforcement_1.to_s)
+            end
+            within(cells[2]) do
+              expect(page).to have_content("0 days received")
+            end
+          end
+        end
+      end
+    end
+  end
+
+  it "has a link to the enforcement show page", capybara: true do
+    visit "/enforcements"
+    click_link "All cases"
+    click_link(enforcement.case_record.id)
+    expect(page).to have_current_path("/enforcements/#{enforcement.case_record.id}")
+  end
+end


### PR DESCRIPTION
### Description of change

Added Enforcement index page, which includes all front end components but some functionality and components are covered by later tickets, namely:

- Search and filtering
- Addition of other tabs besides "All" ("assigned to me" and "unassigned")
- Population of status bar with accurate case numbers based on filters (for now hard coded to 1)
- Status' for enforcement
- Enforcement reference (uuid is used as a placeholder)

### Story Link

https://trello.com/c/a58dUvg5/891-create-enforcement-index-dashboard-page

### Screenshots

<img width="808" height="781" alt="image" src="https://github.com/user-attachments/assets/2af0d7b7-806e-4f21-94f1-77aaef7b96b2" />
<img width="726" height="797" alt="image" src="https://github.com/user-attachments/assets/774d5098-724a-4f42-92a0-9e7696eca3a8" />

