### PR TITLE
HoT small fixes

### DIFF
--- a/app/components/sortable/list_item_component.html.erb
+++ b/app/components/sortable/list_item_component.html.erb
@@ -14,7 +14,7 @@
       <h2 class="govuk-heading-m"><%= record.title %></h2>
     <% end %>
 
-    <% if current_request %>
+    <% if current_request && show_status_tag %>
       <p style="float: none">
         <%= render(StatusTags::BaseComponent.new(status: status(record))) %>
       </p>

--- a/app/components/sortable/list_item_component.rb
+++ b/app/components/sortable/list_item_component.rb
@@ -4,7 +4,7 @@ module Sortable
   class ListItemComponent < ViewComponent::Base
     include ConditionsHelper
 
-    def initialize(record:, record_class:, record_controller:, record_sortable_url:, edit_record_url:, remove_record_url: nil, current_request: nil)
+    def initialize(record:, record_class:, record_controller:, record_sortable_url:, edit_record_url:, remove_record_url: nil, current_request: nil, show_status_tag: true)
       @record = record
       @record_class = record_class
       @record_controller = record_controller
@@ -12,7 +12,10 @@ module Sortable
       @edit_record_url = edit_record_url
       @remove_record_url = remove_record_url
       @current_request = current_request
+      @show_status_tag = show_status_tag
     end
+
+    attr_reader :show_status_tag
 
     private
 

--- a/app/components/task_list_items/assessment/heads_of_terms_component.rb
+++ b/app/components/task_list_items/assessment/heads_of_terms_component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module TaskListItems
+  module Assessment
+    class HeadsOfTermsComponent < TaskListItems::BaseComponent
+      def initialize(planning_application:)
+        @planning_application = planning_application
+      end
+
+      private
+
+      attr_reader :planning_application
+
+      def link_text
+        "Suggest heads of terms"
+      end
+
+      def link_path
+        planning_application_assessment_terms_path(@planning_application)
+      end
+
+      def status_tag_component
+        StatusTags::HeadsOfTermsComponent.new(heads_of_term: planning_application.heads_of_term)
+      end
+    end
+  end
+end

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -71,4 +71,8 @@ module PlanningApplicationHelper
       "Consultees"
     end
   end
+
+  def heads_of_terms_task_header(planning_application)
+    planning_application.pre_application? ? "Suggest heads of terms" : "Add heads of terms"
+  end
 end

--- a/app/views/planning_applications/assessment/tasks/_assessment_information.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_assessment_information.html.erb
@@ -30,5 +30,13 @@
             )
           ) %>
     <% end %>
+
+    <% if @planning_application.heads_of_terms? && @planning_application.pre_application? %>
+      <%= render(
+            TaskListItems::Assessment::HeadsOfTermsComponent.new(
+              planning_application: @planning_application
+            )
+          ) %>
+    <% end %>
   </ul>
 </li>

--- a/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
+++ b/app/views/planning_applications/assessment/tasks/_complete_assessment.html.erb
@@ -77,7 +77,7 @@
         </div>
       </li>
     <% end %>
-    <% if @planning_application.heads_of_terms? %>
+    <% if @planning_application.heads_of_terms? && !@planning_application.pre_application? %>
       <li class="app-task-list__item" id="add-heads-of-terms">
         <span class="app-task-list__task-name">
           <%= govuk_link_to "Add heads of terms", planning_application_assessment_terms_path(@planning_application) %>

--- a/app/views/planning_applications/assessment/terms/index.html.erb
+++ b/app/views/planning_applications/assessment/terms/index.html.erb
@@ -7,14 +7,18 @@
       locals: {planning_application: @planning_application}
     ) %>
 
-<% content_for :title, "Add heads of terms" %>
+<% content_for :title, heads_of_terms_task_header(@planning_application) %>
 
 <%= render(
       partial: "shared/proposal_header",
-      locals: {heading: "Add heads of terms"}
+      locals: {heading: heads_of_terms_task_header(@planning_application)}
     ) %>
 
 <%= render(ReviewerCommentComponent.new(comment: @heads_of_term.current_review)) %>
