### PR TITLE
Add consultee tasks for consultation

### DIFF
--- a/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
+++ b/app/controllers/planning_applications/consultee/assign_constraints_controller.rb
@@ -10,7 +10,7 @@ module PlanningApplications
         respond_to do |format|
           if planning_application_constraint.update(assignment_params)
             format.html do
-              redirect_to planning_application_consultees_url(@planning_application)
+              redirect_to redirect_url
             end
           else
             format.html { render :index }
@@ -19,6 +19,14 @@ module PlanningApplications
       end
 
       private
+
+      def redirect_url
+        if params[:task_slug].present?
+          task_path(@planning_application, params[:task_slug])
+        else
+          planning_application_consultees_url(@planning_application)
+        end
+      end
 
       def planning_application_constraint
         PlanningApplicationConstraint.find(constraint_id)

--- a/app/controllers/planning_applications/consultee/constraint_consultees_controller.rb
+++ b/app/controllers/planning_applications/consultee/constraint_consultees_controller.rb
@@ -9,10 +9,18 @@ module PlanningApplications
       def destroy
         constraint_consultee.destroy!
 
-        redirect_to planning_application_consultees_url(@planning_application), notice: t("consultee_constraint_consultees.destroy.success")
+        redirect_to redirect_url, notice: t("consultee_constraint_consultees.destroy.success")
       end
 
       private
+
+      def redirect_url
+        if params[:task_slug].present?
+          task_path(@planning_application, params[:task_slug])
+        else
+          planning_application_consultees_url(@planning_application)
+        end
+      end
 
       def constraint_consultee
         @constraint_consultee ||= ::PlanningApplicationConstraintConsultee

--- a/app/forms/tasks/add_and_assign_consultees_form.rb
+++ b/app/forms/tasks/add_and_assign_consultees_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Tasks
+  class AddAndAssignConsulteesForm < Form
+    self.task_actions = %w[save_draft save_and_complete]
+
+    delegate :consultation, to: :planning_application
+
+    def consultees
+      @consultees ||= consultation&.consultees || Consultee.none
+    end
+
+    def constraints
+      @constraints ||= planning_application.planning_application_constraints
+    end
+  end
+end

--- a/app/forms/tasks/send_emails_to_consultees_form.rb
+++ b/app/forms/tasks/send_emails_to_consultees_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Tasks
+  class SendEmailsToConsulteesForm < Form
+    include BopsCore::Tasks::SendEmailsToConsulteesForm
+  end
+end

--- a/app/forms/tasks/view_consultee_responses_form.rb
+++ b/app/forms/tasks/view_consultee_responses_form.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Tasks
+  class ViewConsulteeResponsesForm < Form
+    include BopsCore::Tasks::ViewConsulteeResponsesForm
+  end
+end

--- a/app/views/planning_applications/consultees/new.html.erb
+++ b/app/views/planning_applications/consultees/new.html.erb
@@ -24,6 +24,9 @@
       <%= form.govuk_error_summary %>
 
       <%= form.hidden_field :constraint, value: @constraint.id %>
+      <% if params[:task_slug].present? %>
+        <%= hidden_field_tag :task_slug, params[:task_slug] %>
+      <% end %>
       <%= form.govuk_collection_check_boxes :consultee_ids,
             @consultation.consultees,
             :id,
@@ -34,7 +37,8 @@
 
       <div class="govuk-button-group">
         <%= form.submit "Assign consultees", class: "govuk-button", data: {module: "govuk-button"} %>
-        <%= govuk_button_link_to "Back", planning_application_consultation_path(@planning_application), secondary: true %>
+        <% back_path = params[:task_slug].present? ? task_path(@planning_application, params[:task_slug]) : planning_application_consultation_path(@planning_application) %>
+        <%= govuk_button_link_to "Back", back_path, secondary: true %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -53,7 +53,7 @@
                   <% if use_preapps_routes %>
                     <%= govuk_link_to "Assign another consultee", bops_preapps.new_consultee_path(reference: planning_application.reference, constraint_id: constraint.id, task_slug: task_slug) %>
                   <% else %>
-                    <%= govuk_link_to "Assign another consultee", main_app.new_planning_application_consultee_path(planning_application, constraint: constraint) %>
+                    <%= govuk_link_to "Assign another consultee", main_app.new_planning_application_consultee_path(planning_application, constraint: constraint, task_slug: task_slug) %>
                   <% end %>
                 </div>
               <% end %>
