### PR TITLE
Add documents to case records

### DIFF
--- a/app/models/case_record.rb
+++ b/app/models/case_record.rb
@@ -6,6 +6,7 @@ class CaseRecord < ApplicationRecord
   delegated_type :caseable, types: %w[Enforcement PlanningApplication], dependent: :destroy
 
   has_many :tasks, -> { order(:position) }, as: :parent, dependent: :destroy, autosave: true
+  has_many :documents, dependent: :destroy
 
   belongs_to :local_authority
   belongs_to :user, optional: true

--- a/app/models/consideration_set.rb
+++ b/app/models/consideration_set.rb
@@ -2,6 +2,7 @@
 
 class ConsiderationSet < ApplicationRecord
   belongs_to :planning_application
+  alias_method :parent_record, :planning_application
 
   with_options dependent: :destroy do
     has_many :considerations, -> { order(position: :asc) }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -35,6 +35,7 @@ class Document < ApplicationRecord
     belongs_to :site_visit
     belongs_to :submission
     belongs_to :user
+    belongs_to :case_record
   end
 
   has_one :replacement_document_validation_request,
@@ -404,6 +405,10 @@ class Document < ApplicationRecord
     else
       :not_started
     end
+  end
+
+  def parent_record
+    planning_application || case_record || submission
   end
 
   private

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -7,6 +7,8 @@ class Enforcement < ApplicationRecord
 
   include Enforcement::Notification
 
+  delegate :documents, to: :case_record
+
   STATUS_COLOURS = {
     closed: "red",
     not_started: "blue",

--- a/app/views/planning_applications/supply_documents.html.erb
+++ b/app/views/planning_applications/supply_documents.html.erb
@@ -17,7 +17,7 @@
         Submitted documents
       </h2>
       <div data-download-target="documentsElement">
-        <ul class="app-task-list__items">
+        <ul class="app-task-list__items govuk-!-padding-left-0">
           <% if @planning_application.documents.active.empty? %>
             <li id="check-supplied-document" class="app-task-list__item">
               <span class="app-task-list__task-name">

--- a/db/migrate/20250819104151_add_case_record_id_to_documents.rb
+++ b/db/migrate/20250819104151_add_case_record_id_to_documents.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddCaseRecordIdToDocuments < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :documents, :case_record, type: :uuid, null: true, index: {algorithm: :concurrently}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_15_125949) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_19_104151) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -436,7 +436,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_15_125949) do
     t.bigint "submission_id"
     t.jsonb "metadata", default: {}, null: false
     t.boolean "checked", default: false, null: false
+    t.uuid "case_record_id"
     t.index ["api_user_id"], name: "ix_documents_on_api_user_id"
+    t.index ["case_record_id"], name: "ix_documents_on_case_record_id"
     t.index ["document_checklist_items_id"], name: "ix_documents_on_document_checklist_items_id"
     t.index ["evidence_group_id"], name: "ix_documents_on_evidence_group_id"
     t.index ["neighbour_response_id"], name: "ix_documents_on_neighbour_response_id"

--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_accordion.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_accordion.html.erb
@@ -49,5 +49,66 @@
     <% end %>
   <% end %>
 
