### PR TITLE
Add public API endpoint for redacted submission

### DIFF
--- a/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
+++ b/engines/bops_api/app/controllers/bops_api/v2/public/planning_applications_controller.rb
@@ -23,6 +23,15 @@ module BopsApi
           end
         end
 
+        def submission
+          @planning_application = find_planning_application params[:id]
+          @submission = Application::PublicSubmissionWhitelistingService.new(planning_application: @planning_application).call
+
+          respond_to do |format|
+            format.json
+          end
+        end
+
         private
 
         def pagination_params

--- a/engines/bops_api/app/services/bops_api/application/public_submission_whitelisting_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/public_submission_whitelisting_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module BopsApi
+  module Application
+    class PublicSubmissionWhitelistingService
+      class WhitelistingError < StandardError; end
+
+      def initialize(planning_application:)
+        @planning_application = planning_application
+      end
+
+      def call
+        return unless (submission = planning_application.params_v2.deep_symbolize_keys)
+
+        filter_submission(FILTER, submission)
+      rescue => e
+        raise WhitelistingError, e.message
+      end
+
+      FILTER = {
+        data: {
+          application: {
+            type: %i[value description]
+          },
+          applicant: {
+            name: %i[first last]
+          },
+          property: {
+            address: %i[singleline title street postcode town]
+          },
+          proposal: %i[description]
+        },
+        metadata: %i[id source]
+      }
+
+      private
+
+      attr_reader :planning_application
+
+      def filter_submission(filter, source, destination = nil)
+        if destination.nil?
+          destination = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
+        end
+
+        if filter.is_a?(Hash)
+          filter.each do |key, subfilter|
+            filter_submission(subfilter, source[key], destination[key]) if source.key?(key)
+          end
+        elsif filter.is_a?(Array)
+          filter.each do |key|
+            destination[key] = source[key] if source.key?(key)
+          end
+        else
+          raise ArgumentError, "Unexpected filter type: #{filter.inspect}"
+        end
+
+        destination
+      end
+    end
+  end
+end

--- a/engines/bops_api/app/views/bops_api/v2/public/planning_applications/submission.json.jbuilder
+++ b/engines/bops_api/app/views/bops_api/v2/public/planning_applications/submission.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.key_format! camelize: :lower
+
+json.partial! "bops_api/v2/shared/application", planning_application: @planning_application
+
+json.submission @submission

--- a/engines/bops_api/config/routes.rb
+++ b/engines/bops_api/config/routes.rb
@@ -43,6 +43,7 @@ BopsApi::Engine.routes.draw do
         resources :application_types, only: :index
         resources :planning_applications, only: [:show] do
           get :search, on: :collection
+          get :submission, on: :member
           resource :documents, only: [:show]
           get "comments/public", to: "neighbour_responses#index"
           get "comments/specialist", to: "consultee_responses#index"

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/whitelistApplicationSubmission.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/whitelistApplicationSubmission.json
@@ -1,0 +1,29 @@
+{
+  "application": {
+    "type": {
+      "value": "pp.full.householder",
+      "description": "Planning Permission - Full householder"
+    }
+  },
+  "applicant": {
+    "name": {
+      "first": "David",
+      "last": "Bowie"
+    }
+  },
+  "property": {
+    "address": {
+      "title": "40, STANSFIELD ROAD, LONDON",
+      "street": "STANSFIELD ROAD",
+      "postcode": "SW9 9RZ",
+      "town": "LONDON"
+    }
+  },
+  "proposal": {
+    "description": "Roof extension to the rear of the property, incorporating starship launchpad."
+  },
+  "metadata": {
+    "id": "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
+    "source": "PlanX"
+  }
+}

--- a/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
+++ b/engines/bops_api/spec/requests/v2/public/planning_applications_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe "BOPS public API" do
     )
   end
 
+  let(:submission) { create(:planx_planning_data, params_v2: example_fixture("application/planningPermission/fullHouseholder.json")) }
+  let(:planning_application_with_submission) { create(:planning_application, :planning_permission, :published, local_authority:, planx_planning_data: submission) }
+
   let(:page) { 1 }
   let(:resultsPerPage) { 5 }
   let(:invalidated) { create(:planning_application, :with_boundary_geojson_features, :published, local_authority:, application_type:, description: "This is not valid even if marked as published", status: :invalidated) }
