### PR TITLE
Set target date on determined applications

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1087,7 +1087,12 @@ class PlanningApplication < ApplicationRecord
   end
 
   def set_key_dates
-    return if environment_impact_assessment_required? || time_extension_validation_requests.any?(:accepted) || determined_at.present?
+    return if environment_impact_assessment_required? || time_extension_validation_requests.any?(:accepted)
+
+    if determination_date.present? && target_date.blank?
+      self.target_date = determination_date
+      return
+    end
 
     self.expiry_date = application_type_determination_period.days.after(validated_at || received_at)
     self.target_date = 35.days.after(validated_at || received_at)

--- a/spec/services/planning_applications_creation_spec.rb
+++ b/spec/services/planning_applications_creation_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe PlanningApplicationsCreation do
   let(:application_type) { create(:application_type, :ldc_existing, local_authority: local_authority) }
 
   context "with an application that was determined in the past" do
-    target_date = 1.week.from_now.in_time_zone.to_date
     received_at_date = Time.zone.parse("2025-05-27 10:38:35.469341000 +0100")
     assessment_date = Time.zone.parse("2025-05-28 10:38:35.469341000 +0100")
     in_committee_at = Time.zone.parse("2025-05-29 10:38:35.469341000 +0100")
     determined_at = Time.zone.parse("2025-06-14 10:38:35.469341000 +0100")
+    determination_date = Time.zone.parse("2025-06-14 10:38:35.469341000 +0100")
 
     let(:params) do
       {
@@ -40,8 +40,8 @@ RSpec.describe PlanningApplicationsCreation do
         previous_references: ["HZY-43232"],
         payment_amount: 892,
         returned_at: nil,
-        target_date: target_date,
-        determined_at: determined_at,
+        determined_at: determination_date,
+        determination_date: determination_date,
         valid_description: true,
         in_committee_at: in_committee_at,
         ownership_certificate_checked: true,
@@ -85,7 +85,8 @@ RSpec.describe PlanningApplicationsCreation do
         valid_ownership_certificate: true,
         previous_references: ["HZY-43232"],
         returned_at: nil,
-        target_date: target_date,
+        target_date: determination_date.to_date,
+        determination_date: determination_date,
         determined_at: determined_at,
         valid_description: true,
         in_committee_at: in_committee_at,


### PR DESCRIPTION
### Description of change

This fix does two things to improve the import of legacy applications:

- Uses `determination_date` rather than `determined_at` so that status is correct
- Sets the target date to the `determination_date` if the latter is present, and returns so the target date is not overwritten

### Story Link

Necessary for https://trello.com/c/BR3uNNVj/790-export-sample-records-from-medway-as-new-as-possible-and-as-old-as-possible-householder-and-major

