### PR TITLE
Update enforcement index page styling

### DIFF
--- a/app/services/task_loader.rb
+++ b/app/services/task_loader.rb
@@ -45,6 +45,7 @@ class TaskLoader
         name: node["name"],
         slug: node["slug"],
         optional: node.key?("optional") ? node["optional"] : false,
+        section: node["section"],
         status: node["status"],
         position: index
       )

--- a/config/task_workflows/enforcement.yml
+++ b/config/task_workflows/enforcement.yml
@@ -1,4 +1,5 @@
 - name: "Check breach report"
+  section: "Check"
   tasks:
     - name: "Check report details"
       tasks:
@@ -12,6 +13,7 @@
     - name: "Start investigation"
 
 - name: "Investigate and decide"
+  section: "Investigate"
   tasks:
     - name: "Update site and owner details"
       tasks:
@@ -37,8 +39,10 @@
         - name: "Submit recommendation"
 
 - name: "Review recommendation"
+  section: "Review"
 
 - name: "Serve notice and monitor compliance"
+  section: "Serve and monitor"
   tasks:
     - name: "Serve notice"
       tasks:
@@ -47,3 +51,4 @@
     - name: "Required actions"
 
 - name: "Process an appeal"
+  section: "Appeal"

--- a/db/migrate/20250805101634_add_section_to_tasks.rb
+++ b/db/migrate/20250805101634_add_section_to_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSectionToTasks < ActiveRecord::Migration[7.2]
+  def change
+    add_column :tasks, :section, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_03_134715) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_05_101634) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -1191,6 +1191,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_03_134715) do
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "section"
     t.index ["parent_type", "parent_id", "name"], name: "index_tasks_on_parent_and_name", unique: true
     t.index ["parent_type", "parent_id", "slug"], name: "index_tasks_on_parent_and_slug"
     t.index ["parent_type", "parent_id"], name: "index_tasks_on_parent"

--- a/engines/bops_enforcements/app/controllers/bops_enforcements/enforcements_controller.rb
+++ b/engines/bops_enforcements/app/controllers/bops_enforcements/enforcements_controller.rb
@@ -5,6 +5,7 @@ module BopsEnforcements
     before_action :set_enforcements, only: %i[index]
     before_action :set_enforcement, only: %i[show]
     before_action :set_case_record, only: %i[show]
+    before_action :set_grouped_tasks, only: %i[show]
 
     def index
       respond_to do |format|
@@ -44,6 +45,10 @@ module BopsEnforcements
 
     def set_case_record
       @case_record = @enforcement.case_record
+    end
+
+    def set_grouped_tasks
+      @grouped_tasks = @case_record.tasks.group_by(&:section)
     end
   end
 end

--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/show.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/show.html.erb
@@ -12,12 +12,19 @@
       accordion.with_section(heading_text: "Photos") { tag.p("Content") }
     end %>
 
-<%= govuk_task_list(id_prefix: "enforcement") do |task_list| %>
-  <% @enforcement.case_record.tasks.each do |task| %>
-    <%= task_list.with_item(
-          title: task.name,
-          href: task_path(@case_record, task),
-          status: task_status_tag(task)
-        ) %>
+<div id="enforcement-tasks">
+  <% @grouped_tasks.each do |section, tasks| %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9 application-step-heading"><%= section %></h2>
+    <%= govuk_task_list(id_prefix: "#{section}-section", html_attributes: {id: "#{section}-section"}) do |task_list| %>
+      <% tasks.each do |task| %>
+      <%= task_list.with_item(
+            title: task.name,
+            href: task_path(@case_record, task),
+            status: task_status_tag(task)
+          ) %>
+      <% end %>
+    <% end %>
   <% end %>
-<% end %>
+</div>
+
+<%= govuk_button_link_to "Close the case", "#", warning: true %>

--- a/spec/system/enforcements/show_spec.rb
+++ b/spec/system/enforcements/show_spec.rb
@@ -4,19 +4,23 @@ require "rails_helper"
 
 RSpec.describe "Enforcement show page", type: :system do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:case_record) { build(:case_record, local_authority:) }
-  let(:enforcement) { create(:enforcement, case_record:) }
+  let!(:case_record) { build(:case_record, local_authority:) }
+  let!(:enforcement) { create(:enforcement, case_record:) }
   let(:user) { create(:user, local_authority:) }
+  let!(:task) { create(:task, parent: case_record, section: "Check", name: "Test task 1", slug: "test-task-1") }
+  let!(:task2) { create(:task, parent: case_record, section: "Check", name: "Test task 2", slug: "test-task-2") }
+  let!(:task3) { create(:task, parent: case_record, section: "Investigate", name: "Test task 3", slug: "test-task-3") }
 
-  before { sign_in user }
+  before do
+    sign_in(user)
+    visit "/enforcements/#{enforcement.case_record.id}/"
+  end
 
   it "has a show page with basic details" do
-    visit "/enforcements/#{enforcement.case_record.id}/"
     expect(page).to have_content(enforcement.address)
   end
 
   it "has a link to the breach report page" do
-    visit "/enforcements/#{enforcement.case_record.id}/"
     click_link "Check breach report"
     expect(page).to have_selector("h1", text: "Check breach report")
   end
@@ -32,8 +36,40 @@ RSpec.describe "Enforcement show page", type: :system do
 
   context "when not assigned to an officer" do
     it "shows no assigned officer" do
-      visit "/enforcements/#{enforcement.case_record.id}/"
       expect(page).to have_content("Unassigned")
+    end
+  end
+
+  it "shows the correct grouping of tasks", capybara: true do
+    within("#enforcement-tasks") do
+      expect(page).to have_selector("h2", count: 5)
+      h2s = all("h2", count: 5)
+
+      expect(h2s[0]).to have_text("Check")
+      within("#Check-section") do
+        lis = all("li", count: 3)
+        expect(lis[0]).to have_text("Check breach report")
+        expect(lis[1]).to have_text(task.name)
+        expect(lis[2]).to have_text(task2.name)
+      end
+
+      expect(h2s[1]).to have_text("Investigate")
+      within("#Investigate-section") do
+        lis = all("li", count: 2)
+        expect(lis[0]).to have_text("Investigate and decide")
+        expect(lis[1]).to have_text(task3.name)
+      end
+
+      expect(h2s[2]).to have_text("Review")
+      within("#Review-section") do
+        expect(page).to have_selector("li", text: "Review recommendation")
+      end
+
+      expect(h2s[4]).to have_text("Appeal")
+      within("#Appeal-section") do
+        lis = all("li", count: 1)
+        expect(lis[0]).to have_text("Process an appeal")
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

Add section headings to enforcement landing page and close the case button

### Story Link

https://trello.com/c/T1QnDz9N/924-enforcement-landing-page-doesnt-match-the-design

### Screenshots

<img width="937" height="670" alt="image" src="https://github.com/user-attachments/assets/94f79676-8e4b-495a-b374-9a880114d810" />
