### PR TITLE
Able to save and complete after saving immunity review bug

### DIFF
--- a/app/controllers/planning_applications/assessment/assess_immunity_detail_permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/assessment/assess_immunity_detail_permitted_development_rights_controller.rb
@@ -37,7 +37,6 @@ module PlanningApplications
         @form = AssessImmunityDetailPermittedDevelopmentRightForm.new(
           planning_application: @planning_application
         )
-
         if @form.update(form_params)
           redirect_to planning_application_assessment_tasks_path(@planning_application), notice: t(".success")
         else

--- a/app/form_models/assess_immunity_detail_permitted_development_right_form.rb
+++ b/app/form_models/assess_immunity_detail_permitted_development_right_form.rb
@@ -104,7 +104,6 @@ class AssessImmunityDetailPermittedDevelopmentRightForm
 
   def update(attributes)
     assign_attributes(attributes)
-
     ActiveRecord::Base.transaction do
       valid? && update_review! && update_permitted_development_right!
     end

--- a/app/models/immunity_detail.rb
+++ b/app/models/immunity_detail.rb
@@ -52,7 +52,7 @@ class ImmunityDetail < ApplicationRecord
   private
 
   def should_create_review?
-    return if current_evidence_review_immunity_detail.nil?
+    return if current_evidence_review_immunity_detail.nil? || current_evidence_review_immunity_detail.in_progress?
     current_evidence_review_immunity_detail.status_changed? && current_evidence_review_immunity_detail_review.status_change == %w[to_be_reviewed complete]
   end
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -148,7 +148,7 @@ class Review < ApplicationRecord
     return if enforcement?
 
     last_evidence_review_immunity_detail = owner.current_evidence_review_immunity_detail
-    return unless last_evidence_review_immunity_detail
+    return if last_evidence_review_immunity_detail.nil? || last_evidence_review_immunity_detail.in_progress?
     return if last_evidence_review_immunity_detail.reviewed_at?
 
     raise NotCreatableError,
@@ -159,7 +159,7 @@ class Review < ApplicationRecord
     return if evidence?
 
     last_enforcement_review_immunity_detail = owner.current_enforcement_review_immunity_detail
-    return unless last_enforcement_review_immunity_detail
+    return if last_enforcement_review_immunity_detail.nil? || last_enforcement_review_immunity_detail.in_progress?
     return if last_enforcement_review_immunity_detail.reviewed_at?
 
     raise NotCreatableError,

--- a/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/evidence_of_immunity_spec.rb
@@ -131,6 +131,54 @@ RSpec.describe "Evidence of immunity", type: :system do
         expect(list_item("Check and assess")).to have_content("In progress")
       end
 
+      it "I can save and mark complete after saving to come back later" do
+        click_link "Check and assess"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Not started")
+
+        click_link "Evidence of immunity"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/immunity_details/new")
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
+
+        click_button "Utility bills (1)"
+
+        within(:open_accordion) do
+          within_fieldset("Runs until") do
+            fill_in "Day", with: "03"
+            fill_in "Month", with: "12"
+            fill_in "Year", with: "2021"
+          end
+
+          fill_in "Add comment", with: "This is my comment about utility bills"
+        end
+
+        click_button "Save and come back later"
+
+        expect(page).to have_current_path("/planning_applications/#{reference}/assessment/tasks")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "In progress")
+
+        click_link "Evidence of immunity"
+
+        expect(page).to have_current_path(%r{^/planning_applications/#{reference}/assessment/immunity_details/\d+/edit})
+        expect(page).to have_selector("h1", text: "Evidence of immunity")
+
+        click_button "Building control certificates (1)"
+
+        within(:open_accordion) do
+          within_fieldset("Starts from") do
+            expect(page).to have_field("Day", with: "10")
+            expect(page).to have_field("Month", with: "2")
+            expect(page).to have_field("Year", with: "2012")
+          end
+        end
+
+        click_button "Save and mark as complete"
+        expect(page).to have_content("Evidence of immunity successfully updated")
+        expect(page).to have_list_item_for("Evidence of immunity", with: "Completed")
+      end
+
       it "I can save and mark as complete the evidence of immunity" do
         click_link "Check and assess"
 


### PR DESCRIPTION
### Description of change

A bug was reported whereby marking immunity review as 'save and come back later' followed by reloading the page and 'save and mark as complete' would result in an error. This PR implements a fix for this bug.

### Story Link

https://trello.com/c/lbGoV1nz/1171-unable-to-save-evidence-of-immunity-from-save-return-state

### Decisions 

I have updated the status when it is sent back from the reviewer, but not for the second task "Assess Immunity", this needs to be reviewed as part of another ticket.


