### PR TITLE
Add ability to change consultee response email address

### DIFF
--- a/app/models/consultee/response.rb
+++ b/app/models/consultee/response.rb
@@ -18,7 +18,8 @@ class Consultee
       objected
     ].index_with(&:to_s), scopes: false
 
-    validates :name, :response, :summary_tag, :received_at, presence: true
+    validates :name, :response, :email, :summary_tag, :received_at, presence: true
+    validate :email_domain_matches_consultee
 
     with_options on: :redaction do
       validates :redacted_by, presence: true
@@ -64,6 +65,15 @@ class Consultee
     def documents=(files)
       files.compact_blank.each do |file|
         documents.new(file: file)
+      end
+    end
+
+    def email_domain_matches_consultee
+      submitted_domain = email.split("@").last
+      consultee_domain = consultee.email_address.split("@").last
+
+      if submitted_domain != consultee_domain
+        errors.add(:email, "Email must be a [#{consultee_domain}] email address.")
       end
     end
 

--- a/app/presenters/consultee_presenter.rb
+++ b/app/presenters/consultee_presenter.rb
@@ -125,7 +125,7 @@ class ConsulteePresenter
 
   def last_corresponded_at
     if last_received_at.present?
-      I18n.t("planning_applications.consultee.responses.last_received", date: format_date(last_received_at))
+      I18n.t("planning_applications.consultee.responses.last_received", date: format_date(last_received_at), email: consultee.responses.last.email)
     elsif last_contacted_at.present?
       I18n.t("planning_applications.consultee.responses.last_contacted", date: format_date(last_contacted_at))
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -805,7 +805,7 @@ en:
     awaiting_response: Awaiting response
     failed: Failed
     last_email_delivered_at: Last consulted on %-d %B %Y
-    last_received_at: Last received on %-d %B %Y
+    last_received_at: Submitted by %{@co} %-d %B %Y
     not_consulted: Not consulted
     objected: Objection
     sending: Sending
@@ -1683,7 +1683,7 @@ en:
         index:
           make_public: The planning application must be made public on the BOPS Public Portal before you can send emails to consultees.
         last_contacted: Last contacted on %{date}
-        last_received: Last received on %{date}
+        last_received: Submitted by %{email} on %{date}
         no_responses: No responses received yet.
         update:
           success: Response was successfully published.

--- a/engines/bops_consultees/app/controllers/bops_consultees/consultee_responses_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/consultee_responses_controller.rb
@@ -30,7 +30,7 @@ module BopsConsultees
     end
 
     def consultee_response_params
-      params.require(:consultee_response).permit(:summary_tag, :response, documents: [])
+      params.require(:consultee_response).permit(:summary_tag, :response, :email, documents: [])
     end
 
     def render_expired

--- a/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
@@ -2,9 +2,9 @@
 
 module BopsConsultees
   class PlanningApplicationsController < ApplicationController
-    before_action :authenticate_with_sgid!, only: :show
     before_action :set_planning_application, only: %i[show resend_link]
     before_action :set_consultee, only: %i[show resend_link]
+    before_action :authenticate_with_sgid!, only: :show
     before_action :set_consultee_response, only: :show
     before_action :ensure_magic_link_resend_allowed, only: :resend_link
 
@@ -21,13 +21,23 @@ module BopsConsultees
     end
 
     def resend_link
