### PR TITLE
Add application decision filter to API

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -184,6 +184,10 @@ class PlanningApplication < ApplicationRecord
     joins(:consultation)
       .where(consultations: {end_date: from..to})
   }
+  scope :for_council_decision, ->(decision) {
+    where(decision: decision)
+      .where.not(determination_date: nil)
+  }
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create

--- a/engines/bops_api/app/controllers/bops_api/application_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/application_controller.rb
@@ -37,6 +37,7 @@ module BopsApi
         :publishedAtTo,
         :consultationEndDateFrom,
         :consultationEndDateTo,
+        :councilDecision,
         applicationStatus: [],
         applicationType: [])
     end

--- a/engines/bops_api/app/services/bops_api/application/search_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/search_service.rb
@@ -23,6 +23,7 @@ module BopsApi
         @scope = filter_by_application_type_code
         @scope = filter_by_application_status
         @scope = apply_date_filters
+        @scope = filter_by_application_decision
         @scope = search
         @scope = sort
 
@@ -74,6 +75,14 @@ module BopsApi
             current
           end
         end
+      end
+
+      def filter_by_application_decision
+        decision = params[:councilDecision]
+
+        return scope if decision.blank?
+
+        scope.for_council_decision(decision)
       end
 
       def parse_date(date_string)

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "BOPS API" do
   let("ids[]") { [] }
   let("applicationStatus[]") { [] }
   let("applicationType[]") { [] }
+  let("councilDecision") { nil }
   let(:orderBy) { "desc" }
   let(:sortBy) { "publishedAt" }
 

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "BOPS public API" do
   let(:invalidated) { create(:planning_application, :with_boundary_geojson_features, :published, local_authority:, application_type:, description: "This is not valid even if marked as published", status: :invalidated) }
   let("applicationStatus[]") { [] }
   let("applicationType[]") { [] }
+  let("councilDecision") { nil }
   let(:orderBy) { "desc" }
   let(:sortBy) { "publishedAt" }
 

--- a/engines/bops_api/spec/services/application/search_service_spec.rb
+++ b/engines/bops_api/spec/services/application/search_service_spec.rb
@@ -390,5 +390,28 @@ RSpec.describe BopsApi::Application::SearchService do
         expect(results).to eq([mid, new])
       end
     end
+
+    context "when filtering by decision" do
+      let(:local_authority) { create(:local_authority) }
+
+      let!(:app1) { create(:planning_application, :in_assessment) }
+      let!(:app2) { create(:planning_application, :determined) }
+
+      context "when no applicaton decisions are provided" do
+        let(:params) { {councilDecision: nil} }
+
+        it "returns matching applications" do
+          expect(results).to match_array([app1, app2])
+        end
+      end
+
+      context "when one matching application decision is provided" do
+        let(:params) { {councilDecision: "granted"} }
+
+        it "returns matching applications" do
+          expect(results).to match_array([app2])
+        end
+      end
+    end
   end
 end

--- a/engines/bops_api/spec/support/schemas.rb
+++ b/engines/bops_api/spec/support/schemas.rb
@@ -147,6 +147,16 @@ RSpec.configure do |config|
           enum: ["publishedAt", "receivedAt"],
           default: "receivedAt"
         }
+
+      parameter name: :councilDecision,
+        in: :query,
+        description: "Filter by council decision",
+        schema: {
+          type: :string,
+          required: false,
+          enum: ["refused", "granted", "not_required"],
+          default: nil
+        }
     end
 
     private

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -35418,6 +35418,17 @@ paths:
           - publishedAt
           - receivedAt
           default: receivedAt
+      - name: councilDecision
+        in: query
+        description: Filter by council decision
+        schema:
+          type: string
+          required: false
+          enum:
+          - refused
+          - granted
+          - not_required
+          default:
       responses:
         '200':
           description: returns planning applications when searching by a reference
@@ -35955,6 +35966,17 @@ paths:
           - publishedAt
           - receivedAt
           default: receivedAt
+      - name: councilDecision
+        in: query
+        description: Filter by council decision
+        schema:
+          type: string
+          required: false
+          enum:
+          - refused
+          - granted
+          - not_required
+          default:
       - name: resultsPerPage
         in: query
         schema:


### PR DESCRIPTION
### Description of change

Able to filter by application decision (refused, granted, not_required) in the API.

### Story Link

https://trello.com/c/p5gYlXxj/869-api-search-filter-decision
