### PR TITLE
Add address to site history record

### DIFF
--- a/app/controllers/planning_applications/assessment/site_histories_controller.rb
+++ b/app/controllers/planning_applications/assessment/site_histories_controller.rb
@@ -90,7 +90,7 @@ module PlanningApplications
       end
 
       def planning_history_params
-        params.require(:site_history).permit(:reference, :description, :decision, :other_decision, :date, :comment)
+        params.require(:site_history).permit(:reference, :description, :decision, :other_decision, :date, :comment, :address)
       end
 
       def redirect_path

--- a/app/models/site_history.rb
+++ b/app/models/site_history.rb
@@ -7,7 +7,7 @@ class SiteHistory < ApplicationRecord
 
   alias_attribute :reference, :application_number
 
-  validates :reference, :description, :decision, presence: true
+  validates :application_number, :description, :decision, :date, presence: true
   validates :date, date: {on_or_before: :current}
 
   def decision_label

--- a/app/views/planning_applications/assessment/site_histories/_form.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_form.html.erb
@@ -4,6 +4,7 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_field :reference, width: "one-half" %>
+      <%= form.govuk_text_field :address %>
       <%= form.govuk_text_area :description, rows: 3 %>
 
       <%= form.govuk_radio_buttons_fieldset(:decision, legend: {text: "What was the decision?", size: "s"}) do %>

--- a/app/views/planning_applications/assessment/site_histories/_table.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_table.html.erb
@@ -1,46 +1,52 @@
 <% if site_histories.blank? %>
-  <p class="govuk-!-padding-6 govuk-!-margin-bottom-6 background-light-grey">
-    <strong>There is no site history for this property.</strong>
-  </p>
+  <div class="govuk-!-padding-3 govuk-!-margin-bottom-6 background-light-grey">
+    <p class="govuk-!-margin-bottom-2 govuk-!-margin-top-3"><strong>There is no site history for this property.</strong></p>
+    <p> Add new site history that's relevant to the proposal</p>
+  </div>
 <% else %>
-  <%= govuk_table(classes: "planning-history-table") do |table| %>
-    <% table.with_head do |head| %>
-      <% head.with_row do |row| %>
-        <% row.with_cell(text: "Application number") %>
-        <% row.with_cell(text: "Decision") %>
-        <% row.with_cell(text: "Description") %>
-        <% row.with_cell(text: "Relevance to proposal") %>
-        <% row.with_cell(text: "Date") %>
+  <% site_histories.each do |site_history| %>
+    <div class="govuk-summary-card" id="<%= site_history.reference %>">
+      <div class="govuk-summary-card__title-wrapper">
+        <div class="flex-between">
+            <h2 class="govuk-summary-card__title govuk-!-display-inline-block">
+              <%= site_history.reference %>
+            </h2>
+
+            <%= govuk_tag(
+                  text: site_history.decision_label,
+                  colour: t(site_history.decision_type, scope: :planning_application_tags),
+                  classes: "govuk-!-margin-top-1 govuk-!-margin-bottom-2 govuk-!-display-inline-block"
+                ) %>
+        </div>
+
+          <p class="govuk-body-s govuk-!-padding-top-2">
+            Decided on <%= site_history.date.to_fs(:day_month_year_slashes) %>
+          </p>
+      </div>
+      <div class="govuk-summary-card__content">
+        <p class="govuk-body govuk-!-margin-bottom-2">
+          <strong>Address: </strong>
+          <%= site_history.address.presence || "No address given" %>
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-2">
+          <strong>Description: </strong>
+          <%= site_history.description %>
+        </p>
+        <p class="govuk-body govuk-!-margin-bottom-2">
+          <strong>Relevance of application: </strong>
+          <%= site_history.comment.presence || "No comment provided" %>
+        </p>
         <% if show_action %>
