### PR TITLE
Change display text for consultee response tags

### DIFF
--- a/app/models/consultee/response.rb
+++ b/app/models/consultee/response.rb
@@ -12,11 +12,11 @@ class Consultee
 
     attr_readonly :response
 
-    enum :summary_tag, {
-      approved: "approved",
-      amendments_needed: "amendments_needed",
-      objected: "objected"
-    }, scopes: false
+    enum :summary_tag, %i[
+      approved
+      amendments_needed
+      objected
+    ].index_with(&:to_s), scopes: false
 
     validates :name, :response, :summary_tag, :received_at, presence: true
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -779,12 +779,12 @@ en:
   consultee_response:
     summary_tags:
       amendments_needed: Amendments needed
-      approved: Approved
-      objected: Objected
+      approved: No objection
+      objected: Objection
   consultee_response_component:
     amendments_needed: Amendments needed
-    approved: Approved
-    objected: Objected
+    approved: No objection
+    objected: Objection
     private: Private
     published: Published
     received_on: Received on %-d %B %Y
@@ -798,13 +798,13 @@ en:
     heading: Responses
   consultee_responses_component:
     amendments_needed: Amendments needed
-    approved: Approved
+    approved: No objection
     awaiting_response: Awaiting response
     failed: Failed
     last_email_delivered_at: Last consulted on %-d %B %Y
     last_received_at: Last received on %-d %B %Y
     not_consulted: Not consulted
-    objected: Objected
+    objected: Objection
     sending: Sending
     upload_new_response: Upload new response
     view_all_responses: View all responses (%{count})
@@ -818,7 +818,7 @@ en:
     sending: Sending
   consultee_summary_component:
     amendments_needed: Amendments needed
-    approved: Approved
+    approved: No objection
     awaiting_response: Awaiting response
     consulted_on: Consulted on
     email_address: Email address
@@ -826,7 +826,7 @@ en:
     heading: Consultee
     last_received_on: Last received on
     name: Name
-    objected: Objected
+    objected: Objection
     organisation: Organisation
     role: Role
     sending: Sending

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Planning applications", type: :system do
       end
 
       it "successfully submits two comments" do
-        choose "Approved"
+        choose "No objection"
 
         click_button "Submit Response"
 
@@ -63,7 +63,7 @@ RSpec.describe "Planning applications", type: :system do
 
           within ".consultee-response:first-of-type" do
             expect(page).to have_selector("p time", text: "Received on #{today.to_fs}")
-            expect(page).to have_selector("p span", text: "Approved")
+            expect(page).to have_selector("p span", text: "No objection")
             expect(page).to have_selector("p span", text: "Private")
             expect(page).to have_selector("p", text: "We are happy for this application to proceed")
           end

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
       expect(page).to have_selector("h1", text: "Upload consultee response")
       expect(page).to have_selector("h2", text: "Add a new response")
 
-      choose "Approved"
+      choose "No objection"
       fill_in "Response", with: "We are happy for this application to proceed"
 
       click_button "Save response"
@@ -211,7 +211,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
 
         within ".govuk-summary-list__row:nth-of-type(7)" do
           expect(page).to have_selector("dt", text: "Status")
-          expect(page).to have_selector("dd", text: "Approved")
+          expect(page).to have_selector("dd", text: "No objection")
         end
       end
 
@@ -220,7 +220,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
 
         within ".consultee-response:first-of-type" do
           expect(page).to have_selector("p time", text: "Received on #{today.to_fs}")
-          expect(page).to have_selector("p span", text: "Approved")
+          expect(page).to have_selector("p span", text: "No objection")
           expect(page).to have_selector("p span", text: "Private")
           expect(page).to have_selector("p", text: "We are happy for this application to proceed")
 
@@ -343,7 +343,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
       expect(page).to have_selector("h1", text: "Upload consultee response")
       expect(page).to have_selector("h2", text: "Add a new response")
 
-      choose "Approved"
+      choose "No objection"
       fill_in "Response", with: "We are happy for this application to proceed"
       attach_file("Upload documents", "spec/fixtures/files/images/proposed-floorplan.png")
 
@@ -408,7 +408,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
 
         within ".govuk-summary-list__row:nth-of-type(7)" do
           expect(page).to have_selector("dt", text: "Status")
-          expect(page).to have_selector("dd", text: "Approved")
+          expect(page).to have_selector("dd", text: "No objection")
         end
       end
 
@@ -417,7 +417,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
 
         within ".consultee-response:first-of-type" do
           expect(page).to have_selector("p time", text: "Received on #{today.to_fs}")
-          expect(page).to have_selector("p span", text: "Approved")
+          expect(page).to have_selector("p span", text: "No objection")
           expect(page).to have_selector("p span", text: "Private")
           expect(page).to have_selector("p", text: "We are happy for this application to proceed")
 


### PR DESCRIPTION
### Description of change

The positive/negative text should be 'no objection'/'objection', not 'approved'/'objected'.

This (hopefully) doesn't need to change the internal representation, only the i18n labels.

### Story Link

https://trello.com/c/8EqlUznU/1279-update-consultee-responses-stances-with-the-right-term-on-the-upload-consultee-responses-page