-  <%= accordion.with_section(heading_text: "Documents and Photos") { tag.p("Content") } %>
+  <%= accordion.with_section(heading_text: "Documents and Photos") do %>
+  <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full" data-controller="download" data-application-reference-value="<%= @enforcement.case_record.id %>">
+    <div id="check-tag-documents-tasks">
+      <div data-download-target="documentsElement">
+        <ul class="app-task-list__items govuk-!-padding-left-0">
+          <% if @enforcement.case_record.documents.active.empty? %>
+            <li id="check-supplied-document" class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                There are no active documents
+              </span>
+            </li>
+          <% else %>
+            <div data-download-target="button" class="display-flex">
+              <%= govuk_button_link_to "Download all documents", data: {action: "click->download#submit"}, secondary: true %>
+            </div>
+
+            <%= govuk_table(classes: "govuk-!-margin-top-4") do |table| %>
+              <% table.with_head do |head| %>
+                <% head.with_row do |row| %>
+                  <% row.with_cell(text: "Document name") %>
+                  <% row.with_cell(text: "Date received") %>
+                  <% row.with_cell(text: "Visibility") %>
+                <% end %>
+              <% end %>
+
+              <% table.with_body do |body| %>
+                <% @enforcement.case_record.documents.active.each do |document| %>
+                  <% next unless document.representable? %>
+                  <% body.with_row(
+                       html_attributes: {
+                         "data-document-url-value" => url_for_document(document),
+                         "data-document-title-value" => document.file.filename
+                       }
+                     ) do |row| %>
+                    <%= row.with_cell do %>
+                      <p><%= link_to_document(truncate(document.reference_or_name, length: 50), document) %></p>
+
+                      <% if document.tags.present? %>
+                        <% document.tags.each do |tag| %>
+                          <strong class="govuk-tag govuk-tag--grey document-tag"><%= I18n.t(:"#{tag}", scope: :document_tags) %></strong>
+                        <% end %>
+                      <% else %>
+                        <p class="govuk govuk-!-margin-bottom-1">
+                          <em>No tags added</em>
+                        </p>
+                      <% end %>
+                    <% end %>
+
+                    <%= row.with_cell(text: document.received_at_or_created || "-") %>
+                    <%= row.with_cell(text: document.publishable? ? "Public" : "Sensitive") %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+  <% end %>
 <% end %>

--- a/engines/bops_submissions/app/controllers/bops_submissions/v2/submissions_controller.rb
+++ b/engines/bops_submissions/app/controllers/bops_submissions/v2/submissions_controller.rb
@@ -8,7 +8,7 @@ module BopsSubmissions
 
       def create
         @submission = creation_service.call
-        SubmissionProcessorJob.perform_later(@submission.id)
+        SubmissionProcessorJob.perform_later(@submission.id, @current_api_user)
 
         respond_to do |format|
           format.json

--- a/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
+++ b/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
@@ -4,7 +4,7 @@ module BopsSubmissions
   class SubmissionProcessorJob < ApplicationJob
     queue_as :submissions
 
-    def perform(submission_id)
+    def perform(submission_id, current_api_user)
       submission = Submission.find(submission_id)
       submission.start! if submission.may_start?
 
@@ -12,7 +12,7 @@ module BopsSubmissions
         ZipExtractionService.new(submission:).call
         Application::CreationService.new(submission:).call!
       elsif submission.planx?
-        Enforcement::CreationService.new(submission:).call!
+        Enforcement::CreationService.new(submission:, user: current_api_user).call!
       end
 
       submission.complete!

--- a/engines/bops_submissions/app/services/bops_submissions/documents_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/documents_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module BopsSubmissions
+  class DocumentsService
+    def initialize(case_record:, user:, files:)
+      @case_record = case_record
+      @user = user
+      @files = files
+    end
+
+    def call!
+      files.each do |file|
+        url = file["name"]
+        tags = file["type"].flat_map { |type| Array(type["value"]) }
+        description = file["description"]
+
+        upload(case_record, user, url, tags, description)
+      end
+    end
+
+    private
+
+    attr_reader :case_record, :user, :files
+
+    def upload(case_record, user, url, tags, description)
+      if user.file_downloader.blank?
+        raise Errors::FileDownloaderNotConfiguredError, "Please configure the file downloader for API user '#{user.id}'"
+      end
+
+      file = user.file_downloader.get(url: url)
+      name = URI.decode_uri_component(File.basename(URI.parse(url).path))
+
+      case_record.documents.create! do |document|
+        document.tags = tags
+        document.applicant_description = description
+        document.file.attach(io: file.open, filename: name)
+      end
+    end
+  end
+end

--- a/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
+++ b/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         expect(creator).to receive(:call!).ordered
         expect(submission).to receive(:complete!).ordered
 
-        described_class.perform_now(submission.id)
+        described_class.perform_now(submission.id, current_api_user: nil)
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         expect(submission).to receive(:update!).with(error_message: "An error!").ordered.and_call_original
 
         expect {
-          described_class.perform_now(submission.id)
+          described_class.perform_now(submission.id, current_api_user: nil)
         }.to raise_error(StandardError, "An error!")
 
         expect(submission.reload.status).to eq("failed")
