### PR TITLE
Update check publicity task links

### DIFF
--- a/app/forms/tasks/check_publicity_form.rb
+++ b/app/forms/tasks/check_publicity_form.rb
@@ -10,5 +10,21 @@ module Tasks
     end
 
     attr_reader :press_notice, :site_notice
+
+    def site_notice_not_required?
+      !site_notice&.required? && planning_application.site_notices.any?
+    end
+
+    def site_notice_resolved?
+      site_notice&.complete?
+    end
+
+    def site_notice_url
+      task_path(planning_application, slug: "/#{task.parent.full_slug}/site-notice", return_to: task.full_slug)
+    end
+
+    def press_notice_url
+      task_path(planning_application, slug: "/#{task.parent.full_slug}/press-notice", return_to: task.full_slug)
+    end
   end
 end

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -19,7 +19,7 @@ class SiteNotice < ApplicationRecord
   delegate :local_authority, to: :planning_application
 
   scope :by_created_at_desc, -> { order(created_at: :desc) }
-  scope :required, -> { where(required: true) }
+  scope :required, -> { where(required: true).order(id: :asc) }
 
   validates :required, inclusion: {in: [true, false]}
   validates :quantity,

--- a/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
@@ -1,6 +1,6 @@
 <%= render "task_header", task: @task %>
 
-<% unless @form.site_notice&.complete? && @form.press_notice&.complete? %>
+<% unless @form.site_notice_resolved? && @form.press_notice&.complete? %>
   <div
     class="govuk-notification-banner"
     role="alert"
@@ -14,28 +14,27 @@
       </h2>
     </div>
     <div class="govuk-notification-banner__content">
-      <!-- TODO: these links (and those further down) will need to be migrated to the new tasks once Consultation is done -->
       <% if @form.site_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), no_visited_state: true %>
+          <%= govuk_link_to t(".create_site_notice"), @form.site_notice_url, no_visited_state: true %>
         </p>
       <% elsif @form.site_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".site_notice_incomplete") %>
-          <%= govuk_link_to t(".confirm_site_notice"), edit_planning_application_site_notice_path(@planning_application, @form.site_notice), no_visited_state: true %>
+          <%= govuk_link_to t(".confirm_site_notice"), @form.site_notice_url, no_visited_state: true %>
         </p>
       <% end %>
 
       <% if @form.press_notice.nil? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), no_visited_state: true %>
+          <%= govuk_link_to t(".create_press_notice"), @form.press_notice_url, no_visited_state: true %>
         </p>
       <% elsif @form.press_notice.incomplete? %>
         <p class="govuk-notification-banner__heading">
           <%= t(".press_notice_incomplete") %>
-          <%= govuk_link_to t(".confirm_press_notice"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %>
+          <%= govuk_link_to t(".confirm_press_notice"), @form.press_notice_url, no_visited_state: true %>
         </p>
       <% end %>
     </div>
@@ -46,10 +45,16 @@
 <div id="site-notice-check">
   <h2><%= t(".check_site_notice") %></h2>
 
-  <% if @form.site_notice.nil? %>
+  <% if @form.site_notice_not_required? %>
+    <p>
+      <%= t(".site_notice_not_required") %>
+      <br>
+      <%= govuk_link_to t(".mark_site_notice_as_required"), @form.site_notice_url, no_visited_state: true, class: "govuk-body-s" %>
+    </p>
+  <% elsif @form.site_notice.nil? %>
     <p>
       <%= t(".site_notice_incomplete") %>
-      <%= govuk_link_to t(".create_site_notice"), new_planning_application_site_notice_path(@planning_application), no_visited_state: true %>
+      <%= govuk_link_to t(".create_site_notice"), @form.site_notice_url, no_visited_state: true %>
     </p>
   <% elsif @form.site_notice.required? %>
     <%= govuk_table(
@@ -71,10 +76,10 @@
           </p>
           <ul class="govuk-list">
             <li>
-              <%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %>
+              <%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true, class: "govuk-body-s") %>
             </li>
             <li>
-              <%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @form.site_notice), no_visited_state: true %>
+              <%= govuk_link_to t(".view_more_documents"), @form.site_notice_url, no_visited_state: true, class: "govuk-body-s" %>
             </li>
           </ul>
         </div>
@@ -89,7 +94,7 @@
       <p>
         <%= t(".no_documents_uploaded") %>
         <br>
-        <%= govuk_link_to t(".upload_evidence"), edit_planning_application_site_notice_path(@planning_application, @form.site_notice), no_visited_state: true, class: "govuk-body-s" %>
+        <%= govuk_link_to t(".upload_display_evidence"), @form.site_notice_url, no_visited_state: true, class: "govuk-body-s" %>
       </p>
     <% end %>
     <% if @form.site_notice.internal_team_email? %>
