### PR TITLE
Store a schema for submissions and set it based on the request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,9 @@ locales:
 	$(DOCKER-RUN) console i18n-tasks normalize
 
 api-docs:
-	$(DOCKER-RUN) console rake api:docs:generate
+	$(DOCKER-RUN) console rake api:docs:generate submission_api:docs:generate
 
-submission-api-docs:
-	$(DOCKER-RUN) console rake submission_api:docs:generate
+submission-api-docs: api-docs
 
 submission-api-specs: submissions-specs
 	@: # noop: for backwards compatibility with a name that didn't fit the pattern

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -51,7 +51,7 @@ class Submission < ApplicationRecord
   end
 
   def source
-    @source ||= request_body.dig("metadata", "source") || "Planning Portal"
+    @source ||= odp? ? request_body.dig("metadata", "source") : "Planning Portal"
   end
 
   def request_body
@@ -59,10 +59,10 @@ class Submission < ApplicationRecord
   end
 
   def planning_portal?
-    source == "Planning Portal"
+    schema == "planning-portal"
   end
 
-  def planx?
-    source == "PlanX"
+  def odp?
+    schema == "odp"
   end
 end

--- a/db/migrate/20250909153407_add_schema_to_submission.rb
+++ b/db/migrate/20250909153407_add_schema_to_submission.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddSchemaToSubmission < ActiveRecord::Migration[7.2]
+  class Submission < ActiveRecord::Base; end
+
+  def change
+    add_column :submissions, :schema, :string
+
+    up_only do
+      Submission.where(schema: [nil, ""]).find_each do |submission|
+        submission.update(schema: submission.request_body.dig("metadata", "source").present? ? "odp" : "planning-portal")
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_03_140340) do
+ActiveRecord::Schema[7.2].define(version: 2025_09_09_153407) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -1184,6 +1184,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_03_140340) do
     t.string "external_uuid"
     t.string "error_message"
     t.jsonb "application_payload", default: {}, null: false
+    t.string "schema"
     t.index ["external_uuid"], name: "ix_submissions_on_external_uuid", unique: true
     t.index ["local_authority_id"], name: "ix_submissions_on_local_authority_id"
     t.index ["status"], name: "ix_submissions_on_status"

--- a/engines/bops_admin/spec/system/submissions_spec.rb
+++ b/engines/bops_admin/spec/system/submissions_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe "Submissions", type: :system do
   before { sign_in(admin) }
 
   it "shows paginated submissions and allows viewing details" do
-    create_list(:submission, 4, local_authority:)
-    create_list(:submission, 4, :failed, local_authority:)
-    create_list(:submission, 4, :completed, local_authority:)
+    create_list(:submission, 4, :planning_portal, local_authority:)
+    create_list(:submission, 4, :planning_portal, :failed, local_authority:)
+    create_list(:submission, 4, :planning_portal, :completed, local_authority:)
     submissions = local_authority.submissions.by_created_at_desc
     visit "/admin/submissions"
 
