### PR TITLE
Add whitelisted fields to public submission endpoint

### DIFF
--- a/engines/bops_api/app/services/bops_api/application/documents_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/documents_service.rb
@@ -32,6 +32,7 @@ module BopsApi
         name = URI.decode_uri_component(File.basename(URI.parse(url).path))
 
         planning_application.documents.create! do |document|
+          document.api_user = user
           document.tags = tags
           document.applicant_description = description
           document.file.attach(io: file.open, filename: name)

--- a/engines/bops_api/app/services/bops_api/application/public_submission_whitelisting_service.rb
+++ b/engines/bops_api/app/services/bops_api/application/public_submission_whitelisting_service.rb
@@ -7,35 +7,42 @@ module BopsApi
 
       def initialize(planning_application:)
         @planning_application = planning_application
+        @submission = planning_application.params_v2
       end
 
       def call
-        return unless (submission = planning_application.params_v2)
+        return unless submission
 
-        filter_submission(FILTER, submission)
+        result = filter_submission(FILTER, submission)
+
+        result[:files] = whitelisted_files if submission["files"]
+        result
       rescue => e
         raise WhitelistingError, e.message
       end
 
       FILTER = {
         data: {
-          application: {
-            type: %i[value description]
-          },
-          applicant: {
-            name: %i[first last]
-          },
-          property: {
-            address: %i[singleline title street postcode town]
-          },
-          proposal: %i[description]
-        },
-        metadata: %i[id source]
+          application: %i[type declaration planningApp leadDeveloper vacantBuildingCredit],
+          applicant: %i[name type address agent],
+          property: %i[
+            address boundary flood planning localAuthorityDistrict
+            region trees type units ward occupation ownership parking
+            socialLandlord titleNumber EPC
+          ],
+          proposal: %i[
+            access boundary charging cost date description
+            ecology energy extend flood greenRoof new newBuildings newDwellings
+            newStoreys parking projectType structures units urbanGreeningFactor
+            utilities waste water
+          ],
+          user: %i[role]
+        }
       }
 
       private
 
-      attr_reader :planning_application
+      attr_reader :planning_application, :submission
 
       def filter_submission(filter, source, destination = nil)
         if destination.nil?
@@ -55,6 +62,28 @@ module BopsApi
         end
 
         destination
+      end
+
+      def submission_file_names
+        submission["files"].map do |file|
+          URI.decode_uri_component(File.basename(URI.parse(file["name"]).path))
+        end
+      end
+
+      def whitelisted_files
+        planning_application.documents.map do |document|
+          filename = document.file.filename.to_s
+          if document.publishable? && submission_file_names.include?(filename)
+            {
+              name: filename,
+              type: document.tags.map { |tag| {"value" => tag, "description" => tag.humanize} }
+            }
+          else
+            {
+              name: "Unpublished document - sensitive"
+            }
+          end
+        end
       end
     end
   end

--- a/engines/bops_api/schemas/odp/v0.7.5/applicationSubmission.json
+++ b/engines/bops_api/schemas/odp/v0.7.5/applicationSubmission.json
@@ -27,8 +27,7 @@
             }
           },
           "required": [
-            "data",
-            "metadata"
+            "data"    
           ]
         },
         {

--- a/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/whitelistApplicationSubmission.json
+++ b/engines/bops_api/spec/fixtures/examples/odp/v0.7.5/whitelistApplicationSubmission.json
@@ -5,25 +5,331 @@
       "description": "Planning Permission - Full householder"
     }
   },