@@ -61,7 +61,7 @@
               <% if use_preapps_routes %>
                 <%= govuk_link_to "Assign consultee", bops_preapps.new_consultee_path(reference: planning_application.reference, constraint_id: constraint.id, task_slug: task_slug) %>
               <% else %>
-                <%= govuk_link_to "Assign consultee", main_app.new_planning_application_consultee_path(planning_application, constraint: constraint) %>
+                <%= govuk_link_to "Assign consultee", main_app.new_planning_application_consultee_path(planning_application, constraint: constraint, task_slug: task_slug) %>
               <% end %>
             <% else %>
               &ndash;
@@ -101,7 +101,7 @@
                     <% remove_path = if use_preapps_routes
                          bops_preapps.constraint_consultee_path(reference: planning_application.reference, id: constraint_consultee.id, task_slug: task_slug)
                        else
-                         main_app.planning_application_consultees_constraint_consultee_path(planning_application, constraint_consultee)
+                         main_app.planning_application_consultees_constraint_consultee_path(planning_application, constraint_consultee, task_slug: task_slug)
                        end %>
                     <%= govuk_link_to "Remove",
                           remove_path,

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/add-and-assign-consultees/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/add-and-assign-consultees/show.html.erb
@@ -1,0 +1,66 @@
+<%= render "task_header", task: @task %>
+
+<%= content_tag :div, data: {
+      controller: "consultees",
+      consultees_planning_application_id: @planning_application.reference,
+      consultees_confirmation_message: "Send emails to consultees",
+      consultees_prompt_message: "Select a consultee",
+      consultees_error_message: "Unable to add consultee",
+      consultees_target: "allConsultees"
+    } do %>
+  <section class="consultee-selection govuk-!-margin-top-6">
+    <h2><%= t(".select_constraints_heading") %></h2>
+
+    <p class="govuk-body"><%= t(".select_constraints_description") %></p>
+
+    <div
+      class="govuk-checkboxes consultee-selection__list"
+      data-module="govuk-checkboxes">
+      <% manageable_consultees = !@planning_application.determined? %>
+      <% @form.constraints.each do |constraint| %>
+        <% form_data_attributes = {} %>
+        <% form_data_attributes[:controller] = "auto-submit" if manageable_consultees %>
+
+        <%= form_with scope: :planning_application_constraint,
+              url: planning_application_consultees_assign_constraint_path(@planning_application),
+              method: :post,
+              local: true,
+              data: form_data_attributes,
+              class: "consultee-selection__form" do |constraint_form| %>
+          <%= constraint_form.hidden_field :constraint, value: constraint.id %>
+          <%= hidden_field_tag :task_slug, @task.full_slug %>
+          <div class="govuk-checkboxes__item">
+            <% checkbox_options = {
+                 class: "govuk-checkboxes__input",
+                 id: dom_id(constraint, :consultation_required),
+                 data: manageable_consultees ? {action: "change->auto-submit#submit"} : nil,
+                 disabled: !manageable_consultees
+               } %>
+            <%= check_box_tag(
+                  "planning_application_constraint[consultation_required][]",
+                  "true",
+                  constraint.consultation_required?,
+                  **checkbox_options
+                ) %>
+            <%= label_tag dom_id(constraint, :consultation_required),
+                  constraint.type_code,
+                  class: "govuk-label govuk-checkboxes__label" %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  </section>
+
+  <%= form_with model: @form, url: @form.url, data: {consultees_target: "form"} do |form| %>
+    <%= form.govuk_error_summary %>
+
+    <section class="govuk-!-margin-top-7">
+      <h2><%= t(".assign_consultees_heading") %></h2>
+
+      <%= render "shared/consultees_table", planning_application: @planning_application, consultation: @form.consultation, show_assign: true, task_slug: @task.full_slug %>
+      <%= render AddConsulteeComponent.new(consultees: @form.consultees, form: form) %>
+    </section>
+
+    <%= render "task_submit_buttons", form: form %>
+  <% end %>
+<% end %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/send-emails-to-consultees/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/send-emails-to-consultees/show.html.erb
@@ -1,0 +1,51 @@
+<div data-controller="unsaved-changes"
+     data-action="beforeunload@window->unsaved-changes#handleBeforeUnload">
+  <%= form_with model: @form, url: @form.url,
+        data: {consultees_target: "form", unsaved_changes_target: "form", action: "submit->unsaved-changes#handleSubmit"} do |form| %>
+    <%= form.govuk_error_summary %>
+
+  <%= render "task_header", task: @task %>
+
+  <div class="govuk-grid-row">
+    <%= content_tag(:div, class: "govuk-grid-column-full", data: {
+          controller: "consultees",
+          consultees_planning_application_id: @planning_application.reference,
+          consultees_confirmation_message: t(".confirmation_message"),
+          consultees_prompt_message: t(".prompt_message"),
+          consultees_error_message: t(".error_message")
+        }) do %>
+      <h2>
+        <div class="govuk-hint govuk-!-margin-bottom-0">Step 1</div>
+        <%= t(".header") %>
+      </h2>
+
+      <%= render ConsulteesTableComponent.new(consultees: @form.consultees) %>
+
+      <%= render NoConsulteesComponent.new(consultees: @form.consultees) %>
+
+      <%= render ConsulteeEmailComponent.new(form: form) %>
+
+      <div class="govuk-form-group" id="response-period">
+        <h2>
+          <div class="govuk-hint govuk-!-margin-bottom-0">Step 3</div>
+          <%= form.govuk_label :consultee_response_period, text: t(".response_period.label"), size: "m" %>
+        </h2>
+
+        <p class="govuk-hint">
+          <%= t(".response_period.hint") %>
+        </p>
+
+        <div class="govuk-input__wrapper">
+          <%= form.govuk_text_field :consultee_response_period, class: "govuk-input", label: -> {}, required: true %>
+
+          <div class="govuk-input__suffix" aria-hidden="true">days</div>
+        </div>
+      </div>
+
+        <div class="govuk-button-group">
+          <%= form.govuk_task_button t(".submit"), id: "send-emails-button", data: {consultees_target: "submit"} %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_consultee_panel.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_consultee_panel.html.erb
@@ -1,0 +1,44 @@
+<%# locals: (consultee:, planning_application:, show_divider: true, show_action: true) %>
+
+<article class="consultee-panel">
+  <div class="consultee-panel__heading">
+    <div class="consultee-panel__title">
+      <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= consultee.name %></h4>
+      <% if consultee.role_line.present? %>
+        <p class="govuk-body-s govuk-!-margin-bottom-1"><%= consultee.role_line %></p>
+      <% end %>
+    </div>
+    <div class="consultee-panel__type">
+      <%= consultee.type_tag %>
+    </div>
+  </div>
+
+  <% if consultee.last_corresponded_at.present? %>
+    <p class="govuk-hint govuk-!-margin-bottom-3"><%= consultee.last_corresponded_at %></p>
+  <% end %>
+
+  <div class="consultee-panel__status">
+    <%= consultee.status_tag %>
+  </div>
+
+  <p class="govuk-body">
+    <%= consultee.response_snippet || consultee.fallback_response_text %>
+  </p>
+
+  <% if show_action %>
+    <div class="consultee-panel__actions">
+      <% if consultee.has_responses? %>
+        <div class="consultee-panel__action">
+          <%= govuk_link_to consultee.view_all_responses_label, consultee.view_all_responses_path %>
+        </div>
+      <% end %>
+      <div class="consultee-panel__action">
+        <%= govuk_link_to consultee.upload_new_response_label, consultee.upload_new_response_path %>
+      </div>
+    </div>
+  <% end %>
+</article>
+
+<% if show_divider %>
+  <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+<% end %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_consultee_tabs.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_consultee_tabs.html.erb
@@ -1,0 +1,35 @@
+<%# locals: (tabs:, planning_application:, show_action: true) %>
+
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title"><%= t(".tabs_title") %></h2>
+
+  <ul class="govuk-tabs__list">
+    <% tabs.each_with_index do |tab, index| %>
+      <li class="govuk-tabs__list-item <%= "govuk-tabs__list-item--selected" if index.zero? %>">
+        <a class="govuk-tabs__tab" href="#consultee-tab-<%= tab.key %>">
+          <%= tab.title %>
+        </a>
+      </li>
+    <% end %>
+  </ul>
+
+  <% tabs.each_with_index do |tab, index| %>
+    <div class="govuk-tabs__panel <%= "govuk-tabs__panel--hidden" unless index.zero? %>" id="consultee-tab-<%= tab.key %>">
+      <% consultee_list = tab.consultees.sort_by { |presenter| presenter.name.to_s.downcase } %>
+      <h2 class="govuk-heading-m"><%= tab.heading %></h2>
+      <% if consultee_list.empty? %>
+        <p class="govuk-body"><%= t(".no_consultees_in_tab") %></p>
+      <% else %>
+        <% consultee_list.each_with_index do |consultee_presenter, presenter_index| %>
+          <%= render partial: "tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/consultee_panel",
+                locals: {
+                  consultee: consultee_presenter,
+                  planning_application: planning_application,
+                  show_divider: presenter_index < consultee_list.size - 1,
+                  show_action: show_action
+                } %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_summary_panel.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/_summary_panel.html.erb
@@ -1,0 +1,41 @@
+<% summary = @form.response_summary %>
+
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title"><%= t(".response_summary.title") %></h2>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= govuk_summary_list(classes: "govuk-summary-list--no-border") do |list| %>
+      <% list.with_row do |row| %>
+        <% row.with_key { t("tasks.consultees-neighbours-and-publicity.consultees.view-consultee-responses.summary_panel.response_summary.total_consultees") } %>
+        <% row.with_value do %>
+          <strong><%= summary[:total] %></strong>
+        <% end %>
+      <% end %>
+
+      <% list.with_row do |row| %>
+        <% row.with_key { t("tasks.consultees-neighbours-and-publicity.consultees.view-consultee-responses.summary_panel.response_summary.responded") } %>
+
+        <% row.with_value do %>
+          <span class="govuk-tag govuk-tag--green"><%= summary[:responded] %></span>
+        <% end %>
+      <% end %>
+
+      <% list.with_row do |row| %>
+        <% row.with_key { t("tasks.consultees-neighbours-and-publicity.consultees.view-consultee-responses.summary_panel.response_summary.awaiting_response") } %>
+
+        <% row.with_value do %>
+          <span class="govuk-tag govuk-tag--yellow"><%= summary[:awaiting] %></span>
+        <% end %>
+      <% end %>
+
+      <% list.with_row do |row| %>
+        <% row.with_key { t("tasks.consultees-neighbours-and-publicity.consultees.view-consultee-responses.summary_panel.response_summary.not_consulted") } %>
+
+        <% row.with_value do %>
+          <span class="govuk-tag govuk-tag--grey"><%= summary[:not_consulted] %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/show.html.erb
@@ -1,0 +1,26 @@
+<%= render "task_header", task: @task %>
+
+<% if @form.consultation.present? && @form.consultees.any? %>
+  <div class="govuk-!-margin-top-6">
+    <%= render partial: "tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/summary_panel" %>
+  </div>
+
+  <% presenters = consultee_presenters(@form.consultees, @planning_application) %>
+  <% tabs = consultee_tabs(presenters) %>
+
+  <div class="govuk-grid-row govuk-!-margin-top-6">
+    <div class="govuk-grid-column-full">
+      <%= render partial: "tasks/consultees-neighbours-and-publicity/consultees/view-consultee-responses/consultee_tabs",
+            locals: {tabs: tabs, planning_application: @planning_application, show_action: !@planning_application.determined?} %>
+    </div>
+  </div>
+<% else %>
+  <div class="govuk-inset-text govuk-!-margin-top-6">
+    <p class="govuk-body"><%= t(".no_consultees") %></p>
+  </div>
+<% end %>
+
+<%= form_with model: @form, url: @form.url do |form| %>
+  <%= form.govuk_error_summary %>
+  <%= render "task_submit_buttons", form: form %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2805,7 +2805,41 @@ en:
             no_recommended_html: No <strong>(recommended based on submission data)</strong>
             'yes': 'Yes'
             yes_recommended_html: Yes <strong>(recommended based on submission data)</strong>
