### PR TITLE
Paginate tabs and preload associations

### DIFF
--- a/app/components/planning_applications/panel_component.html.erb
+++ b/app/components/planning_applications/panel_component.html.erb
@@ -37,7 +37,5 @@
     </tbody>
   </table>
 
-  <% if type == :all %>
-    <%= pagination %>
-  <% end %>
+  <%= pagination %>
 <% end %>

--- a/app/components/planning_applications/panel_component.rb
+++ b/app/components/planning_applications/panel_component.rb
@@ -13,16 +13,11 @@ module PlanningApplications
     attr_reader :type, :search
 
     def before_render
-      @pagy, @paginated_applications = pagy(@planning_applications, overflow: :last_page)
+      @pagy, @paginated_applications = pagy(@planning_applications, page_param: page_param, overflow: :last_page)
     end
 
     def planning_applications
-      case type
-      when :all
-        @paginated_applications
-      else
-        @planning_applications
-      end
+      @paginated_applications
     end
 
     def pagination
@@ -42,7 +37,7 @@ module PlanningApplications
     end
 
     def pagination_url(page:)
-      pagy_url_for(@pagy, page) + "##{type}"
+      pagy_url_for(@pagy, page, absolute: false) + "##{type}"
     end
 
     def title
@@ -80,6 +75,10 @@ module PlanningApplications
         status_tag
         user_name
       ]
+    end
+
+    def page_param
+      "page_#{type}"
     end
   end
 end

--- a/app/services/planning_application_search.rb
+++ b/app/services/planning_application_search.rb
@@ -74,7 +74,10 @@ class PlanningApplicationSearch
   end
 
   def all_applications
-    @all_applications ||= local_authority.planning_applications.accepted.by_status_order.by_application_type
+    @all_applications ||= local_authority.planning_applications.accepted.by_status_order.by_application_type.preload(
+      {application_type: :config},
+      {case_record: :user}
+    )
   end
 
   def current_user


### PR DESCRIPTION
### Description of change

Paginate tabs and preload associations
- Planning applications index was taking several seconds to load, ideally we would load record as you select each tab but this is a quick win

