### PR TITLE
Add site notice quantity and location instructions

### DIFF
--- a/app/controllers/planning_applications/site_notices_controller.rb
+++ b/app/controllers/planning_applications/site_notices_controller.rb
@@ -80,7 +80,7 @@ module PlanningApplications
     end
 
     def site_notice_params
-      params.require(:site_notice).permit(:required, :displayed_at, :method, :internal_team_email, documents: [])
+      params.require(:site_notice).permit(:required, :displayed_at, :method, :internal_team_email, :quantity, :location_instructions, documents: [])
     end
 
     def send_mail

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -15,6 +15,9 @@ class SiteNotice < ApplicationRecord
   scope :by_created_at_desc, -> { order(created_at: :desc) }
 
   validates :required, inclusion: {in: [true, false]}
+  validates :quantity,
+    presence: true,
+    numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 100}
 
   with_options on: :confirmation do
     validates :displayed_at,

--- a/app/views/planning_application_mailer/internal_team_site_notice_mail.erb
+++ b/app/views/planning_application_mailer/internal_team_site_notice_mail.erb
@@ -6,6 +6,12 @@ Description: <%= @planning_application.description %>
 
 The site notice for this application is ready for display.
 
+Number of site notices requested: <%= @site_notice.quantity %>
+
+<% if @site_notice.location_instructions.present? %>
+Location instructions: <%= @site_notice.location_instructions %>
+<% end -%>
+
 To print the site notice, go to:
 <%= @planning_application.site_notice_link %>
 

--- a/app/views/planning_application_mailer/site_notice_mail.text.erb
+++ b/app/views/planning_application_mailer/site_notice_mail.text.erb
@@ -15,7 +15,13 @@ Download the site notice as a printable PDF at <%= @planning_application.site_no
 You can use a clear plastic bag or sticky polythene film to protect it from bad weather.
 
 3. Display the site notice
+Number of site notices requested: <%= @site_notice.quantity %>
+
+<% if @site_notice.location_instructions.present? %>
+Location instructions: <%= @site_notice.location_instructions %>
+<% else %>
 This must be in a public place at or near the location of your proposed development. It must be visible by people using public roads and footpaths. For example, you could attach the notice to a lamppost or wall outside the property. Make sure the site notice is securely fixed.
+<% end -%>
 
 4. Tell us when you put it up
 Send an email to <%= @planning_application.user.email %> including:

--- a/app/views/planning_applications/site_notices/new.html.erb
+++ b/app/views/planning_applications/site_notices/new.html.erb
@@ -39,6 +39,15 @@
     <% end %>
 
     <%= tag.div(id: "site-notice-options", class: class_names("govuk-!-display-none": @site_notice.errors.blank?)) do %>
+      <%= form.govuk_number_field :quantity,
+            label: {text: t("planning_applications.site_notices.quantity.label")},
+            width: "one-quarter",
+            min: 1 %>
+
+      <%= form.govuk_text_area :location_instructions,
+            label: {text: t("planning_applications.site_notices.location_instructions.label")}, hint: {text: t("planning_applications.site_notices.location_instructions.hint")},
+            rows: 5 %>
+
       <div class="grey-box" id="email-site-notice">
         <%= form.govuk_radio_buttons_fieldset(
               :method,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -522,6 +522,12 @@ en:
               date_not_on_or_before: The date the site notice was displayed must be on or before today
             documents:
               blank: Provide documentary evidence that the site notice was displayed
+            quantity:
+              blank: Enter the number of site notices required
+              greater_than_or_equal_to: Number of site notices must be 1 or more
+              less_than_or_equal_to: Number of site notices must be 100 or less
+              not_a_number: Enter the number of site notices as a whole number
+              not_an_integer: Enter the number of site notices as a whole number
             required:
               inclusion: Choose 'Yes' or 'No'
         site_visit:
@@ -2052,6 +2058,11 @@ en:
         assign_user_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">assigned to an officer</a> before you can create a site notice.
         make_public_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">made public on the BOPS Public Portal</a> before you can create a site notice.
         success: Site notice was successfully %{action}
+      location_instructions:
+        hint: Optional. Anything you add here may be shared with the recipient (including the applicant).
+        label: Where should notices be displayed?
+      quantity:
+        label: Number of site notices
       update:
         success: Site notice was successfully updated
     steps:

--- a/db/migrate/20250922141123_add_quantity_and_location_instructions_to_site_notices.rb
+++ b/db/migrate/20250922141123_add_quantity_and_location_instructions_to_site_notices.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddQuantityAndLocationInstructionsToSiteNotices < ActiveRecord::Migration[8.0]
+  def up
+    add_column :site_notices, :quantity, :integer, default: 1, null: false
+    add_column :site_notices, :location_instructions, :text
+
+    safety_assured { execute("UPDATE site_notices SET quantity = 1 WHERE quantity IS NULL") }
+  end
+
+  def down
+    remove_column :site_notices, :location_instructions
+    remove_column :site_notices, :quantity
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_09_09_153407) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_141123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -1150,6 +1150,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_09_09_153407) do
     t.datetime "updated_at", null: false
     t.date "expiry_date"
     t.string "internal_team_email"
