### PR TITLE
Setup task workflow for pre-apps

### DIFF
--- a/app/models/case_record.rb
+++ b/app/models/case_record.rb
@@ -39,10 +39,10 @@ class CaseRecord < ApplicationRecord
   end
 
   def load_tasks!
-    return if tasks.exists? || planning_application?
+    return if tasks.exists?
+    return if planning_application? && !planning_application.pre_application?
 
-    key = caseable_type.underscore
-    TaskLoader.new(self, key).load!
+    TaskLoader.new(self, caseable.task_workflow).load!
   rescue => e
     errors.add(:base, "Couldn’t create case record tasks workflow: #{e.message}")
     throw(:abort)

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -85,6 +85,10 @@ class Enforcement < ApplicationRecord
     @complainant ||= Complainant.new(submission.request_body&.dig("data", "complainant"))
   end
 
+  def task_workflow
+    model_name.singular
+  end
+
   private
 
   def factory

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1051,6 +1051,10 @@ class PlanningApplication < ApplicationRecord
     pre_application? ? "pre-application" : "application"
   end
 
+  def task_workflow
+    application_type_name
+  end
+
   private
 
   def create_fee_calculation

--- a/config/task_workflows/pre_application.yml
+++ b/config/task_workflows/pre_application.yml
@@ -1,0 +1,8 @@
+- name: "Check and validate"
+  section: "Validation"
+- name: "Consultees"
+  section: "Consultation"
+- name: "Check and assess"
+  section: "Assessment"
+- name: "View recommendation"
+  section: "Review"

--- a/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
@@ -38,7 +38,11 @@ module BopsCore
     private
 
     def set_case_record
-      @case_record = @current_local_authority.case_records.find(params[:case_id])
+      @case_record = if params[:reference]
+        PlanningApplication.find_by(reference: params[:reference]).case_record
+      else
+        @current_local_authority.case_records.find(params[:case_id])
+      end
     end
 
     def find_task

--- a/engines/bops_preapps/app/controllers/bops_preapps/pre_applications_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/pre_applications_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module BopsPreapps
+  class PreApplicationsController < ApplicationController
+    before_action :set_planning_application, only: %i[show]
+    before_action :set_case_record, only: %i[show]
+    before_action :set_grouped_tasks, only: %i[show]
+
+    def show
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    private
+
+    def set_planning_application
+      @planning_application = PlanningApplication.find_by(reference: params[:id])
+    end
+
+    def set_case_record
+      @case_record = @planning_application.case_record
+    end
+
+    def set_grouped_tasks
+      @grouped_tasks = @case_record.tasks.group_by(&:section)
+    end
+  end
+end

--- a/engines/bops_preapps/app/controllers/bops_preapps/tasks_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/tasks_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module BopsPreapps
+  class TasksController < ApplicationController
+    include BopsCore::TasksController
+
+    before_action :set_planning_application, only: %i[show]
+    before_action :build_form, only: %i[edit update]
+    # before_action :ensure_case_is_not_closed, only: %i[show edit update]
+
+    private
+
+    def set_planning_application
+      @planning_application = @case_record.caseable
+    end
+
+    def template_for(action)
+      path = "bops_preapps/tasks/#{@task.full_slug}/#{action}"
+      lookup_context.exists?(path) ? path : "bops_preapps/tasks/generic/#{action}"
+    end
+
+    def build_form
+      klass = BopsPreapps::Tasks.form_for(@task.slug)
+
+      @form = klass.new(@task)
+    end
+  end
+end

--- a/engines/bops_preapps/app/forms/bops_preapps/tasks.rb
+++ b/engines/bops_preapps/app/forms/bops_preapps/tasks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module BopsPreapps
+  module Tasks
+    class << self
+      def form_for(slug)
+        form_name = "#{slug.underscore}_form".camelcase
+        begin
+          "BopsPreapps::Tasks::#{form_name}".constantize
+        rescue
+          BaseForm
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_preapps/app/forms/bops_preapps/tasks/base_form.rb
+++ b/engines/bops_preapps/app/forms/bops_preapps/tasks/base_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BopsPreapps
+  module Tasks
+    class BaseForm
+      include ActiveModel::Model
+      include BopsPreapps::Engine.routes.url_helpers
+
+      attr_reader :task, :case_record
+      delegate :parent, to: :task
+
+      def initialize(task)
+        @task = task
+        @case_record = @task.case_record
+        @planning_application = @task.case_record.planning_application
+      end
+
+      def update(params)
+        task.update(permitted_fields(params))
+      end
+
+      def permitted_fields(params)
+        params.require(:task).permit(:status, :started_at, :completed_at)
+      end
+
+      def redirect_url
+        enforcement_path(@case_record)
+      end
+    end
+  end
+end

