### PR TITLE
Add addresses to site history in preapp report

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2936,9 +2936,13 @@ en:
         mark_as_valid: Red line boundary was successfully marked as valid
         success: Red line boundary check was successfully saved
       check-site-history:
-        add_site_history: Site history successfully recorded
+        add_site_history:
+          failure: Unable to save site history record
+          success: Site history successfully recorded
         failure: Failed to save site history review
-        save_draft: Draft site history check successfully saved
+        save_draft:
+          failure: Unable to save draft site history check
+          success: Draft site history check successfully saved
         success: Site history was successfully marked as reviewed
       confirm-community-infrastructure-levy-cil:
         failure: Failed to confirm CIL liability check

--- a/engines/bops_preapps/config/locales/en.yml
+++ b/engines/bops_preapps/config/locales/en.yml
@@ -163,7 +163,9 @@ en:
           failure: Failed to save requested services
           success: Requested services successfully saved
         check-site-history:
-          add_site_history: Site history successfully recorded
+          add_site_history:
+            failure: Unable to save site history record
+            success: Site history successfully recorded
           failure: Failed to save site history review
           save_draft: Draft site history check successfully saved
           success: Site history was successfully marked as reviewed

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/_site_history_table.html.erb
@@ -19,7 +19,10 @@
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dd class="govuk-summary-list__value">
-            <strong>Description: </strong><%= site_history.description %>
+            <strong>Address: </strong><%= site_history.address %>
+            <div class="govuk-!-margin-top-2">
+              <strong>Description: </strong><%= site_history.description %>
+            </div>
             <div class="govuk-!-margin-top-2">
               <% if site_history.comment %>
               <strong>Officer comment:</strong> <%= site_history.comment %>


### PR DESCRIPTION
### Description of change

Update site history component on preapp report to include site address.
I also added a few of the failure messages as these were missing for some of the task actions

### Story Link

https://trello.com/c/de9tpJTY/1933-show-site-history-addresses-in-pre-app-report
### Screenshots

<img width="1018" height="408" alt="image" src="https://github.com/user-attachments/assets/739aa428-15d2-41d4-864f-83934666f0e6" />
