### PR TITLE
Enable application status filter on other endpoint

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -26,7 +26,28 @@ module BopsApi
         private
 
         def pagination_params
-          params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :q, :page, :format, :reference, :description, :postcode, :publishedAtFrom, :publishedAtTo, :receivedAtFrom, :receivedAtTo, :validatedAtFrom, :validatedAtTo, :consultationEndDateFrom, :consultationEndDateTo, applicationType: [])
+          params.permit(
+            :sortBy,
+            :orderBy,
+            :resultsPerPage,
+            :query,
+            :q,
+            :page,
+            :format,
+            :reference,
+            :description,
+            :postcode,
+            :publishedAtFrom,
+            :publishedAtTo,
+            :receivedAtFrom,
+            :receivedAtTo,
+            :validatedAtFrom,
+            :validatedAtTo,
+            :consultationEndDateFrom,
+            :consultationEndDateTo,
+            applicationStatus: [],
+            applicationType: []
+          )
         end
       end
     end

--- a/engines/bops_api/app/services/bops_api/application/search_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/search_service.rb
@@ -44,18 +44,19 @@ module BopsApi
 
         codes = Array(params[:applicationType])
           .flat_map { |c| c.to_s.split(",") }
-          .map(&:presence)
-          .compact
+          .compact_blank
           .uniq
 
         scope.for_application_type_codes(codes)
       end
 
       def filter_by_application_status
-        status = params[:applicationStatus]
-        return scope if status.blank?
+        return scope if params[:applicationStatus].blank?
 
-        status = status.split(",").compact_blank if status.is_a? String
+        status = Array(params[:applicationStatus])
+          .flat_map { |c| c.to_s.split(",") }
+          .compact_blank
+          .uniq
 
         scope.where(status:)
       end

--- a/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
@@ -26,8 +26,7 @@ module BopsApi
         if types_param.present?
           codes = Array(types_param)
             .flat_map { |c| c.to_s.split(",") }
-            .map(&:presence)
-            .compact
+            .compact_blank
             .uniq
 
           scope = scope.for_application_type_codes(codes)

--- a/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission/planning_applications_search_service.rb
@@ -22,6 +22,16 @@ module BopsApi
       private
 
       def filter_by(scope)
+        status_param = params[:applicationStatus]
+        if status_param.present?
+          status = Array(status_param)
+            .flat_map { |c| c.to_s.split(",") }
+            .compact_blank
+            .uniq
+
+          scope = scope.where(status:)
+        end
+
         types_param = params[:applicationType]
         if types_param.present?
           codes = Array(types_param)


### PR DESCRIPTION
### Description of change

Add application status filter to the postsubmission search endpoint, and try to bring the two search services slightly more in line with one another.

### Story Link

<https://trello.com/c/xwviKkg1/868-api-search-filter-application-status>