@@ -101,22 +106,16 @@
             data_module: "govuk-button"
           ) %>
     <% end %>
-  <% else %>
-    <p>
-      <%= t(".site_notice_not_required") %>
-      <br>
-      <%= govuk_link_to t(".mark_site_notice_as_required"), new_planning_application_site_notice_path(@planning_application), no_visited_state: true, class: "govuk-body-s" %>
-    </p>
   <% end %>
 </div>
-
+<%= govuk_section_break %>
 <div id="press-notice-check">
   <h2><%= t(".check_press_notice") %></h2>
 
   <% if @form.press_notice.nil? %>
     <p>
       <%= t(".press_notice_incomplete") %>
-      <%= govuk_link_to t(".create_press_notice"), planning_application_press_notice_path(@planning_application), no_visited_state: true %>
+      <%= govuk_link_to t(".create_press_notice"), @form.press_notice_url, no_visited_state: true %>
     </p>
   <% elsif @form.press_notice.required? %>
     <%= govuk_table(
@@ -124,7 +123,7 @@
           rows: [
             [
               @form.press_notice.reason,
-              @form.press_notice.displayed_at&.to_fs(:day_month_year_slashes) || "–",
+              @form.press_notice.published_at&.to_fs(:day_month_year_slashes) || "–",
               @form.press_notice.uploaded_by&.name || "–",
               @form.press_notice.expiry_date&.to_fs(:day_month_year_slashes) || "–"
             ]
@@ -139,10 +138,10 @@
           </p>
           <ul class="govuk-list">
             <li>
-              <%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %>
+              <%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true, class: "govuk-body-s") %>
             </li>
             <li>
-              <%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true %>
+              <%= govuk_link_to t(".view_more_documents"), @form.press_notice_url, no_visited_state: true, class: "govuk-body-s" %>
             </li>
           </ul>
         </div>
@@ -157,7 +156,7 @@
       <p>
         <%= t(".no_documents_uploaded") %>
         <br>
-        <%= govuk_link_to t(".upload_evidence"), planning_application_press_notice_confirmation_path(@planning_application), no_visited_state: true, class: "govuk-body-s" %>
+        <%= govuk_link_to t(".upload_evidence"), @form.press_notice_url, no_visited_state: true, class: "govuk-body-s" %>
       </p>
     <% end %>
     <% if current_local_authority.press_notice_email? %>
@@ -173,7 +172,7 @@
     <p>
       <%= t(".press_notice_not_required") %>
       <br>
-      <%= govuk_link_to t(".mark_press_notice_as_required"), planning_application_press_notice_path(@planning_application), no_visited_state: true, class: "govuk-body-s" %>
+      <%= govuk_link_to t(".mark_press_notice_as_required"), @form.press_notice_url, no_visited_state: true, class: "govuk-body-s" %>
     </p>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2721,24 +2721,30 @@ en:
           show:
             check_press_notice: Check press notice
             check_site_notice: Check site notice
-            confirm_press_notice: Confirm press notice
-            confirm_site_notice: Confirm site notice
-            create_press_notice: Create press notice
-            create_site_notice: Create site notice
+            confirm_press_notice: Confirm press notice display
+            confirm_site_notice: Confirm site notice display
+            create_press_notice: Create press notice or mark not required
+            create_site_notice: Create site notice or mark not required
             display_date: Display date
             edit: Edit site notice and press notice check
             evidence_of_press_notice: Evidence of press notice
             evidence_of_site_notice: Evidence of site notice
             expiry_date: Expiry date
+            mark_press_notice_as_required: Mark press notice as required
+            mark_site_notice_as_required: Mark site notice as required
             no_documents_uploaded: No documents uploaded
             press_notice: Press notice
             press_notice_incomplete: Press notice task incomplete
             press_notice_not_required: Press notice marked as not required for this application
             publication_date: Publication date
             reasons_for_press_notice: Reasons for press notice
+            request_press_notice_confirmation: Request new document
+            request_site_notice_confirmation: Request document from internal team
             site_notice: Site notice
             site_notice_incomplete: Site notice task incomplete
+            site_notice_not_required: Site notice not required
             title: Site notice and press notice
+            upload_display_evidence: Confirm display
             upload_evidence: Upload evidence
             uploaded_by: Uploaded by
             view_in_new_window: View in new window

--- a/spec/system/tasks/check_publicity_spec.rb
+++ b/spec/system/tasks/check_publicity_spec.rb
@@ -29,4 +29,167 @@ RSpec.describe "Check description task", type: :system do
       end
     end
   end
+
+  describe "site notice section", :capybara do
+    let(:planning_application) { create(:planning_application, :planning_permission, local_authority:) }
+
+    before { sign_in(user) }
+
+    context "when no site notice exists" do
+      before do
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows create site notice link in banner and section" do
+        within ".govuk-notification-banner" do
+          expect(page).to have_content("Site notice task incomplete")
+          expect(page).to have_link("Create site notice")
+        end
+
+        within "#site-notice-check" do
+          expect(page).to have_content("Site notice task incomplete")
+          expect(page).to have_link("Create site notice")
+        end
+      end
+    end
+
+    context "when site notice is marked as not required" do
+      before do
+        create(:site_notice, planning_application:, required: false)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows not required message and link to mark as required" do
+        within "#site-notice-check" do
+          expect(page).to have_content("Site notice not required")
+          expect(page).to have_link("Mark site notice as required")
+        end
+      end
+    end
+
+    context "when site notice exists but has not been displayed" do
+      before do
+        create(:site_notice, planning_application:)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows confirm link in banner and incomplete evidence section" do
+        within ".govuk-notification-banner" do
+          expect(page).to have_content("Site notice task incomplete")
+          expect(page).to have_link("Confirm site notice")
+        end
+
+        within "#site-notice-check" do
+          expect(page).to have_content("–")
+          expect(page).to have_content("Evidence of site notice")
+          expect(page).to have_content("No documents uploaded")
+          expect(page).to have_link("Confirm display")
+        end
+      end
+    end
+
+    context "when site notice has been displayed" do
+      before do
+        create(:site_notice, planning_application:, displayed_at: Date.new(2026, 1, 1))
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows display date in table and no documents message" do
+        within ".govuk-notification-banner" do
+          expect(page).not_to have_link("Create site notice")
+          expect(page).not_to have_link("Confirm site notice")
+        end
+
+        within "#site-notice-check" do
+          expect(page).to have_content("01/01/2026")
+          expect(page).to have_content("No documents uploaded")
+          expect(page).to have_link("Confirm display")
+        end
+      end
+    end
+  end
+
+  describe "press notice section", :capybara do
+    let(:planning_application) { create(:planning_application, :planning_permission, local_authority:) }
+
+    before { sign_in(user) }
+
+    context "when no press notice exists" do
+      before do
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows create press notice link in banner and section" do
+        within ".govuk-notification-banner" do
+          expect(page).to have_content("Press notice task incomplete")
+          expect(page).to have_link("Create press notice")
+        end
+
+        within "#press-notice-check" do
+          expect(page).to have_content("Press notice task incomplete")
+          expect(page).to have_link("Create press notice")
+        end
+      end
+    end
+
+    context "when press notice is marked as not required" do
+      before do
+        create(:press_notice, planning_application:)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows not required message and link to mark as required" do
+        within ".govuk-notification-banner" do
+          expect(page).not_to have_link("Create press notice")
+          expect(page).not_to have_link("Confirm press notice")
+        end
+
+        within "#press-notice-check" do
+          expect(page).to have_content("Press notice marked as not required for this application")
+          expect(page).to have_link("Mark press notice as required")
+        end
+      end
+    end
+
+    context "when press notice exists but has not been published" do
+      before do
+        create(:press_notice, :required, planning_application:)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows confirm link in banner and incomplete evidence section" do
+        within ".govuk-notification-banner" do
+          expect(page).to have_content("Press notice task incomplete")
+          expect(page).to have_link("Confirm press notice")
+        end
+
+        within "#press-notice-check" do
+          expect(page).to have_content("–")
+          expect(page).to have_content("Evidence of press notice")
+          expect(page).to have_content("No documents uploaded")
+          expect(page).to have_link("Upload evidence")
+        end
+      end
+    end
+
+    context "when press notice has been published" do
+      before do
+        create(:press_notice, :required, planning_application:, published_at: Date.new(2026, 1, 1))
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/check-publicity"
+      end
+
+      it "shows publication date in table and no documents message" do
+        within ".govuk-notification-banner" do
+          expect(page).not_to have_link("Create press notice")
+          expect(page).not_to have_link("Confirm press notice")
+        end
+
+        within "#press-notice-check" do
+          expect(page).to have_content("01/01/2026")
+          expect(page).to have_content("No documents uploaded")
+          expect(page).to have_link("Upload evidence")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Update links in check publicity task to go to new consultation task pages

### Story Link

https://trello.com/c/uKJmahSa/1927-update-links-in-check-publicity-task-to-new-consultation-tasks
