### PR TITLE
Return an empty NeighbourResponse relation when no consultation exists

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
@@ -7,10 +7,12 @@ module BopsApi
         def index
           @planning_application = find_planning_application params[:planning_application_id]
           @consultation = @planning_application.consultation
-          if @consultation.nil?
-            raise BopsApi::Errors::InvalidRequestError, "Consultation not found"
+
+          @neighbour_responses = if @consultation
+            @consultation.neighbour_responses.redacted
+          else
+            NeighbourResponse.none
           end
-          @neighbour_responses = @consultation.neighbour_responses.redacted
 
           @pagy, @comments = BopsApi::Postsubmission::CommentsPublicService.new(
             @neighbour_responses,


### PR DESCRIPTION
### Description of change

- Return an empty NeighbourResponse relation when no consultation exists
- This change ensures the controller returns an empty AR relation for pagination, summary counts, and JSON rendering when there’s no associated consultation.
- This change avoids blowing up and sending to AppSignal: BopsApi::Errors::InvalidRequestError: Consultation not found https://appsignal.com/southwark-bops/sites/604f8b2b02644464664ae01c/exceptions/incidents/937/samples/timestamp/2025-07-22T07:48:53Z

