### PR TITLE
Prevent publication of closed/withdrawn/returned applications

### DIFF
--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -165,10 +165,6 @@ module PlanningApplicationStatus
       true unless closed_or_cancelled?
     end
 
-    def validated?
-      true unless not_started? || invalidated?
-    end
-
     def can_validate?
       true unless awaiting_determination? || closed_or_cancelled?
     end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -405,6 +405,10 @@ class PlanningApplication < ApplicationRecord
     (awaiting_determination? && !pending_review?) || determined?
   end
 
+  def validated?
+    validated_at.present? && invalidated_at.blank?
+  end
+
   def can_publish?
     publishable? && validated?
   end

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -193,7 +193,7 @@ class PlanningApplication < ApplicationRecord
 
   before_validation :set_application_number, on: :create
   before_validation :set_reference, on: :create
-  before_validation :reset_published_at, unless: :can_publish?
+  before_validation :reset_published_at, unless: [:can_publish?, :validated?]
   before_save :set_lat_and_long
   before_create :set_received_at
   before_create :set_key_dates

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1133,7 +1133,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def validation_date?
-    !validated_at.nil?
+    validated_at.present?
   end
 
   def public_comment_present

--- a/spec/factories/planning_application.rb
+++ b/spec/factories/planning_application.rb
@@ -408,6 +408,15 @@ FactoryBot.define do
       end
     end
 