@@ -272,6 +275,42 @@ RSpec.describe "BOPS public API" do
           press_notice_response = data["application"]["pressNotice"]
           expect(press_notice_response["required"]).to eq(press_notice.required)
           expect(press_notice_response["reason"]).to eq(press_notice.reason)
+        end
+      end
+    end
+  end
+
+  path "/api/v2/public/planning_applications/{reference}/submission" do
+    it "validates successfully against the example applicationSubmission json" do
+      resolved_schema = load_and_resolve_schema(name: "applicationSubmission", version: BopsApi::Schemas::DEFAULT_ODP_VERSION)
+
+      schemer = JSONSchemer.schema(resolved_schema)
+      example_json = example_fixture("applicationSubmission.json")
+      expect(schemer.valid?(example_json)).to eq(true)
+    end
+
+    get "Retrieves the planning application submission given a reference" do
+      tags "Planning applications"
+      produces "application/json"
+
+      parameter name: :reference, in: :path, schema: {
+        type: :string,
+        description: "The planning application reference"
+      }
+
+      response "200", "returns planning application submission when searching by the reference" do
+        example "application/json", :default, example_fixture("whitelistApplicationSubmission.json")
+        schema "$ref" => "#/components/schemas/ApplicationSubmission"
+
+        let(:reference) { planning_application_with_submission.reference }
+        let(:redacted_submission) { BopsApi::Application::PublicSubmissionWhitelistingService.new(planning_application: planning_application_with_submission).call }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data["application"]["reference"]).to eq(reference)
+          expect(redacted_submission.dig("data", "application")).not_to have_key("extra_field")
+          expect(redacted_submission.dig("data")).not_to have_key("fee")
+          expect(redacted_submission.dig("data", "applicant")).not_to have_key("email")
         end
       end
     end

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -36576,6 +36576,49 @@ paths:
                           metadata:
                             byteSize: 258315
                             contentType: image/png
+  "/api/v2/public/planning_applications/{reference}/submission":
+    get:
+      summary: Retrieves the planning application submission given a reference
+      tags:
+      - Planning applications
+      parameters:
+      - name: reference
+        in: path
+        schema:
+          type: string
+          description: The planning application reference
+        required: true
+      responses:
+        '200':
+          description: returns planning application submission when searching by the
+            reference
+          content:
+            application/json:
+              examples:
+                default:
+                  value:
+                    application:
+                      type:
+                        value: pp.full.householder
+                        description: Planning Permission - Full householder
+                    applicant:
+                      name:
+                        first: David
+                        last: Bowie
+                    property:
+                      address:
+                        title: 40, STANSFIELD ROAD, LONDON
+                        street: STANSFIELD ROAD
+                        postcode: SW9 9RZ
+                        town: LONDON
+                    proposal:
+                      description: Roof extension to the rear of the property, incorporating
+                        starship launchpad.
+                    metadata:
+                      id: 81bcaa0f-baf5-4573-ba0a-ea868c573faf
+                      source: PlanX
+              schema:
+                "$ref": "#/components/schemas/ApplicationSubmission"
   "/api/v2/validation_requests":
     get:
       summary: Retrieves a paginated list of notified validation requests for an LPA


### PR DESCRIPTION
### Description of change

Created a new public API endpoint for publishing application submissions. At present it only returns a few specified fields with the aim to add more once DPR have confirmed requirements.

### Story Link

https://trello.com/c/5poBwlC8/1196-create-a-public-api-endpoint-for-exposing-redacted-data-from-plan-x-submission-to-meet-requirements-for-application-form

### Screenshots

<img width="1141" height="656" alt="image" src="https://github.com/user-attachments/assets/a64fa576-4174-4d46-8816-62c141623604" />

### Decisions 

- Approach to whitelist as opposed to redact, only specific data has been included.

### Known issues

Things you know need further follow on work but aren't in scope of this issue

1. Document titles and categories may suggest sensitive data e.g. "Evidence for application fee exemption - disability: Disability Evidence Document_2025-05-06_104546.pdf".