@@ -55,6 +55,7 @@ RSpec.describe "Submissions", type: :system do
     let(:submission) do
       create(
         :submission,
+        :planning_portal,
         request_body: {
           "applicationRef" => "PT-10087984",
           "documentLinks" => [
@@ -175,6 +176,7 @@ RSpec.describe "Submissions", type: :system do
     let(:submission) do
       create(
         :submission,
+        :planning_portal,
         request_body: {
           "applicationRef" => "PT-10087984",
           "documentLinks" => [

--- a/engines/bops_enforcements/spec/system/check_details/check_report_details_spec.rb
+++ b/engines/bops_enforcements/spec/system/check_details/check_report_details_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Check report details", type: :system, capybara: true do
   let!(:submission) do
     create(
       :submission,
+      :planning_portal,
       local_authority: local_authority,
       request_body: json_fixture_api("examples/odp/v0.7.5/enforcement/breach.json")
     )

--- a/engines/bops_enforcements/spec/system/close_spec.rb
+++ b/engines/bops_enforcements/spec/system/close_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Enforcement close page", type: :system do
   let!(:submission) do
     create(
       :submission,
+      :planning_portal,
       local_authority: local_authority,
       request_body: json_fixture_api("examples/odp/v0.7.5/enforcement/breach.json")
     )

--- a/engines/bops_enforcements/spec/system/show_spec.rb
+++ b/engines/bops_enforcements/spec/system/show_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Enforcement show page", type: :system do
   let!(:submission) do
     create(
       :submission,
+      :planning_portal,
       local_authority: local_authority,
       request_body: json_fixture_api("examples/odp/v0.7.5/enforcement/breach.json")
     )

--- a/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
+++ b/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
@@ -11,7 +11,7 @@ module BopsSubmissions
       if submission.planning_portal?
         ZipExtractionService.new(submission:).call
         Application::PlanningPortalCreationService.new(submission:).call!
-      elsif submission.planx?
+      elsif submission.odp?
         if submission.request_body.dig(:data, :application, :type, :value) == "breach"
           Enforcement::CreationService.new(submission:, user: current_api_user).call!
         else
@@ -25,6 +25,8 @@ module BopsSubmissions
             email_sending_permitted: send_email
           ).call!
         end
+      else
+        raise "Unknown schema: #{submission.schema}"
       end
 
       submission.complete!

--- a/engines/bops_submissions/app/services/bops_submissions/creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/creation_service.rb
@@ -13,18 +13,20 @@ module BopsSubmissions
       Referer
     ].freeze
 
-    def initialize(params:, headers:, local_authority:)
+    def initialize(params:, headers:, local_authority:, schema: nil)
       @params = params
       @headers = headers
       @local_authority = local_authority
+      @schema = schema
     end
 
-    attr_reader :params, :headers, :local_authority
+    attr_reader :params, :headers, :local_authority, :schema
 
     def call
       submission = local_authority.submissions.create!(
         request_headers: filtered_request_headers,
-        request_body: params
+        request_body: params,
+        schema:
       )
 
       submission.update!(external_uuid: SecureRandom.uuid_v7)

--- a/engines/bops_submissions/spec/controllers/v2/submissions_controller_spec.rb
+++ b/engines/bops_submissions/spec/controllers/v2/submissions_controller_spec.rb
@@ -59,16 +59,12 @@ RSpec.describe BopsSubmissions::V2::SubmissionsController, type: :controller do
   end
 
   context "when submitting a planning application from planning portal" do
-    let(:creation_service) { instance_double(BopsSubmissions::Application::PlanningPortalCreationService) }
     let(:planning_application) { instance_double(PlanningApplication) }
     let(:json_data) { json_fixture_submissions("planning_portal.json") }
 
     before do
       expect(BopsApi::Application::CreationService).not_to receive(:new)
-      expect(BopsSubmissions::Application::PlanningPortalCreationService).to receive(:new).and_return(creation_service)
       expect(BopsSubmissions::Enforcement::CreationService).not_to receive(:new)
-
-      expect(creation_service).to receive(:call!).and_return(planning_application)
 
       stub_request(:get, json_data["documentLinks"].first["documentLink"])
         .to_return(
@@ -78,13 +74,39 @@ RSpec.describe BopsSubmissions::V2::SubmissionsController, type: :controller do
         )
     end
 
-    it "planning_portal.json can be submitted" do
-      post :create, as: :json, body: json_data.to_json
+    context "with a valid schema parameter" do
+      let(:body) { json_data.merge(schema: "planning-portal") }
+      let(:creation_service) { instance_double(BopsSubmissions::Application::PlanningPortalCreationService) }
 
-      perform_enqueued_jobs
+      before do
+        expect(BopsSubmissions::Application::PlanningPortalCreationService).to receive(:new).and_return(creation_service)
+        expect(creation_service).to receive(:call!).and_return(planning_application)
+      end
 
-      expect(response).to have_http_status(:ok)
-      expect(response).to render_template("bops_submissions/v2/submissions/create")
+      it "planning_portal.json can be submitted" do
+        post :create, as: :json, body: body.to_json
+
+        perform_enqueued_jobs
+
+        expect(response).to have_http_status(:ok)
+        expect(response).to render_template("bops_submissions/v2/submissions/create")
+      end
+    end
+
+    context "without the correct schema parameter" do
+      before do
+        expect(BopsSubmissions::Application::PlanningPortalCreationService).not_to receive(:new)
+      end
+
+      it "planning_portal.json fails without schema parameter" do
+        post :create, as: :json, body: json_data.to_json
+
+        expect {
+          perform_enqueued_jobs
+        }.not_to change(Submission, :count)
+
+        expect(response).to have_http_status(:internal_server_error)
+      end
     end
   end
 

--- a/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
+++ b/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
-  let!(:submission) { create(:submission, status: "submitted") }
+  let!(:submission) { create(:submission, :planning_portal, status: "submitted") }
 
   before do
     allow(Submission)

--- a/engines/bops_submissions/spec/services/application/planning_portal_creation_service_spec.rb
+++ b/engines/bops_submissions/spec/services/application/planning_portal_creation_service_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority: local_authority,
           json_file: json_fixture_submissions("files/applications/PT-10087984.json")
         )
@@ -74,6 +75,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority:,
           json_file: fixture
         )
@@ -93,6 +95,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority:,
           json_file: nil
         )
@@ -108,6 +111,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority:,
           json_file: {}
         )
@@ -123,6 +127,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority:,
           json_file: {"foo" => "bar"}
         )
@@ -137,6 +142,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
       let(:submission) do
         create(
           :submission,
+          :planning_portal,
           local_authority:,
           json_file: {"applicationData" => {}}
         )

--- a/engines/bops_submissions/swagger/v2/submissions/swagger_doc.yaml
+++ b/engines/bops_submissions/swagger/v2/submissions/swagger_doc.yaml
@@ -142,7 +142,15 @@ paths:
       - Submissions
       security:
       - bearerAuth: []
