### PR TITLE
Edit styling check details page enforcement

### DIFF
--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -4,11 +4,13 @@ module TasksHelper
   def task_status_tag(task)
     colour = case task.status
     when "completed"
-      "green"
+      "grey"
     else
       "blue"
     end
 
-    govuk_tag(text: task.status.humanize, colour:)
+    classes = (task.status == "completed") ? "govuk-tag--status-review_complete" : ""
+
+    govuk_tag(text: task.status.humanize, colour:, classes:)
   end
 end

--- a/app/views/tasks/check-breach-report/check-report-details/edit.html.erb
+++ b/app/views/tasks/check-breach-report/check-report-details/edit.html.erb
@@ -16,7 +16,7 @@
 <% end %>
 
 <div id="quick-close-case">
-  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Quick close </h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-8"> Quick close </h2>
   <p class="govuk-body">
     If you believe this case can be closed without an investigation you can
     <%= govuk_link_to "close the case.", class: "govuk-body", no_visited_state: true %>
@@ -25,7 +25,7 @@
 </div>
 
 <div id="quick-recommendation">
-  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Quick recommendation </h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-8"> Quick recommendation </h2>
   <p class="govuk-body">
     If you believe this case is not expedient to enforce you can
     <%= govuk_link_to "make a recommendation.", class: "govuk-body", no_visited_state: true %>
@@ -34,19 +34,19 @@
 </div>
 
 <div id="urgent-tag">
-  <h2 class="govuk-heading-m govuk-!-margin-top-5"> Is this case urgent? </h2>
+  <h2 class="govuk-heading-m govuk-!-margin-top-8"> Is this case urgent? </h2>
   <%= form_with model: [@task, @enforcement], url: task_path(@case_record, @task), method: :patch do |form| %>
     <div>
       <%= form.govuk_check_box :urgent, 1, 0, label: {text: "Select here if the case is urgent"}, multiple: false %>
     </div>
 
     <div id="quick-recommendation">
-      <h2 class="govuk-heading-m govuk-!-margin-top-5"> Check description </h2>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8"> Check description </h2>
       <p class="govuk-body govuk-!-margin-bottom-1"> <%= @enforcement.description %></p>
       <%= govuk_link_to "Edit desciption", class: "govuk-body-small govuk-!-margin-top-1", no_visited_state: true %>
     </div>
 
-    <%= form.govuk_submit "Save and mark complete", class: "govuk-!-margin-top-5" do %>
+    <%= form.govuk_submit "Save and mark as complete", class: "govuk-!-margin-top-8" do %>
       <%= govuk_button_link_to "Back", task_path(@case_record, @task.parent), secondary: true %>
     <% end %>
   <% end %>

--- a/spec/system/enforcements/check_report_details_spec.rb
+++ b/spec/system/enforcements/check_report_details_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Check breach report", type: :system, capybara: true do
     click_link "Check report details"
     check "Select here if the case is urgent"
 
-    click_button "Save and mark complete"
+    click_button "Save and mark as complete"
     expect(page).to have_content("Task updated successfully")
     expect(page).to have_content("urgent")
 


### PR DESCRIPTION
### Description of change

Small tweaks to enforcement check details page after design feedback:

- Change completed status tag to transparent
- Increase spacing around action elements
- Change button text to 'Save and mark as compelte"

### Story Link

https://trello.com/c/ij63yttL#comment-688a1f32e9a1ae7f87f5134d

### Screenshots

<img width="1312" height="651" alt="image" src="https://github.com/user-attachments/assets/802efd9f-9abf-4d23-9014-4a2d201589fc" />
 
<img width="908" height="508" alt="image" src="https://github.com/user-attachments/assets/a042e064-fc12-4b4a-a093-526d2aebcfac" />

