### PR TITLE
Set os_vector_tiles_api_key in tests

### DIFF
--- a/engines/bops_api/spec/jobs/create_neighbour_boundary_geojson_job_spec.rb
+++ b/engines/bops_api/spec/jobs/create_neighbour_boundary_geojson_job_spec.rb
@@ -5,10 +5,6 @@ require "rails_helper"
 RSpec.describe BopsApi::CreateNeighbourBoundaryGeojsonJob, type: :job do
   let!(:planning_application) { create(:planning_application, neighbour_boundary_geojson: nil) }
 
-  before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-  end
-
   context "OS places returns addresses" do
     it "creates geojson for planning application" do
       stub_os_places_api_request_for_radius(planning_application.latitude, planning_application.longitude)

--- a/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications/validation_requests_spec.rb
@@ -34,8 +34,6 @@ RSpec.describe "BOPS API" do
     create(:api_user, :validation_requests_ro, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
     create(:api_user, :validation_requests_ro, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
     create(:application_type, :ldc_existing)
-
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
   let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }

--- a/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/planning_applications_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe "BOPS API" do
     create(:application_type_config, :minor)
     create(:application_type_config, :major)
     create(:application_type_config, :pre_application)
-
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
   let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }

--- a/engines/bops_api/spec/requests/v2/validation_requests_spec.rb
+++ b/engines/bops_api/spec/requests/v2/validation_requests_spec.rb
@@ -37,8 +37,6 @@ RSpec.describe "BOPS API" do
     create(:api_user, :validation_requests_ro, token: "bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw", local_authority:)
     create(:api_user, :validation_requests_ro, name: "other", token: "bops_pDzTZPTrC7HiBiJHGEJVUSkX2PVwkk1d4mcTm9PgnQ", local_authority: southwark)
     create(:application_type, :ldc_existing)
-
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
   end
 
   let(:Authorization) { "Bearer bops_EjWSP1javBbvZFtRYiWs6y5orH4R748qapSGLNZsJw" }

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
             headers: {"Content-Type" => content_type}
           )
       end
-      Rails.configuration.os_vector_tiles_api_key = "testtest"
       stub_os_places_api_request_for_radius(51.4656522, -0.1185926)
     end
 

--- a/engines/bops_core/spec/controllers/bops_core/application_controller_spec.rb
+++ b/engines/bops_core/spec/controllers/bops_core/application_controller_spec.rb
@@ -26,9 +26,6 @@ RSpec.describe BopsCore::ApplicationController, type: :controller do
   end
 
   describe "#set_current" do
-    before do
-    end
-
     it "sets the current local authority" do
       get :index
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,3 +37,5 @@ RSpec.configure do |config|
   config.include(SystemSpecHelpers)
   config.include Rails.application.routes.url_helpers
 end
+
+Rails.configuration.os_vector_tiles_api_key = "testtest"

