### PR TITLE
Prevent unvalidated applications from being published

### DIFF
--- a/app/components/status_tags/publish_determination_component.rb
+++ b/app/components/status_tags/publish_determination_component.rb
@@ -15,7 +15,7 @@ module StatusTags
     def status
       if planning_application.publish_complete?
         :complete
-      elsif planning_application.can_publish? && user.assessor?
+      elsif planning_application.ready_to_publish? && user.assessor?
         :waiting
       end
     end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -301,7 +301,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def ensure_planning_application_is_publishable
-    return if @planning_application.validated? && @planning_application.publishable?
+    return if @planning_application.can_publish?
 
     redirect_to planning_application_assessment_tasks_path(@planning_application),
       alert: t(".not_publishable", application_type: @planning_application.application_type.description)

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -301,7 +301,7 @@ class PlanningApplicationsController < AuthenticationController
   end
 
   def ensure_planning_application_is_publishable
-    return if @planning_application.publishable?
+    return if @planning_application.validated? && @planning_application.publishable?
 
     redirect_to planning_application_assessment_tasks_path(@planning_application),
       alert: t(".not_publishable", application_type: @planning_application.application_type.description)

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -193,7 +193,7 @@ class PlanningApplication < ApplicationRecord
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create
-  before_validation :reset_published_at, unless: :publishable?
+  before_validation :reset_published_at, unless: :can_publish?
   before_save :set_lat_and_long
   before_create :set_received_at
   before_create :set_key_dates
@@ -406,6 +406,10 @@ class PlanningApplication < ApplicationRecord
   end
 
   def can_publish?
+    publishable? && validated?
+  end
+
+  def ready_to_publish?
     awaiting_determination? && !pending_review?
   end
 

--- a/app/views/documents/_document_row_info.html.erb
+++ b/app/views/documents/_document_row_info.html.erb
@@ -20,7 +20,7 @@
       Drawing number: <strong><%= document.numbers %></strong>
     </p>
   <% end %>
-  <% if document.planning_application.publishable? && document.planning_application.validated? %>
+  <% if document.planning_application.can_publish? %>
     <p class="govuk-!-margin-bottom-1">
       Included in decision notice: <strong><%= document.referenced_in_decision_notice? ? "Yes" : "No" %></strong>
     </p>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -47,7 +47,7 @@
 
     <% task_list.with_item(
          title: "Publish determination",
-         href: (@planning_application.can_publish? || @planning_application.publish_complete?) && current_user.reviewer? && publish_planning_application_path(@planning_application),
+         href: (@planning_application.ready_to_publish? || @planning_application.publish_complete?) && current_user.reviewer? && publish_planning_application_path(@planning_application),
          html_attributes: {aria: {describedby: "publish_completed"}}
        ) do |item| %>
       <% item.with_status(text: render(StatusTags::PublishDeterminationComponent.new(planning_application: @planning_application, user: current_user))) %>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -36,7 +36,7 @@
       </p>
     <% end %>
 
-    <% if @planning_application.validated? && @planning_application.publishable? %>
+    <% if @planning_application.can_publish? %>
       <p>
         Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
       </p>

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -36,7 +36,7 @@
       </p>
     <% end %>
 
-    <% if @planning_application.publishable? %>
+    <% if @planning_application.validated? && @planning_application.publishable? %>
       <p>
         Public on BOPS Public Portal: <strong><%= @planning_application.make_public? ? "Yes" : "No" %></strong><span class="assignment_cta"><%= govuk_link_to "Change", make_public_planning_application_path(@planning_application) %></span>
       </p>


### PR DESCRIPTION
### Description of change

We had a mixup between the application type feature `publishable?` and the status of a particular application being publishable. So in a couple of places we were checking that the application type permitted publication, and rejecting if not; but this then allowed applications that hadn't been validated, but whose type permitted publication, to be made public.

### Story Link

https://trello.com/c/vOQfM9PO/1267-application-which-is-not-valid-has-been-published-this-should-be-prevented
