### PR TITLE
Disable notify neighbours of committee meeting when application to b reviewed

### DIFF
--- a/app/components/status_tags/add_committee_decision_component.rb
+++ b/app/components/status_tags/add_committee_decision_component.rb
@@ -16,8 +16,10 @@ module StatusTags
     def status
       if (planning_application.awaiting_determination? || planning_application.to_be_reviewed?) && planning_application.committee_details_filled?
         :complete
-      else
+      elsif planning_application.in_committee?
         :not_started
+      else
+        :cannot_start_yet
       end
     end
   end

--- a/app/components/task_list_items/reviewing/notify_committee_component.rb
+++ b/app/components/task_list_items/reviewing/notify_committee_component.rb
@@ -11,10 +11,14 @@ module TaskListItems
 
       attr_reader :planning_application
 
-      delegate(:committee_decision, to: :planning_application)
+      delegate(:committee_decision, :to_be_reviewed?, to: :planning_application)
 
       def link_text
         t(".link_text")
+      end
+
+      def link_active?
+        !to_be_reviewed?
       end
 
       def link_path
@@ -32,6 +36,8 @@ module TaskListItems
       def status
         if planning_application.in_committee_at.present?
           :complete
+        elsif to_be_reviewed?
+          :cannot_start_yet
         else
           :not_started
         end

--- a/app/views/planning_applications/review/tasks/_committee.html.erb
+++ b/app/views/planning_applications/review/tasks/_committee.html.erb
@@ -10,7 +10,7 @@
               planning_application: @planning_application
             )
           ) %>
-      <li class="app-task-list__item">
+      <li class="app-task-list__item" id="update-decision-notice">
         <span class="app-task-list__task-name">
           <%= link_to_if(
                 @planning_application.in_committee?,

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -36,6 +36,28 @@ RSpec.describe "Send notification to neighbours of committee" do
     end
   end
 
+  context "when the application is to be reviewed" do
+    before do
+      planning_application.request_correction!
+      planning_application.committee_decision.update(recommend: true, reasons: ["The first reason"])
+      planning_application.committee_decision.current_review.update(review_status: "review_complete", action: "accepted")
+    end
+
+    it "does not show the option to send to committee" do
+      visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
+
+      expect(page).to have_content("Review and sign-off")
+
+      expect(page).not_to have_link "Notify neighbours of committee meeting"
+      within("#notify-neighbours-of-committee-meeting") do
+        expect(page).to have_content "Cannot start yet"
+      end
+      within("#update-decision-notice") do
+        expect(page).to have_content "Cannot start yet"
+      end
+    end
+  end
+
   context "when the assessor has recommended the application go to committee" do
     before do
       consultation = planning_application.consultation


### PR DESCRIPTION
### Description of change

Disable notify neighbours of committee meeting when application to b reviewed

### Story Link

https://trello.com/c/8fT9elbN/975-500-error-when-sending-committee-notifications-need-to-handled-blocked-progression-from-to-be-reviewed-to-committee-letter-sendi
