### PR TITLE
Add view neighbour response task

### DIFF
--- a/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/redact_neighbour_responses_controller.rb
@@ -5,6 +5,7 @@ module PlanningApplications
     before_action :set_planning_application
     before_action :set_consultation
     before_action :set_neighbour_response
+    before_action :show_sidebar
 
     def edit
       respond_to do |format|
@@ -45,7 +46,17 @@ module PlanningApplications
     end
 
     def neighbour_responses_path
-      planning_application_consultation_neighbour_responses_path(@planning_application)
+      if @planning_application.case_record.find_task_by_slug_path("consultees-neighbours-and-publicity/neighbours/view-neighbour-responses")
+        task_path(@planning_application, slug: "consultees-neighbours-and-publicity/neighbours/view-neighbour-responses")
+      else
+        planning_application_consultation_neighbour_responses_path(@planning_application)
+      end
+    end
+
+    def show_sidebar
+      @show_sidebar = if use_new_sidebar_layout?(@planning_application)
+        @planning_application.case_record.tasks.find_by(section: "Consultation")
+      end
     end
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,4 +9,11 @@ class TasksController < AuthenticationController
   before_action :show_sidebar
   before_action :show_header
   before_action :build_form
+
+  private
+
+  def failure_template
+    return :edit if params[:task_action] == "update_neighbour_response"
+    super
+  end
 end

--- a/app/forms/tasks/view_neighbour_responses_form.rb
+++ b/app/forms/tasks/view_neighbour_responses_form.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+module Tasks
+  class ViewNeighbourResponsesForm < Form
+    self.task_actions = %w[save_draft save_and_complete add_neighbour_response update_neighbour_response]
+
+    attribute :name, :string
+    attribute :email, :string
+    attribute :address, :string
+    attribute :new_address, :string
+    attribute :received_at, :date
+    attribute :summary_tag, :string
+    attribute :tags, :list, default: []
+    attribute :response, :string
+    attribute :files, array: true
+
+    after_initialize do
+      @consultation = planning_application.consultation
+      @neighbour_responses = @consultation.neighbour_responses.includes(
+        %i[neighbour redacted_by documents]
+      ).select(&:persisted?)
+      @neighbour_response = if params[:id].present?
+        @consultation.neighbour_responses.find(params[:id])
+      else
+        @consultation.neighbour_responses.new
+      end
+
+      if @neighbour_response.persisted?
+        self.name = @neighbour_response.name
+        self.email = @neighbour_response.email
+        self.address = @neighbour_response.neighbour&.address
+        self.received_at = @neighbour_response.received_at
+        self.summary_tag = @neighbour_response.summary_tag
+        self.tags = @neighbour_response.tags
+        self.response = @neighbour_response.response
+      end
+    end
+
+    with_options on: :add_neighbour_response do
+      validates :name, presence: {message: "Enter neighbour name"}
+      validate :address_or_new_address_present
+      validates :response, presence: {message: "Enter neighbour response"}
+      validates :summary_tag, presence: {message: "Please choose at least one relevant tag"}
+      validates :received_at, presence: {message: "Enter when response was received"}
+    end
+
+    with_options on: :update_neighbour_response do
+      validate :address_or_new_address_present
+    end
+
+    attr_reader :neighbour_response, :neighbour_responses, :consultation
+
+    def new_neighbour_response_url
+      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true)
+    end
+
+    def edit_neighbour_response_url(neighbour_response)
+      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: neighbour_response.id, only_path: true)
+    end
+
+    def update_neighbour_response_url
+      route_for(:task_component, planning_application, slug: task.full_slug, id: neighbour_response.id, only_path: true)
+    end
+
+    private
+
+    def address_or_new_address_present
+      if address.blank? && new_address.blank?
+        errors.add(:address, "Enter a neighbour address or add a new one")
+      end
+    end
+
+    def add_neighbour_response
+      neighbour = find_or_build_neighbour
+
+      if neighbour&.new_record? && !neighbour.valid?
+        errors.merge!(neighbour.errors)
+        return false
+      end
+
+      neighbour_response = consultation.neighbour_responses.build(
+        consultation_id: consultation.id,
+        name: name,
+        email: email,
+        received_at: received_at,
+        summary_tag: summary_tag,
+        tags: tags,
+        response: response
+      )
+
+      transaction do
+        neighbour_response.neighbour = neighbour
+        neighbour_response.save!
+        create_files(neighbour_response) if files_present?
+        create_audit_log(neighbour_response)
+        task.start!
+      end
+    end
+
+    def update_neighbour_response
+      updated_neighbour = find_or_build_neighbour
+
+      if updated_neighbour&.new_record? && !updated_neighbour.valid?
+        errors.merge!(updated_neighbour.errors)
+        return false
+      end
+
+      transaction do
+        update_attrs = {
+          name: name,
+          email: email,
+          received_at: received_at,
+          summary_tag: summary_tag,
+          tags: tags
+        }
+
+        if updated_neighbour.present? && updated_neighbour != neighbour_response.neighbour
+          updated_neighbour.save! if updated_neighbour.new_record?
+          update_attrs[:neighbour] = updated_neighbour
+        end
+
+        neighbour_response.update!(update_attrs)
+        create_edit_audit_log
+        task.in_progress!
+      end
+    end
+
+    def find_or_build_neighbour
+      if new_address.present?
+        consultation.neighbours.find_or_initialize_by(address: new_address) do |n|
+          n.selected = false
+          n.source = "sent_comment"
+        end
+      elsif address.present?
+        consultation.neighbours.find_by(address: address)
+      end
+    end
+
+    def create_files(neighbour_response)
+      files.compact_blank.each do |file|
+        planning_application.documents.create!(file:, owner: neighbour_response)
+      end
+    end
+
+    def files_present?
+      files&.compact_blank&.any?
+    end
+
+    def create_edit_audit_log
+      Audit.create!(
+        planning_application_id: planning_application.id,
+        user: Current.user,
+        activity_type: "neighbour_response_edited",
+        audit_comment: "Neighbour response from #{neighbour_response.neighbour.address} was edited"
+      )
+    end
+
+    def create_audit_log(neighbour_response)
+      Audit.create!(
+        planning_application_id: planning_application.id,
+        user: Current.user,
+        activity_type: "neighbour_response_uploaded",
+        audit_comment: "Neighbour response from #{neighbour_response.neighbour.address} was uploaded"
+      )
+    end
+
+    def form_params(params)
+      params.fetch(param_key, {}).permit(:name, :email, :address, :new_address, :received_at, :summary_tag, :response, tags: [], files: [])
+    end
+  end
+end

