### PR TITLE
Update press site notice mailer

### DIFF
--- a/app/mailers/planning_application_mailer.rb
+++ b/app/mailers/planning_application_mailer.rb
@@ -131,6 +131,7 @@ class PlanningApplicationMailer < ApplicationMailer
     @planning_application = site_notice.planning_application
     @local_authority = @planning_application.local_authority
     @site_notice = site_notice
+    @site_notice_task = @planning_application.case_record&.find_task_by_slug_path("consultees-neighbours-and-publicity/publicity/site-notice")
     @user = user
     reference = @planning_application.reference
     email = @site_notice.internal_team_email
@@ -159,6 +160,7 @@ class PlanningApplicationMailer < ApplicationMailer
     @planning_application = press_notice.planning_application
     @local_authority = @planning_application.local_authority
     @press_notice = press_notice
+    @press_notice_task = @planning_application.case_record&.find_task_by_slug_path("consultees-neighbours-and-publicity/publicity/press-notice")
     @user = user
     reference = @planning_application.reference
     email = @press_notice.press_notice_email

--- a/app/views/planning_application_mailer/press_notice_confirmation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/press_notice_confirmation_request_mail.text.erb
@@ -4,6 +4,6 @@ Address: <%= @planning_application.address %>
 
 Please use this link to upload evidence of a press notice for this application:
 
-<%= planning_application_press_notice_confirmation_url(@planning_application, subdomain: @local_authority.subdomain) %>
+<%= @press_notice_task ? edit_task_component_url(@planning_application, slug: @press_notice_task.full_slug, id: @press_notice.id, subdomain: @local_authority.subdomain) : planning_application_press_notice_confirmation_url(@planning_application, subdomain: @local_authority.subdomain) %>
 
 Case officer: <%= @user.name %>

--- a/app/views/planning_application_mailer/site_notice_confirmation_request_mail.text.erb
+++ b/app/views/planning_application_mailer/site_notice_confirmation_request_mail.text.erb
@@ -4,6 +4,6 @@ Address: <%= @planning_application.address %>
 
 Please use this link to upload evidence of a site notice in place for this application:
 
-<%= edit_planning_application_site_notice_url(@planning_application, @site_notice, subdomain: @local_authority.subdomain) %>
+<%= @site_notice_task ? edit_task_component_url(@planning_application, slug: @site_notice_task.full_slug, id: @site_notice.id, subdomain: @local_authority.subdomain) : edit_planning_application_site_notice_url(@planning_application, @site_notice, subdomain: @local_authority.subdomain) %>
 
 Case officer: <%= @user.name %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/_table.html.erb
@@ -36,6 +36,9 @@
           <strong class="govuk-tag govuk-tag--blue">Requested</strong>
         <% end %>
       <% end %>
+      <% unless press_notice.published_at? %>
+        <% row.with_action(text: "Send reminder", href: planning_application_press_notice_confirmation_requests_path(@planning_application, press_notice), visually_hidden_text: "for press notice #{index + 1}") %>
+      <% end %>
     <% end %>
 
     <% summary_list.with_row do |row| %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
@@ -57,6 +57,9 @@
           <strong class="govuk-tag govuk-tag--blue">Sent</strong>
         <% end %>
       <% end %>
+      <% unless site_notice.displayed_at? && site_notice.documents.any? %>
+        <% row.with_action(text: "Send reminder", href: planning_application_site_notice_confirmation_requests_path(@planning_application, site_notice), visually_hidden_text: "for site notice #{index + 1}") %>
+      <% end %>
     <% end %>
 
     <% summary_list.with_row do |row| %>

--- a/spec/mailer/planning_application_mailer_spec.rb
+++ b/spec/mailer/planning_application_mailer_spec.rb
@@ -1663,4 +1663,133 @@ RSpec.describe PlanningApplicationMailer, type: :mailer do
       )
     end
   end
