### PR TITLE
Update logic so normal status tag shows

### DIFF
--- a/engines/bops_core/app/presenters/bops_core/status_presenter.rb
+++ b/engines/bops_core/app/presenters/bops_core/status_presenter.rb
@@ -14,7 +14,7 @@ module BopsCore
 
     included do
       def status_tag
-        return pre_app_status_tag if pre_application?
+        return pre_app_status_tag if pre_application? && determined?
 
         classes = ["govuk-tag govuk-tag--#{status_tag_colour}"]
 
@@ -28,7 +28,6 @@ module BopsCore
       end
 
       def pre_app_status_tag
-        return if in_assessment? || not_started?
         classes = ["govuk-tag govuk-tag--#{pre_app_status_tag_colour}"]
 
         tag.span class: classes do


### PR DESCRIPTION
### Description of change

This is an update to an earlier ticket which improves the status tag logic to only show preapp status tag when application is determined.

### Story Link

https://trello.com/c/NgFDoQsB/1207-application-status-in-the-assessment-stage-turns-out-wrong-after-officer-completed-summary-of-advice-task

