### PR TITLE
Able to show last consultee response email address in form

### DIFF
--- a/app/models/consultee/response.rb
+++ b/app/models/consultee/response.rb
@@ -73,7 +73,7 @@ class Consultee
       consultee_domain = consultee.email_address.split("@").last
 
       if submitted_domain != consultee_domain
-        errors.add(:email, "Email must be a [#{consultee_domain}] email address.")
+        errors.add(:email, "Email must be a #{consultee_domain} email address.")
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -809,7 +809,7 @@ en:
     awaiting_response: Awaiting response
     failed: Failed
     last_email_delivered_at: Last consulted on %-d %B %Y
-    last_received_at: Submitted by %{@co} %-d %B %Y
+    last_received_at: Last received on %-d %B %Y
     not_consulted: Not consulted
     objected: Objection
     sending: Sending

--- a/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
+++ b/engines/bops_consultees/app/controllers/bops_consultees/planning_applications_controller.rb
@@ -6,6 +6,7 @@ module BopsConsultees
     before_action :set_consultee, only: %i[show resend_link]
     before_action :authenticate_with_sgid!, only: :show
     before_action :set_consultee_response, only: :show
+    before_action :set_consultee_response_form_email, only: :show
     before_action :ensure_magic_link_resend_allowed, only: :resend_link
 
     def index
@@ -56,6 +57,11 @@ module BopsConsultees
 
     def set_consultee_response
       @consultee_response = @consultee.responses.new
+    end
+
+    def set_consultee_response_form_email
+      last_consultee_response = @consultee.responses.where.not(received_at: nil).order(received_at: :desc).last
+      @response_form_email = last_consultee_response&.email.presence || @consultee.email_address
     end
 
     def render_expired

--- a/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/consultee_responses/_form.html.erb
@@ -22,9 +22,9 @@
         multiple: true %>
 
   <%= form.govuk_text_field :email,
-        label: {text: "Officer submitting comment"},
+        label: {text: "Your email address"},
         hint: {text: "Ensure your email address is correct to receive any further correspondence or consultations."},
-        value: @consultee.email_address %>
+        value: @response_form_email %>
 
   <div class="govuk-button-group">
     <%= form.submit "Submit Response", class: "govuk-button govuk-button--primary govuk-!-margin-top-5" %>

--- a/engines/bops_consultees/app/views/bops_consultees/planning_applications/index.html.erb
+++ b/engines/bops_consultees/app/views/bops_consultees/planning_applications/index.html.erb
@@ -21,7 +21,7 @@
 
         <%= form.govuk_text_field :email,
               label: {text: "Request a new email for"},
-              hint: {text: "The email must be a [#{@consultee.email_address.split("@").last}] address."} %>
+              hint: {text: "The email must be a #{@consultee.email_address.split("@").last} address."} %>
 
         <p>
           Contact <%= govuk_mail_to(current_local_authority.feedback_email) %> if you think there's a problem.

--- a/engines/bops_consultees/spec/system/planning_applications_spec.rb
+++ b/engines/bops_consultees/spec/system/planning_applications_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe "Planning applications", type: :system do
         expect(page).to have_content("Response can't be blank")
 
         fill_in "Response", with: "We are happy for this application to proceed"
-        fill_in "Officer submitting comment", with: "tom@gmail.com"
+        fill_in "Your email address", with: "tom@gmail.com"
 
         click_button "Submit Response"
-        expect(page).to have_content("Email must be a [council.gov.uk] email address.")
+        expect(page).to have_content("Email must be a council.gov.uk email address.")
 
-        fill_in "Officer submitting comment", with: "tom@council.gov.uk"
+        fill_in "Your email address", with: "tom@council.gov.uk"
         click_button "Submit Response"
 
         expect(page).to have_content("Your response has been updated")
@@ -102,14 +102,14 @@ RSpec.describe "Planning applications", type: :system do
         expect(page).not_to have_content(planning_application.full_address)
         expect(page).not_to have_content(reference)
         expect(page).to have_content("Magic link expired")
-        expect(page).to have_content("The email must be a [council.gov.uk] address.")
+        expect(page).to have_content("The email must be a council.gov.uk address.")
         expect(page).to have_content("Contact #{local_authority.feedback_email} if you think there's a problem.")
 
         fill_in "Request a new email for", with: "tom@gmail.com"
 
         delivered_emails = mail.count
         click_button("Request a new magic link")
-        expect(page).to have_content("Email must be a [council.gov.uk] address.")
+        expect(page).to have_content("Email must be a council.gov.uk address.")
 
         fill_in "Request a new email for", with: "tom@council.gov.uk"
         click_button("Request a new magic link")

--- a/engines/bops_core/app/models/bops_core/magic_link/expired_magic_link_form.rb
+++ b/engines/bops_core/app/models/bops_core/magic_link/expired_magic_link_form.rb
@@ -18,7 +18,7 @@ module BopsCore
         consultee_domain = consultee.email_address.split("@").last
 
         if submitted_domain != consultee_domain
-          errors.add(:email, "Email must be a [#{consultee_domain}] address.")
+          errors.add(:email, "Email must be a #{consultee_domain} address.")
         end
       end
     end


### PR DESCRIPTION
### Description of change

Some changes to previous PR: https://github.com/unboxed/bops/pull/2589

- Change “Officer submitting comment” to “Your email address”
- Consultee response form should use response email address when available
- Some small language changes and clean up

### Story Link

https://trello.com/c/MYVbxoyF/1138-resolve-the-consultee-journey-when-a-shared-mailbox-is-receiving-the-requests-for-comments-notification-and-securelink-sign-in

