### PR TITLE
Force colour output for cucumber

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -153,7 +153,7 @@ jobs:
           RAILS_ENV: test
           OTP_SECRET_ENCRYPTION_KEY: testtest
         run: |
-          bundle exec cucumber
+          bundle exec cucumber --color
 
       - name: Expose GitHub Runtime for Docker build
         uses: crazy-max/ghaction-github-runtime@v3

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -2,5 +2,7 @@
 
 desc "Run cucumber"
 task cucumber: :environment do
-  exit 1 unless system "cucumber"
+  cmd = "cucumber"
+  cmd << " --color" if ENV["CI"].present?
+  exit 1 unless cmd
 end


### PR DESCRIPTION
Github actions output appears not to be a tty so colour is disabled. Force-enable it if `CI` is set.