### PR TITLE
Redirect to review tasks if application is to be reviewed

### DIFF
--- a/app/controllers/planning_applications/review/notifications_controller.rb
+++ b/app/controllers/planning_applications/review/notifications_controller.rb
@@ -3,6 +3,7 @@
 module PlanningApplications
   module Review
     class NotificationsController < BaseController
+      before_action :redirect_to_review_tasks, if: :to_be_reviewed?
       before_action :set_committee_decision
 
       def new
@@ -82,6 +83,14 @@ module PlanningApplications
           user: Current.user,
           activity_type: "committee_details_sent"
         )
+      end
+
+      def redirect_to_review_tasks
+        redirect_to planning_application_review_tasks_path(@planning_application)
+      end
+
+      def to_be_reviewed?
+        @planning_application.to_be_reviewed?
       end
     end
   end

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe "Send notification to neighbours of committee" do
       within("#update-decision-notice") do
         expect(page).to have_content "Cannot start yet"
       end
+
+      visit "/planning_applications/#{planning_application.reference}/review/committee_decisions/#{planning_application.committee_decision.id}/notifications/edit"
+      expect(page).to have_current_path "/planning_applications/#{planning_application.reference}/review/tasks"
     end
   end
 


### PR DESCRIPTION
### Story Link

https://trello.com/c/8fT9elbN/975-500-error-when-sending-committee-notifications-need-to-handled-blocked-progression-from-to-be-reviewed-to-committee-letter-sendi


