### PR TITLE
Add line break in validation notification

### DIFF
--- a/app/views/shared/_description_change_auto_closed_banner.html.erb
+++ b/app/views/shared/_description_change_auto_closed_banner.html.erb
@@ -6,7 +6,7 @@
         C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
       <div class="moj-banner__message">
         <% if @planning_application.description_change_validation_requests.auto_closed.any?(&:immediate_auto_closed?) %>
-          <strong> Applicant has been notified of the description change. </strong>
+          <strong> Applicant has been notified of the description change. </strong><br>
           <%= govuk_link_to "View description change", planning_application_validation_validation_request_path(@planning_application, @planning_application.latest_auto_closed_description_request) %>
         <% else %>
           <strong> Description change request has been automatically accepted </strong> after 5 days.<br>


### PR DESCRIPTION
### Description of change

Rebecca had already fixed the main issue detailed in the ticket below - all that this PR does is add a line break to keep the style consistent.

### Story Link

https://trello.com/c/alrkof5g/1169-after-making-changes-to-a-description-the-notification-banner-on-application-landing-page-shows-irrelevant-message-to-the-contex