-  "applicant": {
-    "name": {
-      "first": "David",
-      "last": "Bowie"
-    }
-  },
-  "property": {
-    "address": {
-      "title": "40, STANSFIELD ROAD, LONDON",
-      "street": "STANSFIELD ROAD",
-      "postcode": "SW9 9RZ",
-      "town": "LONDON"
-    }
-  },
-  "proposal": {
-    "description": "Roof extension to the rear of the property, incorporating starship launchpad."
-  },
-  "metadata": {
-    "id": "81bcaa0f-baf5-4573-ba0a-ea868c573faf",
-    "source": "PlanX"
+  "submission": {
+    "data": {
+      "application": {
+        "type": {
+          "value": "pp.full.householder",
+          "description": "Planning Permission - Full householder"
+        },
+        "declaration": {
+          "accurate": true,
+          "connection": {
+            "value": "none"
+          }
+        }
+      },
+      "applicant": {
+        "name": {
+          "first": "David",
+          "last": "Bowie"
+        },
+        "type": "individual",
+        "address": {
+          "sameAsSiteAddress": true
+        },
+        "agent": {
+          "name": {
+            "first": "Ziggy",
+            "last": "Stardust"
+          },
+          "email": "ziggystardust@example.com",
+          "phone": {
+            "primary": "02001233456"
+          },
+          "address": {
+            "line1": "40 Stansfield Road",
+            "line2": "Brixton",
+            "town": "London",
+            "county": "Greater London",
+            "postcode": "SW9 9RZ",
+            "country": "UK"
+          }
+        }
+      },
+      "property": {
+        "address": {
+          "latitude": 51.4656522,
+          "longitude": -0.1185926,
+          "x": 530787,
+          "y": 175754,
+          "title": "40, STANSFIELD ROAD, LONDON",
+          "singleLine": "40, STANSFIELD ROAD, LONDON, SW9 9RZ",
+          "source": "Ordnance Survey",
+          "uprn": "100021892955",
+          "usrn": "21901294",
+          "pao": "40",
+          "street": "STANSFIELD ROAD",
+          "town": "LONDON",
+          "postcode": "SW9 9RZ"
+        },
+        "boundary": {
+          "site": {
+            "type": "Feature",
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ],
+                  [
+                    -0.1185938715934822,
+                    51.465724418998775
+                  ],
+                  [
+                    -0.1184195280075143,
+                    51.46552473766957
+                  ],
+                  [
+                    -0.11848390102387167,
+                    51.4655038504508
+                  ],
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ]
+                ]
+              ]
+            },
+            "properties": null
+          },
+          "area": {
+            "hectares": 0.012592,
+            "squareMetres": 125.92
+          }
+        },
+        "planning": {
+          "sources": [
+            "https://api.editor.planx.dev/gis/lambeth?geom=POLYGON+%28%28-0.1186569035053321+51.465703531871384%2C+-0.1185938715934822+51.465724418998775%2C+-0.1184195280075143+51.46552473766957%2C+-0.11848390102387167+51.4655038504508%2C+-0.1186569035053321+51.465703531871384%29%29&analytics=false&sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf",
+            "https://api.editor.planx.dev/roads?usrn=21901294"
+          ],
+          "designations": [
+            {
+              "value": "article4",
+              "description": "Article 4 Direction area",
+              "intersects": false
+            },
+            {
+              "value": "article4.caz",
+              "description": "Central Activities Zone (CAZ)",
+              "intersects": false
+            },
+            {
+              "value": "tpo",
+              "description": "Tree Preservation Order (TPO) or zone",
+              "intersects": false
+            },
+            {
+              "value": "listed",
+              "description": "Listed Building",
+              "intersects": false
+            },
+            {
+              "value": "monument",
+              "description": "Site of a Scheduled Monument",
+              "intersects": false
+            },
+            {
+              "value": "designated",
+              "description": "Designated land",
+              "intersects": false
+            },
+            {
+              "value": "nature.SAC",
+              "description": "Special Area of Conservation (SAC)",
+              "intersects": false
+            },
+            {
+              "value": "nature.ASNW",
+              "description": "Ancient Semi-Natural Woodland (ASNW)",
+              "intersects": false
+            },
+            {
+              "value": "nature.SSSI",
+              "description": "Site of Special Scientific Interest (SSSI)",
+              "intersects": false
+            },
+            {
+              "value": "locallyListed",
+              "description": "Locally Listed Building",
+              "intersects": false
+            },
+            {
+              "value": "nature.SPA",
+              "description": "Special Protection Area (SPA)",
+              "intersects": false
+            },
+            {
+              "value": "designated.WHS",
+              "description": "UNESCO World Heritage Site or buffer zone",
+              "intersects": false
+            },
+            {
+              "value": "registeredPark",
+              "description": "Historic Park or Garden",
+              "intersects": false
+            },
+            {
+              "value": "designated.AONB",
+              "description": "Area of Outstanding Natural Beauty (AONB)",
+              "intersects": false
+            },
+            {
+              "value": "designated.nationalPark",
+              "description": "National Park",
+              "intersects": false
+            },
+            {
+              "value": "designated.conservationArea",
+              "description": "Conservation Area",
+              "intersects": false
+            },
+            {
+              "value": "designated.nationalPark.broads",
+              "description": "National Park - Broads",
+              "intersects": false
+            },
+            {
+              "value": "road.classified",
+              "description": "Classified Road",
+              "intersects": false
+            }
+          ]
+        },
+        "localAuthorityDistrict": [
+          "Lambeth"
+        ],
+        "region": "London",
+        "type": {
+          "value": "residential.dwelling.house.terrace",
+          "description": "Terrace"
+        },
+        "titleNumber": {
+          "known": "No"
+        },
+        "EPC": {
+          "known": "No"
+        },
+        "parking": {
+          "cars": {
+            "count": 1
+          },
+          "cycles": {
+            "count": 2
+          }
+        }
+      },
+      "proposal": {
+        "projectType": [
+          {
+            "value": "extend.roof.dormer",
+            "description": "Add a roof dormer"
+          }
+        ],
+        "description": "Roof extension to the rear of the property, incorporating starship launchpad.",
+        "boundary": {
+          "site": {
+            "type": "Feature",
+            "geometry": {
+              "type": "Polygon",
+              "coordinates": [
+                [
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ],
+                  [
+                    -0.1185938715934822,
+                    51.465724418998775
+                  ],
+                  [
+                    -0.1184195280075143,
+                    51.46552473766957
+                  ],
+                  [
+                    -0.11848390102387167,
+                    51.4655038504508
+                  ],
+                  [
+                    -0.1186569035053321,
+                    51.465703531871384
+                  ]
+                ]
+              ]
+            },
+            "properties": null
+          },
+          "area": {
+            "hectares": 0.012592,
+            "squareMetres": 125.92
+          }
+        },
+        "date": {
+          "start": "2024-05-01",
+          "completion": "2024-05-02"
+        },
+        "extend": {
+          "area": {
+            "squareMetres": 45
+          }
+        },
+        "parking": {
+          "cars": {
+            "count": 1,
+            "difference": 0
+          },
+          "cycles": {
+            "count": 2,
+            "difference": 0
+          }
+        }
+      }
+    },
+    "files": [
+      {
+        "name": "https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf",
+        "type": [
+          {
+            "value": "roofPlan.existing",
+            "description": "Roof plan - existing"
+          },
+          {
+            "value": "roofPlan.proposed",
+            "description": "Roof plan - proposed"
+          }
+        ]
+      },
+      {
+        "name": "https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf",
+        "type": [
+          {
+            "value": "sitePlan.existing",
+            "description": "Site plan - existing"
+          },
+          {
+            "value": "sitePlan.proposed",
+            "description": "Site plan - proposed"
+          }
+        ]
+      },
+      {
+        "name": "https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf",
+        "type": [
+          {
+            "value": "elevations.existing",
+            "description": "Elevations - existing"
+          },
+          {
+            "value": "elevations.proposed",
+            "description": "Elevations - proposed"
+          }
+        ]
+      },
+      {
+        "name": "Unpublished document - sensitive"
+      }
+    ]
   }
 }