+    consultees-neighbours-and-publicity:
+      consultees:
+        add-and-assign-consultees:
+          show:
+            assign_consultees_heading: Assign consultees
+            select_constraints_description: Review the planning constraints and select which ones require consultation.
+            select_constraints_heading: Select constraints that require consultation
+        send-emails-to-consultees:
+          show:
+            confirmation_message: Send emails to consultees?
+            error_message: 'Error: Unable to add the consultee to the list'
+            header: Select the consultees to consult
+            prompt_message: Please search for a consultee first
+            response_period:
+              hint: Enter the number of days that consultees have to respond.
+              label: Set response period
+            submit: Send emails to consultees
+        view-consultee-responses:
+          consultee_tabs:
+            no_consultees_in_tab: No consultees in this category.
+            tabs_title: Consultee responses
+          show:
+            no_consultees: No consultees have been added yet. Add consultees and send emails before viewing responses.
+          summary_panel:
+            response_summary:
+              awaiting_response: Awaiting response
+              not_consulted: Not consulted
+              responded: Responded
+              title: Response summary
+              total_consultees: Total consultees
     update:
+      add-and-assign-consultees:
+        failure: Unable to save consultee assignments
+        save_draft: Consultee assignments draft was saved
+        success: Consultees have been successfully assigned
       add-and-assign-neighbours:
         add_addresses:
           failure: Unable to add neighbour addresses