--- a/engines/bops_preapps/app/views/bops_preapps/pre_applications/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/pre_applications/show.html.erb
@@ -1,0 +1,16 @@
+<h1 class="govuk-heading-l">Application</h1>
+
+<div id="pre-application-tasks">
+  <% @grouped_tasks.each do |section, tasks| %>
+    <h2 class="govuk-heading-m govuk-!-margin-top-9 application-step-heading"><%= section %></h2>
+    <%= govuk_task_list(id_prefix: "#{section}-section", html_attributes: {id: "#{section}-section"}) do |task_list| %>
+      <% tasks.each do |task| %>
+        <% task_list.with_item(
+             title: task.name,
+             href: task_path(@planning_application, task),
+             status: task_status_tag(task)
+           ) %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Check and Validate</h1>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/generic/edit.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/generic/edit.html.erb
@@ -1,0 +1,15 @@
+<%= govuk_task_list(id_prefix: "#") do |task_list| %>
+  <% @task.tasks.each do |task| %>
+    <%= task_list.with_item(
+          title: task.name,
+          href: edit_task_path(@planning_application, task),
+          status: task_status_tag(task)
+        ) %>
+  <% end %>
+<% end %>
+
+<% if @task.top_level? %>
+  <%= govuk_button_link_to "Back", pre_application_path(@planning_application), secondary: true %>
+<% else %>
+  <%= govuk_button_link_to "Back", task_path(@case_record, @task.parent), secondary: true %>
+<% end %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/generic/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/generic/show.html.erb
@@ -1,0 +1,15 @@
+<%= govuk_task_list(id_prefix: "#") do |task_list| %>
+  <% @task.tasks.each do |task| %>
+    <%= task_list.with_item(
+          title: task.name,
+          href: edit_task_path(@planning_application, task),
+          status: task_status_tag(task)
+        ) %>
+  <% end %>
+<% end %>
+
+<% if @task.top_level? %>
+  <%= govuk_button_link_to "Back", pre_application_path(@planning_application), secondary: true %>
+<% else %>
+  <%= govuk_button_link_to "Back", task_path(@case_record, @task.parent), secondary: true %>
+<% end %>

--- a/engines/bops_preapps/config/routes.rb
+++ b/engines/bops_preapps/config/routes.rb
@@ -4,4 +4,15 @@ BopsPreapps::Engine.routes.draw do
   root to: redirect("dashboard")
 
   resource :dashboard, only: %i[show]
+  resources :pre_applications, only: %(show), path: "/cases"
+
+  scope "/cases/:reference" do
+    resources :assign_users, only: %i[index] do
+      patch :update, on: :collection
+    end
+
+    get "/*slug/edit", to: "tasks#edit", as: :edit_task
+    patch "/*slug", to: "tasks#update"
+    get "/*slug", to: "tasks#show", as: :task
+  end
 end

--- a/engines/bops_preapps/spec/system/show_spec.rb
+++ b/engines/bops_preapps/spec/system/show_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Show page", type: :system do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:planning_application) { create(:planning_application, :pre_application, local_authority: local_authority) }
+
+  before do
+    visit "/preapps/cases/#{planning_application.reference}"
+  end
+
+  it "I can view the show page" do
+    expect(page).to have_current_path("/preapps/cases/#{planning_application.reference}")
+    expect(page).to have_content("Application")
+  end
+
+  it "Shows the top level tasks" do
+    expect(page).to have_link("Check and validate")
+    expect(page).to have_link("Consultees")
+    expect(page).to have_link("Check and assess")
+  end
+end


### PR DESCRIPTION
### Description of change

Add task setup for pre-apps, including base forms, generic views and yml file.

### Story Link

https://trello.com/c/NIPm7GVa/1221-set-up-pre-apps-to-use-task-model-framework

### Screenshots

<img width="878" height="641" alt="image" src="https://github.com/user-attachments/assets/a2723007-9105-4b05-a204-b6a3e7b4fbd6" />

### Decisions

- At present the top level tasks have been added only to test the functionality and views.
- The proposed url is `/preapps/cases/reference/` this means we have had to handle the case record allocation slightly different to Enforcements where the UUID is being used in the routes
- Simple tests have been added to check the tasks are being created
- Further PRs will be needed to migrate each of the individual pre-app sections