+
+  describe "#site_notice_confirmation_request_mail" do
+    let(:user) { create(:user, local_authority:) }
+    let(:application_type) { create(:application_type, :planning_permission) }
+
+    let(:site_notice) do
+      create(
+        :site_notice,
+        planning_application:,
+        internal_team_email: "sitenotices@example.com"
+      )
+    end
+
+    let(:mail) do
+      described_class.site_notice_confirmation_request_mail(site_notice, user)
+    end
+
+    let(:mail_body) { mail.body.encoded }
+
+    it "emails the internal team" do
+      expect(mail.to).to contain_exactly("sitenotices@example.com")
+    end
+
+    it "sets the subject" do
+      travel_to("2022-01-01") do
+        expect(mail.subject).to eq(
+          "Request for confirmation of a site notice for #{planning_application.reference}"
+        )
+      end
+    end
+
+    it "includes the reference" do
+      expect(mail_body).to include("## Application reference number: #{planning_application.reference}")
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include("Address: #{planning_application.address}")
+    end
+
+    it "includes the case officer name" do
+      expect(mail_body).to include("Case officer: #{user.name}")
+    end
+
+    it "includes the task edit url when the task exists" do
+      expect(mail_body).to include(
+        "http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/consultees-neighbours-and-publicity/publicity/site-notice/#{site_notice.id}/edit"
+      )
+    end
+
+    context "when no task exists" do
+      before do
+        allow(planning_application.case_record).to receive(:find_task_by_slug_path).and_return(nil)
+      end
+
+      it "includes the fallback site notice edit url" do
+        expect(mail_body).to include(
+          "http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/site_notices/#{site_notice.id}/edit"
+        )
+      end
+    end
+  end
+
+  describe "#press_notice_confirmation_request_mail" do
+    let!(:local_authority) do
+      create(
+        :local_authority,
+        :default,
+        press_notice_email: "pressnotice@example.com"
+      )
+    end
+    let(:user) { create(:user, local_authority:) }
+    let(:application_type) { create(:application_type, :planning_permission) }
+
+    let(:press_notice) do
+      create(
+        :press_notice,
+        :required,
+        planning_application:
+      )
+    end
+
+    let(:mail) do
+      described_class.press_notice_confirmation_request_mail(press_notice, user)
+    end
+
+    let(:mail_body) { mail.body.encoded }
+
+    it "emails the press notice team" do
+      expect(mail.to).to contain_exactly("pressnotice@example.com")
+    end
+
+    it "sets the subject" do
+      travel_to("2022-01-01") do
+        expect(mail.subject).to eq(
+          "Request for confirmation of a press notice for #{planning_application.reference}"
+        )
+      end
+    end
+
+    it "includes the reference" do
+      expect(mail_body).to include("## Application reference number: #{planning_application.reference}")
+    end
+
+    it "includes the address" do
+      expect(mail_body).to include("Address: #{planning_application.address}")
+    end
+
+    it "includes the case officer name" do
+      expect(mail_body).to include("Case officer: #{user.name}")
+    end
+
+    it "includes the task edit url when the task exists" do
+      expect(mail_body).to include(
+        "http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/consultees-neighbours-and-publicity/publicity/press-notice/#{press_notice.id}/edit"
+      )
+    end
+
+    context "when no task exists" do
+      before do
+        allow(planning_application.case_record).to receive(:find_task_by_slug_path).and_return(nil)
+      end
+
+      it "includes the fallback press notice confirmation url" do
+        expect(mail_body).to include(
+          "http://#{local_authority.subdomain}.bops.services/planning_applications/#{planning_application.reference}/press_notice/confirmation"
+        )
+      end
+    end
+  end
 end

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -65,6 +65,16 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
     PlanningApplicationMailer.press_notice_mail(PressNotice.required.last)
   end
 
+  def site_notice_confirmation_request_mail
+    site_notice = SiteNotice.where.not(internal_team_email: nil).last
+    PlanningApplicationMailer.site_notice_confirmation_request_mail(site_notice, site_notice.planning_application.user)
+  end
+
+  def press_notice_confirmation_request_mail
+    press_notice = PressNotice.required.last
+    PlanningApplicationMailer.press_notice_confirmation_request_mail(press_notice, press_notice.planning_application.user)
+  end
+
   private
 
   def planning_application


### PR DESCRIPTION
### Description of change

Update links in reminder emails for press and site notices and add links to "Send reminder" in tables when unconfirmed / unpublished.

### Story Link

https://trello.com/c/uKJmahSa/1927-update-site-and-press-notice-emails-to-include-new-task-links

### Screenshots


<img width="1465" height="633" alt="image" src="https://github.com/user-attachments/assets/d08a9e66-653d-4759-940c-628e898fb9a4" />
<img width="1127" height="597" alt="image" src="https://github.com/user-attachments/assets/0ce43187-05be-412b-a4a6-efa62aaf4e6c" />
