### PR TITLE
Do not show consultee or neighbour response in documents list

### DIFF
--- a/app/controllers/planning_applications/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/neighbour_responses_controller.rb
@@ -67,7 +67,7 @@ module PlanningApplications
 
     def create_files(response)
       neighbour_response_params[:files].compact_blank.each do |file|
-        @planning_application.documents.create!(file:, neighbour_response: response)
+        @planning_application.documents.create!(file:, owner: response)
       end
     end
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -29,8 +29,8 @@ class Document < ApplicationRecord
     belongs_to :api_user
     belongs_to :document_checklist_item
     belongs_to :evidence_group
-    belongs_to :neighbour_response
     belongs_to :owner, polymorphic: true
+    belongs_to :neighbour_response
     belongs_to :site_notice
     belongs_to :site_visit
     belongs_to :submission
@@ -221,7 +221,7 @@ class Document < ApplicationRecord
   TAGS = DRAWING_TAGS + EVIDENCE_TAGS + SUPPORTING_DOCUMENT_TAGS
 
   PERMITTED_CONTENT_TYPES = ["application/pdf", "image/png", "image/jpeg"].freeze
-  EXCLUDED_OWNERS = %w[PressNotice SiteNotice SiteVisit Appeal].freeze
+  EXCLUDED_OWNERS = %w[PressNotice SiteNotice SiteVisit Appeal Consultee::Response NeighbourResponse].freeze
 
   attr_accessor :replacement_file
 

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -6,7 +6,7 @@ class NeighbourResponse < ApplicationRecord
 
   validates_associated :neighbour
 
-  has_many :documents, dependent: :destroy
+  has_many :documents, as: :owner, dependent: :destroy
 
   attr_readonly :response
 

--- a/app/services/neighbour_response_creation_service.rb
+++ b/app/services/neighbour_response_creation_service.rb
@@ -41,7 +41,7 @@ class NeighbourResponseCreationService
 
   def create_files(response)
     params[:files].each do |file|
-      planning_application.documents.create!(file:, neighbour_response: response)
+      planning_application.documents.create!(file:, owner: response)
     end
   end
 

--- a/engines/bops_applicants/app/models/bops_applicants/neighbour_response_form.rb
+++ b/engines/bops_applicants/app/models/bops_applicants/neighbour_response_form.rb
@@ -125,7 +125,7 @@ module BopsApplicants
         end
 
         files.each do |file|
-          documents.create!(file: file, neighbour_response: response)
+          documents.create!(file: file, owner: response)
         end
       end
 

--- a/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/neighbour_responses_spec.rb
@@ -267,6 +267,9 @@ RSpec.describe "View neighbour responses", type: :system, js: true do
     expect(page).to have_content(neighbour.address.to_s)
     expect(page).to have_content("I think this proposal looks great")
     expect(page).to have_content("proposed-floorplan")
+
+    visit "/planning_applications/#{planning_application.reference}/documents"
+    expect(page).to_not have_content("proposed-floorplan.png")
   end
 
   it "shows error messages" do

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -353,6 +353,7 @@ RSpec.describe "Consultation", type: :system, js: true do
 
       choose "Approved"
       fill_in "Response", with: "We are happy for this application to proceed"
+      attach_file("Upload documents", "spec/fixtures/files/images/proposed-floorplan.png")
 
       click_button "Save response"
       expect(page).to have_text("Response was successfully uploaded.")
@@ -455,6 +456,9 @@ RSpec.describe "Consultation", type: :system, js: true do
         expect(page).to have_selector("li:last-child a", text: "View consultee responses")
         expect(page).to have_selector("li:last-child .govuk-tag", text: "In progress")
       end
+
+      visit "/planning_applications/#{planning_application.reference}/documents"
+      expect(page).to_not have_content("proposed-floorplan.png")
     end
   end
 end


### PR DESCRIPTION
### Description of change

Documents uploaded with neighbour and consultee responses are showing in the documents list

### Story Link

https://trello.com/c/pvozzZyV/965-documents-uploaded-with-neighbour-and-consultee-responses-are-showing-in-the-documents-list

