### PR TITLE
Disable immunity by default and enable it only for the relevant types

### DIFF
--- a/app/models/application_type_feature.rb
+++ b/app/models/application_type_feature.rb
@@ -10,7 +10,7 @@ class ApplicationTypeFeature
     description_change_requires_validation: true,
     eia: true,
     heads_of_terms: true,
-    immunity: true,
+    immunity: false,
     informatives: false,
     legislative_requirements: true,
     ownership_details: true,

--- a/db/seeds/application_types.yml
+++ b/db/seeds/application_types.yml
@@ -8,6 +8,7 @@
   determination_period_days: 56
   features:
     assess_against_policies: true
+    immunity: true
   steps:
     - validation
     - assessment
@@ -35,6 +36,7 @@
   determination_period_days: 56
   features:
     assess_against_policies: true
+    immunity: true
   steps:
     - validation
     - assessment

--- a/spec/factories/application_type_config.rb
+++ b/spec/factories/application_type_config.rb
@@ -16,7 +16,8 @@ FactoryBot.define do
       features {
         {
           assess_against_policies: true,
-          heads_of_terms: false
+          heads_of_terms: false,
+          immunity: true
         }
       }
 
@@ -91,6 +92,7 @@ FactoryBot.define do
         {
           "assess_against_policies" => true,
           "heads_of_terms" => false,
+          "immunity" => true,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []
@@ -110,6 +112,7 @@ FactoryBot.define do
         {
           "assess_against_policies" => true,
           "heads_of_terms" => false,
+          "immunity" => true,
           "informatives" => true,
           "planning_conditions" => false,
           "consultation_steps" => []

--- a/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/assess_immunity_detail_permitted_development_right_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
 
   let(:planning_application) do
-    create(:planning_application, :in_assessment, local_authority: default_local_authority)
+    create(:planning_application, :in_assessment, :ldc_existing, local_authority: default_local_authority)
   end
 
   let!(:immunity_detail) do
@@ -316,7 +316,7 @@ RSpec.describe "Assess immunity detail permitted development right", type: :syst
 
   context "when planning application has not been validated yet" do
     let!(:planning_application) do
-      create(:planning_application, :not_started, local_authority: default_local_authority)
+      create(:planning_application, :not_started, :ldc_existing, local_authority: default_local_authority)
     end
 
     it "does not allow me to visit the page" do

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Immunity", type: :system do
 
   context "when immune" do
     let(:planning_application) do
-      create(:planning_application, :in_assessment, :with_immunity, local_authority: default_local_authority)
+      create(:planning_application, :in_assessment, :ldc_existing, :with_immunity, local_authority: default_local_authority)
     end
 
     before do
@@ -51,7 +51,7 @@ RSpec.describe "Immunity", type: :system do
 
   context "when there is both an assessment and review for the immunity of an application" do
     let(:planning_application) do
-      create(:planning_application, :in_assessment, local_authority: default_local_authority)
+      create(:planning_application, :in_assessment, :ldc_existing, local_authority: default_local_authority)
     end
 
     let!(:immunity_detail) { create(:immunity_detail, planning_application:) }

--- a/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
+++ b/spec/system/planning_applications/assessing/permitted_development_right_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Permitted development right" do
   let!(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
 
   let!(:planning_application) do
-    create(:planning_application, :in_assessment, local_authority: default_local_authority)
+    create(:planning_application, :in_assessment, :ldc_existing, local_authority: default_local_authority)
   end
 
   before do

--- a/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/review/evidence_of_immunity_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Reviewing evidence of immunity", type: :system do
       :planning_application,
       :awaiting_determination,
       :with_recommendation,
+      :ldc_existing,
       :with_immunity,
       local_authority: default_local_authority,
       decision: :granted

--- a/spec/system/planning_applications/review/immunity_enforcement_spec.rb
+++ b/spec/system/planning_applications/review/immunity_enforcement_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Reviewing immunity enforcement" do
       :planning_application,
       :awaiting_determination,
       :with_recommendation,
+      :ldc_existing,
       :with_immunity,
       local_authority: default_local_authority,
       decision: :granted


### PR DESCRIPTION
### Description of change

This was enabled by default when I added it in #2441 but in fact should be off for most application types and only enabled for a handful.

### Story Link

<https://trello.com/c/4vbpEPDH/901-extract-immunity-detail-into-an-application-type-feature-to-allow-them-to-toggle-on-and-off-for-preapps>
