### PR TITLE
Use dig not [] to be more resilient to missing keys

### DIFF
--- a/engines/bops_api/app/services/bops_api/application/creation_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/creation_service.rb
@@ -51,10 +51,10 @@ module BopsApi
       def parsers
         {
           "ApplicantParser" => data_params[:applicant],
-          "AgentParser" => data_params[:applicant][:agent],
-          "FeeParser" => data_params[:application][:fee],
-          "AddressParser" => data_params[:property][:address],
-          "ApplicationTypeParser" => data_params[:application][:type],
+          "AgentParser" => data_params.dig(:applicant, :agent),
+          "FeeParser" => data_params.dig(:application, :fee),
+          "AddressParser" => data_params.dig(:property, :address),
+          "ApplicationTypeParser" => data_params.dig(:application, :type),
           "PreAssessmentParser" => params[:preAssessment],
           "ProposalParser" => data_params[:proposal],
           "ProposalDetailsParser" => params[:responses]


### PR DESCRIPTION
### Description of change

Enforcement submission failed because there was no `applicant` section and so the `applicant.agent` section couldn't be read. Using `dig` when the section is not top-level means we won't be so vulnerable to this.