### PR TITLE
Base redirect destination on application status not user role

### DIFF
--- a/app/controllers/planning_applications/assessment/permitted_development_rights_controller.rb
+++ b/app/controllers/planning_applications/assessment/permitted_development_rights_controller.rb
@@ -61,7 +61,7 @@ module PlanningApplications
       end
 
       def redirect_path
-        if current_user.reviewer?
+        if @planning_application.awaiting_determination?
           planning_application_review_tasks_path(@planning_application)
         else
           planning_application_assessment_tasks_path(@planning_application)


### PR DESCRIPTION
### Description of change

When the user is a reviewer, they were being redirected to the reviewer task list even if the application wasn't in review. The correct thing seems to be to redirect based on application status, not user role.

### Story Link

https://trello.com/c/em02fdgY/1233-when-assessing-an-application-i-save-the-permitted-development-rights-task-and-end-up-on-the-review-tasklist
