### PR TITLE
Filter by public specialist sentiment

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/neighbour_responses_controller.rb
@@ -4,6 +4,8 @@ module BopsApi
   module V2
     module Public
       class NeighbourResponsesController < PublicController
+        include ParamHelpers
+
         def index
           @planning_application = find_planning_application params[:planning_application_id]
           @consultation = @planning_application.consultation
@@ -36,7 +38,11 @@ module BopsApi
 
         # Permit and return the required parameters
         def pagination_params
-          params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :page, :format, :planning_application_id)
+          permitted = params.permit(:sortBy, :orderBy, :resultsPerPage, :query, :page, :format, :planning_application_id, :sentiment)
+          if permitted[:sentiment].present?
+            permitted[:sentiment] = handle_comma_separated_param(permitted[:sentiment])
+          end
+          permitted
         end
       end
     end

--- a/engines/bops_api/app/controllers/concerns/bops_api/param_helpers.rb
+++ b/engines/bops_api/app/controllers/concerns/bops_api/param_helpers.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module ParamHelpers
+    extend ActiveSupport::Concern
+
+    # when a parameter is an array of comma-separated values, this method will split them into an array
+    def handle_comma_separated_param(param)
+      Array(param).flat_map { |v| v.to_s.split(",") }.compact_blank.uniq
+    end
+  end
+end

--- a/engines/bops_api/app/services/bops_api/postsubmission/comments_public_service.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission/comments_public_service.rb
@@ -12,6 +12,13 @@ module BopsApi
           "id" => {column: "neighbour_responses.id", default_order: "asc"}
         }
       end
+
+      # Defines allowed sentiment values and their corresponding database values
+      def allowed_sentiment_values
+        NeighbourResponse.summary_tags.keys.map do |s|
+          {s.to_s.camelize(:lower) => {value: s}}
+        end
+      end
     end
   end
 end

--- a/engines/bops_api/app/services/bops_api/postsubmission/comments_specialist_service.rb
+++ b/engines/bops_api/app/services/bops_api/postsubmission/comments_specialist_service.rb
@@ -12,6 +12,13 @@ module BopsApi
           "id" => {column: "consultee_responses.id", default_order: "asc"}
         }
       end
+
+      # Defines allowed sentiment values and their corresponding database values
+      def allowed_sentiment_values
+        Consultee::Response.summary_tags.keys.map do |s|
+          {s.to_s.camelize(:lower) => {value: s}}
+        end
+      end
     end
   end
 end

--- a/engines/bops_api/spec/controllers/concerns/bops_api/param_helpers_spec.rb
+++ b/engines/bops_api/spec/controllers/concerns/bops_api/param_helpers_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+class DummyController
+  include BopsApi::ParamHelpers
+end
+
+RSpec.describe BopsApi::ParamHelpers do
+  let(:controller) { DummyController.new }
+
+  describe "#handle_comma_separated_param" do
+    it "splits comma-separated values into an array" do
+      result = controller.handle_comma_separated_param("a,b")
+      expect(result).to eq(["a", "b"])
+    end
+
+    it "handles array values" do
+      result = controller.handle_comma_separated_param(["a", "b"])
+      expect(result).to eq(["a", "b"])
+    end
+
+    it "removes blank values" do
+      result = controller.handle_comma_separated_param("a,,")
+      expect(result).to eq(["a"])
+    end
+
+    it "removes duplicate values" do
+      result = controller.handle_comma_separated_param("a,a,b")
+      expect(result).to eq(["a", "b"])
+    end
+  end
+end

--- a/engines/bops_api/spec/controllers/v2/public/consultee_responses_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/public/consultee_responses_controller_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::V2::Public::ConsulteeResponsesController, type: :controller do
+  routes { BopsApi::Engine.routes }
+  render_views
+
+  let(:southwark) { create(:local_authority, :southwark) }
+  let(:planning_application) { create(:planning_application, :published, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority: southwark) }
+  let(:consultation) { planning_application.consultation }
+
+  before do
+    request.set_header("HTTP_HOST", "southwark.bops.test")
+    request.set_header("bops.local_authority", southwark)
+
+    allow_any_instance_of(BopsApi::V2::Public::ConsulteeResponsesController)
+      .to receive(:find_planning_application)
+      .and_return(planning_application)
+
+    # create a consultee with a response for each sentiment
+    Consultee::Response.summary_tags.keys.each do |sentiment|
+      create(:consultee, :consulted, responses: build_list(:consultee_response, 1, :with_redaction, summary_tag: sentiment), consultation: planning_application.consultation)
+    end
+  end
+
+  describe "GET #index" do
+    context "when consultation exists" do
+      it "returns a successful response and expected json keys" do
+        get :index, params: {planning_application_id: planning_application.reference}, format: :json
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["pagination"]).to eq({"resultsPerPage" => 10, "currentPage" => 1, "totalPages" => 1, "totalResults" => 3, "totalAvailableItems" => 3})
+        expect(json["comments"].size).to eq(3)
+      end
+    end
+
+    context "when consultation is missing" do
+      before do
+        allow(planning_application).to receive(:consultation).and_return(nil)
+      end
+
+      it "returns an InvalidRequestError" do
+        get :index, params: {planning_application_id: planning_application.reference}, format: :json
+        expect(response).to have_http_status(:bad_request)
+        json = JSON.parse(response.body)
+        expect(json["error"]["message"]).to eq("Bad Request")
+        expect(json["error"]["detail"]).to eq("Consultation not found")
+      end
+    end
+  end
+
+  describe "#pagination_params" do
+    it "handles single sentiment values" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "approved"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["approved"])
+    end
+
+    it "handles comma-separated sentiment values" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "approved,objected"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["approved", "objected"])
+    end
+
+    it "handles comma-separated sentiment values with duplicates" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "approved,objected,approved"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["approved", "objected"])
+    end
+  end
+end