@@ -2938,6 +2972,9 @@ en:
       review-documents-for-recommendation:
         failure: Failed to save document review
         success: Successfully saved document review
+      send-emails-to-consultees:
+        failure: Failed to send emails to consultees
+        success: Emails have been sent to the selected consultees
       send-letters-to-neighbours:
         send_letters:
           failure: Failed to send letters to neighbours
@@ -2998,6 +3035,10 @@ en:
       upload-redacted-documents:
         failure: Failed to upload redacted documents
         success: Redacted documents successfully uploaded
+      view-consultee-responses:
+        failure: Failed to save consultee responses review
+        save_draft: Consultee responses review draft was saved
+        success: Consultee responses review was successfully saved
       view-neighbour-responses:
         add_neighbour_response:
           failure: Failed to save neighbour response

--- a/config/task_workflows/other.yml
+++ b/config/task_workflows/other.yml
@@ -36,6 +36,12 @@
 - name: "Consultees, neighbours and publicity"
   section: "Consultation"
   tasks:
+    - name: Consultees
+      section: Consultees
+      tasks:
+        - name: Add and assign consultees
+        - name: Send emails to consultees
+        - name: View consultee responses
     - name: Neighbours
       section: Neighbours
       tasks:

--- a/config/task_workflows/planning_permission.yml
+++ b/config/task_workflows/planning_permission.yml
@@ -36,6 +36,12 @@
 - name: "Consultees, neighbours and publicity"
   section: "Consultation"
   tasks:
