### PR TITLE
Don't allow access to consultation until the application is validated

### DIFF
--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -406,7 +406,7 @@ class PlanningApplication < ApplicationRecord
   end
 
   def validated?
-    validated_at.present? && invalidated_at.blank?
+    validated_at.present? && (invalidated_at.blank? || invalidated_at < validated_at)
   end
 
   def can_publish?

--- a/app/views/planning_applications/steps/_consultation.html.erb
+++ b/app/views/planning_applications/steps/_consultation.html.erb
@@ -1,6 +1,11 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-9 application-step-heading">Consultation</h2>
 <%= govuk_task_list(id_prefix: "consultation-section", html_attributes: {id: "consultation-section"}) do |task_list|
       task_list.with_item(title: consultation_task_title(@planning_application),
-        href: planning_application_consultation_path(@planning_application),
-        status: render(StatusTags::BaseComponent.new(status: @planning_application.consultation.status)))
+        href: @planning_application.validated? && planning_application_consultation_path(@planning_application)) do |item|
+        if @planning_application.validated?
+          item.with_status(text: render(StatusTags::BaseComponent.new(status: @planning_application.consultation.status)))
+        else
+          item.with_status(text: "Cannot start yet", cannot_start_yet: true)
+        end
+      end
     end %>

--- a/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
+++ b/spec/system/planning_applications/consulting/send_emails_to_consultees_spec.rb
@@ -457,37 +457,16 @@ RSpec.describe "Consultation", type: :system, js: true do
       )
     end
 
-    it "doesn't send emails to consultees" do
+    it "doesn't allow access to the consultation" do
       sign_in assessor
 
       visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_selector("h1", text: "Application")
 
       within "#consultation-section" do
-        expect(page).to have_selector("li:first-child a", text: "Consultees, neighbours and publicity")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:first-child", text: "Consultees, neighbours and publicity")
+        expect(page).to have_selector("li:first-child", text: "Cannot start yet")
       end
-
-      click_link "Consultees, neighbours and publicity"
-      expect(page).to have_selector("h1", text: "Consultation")
-
-      within "#consultation-end-date" do
-        expect(page).to have_text("Consultation end Not yet started")
-      end
-
-      within "#consultee-tasks" do
-        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
-      end
-
-      click_link "Send emails to consultees"
-      expect(page).to have_selector("h1", text: "Send emails to consultees")
-
-      accept_confirm(text: "Send emails to consultees?") do
-        click_button "Send emails to consultees"
-      end
-
-      expect(page).to have_selector("[role=alert] li", text: "Emails can’t be sent out when a planning application has not been started")
     end
   end
 
@@ -554,37 +533,16 @@ RSpec.describe "Consultation", type: :system, js: true do
       )
     end
 
-    it "doesn't send emails to consultees" do
+    it "doesn't allow access to the consultation" do
       sign_in assessor
 
       visit "/planning_applications/#{planning_application.reference}"
       expect(page).to have_selector("h1", text: "Application")
 
       within "#consultation-section" do
-        expect(page).to have_selector("li:first-child a", text: "Consultees, neighbours and publicity")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:first-child", text: "Consultees, neighbours and publicity")
+        expect(page).to have_selector("li:first-child", text: "Cannot start yet")
       end
-
-      click_link "Consultees, neighbours and publicity"
-      expect(page).to have_selector("h1", text: "Consultation")
-
-      within "#consultation-end-date" do
-        expect(page).to have_text("Consultation end Not yet started")
-      end
-
-      within "#consultee-tasks" do
-        expect(page).to have_selector("li:nth-child(2) a", text: "Send emails to consultees")
-        expect(page).to have_selector("li:nth-child(2) .govuk-tag", text: "Not started")
-      end
-
-      click_link "Send emails to consultees"
-      expect(page).to have_selector("h1", text: "Send emails to consultees")
-
-      accept_confirm(text: "Send emails to consultees?") do
-        click_button "Send emails to consultees"
-      end
-
-      expect(page).to have_selector("[role=alert] li", text: "Emails can’t be sent out when a planning application is invalid")
     end
   end
 

--- a/spec/system/planning_applications/preapplications_spec.rb
+++ b/spec/system/planning_applications/preapplications_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe "assigning planning application" do
       end
 
       within("#consultation-section") do
-        expect(page).to have_selector("li:first-child a", text: "Consultees")
-        expect(page).to have_selector("li:first-child .govuk-tag", text: "Not started")
+        expect(page).to have_selector("li:first-child", text: "Consultees")
+        expect(page).to have_selector("li:first-child", text: "Cannot start yet")
       end
 
       within("#assess-section") do


### PR DESCRIPTION
### Description of change

The consultation process can't happen until an application has been validated - allowing access beforehand can lead to officers trying to send consultation emails before it is available and whilst we have errors to prevent this they can't be rectified on the page.

### Story Link

https://trello.com/c/vHHUbYg3

### Screenshots

<img width="960" height="283" alt="image" src="https://github.com/user-attachments/assets/57c598ae-7c3b-4116-a7b8-43a1853c2c95" />

### Decisions

The `validated?` query checks for the `invalidated_at` timestamp to be blank but doing only this prevents an invalidated application becoming validated. Need to confirm that an application can move from invalidated to validated before merging.

