### PR TITLE
Allow editing documents in review stage

### DIFF
--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -182,7 +182,11 @@ module PlanningApplicationStatus
     end
 
     def closed_or_cancelled?
-      determined? || returned? || withdrawn? || closed?
+      determined? || cancelled?
+    end
+
+    def cancelled?
+      returned? || withdrawn? || closed?
     end
 
     def can_submit_recommendation?
@@ -202,7 +206,7 @@ module PlanningApplicationStatus
     end
 
     def can_edit_documents?
-      can_validate? || publish_complete?
+      !cancelled?
     end
 
     def review_complete?

--- a/spec/system/documents/archive_spec.rb
+++ b/spec/system/documents/archive_spec.rb
@@ -207,8 +207,8 @@ RSpec.describe "Documents index page" do
       visit "/planning_applications/#{awaiting_determination_planning_application.id}/documents"
     end
 
-    it "Archive button is not visible" do
-      expect(page).not_to have_link("Archive")
+    it "Archive button is still visible" do
+      expect(page).to have_link("Archive")
     end
   end
 


### PR DESCRIPTION
### Description of change

Previously editing documents has been limited to the assessment stage: specifically, not 'closed or cancelled' (except if determined, for some reason?) and not awaiting determination.

However it doesn't seem like there's any reason to prevent editing the documents in review (`awaiting_determination`), and council officers seem to want this ability.

This means the condition is just any case that is either open or has been determined (i.e., not closed for other reasons).

### Story Link

<https://trello.com/c/9ohGQVqC/1158-support-editing-documents-during-awaiting-determination-stage-of-an-application>