### PR TITLE
Able to download all consultee documents

### DIFF
--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/_documents_list.html.erb
@@ -2,12 +2,14 @@
   Review the documents submitted by the applicant
 </p>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-controller="download" data-application-reference-value="<%= @planning_application.reference %>">
   <div class="govuk-grid-column-full">
-    <table class="govuk-table current-documents">
+    <table class="govuk-table current-documents govuk-!-margin-bottom-3" data-download-target="documentsElement">
       <tbody class="govuk-table__body">
         <% @planning_application.documents.for_consultees.each do |document| %>
-          <tr class="govuk-table__row" id="<%= dom_id(document) %>">
+          <tr class="govuk-table__row" id="<%= dom_id(document) %>"
+              data-document-title-value="<%= document.file.filename %>"
+              data-document-url-value="<%= url_for_document(document) %>">
             <td class="govuk-table__cell govuk-!-width-one-quarter">
               <% if document.representable? %>
                 <%= image_tag(main_app.uploaded_file_url(document.representation(resize_to_fill: [360, 240, gravity: "North"]))) %>
@@ -36,5 +38,9 @@
         <% end %>
       </tbody>
     </table>
+      <div data-download-target="button" class="govuk-body govuk-!-margin-top-3 govuk-!-margin-bottom-6 display-flex">
+        <%= govuk_link_to "Download all documents", data: {action: "click->download#submit"} %>
+      </div>
+    <hr>
   </div>
 </div>

--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/show.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/show.html.erb
@@ -110,8 +110,11 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <h2 class="govuk-heading-m">Submitted documents</h2>
-
-<%= render "bops_consultees/planning_applications/documents_list" %>
+<% if @planning_application.documents.for_consultees.any? %>
+  <%= render "bops_consultees/planning_applications/documents_list" %>
+<% else %>
+  <p class="govuk-body">There are no available documents to review.</p>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full" id="comments-form">

--- a/engines/bops_consultees/spec/system/download_documents_spec.rb
+++ b/engines/bops_consultees/spec/system/download_documents_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "zip"
+
+RSpec.describe "Download consultee documents", type: :system, capybara: true do
+  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:planning_application) { create(:planning_application, :pre_application, local_authority:, user:, documents:) }
+  let(:consultee) { create(:consultee, :external, email_address: "james.consultee@council.gov.uk", consultation: planning_application.consultation) }
+  let(:sgid) { consultee.sgid(expires_in: 1.day, for: "magic_link") }
+  let(:reference) { planning_application.reference }
+  let(:user) { create(:user) }
+  let(:documents) { create_list(:document, 3, :with_file, :consultees) }
+  let(:download_path) { Rails.root.join("tmp/downloads", "#{planning_application.reference}.zip") }
+
+  let(:today) do
+    Time.zone.today
+  end
+
+  before do
+    planning_application.consultation.start_deadline
+    visit "/consultees/planning_applications/#{reference}?sgid=#{sgid}"
+  end
+
+  it "downloads all documents as a zip file" do
+    expect(page).to have_current_path("/consultees/planning_applications/#{reference}?sgid=#{sgid}")
+    expect(page).to have_link("Download all documents")
+
+    click_link "Download all documents"
+    sleep 3
+
+    expect(File).to exist(download_path)
+    zip_files = []
+    Zip::File.open(download_path) do |files|
+      files.each do |file|
+        zip_files << file.name
+      end
+    end
+
+    pp zip_files
+    expect(zip_files).to include(
+      "proposed-floorplan.png",
+      "proposed-floorplan (1).png",
+      "proposed-floorplan (2).png"
+    )
+  end
+end

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe "Planning applications", type: :system do
         expect(page).to have_content("Response can't be blank")
 
         fill_in "Response", with: "We are happy for this application to proceed"
-        fill_in "Officer submitting comment", with: "tom@gmail.com"
+        fill_in "Your email address", with: "tom@gmail.com"
 
         click_button "Submit Response"
-        expect(page).to have_content("Email must be a [council.gov.uk] email address.")
+        expect(page).to have_content("Email must be a council.gov.uk email address.")
 
-        fill_in "Officer submitting comment", with: "tom@council.gov.uk"
+        fill_in "Your email address", with: "tom@council.gov.uk"
         click_button "Submit Response"
 
         expect(page).to have_content("Your response has been updated")
@@ -102,14 +102,14 @@ RSpec.describe "Planning applications", type: :system do
         expect(page).not_to have_content(planning_application.full_address)
         expect(page).not_to have_content(reference)
         expect(page).to have_content("Magic link expired")
-        expect(page).to have_content("The email must be a [council.gov.uk] address.")
+        expect(page).to have_content("The email must be a council.gov.uk address.")
         expect(page).to have_content("Contact #{local_authority.feedback_email} if you think there's a problem.")
 
         fill_in "Request a new email for", with: "tom@gmail.com"
 
         delivered_emails = mail.count
         click_button("Request a new magic link")
-        expect(page).to have_content("Email must be a [council.gov.uk] address.")
+        expect(page).to have_content("Email must be a council.gov.uk address.")
 
         fill_in "Request a new email for", with: "tom@council.gov.uk"
         click_button("Request a new magic link")


### PR DESCRIPTION
### Description of change

Able to download all documents from consultee page.

### Story Link

https://trello.com/c/WXgPLqSe/1012-as-a-consultee-im-able-to-bulk-download-all-the-documents-in-one-go-so-that-i-can-check-related-documents-quickly

### Screenshots

<img width="875" height="719" alt="image" src="https://github.com/user-attachments/assets/1970da56-7604-48b1-a48e-c3c2c0b1854e" />
