### PR TITLE
Show constraint entity pre-app report

### DIFF
--- a/engines/bops_reports/app/controllers/bops_reports/planning_applications/base_controller.rb
+++ b/engines/bops_reports/app/controllers/bops_reports/planning_applications/base_controller.rb
@@ -52,7 +52,7 @@ module BopsReports
       end
 
       def set_constraints
-        @constraints = @planning_application.constraints.group_by(&:category)
+        @constraints = @planning_application.planning_application_constraints.group_by(&:category)
       end
 
       def set_recommendation

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_constraints_table.html.erb
@@ -11,7 +11,15 @@
           <% values.each do |value| %>
             <div class="govuk-summary-list__row">
               <dd class="govuk-summary-list__value">
-                <%= value.type.humanize %>
+                <%= value.type_code %>
+                <% if value.entities.present? %>
+                  <ul class="govuk-list">
+                    <% value.entities.each do |name, entity| %>
+                      <% entity_name = name.present? ? name.titleize : "Entity ##{entity}" %>
+                      <li><%= govuk_link_to entity_name, planning_data_entity_url(entity), new_tab: true %></li>
+                    <% end %>
+                  </ul>
+                <% end %>
               </dd>
             </div>
           <% end %>

--- a/engines/bops_reports/spec/system/pre_application_report_spec.rb
+++ b/engines/bops_reports/spec/system/pre_application_report_spec.rb
@@ -280,12 +280,12 @@ RSpec.describe "Pre-application report" do
 
       within("#site-constraints-heritage_and_conservation") do
         expect(page).to have_content("Heritage and conservation")
-        expect(page).to have_content("Designated conservationarea")
+        expect(page).to have_content("Conservation area")
       end
 
       within("#site-constraints-trees") do
         expect(page).to have_content("Trees")
-        expect(page).to have_content("Tpo")
+        expect(page).to have_content("Tree preservation zone")
       end
     end
   end


### PR DESCRIPTION
### Description of change

Update way constraints are shown on Pre-App report to include entity name where present.

### Story Link

https://trello.com/c/lgQ063pq/822-in-relevant-site-constraints-show-the-name-of-the-conservation-area