+    - name: Consultees
+      section: Consultees
+      tasks:
+        - name: Add and assign consultees
+        - name: Send emails to consultees
+        - name: View consultee responses
     - name: Neighbours
       section: Neighbours
       tasks:

--- a/config/task_workflows/prior_approval.yml
+++ b/config/task_workflows/prior_approval.yml
@@ -36,6 +36,12 @@
 - name: "Consultees, neighbours and publicity"
   section: "Consultation"
   tasks:
+    - name: Consultees
+      section: Consultees
+      tasks:
+        - name: Add and assign consultees
+        - name: Send emails to consultees
+        - name: View consultee responses
     - name: Neighbours
       section: Neighbours
       tasks:

--- a/engines/bops_core/app/forms/bops_core/tasks/send_emails_to_consultees_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/send_emails_to_consultees_form.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Tasks
+    module SendEmailsToConsulteesForm
+      extend ActiveSupport::Concern
+
+      included do
+        class << self
+          def model_name
+            ActiveModel::Name.new(self, nil, "Consultation")
+          end
+        end
+
+        attribute :consultee_message_subject, :string
+        attribute :consultee_message_body, :string
+        attribute :consultee_response_period, :integer
+        attribute :email_reason, :string
+
+        attr_accessor :consultees_attributes
+
+        after_initialize do
+          consultation
+
+          self.consultee_message_subject = consultation.consultee_message_subject
+          self.consultee_message_body = consultation.consultee_message_body
+          self.consultee_response_period = consultation.consultee_response_period
+          self.email_reason = consultation.email_reason
+        end
+
+        delegate :default_consultee_message_body, :default_consultee_message_subject, to: :consultation
+      end
+
+      def consultation
+        @consultation ||= planning_application.consultation || planning_application.create_consultation!
+      end
+
+      def consultees
+        consultation.consultees
+      end
+
+      private
+
+      def save_and_complete
+        if consultation.send_consultee_emails(form_params(params))
+          task.complete!
+        else
+          errors.merge!(consultation.errors)
+          false
+        end
+      end
+
+      def form_params(params)
+        params.require(:consultation).permit(
+          :consultee_message_subject,
+          :consultee_message_body,
+          :consultee_response_period,
+          :email_reason,
+          consultees_attributes: %i[id selected]
+        )
+      end
+    end
+  end
+end

