### PR TITLE
Consultees flaky test

### DIFF
--- a/engines/bops_core/spec/support/shared_examples/check_consultees.rb
+++ b/engines/bops_core/spec/support/shared_examples/check_consultees.rb
@@ -16,13 +16,14 @@ RSpec.shared_examples "check consultees task", :capybara do |application_type|
     end
 
     click_button "Save changes"
+    expect(page).to have_content("Check consultees")
 
     expect(task.reload).to be_in_progress
     expect(planning_application.reload.consultation.current_review).to be_nil
 
     click_button "Save and mark as complete"
 
-    expect(page).to have_selector("h1", text: "Check consultees")
+    expect(page).to have_content("Consultees were successfully marked as reviewed")
     expect(task.reload).to be_completed
 
     review = planning_application.reload.consultation.current_review


### PR DESCRIPTION
### Description of change

Test was intermittently failing on checking task status completion. Previously was checking for `h1` which might have been passed before page was fully loaded. Changed to check for success message to hopefully make more reliable.

