### PR TITLE
Update summary of advice to show unredacted responses

### DIFF
--- a/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
+++ b/app/views/planning_applications/assessment/assessment_details/summary_of_advice/_tabs.html.erb
@@ -37,7 +37,7 @@
               id: "consultee-response-#{consultee_response.id}"
             ) do |component| %>
           <% component.with_title { consultee_response.name } %>
-          <% component.with_body { consultee_response.comment } %>
+          <% component.with_body { consultee_response.response } %>
           <% component.with_status do %>
             <% case consultee_response.summary_tag %>
             <% when "amendments_needed" %>


### PR DESCRIPTION
### Description of change

We don't need the Summary of Advice table for preapps to show unredacted consultee responses as it's for internal use only.

### Story Link

https://trello.com/c/mkPsAmcK/1226-show-unredacted-consultee-comments-in-the-table-on-summary-of-advice

