### PR TITLE
Handle polygon_geojson read/write for JSONB compatibility

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -316,17 +316,8 @@ class Consultation < ApplicationRecord
     end_date >= Time.zone.today
   end
 
-  def polygon_geojson
-    value = super
-    value.is_a?(String) ? JSON.parse(value) : value
-  end
-
-  def polygon_geojson_before_type_cast
-    polygon_geojson.to_json
-  end
-
   def polygon_geojson=(value)
-    if value.is_a?(String) && value.present?
+    if value.present?
       parsed = JSON.parse(value)
       self.polygon_search = geometry_collection(value) if parsed.present?
       super(parsed)

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -316,9 +316,23 @@ class Consultation < ApplicationRecord
     end_date >= Time.zone.today
   end
 
+  def polygon_geojson
+    value = super
+    value.is_a?(String) ? JSON.parse(value) : value
+  end
+
+  def polygon_geojson_before_type_cast
+    polygon_geojson.to_json
+  end
+
   def polygon_geojson=(value)
-    self.polygon_search = geometry_collection(value) if value.present? && JSON.parse(value).present?
-    super
+    if value.is_a?(String) && value.present?
+      parsed = JSON.parse(value)
+      self.polygon_search = geometry_collection(value) if parsed.present?
+      super(parsed)
+    else
+      super
+    end
   end
 
   def polygon_fill_colour

--- a/app/views/shared/_location_map.html.erb
+++ b/app/views/shared/_location_map.html.erb
@@ -72,7 +72,10 @@
     const map = document.querySelector("my-map");
 
     map.addEventListener("geojsonChange", ({ detail: geoJSON }) => {
-      document.querySelector("[id^='<%= locals[:geojson_field] %>']").value = JSON.stringify(geoJSON["EPSG:3857"]);
+      const geojson = geoJSON["EPSG:3857"];
+      if (geojson !== undefined) {
+        document.querySelector("[id^='<%= locals[:geojson_field] %>']").value = JSON.stringify(geojson);
+      }
     });
   <% end %>
 

--- a/db/migrate/20260416090501_fix_double_serialized_polygon_geojson.rb
+++ b/db/migrate/20260416090501_fix_double_serialized_polygon_geojson.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class FixDoubleSerializedPolygonGeojson < ActiveRecord::Migration[8.0]
+  def change
+    up_only do
+      Consultation.find_each do |consultation|
+        polygon_geojson = consultation.read_attribute(:polygon_geojson)
+        next if polygon_geojson.blank?
+
+        if polygon_geojson.is_a?(String)
+          begin
+            parsed_json = JSON.parse(polygon_geojson)
+            consultation.update_column(:polygon_geojson, parsed_json)
+          rescue JSON::ParserError
+          end
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_194539) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_16_090501) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -238,6 +238,43 @@ RSpec.describe Consultation do
     end
   end
 
+  describe "#polygon_geojson=" do
+    let(:consultation) { create(:consultation) }
+
+    let(:valid_geojson) do
+      {
+        "type" => "FeatureCollection",
+        "features" => [
+          {
+            "type" => "Feature",
+            "properties" => {},
+            "geometry" => {
+              "type" => "Polygon",
+              "coordinates" => [
+                [
+                  [-0.07739927369747812, 51.501345554406896],
+                  [-0.0778893839394212, 51.501002280754676],
+                  [-0.07690508968054104, 51.50102474569704],
+                  [-0.07676672973966252, 51.50128963605792],
+                  [-0.07739927369747812, 51.501345554406896]
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    end
+
+    context "with valid GeoJSON" do
+      it "sets polygon_search from the geojson" do
+        consultation.polygon_geojson = valid_geojson.to_json
+
+        expect(consultation.polygon_search).to be_present
+        expect(consultation.polygon_geojson).to eq(valid_geojson)
+      end
+    end
+  end
+
   describe "#polygon_search_and_boundary_geojson" do
     let!(:consultation) { create(:consultation, :with_polygon_search, planning_application:) }
 


### PR DESCRIPTION
### Description of change

The geojson value was passed as a raw string to super, causing double-serialization in the JSONB column. Also guard against undefined EPSG:3857 data in the JS to prevent invalid submissions.

### Story Link

https://trello.com/c/3tk4NN0F/1909-neighbour-geojson-boundary-is-stored-as-a-string-in-the-jsonb-field-and-causes-errors-when-trying-to-re-read

