### PR TITLE
Fixes for resending neighbour letters

### DIFF
--- a/app/forms/tasks/send_letters_to_neighbours_form.rb
+++ b/app/forms/tasks/send_letters_to_neighbours_form.rb
@@ -2,7 +2,7 @@
 
 module Tasks
   class SendLettersToNeighboursForm < Form
-    self.task_actions = %w[save_and_complete save_draft send_letters]
+    self.task_actions = %w[send_letters]
 
     attribute :deadline_extension, :integer
     attribute :neighbour_letter_text, :string
@@ -18,18 +18,6 @@ module Tasks
 
     private
 
-    def save_and_complete
-      super do
-        update_consultation!
-      end
-    end
-
-    def save_draft
-      super do
-        update_consultation!
-      end
-    end
-
     def send_letters
       update_consultation!
       deliver_letters!
@@ -37,7 +25,7 @@ module Tasks
       create_review!
       record_audit_for_letters_sent!
 
-      @task.in_progress!
+      @task.complete!
     end
 
     def neighbours_to_contact

--- a/app/services/letter_sending_service.rb
+++ b/app/services/letter_sending_service.rb
@@ -13,29 +13,28 @@ class LetterSendingService
     @letter_type = letter_type
   end
 
-  def deliver!(neighbour)
+  def deliver!(neighbour, text: letter_content, batch: nil)
     return if resend_reason.nil? && NeighbourLetter.find_by(neighbour:).present? && consultation_letter?
 
-    letter_record = NeighbourLetter.new(neighbour:, text: letter_content, resend_reason:)
+    if resend_reason.present?
+      text = "# Application updated\nThis application has been updated. Reason: #{resend_reason}\n\n" + text
+    end
+
+    letter_record = NeighbourLetter.new(neighbour:, text:, resend_reason:)
 
     ActiveRecord::Base.transaction do
       letter_record.save!
       consultation.start_deadline if consultation_letter?
     end
 
-    if @batch
-      @batch.neighbour_letters << letter_record
+    if batch
+      batch.neighbour_letters << letter_record
+      batch.update!(text:)
     end
-
-    if resend_reason.present?
-      @letter_content.prepend "# Application updated\nThis application has been updated. Reason: #{resend_reason}\n\n"
-    end
-
-    @batch&.update!(text: letter_content)
 
     return if @local_authority.notify_error_status.present?
 
-    personalisation = {message: letter_content, heading:}
+    personalisation = {message: text, heading:}
     personalisation.merge! neighbour.format_address_lines
 
     begin
@@ -64,10 +63,9 @@ class LetterSendingService
   end
 
   def deliver_batch!(neighbours)
-    @batch = consultation.neighbour_letter_batches.new(text: letter_content)
-
+    batch = consultation.neighbour_letter_batches.new(text: letter_content)
     neighbours.each do |neighbour|
-      deliver!(neighbour)
+      deliver!(neighbour, text: letter_content, batch:)
     rescue => e
       Appsignal.send_error(e)
       next

--- a/app/views/tasks/consultees-neighbours-and-publicity/neighbours/send-letters-to-neighbours/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/neighbours/send-letters-to-neighbours/show.html.erb
@@ -31,12 +31,6 @@
   <%= render "#{@form.partial_path}/letter_template", planning_application: @planning_application, consultation: @form.consultation, form: form %>
 
   <div class="govuk-button-group govuk-!-margin-top-5 align-buttons">
-    <%= form.govuk_task_button "Send letters", action: :send_letters, secondary: true %>
+    <%= form.govuk_task_button "Send letters", action: :send_letters %>
   </div>
-<% end %>
-
-<%= form_with model: @form, url: @form.url do |form| %>
-  <%= form.hidden_field :neighbour_letter_text %>
-
-  <%= render "task_submit_buttons", form: %>
 <% end %>

--- a/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
+++ b/spec/system/planning_applications/consulting/send_letters_to_neighbours_spec.rb
@@ -253,7 +253,8 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
   end
 
   context "when letters have already been sent" do
-    let(:neighbour) { create(:neighbour, address: "1, Test Lane, E1 5AT", consultation:) }
+    let(:neighbour1) { create(:neighbour, address: "1, Test Lane, E1 5AT", consultation:) }
+    let(:neighbour2) { create(:neighbour, address: "3, Test Lane, E1 5AT", consultation:) }
 
     before do
       travel_to(2.weeks.ago) do