--- a/engines/bops_core/app/forms/bops_core/tasks/view_consultee_responses_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/view_consultee_responses_form.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module BopsCore
+  module Tasks
+    module ViewConsulteeResponsesForm
+      extend ActiveSupport::Concern
+
+      included do
+        self.task_actions = %w[save_draft save_and_complete]
+
+        delegate :consultation, to: :planning_application
+      end
+
+      def consultees
+        @consultees ||= consultation&.consultees&.sorted || []
+      end
+
+      def response_summary
+        @response_summary ||= calculate_response_summary
+      end
+
+      private
+
+      def calculate_response_summary
+        counts = {total: 0, responded: 0, awaiting: 0, not_consulted: 0}
+
+        consultees.each do |consultee|
+          counts[:total] += 1
+          if consultee.responses?
+            counts[:responded] += 1
+          elsif consultee.awaiting_response?
+            counts[:awaiting] += 1
+          elsif consultee.not_consulted?
+            counts[:not_consulted] += 1
+          end
+        end
+
+        counts
+      end
+    end
+  end
+end

--- a/engines/bops_preapps/app/forms/bops_preapps/tasks/send_emails_to_consultees_form.rb
+++ b/engines/bops_preapps/app/forms/bops_preapps/tasks/send_emails_to_consultees_form.rb
@@ -3,58 +3,7 @@
 module BopsPreapps
   module Tasks
     class SendEmailsToConsulteesForm < Form
-      class << self
-        def model_name
-          ActiveModel::Name.new(self, nil, "Consultation")
-        end
-      end
-
-      attribute :consultee_message_subject, :string
-      attribute :consultee_message_body, :string
-      attribute :consultee_response_period, :integer
-      attribute :email_reason, :string
-
-      attr_accessor :consultees_attributes
-
-      after_initialize do
-        consultation
-
-        self.consultee_message_subject = consultation.consultee_message_subject
-        self.consultee_message_body = consultation.consultee_message_body
-        self.consultee_response_period = consultation.consultee_response_period
-        self.email_reason = consultation.email_reason
-      end
-
-      delegate :default_consultee_message_body, :default_consultee_message_subject, to: :consultation
-
-      def consultation
-        @consultation ||= planning_application.consultation || planning_application.create_consultation!
-      end
-
-      def consultees
-        consultation.consultees
-      end
-
-      private
-
-      def save_and_complete
-        if consultation.send_consultee_emails(form_params(params))
-          task.complete!
-        else
-          errors.merge!(consultation.errors)
-          false
-        end
-      end
-
-      def form_params(params)
-        params.require(:consultation).permit(
-          :consultee_message_subject,
-          :consultee_message_body,
-          :consultee_response_period,
-          :email_reason,
-          consultees_attributes: %i[id selected]
-        )
-      end
+      include BopsCore::Tasks::SendEmailsToConsulteesForm
     end
   end
 end

--- a/engines/bops_preapps/app/forms/bops_preapps/tasks/view_consultee_responses_form.rb
+++ b/engines/bops_preapps/app/forms/bops_preapps/tasks/view_consultee_responses_form.rb
@@ -3,36 +3,7 @@
 module BopsPreapps
   module Tasks
     class ViewConsulteeResponsesForm < Form
-      self.task_actions = %w[save_draft save_and_complete]
-
-      delegate :consultation, to: :planning_application
-
-      def consultees
-        @consultees ||= consultation&.consultees&.sorted || []
-      end
-
-      def response_summary
-        @response_summary ||= calculate_response_summary
-      end
-
-      private
-
-      def calculate_response_summary
-        counts = {total: 0, responded: 0, awaiting: 0, not_consulted: 0}
-
-        consultees.each do |consultee|
-          counts[:total] += 1
-          if consultee.responses?
-            counts[:responded] += 1
-          elsif consultee.awaiting_response?
-            counts[:awaiting] += 1
-          elsif consultee.not_consulted?
-            counts[:not_consulted] += 1
-          end
-        end
-
-        counts
-      end
+      include BopsCore::Tasks::ViewConsulteeResponsesForm
     end
   end
 end