-      BopsCore::MagicLinkMailerJob.perform_later(
-        resource: @consultee,
-        planning_application: @planning_application.presented
+      @form = BopsCore::MagicLink::ExpiredMagicLinkForm.new(
+        email: params.dig(:magic_link_expired_magic_link_form, :email),
+        consultee: @consultee
       )
 
-      respond_to do |format|
-        format.html { redirect_to root_url, notice: t(".success", email: @consultee.email_address) }
+      if @form.valid?
+        BopsCore::MagicLinkMailerJob.perform_later(
+          resource: @consultee,
+          planning_application: @planning_application.presented,
+          email: params.dig(:magic_link_expired_magic_link_form, :email)
+        )
+        respond_to do |format|
+          format.html { redirect_to root_url, notice: t(".success", email: params.dig(:magic_link_expired_magic_link_form, :email)) }
+        end
+      else
+        @expired_resource = @consultee
+        render_expired
       end
     end
 
@@ -35,6 +45,10 @@ module BopsConsultees
 
     def set_consultee
       expired_resource = BopsCore::SgidAuthenticationService.new(sgid).expired_resource
+      if expired_resource.nil?
+        render_not_found and return
+      end
+
       @consultee = @planning_application.consultation.consultees.find(expired_resource.id)
     rescue ActiveRecord::RecordNotFound
       render_not_found
@@ -45,6 +59,10 @@ module BopsConsultees
     end
 
     def render_expired
+      @form ||= BopsCore::MagicLink::ExpiredMagicLinkForm.new(
+        email: @consultee.email_address,
+        consultee: @consultee
+      )
       render "bops_consultees/planning_applications/index"
     end
 

--- a/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
@@ -21,6 +21,11 @@
         hint: {text: "Add any relevant documents."},
         multiple: true %>
 
+  <%= form.govuk_text_field :email,
+        label: {text: "Officer submitting comment"},
+        hint: {text: "Ensure your email address is correct to receive any further correspondence or consultations."},
+        value: @consultee.email_address %>
+
   <div class="govuk-button-group">
     <%= form.submit "Submit Response", class: "govuk-button govuk-button--primary govuk-!-margin-top-5" %>
   </div>

--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/index.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/index.html.erb
@@ -11,11 +11,28 @@
     </h1>
 
     <% if @expired_resource %>
-      <h2 class="govuk-heading-s">Your magic link has expired</h2>
-      <p>
-        Contact <%= govuk_mail_to(current_local_authority.feedback_email) %> if you think there's a problem.
-      </p>
-      <%= govuk_button_to "Send a new magic link", resend_link_planning_application_path(params[:reference], sgid: params[:sgid]) %>
+      <h2 class="govuk-heading-s">Magic link expired</h2>
+      <%= form_with model: @form,
+            url: resend_link_planning_application_path(params[:reference], sgid: params[:sgid]),
+            method: :post,
+            class: "govuk-!-margin-top-5" do |form| %>
+
+        <%= form.govuk_error_summary %>
+
+        <%= form.govuk_text_field :email,
+              label: {text: "Request a new email for"},
+              hint: {text: "The email must be a [#{@consultee.email_address.split("@").last}] address."} %>
+
+        <p>
+          Contact <%= govuk_mail_to(current_local_authority.feedback_email) %> if you think there's a problem.
+        </p>
+
+        <div class="govuk-button-group">
+          <%= form.submit "Request a new magic link",
+                class: "govuk-button govuk-button--primary govuk-!-margin-top-5" %>
+        </div>
+      <% end %>
+
     <% elsif params[:sgid].blank? %>
       <h2 class="govuk-heading-s">You are not authenticated</h2>
       <p>

--- a/engines/bops_core/app/jobs/bops_core/magic_link_mailer_job.rb
+++ b/engines/bops_core/app/jobs/bops_core/magic_link_mailer_job.rb
@@ -4,10 +4,11 @@ module BopsCore
   class MagicLinkMailerJob < ApplicationJob
     queue_as :low_priority
 
-    def perform(resource:, planning_application:)
+    def perform(resource:, planning_application:, email:)
       MagicLinkMailer.magic_link_mail(
         resource: resource,
-        planning_application: planning_application
+        planning_application: planning_application,
+        email: email
       ).deliver_now
     end
   end

--- a/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
+++ b/engines/bops_core/app/mailers/concerns/bops_core/magic_link_mailer.rb
@@ -2,7 +2,7 @@
 
 module BopsCore
   class MagicLinkMailer < ApplicationMailer
-    def magic_link_mail(resource:, planning_application:, subject: "Your BOPS magic link")
+    def magic_link_mail(resource:, planning_application:, email:, subject: "Your BOPS magic link")
       resource.touch(:magic_link_last_sent_at)
 
       @resource = resource
@@ -10,10 +10,11 @@ module BopsCore
       @planning_application = planning_application
       @subdomain = planning_application.local_authority.subdomain
       @url = magic_link_url
+      @email = email
 
       view_mail(
         NOTIFY_TEMPLATE_ID,
-        to: resource.email_address,
+        to: email,
         subject:,
         reply_to_id: planning_application.local_authority.email_reply_to_id
       )
@@ -21,7 +22,7 @@ module BopsCore
 
     private
 
-    attr_reader :resource, :sgid, :subdomain, :planning_application
+    attr_reader :resource, :sgid, :subdomain, :planning_application, :email
 
     def magic_link_url
       case resource

--- a/engines/bops_core/app/models/bops_core/magic_link/expired_magic_link_form.rb
+++ b/engines/bops_core/app/models/bops_core/magic_link/expired_magic_link_form.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+module BopsCore
+  module MagicLink
+    class ExpiredMagicLinkForm
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      attr_accessor :email, :consultee
+
+      validates :email, presence: true
+      validate :email_domain_matches_consultee
+
+      def email_domain_matches_consultee
+        submitted_domain = email.split("@").last
+        consultee_domain = consultee.email_address.split("@").last
+
+        if submitted_domain != consultee_domain
+          errors.add(:email, "Email must be a [#{consultee_domain}] address.")
+        end
+      end
+    end
+  end
+end

--- a/engines/bops_core/spec/jobs/bops_core/magic_link_mailer_job_spec.rb
+++ b/engines/bops_core/spec/jobs/bops_core/magic_link_mailer_job_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe BopsCore::MagicLinkMailerJob, type: :job do
 
   it "enqueues the job" do
     expect {
-      BopsCore::MagicLinkMailerJob.perform_later(resource: consultee, planning_application:)
-    }.to have_enqueued_job(BopsCore::MagicLinkMailerJob).with(resource: consultee, planning_application:)
+      BopsCore::MagicLinkMailerJob.perform_later(resource: consultee, planning_application:, email: consultee.email_address)
+    }.to have_enqueued_job(BopsCore::MagicLinkMailerJob).with(resource: consultee, planning_application:, email: consultee.email_address)
   end
 
   it "updates the magic link last sent at time" do