-          <% row.with_cell(text: "Action") %>
+          <%= govuk_link_to "Edit",
+                edit_planning_application_assessment_site_history_path(@planning_application, site_history),
+                class: "govuk-!-display-inline-block" %>
+          <p class="govuk-!-display-inline-block">|</p>
+          <%= govuk_link_to "Remove",
+                planning_application_assessment_site_history_path(@planning_application, site_history),
+                method: :delete, class: "govuk-!-display-inline-block govuk-!-margin-bottom-1",
+                data: {confirm: "This action cannot be undone.\nAre you sure you want to remove this site history?"} %>
         <% end %>
-      <% end %>
-    <% end %>
-
-    <% table.with_body do |body| %>
-      <% site_histories.each do |site_history| %>
-        <% body.with_row do |row| %>
-          <% row.with_cell(text: site_history.reference) %>
-          <% row.with_cell do %>
-            <%= govuk_tag(text: site_history.decision_label, colour: t(site_history.decision_type, scope: :planning_application_tags)) %>
-          <% end %>
-          <% row.with_cell(text: site_history.description) %>
-          <% row.with_cell(text: site_history.comment) %>
-          <% row.with_cell(text: site_history.date? ? site_history.date.to_fs(:day_month_year_slashes) : "–") %>
-          <% if show_action %>
-            <% row.with_cell do %>
-                <%= govuk_link_to "Edit",
-                      edit_planning_application_assessment_site_history_path(@planning_application, site_history),
-                      class: "govuk-!-display-inline-block" %>
-
-                <%= govuk_link_to "Remove",
-                      planning_application_assessment_site_history_path(@planning_application, site_history),
-                      method: :delete, class: "govuk-!-display-inline-block govuk-!-margin-left-1",
-                      data: {confirm: "This action cannot be undone.\nAre you sure you want to remove this site history?"} %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% end %>
+      </div>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/planning_applications/assessment/site_histories/index.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/index.html.erb
@@ -18,7 +18,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h2 class="govuk-heading-m">Summary of the relevant historical applications</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-top-2">Summary of the relevant historical applications</h2>
+    <p class="govuk-body">Past applications for this site or relevant nearby locations:</p>
 
     <%= render "table", site_histories: @site_histories, show_action: true %>
 

--- a/db/migrate/20250924153729_add_address_to_site_histories.rb
+++ b/db/migrate/20250924153729_add_address_to_site_histories.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddAddressToSiteHistories < ActiveRecord::Migration[8.0]
+  def change
+    add_column :site_histories, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_22_141123) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_24_153729) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "plpgsql"
@@ -1138,6 +1138,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_22_141123) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "comment"
+    t.string "address"
     t.index ["planning_application_id"], name: "ix_site_histories_on_planning_application_id"
   end
 

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
@@ -1,35 +1,33 @@
-<% if @planning_application.site_histories.any? %>
-  <% @planning_application.site_histories.each do |site_history| %>
-    <div class="govuk-summary-card">
-      <div class="govuk-summary-card__title-wrapper">
-        <div class="display-flex govuk-!-padding-bottom-2">
-          <h2 class="govuk-summary-card__title">
-            <%= site_history.application_number %>
-          </h2>
-          <%= govuk_tag(text: site_history.decision_label, colour: t(site_history.decision_type, scope: :planning_application_tags), html_attributes: {class: "govuk-!-padding-top-2"}) %>
-        </div>
-        <p class="govuk-!-font-size-16  govuk-secondary-text-colour">
-          Decided on <%= site_history.date %>
-        </p>
+<% @planning_application.site_histories.each do |site_history| %>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <div class="display-flex govuk-!-padding-bottom-2">
+        <h2 class="govuk-summary-card__title">
+          <%= site_history.application_number %>
+        </h2>
+        <%= govuk_tag(text: site_history.decision_label, colour: t(site_history.decision_type, scope: :planning_application_tags), html_attributes: {class: "govuk-!-padding-top-2"}) %>
       </div>
