### PR TITLE
Disable reviewer from access report when not validated

### DIFF
--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-9 application-step-heading">Review</h2>
 <%= govuk_task_list(id_prefix: "review-section", html_attributes: {id: "review-section"}) do |task_list| %>
   <% if @planning_application.pre_application? %>
-    <% if current_user.reviewer? %>
+    <% if current_user.reviewer? && @planning_application.validated? %>
       <% task_list.with_item(
            title: "Review and sign-off",
            href: bops_reports.planning_application_path(@planning_application),

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -496,19 +496,22 @@
   <h2 class="govuk-heading-m"><%= t(".next_steps_heading") %></h2>
 
   <% if @current_local_authority.submission_url && @current_local_authority.submission_guidance_url %>
-    <p>
-      <%= t(".next_steps_intro_html") %>
-    </p>
+    <% if @planning_application.recommended_application_type %>
+      <p>
+        <%= t(".next_steps_intro_html") %>
+      </p>
 
-    <%= t(".next_steps_list_html") %>
-
-    <p>
-      <%= t(
-            ".next_steps_outro_html",
-            planning_service_link: @current_local_authority.submission_url,
-            application_type: @planning_application.recommended_application_type.human_name
-          ) %>
-    </p>
+      <%= t(".next_steps_list_html") %>
+      <p>
+        <%= t(
+              ".next_steps_outro_html",
+              planning_service_link: @current_local_authority.submission_url,
+              application_type: @planning_application.recommended_application_type.human_name
+            ) %>
+      </p>
+    <% else %>
+      <p>Next steps cannot be displayed until a recommended application type has been set.</p>
+    <% end %>
   <% elsif editing_enabled? %>
     <p>
       You must set the application submission url in local authority settings before displaying next steps to the applicant.

--- a/spec/system/planning_applications/preapplications_spec.rb
+++ b/spec/system/planning_applications/preapplications_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "assigning planning application" do
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }
+  let(:reviewer) { create(:user, :reviewer, local_authority:) }
 
   context "when application is a preapp" do
     let(:planning_application) { create(:planning_application, :pre_application, local_authority:) }
@@ -26,6 +27,54 @@ RSpec.describe "assigning planning application" do
       check "Site visit"
       click_button "Save"
       expect(page).to have_content("Requested services: Site visit Change")
+    end
+  end
+
+  context "when pre-app is not started" do
+    let(:planning_application) { create(:planning_application, :pre_application, status: :not_started, local_authority:) }
+
+    it "correctly displays index task list to an assessor" do
+      sign_in(assessor)
+      visit "/planning_applications/#{planning_application.reference}/"
+
+      within("#validation-section") do
+        expect(page).to have_selector("li:first-child a", text: "Check and validate")
+        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+      end
+
+      within("#consultation-section") do
+        expect(page).to have_selector("li:first-child a", text: "Consultees")
+        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+      end
+
+      within("#assess-section") do
+        expect(page).to have_selector("li:first-child", text: "Check and assess")
+        expect(page).to have_selector("li:first-child", text: "Cannot start yet")
+      end
+
+      within("#review-section") do
+        expect(page).to have_selector("li:first-child", text: "View recommendation")
+        expect(page).to have_selector("li:first-child", text: "Cannot start yet")
+      end
+    end
+  end
+
+  context "when pre-app is in assessment", :capybara do
+    let(:planning_application) { create(:planning_application, :pre_application, local_authority:) }
+
+    it "correctly displays index task list to an reviewer" do
+      sign_in(reviewer)
+      visit "/planning_applications/#{planning_application.reference}/"
+
+      within("#validation-section") do
+        expect(page).to have_selector("li:first-child a", text: "Check and validate")
+        expect(page).to have_selector("li:first-child .govuk-tag", text: "Completed")
+      end
+
+      within("#review-section") do
+        expect(page).to have_selector("li:first-child a", text: "Review and sign-off")
+        expect(page).not_to have_selector("li:first-child", text: "Cannot start yet")
+      end
     end
   end
 


### PR DESCRIPTION
### Description of change

Disable review and sign off link for reviewers unless planning application is validated. Added some empty state logic for when no recommended application type has been set.

### Story Link

https://trello.com/c/myxATVFk/1160-pre-apps-have-review-and-sign-off-enabled-when-it-is-not-allowed-leading-to-an-error