@@ -73,7 +73,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         expect(Appsignal).to receive(:report_error).with(instance_of(ActiveRecord::RecordNotFound))
 
         expect {
-          described_class.perform_now(1)
+          described_class.perform_now(1, current_api_user: nil)
         }.to raise_error(ActiveRecord::RecordNotFound, "not found")
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         expect(submission).to receive(:update!).with(error_message: "Submission has no JSON").ordered.and_call_original
 
         expect {
-          described_class.perform_now(submission.id)
+          described_class.perform_now(submission.id, current_api_user: nil)
         }.to raise_error(ArgumentError, "Submission has no JSON")
 
         expect(submission.reload.status).to eq("failed")
@@ -130,7 +130,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         create(:application_type, :planning_permission)
 
         expect {
-          described_class.perform_now(submission.id)
+          described_class.perform_now(submission.id, current_api_user: nil)
         }.not_to raise_error
 
         pa = PlanningApplication.last

--- a/engines/bops_submissions/spec/services/enforcement/creation_service_spec.rb
+++ b/engines/bops_submissions/spec/services/enforcement/creation_service_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe BopsSubmissions::Enforcement::CreationService, type: :service do
         request_body: json_fixture_api("examples/odp/v0.7.5/enforcement/breach.json")
       )
     end
-    let(:service) { described_class.new(submission: submission) }
+    let!(:api_user) { create(:api_user, :swagger) }
+    let(:service) { described_class.new(submission: submission, user: api_user) }
     let!(:expected_proposal_details) do
       submission.request_body["responses"]
     end

--- a/engines/bops_submissions/swagger/v2/submissions/swagger_doc.yaml
+++ b/engines/bops_submissions/swagger/v2/submissions/swagger_doc.yaml
@@ -417,4 +417,262 @@ paths:
                         optional: []
                       fee:
                         notApplicable: true
