### PR TITLE
Add auditable to audits table

### DIFF
--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -13,6 +13,7 @@ module Tasks
     attribute :documents, array: true
 
     after_initialize do
+      @site_notices = planning_application.site_notices
       @site_notice = if params[:id].present?
         planning_application.site_notices.find(params[:id]).tap do |sn|
           self.displayed_at ||= sn.displayed_at
@@ -38,7 +39,7 @@ module Tasks
       route_for(:task_component, planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
     end
 
-    attr_reader :site_notice
+    attr_reader :site_notice, :site_notices
 
     with_options on: :create_site_notice do
       validates :quantity, presence: {message: "Enter number of site notices"}
@@ -86,13 +87,7 @@ module Tasks
 
     def mark_not_required
       transaction do
-        Audit.create!(
-          planning_application_id: planning_application.id,
-          user: Current.user,
-          activity_type: "site_notice_not_required",
-          audit_comment: "Site notice was marked as not required"
-        )
-
+        site_notice.update!(required: false)
         task.completed!
       end
     end
@@ -117,12 +112,7 @@ module Tasks
     end
 
     def create_audit(comment)
-      Audit.create!(
-        planning_application_id: planning_application.id,
-        user: Current.user,
-        activity_type: "site_notice_created",
-        audit_comment: comment
-      )
+      site_notice.audit!(activity_type: "site_notice_created", audit_comment: comment)
     end
 
     def build_site_notice

--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -4,6 +4,7 @@ class Audit < ApplicationRecord
   belongs_to :planning_application
   belongs_to :user, optional: true
   belongs_to :api_user, optional: true
+  belongs_to :auditable, polymorphic: true, optional: true
 
   scope :by_created_at, -> { order(created_at: :asc) }
   scope :with_user_and_api_user, -> { preload(:user, :api_user) }

--- a/app/models/concerns/auditable.rb
+++ b/app/models/concerns/auditable.rb
@@ -7,14 +7,16 @@ module Auditable
     private
 
     def audit!(activity_type:, activity_information: nil, audit_comment: nil)
-      audits.create!(
+      audit_attrs = {
         user: current_user,
         activity_type:,
         activity_information:,
         audit_comment:,
         api_user: current_api_user,
         automated_activity: no_current_user?
-      )
+      }
+      audit_attrs[:planning_application] = planning_application if respond_to?(:planning_application, true)
+      audits.create!(audit_attrs)
     end
 
     def no_current_user?

--- a/app/models/site_notice.rb
+++ b/app/models/site_notice.rb
@@ -6,15 +6,20 @@ class SiteNotice < ApplicationRecord
   SAFE_TAGS = %w[div h1 h2 h3 p ul li table tr td th hr].freeze
   SAFE_ATTRIBUTES = %w[style].freeze
 
+  include Auditable
   include DateValidateable
   include Consultable
 
+  public :audit!
+
   belongs_to :planning_application
+  has_many :audits, as: :auditable
   has_many :documents, as: :owner, dependent: :destroy, autosave: true
 
   delegate :local_authority, to: :planning_application
 
   scope :by_created_at_desc, -> { order(created_at: :desc) }
+  scope :required, -> { where(required: true) }
 
   validates :required, inclusion: {in: [true, false]}
   validates :quantity,
@@ -38,6 +43,7 @@ class SiteNotice < ApplicationRecord
   before_create :ensure_publicity_feature!
 
   after_update :extend_consultation!, if: :saved_change_to_displayed_at?
+  after_save :audit_site_notice!, if: :audit_required?
 
   attr_reader :method
 
@@ -142,5 +148,13 @@ class SiteNotice < ApplicationRecord
 
   def document_presence
     errors.add(:documents, "Upload a photo or document of the site notice to continue") if documents.empty?
+  end
+
+  def audit_required?
+    saved_change_to_required? && !required?
+  end
+
+  def audit_site_notice!
+    audit!(activity_type: "site_notice_not_required", audit_comment: "Site notice has been marked as not required")
   end
 end

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
@@ -12,7 +12,7 @@
 
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Arranged via" } %>
-      <% row.with_value { audit.audit_comment } %>
+      <% row.with_value { site_notice.audits.find_by(activity_type: "site_notice_created")&.audit_comment } %>
     <% end %>
 
     <% summary_list.with_row do |row| %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/show.html.erb
@@ -42,7 +42,17 @@
       <%= govuk_button_link_to "Back", @form.back_url, secondary: true %>
     </div>
   <% end %>
-<% elsif @planning_application.site_notices.empty? && @planning_application.audits.where(activity_type: "site_notice_not_required").none? %>
+<% elsif @form.site_notices.where(required: true).any? %>
+    <% @planning_application.site_notices.required.each_with_index do |site_notice, index| %>
+      <%= render "tasks/consultees-neighbours-and-publicity/publicity/site-notice/table", site_notice: site_notice, index: index %>
+  <% end %>
+  <%= form_with model: @form, url: @form.url do |form| %>
+    <div class="govuk-button-group">
+      <%= render "task_submit_buttons", form: form, save_draft: false %>
+      <%= govuk_button_link_to "Add another site notice", @form.new_site_notice_url, secondary: true, class: "govuk-!-margin-left-3" %>
+    </div>
+  <% end %>
+<% elsif @form.site_notices.where.not(id: nil).empty? %>
   <p class="govuk-body govuk-!-margin-top-4"> No site notices have been created for this application</p>
   <%= form_with model: @form, url: @form.url do |form| %>
     <div class="govuk-button-group" id="site-notice-form-actions">
@@ -50,7 +60,7 @@
       <%= form.govuk_task_button "Mark as not required", action: "mark_not_required", secondary: true %>
     </div>
   <% end %>
-<% elsif @planning_application.audits.where(activity_type: "site_notice_not_required").any? %>
+<% else %>
   <div class="govuk-inset-text">
     Site notices are not required for this application
   </div>
@@ -58,18 +68,6 @@
     <div class="govuk-button-group" id="site-notice-form-actions">
       <%= govuk_button_link_to "Create site notice", @form.new_site_notice_url %>
       <%= form.govuk_task_button "Mark as not required", action: "mark_not_required", secondary: true %>
-    </div>
-  <% end %>
-<% else %>
-  <% site_notice_audits = @planning_application.audits.where(activity_type: "site_notice_created").to_a %>
-  <% @planning_application.site_notices.order(id: :asc).each_with_index do |site_notice, index| %>
-    <% audit = site_notice_audits.min_by { |a| (a.created_at - site_notice.created_at).abs } %>
-      <%= render "tasks/consultees-neighbours-and-publicity/publicity/site-notice/table", site_notice: site_notice, audit: audit, index: index %>
-  <% end %>
-  <%= form_with model: @form, url: @form.url do |form| %>
-    <div class="govuk-button-group">
-      <%= render "task_submit_buttons", form: form, save_draft: false %>
-      <%= govuk_button_link_to "Add another site notice", @form.new_site_notice_url, secondary: true, class: "govuk-!-margin-left-3" %>
     </div>
   <% end %>
 <% end %>

--- a/db/migrate/20260421135314_add_auditable_to_audits.rb
+++ b/db/migrate/20260421135314_add_auditable_to_audits.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddAuditableToAudits < ActiveRecord::Migration[8.1]
+  def change
+    add_column :audits, :auditable_type, :string
+    add_column :audits, :auditable_id, :bigint
+    add_index :audits, [:auditable_type, :auditable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_16_090501) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_135314) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -176,6 +176,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_16_090501) do
     t.string "activity_type", null: false
     t.bigint "api_user_id"
     t.string "audit_comment"
