### PR TITLE
Able to add another press notice

### DIFF
--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/show.html.erb
@@ -38,6 +38,8 @@
   <%= form_with model: @form, url: @form.url do |form| %>
     <div class="govuk-button-group" id="press-notice-form-actions">
       <%= render "task_submit_buttons", form: form, save_draft: false %>
+      <%= govuk_button_link_to "Add another press notice", @form.new_press_notice_url, secondary: true, class: "govuk-!-margin-left-3" %>
+
     </div>
   <% end %>
 <% elsif @form.press_notices.where.not(id: nil).empty? %>

--- a/spec/system/tasks/press_notice_spec.rb
+++ b/spec/system/tasks/press_notice_spec.rb
@@ -154,14 +154,6 @@ RSpec.describe "Press notice task", js: true do
         requested_at: Time.zone.now,
         created_at: 2.hours.ago)
     end
-    let!(:newer_press_notice) do
-      create(:press_notice,
-        planning_application:,
-        required: true,
-        reasons: %w[environment],
-        requested_at: Time.zone.now,
-        created_at: 1.hour.ago)
-    end
 
     before do
       within :sidebar do
@@ -169,7 +161,19 @@ RSpec.describe "Press notice task", js: true do
       end
     end
 
-    it "displays press notices with the most recently created first" do
+    it "allows adding of a second press notice" do
+      cards = all(".govuk-summary-card")
+      expect(cards.length).to eq(1)
+
+      expect(page).to have_content("The application is for a Major Development")
+      click_link "Add another press notice"
+      check "An environmental statement accompanies this application"
+
+      click_button "Send request"
+
+      expect(page).to have_content("Successfully sent press notice email")
+      expect(task.reload).to be_in_progress
+      expect(page).to have_content("An environmental statement accompanies this application")
       cards = all(".govuk-summary-card")
       expect(cards.length).to eq(2)
 


### PR DESCRIPTION
### Description of change

Able to add another press notice when one exists already, functionality was present but the button was not rendered on previous PR.

### Story Link

https://trello.com/c/23t7fyTO/1906-consultation-press-notice

### Screenshots

<img width="1113" height="506" alt="image" src="https://github.com/user-attachments/assets/1b3699e3-6e65-4157-a6d4-df678f2c1853" />
