### PR TITLE
Update check publicity urls and warning

### DIFF
--- a/app/forms/tasks/check_publicity_form.rb
+++ b/app/forms/tasks/check_publicity_form.rb
@@ -20,11 +20,11 @@ module Tasks
     end
 
     def site_notice_url
-      task_path(planning_application, slug: "/#{task.parent.full_slug}/site-notice", return_to: task.full_slug)
+      task_path(planning_application, slug: "consultees-neighbours-and-publicity/publicity/site-notice", return_to: task.full_slug)
     end
 
     def press_notice_url
-      task_path(planning_application, slug: "/#{task.parent.full_slug}/press-notice", return_to: task.full_slug)
+      task_path(planning_application, slug: "consultees-neighbours-and-publicity/publicity/press-notice", return_to: task.full_slug)
     end
   end
 end

--- a/app/helpers/planning_application_helper.rb
+++ b/app/helpers/planning_application_helper.rb
@@ -60,6 +60,22 @@ module PlanningApplicationHelper
     end
   end
 
+  def confirm_site_notice_path(planning_application)
+    if planning_application.case_record&.find_task_by_slug_path(CaseRecord::CONFIRM_SITE_NOTICE_SLUG)
+      task_path(planning_application, slug: CaseRecord::CONFIRM_SITE_NOTICE_SLUG)
+    else
+      edit_planning_application_site_notice_path(planning_application, planning_application.site_notice)
+    end
+  end
+
+  def confirm_press_notice_path(planning_application)
+    if planning_application.case_record&.find_task_by_slug_path(CaseRecord::CONFIRM_PRESS_NOTICE_SLUG)
+      task_path(planning_application, slug: CaseRecord::CONFIRM_PRESS_NOTICE_SLUG)
+    else
+      planning_application_press_notice_confirmation_path(planning_application)
+    end
+  end
+
   def appeal_link_and_translation(planning_application)
     if planning_application.appeal_lodged?
       [".update_appeal", edit_planning_application_appeal_validate_path(planning_application)]

--- a/app/models/case_record.rb
+++ b/app/models/case_record.rb
@@ -6,6 +6,8 @@ class CaseRecord < ApplicationRecord
   CHECK_FEE_SLUG = "check-and-validate/check-application-details/check-fee"
   CHECK_RED_LINE_BOUNDARY_SLUG = "check-and-validate/check-application-details/check-red-line-boundary"
   DRAW_RED_LINE_BOUNDARY_SLUG = "check-and-validate/check-application-details/draw-red-line-boundary"
+  CONFIRM_SITE_NOTICE_SLUG = "consultees-neighbours-and-publicity/publicity/site-notice"
+  CONFIRM_PRESS_NOTICE_SLUG = "consultees-neighbours-and-publicity/publicity/press-notice"
 
   delegated_type :caseable, types: %w[Enforcement PlanningApplication], dependent: :destroy
 

--- a/app/views/shared/_dates_and_assignment_header.html.erb
+++ b/app/views/shared/_dates_and_assignment_header.html.erb
@@ -4,14 +4,14 @@
       <% if display_or_publish_required?(@planning_application, :site) %>
         <div id="confirm-site-notice-warning">
           <%= govuk_warning_text(
-                text: link_to("Confirm site notice display date", edit_planning_application_site_notice_path(@planning_application, @planning_application.site_notice))
+                text: link_to("Confirm site notice display date", confirm_site_notice_path(@planning_application))
               ) %>
         </div>
       <% end %>
       <% if display_or_publish_required?(@planning_application, :press) %>
         <div id="confirm-press-notice-warning">
           <%= govuk_warning_text(
-                text: govuk_link_to("Confirm press notice publication date", planning_application_press_notice_confirmation_path(@planning_application))
+                text: govuk_link_to("Confirm press notice publication date", confirm_press_notice_path(@planning_application))
               ) %>
         </div>
       <% end %>

--- a/spec/system/planning_applications/consultation_spec.rb
+++ b/spec/system/planning_applications/consultation_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Consultation", show_sidebar: false, type: :system do
       within("#confirm-site-notice-warning .govuk-warning-text") do
         expect(page).to have_link(
           "Confirm site notice display date",
-          href: edit_planning_application_site_notice_path(planning_application, site_notice)
+          href: "/planning_applications/#{planning_application.reference}/consultees-neighbours-and-publicity/publicity/site-notice"
         )
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe "Consultation", show_sidebar: false, type: :system do
       within("#confirm-press-notice-warning .govuk-warning-text") do
         expect(page).to have_link(
           "Confirm press notice publication date",
-          href: "/planning_applications/#{planning_application.reference}/press_notice/confirmation"
+          href: "/planning_applications/#{planning_application.reference}/consultees-neighbours-and-publicity/publicity/press-notice"
         )
       end
     end


### PR DESCRIPTION
### Description of change

Update link urls which had erroneously included wrong parent slug. Conditionally update warnings in dates and assignment header to include new task links.

### Story Link

https://trello.com/c/tl49DBcw/1935-update-links-in-check-publicity-task-to-new-consultation-tasks

