### PR TITLE
Add content to enforcement accordion

### DIFF
--- a/app/models/complainant.rb
+++ b/app/models/complainant.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Complainant
+  def initialize(data)
+    @data = data || {}
+  end
+
+  def name
+    [@data.dig("name", "first"), @data.dig("name", "last")].compact.join(" ")
+  end
+
+  def email
+    @data.dig("email")
+  end
+
+  def phone
+    @data.dig("phone", "primary")
+  end
+
+  def address
+    [
+      @data.dig("address", "line1"),
+      @data.dig("address", "town"),
+      @data.dig("address", "postcode"),
+      @data.dig("address", "country")
+    ].compact.compact_blank.join(", ")
+  end
+
+  private
+
+  def dig(*keys)
+    @data.dig(*keys)
+  end
+end

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -82,6 +82,10 @@ class Enforcement < ApplicationRecord
     lonlat&.x
   end
 
+  def complainant
+    @complainant ||= Complainant.new(submission.request_body&.dig("data", "complainant"))
+  end
+
   private
 
   def factory

--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_accordion.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_accordion.html.erb
@@ -1,20 +1,53 @@
 <%= govuk_accordion do |accordion| %>
   <%= accordion.with_section(heading_text: "Breach report") do %>
-    <% @enforcement.proposal_details.each do |proposal_detail| %>
-      <%= render(
-            ProposalDetails::SummaryComponent.new(proposal_detail: proposal_detail)
-          ) %>
-    <% end %>
+  <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Question", classes: "govuk-!-width-one-half") %>
+          <% row.with_cell(text: "Answer") %>
+        <% end %>
+      <% end %>
+      <% table.with_body do |body| %>
+          <% @enforcement.proposal_details.each_with_index do |proposal_detail, index| %>
+        <% body.with_row do |row| %>
+            <%= row.with_cell(text: "#{index + 1}. #{proposal_detail.question}") %>
+            <%= row.with_cell(text: proposal_detail.response_values.join(", ").to_s, classes: "govuk-!-font-weight-bold") %>
+          <% end %>
+        <% end %>
+      <% end %>
   <% end %>
+<% end %>
 
   <%= accordion.with_section(heading_text: "Site location") do %>
     <p>This digital red line boundary was submitted by the complainant.</p>
     <%= render "shared/location_map", locals: {in_accordion: true, geojson: @enforcement.boundary_geojson} %>
   <% end %>
 
-   <%= accordion.with_section(heading_text: "Complainant details") { tag.p("Content") } %>
-   <%= accordion.with_section(heading_text: "Site owner and interested parties") { tag.p("Content") } %>
-   <%= accordion.with_section(heading_text: "Documents") { tag.p("Content") } %>
-   <%= accordion.with_section(heading_text: "Photos") { tag.p("Content") } %>
+  <%= accordion.with_section(heading_text: "Complainant details") do %>
+    <%= govuk_table do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: "Question", classes: "govuk-!-width-one-half") %>
+          <% row.with_cell(text: "Answer") %>
+        <% end %>
+      <% end %>
+      <% table.with_body do |body| %>
+        <% body.with_row do |row| %>
+          <%= row.with_cell(text: "Name") %>
+          <%= row.with_cell(text: @enforcement.complainant.name, classes: "govuk-!-font-weight-bold") %>
+        <% end %>
+        <% body.with_row do |row| %>
+          <%= row.with_cell(text: "Address") %>
+          <%= row.with_cell(text: @enforcement.complainant.address, classes: "govuk-!-font-weight-bold") %>
+        <% end %>
+        <% body.with_row do |row| %>
+          <%= row.with_cell(text: "Email") %>
+          <%= row.with_cell(text: @enforcement.complainant.email, classes: "govuk-!-font-weight-bold") %>
 
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= accordion.with_section(heading_text: "Documents and Photos") { tag.p("Content") } %>
 <% end %>

--- a/engines/bops_submissions/app/services/bops_submissions/enforcement/creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/enforcement/creation_service.rb
@@ -19,6 +19,8 @@ module BopsSubmissions
             local_authority: local_authority
           )
 
+          # document creation service here
+
           enforcement
         end
       end
