### PR TITLE
Add default address to site history

### DIFF
--- a/app/views/planning_applications/assessment/site_histories/_form.html.erb
+++ b/app/views/planning_applications/assessment/site_histories/_form.html.erb
@@ -4,7 +4,7 @@
       <%= form.govuk_error_summary %>
 
       <%= form.govuk_text_field :reference, width: "one-half" %>
-      <%= form.govuk_text_field :address %>
+      <%= form.govuk_text_field :address, value: @planning_application.address %>
       <%= form.govuk_text_area :description, rows: 3 %>
 
       <%= form.govuk_radio_buttons_fieldset(:decision, legend: {text: "What was the decision?", size: "s"}) do %>


### PR DESCRIPTION
### Description of change

Previous ticket AC missed, default address field to planning application address.

### Story Link

https://trello.com/c/5SAxxn2D/1030-relevant-site-history-add-address-details-of-the-site-history

### Screenshots

<img width="655" height="797" alt="image" src="https://github.com/user-attachments/assets/0bfff3f9-deb8-4ff6-8750-e61e46afbeab" />