--- a/engines/bops_api/spec/services/application/public_submission_whitelisting_service_spec.rb
+++ b/engines/bops_api/spec/services/application/public_submission_whitelisting_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BopsApi::Application::PublicSubmissionWhitelistingService, type: :service do
+  describe "#call" do
+    let!(:local_authority) { create(:local_authority) }
+
+    let(:submission) { json_fixture_api("examples/odp/v0.6.0/validPlanningPermission.json") }
+    let(:planx_planning_data) { create(:planx_planning_data, params_v2: submission) }
+
+    let(:published_document) { create(:document, :with_file, :with_tags, publishable: true) }
+    let(:unpublished_document) { create(:document, :with_other_file, :floorplan_tags, publishable: false) }
+
+    let(:planning_application) do
+      create(
+        :planning_application,
+        :determined,
+        documents: [published_document, unpublished_document],
+        local_authority:,
+        planx_planning_data:
+      )
+    end
+
+    subject(:whitelisted_submission) do
+      described_class.new(planning_application:).call
+    end
+
+    it "only shows the whitelisted fields in the submission" do
+      expect(whitelisted_submission.dig(:data, :application, :type)).to be_present
+      expect(whitelisted_submission.dig(:data, :applicant, :email)).not_to be_present
+      expect(whitelisted_submission.dig(:metadata)).not_to be_present
+    end
+
+    it "does not expose the fee information in the submission responses" do
+      expect(whitelisted_submission.dig(:data, :application)).not_to have_key(:fee)
+    end
+
+    context "with publishable and unpublishable documents" do
+      let(:filename) do
+        URI.decode_uri_component(File.basename(URI.parse(submission["files"][0]["name"]).path))
+      end
+
+      before do
+        published_document.file.blob.update!(filename: filename)
+      end
+
+      let(:whitelisted_submission) { described_class.new(planning_application:).call }
+      let(:files) { whitelisted_submission[:files] }
+
+      it "shows the correct number of documents" do
+        expect(files.count).to eq(planning_application.documents.count)
+      end
+
+      it "correctly displays documents" do
+        names = files.map { |file| file[:name] }
+        expect(names).to include(published_document.file.filename.to_s)
+        expect(names).to include("Unpublished document - sensitive")
+        expect(names).not_to include(unpublished_document.file.filename.to_s)
+
+        expect(names.count("myPlans.pdf")).to eq(1)
+        expect(names.count("Unpublished document - sensitive")).to eq(1)
+      end
+    end
+  end
+end