@@ -262,9 +263,12 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
 
       sign_in assessor
 
-      neighbour_letter = create(:neighbour_letter, neighbour:, status: "submitted", notify_id: "123")
-      neighbour.touch(:last_letter_sent_at)
-      stub_get_notify_status(notify_id: neighbour_letter.notify_id)
+      neighbour_letter1 = create(:neighbour_letter, neighbour: neighbour1, status: "submitted", notify_id: "123")
+      neighbour_letter2 = create(:neighbour_letter, neighbour: neighbour2, status: "submitted", notify_id: "456")
+      neighbour1.touch(:last_letter_sent_at)
+      neighbour2.touch(:last_letter_sent_at)
+      stub_get_notify_status(notify_id: neighbour_letter1.notify_id)
+      stub_get_notify_status(notify_id: neighbour_letter2.notify_id)
     end
 
     it "shows that letters have been sent" do
@@ -276,7 +280,7 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
 
       click_link "Send letters to neighbours"
       within("#selected-neighbours-list") do
-        expect(page).to have_content(neighbour.address)
+        expect(page).to have_content(neighbour1.address)
       end
     end
 
@@ -295,7 +299,8 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
       expect(page).to have_current_path("/planning_applications/#{reference}/consultation/neighbour_letters")
       expect(page).to have_content("Letters have been sent to neighbours")
 
-      expect(neighbour.neighbour_letters.length).to eq(2)
+      expect(neighbour1.neighbour_letters.length).to eq(2)
+      expect(neighbour2.neighbour_letters.length).to eq(2)
       expect(consultation.reload.end_date).to be_after(orig_deadline)
     end
 
@@ -305,7 +310,8 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
       click_link "Send letters to neighbours"
 
       click_button "Confirm and send letters"
-      expect(neighbour.neighbour_letters.length).to eq(1)
+      expect(neighbour1.neighbour_letters.length).to eq(1)
+      expect(neighbour2.neighbour_letters.length).to eq(1)
     end
 
     it "requires a reason to resend letters" do
@@ -317,7 +323,7 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
 
       click_button "Confirm and send letters"
       expect(page).to have_content "Provide a reason when resending letters to previously contacted neighbours"
-      expect(neighbour.neighbour_letters.length).to eq(1)
+      expect(neighbour1.neighbour_letters.length).to eq(1)
     end
 
     it "includes a reason in the letter when resending letters" do
@@ -329,17 +335,20 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
       fill_in("Resend reason",
         with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
-      expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
-        personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A/))).and_call_original
+      expect_any_instance_of(Notifications::Client).to receive(:send_letter).twice.with(template_id: anything,
+        personalisation: hash_including(message: match_regex(/\A# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A/))).and_call_original
 
       click_button "Confirm and send letters"
       expect(page).to have_current_path("/planning_applications/#{reference}/consultation/neighbour_letters")
       expect(page).to have_content("Letters have been sent to neighbours")
+
+      expect(neighbour1.last_letter.text).to match_regex(/\A# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A/)
+      expect(neighbour2.last_letter.text).to match_regex(/\A# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A/)
     end
 
     context "when the neighbour sent a comment" do
       before do
-        neighbour.update!(source: "sent_comment")
+        neighbour1.update!(source: "sent_comment")
       end
 
       it "allows setting a reason when resend letters" do
@@ -351,7 +360,7 @@ RSpec.describe "Send letters to neighbours", :js, show_sidebar: false, type: :sy
         fill_in("Resend reason",
           with: "Previous letter mistakenly listed applicant's address as Buckingham Palace.")
 
-        expect_any_instance_of(Notifications::Client).to receive(:send_letter).with(template_id: anything,
+        expect_any_instance_of(Notifications::Client).to receive(:send_letter).twice.with(template_id: anything,
           personalisation: hash_including(message: match_regex(/# Application updated\nThis application has been updated. Reason: Previous letter mistakenly listed applicant's address as Buckingham Palace.\n\n# The Town and Country Planning \(General Permitted Development\) \(England\) Order 2015 Part 1, Class A/))).and_call_original
 
         click_button "Confirm and send letters"


### PR DESCRIPTION
### Description of change

Removing the superfluous save buttons from the send-letters task, and fixing a pre-existing bug where the resend reason would be duplicated across multiple resent letters.

### Story Link

https://trello.com/c/unmtwwgk/1860-consultation-send-letters-to-neighbours