### PR TITLE
Show full date in dashboard

### DIFF
--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -21,6 +21,6 @@ class PlanningApplicationPresenter
   end
 
   %i[awaiting_determination_at expiry_date outcome_date].each do |date|
-    define_method(:"formatted_#{date}") { send(date).to_date.to_fs(:day_month_only) }
+    define_method(:"formatted_#{date}") { send(date).to_date.to_fs }
   end
 end

--- a/app/presenters/planning_application_presenter.rb
+++ b/app/presenters/planning_application_presenter.rb
@@ -21,6 +21,6 @@ class PlanningApplicationPresenter
   end
 
   %i[awaiting_determination_at expiry_date outcome_date].each do |date|
-    define_method(:"formatted_#{date}") { send(date).to_date.to_fs }
+    define_method(:"formatted_#{date}") { public_send(date).to_date.to_fs }
   end
 end

--- a/config/initializers/date_formatter.rb
+++ b/config/initializers/date_formatter.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-day_month_only = "%-d %B"
-day_month_year = "#{day_month_only} %Y"
+day_month_year = "%-d %B %Y"
 
 Date::DATE_FORMATS[:day_month_year] = day_month_year
 Time::DATE_FORMATS[:day_month_year] = "#{day_month_year} %H:%M"
@@ -14,7 +13,6 @@ day_month_year_slashes = "%d/%m/%Y"
 Date::DATE_FORMATS[:day_month_year_slashes] = day_month_year_slashes
 Time::DATE_FORMATS[:day_month_year_slashes] = day_month_year_slashes
 
-Date::DATE_FORMATS[:day_month_only] = day_month_only
 Time::DATE_FORMATS[:time_only] = "%H:%M"
 
 day_month_year_seconds = "%-d %B %Y %H:%M:%S"

--- a/engines/bops_applicants/app/views/bops_applicants/validation_requests/_cancelled.html.erb
+++ b/engines/bops_applicants/app/views/bops_applicants/validation_requests/_cancelled.html.erb
@@ -14,6 +14,6 @@
   <%= render(FormattedContentComponent.new(text: validation_request.cancel_reason)) %>
 
   <p>
-    <%= validation_request.cancelled_at.to_time.to_fs(:day_month_year) %>
+    <%= validation_request.cancelled_at.to_time.to_fs %>
   </p>
 </div>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -962,7 +962,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
         "This is a copy of your neighbour consultation letter."
       )
       expect(mail_body).to include(
-        "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs(:day_month_year)}"
+        "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}"
       )
       expect(mail_body).to include(
         "A prior approval application has been made for the development described below:"
@@ -985,7 +985,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
       it "correctly sets the response date based on the next business day" do
         expect(mail_body).to include(
-          "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs(:day_month_year)}"
+          "Submit your comments by #{(1.business_day.from_now + 21.days).to_date.to_fs}"
         )
       end
     end


### PR DESCRIPTION
### Description of change

Show full expiry date in the dashboard instead of just the day and the month, as this seems confusing especially for older dates (not the current year) or when the submission date and expiry date are in different years.

### Story Link

<https://trello.com/c/jGzBOQb9/916-applications-are-organised-by-expiry-date-based-on-month-only-not-month-and-year>

### Screenshots
<img width="1039" height="347" alt="Screenshot 2025-08-05 at 11 55 23" src="https://github.com/user-attachments/assets/c78a2f8a-510a-42b4-843f-881c59861463" />
