### PR TITLE
Avoid using preapp routes for non-preapps

### DIFF
--- a/engines/bops_core/app/views/bops_core/tasks/check-and-assess/check-application/check-consultees/show.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/check-and-assess/check-application/check-consultees/show.html.erb
@@ -28,7 +28,7 @@
         planning_application: @planning_application,
         consultation: @planning_application.consultation,
         show_assign: true,
-        use_preapps_routes: true,
+        use_preapps_routes: @planning_application.pre_application?,
         task_slug: @task.full_slug %>
 <% end %>
 


### PR DESCRIPTION
Consultees table is unconditionally using the preapps routes from a template in core, which means if loaded from the non-preapp version of the task it'll break.