### PR TITLE
Update check breach report page remove surplus tasks

### DIFF
--- a/config/task_workflows/enforcement.yml
+++ b/config/task_workflows/enforcement.yml
@@ -5,11 +5,6 @@
       tasks:
         - name: "Check description"
           optional: true
-
-    - name: "Check site location"
-    - name: "Review constraints"
-    - name: "Review site history"
-    - name: "Review documents"
     - name: "Start investigation"
 
 - name: "Investigate and decide"

--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_enforcement.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_enforcement.html.erb
@@ -1,7 +1,7 @@
 <%# locals: (title: "Enforcement case", with_dates: false, with_assignment: false, enforcement: nil) %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" id="planning-application-details">
+  <div class="govuk-grid-column-two-thirds" id="case-details">
     <h1 class="govuk-heading-l"><%= title %></h1>
     <p class="govuk-body">
       <strong><%= @enforcement.address %></strong>
@@ -9,7 +9,7 @@
       Case reference <strong><%= @enforcement.case_record.id %></strong>
     </p>
 
-    <div id="planning-application-statuses-tags">
+    <div id="case-statuses-tags">
       <p class="govuk-body">
         <span class="govuk-!-margin-left-1">
           <span class="govuk-tag"><%= @enforcement.status %></span>

--- a/engines/bops_enforcements/app/views/bops_enforcements/tasks/check-breach-report/show.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/tasks/check-breach-report/show.html.erb
@@ -1,43 +1,22 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" id="<%= @task.slug %>">
-    <h1 class="govuk-heading-l">Check breach report</h1>
-    <p class="govuk-body">
-      <strong><%= @enforcement.address %></strong>
-      <br>
-      Case reference <strong><%= @enforcement.case_record.id %></strong>
-    </p>
+<%= render @enforcement, with_dates: true, with_assignment: true, title: "Check breach report" %>
 
-    <div id="planning-application-statuses-tags">
-      <p class="govuk-body">
-        <span class="govuk-!-margin-left-1">
-          <span class="govuk-tag"><%= @enforcement.status %></span>
-        </span>
-        <% if @enforcement.urgent? %>
-          <span class="govuk-!-margin-left-1">
-            <span class="govuk-tag govuk-tag--orange">urgent</span>
-          </span>
-        <% end %>
-      </p>
-    </div>
-
-    <p class="govuk-body">
-      <%= @enforcement.description || "No description" %>
-    </p>
-  </div>
-</div>
-
-<%= govuk_task_list(id_prefix: "breach-report") do |task_list| %>
-  <% @task.tasks.each do |task| %>
-      <%= task_list.with_item(
-            title: task.name,
-            href: edit_task_path(@case_record, task),
-            status: task_status_tag(task)
-          ) %>
+<div class="govuk-!-margin-top-5">
+  <%= govuk_task_list(id_prefix: "breach-report") do |task_list| %>
+    <% @task.tasks.each do |task| %>
+        <%= task_list.with_item(
+              title: task.name,
+              href: edit_task_path(@case_record, task),
+              status: task_status_tag(task)
+            ) %>
+      <% end %>
     <% end %>
-  <% end %>
 
-<%= form_with model: @enforcement, url: "#", local: true do |form| %>
-  <%= form.govuk_submit "Close the case", class: "govuk-button govuk-button--warning" do %>
+  <div>
     <%= govuk_button_link_to "Back", enforcement_path(@enforcement), secondary: true %>
-  <% end %>
-<% end %>
+  </div>
+
+  <div>
+    <%= govuk_button_link_to "Close the case", "#", warning: true %>
+  </div>
+
+</div>

--- a/spec/system/enforcements/check_details/check_breach_report_spec.rb
+++ b/spec/system/enforcements/check_details/check_breach_report_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Check breach report index page", type: :system, capybara: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:case_record) { build(:case_record, local_authority:) }
+  let(:enforcement) { create(:enforcement, case_record:) }
+  let(:user) { create(:user, local_authority:) }
+
+  before do
+    sign_in user
+    visit "/cases/#{enforcement.case_record.id}/check-breach-report"
+  end
+
+  it "displays the correct tasks" do
+    within("#case-details") do
+      expect(page).to have_content("Case reference #{case_record.id}")
+      expect(page).to have_content(enforcement.address)
+    end
+
+    within("#dates-details") do
+      expect(page).to have_content("Received #{enforcement.received_at.to_date.to_fs}")
+    end
+
+    expect(page).to have_link("Check report details")
+    expect(page).to have_link("Start investigation")
+
+    expect(page).to have_selector("a", text: "Close the case")
+  end
+end

--- a/spec/system/enforcements/check_details/check_report_details_spec.rb
+++ b/spec/system/enforcements/check_details/check_report_details_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Check breach report", type: :system, capybara: true do
+RSpec.describe "Check report details", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
   let(:case_record) { build(:case_record, local_authority:) }
   let(:enforcement) { create(:enforcement, case_record:) }


### PR DESCRIPTION
### Description of change

Update check breach report page including removal of depreciated tasks. The following tasks have been kept as they are deemed to be minimum required for completing the 'check' module and then handling the case outside BOPS:
- Check report details 
- Start an investigation
- Close the case

### Story Link

https://trello.com/c/Xa5yoHk0/759-check-enforcement-task-list-page

### Screenshots

<img width="882" height="706" alt="image" src="https://github.com/user-attachments/assets/4f61f4c8-09bf-4be2-873a-138a09b9036c" />