+    t.integer "quantity", default: 1, null: false
+    t.text "location_instructions"
     t.index ["planning_application_id"], name: "ix_site_notices_on_planning_application_id"
   end
 

--- a/spec/factories/site_notice.rb
+++ b/spec/factories/site_notice.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :site_notice do
     required { true }
     content { "This is a site notice" }
+    quantity { 1 }
     planning_application
   end
 end

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1019,7 +1019,14 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       planning_application.consultation
     end
 
-    let(:site_notice) { create(:site_notice, planning_application:) }
+    let!(:site_notice) do
+      create(
+        :site_notice,
+        planning_application:,
+        quantity: 3,
+        location_instructions: "Corner of the High Street by the substation"
+      )
+    end
 
     let(:site_notice_mail) do
       described_class.site_notice_mail(planning_application, planning_application.applicant_email)
@@ -1047,7 +1054,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application number PlanX-22-00100-PA1A"
+        "Application number #{planning_application.reference_in_full}"
       )
     end
 
@@ -1089,7 +1096,14 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       planning_application.consultation
     end
 
-    let(:site_notice) { create(:site_notice, planning_application:) }
+    let!(:site_notice) do
+      create(
+        :site_notice,
+        planning_application:,
+        quantity: 3,
+        location_instructions: "Corner of the High Street by the substation"
+      )
+    end
 
     let(:internal_team_site_notice_mail) do
       described_class.internal_team_site_notice_mail(planning_application, planning_application.applicant_email)
@@ -1117,7 +1131,7 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
 
     it "includes the reference" do
       expect(mail_body).to include(
-        "Application number PlanX-22-00100-PA1A"
+        "Application number #{planning_application.reference_in_full}"
       )
     end
 
@@ -1127,6 +1141,13 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
       expect(mail_body).to include(
         "https://planx.bops-applicants.services/planning_applications/#{planning_application.reference}/site_notice"
+      )
+    end
+
+    it "includes the requested quantity and location instructions" do
+      expect(mail_body).to include("Number of site notices requested: 3")
+      expect(mail_body).to include(
+        "Location instructions: Corner of the High Street by the substation"
       )
     end
   end

--- a/spec/models/site_notice_spec.rb
+++ b/spec/models/site_notice_spec.rb
@@ -18,6 +18,37 @@ RSpec.describe SiteNotice do
       end
     end
 