@@ -18,7 +18,7 @@ RSpec.describe BopsCore::MagicLinkMailerJob, type: :job do
 
     expect {
       perform_enqueued_jobs do
-        BopsCore::MagicLinkMailerJob.perform_now(resource: consultee, planning_application:)
+        BopsCore::MagicLinkMailerJob.perform_now(resource: consultee, planning_application:, email: consultee.email_address)
       end
     }.to change { consultee.magic_link_last_sent_at }.from(nil).to("2025-01-30".to_datetime)
   end
@@ -26,7 +26,7 @@ RSpec.describe BopsCore::MagicLinkMailerJob, type: :job do
   it "sends the email" do
     expect {
       perform_enqueued_jobs do
-        BopsCore::MagicLinkMailerJob.perform_now(resource: consultee, planning_application:)
+        BopsCore::MagicLinkMailerJob.perform_now(resource: consultee, planning_application:, email: consultee.email_address)
       end
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
   end

--- a/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
+++ b/engines/bops_core/spec/mailers/bops_core/magic_link_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BopsCore::MagicLinkMailer, type: :mailer do
     let(:consultation) { create(:consultation) }
     let(:consultee) { create(:consultee, consultation:, email_address: "consultee@example.com", name: "Bops Consultee") }
     let(:planning_application) { consultation.planning_application }
-    let(:mail) { described_class.magic_link_mail(resource: consultee, planning_application:, subject: "Your magic link") }
+    let(:mail) { described_class.magic_link_mail(resource: consultee, planning_application:, email: consultee.email_address, subject: "Your magic link") }
 
     before do
       allow(consultee).to receive(:sgid).and_return("123456789")

--- a/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
+++ b/spec/system/planning_applications/consulting/view_consultee_responses_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "View consultee responses", type: :system, js: true do
+RSpec.describe "View consultee responses", type: :system, capybara: true, js: true do
   let(:api_user) { create(:api_user, :planx) }
   let(:local_authority) { create(:local_authority, :default) }
   let(:assessor) { create(:user, :assessor, local_authority:) }
@@ -160,7 +160,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
       within "#consultee-tab-all" do
         within(".consultee-panel:nth-of-type(2)") do
           expect(page).to have_selector(".consultee-panel__status .govuk-tag", text: "No objection")
-          expect(page).to have_text("Last received on #{today.to_fs(:day_month_year)}")
+          expect(page).to have_text("Submitted by #{external_consultee.email_address} on #{today.to_fs(:day_month_year)}")
           expect(page).to have_text("We are happy for this application to proceed")
           expect(page).to have_link("View all responses (1)")
         end
@@ -357,7 +357,7 @@ RSpec.describe "View consultee responses", type: :system, js: true do
       within "#consultee-tab-all" do
         within(".consultee-panel:nth-of-type(2)") do
           expect(page).to have_selector(".consultee-panel__status .govuk-tag", text: "No objection")
-          expect(page).to have_text("Last received on #{today.to_fs(:day_month_year)}")
+          expect(page).to have_text("Submitted by #{external_consultee.email_address} on #{today.to_fs(:day_month_year)}")
           expect(page).to have_text("We are happy for this application to proceed")
           expect(page).to have_link("View all responses (1)")
         end


### PR DESCRIPTION
### Description of change

Able to change the email address for an external consultee that receives the secure link email. Able to capture the email address of the respondent as part of the consultee response.

### Story Link

https://trello.com/c/MYVbxoyF/1138-resolve-the-consultee-journey-when-a-shared-mailbox-is-receiving-the-requests-for-comments-notification-and-securelink-sign-in

### Screenshots

<img width="853" height="729" alt="image" src="https://github.com/user-attachments/assets/4ee008f2-4869-48bc-a423-4d68d4854222" />


