### PR TITLE
Add parallel test sharding support to slow workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,32 @@ jobs:
               directories: "system",
               additional_spec_opts: "--tag 'capybara' --tag 'js'",
               want_pdf: true,
+              shard: 1,
+              total_shards: 4,
+            }
+          - {
+              group: "system: capybara",
+              directories: "system",
+              additional_spec_opts: "--tag 'capybara' --tag 'js'",
+              want_pdf: true,
+              shard: 2,
+              total_shards: 4,
+            }
+          - {
+              group: "system: capybara",
+              directories: "system",
+              additional_spec_opts: "--tag 'capybara' --tag 'js'",
+              want_pdf: true,
+              shard: 3,
+              total_shards: 4,
+            }
+          - {
+              group: "system: capybara",
+              directories: "system",
+              additional_spec_opts: "--tag 'capybara' --tag 'js'",
+              want_pdf: true,
+              shard: 4,
+              total_shards: 4,
             }
           - { group: "components", want_pdf: true }
           - {
@@ -91,6 +117,8 @@ jobs:
       include: "${{matrix.specs.module || 'spec'}}/${{matrix.specs.directories || matrix.specs.group}}/${{matrix.specs.pattern || '**/*_spec.rb'}}"
       want-pdf: "${{ !!matrix.specs.want_pdf }}"
       additional_spec_opts: "${{ matrix.specs.additional_spec_opts }}"
+      shard: ${{ matrix.specs.shard }}
+      total-shards: ${{ matrix.specs.total_shards }}
     secrets: inherit
 
   cucumber:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,6 +34,14 @@ on:
         type: string
         required: false
         default: ""
+      total-shards:
+        type: number
+        required: false
+        default: 1
+      shard:
+        type: number
+        required: false
+        default: 1
 
 jobs:
   tests:
@@ -113,14 +121,27 @@ jobs:
         run: bundle exec rake assets:precompile
 
       - name: Run rspec specs
-        if: ${{ inputs.test-runner == 'rspec' }}
+        if: ${{ inputs['test-runner'] == 'rspec' }}
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/test
           RAILS_ENV: test
           OTP_SECRET_ENCRYPTION_KEY: testtest
-          SPEC_OPTS: '-f doc --force-color --exclude "${{ inputs.exclude }}" --pattern "${{ inputs.include }}" ${{ inputs.additional_spec_opts }}'
+          SPEC_OPTS: >
+            -f doc --force-color
+            --exclude "${{ inputs.exclude }}"
+            --pattern "${{ inputs.include }}"
+            ${{ inputs.additional_spec_opts }}
         run: |
-          bundle exec rake spec
+          if [ ${{ inputs['total-shards'] }} -gt 1 ]; then
+            bundle exec parallel_rspec \
+              --type rspec \
+              --pattern "${{ inputs.include }}" \
+              -n ${{ inputs['total-shards'] }} \
+              --only-group ${{ inputs.shard }} \
+              ${{ inputs.additional_spec_opts }}
+          else
+            bundle exec rake spec
+          fi
 
       - name: Define artifact name
         if: ${{ failure() }}

--- a/Gemfile
+++ b/Gemfile
@@ -102,5 +102,6 @@ group :test do
   gem "email_spec"
   gem "factory_bot_rails"
   gem "openapi3_parser", require: false
+  gem "parallel_tests"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,8 @@ GEM
     ostruct (0.6.0)
     pagy (9.3.3)
     parallel (1.25.1)
+    parallel_tests (5.3.0)
+      parallel
     parser (3.3.7.0)
       ast (~> 2.4.1)
       racc
@@ -749,6 +751,7 @@ DEPENDENCIES
   os_national_grid (~> 0.1.0)
   ostruct
   pagy
+  parallel_tests
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 6)


### PR DESCRIPTION
### Description of change

Add parallel test sharding support to slow workflows (system tests taking over 15 mins to complete)
- Expose `shard` and `total-shards` inputs in Testing reusable workflow
- Pass `matrix.specs.shard` and `matrix.specs.total_shards` from CI build job

