### PR TITLE
Fix hard line breaks in email templates

### DIFF
--- a/engines/bops_enforcements/config/locales/en.yml
+++ b/engines/bops_enforcements/config/locales/en.yml
@@ -13,19 +13,13 @@ en:
 
           Dear %{complainant_name},
 
-          Thank you for contacting the Planning Enforcement Team. This email is an update
-          about your report from %{report_date} regarding a possible breach of planning rules
-          at the above property.
+          Thank you for contacting the Planning Enforcement Team. This email is an update about your report from %{report_date} regarding a possible breach of planning rules at the above property.
 
-          Following a review, we found that **an existing enforcement case is already open for this
-          issue**.%{additional_comment}
+          Following a review, we found that **an existing enforcement case is already open for this issue**.%{additional_comment}
 
-          Because an existing case is already in progress, we will not be taking any further action
-          on your new report. The information you provided has been added to the existing case file.
+          Because an existing case is already in progress, we will not be taking any further action on your new report. The information you provided has been added to the existing case file.
 
-          Some extension or alteration can be undertaken to residential properties under permitted
-          development rights, without the need for planning permission. Should you have any queries
-          please contact me via email %{officer_email}
+          Some extension or alteration can be undertaken to residential properties under permitted development rights, without the need for planning permission. Should you have any queries please contact me via email %{officer_email}
 
           Yours
           %{council_name}
@@ -36,18 +30,13 @@ en:
 
           Dear %{complainant_name},
 
-          Thank you for contacting the Planning Enforcement Team. This email is an update
-          about your report from %{report_date} regarding a possible breach of planning rules
-          at the above property.
+          Thank you for contacting the Planning Enforcement Team. This email is an update about your report from %{report_date} regarding a possible breach of planning rules at the above property.
 
-          Following further investigation, the Council will not be taking any further action
-          regarding this issue and **this case will be closed**. This is for the following reasons:
+          Following further investigation, the Council will not be taking any further action regarding this issue and **this case will be closed**. This is for the following reasons:
 
           - %{reason}%{additional_comment}
 
-          Some extension or alteration can be undertaken to residential properties under permitted
-          development rights, without the need for planning permission. Should you have any queries
-          please contact me via email %{officer_email}
+          Some extension or alteration can be undertaken to residential properties under permitted development rights, without the need for planning permission. Should you have any queries please contact me via email %{officer_email}
 
           Yours
           %{council_name}


### PR DESCRIPTION
Apparently GDS has mucked up markdown.

https://trello.com/c/mgegwKCQ/756-notify-complainant-via-email-when-case-closed-without-investigation