+    describe "#quantity" do
+      subject(:site_notice) { build(:site_notice, quantity:) }
+
+      context "when blank" do
+        let(:quantity) { nil }
+
+        it "validates presence" do
+          expect { site_notice.valid? }.to change { site_notice.errors[:quantity] }
+            .to(include("Enter the number of site notices required"))
+        end
+      end
+
+      context "when not an integer" do
+        let(:quantity) { 1.5 }
+
+        it "validates integer value" do
+          expect { site_notice.valid? }.to change { site_notice.errors[:quantity] }
+            .to(["Enter the number of site notices as a whole number"])
+        end
+      end
+
+      context "when less than 1" do
+        let(:quantity) { 0 }
+
+        it "validates minimum value" do
+          expect { site_notice.valid? }.to change { site_notice.errors[:quantity] }
+            .to(["Number of site notices must be 1 or more"])
+        end
+      end
+    end
+
     describe "#displayed_at" do
       let(:planning_application) { create(:planning_application, consultation:) }
       let(:consultation) { create(:consultation) }

--- a/spec/system/planning_applications/publicity/create_site_notice_spec.rb
+++ b/spec/system/planning_applications/publicity/create_site_notice_spec.rb
@@ -40,6 +40,11 @@ RSpec.describe "Create a site notice", js: true do
 
     choose "Yes"
 
+    expect(page).to have_field("Number of site notices", with: 1)
+
+    fill_in "Number of site notices", with: "2"
+    fill_in "Where should notices be displayed?", with: "Display on both entrances"
+
     expect(page).to have_content("Print the site notice")
 
     fill_in "Day", with: "1"
@@ -52,7 +57,10 @@ RSpec.describe "Create a site notice", js: true do
     expect(page).to have_content("Site notice was successfully created")
     expect(page).to have_link("Download site notice PDF", href: "#")
 
-    expect(planning_application.site_notice.content).not_to include "This application is subject to an Environmental Impact Assessment (EIA)."
+    site_notice = planning_application.reload.site_notice
+    expect(site_notice.quantity).to eq(2)
+    expect(site_notice.location_instructions).to eq("Display on both entrances")
+    expect(site_notice.content).not_to include "This application is subject to an Environmental Impact Assessment (EIA)."
   end
 
   it "allows officers to create a site notice and email it to the agent" do
@@ -60,6 +68,12 @@ RSpec.describe "Create a site notice", js: true do
     expect(page).to have_content("Send site notice")
 
     choose "Yes"
+
+    expect(page).to have_field("Number of site notices", with: 1)
+    expect(page).to have_content("Optional. Anything you add here may be shared with the recipient (including the applicant).")
+
+    fill_in "Number of site notices", with: "4"
+    fill_in "Where should notices be displayed?", with: "Attach near the front gate and rear alley"
 
     expect(page).to have_content("Email the site notice")
 
@@ -83,6 +97,11 @@ RSpec.describe "Create a site notice", js: true do
 
     choose "Yes"
 
+    expect(page).to have_field("Number of site notices", with: 1)
+
+    fill_in "Number of site notices", with: "4"
+    fill_in "Where should notices be displayed?", with: "Attach near the front gate and rear alley"
+
     choose "Send it by email to applicant"
 
     click_button "Email site notice and mark as complete"
@@ -101,6 +120,11 @@ RSpec.describe "Create a site notice", js: true do
     expect(page).to have_content("Send site notice")
 
     choose "Yes"
+
+    expect(page).to have_field("Number of site notices", with: 1)
+
+    fill_in "Number of site notices", with: "3"
+    fill_in "Where should notices be displayed?", with: "Corner by the substation and rear alley"
 
     expect(page).to have_content("Email the site notice")
 
@@ -122,6 +146,9 @@ RSpec.describe "Create a site notice", js: true do
 
     expect(email_notification.to).to contain_exactly("internal@email.com")
     expect(email_notification.subject).to eq("Site notice for application number 23-00100-PA1A")
+    expect(email_notification.body.encoded).to include("Number of site notices requested: 3")
+    expect(email_notification.body.encoded)
+      .to include("Location instructions: Corner by the substation and rear alley")
   end
 
   it "allows officers to confirm site notice is not needed" do


### PR DESCRIPTION
### Description of change

Allow officers to add site notice quantity and location instructions

### Story Link

https://trello.com/c/CSefDWWz/1269-support-officers-to-provide-additional-instructions-on-site-notice
