### PR TITLE
Update link in case officer error message

### DIFF
--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -75,6 +75,15 @@ module Tasks
       end
     end
 
+    def flash(type, controller)
+      case action
+      when "create_site_notice"
+        flash_for_create_site_notice(type, controller)
+      else
+        super
+      end
+    end
+
     private
 
     def form_params(params)
@@ -91,7 +100,7 @@ module Tasks
     def application_must_be_assigned
       return if planning_application.user.present?
 
-      errors.add :base, :invalid, message: "The application must be assigned to a case officer before sending a site notice"
+      errors.add :base, :invalid, message: "The application must be assigned to a case officer"
     end
 
     def mark_not_required
@@ -117,6 +126,26 @@ module Tasks
         end
         create_audit(comment)
         task.in_progress!
+      end
+    end
+
+    def flash_for_create_site_notice(type, controller)
+      result = case type
+      when :notice
+        "success"
+      when :alert
+        "failure"
+      end
+
+      return if result.nil?
+
+      if result == "failure" && planning_application.user.blank?
+        controller.t(
+          :".#{slug}.#{action}.assign_user_html",
+          href: controller.planning_application_assign_users_path(planning_application)
+        )
+      else
+        controller.t(:".#{slug}.#{action}.#{result}")
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3011,6 +3011,7 @@ en:
           failure: Unable to save display details
           success: Successfully saved display details
         create_site_notice:
+          assign_user_html: The planning application must be <a class="govuk-notification-banner__link" href="%{href}">assigned to an officer</a> before you can create a site notice.
           failure: Unable to generate site notice
           success: Successfully generated site notice
         failure: Unable to save site notice task

--- a/spec/system/tasks/site_notice_spec.rb
+++ b/spec/system/tasks/site_notice_spec.rb
@@ -224,4 +224,36 @@ RSpec.describe "Site notice task", js: true do
       end
     end
   end
+
+  describe "creating a single site notice with no user" do
+    let!(:planning_application_2) do
+      create(:planning_application,
+        :from_planx_prior_approval,
+        :with_boundary_geojson,
+        :published,
+        application_type:,
+        local_authority: default_local_authority,
+        agent_email: "agent@example.com",
+        applicant_email: "applicant@example.com")
+    end
+
+    before do
+      visit "/planning_applications/#{planning_application_2.reference}"
+      click_link "Consultees, neighbours and publicity"
+      within :sidebar do
+        click_link "Site notice"
+      end
+
+      click_link "Create site notice"
+    end
+
+    it "displays the relevant error messages" do
+      fill_in "Quantity", with: "2"
+      choose "Print the site notice"
+
+      click_button "Send site notice"
+
+      expect(page).to have_content("The planning application must be assigned to an officer before you can create a site notice.")
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Update flash error message for unassigned case officer in site notice to link to correct page

### Story Link

https://trello.com/c/U2yJxRSZ/1934-the-link-doesnt-take-user-to-assign-case-officer-but-remains-on-the-same-page

### Screenshots

<img width="1512" height="731" alt="image" src="https://github.com/user-attachments/assets/0c63bae6-8e11-4beb-a14a-2a46de5c4156" />

### Decisions 
- I was unable to find a way to override the form error so have included a link in the flash message. This is consistent with the approach on the old flow.