### PR TITLE
Able to skip applicant accept description change

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -113,6 +113,19 @@ class PlanningApplicationMailer < ApplicationMailer
     )
   end
 
+  def description_update_mail(planning_application, description_change_request)
+    @planning_application = planning_application
+    @description_change_request = description_change_request
+
+    view_mail(
+      NOTIFY_TEMPLATE_ID,
+      subject: subject(:description_update_mail,
+        application_type_name: @planning_application.application_type.human_name),
+      to: @planning_application.applicant_and_agent_email.first,
+      reply_to_id: @planning_application.local_authority.email_reply_to_id
+    )
+  end
+
   def description_closure_notification_mail(planning_application, description_change_request)
     @planning_application = planning_application
     @description_change_request = description_change_request

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -823,7 +823,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def closed_pre_validation_requests
-    requests_excluding_time_extension.closed - requests_excluding_time_extension.closed.post_validation
+    requests_excluding_time_extension.closed.reject(&:immediate_auto_closed?) - requests_excluding_time_extension.closed.post_validation
   end
 
   def open_post_validation_requests?

--- a/app/models/validation_request.rb
+++ b/app/models/validation_request.rb
@@ -271,6 +271,12 @@ class ValidationRequest < ApplicationRecord
     ).deliver_now
   end
 
+  def immediate_auto_closed?
+    return false if auto_closed_at.blank?
+
+    (auto_closed_at - created_at) < 60.seconds
+  end
+
   private
 
   def send_and_add_events
@@ -322,6 +328,13 @@ class ValidationRequest < ApplicationRecord
 
   def send_description_request_email
     PlanningApplicationMailer.description_change_mail(
+      planning_application,
+      self
+    ).deliver_now
+  end
+
+  def send_description_update_email
+    PlanningApplicationMailer.description_update_mail(
       planning_application,
       self
     ).deliver_now

--- a/app/views/planning_application_mailer/description_update_mail.text.erb
+++ b/app/views/planning_application_mailer/description_update_mail.text.erb
@@ -1,0 +1,18 @@
+Application reference number: <%= @planning_application.reference_in_full %>
+Address: <%= @planning_application.full_address %>
+
+Dear <%= @planning_application.agent_or_applicant_name %>,
+
+Your case officer has updated the description of development for your application. Descriptions are updated to provide consistent information and to remove any errors.
+
+Your previous description:
+<%= @description_change_request.specific_attributes["previous_description"] %>
+
+Your new description:
+<%= @description_change_request.specific_attributes["proposed_description"] %>
+
+If you need help with your application, contact us at <%= @planning_application.local_authority.email_address %>.
+
+Regards,
+
+<%= @planning_application.local_authority.council_name %>

--- a/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
@@ -17,13 +17,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <% if @planning_application.application_type.description_change_requires_validation? %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-3">
-        Suggest a new description to the applicant
-      </h2>
+      <h3 class="govuk-heading-s govuk-!-margin-top-3">
+       Update the description or suggest a new description to the applicant
+      </h3>
 
-      <p>
-        This will be sent to the applicant immediately. If the applicant does not respond within 5 days, the amended description will be automatically accepted.
-      </p>
     <% else %>
       <h2 class="govuk-heading-m govuk-!-margin-top-3">
         Update description
@@ -59,16 +56,29 @@
       <% end %>
       <%= form.hidden_field(:type, value: "DescriptionChangeValidationRequest") %>
       <%= form.govuk_text_area :proposed_description,
-            label: {size: "s", text: "Enter an amended description" + (@planning_application.application_type.description_change_requires_validation? ? " to send to the applicant" : "")},
+            value: @planning_application.description,
+            label: {size: "s", text: "Enter an amended description"},
             rows: 5 %>
       <% if @planning_application.not_started? %>
         <%= form.hidden_field(:return_to, value: planning_application_validation_tasks_path(@planning_application)) %>
       <% else %>
         <%= form.hidden_field(:return_to, value: @back_path) %>
       <% end %>
