### PR TITLE
Able to filter urgent cases on index page

### DIFF
--- a/app/components/enforcements/search_component.html.erb
+++ b/app/components/enforcements/search_component.html.erb
@@ -2,7 +2,7 @@
       model: search,
       scope: "",
       method: :get,
-      url: enforcements_path
+      url: enforcements_path(anchor: "enforcements")
     ) do |form| %>
   <%# add in error summary with search %>
   <div class="search-form-inputs">
@@ -26,7 +26,7 @@
     <% accordion.with_section(heading_text: "Filters") do %>
       <div class="govuk-accordion__section-content govuk-!-padding-bottom-0">
         <p><strong>Priority</strong></p>
-        <%= form.govuk_check_box(:urgent, "Urgent", small: true, legend: nil, class: "display-flex") %>
+        <%= form.govuk_check_box(:urgent, true, multiple: false, legend: nil, checked: params["urgent"] == "true", class: "display-flex") %>
         <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       </div>
 

--- a/app/controllers/enforcements_controller.rb
+++ b/app/controllers/enforcements_controller.rb
@@ -24,6 +24,10 @@ class EnforcementsController < AuthenticationController
       .enforcements
       .joins(:case_record)
       .by_received_at_desc
+
+    if params["urgent"]
+      @enforcements = @enforcements.where(urgent: true)
+    end
   end
 
   def set_enforcement
@@ -31,6 +35,10 @@ class EnforcementsController < AuthenticationController
       .enforcements
       .joins(:case_record)
       .find_by!(case_record: {id: params[:id]})
+  end
+
+  def filter_params
+    params.permit(:urgent)
   end
 
   def set_case_record

--- a/spec/system/enforcements/index_spec.rb
+++ b/spec/system/enforcements/index_spec.rb
@@ -73,10 +73,31 @@ RSpec.describe "Enforcement index page", type: :system do
     end
   end
 
-  it "has a link to the enforcement show page", capybara: true do
+  it "has a link to the enforcement show page" do
     visit "/enforcements"
     click_link "All cases"
     click_link(enforcement.case_record.id)
     expect(page).to have_current_path("/enforcements/#{enforcement.case_record.id}")
+  end
+
+  it "allows me to filter by urgent cases", capybara: true do
+    enforcement_1.update(urgent: true)
+
+    visit "/enforcements"
+    click_link "All cases"
+
+    within("#filters-section") do
+      click_on "Filters"
+
+      check "Urgent"
+      click_button "Apply filters"
+    end
+
+    within("#filters-content") do
+      expect(page).to have_checked_field("Urgent")
+    end
+
+    expect(page).to have_content(enforcement_1.to_s)
+    expect(page).not_to have_content(enforcement.to_s)
   end
 end


### PR DESCRIPTION
### Description of change

On Enforcement index page able to filter by urgent cases

### Story Link

https://trello.com/c/b1Wlzxi0/906-add-filter-for-priority-on-enforcements-dashboard
