### PR TITLE
Set case record id in migration

### DIFF
--- a/db/migrate/20250714195355_create_planning_application_case_records.rb
+++ b/db/migrate/20250714195355_create_planning_application_case_records.rb
@@ -11,6 +11,7 @@ class CreatePlanningApplicationCaseRecords < ActiveRecord::Migration[7.2]
           caseable_id: pa.id,
           caseable_type: "PlanningApplication"
         ) do |record|
+          record.id = SecureRandom.uuid_v7
           record.local_authority_id = pa.attributes["local_authority_id"]
           record.user_id = pa.attributes["user_id"]
           record.submission_id = pa.attributes["submission_id"]


### PR DESCRIPTION
Because #2495 override the CaseRecord class, this meant the after_initialize hook was no longer setting the id column, which causes validation to fail. Set the ID explicitly here so it's never null.
