### PR TITLE
Backfill owner_type/owner_id for NeighbourResponse documents

### DIFF
--- a/db/migrate/20250903130400_backfill_document_owner_from_neighbour_response_id.rb
+++ b/db/migrate/20250903130400_backfill_document_owner_from_neighbour_response_id.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class BackfillDocumentOwnerFromNeighbourResponseId < ActiveRecord::Migration[7.2]
+  def change
+    up_only do
+      safety_assured do
+        execute <<~SQL
+          UPDATE documents
+            SET owner_type = 'NeighbourResponse',
+                owner_id   = neighbour_response_id
+          WHERE neighbour_response_id IS NOT NULL
+            AND owner_id IS NULL
+            AND owner_type IS NULL;
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_02_113317) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_03_130400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"


### PR DESCRIPTION
### Description of change

Populate Document.owner fields from neighbour_response_id so we can standardise on the polymorphic association and remove the legacy column in a follow-up migration.