+                    schema: https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.5/schemas/enforcement.json  
+              ValidEnforcementWithDocsSubmissionEvent:
+                summary: Enforcement Submission with documents
+                value:
+                  data:
+                    complainant:
+                      name:
+                        first: Ebenezer
+                        last: Scrooge
+                      phone:
+                        primary: '0123456789'
+                      email: scrooge@waltdisney.com
+                      address:
+                        line1: 16 Bayham Street
+                        town: Camden Town
+                        postcode: NW1 0JU
+                        country: UK
+                    property:
+                      address:
+                        latitude: 51.3873264
+                        longitude: 0.506217
+                        x: 574479.44
+                        "y": 168345.09
+                        title: CHARES DICKENS WRITING CHALET, EASTGATE HOUSE, HIGH
+                          STREET, ROCHESTER
+                        source: Ordnance Survey
+                        uprn: '000044009430'
+                        usrn: '32100913'
+                        pao: EASTGATE HOUSE
+                        sao: CHARES DICKENS WRITING CHALET
+                        street: HIGH STREET
+                        town: ROCHESTER
+                        postcode: ME1 1EW
+                        singleLine: CHARES DICKENS WRITING CHALET, EASTGATE HOUSE,
+                          HIGH STREET, ROCHESTER, MEDWAY, ME1 1EW
+                      localAuthorityDistrict:
+                      - Medway
+                      region: South East
+                      ward: Rochester West & Borstal
+                      type:
+                        value: commercial.leisure.museum
+                        description: Museum / Gallery
+                      boundary:
+                        site:
+                          type: Feature
+                          geometry:
+                            type: MultiPolygon
+                            coordinates:
+                            - - - - 0.505988
+                                  - 51.387438
+                                - - 0.506138
+                                  - 51.387255
+                                - - 0.50611
+                                  - 51.387246
+                                - - 0.506194
+                                  - 51.387139
+                                - - 0.506242
+                                  - 51.387121
+                                - - 0.506268
+                                  - 51.387094
+                                - - 0.506472
+                                  - 51.387173
+                                - - 0.506466
+                                  - 51.387181
+                                - - 0.506792
+                                  - 51.3873
+                                - - 0.506823
+                                  - 51.387266
+                                - - 0.506854
+                                  - 51.387278
+                                - - 0.506909
+                                  - 51.387252
+                                - - 0.506984
+                                  - 51.38728
+                                - - 0.506968
+                                  - 51.38732
+                                - - 0.507142
+                                  - 51.387385
+                                - - 0.507181
+                                  - 51.387375
+                                - - 0.506962
+                                  - 51.387653
+                                - - 0.506961
+                                  - 51.387695
+                                - - 0.506931
+                                  - 51.387733
+                                - - 0.506437
+                                  - 51.387557
+                                - - 0.506425
+                                  - 51.387574
+                                - - 0.505988
+                                  - 51.387438
+                          properties:
+                            name: ''
+                            entity: 12000664748
+                            prefix: title-boundary
+                            dataset: title-boundary
+                            end-date: ''
+                            typology: geography
+                            reference: '32926167'
+                            entry-date: '2024-05-06'
+                            start-date: '2009-02-27'
+                            organisation-entity: '13'
+                        area:
+                          hectares: 0.295809
+                          squareMetres: 2958.09
+                    application:
+                      type:
+                        value: breach
+                        description: Report a planning breach
+                    report:
+                      boundary:
+                        site:
+                          type: Feature
+                          geometry:
+                            type: Polygon
+                            coordinates:
+                            - - - 0.5061100423336052
+                                - 51.387245941504915
+                              - - 0.5061945319175742
+                                - 51.38713965241118
+                              - - 0.5062454938888572
+                                - 51.387138815488186
+                              - - 0.5063232779502891
+                                - 51.38716141240323
+                              - - 0.5063809454441092
+                                - 51.387173966240084
+                              - - 0.5064935982227345
+                                - 51.38722836616
+                              - - 0.5064211785793326
+                                - 51.387287787537105
+                              - - 0.5063098669052146
+                                - 51.387310384378566
+                              - - 0.5061100423336052
+                                - 51.387245941504915
+                          properties:
+                            label: '1'
+                            area.hectares: 0.030997000000000004
+                            area.squareMetres: 309.97
+                            planx_user_action: Drew a custom boundary
+                        area:
+                          squareMetres: 309.97
+                      description: Unauthorised erection of a library in the front
+                        garden
+                      projectType:
+                      - value: outbuilding
+                        description: New or modified outbuilding (eg garage or shed)
+                      date:
+                        start: '2024-12-25'
+                  responses:
+                  - question: Are you reporting any of the following?
+                    responses:
+                    - value: No, none of the above
+                    metadata: {}
+                  - question: Is the property in Medway?
+                    responses:
+                    - value: 'Yes'
+                    metadata:
+                      autoAnswered: true
+                  - question: Has the property or site already been granted planning
+                      permission for the works you're reporting?
+                    responses:
+                    - value: Yes, it's been granted planning permission but I still
+                        think it's a breach
+                    metadata: {}
+                  - question: Enter your contact details
+                    responses:
+                    - value: Ebenezer Scrooge 0123456789 scrooge@waltdisney.com
+                    metadata: {}
+                  - question: Enter your address
+                    responses:
+                    - value: 16 Bayham Street, Camden Town, London, NW1 0JU, UK
+                    metadata: {}
+                  - question: Is the breach currently in progress?
+                    responses:
+                    - value: 'Yes'
+                    metadata: {}
+                  - question: Select the breach you are reporting
+                    responses:
+                    - value: New or modified outbuilding (e.g. garage or shed)
+                    metadata: {}
+                  - question: Describe the work suspected to be a breach
+                    responses:
+                    - value: Unathorised erection of a library in the front garden
+                    metadata: {}
+                  - question: Do you know when the work started?
+                    responses:
+                    - value: 'Yes'
+                    metadata: {}
+                  - question: When did work start?
+                    responses:
+                    - value: '2024-12-25'
+                    metadata: {}
+                  - question: Do you know when the work was completed?
+                    responses:
+                    - value: 'No'
+                    metadata: {}
+                  - question: Which side of the property is the outbuilding on?
+                    responses:
+                    - value: Front
+                    metadata: {}
+                  - question: Do you know any of the dimensions of the outbuilding?
+                    responses:
+                    - value: The library is approximately 4x3 metres
+                    metadata: {}
+                  - question: How many other outbuildings are there?
+                    responses:
+                    - value: '1'
+                    metadata: {}
+                  - question: Do you have any supporting documents or photos?
+                    responses:
+                    - value: 'No'
+                    metadata: {}
+                  - question: Is there anything else you'd like to tell us?
+                    responses:
+                    - value: 'No'
+                    metadata: {}
+                  files:
+                  - name: https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf
+                    type:
+                    - value: otherDrawing
+                      description: Other - drawing
+                  - name: https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf
+                    type:
+                    - value: heritageStatement
+                      description: Heritage Statement
+                  - name: https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf
+                    type:
+                    - value: sitePlan.existing
+                      description: Site plan - existing
+                    - value: sitePlan.proposed
+                      description: Site plan - proposed
+                  - name: https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf
+                    type:
+                    - value: elevations.existing
+                      description: Elevations - existing
+                    - value: elevations.proposed
+                      description: Elevations - proposed
+                  - name: https://api.editor.planx.dev/file/private/311w2id6/floor_plans.pdf
+                    type:
+                    - value: floorPlan.existing
+                      description: Floor plan - existing
+                    - value: floorPlan.proposed
+                      description: Floor plan - proposed
+                  metadata:
+                    id: df4bba83-5f7a-4d82-9ecf-ba2a0fffda72
+                    organisation: MDW
+                    submittedAt: '2025-05-26T15:20:11.297Z'
+                    source: PlanX
+                    service:
+                      flowId: 26ade0b6-f223-4b92-b5e5-5462a2067b1f
+                      url: https://editor.planx.dev/medway/report-a-planning-breach/published
+                      files:
+                        required: []
+                        recommended: []
+                        optional: []
+                      fee:
+                        notApplicable: true
                     schema: https://theopensystemslab.github.io/digital-planning-data-schemas/v0.7.5/schemas/enforcement.json