--- a/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/_responses.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/_responses.html.erb
@@ -1,0 +1,79 @@
+<%= govuk_accordion do |accordion| %>
+  <% neighbour_responses.group_by(&:summary_tag).sort_by { |key, _value| key[0] }.reverse.each_with_index do |(tag, responses), index| %>
+    <% accordion.with_section(heading_text: "#{tag&.capitalize} responses (#{responses.count})") do %>
+      <div id="accordion-default-content-<%= index %>" class="govuk-accordion__section-content" aria-labelledby="accordion-default-heading-<%= index %>">
+        <% responses.group_by { |response| response.neighbour.selected? }.sort_by { |key, _value| key ? 0 : 1 }.each do |selected, sorted_responses| %>
+          <% sorted_responses.each do |response| %>
+            <div class="neighbour-response-section">
+              <div class="govuk-inset-text">
+                <div class="neighbour-response-top-section">
+                  <div class="neighbour-response-content">
+                    <%= render(StatusTags::BaseComponent.new(status: response.summary_tag)) %>
+                    <% if response.neighbour.selected? %>
+                      <strong class="govuk-tag app-task-list__task-tag govuk-!-margin-left-1">Adjoining neighbour</strong>
+                    <% end %>
+                    <br><br>
+                    <ul class="govuk-list">
+                      <li>
+                        <strong><%= response.name %></strong> <span class="govuk-hint"><%= response.email %></span>
+                      </li>
+                      <li class="govuk-hint">
+                        <%= response.neighbour.address %>
+                      </li>
+                      <li class="govuk-hint">
+                        Received on <%= response.received_at.to_fs(:day_month_year_slashes) %>
+                      </li>
+                    </ul>
+                    <%= render ShowMoreTextComponent.new(text: response.comment, length: 100) %>
+                  </div>
+                  <div class="neighbour-tags">
+                    <% response.tags.each do |tag| %>
+                      <div class="govuk-!-margin-bottom-3">
+                        <strong class="govuk-tag govuk-tag--grey"><%= tag.humanize.upcase %></strong>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+                <% if response.documents.any? %>
+                  <tbody class="govuk-table__body">
+                    <% response.documents.each do |document| %>
+                      <tr class="govuk-table__row">
+                        <td class="govuk-table__cell govuk-!-width-one-third">
+                          <p class="govuk-!-margin-bottom-1">
+                            <%= document_thumbnail_link document, thumbnail_args: {resize: "300x212"} %>
+                          </p>
+                          <p>
+                            <%= truncate(document.name.to_s, length: 50) %><br>
+                            <%= link_to_document "View in new window", document %>
+                          </p>
+                        </td>
+                        <td class="govuk-table__cell govuk-!-width-one-third">
+                          <% document.tags.each do |tag| %>
+                            <strong class="govuk-tag govuk-tag--turquoise"><%= I18n.t(:"#{tag}", scope: :document_tags) %></strong>
+                          <% end %>
+                        </td>
+                        <td class="govuk-table__cell govuk-!-width-one-third">
+                          <p class="govuk-!-margin-bottom-1">
+                            <%= document.created_at.to_fs %>
+                          </p>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                <% end %>
+                <br>
+                <p>
+                  <%= govuk_link_to "Redact and publish", edit_planning_application_consultation_redact_neighbour_response_path(@planning_application, response) %>
+                  <% if response.redacted_by.try(:name) %>
+                    (Redacted by: <%= response.redacted_by.name %>)
+                  <% end %>
+                </p>
+                <%= link_to "Edit", @form.edit_neighbour_response_url(response) %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/edit.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/edit.html.erb
@@ -1,0 +1,29 @@
+<%= render "task_header", task: @task %>
+<h2>Edit neighbour response</h2>
+<%= form_with(model: @form, url: @form.update_neighbour_response_url) do |form| %>
+  <%= form.govuk_error_summary %>
+  <%= form.govuk_text_field :name %>
+  <%= form.govuk_text_field :email %>
+  <%= form.govuk_select :address, @form.consultation.selected_neighbour_addresses, options: {include_blank: true}, label: {text: "Select an existing neighbour address"} %>
+  <%= form.govuk_text_field :new_address, label: {text: "Or add a new neighbour address"} %>
+  <%= form.govuk_date_field :received_at, legend: {text: "Response received on", size: "s", tag: "p"} %>
+  <%= form.govuk_radio_buttons_fieldset :summary_tag, legend: {text: "Is the response", size: "m"} do %>
+    <%= form.govuk_radio_button :summary_tag, "supportive", label: {text: "Supportive"} %>
+    <%= form.govuk_radio_button :summary_tag, "neutral", label: {text: "Neutral"} %>
+    <%= form.govuk_radio_button :summary_tag, "objection", label: {text: "An objection"} %>
+  <% end %>
+  <%= form.govuk_collection_check_boxes :tags, NeighbourResponse::TAGS.map, :to_s, :to_s, legend: {text: "Tags", size: "m"} %>
+  <div class="govuk-form-group">
+    <p class="govuk-label govuk-label--s">Response</p>
+    <p class="govuk-hint">This won't be made public</p>
+    <p class="govuk-body"><%= @form.neighbour_response.response %></p>
+  </div>
+  <%= form.govuk_file_field :files,
+        label: {text: "Upload documents"},
+        hint: {text: "Add any documents that the respondent sent."},
+        multiple: true %>
+  <div class="govuk-button-group">
+    <%= form.govuk_task_button "Update response", action: "update_neighbour_response" %>
+    <%= back_link %>
+  </div>
+<% end %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/show.html.erb
@@ -1,0 +1,47 @@
+<%= render "task_header", task: @task %>
+
+<% if params[:new] %>
+    <h2>Add new neighbour response</h2>
+    <%= form_with(model: @form, url: @form.new_neighbour_response_url) do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_text_field :name %>
+      <%= form.govuk_text_field :email %>
+      <%= form.govuk_select :address, @form.consultation.selected_neighbour_addresses, options: {include_blank: true}, label: {text: "Select an existing neighbour address"} %>
+      <%= form.govuk_text_field :new_address, label: {text: "Or add a new neighbour address"} %>
+      <%= form.govuk_date_field :received_at, legend: {text: "Response received on", size: "s", tag: "p"} %>
+      <%= form.govuk_radio_buttons_fieldset :summary_tag, legend: {text: "Is the response", size: "m"} do %>
+          <%= form.govuk_radio_button :summary_tag, "supportive", label: {text: "Supportive"} %>
+          <%= form.govuk_radio_button :summary_tag, "neutral", label: {text: "Neutral"} %>
+          <%= form.govuk_radio_button :summary_tag, "objection", label: {text: "An objection"} %>
+      <% end %>
+      <%= form.govuk_collection_check_boxes :tags, NeighbourResponse::TAGS.map, :to_s, :to_s, legend: {text: "Tags", size: "m"} %>
+      <%= form.govuk_text_area :response, hint: {text: "This won't be made public"} %>
+      <%= form.govuk_file_field :files,
+            label: {text: "Upload documents"},
+            hint: {text: "Add any documents that the respondent sent."},
+            multiple: true %>
+      <div class="govuk-button-group">
+        <%= form.govuk_task_button "Save response", action: "add_neighbour_response" %>
+        <%= back_link %>
+      </div>
+    <% end %>
+<% else %>
+    <% if @planning_application.consultation.end_date %>
+        <h2 class="govuk-!-margin-top-7">Date consultation will end</h2>
+        <p><%= @planning_application.consultation.end_date.to_fs %></p>
+    <% end %>
+
+    <h2 class="govuk-!-margin-top-7">Responses (<%= @form.neighbour_responses.count %>)</h2>
+    <% if @form.neighbour_responses.any? %>
+        <%= render "tasks/consultees-neighbours-and-publicity/neighbours/view-neighbour-responses/responses", neighbour_responses: @form.neighbour_responses %>
+    <% else %>
+        <p>No neighbour responses yet</p>
+    <% end %>
+
+    <%= govuk_link_to "Add neighbour response", @form.new_neighbour_response_url %>
+    <%= form_with model: @form, url: @form.url do |form| %>
+      <div class="govuk-button-group govuk-!-margin-top-5">
+        <%= render "task_submit_buttons", form: form, save_draft: false %>
+      </div>
+    <% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2998,6 +2998,15 @@ en:
       upload-redacted-documents:
         failure: Failed to upload redacted documents
         success: Redacted documents successfully uploaded