-      <div class="govuk-summary-card__content">
-        <dl class="govuk-summary-list">
-          <div class="govuk-summary-list__row">
-            <dd class="govuk-summary-list__value">
-              <strong>Description: </strong><%= site_history.description %>
-              <div class="govuk-!-margin-top-2">
-                <% if site_history.comment %>
-                <strong>Officer comment:</strong> <%= site_history.comment %>
-                <% else %>
-                  <p class="govuk-!-font-size-16  govuk-secondary-text-colour">
-                    No comment added
-                  </p>
-                <% end %>
-              </div>
-            </dd>
-          </div>
-        </dl>
-      </div>
+      <p class="govuk-!-font-size-16  govuk-secondary-text-colour">
+        Decided on <%= site_history.date.to_fs(:day_month_year_slashes) %>
+      </p>
     </div>
-  <% end %>
+    <div class="govuk-summary-card__content">
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dd class="govuk-summary-list__value">
+            <strong>Description: </strong><%= site_history.description %>
+            <div class="govuk-!-margin-top-2">
+              <% if site_history.comment %>
+              <strong>Officer comment:</strong> <%= site_history.comment %>
+              <% else %>
+                <p class="govuk-!-font-size-16  govuk-secondary-text-colour">
+                  No comment added
+                </p>
+              <% end %>
+            </div>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
 <% end %>

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -280,10 +280,13 @@
           ) %>
     <% end %>
   </div>
-  <p>
-    No relevant site history at this site or nearby locations.
-  </p>
-  <%= render "bops_reports/planning_applications/site_history_table" %>
+  <% if @planning_application.site_histories.any? %>
+    <%= render "bops_reports/planning_applications/site_history_table" %>
+  <% else %>
+    <p>
+      No relevant site history at this site or nearby locations.
+    </p>
+  <% end %>
 </section>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/engines/bops_reports/spec/system/pre_application_report_spec.rb
+++ b/engines/bops_reports/spec/system/pre_application_report_spec.rb
@@ -319,7 +319,6 @@ RSpec.describe "Pre-application report" do
   it "displays site history" do
     within("#site-history") do
       expect(page).to have_content("Relevant site history")
-      expect(page).to have_content("No relevant site history at this site or nearby locations.")
 
       within(".govuk-summary-card") do
         expect(page).to have_content("REF123")
@@ -335,10 +334,8 @@ RSpec.describe "Pre-application report" do
 
     expect(page).to have_current_path("/planning_applications/#{reference}/assessment/site_histories?return_to=report")
 
-    within(".planning-history-table") do
-      within(row_with_content("REF123")) do
-        click_link "Edit"
-      end
+    within("#REF123") do
+      click_link "Edit"
     end
 
     fill_in "site-history-comment-field", with: "An amended entry for planning history"

--- a/spec/factories/site_history.rb
+++ b/spec/factories/site_history.rb
@@ -8,5 +8,14 @@ FactoryBot.define do
     description { "An entry for planning history" }
     date { "10/02/1980" }
     decision { :granted }
+    comment { "A comment about relevance of planning history" }
+
+    trait :refused do
+      reference { "REF456" }
+      description { "An entry for planning history that was refused" }
+      date { "11/01/2008" }
+      decision { :refused }
+      comment { "Neighbouring property work of size and scale which was previously refused" }
+    end
   end
 end

--- a/spec/models/site_history_spec.rb
+++ b/spec/models/site_history_spec.rb
@@ -20,8 +20,12 @@ RSpec.describe SiteHistory do
       expect(build(:site_history, decision: nil)).to be_invalid
     end
 
-    it "doesn't validate the presence of a date" do
-      expect(build(:site_history, date: nil)).to be_valid
+    it "validates the presence of a date" do
+      expect(build(:site_history, date: nil)).to be_invalid
+    end
+
+    it "does not validate the presence of an address" do
+      expect(build(:site_history, address: nil)).to be_valid
     end
 
     it "allows dates in the past" do


### PR DESCRIPTION
### Description of change

Add address field to site history and redesign front end to display records.

### Story Link

https://trello.com/c/5SAxxn2D/1030-relevant-site-history-add-address-details-of-the-site-history

### Screenshots
<img width="885" height="819" alt="image" src="https://github.com/user-attachments/assets/72d926d4-ec92-47a4-bd6b-b479effac1c8" />

