### PR TITLE
Do not show pre-app status tag before pre-applications are reviewed

### DIFF
--- a/engines/bops_core/app/presenters/bops_core/status_presenter.rb
+++ b/engines/bops_core/app/presenters/bops_core/status_presenter.rb
@@ -28,6 +28,7 @@ module BopsCore
       end
 
       def pre_app_status_tag
+        return if in_assessment? || not_started?
         classes = ["govuk-tag govuk-tag--#{pre_app_status_tag_colour}"]
 
         tag.span class: classes do

--- a/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
+++ b/spec/system/planning_applications/assessing/summary_of_advice_spec.rb
@@ -107,5 +107,14 @@ RSpec.describe "Summary of Advice", type: :system, capybara: true do
       expect(page).to have_content("Summary tag can't be blank")
       expect(page).to have_content("Entry can't be blank")
     end
+
+    it "does not show summary status tag when in assessment" do
+      click_link "Summary of advice"
+      fill_in "Enter summary of planning considerations and advice. This should summarise any changes the applicant needs to make before they make an application.", with: "Updated summary of advice."
+      choose "Likely to be supported with changes"
+      click_button "Save and mark as complete"
+
+      expect(page).to have_no_content("Likely to be supported with changes")
+    end
   end
 end


### PR DESCRIPTION
### Description of change

We are not supposed to show the summary of advice pre-app status tag until applications are reviewed. 

### Story Link

https://trello.com/c/NgFDoQsB/1207-application-status-in-the-assessment-stage-turns-out-wrong-after-officer-completed-summary-of-advice-task