+
+<% if @planning_application.pre_application? %>
+  <p><%= t(".preapp_reminder") %></p>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -29,15 +33,13 @@
               record_sortable_url: planning_application_assessment_term_position_path(@planning_application, term),
               edit_record_url: edit_planning_application_assessment_term_path(@planning_application, term),
               remove_record_url: planning_application_assessment_term_path(@planning_application, term),
-              current_request: term.current_validation_request
+              current_request: term.current_validation_request,
+              show_status_tag: !@planning_application.pre_application?
             )) %>
       <% end %>
 
     </ol>
     <p><%= t(".drag_and_drop") %></p>
-    <% if @planning_application.pre_application? %>
-      <p><%= t(".preapp_reminder") %></p>
-    <% end %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
+++ b/spec/system/planning_applications/assessing/adding_heads_of_terms_spec.rb
@@ -342,13 +342,13 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
     end
 
     it "you can add new heads of terms" do
-      within("#add-heads-of-terms") do
+      within("#suggest-heads-of-terms") do
         expect(page).to have_content "Optional"
-        click_link "Add heads of terms"
+        click_link "Suggest heads of terms"
       end
 
       expect(page).to have_content("Heads of terms can be added for pre-applications, but no email will be sent to the applicant.")
-      expect(page).to have_selector("h1", text: "Add heads of terms")
+      expect(page).to have_selector("h1", text: "Suggest heads of terms")
       find("span", text: "Add a new heads of terms").click
       expect(page).to have_selector("h2", text: "Add a new heads of term")
 
@@ -370,7 +370,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
       within("#term_#{Term.first.id}") do
         expect(page).to have_selector("span", text: "Heads of term 1")
         expect(page).to have_selector("h2", text: "Title 1")
-        expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
+        expect(page).to have_no_content("Not sent")
         expect(page).to have_selector("p", text: "Custom details 1")
 
         expect(page).to have_link("Remove")
@@ -380,7 +380,7 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
       within("#term_#{Term.second.id}") do
         expect(page).to have_selector("span", text: "Heads of term 2")
         expect(page).to have_selector("h2", text: "Title 2")
-        expect(page).to have_selector("p strong.govuk-tag", text: "Not sent")
+        expect(page).to have_no_content("Not sent")
         expect(page).to have_selector("p", text: "Custom details 2")
       end
 
@@ -388,21 +388,21 @@ RSpec.describe "Add heads of terms", type: :system, capybara: true do
       expect(page).to have_selector("[role=alert] p", text: "Head of terms have been confirmed")
 
       within("#term_#{Term.first.id}") do
-        expect(page).to have_selector(".govuk-tag", text: "Not sent")
+        expect(page).to have_no_content("Not sent")
 
         expect(page).to have_link("Edit")
         expect(page).to have_link("Remove")
       end
 
       within("#term_#{Term.second.id}") do
-        expect(page).to have_selector(".govuk-tag", text: "Not sent")
+        expect(page).to have_no_content("Not sent")
 
         expect(page).to have_link("Edit")
         expect(page).to have_link("Remove")
       end
 
       click_link "Back"
-      within("#add-heads-of-terms") do
+      within("#suggest-heads-of-terms") do
         expect(page).to have_content "Completed"
       end
     end


### PR DESCRIPTION
### Description of change

This adds some amendments to the last PR. The main changes are:

- suppressing the display of status tags for preapp requests (because no emails are ever sent)
- changing the wording and location of the Heads of Terms task on the assessment index page when the planning application is a preapp

### Story Link

https://trello.com/c/1iJIOhd6/1299-enable-heads-of-terms-feature-on-pre-apps

### Screenshots

![sum_ass](https://github.com/user-attachments/assets/7d97ab85-6d8e-4993-a599-ed2d0d952b0b)