+    trait :submitted do
+      status { "awaiting_determination" }
+      decision { "granted" }
+
+      after(:create) do |planning_application|
+        create(:recommendation, planning_application:, submitted: true)
+      end
+    end
+
     trait :with_feedback do
       feedback do
         {
@@ -443,64 +452,6 @@ FactoryBot.define do
         planning_application.planning_application_constraints.first.update!(consultee_id: consultee_1.id)
         planning_application.planning_application_constraints.last.update!(consultee_id: consultee_2.id)
       end
-    end
-
-    factory :not_started_planning_application do
-      status { :not_started }
-
-      factory :invalidated_planning_application do
-        after(:create) do |p|
-          create(
-            :additional_document_validation_request,
-            :pending,
-            planning_application: p
-          )
-
-          p.invalidate!
-        end
-
-        factory :valid_planning_application do
-          after(:create) do |p|
-            p.validation_requests.each(&:close!)
-
-            p.start!
-          end
-
-          factory :in_assessment_planning_application do
-            decision { "granted" }
-
-            after(:create, &:assess!)
-
-            factory :submitted_planning_application do
-              after(:create) do |planning_application|
-                create(:recommendation, planning_application:)
-
-                planning_application.submit!
-              end
-
-              factory :determined_planning_application do
-                after(:create, &:determine!)
-              end
-            end
-          end
-        end
-      end
-    end
-
-    factory :returned_planning_application do
-      after(:create) do |application|
-        application.return!("this will not do")
-      end
-    end
-
-    factory :withdrawn_planning_application do
-      after(:create) do |application|
-        application.withdraw!("no thanks")
-      end
-    end
-
-    factory :closed_planning_application do
-      after(:create, &:close!)
     end
 
     trait :from_planx do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -170,28 +170,14 @@ RSpec.describe PlanningApplication do
         freeze_time { example.run }
       end
 
-      context "when the application type is householder" do
-        let(:planning_application) { build(:planning_application, :planning_permission, :not_started, published_at:) }
+      let(:planning_application) { build(:planning_application, :pre_application, :not_started, published_at:) }
 
-        it "doesn't reset the published_at timestamp" do
-          expect {
-            planning_application.validate!(:create)
-          }.not_to change {
-            planning_application.published_at
-          }.from(published_at)
-        end
-      end
-
-      context "when the application type is pre-application" do
-        let(:planning_application) { build(:planning_application, :pre_application, :not_started, published_at:) }
-
-        it "resets the published_at timestamp" do
-          expect {
-            planning_application.validate!(:create)
-          }.to change {
-            planning_application.published_at
-          }.from(published_at).to(nil)
-        end
+      it "resets the published_at timestamp" do
+        expect {
+          planning_application.validate!(:create)
+        }.to change {
+          planning_application.published_at
+        }.from(published_at).to(nil)
       end
     end
 

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -580,7 +580,7 @@ RSpec.describe PlanningApplication do
   end
 
   describe "deadlines" do
-    let(:planning_application) { create(:not_started_planning_application) }
+    let(:planning_application) { create(:planning_application, :not_started) }
     let(:date) { Time.zone.local(2021, 9, 23, 22, 10, 44) }
 
     before do
@@ -1028,7 +1028,7 @@ RSpec.describe PlanningApplication do
   end
 
   describe "#withdraw_last_recommendation!" do
-    let(:planning_application) { create(:submitted_planning_application) }
+    let(:planning_application) { create(:planning_application, :submitted) }
     let(:user) { create(:user) }
 
     before do

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe PlanningApplication do
       end
 
       context "when the application type is householder" do
-        let(:planning_application) { build(:planning_application, :planning_permission, published_at:) }
+        let(:planning_application) { build(:planning_application, :planning_permission, :not_started, published_at:) }
 
         it "doesn't reset the published_at timestamp" do
           expect {
@@ -183,7 +183,7 @@ RSpec.describe PlanningApplication do
       end
 
       context "when the application type is pre-application" do
-        let(:planning_application) { build(:planning_application, :pre_application, published_at:) }
+        let(:planning_application) { build(:planning_application, :pre_application, :not_started, published_at:) }
 
         it "resets the published_at timestamp" do
           expect {

--- a/spec/models/planning_application_spec.rb
+++ b/spec/models/planning_application_spec.rb
@@ -661,7 +661,7 @@ RSpec.describe PlanningApplication do
   end
 
   describe "#valid_from" do
-    let(:planning_application) { create(:not_started_planning_application) }
+    let(:planning_application) { create(:planning_application, :not_started) }
 
     context "when the application is not valid" do
       it "is nil" do
@@ -670,7 +670,7 @@ RSpec.describe PlanningApplication do
     end
 
     context "when the application is valid" do
-      let(:planning_application) { create(:valid_planning_application) }
+      let(:planning_application) { create(:planning_application, :in_assessment) }
 
       it "is validated at" do
         expect(planning_application.valid_from).to eq(planning_application.validated_at)
@@ -679,7 +679,7 @@ RSpec.describe PlanningApplication do
   end
 
   describe "#valid_from_date" do
-    let(:planning_application) { create(:not_started_planning_application) }
+    let(:planning_application) { create(:planning_application, :not_started) }
 
     context "when the application is valid" do
       context "when there have been validation requests" do
@@ -700,6 +700,7 @@ RSpec.describe PlanningApplication do
             )
           end
 
+          planning_application.validated_at = planning_application.valid_from_date
           planning_application.start!
         end
 
@@ -709,7 +710,10 @@ RSpec.describe PlanningApplication do
       end
 
       context "when there have been no validation requests" do
-        before { planning_application.start! }
+        before do
+          planning_application.validated_at = planning_application.valid_from_date
+          planning_application.start!
+        end
 
         it "returns the received_at value" do
           expect(planning_application.valid_from_date).to eq planning_application.received_at

--- a/spec/presenters/planning_application_presenter_spec.rb
+++ b/spec/presenters/planning_application_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
   subject(:presenter) { described_class.new(view, planning_application) }
 
   let(:context) { ActionView::Base.new }
-  let!(:planning_application) { create(:not_started_planning_application) }
+  let!(:planning_application) { create(:planning_application, :not_started) }
 
   it_behaves_like "Presentable" do
     let(:presented) { create(:planning_application) }
@@ -19,7 +19,7 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
 
   describe "#status_tag" do
     context "when an application is in the invalidated state" do
-      let(:planning_application) { create(:invalidated_planning_application) }
+      let(:planning_application) { create(:planning_application, :invalidated) }
 
       it "shows invalid" do
         expect(presenter.status_tag).to include ">Invalid<"
@@ -131,12 +131,12 @@ RSpec.describe PlanningApplicationPresenter, type: :presenter do
       [:closed, "Closed at", :closed_at]
     ].each do |state, label, date|
       context "when the application is #{state.to_s.humanize}" do
-        let(:planning_application) { create("#{state}_planning_application") }
+        let(:planning_application) { create(:planning_application, state) }
 
         it "shows the '#{date}' date" do
           date = planning_application.send(date)
 
-          expect(presenter.next_relevant_date_tag).to include date.to_fs
+          expect(presenter.next_relevant_date_tag).to include date.to_date.to_fs
         end
 
         it "shows a '#{label}' label" do

--- a/spec/system/planning_applications/preapplications_spec.rb
+++ b/spec/system/planning_applications/preapplications_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "assigning planning application" do
   end
 
   context "when pre-app is not started" do
-    let(:planning_application) { create(:planning_application, :pre_application, status: :not_started, local_authority:) }
+    let(:planning_application) { create(:planning_application, :pre_application, :not_started, local_authority:) }
 
     it "correctly displays index task list to an assessor" do
       sign_in(assessor)

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       context "when there are open post validation requests" do
-        let(:planning_application) { create(:in_assessment_planning_application, local_authority: default_local_authority, user: assessor) }
+        let(:planning_application) { create(:planning_application, :in_assessment, local_authority: default_local_authority, user: assessor) }
         let!(:red_line_boundary_change_validation_request) { create(:red_line_boundary_change_validation_request, :open, :post_validation, planning_application:) }
 
         it "prevents me from submitting the planning application" do
@@ -430,7 +430,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       end
 
       context "when there is an open time extension request" do
-        let(:planning_application) { create(:in_assessment_planning_application, local_authority: default_local_authority, user: assessor) }
+        let(:planning_application) { create(:planning_application, :in_assessment, local_authority: default_local_authority, user: assessor) }
         let!(:time_extension_request) { create(:time_extension_validation_request, :open, planning_application:, post_validation: true) }
 
         it "allows me to submit the planning application" do


### PR DESCRIPTION
### Description of change

A quick change missed over from #2545 for states which shouldn't be publishable.

In the process I've had to fix some tests which had a validation date set even when the status suggested they weren't validated; I've also taken the opportunity to clean up some duplicated factories that should have been traits on the main factory.

### Story Link

https://trello.com/c/vOQfM9PO/1267-application-which-is-not-valid-has-been-published-this-should-be-prevented