-      <div class="govuk-button-group">
-        <%= form.govuk_submit @planning_application.application_type.description_change_requires_validation? ? "Send request" : "Save and mark as complete" %>
-        <%= back_link %>
+      <% if @planning_application.application_type.description_change_requires_validation? %>
+        <div class="display govuk-!-margin-top-3">
+          <%= form.govuk_radio_buttons_fieldset(:skip_applicant_approval, legend: {size: "m", text: "Does this description change require applicant's agreement?"}) do %>
+            <%= form.govuk_radio_button :skip_applicant_approval, false, label: {text: "Yes, applicant agreement needed"} do %>
+              <p>The new description will be sent to the applicant to approve. If the applicant does not respond within 5 days, the amended description will be automatically accepted.</p>
+            <% end %>
+            <%= form.govuk_radio_button :skip_applicant_approval, true, label: {text: "No, update description immediately"} do %>
+              <p>The applicant will be notified of the new description.</p>
+            <% end %>
+          <% end %>
+      <% end %>
+        <div class="govuk-button-group">
+          <%= form.govuk_submit @planning_application.application_type.description_change_requires_validation? ? "Update description" : "Save and mark as complete" %>
+          <%= back_link %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/planning_applications/validation/description_changes/show.html.erb
+++ b/app/views/planning_applications/validation/description_changes/show.html.erb
@@ -19,6 +19,13 @@
         )
       ) %>
 
+    <div class="govuk-inset-text">
+      <h3 class="govuk-heading-s">
+        Existing description
+      </h3>
+      <%= render(FormattedContentComponent.new(text: @planning_application.description)) %>
+    </div>
+
     <% if @planning_application.valid_description.nil? || params[:edit] == "true" %>
       <%= form_with model: @planning_application, url: validate_planning_application_validation_description_changes_path(@planning_application) do |form| %>
         <%= form.govuk_radio_buttons_fieldset :valid_description, legend: {text: "Does the description match the development or use in the plans?"} do %>

--- a/app/views/shared/_assessment_dashboard.html.erb
+++ b/app/views/shared/_assessment_dashboard.html.erb
@@ -30,7 +30,7 @@
       <%= render "shared/time_extension_response_banner" %>
     <% end %>
   <% end %>
-  <% if @planning_application.description_change_validation_requests.where(auto_closed: true).present? %>
+  <% if @planning_application.description_change_validation_requests.auto_closed.any? %>
     <%= render "shared/description_change_auto_closed_banner" %>
   <% end %>
 <% end %>

--- a/app/views/shared/_description_change_auto_closed_banner.html.erb
+++ b/app/views/shared/_description_change_auto_closed_banner.html.erb
@@ -5,8 +5,13 @@
           <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
         C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
       <div class="moj-banner__message">
-        <strong> Description change request has been automatically accepted </strong> after 5 days.<br>
-        <%= govuk_link_to "View description change request", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request) %>
+        <% if @planning_application.description_change_validation_requests.auto_closed.any?(&:immediate_auto_closed?) %>
+          <strong> Applicant has been notified of the description change. </strong>
+          <%= govuk_link_to "View description change", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request) %>
+        <% else %>
+          <strong> Description change request has been automatically accepted </strong> after 5 days.<br>
+          <%= govuk_link_to "View description change request", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request) %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -879,6 +879,7 @@ en:
       decision_notice_mail: Decision on your %{application_type_name} application
       description_change_mail: "%{application_type_name} application - suggested changes"
       description_closure_notification_mail: Changes to your %{application_type_name} application
+      description_update_mail: "%{application_type_name} application - description update"
       internal_team_site_notice_mail: Site notice for application number %{reference}
       invalidation_notice_mail: "%{application_type_name} application - changes needed"
       neighbour_consultation_letter_copy_mail: Neighbour consultation letter copy