--- a/engines/bops_api/swagger/v2/swagger_doc.yaml
+++ b/engines/bops_api/swagger/v2/swagger_doc.yaml
@@ -21602,7 +21602,6 @@ components:
                 type: object
             required:
             - data
-            - metadata
           - type: 'null'
       required:
       - application
@@ -36601,22 +36600,205 @@ paths:
                       type:
                         value: pp.full.householder
                         description: Planning Permission - Full householder
-                    applicant:
-                      name:
-                        first: David
-                        last: Bowie
-                    property:
-                      address:
-                        title: 40, STANSFIELD ROAD, LONDON
-                        street: STANSFIELD ROAD
-                        postcode: SW9 9RZ
-                        town: LONDON
-                    proposal:
-                      description: Roof extension to the rear of the property, incorporating
-                        starship launchpad.
-                    metadata:
-                      id: 81bcaa0f-baf5-4573-ba0a-ea868c573faf
-                      source: PlanX
+                    submission:
+                      data:
+                        application:
+                          type:
+                            value: pp.full.householder
+                            description: Planning Permission - Full householder
+                          declaration:
+                            accurate: true
+                            connection:
+                              value: none
+                        applicant:
+                          name:
+                            first: David
+                            last: Bowie
+                          type: individual
+                          address:
+                            sameAsSiteAddress: true
+                          agent:
+                            name:
+                              first: Ziggy
+                              last: Stardust
+                            email: ziggystardust@example.com
+                            phone:
+                              primary: '02001233456'
+                            address:
+                              line1: 40 Stansfield Road
+                              line2: Brixton
+                              town: London
+                              county: Greater London
+                              postcode: SW9 9RZ
+                              country: UK
+                        property:
+                          address:
+                            latitude: 51.4656522
+                            longitude: -0.1185926
+                            x: 530787
+                            "y": 175754
+                            title: 40, STANSFIELD ROAD, LONDON
+                            singleLine: 40, STANSFIELD ROAD, LONDON, SW9 9RZ
+                            source: Ordnance Survey
+                            uprn: '100021892955'
+                            usrn: '21901294'
+                            pao: '40'
+                            street: STANSFIELD ROAD
+                            town: LONDON
+                            postcode: SW9 9RZ
+                          boundary:
+                            site:
+                              type: Feature
+                              geometry:
+                                type: Polygon
+                                coordinates:
+                                - - - -0.1186569035053321
+                                    - 51.465703531871384
+                                  - - -0.1185938715934822
+                                    - 51.465724418998775
+                                  - - -0.1184195280075143
+                                    - 51.46552473766957
+                                  - - -0.11848390102387167
+                                    - 51.4655038504508
+                                  - - -0.1186569035053321
+                                    - 51.465703531871384
+                              properties:
+                            area:
+                              hectares: 0.012592
+                              squareMetres: 125.92
+                          planning:
+                            sources:
+                            - https://api.editor.planx.dev/gis/lambeth?geom=POLYGON+%28%28-0.1186569035053321+51.465703531871384%2C+-0.1185938715934822+51.465724418998775%2C+-0.1184195280075143+51.46552473766957%2C+-0.11848390102387167+51.4655038504508%2C+-0.1186569035053321+51.465703531871384%29%29&analytics=false&sessionId=81bcaa0f-baf5-4573-ba0a-ea868c573faf
+                            - https://api.editor.planx.dev/roads?usrn=21901294
+                            designations:
+                            - value: article4
+                              description: Article 4 Direction area
+                              intersects: false
+                            - value: article4.caz
+                              description: Central Activities Zone (CAZ)
+                              intersects: false
+                            - value: tpo
+                              description: Tree Preservation Order (TPO) or zone
+                              intersects: false
+                            - value: listed
+                              description: Listed Building
+                              intersects: false
+                            - value: monument
+                              description: Site of a Scheduled Monument
+                              intersects: false
+                            - value: designated
+                              description: Designated land
+                              intersects: false
+                            - value: nature.SAC
+                              description: Special Area of Conservation (SAC)
+                              intersects: false
+                            - value: nature.ASNW
+                              description: Ancient Semi-Natural Woodland (ASNW)
+                              intersects: false
+                            - value: nature.SSSI
+                              description: Site of Special Scientific Interest (SSSI)
+                              intersects: false
+                            - value: locallyListed
+                              description: Locally Listed Building
+                              intersects: false
+                            - value: nature.SPA
+                              description: Special Protection Area (SPA)
+                              intersects: false
+                            - value: designated.WHS
+                              description: UNESCO World Heritage Site or buffer zone
+                              intersects: false
+                            - value: registeredPark
+                              description: Historic Park or Garden
+                              intersects: false
+                            - value: designated.AONB
+                              description: Area of Outstanding Natural Beauty (AONB)
+                              intersects: false
+                            - value: designated.nationalPark
+                              description: National Park
+                              intersects: false
+                            - value: designated.conservationArea
+                              description: Conservation Area
+                              intersects: false
+                            - value: designated.nationalPark.broads
+                              description: National Park - Broads
+                              intersects: false
+                            - value: road.classified
+                              description: Classified Road
+                              intersects: false
+                          localAuthorityDistrict:
+                          - Lambeth
+                          region: London
+                          type:
+                            value: residential.dwelling.house.terrace
+                            description: Terrace
+                          titleNumber:
+                            known: 'No'
+                          EPC:
+                            known: 'No'
+                          parking:
+                            cars:
+                              count: 1
+                            cycles:
+                              count: 2
+                        proposal:
+                          projectType:
+                          - value: extend.roof.dormer
+                            description: Add a roof dormer
+                          description: Roof extension to the rear of the property,
+                            incorporating starship launchpad.
+                          boundary:
+                            site:
+                              type: Feature
+                              geometry:
+                                type: Polygon
+                                coordinates:
+                                - - - -0.1186569035053321
+                                    - 51.465703531871384
+                                  - - -0.1185938715934822
+                                    - 51.465724418998775
+                                  - - -0.1184195280075143
+                                    - 51.46552473766957
+                                  - - -0.11848390102387167
+                                    - 51.4655038504508
+                                  - - -0.1186569035053321
+                                    - 51.465703531871384
+                              properties:
+                            area:
+                              hectares: 0.012592
+                              squareMetres: 125.92
+                          date:
+                            start: '2024-05-01'
+                            completion: '2024-05-02'
+                          extend:
+                            area:
+                              squareMetres: 45
+                          parking:
+                            cars:
+                              count: 1
+                              difference: 0
+                            cycles:
+                              count: 2
+                              difference: 0
+                      files:
+                      - name: https://api.editor.planx.dev/file/private/tbp4kiba/myPlans.pdf
+                        type:
+                        - value: roofPlan.existing
+                          description: Roof plan - existing
+                        - value: roofPlan.proposed
+                          description: Roof plan - proposed
+                      - name: https://api.editor.planx.dev/file/private/5w5v8s8z/other.pdf
+                        type:
+                        - value: sitePlan.existing
+                          description: Site plan - existing
+                        - value: sitePlan.proposed
+                          description: Site plan - proposed
+                      - name: https://api.editor.planx.dev/file/private/7nrefxnn/elevations.pdf
+                        type:
+                        - value: elevations.existing
+                          description: Elevations - existing
+                        - value: elevations.proposed
+                          description: Elevations - proposed
+                      - name: Unpublished document - sensitive
               schema:
                 "$ref": "#/components/schemas/ApplicationSubmission"
   "/api/v2/validation_requests":


### PR DESCRIPTION
### Description of change

Add whitelisted fields to public API submission endpoint. Source [here](https://docs.google.com/spreadsheets/d/1-jhpq3m1KoJatiHrAZAw1TAJN2hDgGzXqVLe8YxsLAs/edit?gid=723637289#gid=723637289).

### Story Link

https://trello.com/c/bgaWB9FO/1258-publish-only-whitelisted-data-and-document-names-to-the-public-submissions-api-to-enable-safe-display-by-dpr

### Screenshots

<img width="1111" height="623" alt="image" src="https://github.com/user-attachments/assets/871d9895-a6b8-44d8-b56a-66415b4c0e6c" />

### Decisions

- Documents that are not `publishable?` have title replaced with "Unpublished document - sensitive"
