### PR TITLE
Fix translation used in close case email form

### DIFF
--- a/engines/bops_enforcements/app/forms/bops_enforcements/tasks/close_case_form.rb
+++ b/engines/bops_enforcements/app/forms/bops_enforcements/tasks/close_case_form.rb
@@ -17,7 +17,7 @@ module BopsEnforcements
 
       def update(params)
         ActiveRecord::Base.transaction do
-          closed_reason = (params[:reason] == "other") ? params[:other_reason] : I18n.t(params[:reason])
+          closed_reason = (params[:reason] == "other") ? params[:other_reason] : I18n.t(params[:reason], scope: "bops_enforcements.tasks.close-case.show.reason")
           enforcement.update!(closed_reason:, closed_detail: params[:detail])
           enforcement.close!
           task.update!(status: "completed")


### PR DESCRIPTION
https://trello.com/c/mgegwKCQ/756-notify-complainant-via-email-when-case-closed-without-investigation