### PR TITLE
Show 'publicly available' question for documents before validation completed

### DIFF
--- a/app/views/documents/form_partials/_privacy.html.erb
+++ b/app/views/documents/form_partials/_privacy.html.erb
@@ -5,13 +5,15 @@
       class: "govuk-input--width-20"
     ) %>
 
-<% if @planning_application.publishable? && @planning_application.validated? %>
-  <div class="display govuk-!-margin-top-3">
-    <%= form.govuk_radio_buttons_fieldset(:referenced_in_decision_notice, inline: true, legend: {size: "s", text: "Do you want to list this document on the decision notice?"}) do %>
-      <%= form.govuk_radio_button :referenced_in_decision_notice, "true", label: {text: "Yes"} %>
-      <%= form.govuk_radio_button :referenced_in_decision_notice, "false", label: {text: "No"} %>
-    <% end %>
-  </div>
+<% if @planning_application.publishable? %>
+  <% if @planning_application.validated? %>
+    <div class="display govuk-!-margin-top-3">
+      <%= form.govuk_radio_buttons_fieldset(:referenced_in_decision_notice, inline: true, legend: {size: "s", text: "Do you want to list this document on the decision notice?"}) do %>
+        <%= form.govuk_radio_button :referenced_in_decision_notice, "true", label: {text: "Yes"} %>
+        <%= form.govuk_radio_button :referenced_in_decision_notice, "false", label: {text: "No"} %>
+      <% end %>
+    </div>
+  <% end %>
 
   <div class="publish govuk-!-margin-top-3">
     <%= form.govuk_radio_buttons_fieldset(:publishable, inline: true, legend: {size: "s", text: "Should this document be made publicly available?"}) do %>


### PR DESCRIPTION
### Description of change

In #2359 we hid the 'should this document be on the decision notice' question for documents on applications that had not yet been validated. However in doing so we also hid the 'should this document be made publicly available' question, which is not correct. That question should appear on all publishable planning applications even before validation is complete.

### Story Link

<https://trello.com/c/zR6aoF66/923-officers-are-not-able-to-mark-a-document-as-public-or-sensitive-at-the-validation-stage-please-update-slack-thread-when-fixed>
