### PR TITLE
Edit site notice task

### DIFF
--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -14,7 +14,9 @@ module Tasks
 
     after_initialize do
       @site_notice = if params[:id].present?
-        planning_application.site_notices.find(params[:id])
+        planning_application.site_notices.find(params[:id]).tap do |sn|
+          self.displayed_at ||= sn.displayed_at
+        end
       else
         planning_application.site_notices.new
       end

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
@@ -2,7 +2,7 @@
   <% card.with_summary_list do |summary_list| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Quantity" } %>
-      <% row.with_value { site_notice.quantity } %>
+      <% row.with_value { site_notice.quantity.to_s } %>
     <% end %>
 
     <% summary_list.with_row do |row| %>
@@ -51,7 +51,7 @@
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Status" } %>
       <% row.with_value do %>
-        <% if site_notice.displayed_at? %>
+        <% if site_notice.displayed_at? && site_notice.documents.any? %>
           <strong class="govuk-tag govuk-tag--green">Displayed</strong>
         <% else %>
           <strong class="govuk-tag govuk-tag--blue">Sent</strong>
@@ -62,7 +62,7 @@
     <% summary_list.with_row do |row| %>
       <% row.with_key(classes: "govuk-summary-list__key") { "Display details" } %>
       <% row.with_value do %>
-        <% if site_notice.displayed_at? %>
+        <% if site_notice.displayed_at? && site_notice.documents.any? %>
           <% site_notice.documents.each do |document| %>
             <div class="display-flex govuk-!-margin-bottom-2">
               <div class="govuk-!-margin-right-3">

--- a/spec/system/tasks/site_notice_spec.rb
+++ b/spec/system/tasks/site_notice_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe "Site notice task", js: true do
       expect(page).to have_content("Site notice 1")
 
       within ".govuk-summary-card" do
+        expect(page).to have_content("2")
         expect(page).to have_content("Near the main entrance and rear gate")
         expect(page).to have_selector("strong.govuk-tag", text: "Sent")
         expect(page).to have_link("Confirm display")
@@ -178,6 +179,7 @@ RSpec.describe "Site notice task", js: true do
       within(cards[0]) do
         expect(page).to have_content("Site notice 1")
         expect(page).to have_content("Front entrance")
+        expect(page).to have_content("Sent")
       end
 
       within(cards[1]) do
@@ -192,7 +194,7 @@ RSpec.describe "Site notice task", js: true do
       end
 
       fill_in "Day", with: "10"
-      fill_in "Month", with: "2"
+      fill_in "Month", with: "3"
       fill_in "Year", with: "2026"
       attach_file "2. Upload evidence of site notice in place", "spec/fixtures/files/images/existing-floorplan.png"
       click_button "Confirm display"


### PR DESCRIPTION
### Description of change

Correct error in quantity displaying in the site notice table
Correct status being incorrectly displayed for site notices that are printed. When you generate a site notice to print internally you are asked to input a `displayed_at` date, which was satisfying the condition to hide the "Confirm display" link, updated condition to also check for documents which are both required to confirm display.

### Story Link

https://trello.com/c/wxcj1HzV/1863-consultation-site-notice
