### PR TITLE
Planning application status

### DIFF
--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -33,7 +33,7 @@ module PlanningApplicationStatus
 
     aasm.attribute_name :status
 
-    aasm whiny_persistence: true, no_direct_assignment: true do
+    aasm whiny_persistence: true, no_direct_assignment: true, timestamps: true do
       state :pending, initial: true
       state :not_started
       state :invalidated, display: "invalid"
@@ -153,8 +153,6 @@ module PlanningApplicationStatus
           after { recommendation.update!(submitted: false) }
         end
       end
-
-      after_all_transitions :timestamp_status_change # FIXME: https://github.com/aasm/aasm#timestamps
     end
 
     def recommendable?

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -351,10 +351,6 @@ class PlanningApplication < ApplicationRecord
     fee_calculation.requested_fee
   end
 
-  def timestamp_status_change
-    update("#{aasm.to_state}_at": Time.zone.now)
-  end
-
   def days_from
     created_at.to_date.business_days_until(Time.previous_business_day(Date.current))
   end


### PR DESCRIPTION
### Description of change

- Use direct aasm for timestamps update
- Prefer the explicit column form for AASM (clearer than attribute_name)