### PR TITLE
Add safe navigation operator for previous references

### DIFF
--- a/app/views/shared/_proposal_header.html.erb
+++ b/app/views/shared/_proposal_header.html.erb
@@ -11,7 +11,7 @@
         <strong><%= @planning_application.full_address %></strong>
         <br>
         <%= t(".application_number") %> <strong><%= @planning_application.reference %></strong>
-        <% if @planning_application.previous_references.any? %>
+        <% if @planning_application.previous_references&.any? %>
           (<%= t(".previously") %>: <strong><%= @planning_application.previous_references.join(", ") %></strong>)
         <% end %>
       </p>


### PR DESCRIPTION
### Description of change

I've added the safe navigation operator to `previous_references` on the planning application show view so the page doesn't break if this field is empty.

### Story Link

https://trello.com/c/BR3uNNVj/790-export-sample-records-from-medway-as-new-as-possible-and-as-old-as-possible-householder-and-major