--- a/spec/system/tasks/add_and_assign_consultees_spec.rb
+++ b/spec/system/tasks/add_and_assign_consultees_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Add and assign consultees task", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :assessor, local_authority:) }
+
+  %i[prior_approval planning_permission].each do |application_type|
+    context "for a #{application_type.to_s.humanize.downcase} case" do
+      let(:planning_application) do
+        create(:planning_application, application_type, :in_assessment, :published, local_authority:)
+      end
+      let!(:consultation) { planning_application.consultation || planning_application.create_consultation! }
+      let(:slug) { "consultees-neighbours-and-publicity/consultees/add-and-assign-consultees" }
+      let(:task) { planning_application.case_record.find_task_by_slug_path!(slug) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "displays the add and assign consultees page" do
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        expect(page).to have_content("Add and assign consultees")
+        expect(page).to have_content("Select constraints that require consultation")
+        expect(page).to have_content("Assign consultees")
+      end
+
+      it "displays planning constraints for selection" do
+        create(:planning_application_constraint, planning_application:)
+
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        expect(page).to have_css(".consultee-selection__list")
+      end
+
+      it "stays on the task page after toggling a constraint checkbox" do
+        constraint = create(:planning_application_constraint, planning_application:)
+        task_url = "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        visit task_url
+
+        check constraint.type_code
+
+        expect(page).to have_current_path(task_url)
+        expect(page).to have_content("Add and assign consultees")
+      end
+
+      it "stays on the task page after removing an assigned consultee" do
+        constraint = create(:planning_application_constraint, planning_application:, consultation_required: true)
+        consultee = create(:consultee, consultation:, name: "Environment Agency")
+        PlanningApplicationConstraintConsultee.create!(planning_application_constraint: constraint, consultee: consultee)
+
+        task_url = "/planning_applications/#{planning_application.reference}/#{slug}"
+        visit task_url
+
+        click_link "Remove"
+
+        expect(page).to have_current_path(task_url)
+        expect(page).to have_content("Add and assign consultees")
+      end
+
+      it "links to assign consultee page with task context" do
+        create(:planning_application_constraint, planning_application:, consultation_required: true)
+
+        task_url = "/planning_applications/#{planning_application.reference}/#{slug}"
+        visit task_url
+
+        click_link "Assign consultee"
+
+        expect(page).to have_content("Assign consultees")
+        click_link "Back"
+
+        expect(page).to have_current_path(task_url)
+      end
+
+      it "saves as draft and marks task in progress" do
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        click_button "Save changes"
+
+        expect(page).to have_content("Consultee assignments draft was saved")
+        expect(task.reload).to be_in_progress
+      end
+
+      it "saves and marks the task as complete" do
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Consultees have been successfully assigned")
+        expect(task.reload).to be_completed
+      end
+    end
+  end
+end

--- a/spec/system/tasks/send_emails_to_consultees_spec.rb
+++ b/spec/system/tasks/send_emails_to_consultees_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Send emails to consultees task", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :assessor, local_authority:) }
+
+  %i[prior_approval planning_permission].each do |application_type|
+    context "for a #{application_type.to_s.humanize.downcase} case" do
+      let(:planning_application) do
+        create(:planning_application, application_type, :in_assessment, :published, local_authority:)
+      end
+      let!(:consultation) { planning_application.consultation || planning_application.create_consultation! }
+      let!(:consultee) { create(:consultee, consultation:, selected: true) }
+      let(:slug) { "consultees-neighbours-and-publicity/consultees/send-emails-to-consultees" }
+      let(:task) { planning_application.case_record.find_task_by_slug_path!(slug) }
+
+      before do
+        sign_in(user)
+      end
+
+      it "sends emails to selected consultees and completes the task" do
+        clear_enqueued_jobs
+
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        expect(page).to have_content("Send emails to consultees")
+        check "Select consultee"
+
+        expect do
+          click_button "Send emails to consultees"
+
+          expect(page).to have_content("Emails have been sent to the selected consultees")
+        end.to have_enqueued_job(SendConsulteeEmailJob).once
+
+        expect(task.reload).to be_completed
+        expect(consultee.reload.status).to eq("sending")
+      end
+
+      it "shows validation errors when no consultees are selected" do
+        consultee.update!(selected: false)
+
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+        click_button "Send emails to consultees"
+
+        expect(page).to have_content("Please select at least one consultee")
+        expect(task.reload).to be_not_started
+      end
+
+      it "allows setting a custom response period" do
+        clear_enqueued_jobs
+
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        check "Select consultee"
+
+        find_field("Set response period").fill_in with: "", fill_options: {clear: :backspace}
+        fill_in "Set response period", with: "30"
+
+        click_button "Send emails to consultees"
+
+        expect(page).to have_content("Emails have been sent to the selected consultees")
+        expect(consultation.reload.end_date).to be_present
+      end
+
+      it "shows the consultees table with correct details" do
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        expect(page).to have_content(consultee.name)
+        expect(page).to have_css("#consultees")
+      end
+
+      it "warns when navigating away with unsaved changes to response period", :js do
+        visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+        find_field("Set response period").fill_in with: "", fill_options: {clear: :backspace}
+        fill_in "Set response period", with: "30"
+
+        dismiss_confirm(text: "You have unsaved changes") do
+          click_link "Home"
+        end
+
+        expect(page).to have_current_path(/send-emails-to-consultees/)
+      end
+    end
+  end
+end

--- a/spec/system/tasks/view_consultee_responses_spec.rb
+++ b/spec/system/tasks/view_consultee_responses_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "View consultee responses task", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :assessor, local_authority:) }
+
+  %i[prior_approval planning_permission].each do |application_type|
+    context "for a #{application_type.to_s.humanize.downcase} case" do
+      let(:planning_application) do
+        create(:planning_application, application_type, :in_assessment, :published, local_authority:)
+      end
+      let!(:consultation) { planning_application.consultation || planning_application.create_consultation! }
+      let(:slug) { "consultees-neighbours-and-publicity/consultees/view-consultee-responses" }
+      let(:task) { planning_application.case_record.find_task_by_slug_path!(slug) }
+
+      before do
+        sign_in(user)
+      end
+
+      context "when there are no consultees" do
+        it "displays a message that no consultees have been added" do
+          visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+          expect(page).to have_content("View consultee responses")
+          expect(page).to have_content("No consultees have been added yet")
+        end
+      end
+
+      context "when there are consultees" do
+        let!(:consultee_not_consulted) do
+          create(:consultee, consultation:, name: "Environment Agency", status: :not_consulted)
+        end
+
+        let!(:consultee_awaiting) do
+          create(:consultee, consultation:, name: "Historic England", status: :awaiting_response)
+        end
+
+        it "displays the response summary panel" do
+          visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+          expect(page).to have_content("Response summary")
+          expect(page).to have_content("Total consultees")
+          expect(page).to have_content("Responded")
+          expect(page).to have_content("Awaiting response")
+          expect(page).to have_content("Not consulted")
+        end
+
+        it "displays the consultee tabs" do
+          visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+          expect(page).to have_content("Consultee responses")
+          expect(page).to have_content("All (2)")
+          expect(page).to have_content(consultee_not_consulted.name)
+          expect(page).to have_content(consultee_awaiting.name)
+        end
+
+        it "saves and marks the task as complete" do
+          visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+          click_button "Save and mark as complete"
+
+          expect(page).to have_content("Consultee responses review was successfully saved")
+          expect(task.reload).to be_completed
+        end
+
+        it "saves as draft and marks task in progress" do
+          visit "/planning_applications/#{planning_application.reference}/#{slug}"
+
+          click_button "Save changes"
+
+          expect(page).to have_content("Consultee responses review draft was saved")
+          expect(task.reload).to be_in_progress
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

Add consultee tasks for consultation 
- Add three new tasks under the consultees section for prior approval,
planning permission, and other application types:
- Add and assign consultees
- Send emails to consultees
- View consultee responses

### Story Link

https://trello.com/c/LFlcfAnP/1855-consultation-send-emails-to-consultees
https://trello.com/c/Qac2YiSN/1856-consultation-view-consultee-responses