-      parameters: []
+      parameters:
+      - name: schema
+        in: query
+        enum:
+        - odp
+        - planning-portal
+        required: false
+        default: odp
+        description: ":\n * `odp` \n * `planning-portal` \n "
       responses:
         '200':
           description: submission accepted

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -4,24 +4,31 @@ FactoryBot.define do
   factory :submission do
     association :local_authority
     request_headers { {"Content-Type" => "application/json"} }
-    request_body {
-      {
-        applicationRef: "10027719",
-        applicationVersion: 1,
-        applicationState: "Submitted",
-        sentDateTime: "2023-06-19T08:45:59.9722472Z",
-        documentLinks: [
-          {
-            documentName: "PT-10027719.zip",
-            documentLink: "https://example.com/PT-10027719.zip",
-            expiryDateTime: "2023-07-19T08:45:59.975412Z",
-            documentType: "application/x-zip-compressed"
-          }
-        ],
-        updated: false
-      }
-    }
+    request_body { {metadata: {source: "dummy"}} }
+
     external_uuid { SecureRandom.uuid_v7 }
+    schema { "odp" }
+
+    trait :planning_portal do
+      request_body {
+        {
+          applicationRef: "10027719",
+          applicationVersion: 1,
+          applicationState: "Submitted",
+          sentDateTime: "2023-06-19T08:45:59.9722472Z",
+          documentLinks: [
+            {
+              documentName: "PT-10027719.zip",
+              documentLink: "https://example.com/PT-10027719.zip",
+              expiryDateTime: "2023-07-19T08:45:59.975412Z",
+              documentType: "application/x-zip-compressed"
+            }
+          ],
+          updated: false
+        }
+      }
+      schema { "planning-portal" }
+    end
 
     trait :enforcement do
       # TODO this should ideally use json_fixture_api, but that helper isn't visible from inside a factory

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Submission do
 
   describe "associations" do
     let(:local_authority) { create(:local_authority) }
-    let(:submission) { create(:submission, local_authority:) }
+    let(:submission) { create(:submission, :planning_portal, local_authority:) }
     let(:case_record) { build(:case_record, local_authority:, submission:) }
     let!(:planning_application) { create(:planning_application, case_record:) }
 
@@ -57,47 +57,48 @@ RSpec.describe Submission do
 
   describe "scopes" do
     it "orders by created_at desc" do
-      older = create(:submission, created_at: 1.day.ago)
-      newer = create(:submission, created_at: 1.hour.ago)
+      older = create(:submission, :planning_portal, created_at: 1.day.ago)
+      newer = create(:submission, :planning_portal, created_at: 1.hour.ago)
       expect(Submission.by_created_at_desc.to_a).to eq([newer, older])
     end
   end
 
   describe "instance methods" do
-    let(:submission) do
-      build(
-        :submission,
-        request_body: {
+    let(:submission) { build(:submission, :planning_portal, request_body:) }
+
+    context "when submitted from planning portal" do
+      let(:request_body) {
+        {
           "applicationRef" => "ABC123",
           "documentLinks" => [
             {"documentLink" => "http://foo"},
             {"documentLink" => "http://bar"}
           ]
         }
-      )
-    end
+      }
 
-    describe "#application_reference" do
-      it "reads applicationRef from the body" do
-        expect(submission.application_reference).to eq("ABC123")
+      describe "#application_reference" do
+        it "reads applicationRef from the body" do
+          expect(submission.application_reference).to eq("ABC123")
+        end
       end
-    end
 
-    describe "#document_link_urls" do
-      it "plucks documentLink entries" do
-        expect(submission.document_link_urls).to contain_exactly("http://foo", "http://bar")
+      describe "#document_link_urls" do
+        it "plucks documentLink entries" do
+          expect(submission.document_link_urls).to contain_exactly("http://foo", "http://bar")
+        end
       end
-    end
 
-    describe "#source" do
-      it "currently always returns Planning Portal" do
-        expect(submission.source).to eq("Planning Portal")
+      describe "#source" do
+        it "is set to Planning Portal when initialising" do
+          expect(submission.source).to eq("Planning Portal")
+        end
       end
     end
   end
 
   describe "state transitions" do
-    let(:submission) { create(:submission) }
+    let(:submission) { create(:submission, :planning_portal) }
 
     around do |example|
       freeze_time { example.run }


### PR DESCRIPTION
### Description of change

Rather than inferring the schema on-demand and defaulting to planning portal, add a `schema` column to submissions. Requests from planning portal must set `schema=planning-portal` in the parameters. Will default to ODP schema.

This is distinct from `source`, which is more specific (e.g., `schema: 'odp'` and `source: 'PlanX'`), because in principle ODP submissions could come from other sources (including, in future, maybe Planning Portal too?).

### Story Link

https://trello.com/c/p3zQECqx/1173-infer-type-of-submission-via-api-key