--- a/engines/bops_api/spec/controllers/v2/public/neighbour_responses_controller_spec.rb
+++ b/engines/bops_api/spec/controllers/v2/public/neighbour_responses_controller_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::V2::Public::NeighbourResponsesController, type: :controller do
+  routes { BopsApi::Engine.routes }
+  render_views
+
+  let(:southwark) { create(:local_authority, :southwark) }
+  let(:planning_application) { create(:planning_application, :published, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority: southwark) }
+  let(:consultation) { planning_application.consultation }
+
+  before do
+    request.set_header("HTTP_HOST", "southwark.bops.test")
+    request.set_header("bops.local_authority", southwark)
+
+    allow_any_instance_of(BopsApi::V2::Public::NeighbourResponsesController)
+      .to receive(:find_planning_application)
+      .and_return(planning_application)
+
+    # Create a neighbour response for each sentiment
+    NeighbourResponse.summary_tags.keys.each do |sentiment|
+      neighbour = create(:neighbour, consultation: consultation)
+      create(:neighbour_response, summary_tag: NeighbourResponse.summary_tags.keys.sample, neighbour: neighbour)
+    end
+  end
+
+  describe "GET #index" do
+    it "returns a successful response and expected json keys" do
+      get :index, params: {planning_application_id: planning_application.reference}, format: :json
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json["pagination"]).to eq({"resultsPerPage" => 10, "currentPage" => 1, "totalPages" => 1, "totalResults" => 3, "totalAvailableItems" => 3})
+      expect(json["comments"].size).to eq(3)
+    end
+  end
+
+  describe "#pagination_params" do
+    it "handles single sentiment values" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "supportive"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["supportive"])
+    end
+
+    it "handles comma-separated sentiment values" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "supportive,neutral"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["supportive", "neutral"])
+    end
+
+    it "handles comma-separated sentiment values with duplicates" do
+      get :index, params: {planning_application_id: planning_application.reference, sentiment: "supportive,neutral,supportive"}, format: :json
+      controller_params = controller.send(:pagination_params)
+      expect(controller_params[:sentiment]).to eq(["supportive", "neutral"])
+    end
+  end
+end

