### PR TITLE
Display pre app status tag

### DIFF
--- a/engines/bops_core/app/presenters/bops_core/status_presenter.rb
+++ b/engines/bops_core/app/presenters/bops_core/status_presenter.rb
@@ -14,11 +14,25 @@ module BopsCore
 
     included do
       def status_tag
+        return pre_app_status_tag if pre_application?
+
         classes = ["govuk-tag govuk-tag--#{status_tag_colour}"]
 
         tag.span class: classes do
           if determined?
             decision.humanize
+          else
+            aasm.human_state.humanize
+          end
+        end
+      end
+
+      def pre_app_status_tag
+        classes = ["govuk-tag govuk-tag--#{pre_app_status_tag_colour}"]
+
+        tag.span class: classes do
+          if (summary = summary_of_advice&.summary_tag)
+            I18n.t("summary_advice.#{summary}.subheading")
           else
             aasm.human_state.humanize
           end
@@ -99,6 +113,22 @@ module BopsCore
         colour = STATUS_COLOURS[planning_application.status.to_sym]
 
         colour || "grey"
+      end
+    end
+
+    def pre_app_status_tag_colour
+      default = STATUS_COLOURS.fetch(planning_application.status.to_sym, "grey")
+      return default unless summary_of_advice
+
+      case summary_of_advice.summary_tag
+      when "complies"
+        "green"
+      when "needs_changes"
+        "yellow"
+      when "does_not_comply"
+        "red"
+      else
+        default
       end
     end
 

--- a/engines/bops_reports/spec/system/recommendation_spec.rb
+++ b/engines/bops_reports/spec/system/recommendation_spec.rb
@@ -158,5 +158,6 @@ RSpec.describe "Recommending and submitting a pre-application report" do
     ).once
 
     expect(page).to have_selector("[role=alert] p", text: "Pre-application report has been sent to the applicant")
+    expect(page).to have_selector("span.govuk-tag--green", text: "Likely to be supported")
   end
 end


### PR DESCRIPTION
### Description of change

Display pre app status tag

### Story Link

https://trello.com/c/QmxRbhSR/910-change-pre-application-status-when-completed

### Known issues [OPTIONAL]

- Probably need to rework how we do "decisions" on pre applications and use this instead of summary of advice. One to take a look at when we focus on pre app improvements