+      view-neighbour-responses:
+        add_neighbour_response:
+          failure: Failed to save neighbour response
+          success: Successfully saved neighbour response
+        failure: Failed to save neighbour response task
+        success: Successfully saved neighbour response task
+        update_neighbour_response:
+          failure: Failed to update neighbour response
+          success: Successfully updated neighbour response
   time:
     formats:
       default: "%-d %B %Y"

--- a/config/task_workflows/other.yml
+++ b/config/task_workflows/other.yml
@@ -41,6 +41,7 @@
       tasks:
         - name: Add and assign neighbours
         - name: Send letters to neighbours
+        - name: View neighbour responses
     - name: Publicity
       section: Publicity
       tasks:

--- a/config/task_workflows/planning_permission.yml
+++ b/config/task_workflows/planning_permission.yml
@@ -41,6 +41,7 @@
       tasks:
         - name: Add and assign neighbours
         - name: Send letters to neighbours
+        - name: View neighbour responses
     - name: Publicity
       section: Publicity
       tasks:

--- a/config/task_workflows/prior_approval.yml
+++ b/config/task_workflows/prior_approval.yml
@@ -41,6 +41,7 @@
       tasks:
         - name: Add and assign neighbours
         - name: Send letters to neighbours
+        - name: View neighbour responses
     - name: Publicity
       section: Publicity
       tasks:

--- a/spec/system/tasks/view_neighbour_responses_spec.rb
+++ b/spec/system/tasks/view_neighbour_responses_spec.rb
@@ -1,0 +1,217 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "View neighbour responses task", type: :system, js: true do
+  include ActionDispatch::TestProcess::FixtureFile
+
+  let(:default_local_authority) { create(:local_authority, :default) }
+  let!(:api_user) { create(:api_user, :planx, local_authority: default_local_authority) }
+  let!(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let!(:application_type) { create(:application_type, :planning_permission) }
+
+  let!(:planning_application) do
+    create(:planning_application, :published, :from_planx_prior_approval,
+      application_type:, local_authority: default_local_authority, api_user:)
+  end
+  let(:task) { planning_application.case_record.find_task_by_slug_path!("consultees-neighbours-and-publicity/neighbours/view-neighbour-responses") }
+  let!(:consultation) { planning_application.consultation }
+  let!(:neighbour) { create(:neighbour, consultation:) }
+
+  before do
+    consultation.update(end_date: "2026-06-10 16:17:35 +0100")
+
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.reference}"
+    click_link "Consultees, neighbours and publicity"
+    within :sidebar do
+      click_link "View neighbour responses"
+    end
+  end
+
+  it "allows planning officer to upload neighbour response who was consulted" do
+    expect(task.reload).to be_not_started
+
+    expect(page).to have_content("10 June 2026")
+    expect(page).to have_content("No neighbour responses yet")
+
+    click_link "Add neighbour response"
+
+    fill_in "Name", with: "Sarah Neighbour"
+    fill_in "Email", with: "sarah@email.com"
+    select(neighbour.address.to_s, from: "Select an existing neighbour address")
+    fill_in "Day", with: "02"
+    fill_in "Month", with: "02"
+    fill_in "Year", with: "2026"
+    fill_in "Response", with: "I think this proposal looks great and I would like to make a really long comment about how great it is and please let this person build this thing."
+    choose "Supportive"
+
+    click_button "Save response"
+
+    expect(page).to have_content("Successfully saved neighbour response")
+    expect(page).not_to have_content("No neighbour responses yet")
+    expect(page).to have_content "Responses (1)"
+    expect(task.reload).to be_in_progress
+
+    click_button "Supportive responses (1)"
+
+    expect(page).to have_content("Sarah Neighbour")
+    expect(page).to have_content("sarah@email.com")
+    expect(page).to have_content(neighbour.address.to_s)
+    expect(page).to have_content("I think this proposal looks great and I would like to make a really long comment about how great...")
+    expect(page).to have_content("Supportive")
+    expect(page).to have_content("Adjoining neighbour")
+
+    click_link "View more"
+
+    expect(page).to have_content("I think this proposal looks great and I would like to make a really long comment about how great it is and please let this person build this thing.")
+
+    # Check audit log
+    visit "/planning_applications/#{planning_application.reference}/audits"
+    within("#audit_#{Audit.last.id}") do
+      expect(page).to have_content("Neighbour response uploaded")
+      expect(page).to have_content(assessor.name)
+      expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    end
+  end
+
+  it "allows planning officer to upload neighbour response who was not consulted" do
+    expect(page).to have_content("No neighbour responses yet")
+
+    click_link "Add neighbour response"
+
+    fill_in "Name", with: "Sarah Neighbour"
+    fill_in "Email", with: "sarah@email.com"
+    fill_in "Or add a new neighbour address", with: "123, Street, AAA111"
+    fill_in "Day", with: "21"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "2023"
+    fill_in "Response", with: "I think this proposal looks great"
+    choose "An objection"
+
+    click_button "Save response"
+
+    expect(page).not_to have_content("No neighbour responses yet")
+    expect(task.reload).to be_in_progress
+
+    click_button "Objection responses (1)"
+
+    expect(page).to have_content("Received on 21/01/2023")
+    expect(page).to have_content("Sarah Neighbour")
+    expect(page).to have_content("sarah@email.com")
+    expect(page).to have_content("123, Street, AAA111")
+    expect(page).to have_content("I think this proposal looks great")
+    expect(page).to have_content("Objection")
+
+    # Check audit log
+    visit "/planning_applications/#{planning_application.reference}/audits"
+    within("#audit_#{Audit.last.id}") do
+      expect(page).to have_content("Neighbour response uploaded")
+      expect(page).to have_content(assessor.name)
+      expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    end
+  end
+
+  it "displays an error when new address format is invalid" do
+    click_link "Add neighbour response"
+
+    fill_in "Name", with: "Sarah Neighbour"
+    fill_in "Email", with: "sarah@email.com"
+    fill_in "Or add a new neighbour address", with: "123 Street"
+    fill_in "Day", with: "21"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "2023"
+    fill_in "Response", with: "I think this proposal looks great"
+    choose "An objection"
+
+    click_button "Save response"
+
+    within(".govuk-error-summary") do
+      expect(page).to have_content("There is a problem")
+      expect(page).to have_content("'123 Street' is invalid")
+      expect(page).to have_content("Enter the property name or number, followed by a comma")
+      expect(page).to have_content("Enter the street name, followed by a comma")
+      expect(page).to have_content("Enter a postcode, like AA11AA")
+    end
+
+    expect(NeighbourResponse.count).to eq(0)
+  end
+
+  it "allows planning officer to edit neighbour responses" do
+    click_link "Add neighbour response"
+
+    fill_in "Name", with: "Sarah Neighbour"
+    fill_in "Email", with: "sarah@email.com"
+    select(neighbour.address.to_s, from: "Select an existing neighbour address")
+    fill_in "Day", with: "21"
+    fill_in "Month", with: "1"
+    fill_in "Year", with: "2026"
+    choose "Supportive"
+    fill_in "Response", with: "I think this proposal looks great"
+
+    click_button "Save response"
+
+    click_button "Supportive responses (1)"
+
+    expect(page).to have_content("Received on 21/01/2026")
+    expect(page).to have_content("Sarah Neighbour")
+    expect(page).to have_content("sarah@email.com")
+    expect(page).to have_content(neighbour.address.to_s)
+    expect(page).to have_content("I think this proposal looks great")
+
+    click_link "Edit"
+
+    fill_in "Name", with: "James Neighbour"
+
+    click_button "Update response"
+    expect(page).to have_content("Successfully updated neighbour response")
+
+    expect(page).to have_content("James Neighbour")
+    expect(page).not_to have_content("Sarah Neighbour")
+
+    # Check audit log
+    visit "/planning_applications/#{planning_application.reference}/audits"
+    within("#audit_#{Audit.last.id}") do
+      expect(page).to have_content("Neighbour response edited")
+      expect(page).to have_content(assessor.name)
+      expect(page).to have_content(Audit.last.created_at.strftime("%d-%m-%Y %H:%M"))
+    end
+  end
+
+  context "when redacting a response" do
+    let!(:neighbour_response) do
+      create(:neighbour_response, :without_redaction, consultation_id: consultation.id, neighbour:, response: "It will be too noisy, I hate my neighbour!")
+    end
+
+    before do
+      visit current_path
+      click_button "Supportive responses (1)"
+    end
+
+    it "does not show the redaction field when editing a response" do
+      click_link "Edit"
+
+      expect(page).not_to have_field("Redacted comment")
+      click_link "Back"
+    end
+
+    it "allows planning officer to redact a response" do
+      expect(page).not_to have_content("Redacted by")
+
+      click_link "Redact and publish"
+
+      fill_in "Redacted comment", with: "It will be too noisy, [redacted]"
+      click_button "Save and publish"
+
+      click_button "Supportive responses (1)"
+      expect(page).to have_content("Redacted by: #{assessor.name}")
+    end
+
+    it "allows planning officer to save and complete the task" do
+      click_button "Save and mark as complete"
+
+      expect(page).to have_content("Successfully saved neighbour response task")
+      expect(task.reload).to be_completed
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add view neighbour responses task.

### Story Link

https://trello.com/c/uFSWHkAT/1861-consultation-view-neighbour-responses

### Screenshots

<img width="1105" height="481" alt="image" src="https://github.com/user-attachments/assets/e4156d6a-8758-4141-b00c-e94388967dfa" />

### Decisions 

- Removed the redacted comment field from the edit page as there is a specific flow for redaction
- Once generated the comment is read only so this field is rendered as a `<p>` on edit page
- Kept the redact and publish content in the old pages with conditional sidebar and redirect. The task already had a 