--- a/features/adding_description_change.feature
+++ b/features/adding_description_change.feature
@@ -32,8 +32,9 @@ Feature: Creating a description change on the application
   Scenario: I cannot create a second description change request when an open one exists
     Given I create a description change request with "A yard full of bananas"
     When I visit the new description change request link
-    And I fill in "Enter an amended description to send to the applicant" with "Mambo number 2"
-    And I press "Send"
+    And I fill in "Enter an amended description" with "Mambo number 2"
+    And I choose "Yes, applicant agreement needed"
+    And I press "Update description"
     Then the page contains "An open description change already exists for this planning application."
 
   Scenario: I can view a notification banner when a request has been auto-closed

--- a/features/step_definitions/description_change_steps.rb
+++ b/features/step_definitions/description_change_steps.rb
@@ -19,8 +19,9 @@ Given("I create a description change request with {string}") do |details|
     And I press "Check description"
     And I choose "No"
     And I press "Save and mark as complete"
-    And I fill in "Enter an amended description to send to the applicant" with "#{details}"
-    And I press "Send"
+    And I fill in "Enter an amended description" with "#{details}"
+    And I choose "Yes, applicant agreement needed"
+    And I press "Update description"
   )
 end
 
@@ -38,7 +39,9 @@ When("I cancel the existing description change request") do
 end
 
 When("the description change request has been auto-closed after 5 days") do
-  @planning_application.description_change_validation_requests.last.auto_close_request!
+  request = @planning_application.description_change_validation_requests.last
+  request.update!(created_at: 6.business_days.ago)
+  request.auto_close_request!
 end
 
 When("the request has been responded to") do

--- a/spec/system/planning_applications/assessing/checking_consistency_spec.rb
+++ b/spec/system/planning_applications/assessing/checking_consistency_spec.rb
@@ -466,11 +466,12 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Enter an amended description to send to the applicant",
+      "Enter an amended description",
       with: "New description"
     )
 
-    click_button("Send")
+    choose "Yes, applicant agreement needed"
+    click_button "Update description"
 
     expect(page).to have_content(
       "Description change request successfully sent."
@@ -498,11 +499,12 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Enter an amended description to send to the applicant",
+      "Enter an amended description",
       with: "New description 2"
     )
 
-    click_button("Send")
+    choose "Yes, applicant agreement needed"
+    click_button "Update description"
 
     expect(page).to have_content(
       "Description change request successfully sent."
@@ -533,11 +535,12 @@ RSpec.describe "checking consistency" do
     click_link("Request a change to the description")
 
     fill_in(
-      "Enter an amended description to send to the applicant",
+      "Enter an amended description",
       with: "New description 3"
     )
 
-    click_button("Send")
+    choose "Yes, applicant agreement needed"
+    click_button "Update description"
 
     expect(page).to have_content(
       "Description change request successfully sent."


### PR DESCRIPTION
### Description of change

Officers making small description change are able to specify that applicant approval is not required. This still triggers a email to the applicant to notify them of the change but not to ask for approval.

### Story Link

https://trello.com/c/GgCNNSc5/926-support-officers-to-correct-insignificant-errors-such-as-typos-in-descriptions-without-requiring-confirmation-from-applicants-or

### Screenshots
<img width="624" height="742" alt="image" src="https://github.com/user-attachments/assets/aa3f05ea-4e65-4562-b4cf-d98fc1ec6b84" />
<img width="509" height="191" alt="image" src="https://github.com/user-attachments/assets/a03ae625-8704-4039-9b01-2f891845547f" />

<img width="854" height="482" alt="image" src="https://github.com/user-attachments/assets/b2d42eb9-761d-479e-b4a5-db5d25e8e09b" />

### Decisions

- A validation request is still made for the change so we are able to store the previous description and current. This means the validation request shows as 'responded' in the list. The request is auto closed.
- To avoid adding a new database field a check is done on the created_at and auto_closed_at date to check for same day close.
- I have excluded immediate auto-closed requests from the response banner on the application show page, and updated the banner for the closure to read "Applicant has been notified of the description change"