--- a/engines/bops_uploads/app/controllers/bops_uploads/files_controller.rb
+++ b/engines/bops_uploads/app/controllers/bops_uploads/files_controller.rb
@@ -3,7 +3,7 @@
 module BopsUploads
   class FilesController < ApplicationController
     before_action :set_blob
-    before_action :set_planning_application
+    before_action :set_parent
     before_action :raise_not_found, unless: :local_authority_matches?
 
     def show
@@ -20,20 +20,23 @@ module BopsUploads
 
     private
 
-    def set_planning_application
-      @planning_application = @blob.planning_application
-    end
+    def set_parent
+      @parent = @blob.parent_record
 
-    def set_submission
-      @submission = @blob.submission
+      case @parent
+      when CaseRecord
+        @case_record = @parent
+      when PlanningApplication
+        @planning_application = @parent
+      when Submission
+        @submission = @parent
+      else
+        raise ArgumentError, "Unexpected parent record: #{@parent.inspect}"
+      end
     end
 
     def local_authority_matches?
-      if @planning_application
-        @planning_application.local_authority == current_local_authority
-      elsif set_submission
-        @submission.local_authority == current_local_authority
-      end
+      @parent && @parent.local_authority == current_local_authority
     end
 
     def raise_not_found

--- a/engines/bops_uploads/lib/bops_uploads/engine.rb
+++ b/engines/bops_uploads/lib/bops_uploads/engine.rb
@@ -37,14 +37,11 @@ module BopsUploads
           when Consideration
             parent_record(record.consideration_set)
           when Document, ConsiderationSet
-            record.planning_application || record.submission
+            record.parent_record
           else
             raise ArgumentError, "Unexpected record type in chain: #{record.inspect}"
           end
         end
-
-        alias_method :planning_application, :parent_record
-        alias_method :submission, :parent_record
       end
     end
   end

--- a/spec/system/enforcements/index_spec.rb
+++ b/spec/system/enforcements/index_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Enforcement index page", type: :system do
     expect(page).to have_selector("h1", text: "Enforcement cases")
   end
 
-  it "displays all planning applications" do
+  it "displays all enforcement cases" do
     visit "/enforcements"
     click_link "All cases"
 


### PR DESCRIPTION
### Description of change

Add documents and photos association to case records and display in the accordion in the enforcement show page.

### Story Link

https://trello.com/c/uX8CQ3NE/1148-populate-enforcement-accordion-content-documents-and-photos

### Screenshots

<img width="909" height="631" alt="image" src="https://github.com/user-attachments/assets/54a84195-9aa8-4e9e-a1ce-e9897f37ff12" />