--- a/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/consultee_responses_spec.rb
@@ -4,242 +4,96 @@ require_relative "../../../swagger_helper"
 
 RSpec.describe "BOPS public API Specialist comments" do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:planning_application) { create(:planning_application, :published, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
 
-  context "when every consulted consultee has exactly one redacted response" do
-    before do
-      25.times do
-        create(:consultee, :internal, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
-      end
+  def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
+    expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
+    expect(data["pagination"]["currentPage"]).to eq(current_page)
+    expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
+    expect(data["pagination"]["totalResults"]).to eq(total_results)
+    expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
+  end
 
-      25.times do
-        create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
-      end
+  def validate_comment_summary(data, total_comments: 50, total_consulted: 50, approved: 50, objected: 0, amendments_needed: 0)
+    expect(data["summary"]["totalComments"]).to eq(total_comments)
+    expect(data["summary"]["totalConsulted"]).to eq(total_consulted)
 
-      25.times do
-        create(:consultee, :internal, consultation: planning_application.consultation)
-      end
+    sentiment = data.dig("summary", "sentiment")
+    expect(sentiment["approved"]).to eq(approved)
+    expect(sentiment["objected"]).to eq(objected)
+    expect(sentiment["amendmentsNeeded"]).to eq(amendments_needed)
+  end
 
-      25.times do
-        create(:consultee, :external, consultation: planning_application.consultation)
-      end
+  def validate_comments(data, count:)
+    expect(data["comments"].size).to eq(count)
+    data["comments"].each do |c|
+      expect(c["id"]).to be_a(Integer)
+      expect(c["sentiment"]).to be_in(%w[approved objected amendmentsNeeded])
+      expect(c["comment"]).to include("*****")
+      expect { DateTime.iso8601(c["receivedAt"]) }.not_to raise_error
     end
+  end
 
-    path "/api/v2/public/planning_applications/{reference}/comments/specialist" do
-      get "Retrieves comments for a planning application" do
-        tags "Planning applications"
-        produces "application/json"
+  path "/api/v2/public/planning_applications/{reference}/comments/specialist" do
+    get "Retrieves published specialist comments for a planning application" do
+      tags "Planning applications"
+      produces "application/json"
 
-        parameter name: :reference, in: :path, schema: {
-          type: :string,
-          description: "The planning application reference"
-        }
+      # add parameters here
 
-        parameter name: :sortBy, in: :query, schema: {
-          type: :string,
-          enum: ["id", "receivedAt"],
-          default: "receivedAt",
-          description: "The sort type for the comments"
-        }, required: false
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
 
-        parameter name: :orderBy, in: :query, schema: {
-          type: :string,
-          enum: ["asc", "desc"],
-          default: "desc",
-          description: "The order for the comments"
-        }, required: false
+      parameter name: :sortBy, in: :query, schema: {
+        type: :string,
+        enum: ["id", "receivedAt"],
+        default: "receivedAt",
+        description: "The sort type for the comments"
+      }, required: false
 
-        parameter name: :resultsPerPage, in: :query, schema: {
-          type: :integer,
-          default: 10,
-          description: "Max result for page"
-        }, required: false
+      parameter name: :orderBy, in: :query, schema: {
+        type: :string,
+        enum: ["asc", "desc"],
+        default: "desc",
+        description: "The order for the comments"
+      }, required: false
 
-        parameter name: :page, in: :query, schema: {
-          type: :integer,
-          default: 1
-        }, required: false
+      parameter name: :resultsPerPage, in: :query, schema: {
+        type: :integer,
+        default: 10,
+        description: "Max result for page"
+      }, required: false
 
-        parameter name: :query, in: :query, schema: {
-          type: :string,
-          description: "Search by redacted comment content"
-        }, required: false
+      parameter name: :page, in: :query, schema: {
+        type: :integer,
+        default: 1
+      }, required: false
 
-        def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
-          expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
-          expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
-          expect(data["pagination"]["totalResults"]).to eq(total_results)
-          expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
-        end
+      parameter name: :query, in: :query, schema: {
+        type: :string,
+        description: "Search by redacted comment content"
+      }, required: false
 
-        def validate_comment_summary(data)
-          expect(data["summary"]["totalComments"]).to eq(50)
-          expect(data["summary"]["totalConsulted"]).to eq(50)
+      parameter name: :sentiment, in: :query,
+        description: "Filter by sentiment",
+        schema: {
+          type: :array,
+          items: {
+            type: :string,
+            enum: ["approved", "amendmentsNeeded", "objected"]
+          }
+        },
+        style: :form,
+        explode: false,
+        required: false
 
-          sentiment = data.dig("summary", "sentiment")
-          expect(sentiment["approved"]).to eq(50)
-          expect(sentiment["objected"]).to eq(0)
-          expect(sentiment["amendmentsNeeded"]).to eq(0)
-        end
+      # Document a standard response based on static json file
+      response "200", "Successful operation" do
+        example "application/json", "Default response", example_fixture("public/comments_specialist.json")
+        schema "$ref" => "#/components/schemas/CommentsSpecialistResponse"
 
-        def validate_comments(data, count:, total_items:)
-          expect(data["comments"].size).to eq(count)
-          data["comments"].each do |c|
-            expect(c["id"]).to be_a(Integer)
-            expect(c["sentiment"]).to be_in(%w[approved objected amendmentsNeeded])
-            expect(c["comment"]).to include("*****")
-            expect { DateTime.iso8601(c["receivedAt"]) }.not_to raise_error
-          end
-        end
-
-        response "200", "returns a planning application's specialist comments given a reference" do
-          example "application/json", :default, example_fixture("public/comments_specialist.json")
-          schema "$ref" => "#/components/schemas/CommentsSpecialistResponse"
-
-          let(:reference) { planning_application.reference }
-
-          run_test! do |response|
-            data = JSON.parse(response.body)
-
-            # pagination
-            validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
-            # comment summary
-            validate_comment_summary(data)
-
-            # comments
-            validate_comments(data, count: 10, total_items: 50)
-          end
-        end
-
-        response "200", "returns planning application's specialist comments paginated given a page and resultsPerPage param" do
-          let(:reference) { planning_application.reference }
-          let(:page) { 2 }
-          let(:resultsPerPage) { 2 }
-
-          run_test! do |response|
-            data = JSON.parse(response.body)
-
-            # pagination
-            validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
-            # comment summary
-            validate_comment_summary(data)
-
-            # comments
-            validate_comments(data, count: 2, total_items: 50)
-          end
-        end
-
-        response "200", "returns a planning application's specialist comments filtering by query" do
-          before do
-            create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction, response: "rude word not like the other comments", redacted_response: "***** not like the other comments"), consultation: planning_application.consultation)
-          end
-
-          let(:reference) { planning_application.reference }
-          let(:query) { "not like the other comments" }
-
-          run_test! do |response|
-            data = JSON.parse(response.body)
-            # pagination
-            validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
-            # comment summary
-            expect(data["summary"]["totalComments"]).to eq(51)
-            expect(data["summary"]["sentiment"]["approved"]).to eq(51)
-            expect(data["summary"]["sentiment"]["objected"]).to eq(0)
-            expect(data["summary"]["sentiment"]["amendmentsNeeded"]).to eq(0)
-
-            # comments
-            validate_comments(data, count: 1, total_items: 1)
-            expect(data["comments"].first["comment"]).to include("***** not like the other comments")
-          end
-        end
-
-        response "200", "returns a planning application's specialist comments filtering by sortBy and orderBy" do
-          let(:reference) { planning_application.reference }
-
-          context "when sortBy is not set and orderBy is not set" do
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck("receivedAt")
-              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-            end
-          end
-
-          shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
-            let(:sortBy) { sort_by }
-            let(:orderBy) { order_by }
-
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck(field)
-
-              expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
-              expect(sorted_values).to eq(expected_order)
-            end
-          end
-
-          context "sortBy is id" do
-            it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
-            it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
-          end
-
-          context "sortBy is receivedAt" do
-            it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
-            it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
-          end
-
-          context "only sortBy is set" do
-            context "sortBy is receivedAt orderBy defaults to desc" do
-              let(:sortBy) { "receivedAt" }
-              run_test! do |response|
-                data = JSON.parse(response.body)
-                sorted_values = data["comments"].pluck("receivedAt")
-                expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-              end
-            end
-
-            context "sortBy is id orderBy defaults to asc" do
-              let(:sortBy) { "id" }
-              run_test! do |response|
-                data = JSON.parse(response.body)
-                sorted_values = data["comments"].pluck("id")
-                expect(sorted_values).to eq(sorted_values.sort) # Ascending order
-              end
-            end
-          end
-
-          context "only orderBy is set" do
-            context "orderBy is asc sortBy defaults to receivedAt" do
-              let(:orderBy) { "asc" }
-              run_test! do |response|
-                data = JSON.parse(response.body)
-                sorted_values = data["comments"].pluck("receivedAt")
-                expect(sorted_values).to eq(sorted_values.sort) # Ascending order
-              end
-            end
-
-            context "orderBy is desc sortBy defaults to receivedAt" do
-              let(:orderBy) { "desc" }
-              run_test! do |response|
-                data = JSON.parse(response.body)
-                sorted_values = data["comments"].pluck("receivedAt")
-                expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-              end
-            end
-          end
-        end
-
-        response "404", "does not return comments for unpublished planning applications" do
-          let(:reference) { planning_application.reference }
-
-          let(:planning_application) { create(:planning_application, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
-
-          run_test! do |response|
-            data = JSON.parse(response.body)
-
-            expect(data["error"]["message"]).to eq("Not Found")
-          end
-        end
-
+        # ensure that the static response is valid against the schema
         it "validates successfully against the example comments_specialist json" do
           resolved_schema = load_and_resolve_schema(name: "comments_specialist", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
           schemer = JSONSchemer.schema(resolved_schema)
@@ -248,92 +102,319 @@ RSpec.describe "BOPS public API Specialist comments" do
           expect(schemer.valid?(example_json)).to eq(true)
         end
       end
-    end
-  end
-  context "when some consultees have no redacted responses or multiple redactions" do
-    path "/api/v2/public/planning_applications/{reference}/comments/specialist" do
-      get "Edge-case scenarios" do
-        tags "Planning applications"
-        produces "application/json"
 
-        parameter name: :reference, in: :path, schema: {type: :string}, required: true
+      context "When running tests on the comments specialist endpoint" do
+        let(:planning_application) { create(:planning_application, :published, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
 
-        response "200", "no redacted responses gives a count of zero" do
+        context "Query params" do
           before do
-            first_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
-            create(:consultee_response, consultee: first_consultee, redacted_response: nil)
+            25.times do
+              create(:consultee, :internal, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
+            end
 
-            second_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
-            create(:consultee_response, consultee: second_consultee, redacted_response: nil)
+            25.times do
+              create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction), consultation: planning_application.consultation)
+            end
+
+            25.times do
+              create(:consultee, :internal, consultation: planning_application.consultation)
+            end
+
+            25.times do
+              create(:consultee, :external, consultation: planning_application.consultation)
+            end
           end
 
-          let(:reference) { planning_application.reference }
+          # no params
+          response "200", "Passing no parameters should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
 
-          run_test! do |response|
-            data = JSON.parse(response.body)
+            run_test! do |response|
+              data = JSON.parse(response.body)
 
-            expect(data["summary"]["totalConsulted"]).to eq(2)
-            expect(data["summary"]["totalComments"]).to eq(0)
-            expect(data["summary"]["sentiment"].values).to all(eq(0))
-            expect(data["comments"]).to eq([])
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
+              # comment summary
+              validate_comment_summary(data)
+              # comments
+              validate_comments(data, count: 10)
+            end
+          end
+
+          # page, resultsPerPage
+          response "200", "Passing page and resultsPerPage params should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:page) { 2 }
+            let(:resultsPerPage) { 2 }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
+              # comment summary
+              validate_comment_summary(data)
+              # comments
+              validate_comments(data, count: 2)
+            end
+          end
+
+          # query
+          response "200", "Passing query should return correct pagination, summary, and comments", document: false do
+            before do
+              create(:consultee, :external, :consulted, responses: build_list(:consultee_response, 1, :with_redaction, response: "rude word not like the other comments", redacted_response: "***** not like the other comments"), consultation: planning_application.consultation)
+            end
+
+            let(:reference) { planning_application.reference }
+            let(:query) { "not like the other comments" }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
+              # comment summary
+              validate_comment_summary(data, total_comments: 51, total_consulted: 51, approved: 51, objected: 0, amendments_needed: 0)
+              # comments
+              validate_comments(data, count: 1)
+              expect(data["comments"].first["comment"]).to include("***** not like the other comments")
+            end
+          end
+
+          # sortBy, orderBy
+          response "200", "Passing sortBy and orderBy should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
+
+            context "when sortBy is not set and orderBy is not set" do
+              run_test! do |response|
+                data = JSON.parse(response.body)
+                sorted_values = data["comments"].pluck("receivedAt")
+                expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+              end
+            end
+
+            shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
+              let(:sortBy) { sort_by }
+              let(:orderBy) { order_by }
+
+              run_test! do |response|
+                data = JSON.parse(response.body)
+                sorted_values = data["comments"].pluck(field)
+
+                expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
+                expect(sorted_values).to eq(expected_order)
+              end
+            end
+
+            context "sortBy is id" do
+              it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
+              it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
+            end
+
+            context "sortBy is receivedAt" do
+              it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
+              it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
+            end
+
+            context "only sortBy is set" do
+              context "sortBy is receivedAt orderBy defaults to desc" do
+                let(:sortBy) { "receivedAt" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+                end
+              end
+
+              context "sortBy is id orderBy defaults to asc" do
+                let(:sortBy) { "id" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("id")
+                  expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+                end
+              end
+            end
+
+            context "only orderBy is set" do
+              context "orderBy is asc sortBy defaults to receivedAt" do
+                let(:orderBy) { "asc" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+                end
+              end
+
+              context "orderBy is desc sortBy defaults to receivedAt" do
+                let(:orderBy) { "desc" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+                end
+              end
+            end
           end
         end
 
-        response "200", "only consultees with redacted responses are counted" do
-          before do
-            third_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
-            create(:consultee_response, :with_redaction, consultee: third_consultee)
-
-            fourth_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
-            create(:consultee_response, consultee: fourth_consultee, redacted_response: nil)
+        # sentiment
+        context "Query params: sentiment" do
+          # Helper method to count sentiments in comments
+          # This method takes an array of comments and returns a hash with sentiment counts
+          def sentiment_counts(comments)
+            comments.pluck("sentiment").each_with_object(Hash.new(0)) { |s, h| h[s] += 1 }
           end
 
-          let(:reference) { planning_application.reference }
+          before do
+            # create a consultee with a response for each sentiment
+            Consultee::Response.summary_tags.keys.each do |sentiment|
+              create(:consultee, :consulted, responses: build_list(:consultee_response, 1, :with_redaction, summary_tag: sentiment), consultation: planning_application.consultation)
+            end
+          end
 
-          run_test! do |response|
-            data = JSON.parse(response.body)
+          response "200", "Singular sentiment", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["approved"] }
 
-            expect(data["summary"]["totalConsulted"]).to eq(2)
-            expect(data["summary"]["totalComments"]).to eq(1)
-            expect(data["summary"]["sentiment"].values.sum).to eq(1)
-            expect(data["comments"].count).to eq(1)
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 3)
+              # comment summary
+              validate_comment_summary(data, total_comments: 3, total_consulted: 3, approved: 1, objected: 1, amendments_needed: 1)
+              # comments
+              validate_comments(data, count: 1)
+
+              # Check that only comments with the specified sentiment are returned
+              expect(sentiment_counts(data["comments"])).to match_array([["approved", 1]])
+            end
+          end
+
+          # ?sentiment=a,b
+          response "200", "Multiple sentiments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["approved", "objected"] }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              expect(sentiment_counts(data["comments"])).to match_array([["approved", 1], ["objected", 1]])
+            end
+          end
+
+          # ?sentiment=invalid
+          response "500", "Invalid sentiments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["amendments_needed", "invalid"] }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              expect(data["error"]["code"]).to match(500)
+              expect(data["error"]["message"]).to match("Internal Server Error")
+              expect(data["error"]["detail"]).to match("Invalid sentiment(s): amendments_needed, invalid. Allowed values: approved, amendmentsNeeded, objected")
+            end
           end
         end
 
-        response "200", "latest response only for multiple redacted comments" do
-          before do
-            fifth_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
-            # Older redacted response:
-            create(
-              :consultee_response,
-              :with_redaction,
-              consultee: fifth_consultee,
-              summary_tag: "objected",
-              received_at: 2.days.ago
-            )
-            # Newer redacted response:
-            create(
-              :consultee_response,
-              :with_redaction,
-              consultee: fifth_consultee,
-              summary_tag: "approved",
-              received_at: 1.hour.ago
-            )
+        context "Comment summary" do
+          response "200", "no redacted responses gives a count of zero", document: false do
+            before do
+              first_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
+              create(:consultee_response, consultee: first_consultee, redacted_response: nil)
+
+              second_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
+              create(:consultee_response, consultee: second_consultee, redacted_response: nil)
+            end
+
+            let(:reference) { planning_application.reference }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              expect(data["summary"]["totalConsulted"]).to eq(2)
+              expect(data["summary"]["totalComments"]).to eq(0)
+              expect(data["summary"]["sentiment"].values).to all(eq(0))
+              expect(data["comments"]).to eq([])
+            end
           end
 
-          let(:reference) { planning_application.reference }
+          response "200", "only consultees with redacted responses are counted", document: false do
+            before do
+              third_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
+              create(:consultee_response, :with_redaction, consultee: third_consultee)
 
-          run_test! do |response|
-            data = JSON.parse(response.body)
+              fourth_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
+              create(:consultee_response, consultee: fourth_consultee, redacted_response: nil)
+            end
 
-            expect(data["summary"]["totalConsulted"]).to eq(1)
-            expect(data["summary"]["totalComments"]).to eq(1)
-            expect(data["summary"]["sentiment"]["approved"]).to eq(1)
-            expect(data["summary"]["sentiment"]["objected"]).to eq(0)
-            expect(data["comments"].count).to eq(2)
-            expect(data["comments"].first["sentiment"]).to eq("approved")
+            let(:reference) { planning_application.reference }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              expect(data["summary"]["totalConsulted"]).to eq(2)
+              expect(data["summary"]["totalComments"]).to eq(1)
+              expect(data["summary"]["sentiment"].values.sum).to eq(1)
+              expect(data["comments"].count).to eq(1)
+            end
+          end
+
+          response "200", "latest response only for multiple redacted comments", document: false do
+            before do
+              fifth_consultee = create(:consultee, :consulted, consultation: planning_application.consultation)
+              # Older redacted response:
+              create(
+                :consultee_response,
+                :with_redaction,
+                consultee: fifth_consultee,
+                summary_tag: "objected",
+                received_at: 2.days.ago
+              )
+              # Newer redacted response:
+              create(
+                :consultee_response,
+                :with_redaction,
+                consultee: fifth_consultee,
+                summary_tag: "approved",
+                received_at: 1.hour.ago
+              )
+            end
+
+            let(:reference) { planning_application.reference }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              expect(data["summary"]["totalConsulted"]).to eq(1)
+              expect(data["summary"]["totalComments"]).to eq(1)
+              expect(data["summary"]["sentiment"]["approved"]).to eq(1)
+              expect(data["summary"]["sentiment"]["objected"]).to eq(0)
+              expect(data["comments"].count).to eq(2)
+              expect(data["comments"].first["sentiment"]).to eq("approved")
+            end
           end
         end
+      end
+
+      # Document: Planning application does not exist
+      response "404", "The requested resource was not found" do
+        schema "$ref" => "#/components/schemas/NotFoundError"
+
+        let(:planning_application) { create(:planning_application, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
+
+        let(:reference) { planning_application.reference }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["error"]["message"]).to eq("Not Found")
+        end
+      end
+
+      # Document: Planning application reference is invalid
+      response "400", "The request was invalid or cannot be served" do
+        schema "$ref" => "#/components/schemas/BadRequestError"
       end
     end
   end

--- a/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/neighbour_responses_spec.rb
@@ -4,21 +4,40 @@ require_relative "../../../swagger_helper"
 
 RSpec.describe "BOPS public API Public comments" do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:application_type) { create(:application_type, :householder) }
 
-  let(:planning_application) { create(:planning_application, :published, local_authority:, application_type:) }
+  def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
+    expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
+    expect(data["pagination"]["currentPage"]).to eq(current_page)
+    expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
+    expect(data["pagination"]["totalResults"]).to eq(total_results)
+    expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
+  end
 
-  before do
-    50.times do
-      neighbour = create(:neighbour, consultation: planning_application.consultation)
-      create(:neighbour_response, neighbour: neighbour)
+  def validate_comment_summary(data, total_comments: 50, total_consulted: 50, supportive: 50, objection: 0, neutral: 0)
+    expect(data["summary"]["totalComments"]).to eq(total_comments)
+
+    sentiment = data.dig("summary", "sentiment")
+    expect(sentiment["supportive"]).to eq(supportive)
+    expect(sentiment["objection"]).to eq(objection)
+    expect(sentiment["neutral"]).to eq(neutral)
+  end
+
+  def validate_comments(data, count:)
+    expect(data["comments"].count).to eq(count)
+    data["comments"].each do |comment|
+      expect(comment["id"]).to be_a(Integer)
+      expect(comment["sentiment"]).to be_in(%w[supportive objection neutral])
+      expect(comment["comment"]).to include("*****")
+      expect { DateTime.iso8601(comment["receivedAt"]) }.not_to raise_error
     end
   end
 
   path "/api/v2/public/planning_applications/{reference}/comments/public" do
-    get "Retrieves comments for a planning application" do
+    get "Retrieves published public comments for a planning application" do
       tags "Planning applications"
       produces "application/json"
+
+      # add parameters here
 
       parameter name: :reference, in: :path, schema: {
         type: :string,
@@ -55,189 +74,257 @@ RSpec.describe "BOPS public API Public comments" do
         description: "Search by redacted comment content"
       }, required: false
 
-      def validate_pagination(data, results_per_page:, current_page:, total_results:, total_available_items:)
-        expect(data["pagination"]["resultsPerPage"]).to eq(results_per_page)
-        expect(data["pagination"]["currentPage"]).to eq(current_page)
-        expect(data["pagination"]["totalPages"]).to eq((total_results.to_f / results_per_page).ceil)
-        expect(data["pagination"]["totalResults"]).to eq(total_results)
-        expect(data["pagination"]["totalAvailableItems"]).to eq(total_available_items)
-      end
+      parameter name: :sentiment, in: :query,
+        description: "Filter by sentiment",
+        schema: {
+          type: :array,
+          items: {
+            type: :string,
+            enum: ["supportive", "neutral", "objection"]
+          }
+        },
+        style: :form,
+        explode: false,
+        required: false
 
-      def validate_comment_summary(data)
-        expect(data["summary"]["totalComments"]).to eq(50)
-        expect(data["summary"]["sentiment"]["supportive"]).to eq(50)
-        expect(data["summary"]["sentiment"]["objection"]).to eq(0)
-        expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
-      end
-
-      def validate_comments(data, count:, total_items:)
-        expect(data["comments"].count).to eq(count)
-        data["comments"].each do |comment|
-          expect(comment["id"]).to be_a(Integer)
-          expect(comment["sentiment"]).to be_in(["supportive", "objection", "neutral"])
-          expect(comment["comment"]).to include("*****")
-          expect { DateTime.iso8601(comment["receivedAt"]) }.not_to raise_error
-        end
-      end
-
-      response "200", "returns a planning application's public comments given a reference" do
-        example "application/json", :default, example_fixture("public/comments_public.json")
+      # Document a standard response based on static json file
+      response "200", "Successful operation" do
+        example "application/json", "Default response", example_fixture("public/comments_public.json")
         schema "$ref" => "#/components/schemas/CommentsPublicResponse"
 
+        # ensure that the static response is valid against the schema
+        it "validates successfully against the example comments_public json" do
+          resolved_schema = load_and_resolve_schema(name: "comments_public", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+          schemer = JSONSchemer.schema(resolved_schema)
+          example_json = example_fixture("public/comments_public.json")
+
+          expect(schemer.valid?(example_json)).to eq(true)
+        end
+      end
+
+      context "When running tests on the comments public endpoint" do
+        let(:planning_application) { create(:planning_application, :published, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
+
+        context "Query params" do
+          before do
+            50.times do
+              neighbour = create(:neighbour, consultation: planning_application.consultation)
+              create(:neighbour_response, neighbour: neighbour)
+            end
+          end
+
+          # no params
+          response "200", "Passing no parameters should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
+              # comment summary
+              validate_comment_summary(data)
+              # comments
+              validate_comments(data, count: 10)
+            end
+          end
+
+          # page, resultsPerPage
+          response "200", "Passing page and resultsPerPage params should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:page) { 2 }
+            let(:resultsPerPage) { 2 }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
+              # comment summary
+              validate_comment_summary(data)
+              # comments
+              validate_comments(data, count: 2)
+            end
+          end
+
+          # query
+          response "200", "Passing query should return correct pagination, summary, and comments", document: false do
+            before do
+              create(:neighbour_response, response: "rude word not like the other comments", redacted_response: "***** not like the other comments", neighbour: create(:neighbour, consultation: planning_application.consultation))
+            end
+
+            let(:reference) { planning_application.reference }
+            let(:query) { "not like the other comments" }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
+              # comment summary
+              validate_comment_summary(data, total_comments: 51, total_consulted: 51, supportive: 51, objection: 0, neutral: 0)
+              # comments
+              validate_comments(data, count: 1)
+              expect(data["comments"].first["comment"]).to include("***** not like the other comments")
+            end
+          end
+
+          # sortBy, orderBy
+          response "200", "Passing sortBy and orderBy should return correct pagination, summary, and comments", document: false do
+            let(:reference) { planning_application.reference }
+
+            context "when sortBy is not set and orderBy is not set " do
+              run_test! do |response|
+                data = JSON.parse(response.body)
+                sorted_values = data["comments"].pluck("receivedAt")
+                expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+              end
+            end
+
+            shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
+              let(:sortBy) { sort_by }
+              let(:orderBy) { order_by }
+
+              run_test! do |response|
+                data = JSON.parse(response.body)
+                sorted_values = data["comments"].pluck(field)
+
+                expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
+                expect(sorted_values).to eq(expected_order)
+              end
+            end
+
+            context "sortBy is id" do
+              it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
+              it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
+            end
+
+            context "sortBy is receivedAt" do
+              it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
+              it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
+            end
+
+            context "only sortBy is set" do
+              context "sortBy is receivedAt orderBy defaults to desc" do
+                let(:sortBy) { "receivedAt" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+                end
+              end
+
+              context "sortBy is id orderBy defaults to asc" do
+                let(:sortBy) { "id" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("id")
+                  expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+                end
+              end
+            end
+
+            context "only orderBy is set" do
+              context "orderBy is asc sortBy defaults to receivedAt" do
+                let(:orderBy) { "asc" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort) # Ascending order
+                end
+              end
+
+              context "orderBy is desc sortBy defaults to receivedAt" do
+                let(:orderBy) { "desc" }
+                run_test! do |response|
+                  data = JSON.parse(response.body)
+                  sorted_values = data["comments"].pluck("receivedAt")
+                  expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
+                end
+              end
+            end
+          end
+        end
+
+        # sentiment
+        context "Query params: sentiment" do
+          # Helper method to count sentiments in comments
+          # This method takes an array of comments and returns a hash with sentiment counts
+          def sentiment_counts(comments)
+            comments.pluck("sentiment").each_with_object(Hash.new(0)) { |s, h| h[s] += 1 }
+          end
+
+          before do
+            # create a neighbour response for each sentiment
+            NeighbourResponse.summary_tags.keys.each do |sentiment|
+              neighbour = create(:neighbour, consultation: planning_application.consultation)
+              create(:neighbour_response, summary_tag: sentiment, neighbour: neighbour)
+            end
+          end
+
+          response "200", "Singular sentiment", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["supportive"] }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              # pagination
+              validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 3)
+              # comment summary
+              validate_comment_summary(data, total_comments: 3, total_consulted: 3, supportive: 1, objection: 1, neutral: 1)
+              # comments
+              validate_comments(data, count: 1)
+
+              # Check that only comments with the specified sentiment are returned
+              expect(sentiment_counts(data["comments"])).to match_array([["supportive", 1]])
+            end
+          end
+
+          # ?sentiment=a,b
+          response "200", "Multiple sentiments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["supportive", "objection"] }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+              expect(sentiment_counts(data["comments"])).to match_array([["supportive", 1], ["objection", 1]])
+            end
+          end
+
+          # ?sentiment=invalid
+          response "500", "Invalid sentiments", document: false do
+            let(:reference) { planning_application.reference }
+            let(:sentiment) { ["invalid"] }
+
+            run_test! do |response|
+              data = JSON.parse(response.body)
+
+              expect(data["error"]["code"]).to match(500)
+              expect(data["error"]["message"]).to match("Internal Server Error")
+              expect(data["error"]["detail"]).to match("Invalid sentiment(s): invalid. Allowed values: supportive, neutral, objection")
+            end
+          end
+        end
+      end
+
+      # Document: Planning application does not exist
+      response "404", "The requested resource was not found" do
+        schema "$ref" => "#/components/schemas/NotFoundError"
+
+        let(:planning_application) { create(:planning_application, :in_assessment, :with_boundary_geojson, :planning_permission, local_authority:) }
+
         let(:reference) { planning_application.reference }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-
-          # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 50, total_available_items: 50)
-
-          # comment summary
-          validate_comment_summary(data)
-
-          # comments
-          validate_comments(data, count: 10, total_items: 50)
-        end
-      end
-
-      response "200", "returns planning application's public comments paginated given a page and resultsPerPage param" do
-        let(:reference) { planning_application.reference }
-        let(:page) { 2 }
-        let(:resultsPerPage) { 2 }
-
-        run_test! do |response|
-          data = JSON.parse(response.body)
-
-          # pagination
-          validate_pagination(data, results_per_page: 2, current_page: 2, total_results: 50, total_available_items: 50)
-
-          # comment summary
-          validate_comment_summary(data)
-
-          # comments
-          validate_comments(data, count: 2, total_items: 50)
-        end
-      end
-
-      response "200", "returns a planning application's public comments filtering by query" do
-        before do
-          create(:neighbour_response, response: "rude word not like the other comments", redacted_response: "***** not like the other comments", neighbour: create(:neighbour, consultation: planning_application.consultation))
-        end
-
-        let(:reference) { planning_application.reference }
-        let(:query) { "not like the other comments" }
-
-        run_test! do |response|
-          data = JSON.parse(response.body)
-
-          # pagination
-          validate_pagination(data, results_per_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_MAXRESULTS, current_page: BopsApi::Postsubmission::PostsubmissionPagination::DEFAULT_PAGE, total_results: 1, total_available_items: 51)
-
-          # comment summary
-          expect(data["summary"]["totalComments"]).to eq(51)
-          expect(data["summary"]["sentiment"]["supportive"]).to eq(51)
-          expect(data["summary"]["sentiment"]["objection"]).to eq(0)
-          expect(data["summary"]["sentiment"]["neutral"]).to eq(0)
-
-          # comments
-          validate_comments(data, count: 1, total_items: 1)
-          expect(data["comments"].first["comment"]).to include("***** not like the other comments")
-        end
-      end
-
-      response "200", "returns a planning application's public comments filtering by sortBy and orderBy" do
-        let(:reference) { planning_application.reference }
-
-        context "when sortBy is not set and orderBy is not set " do
-          run_test! do |response|
-            data = JSON.parse(response.body)
-            sorted_values = data["comments"].pluck("receivedAt")
-            expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-          end
-        end
-
-        shared_examples "sortBy and orderBy validation" do |sort_by, order_by, field|
-          let(:sortBy) { sort_by }
-          let(:orderBy) { order_by }
-
-          run_test! do |response|
-            data = JSON.parse(response.body)
-            sorted_values = data["comments"].pluck(field)
-
-            expected_order = (order_by == "asc") ? sorted_values.sort : sorted_values.sort.reverse
-            expect(sorted_values).to eq(expected_order)
-          end
-        end
-
-        context "sortBy is id" do
-          it_behaves_like "sortBy and orderBy validation", "id", "asc", "id"
-          it_behaves_like "sortBy and orderBy validation", "id", "desc", "id"
-        end
-
-        context "sortBy is receivedAt" do
-          it_behaves_like "sortBy and orderBy validation", "receivedAt", "asc", "receivedAt"
-          it_behaves_like "sortBy and orderBy validation", "receivedAt", "desc", "receivedAt"
-        end
-
-        context "only sortBy is set" do
-          context "sortBy is receivedAt orderBy defaults to desc" do
-            let(:sortBy) { "receivedAt" }
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck("receivedAt")
-              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-            end
-          end
-
-          context "sortBy is id orderBy defaults to asc" do
-            let(:sortBy) { "id" }
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck("id")
-              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
-            end
-          end
-        end
-
-        context "only orderBy is set" do
-          context "orderBy is asc sortBy defaults to receivedAt" do
-            let(:orderBy) { "asc" }
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck("receivedAt")
-              expect(sorted_values).to eq(sorted_values.sort) # Ascending order
-            end
-          end
-
-          context "orderBy is desc sortBy defaults to receivedAt" do
-            let(:orderBy) { "desc" }
-            run_test! do |response|
-              data = JSON.parse(response.body)
-              sorted_values = data["comments"].pluck("receivedAt")
-              expect(sorted_values).to eq(sorted_values.sort.reverse) # Descending order
-            end
-          end
-        end
-      end
-
-      response "404", "does not return comments for unpublished planning applications" do
-        let(:reference) { planning_application.reference }
-
-        let(:planning_application) { create(:planning_application, local_authority:, application_type:) }
-
-        run_test! do |response|
-          data = JSON.parse(response.body)
-
           expect(data["error"]["message"]).to eq("Not Found")
         end
       end
 
-      it "validates successfully against the example comments_public json" do
-        resolved_schema = load_and_resolve_schema(name: "comments_public", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
-        schemer = JSONSchemer.schema(resolved_schema)
-        example_json = example_fixture("public/comments_public.json")
-
-        expect(schemer.valid?(example_json)).to eq(true)
+      # Document: Planning application reference is invalid
+      response "400", "The request was invalid or cannot be served" do
+        schema "$ref" => "#/components/schemas/BadRequestError"
       end
     end
   end

--- a/engines/bops_api/spec/services/postsubmission/comments_public_service_spec.rb
+++ b/engines/bops_api/spec/services/postsubmission/comments_public_service_spec.rb
@@ -36,6 +36,84 @@ RSpec.describe BopsApi::Postsubmission::CommentsPublicService, type: :service do
       end
     end
 
+    context "when a multiple sentiment parameter is provided" do
+      let(:params) { {sentiment: ["supportive", "neutral"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["supportive", "neutral"])
+        allow(scope).to receive(:where).with(summary_tag: ["supportive", "neutral"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when supportive sentiment parameter is provided" do
+      let(:params) { {sentiment: ["supportive"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["supportive"])
+        allow(scope).to receive(:where).with(summary_tag: ["supportive"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when neutral sentiment parameter is provided" do
+      let(:params) { {sentiment: ["neutral"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["neutral"])
+        allow(scope).to receive(:where).with(summary_tag: ["neutral"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when objection sentiment parameter is provided" do
+      let(:params) { {sentiment: ["objection"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["objection"])
+        allow(scope).to receive(:where).with(summary_tag: ["objection"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when a sentiment array is provided and only one item matches" do
+      let(:params) { {sentiment: ["supportive", "neutral"]} }
+
+      it "filters the scope by the sentiment and returns results for the matching item only" do
+        # Assume that only "supportive" has matching results in the scope
+        matching_scope = scope.where(summary_tag: "supportive")
+        allow(scope).to receive(:where).with(summary_tag: ["supportive", "neutral"]).and_return(matching_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, matching_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(matching_scope)
+      end
+    end
+    context "when invalid sentiment is provided" do
+      let(:params) { {sentiment: ["invalidField"]} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid sentiment/)
+      end
+    end
+
     context "sortBy and orderBy" do
       context "when sortBy and orderBy parameters are provided" do
         let(:params) { {sortBy: "id", orderBy: "desc"} }

--- a/engines/bops_api/spec/services/postsubmission/comments_specialist_service_spec.rb
+++ b/engines/bops_api/spec/services/postsubmission/comments_specialist_service_spec.rb
@@ -36,6 +36,84 @@ RSpec.describe BopsApi::Postsubmission::CommentsSpecialistService, type: :servic
       end
     end
 
+    context "when a multiple sentiment parameter is provided" do
+      let(:params) { {sentiment: ["approved", "amendmentsNeeded"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["approved", "amendments_needed"])
+        allow(scope).to receive(:where).with(summary_tag: ["approved", "amendments_needed"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when approved sentiment parameter is provided" do
+      let(:params) { {sentiment: ["approved"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["approved"])
+        allow(scope).to receive(:where).with(summary_tag: ["approved"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when amendmentsNeeded sentiment parameter is provided" do
+      let(:params) { {sentiment: ["amendmentsNeeded"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["amendments_needed"])
+        allow(scope).to receive(:where).with(summary_tag: ["amendments_needed"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when objected sentiment parameter is provided" do
+      let(:params) { {sentiment: ["objected"]} }
+
+      it "filters the scope by the sentiment" do
+        filtered_scope = scope.where(summary_tag: ["objected"])
+        allow(scope).to receive(:where).with(summary_tag: ["objected"]).and_return(filtered_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, filtered_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(filtered_scope)
+      end
+    end
+
+    context "when a sentiment array is provided and only one item matches" do
+      let(:params) { {sentiment: ["approved", "objected"]} }
+
+      it "filters the scope by the sentiment and returns results for the matching item only" do
+        # Assume that only "supportive" has matching results in the scope
+        matching_scope = scope.where(summary_tag: "approved")
+        allow(scope).to receive(:where).with(summary_tag: ["approved", "objected"]).and_return(matching_scope)
+        allow_any_instance_of(BopsApi::Postsubmission::PostsubmissionPagination).to receive(:call).and_return([nil, matching_scope])
+
+        _, result = service.call
+
+        expect(result).to eq(matching_scope)
+      end
+    end
+    context "when invalid sentiment is provided" do
+      let(:params) { {sentiment: ["invalidField"]} }
+
+      it "raises an ArgumentError" do
+        expect { service.call }.to raise_error(ArgumentError, /Invalid sentiment/)
+      end
+    end
+
     context "sortBy and orderBy" do
       context "when sortBy and orderBy parameters are provided" do
         let(:params) { {sortBy: "id", orderBy: "desc"} }

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -35633,7 +35633,7 @@ paths:
                   - suffix
   "/api/v2/public/planning_applications/{reference}/comments/specialist":
     get:
-      summary: Edge-case scenarios
+      summary: Retrieves published specialist comments for a planning application
       tags:
       - Planning applications
       parameters:
@@ -35641,14 +35641,68 @@ paths:
         in: path
         schema:
           type: string
+          description: The planning application reference
         required: true
+      - name: sortBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - id
+          - receivedAt
+          default: receivedAt
+          description: The sort type for the comments
+        required: false
+      - name: orderBy
+        in: query
+        schema:
+          type: string
+          enum:
+          - asc
+          - desc
+          default: desc
+          description: The order for the comments
+        required: false
+      - name: resultsPerPage
+        in: query
+        schema:
+          type: integer
+          default: 10
+          description: Max result for page
+        required: false
+      - name: page
+        in: query
+        schema:
+          type: integer
+          default: 1
+        required: false
+      - name: query
+        in: query
+        schema:
+          type: string
+          description: Search by redacted comment content
+        required: false
+      - name: sentiment
+        in: query
+        description: Filter by sentiment
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - approved
+            - amendmentsNeeded
+            - objected
+        style: form
+        explode: false
+        required: false
       responses:
         '200':
-          description: latest response only for multiple redacted comments
+          description: Successful operation
           content:
             application/json:
               examples:
-                default:
+                Default response:
                   value:
                     pagination:
                       resultsPerPage: 10
@@ -35683,7 +35737,11 @@ paths:
               schema:
                 "$ref": "#/components/schemas/CommentsSpecialistResponse"
         '404':
-          description: does not return comments for unpublished planning applications
+          description: The requested resource was not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundError"
   "/api/v2/public/planning_applications/{reference}/documents":
     get:
       summary: Retrieves documents for a planning application
@@ -35757,7 +35815,7 @@ paths:
                 "$ref": "#/components/schemas/Documents"
   "/api/v2/public/planning_applications/{reference}/comments/public":
     get:
-      summary: Retrieves comments for a planning application
+      summary: Retrieves published public comments for a planning application
       tags:
       - Planning applications
       parameters:
@@ -35806,14 +35864,27 @@ paths:
           type: string
           description: Search by redacted comment content
         required: false
+      - name: sentiment
+        in: query
+        description: Filter by sentiment
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - supportive
+            - neutral
+            - objection
+        style: form
+        explode: false
+        required: false
       responses:
         '200':
-          description: returns a planning application's public comments filtering
-            by sortBy and orderBy
+          description: Successful operation
           content:
             application/json:
               examples:
-                default:
+                Default response:
                   value:
                     pagination:
                       resultsPerPage: 10
@@ -35847,7 +35918,11 @@ paths:
               schema:
                 "$ref": "#/components/schemas/CommentsPublicResponse"
         '404':
-          description: does not return comments for unpublished planning applications
+          description: The requested resource was not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/NotFoundError"
   "/api/v2/public/planning_applications/search":
     get:
       summary: Retrieves planning applications based on a search criteria


### PR DESCRIPTION
Supersedes #2402

### Description of change

In this PR we are updating the public specialist endpoint, allowing to filter the comments by sentiment
