### PR TITLE
Set case record correctly for manually created planning applications

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -230,6 +230,9 @@ class PlanningApplicationsController < AuthenticationController
 
   def build_planning_application
     @planning_application = current_local_authority.planning_applications.new
+    @planning_application.case_record = CaseRecord.new(local_authority: current_local_authority)
+
+    @planning_application
   end
 
   def planning_application_params


### PR DESCRIPTION
### Description of change

Case record didn't get created correctly when building an application for the manual submission form.

### Story Link

<https://trello.com/c/bl6avkS3/950-cannot-create-new-applications-on-bops>
