### PR TITLE
Remove status banner enforcement index

### DIFF
--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/index.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/index.html.erb
@@ -9,23 +9,6 @@
   </div>
 </div>
 
-<div class="status-bar-container status-bar-container--colored">
-  <div class="status-bar govuk-!-margin-bottom-4 govuk-!-padding-bottom-4">
-    <div class="status-panel" id="follow-up-cases">
-      <h3 class="govuk-heading-m"><%= t ".follow_ups", count: 1 %></h3>
-      <%= govuk_link_to enforcements_path, class: "status-filter-link" do %>
-        <p class="govuk-heading-s"><%= t ".follow_ups.title" %></p>
-      <% end %>
-    </div>
-    <div class="status-panel" id="returned-cases">
-      <h3 class="govuk-heading-m"><%= t ".returned_cases", count: 1 %></h3>
-      <%= govuk_link_to enforcements_path, class: "status-filter-link" do %>
-        <p class="govuk-heading-s"><%= t ".returned_cases.title" %></p>
-      <% end %>
-    </div>
-  </div>
-</div>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <div class="govuk-tabs" data-module="govuk-tabs">


### PR DESCRIPTION
### Description of change

Remove status bar in Enforcements index page as this is not relevant for a check-only module.

### Story Link

https://trello.com/c/E5uJ0VBM/982-enforcement-counts-show-as-1-when-they-are-empty

### Screenshots
<img width="895" height="763" alt="image" src="https://github.com/user-attachments/assets/09c43bac-646b-4b73-900f-7cd7c6286048" />