@@ -54,6 +56,12 @@ module BopsSubmissions
           "ProposalDetailsParser" => data[:responses]
         }.transform_keys { |key| Parsers.const_get(key) }
       end
+
+      # def attach_documents!
+      #   submission.documents.find_each do |document|
+      #     document.update!(planning_application: @planning_application)
+      #   end
+      # end
     end
   end
 end

--- a/spec/system/enforcements/check_details/check_report_details_spec.rb
+++ b/spec/system/enforcements/check_details/check_report_details_spec.rb
@@ -1,10 +1,19 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require Rails.root.join("engines/bops_submissions/spec/support/fixture_helper")
 
 RSpec.describe "Check report details", type: :system, capybara: true do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:case_record) { build(:case_record, local_authority:) }
+  let(:local_authority) { create(:local_authority, :default) }
+  let!(:submission) do
+    create(
+      :submission,
+      local_authority: local_authority,
+      request_body: json_fixture_api("v0.7.5/enforcement/breach.json")
+    )
+  end
+  let(:case_record) { build(:case_record, local_authority:, submission: submission) }
   let(:enforcement) { create(:enforcement, case_record:) }
   let(:user) { create(:user, local_authority:) }
 
@@ -15,6 +24,8 @@ RSpec.describe "Check report details", type: :system, capybara: true do
 
   context "when checking report" do
     before do
+      stub_request(:get, "https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857")
+        .to_return(status: 200, body: "", headers: {})
       click_link "Check report details"
     end
 

--- a/spec/system/enforcements/close_spec.rb
+++ b/spec/system/enforcements/close_spec.rb
@@ -1,10 +1,18 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../engines/bops_submissions/spec/support/fixture_helper"
 
 RSpec.describe "Enforcement close page", type: :system do
   let(:local_authority) { create(:local_authority, :default) }
-  let!(:case_record) { build(:case_record, local_authority:) }
+  let!(:submission) do
+    create(
+      :submission,
+      local_authority: local_authority,
+      request_body: json_fixture_api("v0.7.5/enforcement/breach.json")
+    )
+  end
+  let!(:case_record) { build(:case_record, local_authority:, submission: submission) }
   let!(:enforcement) { create(:enforcement, case_record:) }
   let(:user) { create(:user, local_authority:) }
   let!(:task) { create(:task, parent: case_record, section: "Check", name: "Test task 1", slug: "test-task-1") }

--- a/spec/system/enforcements/index_spec.rb
+++ b/spec/system/enforcements/index_spec.rb
@@ -1,11 +1,19 @@
 # frozen_string_literal: true
 
 require "rails_helper"
+require_relative "../../../engines/bops_submissions/spec/support/fixture_helper"
 
 RSpec.describe "Enforcement index page", type: :system do
   let!(:local_authority) { create(:local_authority, :default) }
-  let!(:case_record) { build(:case_record, local_authority:) }
-  let!(:case_record_1) { build(:case_record, local_authority:) }
+  let!(:submission) do
+    create(
+      :submission,
+      local_authority: local_authority,
+      request_body: json_fixture_api("v0.7.5/enforcement/breach.json")
+    )
+  end
+  let!(:case_record) { build(:case_record, local_authority:, submission: submission) }
+  let!(:case_record_1) { build(:case_record, local_authority:, submission: submission) }
   let!(:enforcement) { create(:enforcement, case_record: case_record, received_at: 1.day.ago) }
   let!(:enforcement_1) { create(:enforcement, case_record: case_record_1, received_at: 3.days.ago) }
   let(:user) { create(:user, local_authority:) }


### PR DESCRIPTION
### Description of change

Add breach details and complainant details to enforcement accordion.

Documents and photos will be handled in another ticket.

### Story Link

https://trello.com/c/00rh9jvB/998-populate-enforcement-accordion-content

### Screenshots

<img width="1001" height="719" alt="image" src="https://github.com/user-attachments/assets/aa35a39a-cf80-4896-85b0-f24118271165" />

<img width="882" height="244" alt="image" src="https://github.com/user-attachments/assets/dc29c676-4251-4a8a-ab5e-b2a9fe63b810" />

### Decisions

- Decided to read the complainant details directly from the submission, these are required fields in the schema and we do not anticipate these will be changed.
- Documents and photos will be handled in a separate PR as the back end of these are not set up
- 