+    t.bigint "auditable_id"
+    t.string "auditable_type"
     t.boolean "automated_activity", default: false, null: false
     t.datetime "created_at", null: false
     t.bigint "planning_application_id", null: false

--- a/spec/system/tasks/site_notice_spec.rb
+++ b/spec/system/tasks/site_notice_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe "Site notice task", js: true do
       end
     end
 
-    it "creates an audit but no site notices" do
+    it "creates an audit and not required site notice" do
       expect(page).to have_content("No site notices have been created for this application")
       expect(task.reload).to be_not_started
 
       click_button "Mark as not required"
 
       expect(page).to have_content("Successfully marked site notice as not required")
-      expect(planning_application.site_notices.count).to eq(0)
+      expect(planning_application.site_notices.count).to eq(1)
       expect(page).to have_content("Site notices are not required for this application")
 
       expect(planning_application.audits.where(activity_type: "site_notice_not_required").count).to eq(1)
@@ -67,6 +67,7 @@ RSpec.describe "Site notice task", js: true do
       end
 
       expect(page).to have_content("Site notices are not required for this application")
+      expect(planning_application.site_notices.required.count).to eq(0)
 
       click_link "Create site notice"
 
@@ -77,7 +78,7 @@ RSpec.describe "Site notice task", js: true do
       click_button "Send site notice"
 
       expect(page).to have_content("Successfully generated site notice")
-      expect(planning_application.site_notices.count).to eq(1)
+      expect(planning_application.site_notices.required.count).to eq(1)
       expect(task.reload).to be_in_progress
     end
   end


### PR DESCRIPTION
### Description of change

Add `Auditable` concern to `Audits` and `SiteNotice` model to enable simpler querying of audits in site visit views. This work is a pre-requisite for two other tickets to update links to new consultation pages and update mailer action. 

### Story Link

https://trello.com/c/Z4j2X7dd/1938-update-site-notice-model-to-replicate-press-notice-approach
