### PR TITLE
Account for permissions being nil

### DIFF
--- a/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
@@ -28,7 +28,7 @@
             legend: {text: "Permissions to be granted to this key"}) do %>
         <% ApiUser::VALID_PERMISSIONS.each do |permission| %>
           <%= form.govuk_check_box :permissions, permission,
-                checked: @token.permissions.include?(permission),
+                checked: @token.permissions&.include?(permission),
                 label: {text: tag.code(permission)} %>
         <% end %>
       <% end %>


### PR DESCRIPTION
### Description of change

This can't happen with valid tokens but given the existence of leftover invalid tokens it prevents actually making them valid.
