### PR TITLE
Remove second back button from requirements

### DIFF
--- a/app/views/planning_applications/assessment/requirements/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/requirements/_tabs.html.erb
@@ -51,8 +51,8 @@
           <%= form.govuk_submit("Add requirements", class: "govuk-button--secondary") %>
         <% else %>
           <%= form.govuk_submit("Add requirements") %>
+          <%= govuk_button_link_to t("back"), planning_application_assessment_requirements_path, secondary: true %>
         <% end %>
-        <%= govuk_button_link_to t("back"), planning_application_assessment_requirements_path, secondary: true %>
       </div>
     <% end %>
     </div>


### PR DESCRIPTION
### Description of change

Remove second back button from check and add requirements page.

### Story Link

https://trello.com/c/czeRvpay/1206-there-are-2-back-button-in-the-check-and-add-requirements-task

### Screenshots

<img width="899" height="508" alt="image" src="https://github.com/user-attachments/assets/d61c131b-a1bf-4c05-a554-ef9b1377bb25" />
