### PR TITLE
Delegate the failure template to the form object

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,11 +9,4 @@ class TasksController < AuthenticationController
   before_action :show_sidebar
   before_action :show_header
   before_action :build_form
-
-  private
-
-  def failure_template
-    return :edit if params[:task_action] == "update_neighbour_response"
-    super
-  end
 end

--- a/app/forms/tasks/add_conditions_form.rb
+++ b/app/forms/tasks/add_conditions_form.rb
@@ -44,6 +44,15 @@ module Tasks
       route_for(:planning_application_assessment_condition, planning_application, condition, redirect_to: url, only_path: true)
     end
 
+    def failure_template
+      case action
+      when "update_condition"
+        :edit
+      else
+        super
+      end
+    end
+
     private
 
     def add_condition

--- a/app/forms/tasks/add_pre_commencement_conditions_form.rb
+++ b/app/forms/tasks/add_pre_commencement_conditions_form.rb
@@ -67,6 +67,15 @@ module Tasks
       condition_set.validation_requests.any?(&:pending?)
     end
 
+    def failure_template
+      case action
+      when "update_condition"
+        :edit
+      else
+        super
+      end
+    end
+
     private
 
     def add_condition

--- a/app/forms/tasks/press_notice_form.rb
+++ b/app/forms/tasks/press_notice_form.rb
@@ -53,6 +53,15 @@ module Tasks
       route_for(:edit_task_component, planning_application, slug: task.full_slug, id: press_notice.id, only_path: true)
     end
 
+    def failure_template
+      case action
+      when "confirm_publication"
+        :edit
+      else
+        super
+      end
+    end
+
     private
 
     def other_reason_selected?

--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -66,6 +66,15 @@ module Tasks
       errors.add(:displayed_at, "Display date must be on or after today") if displayed_at < Date.current
     end
 
+    def failure_template
+      case action
+      when "confirm_display"
+        :edit
+      else
+        super
+      end
+    end
+
     private
 
     def form_params(params)

--- a/app/forms/tasks/view_neighbour_responses_form.rb
+++ b/app/forms/tasks/view_neighbour_responses_form.rb
@@ -62,6 +62,15 @@ module Tasks
       route_for(:task_component, planning_application, slug: task.full_slug, id: neighbour_response.id, only_path: true)
     end
 
+    def failure_template
+      case action
+      when "update_neighbour_response"
+        :edit
+      else
+        super
+      end
+    end
+
     private
 
     def address_or_new_address_present

--- a/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
@@ -41,7 +41,7 @@ module BopsCore
               render template_for(:show)
             end
           else
-            render template_for(failure_template), alert: @form.flash(:alert, self)
+            render template_for(@form.failure_template), alert: @form.flash(:alert, self)
           end
         end
       end
@@ -89,12 +89,6 @@ module BopsCore
       return path if path
 
       raise ActionView::MissingTemplate.new(paths, suffix, prefixes, false, action)
-    end
-
-    def failure_template
-      return :edit if params[:task_action].in?(%w[update_site_visit update_condition confirm_publication confirm_display])
-
-      :show
     end
   end
 end

--- a/engines/bops_core/app/forms/bops_core/tasks/form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/form.rb
@@ -118,6 +118,10 @@ module BopsCore
         "tasks/#{task.full_slug}"
       end
 
+      def failure_template
+        :show
+      end
+
       private
 
       def form_params(params)

--- a/engines/bops_core/app/forms/bops_core/tasks/site_visit_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/site_visit_form.rb
@@ -75,6 +75,15 @@ module BopsCore
         route_for(:edit_task, planning_application, task, site_visit_id: planning_application.site_visits.find(site_visit_id), only_path: true)
       end
 
+      def failure_template
+        case action
+        when "update_site_visit"
+          :edit
+        else
+          super
+        end
+      end
+
       private
 
       def site_visits_relation


### PR DESCRIPTION
Doing this in the controller leaks our form object details outside of the individual tasks.