--- a/spec/requests/map_proxy_spec.rb
+++ b/spec/requests/map_proxy_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe MapProxyController, type: :request do
   end
 
   before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-
     stub_request(:get, os_api_url)
       .with(
         headers: {

--- a/spec/services/apis/os_places/client_spec.rb
+++ b/spec/services/apis/os_places/client_spec.rb
@@ -5,10 +5,6 @@ require "rails_helper"
 RSpec.describe Apis::OsPlaces::Client, exclude_stub_any_os_places_api_request: true do
   let(:client) { described_class.new }
 
-  before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-  end
-
   describe "#get" do
     before do
       stub_os_places_api_request_for("SE220HW")

--- a/spec/services/apis/os_places/polygon_search_service_spec.rb
+++ b/spec/services/apis/os_places/polygon_search_service_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Apis::OsPlaces::PolygonSearchService, exclude_stub_any_os_places_api_request: true do
-  before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-  end
-
   describe "#call" do
     let(:geojson) do
       {

--- a/spec/services/apis/os_places/query_spec.rb
+++ b/spec/services/apis/os_places/query_spec.rb
@@ -5,10 +5,6 @@ require "rails_helper"
 RSpec.describe Apis::OsPlaces::Query, exclude_stub_any_os_places_api_request: true do
   let(:query) { described_class.new }
 
-  before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-  end
-
   describe ".find_addresses" do
     before do
       stub_os_places_api_request_for("SE220HW")

--- a/spec/support/api/os_places_helper.rb
+++ b/spec/support/api/os_places_helper.rb
@@ -23,13 +23,7 @@ module OsPlacesHelper
   end
 
   def stub_any_os_vector_request
-    stub_request(:get, /https:\/\/api\.os\.uk\/maps\/vector\/v1\/vts.*/)
-      .with(
-        headers: {
-          "Key" => "testtest",
-          "Accept" => "application/octet-stream"
-        }
-      )
+    stub_request(:get, %r{https://api\.os\.uk/maps/vector/v1/vts.*})
       .to_return(
         status: 200,
         body: "mock tile data",

--- a/spec/system/enforcements/check_details/check_report_details_spec.rb
+++ b/spec/system/enforcements/check_details/check_report_details_spec.rb
@@ -24,8 +24,6 @@ RSpec.describe "Check report details", type: :system, capybara: true do
 
   context "when checking report" do
     before do
-      stub_request(:get, "https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857")
-        .to_return(status: 200, body: "", headers: {})
       click_link "Check report details"
     end
 

--- a/spec/system/enforcements/close_spec.rb
+++ b/spec/system/enforcements/close_spec.rb
@@ -20,9 +20,6 @@ RSpec.describe "Enforcement close page", type: :system do
   let!(:task3) { create(:task, parent: case_record, section: "Investigate", name: "Test task 3", slug: "test-task-3") }
 
   before do
-    stub_request(:get, "https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857")
-      .to_return(status: 200, body: "", headers: {})
-
     sign_in(user)
     visit "/enforcements/#{enforcement.case_record.id}/"
   end

--- a/spec/system/enforcements/show_spec.rb
+++ b/spec/system/enforcements/show_spec.rb
@@ -38,8 +38,6 @@ RSpec.describe "Enforcement show page", type: :system do
     enforcement.update(proposal_details: proposal_details)
 
     sign_in(user)
-    stub_request(:get, "https://api.os.uk/maps/vector/v1/vts/resources/styles?srs=3857")
-      .to_return(status: 200, body: "", headers: {})
     visit "/enforcements/#{enforcement.case_record.id}/"
   end
 

--- a/spec/system/planning_applications/consulting/select_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/select_neighbours_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
     allow(ENV).to receive(:fetch).and_call_original
     allow(ENV).to receive(:fetch).with("BOPS_ENVIRONMENT", "development").and_return("production")
 
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
-
     stub_any_os_places_api_request
 
     sign_in assessor
@@ -162,7 +160,6 @@ RSpec.describe "Send letters to neighbours", type: :system, js: true do
 
     before do
       stub_os_places_api_request_for_polygon(geojson["EPSG:27700"][:features][0])
-      Rails.configuration.os_vector_tiles_api_key = "testtest"
       click_link "Consultees, neighbours and publicity"
       click_link "Select and add neighbours"
 

--- a/spec/system/planning_applications/sitemap_spec.rb
+++ b/spec/system/planning_applications/sitemap_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Drawing a sitemap on a planning application", type: :system, cap
   let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority, name: "Assessor 1") }
 
   before do
-    Rails.configuration.os_vector_tiles_api_key = "testtest"
     stub_planx_api_response_for("POLYGON ((-0.054597 51.537331, -0.054588 51.537287, -0.054453 51.537313, -0.054597 51.537331))").to_return(
       status: 200, body: "{}"
     )

--- a/spec/system/planning_applications/validating/validating_spec.rb
+++ b/spec/system/planning_applications/validating/validating_spec.rb
@@ -77,8 +77,6 @@ RSpec.describe "Planning Application Assessment", type: :system do
     end
 
     context "when planning application has no boundary geojson" do
-      Rails.configuration.os_vector_tiles_api_key = "testtest"
-
       let(:application) do
         create(
           :planning_application,


### PR DESCRIPTION
### Description of change

Some tests failed (locally) due to lack of defined key, which meant it was being taken from the environment and (sometimes) being defined wrongly and/or set to blank.

This was actually being set in many different places, on every test that needed it, which led to it being overlooked when new tests were added; I've now moved it to the spec helper so it's only needed once.
