### PR TITLE
Fix exception on unresolved post-validation request

### DIFF
--- a/app/forms/tasks/review_and_submit_recommendation_form.rb
+++ b/app/forms/tasks/review_and_submit_recommendation_form.rb
@@ -7,6 +7,11 @@ module Tasks
     private
 
     def save_and_complete
+      if planning_application.open_post_validation_requests?
+        errors.add :base, :invalid, message: "All post-validation requests must be resolved before submitting"
+        return false
+      end
+
       super do
         if planning_application.can_submit_recommendation?
           planning_application.submit_recommendation!

--- a/app/forms/tasks/review_and_submit_recommendation_form.rb
+++ b/app/forms/tasks/review_and_submit_recommendation_form.rb
@@ -12,6 +12,8 @@ module Tasks
           planning_application.submit_recommendation!
         end
       end
+    rescue PlanningApplication::SubmitRecommendationError
+      false
     end
 
     def withdraw_recommendation

--- a/app/views/tasks/check-and-assess/complete-assessment/review-and-submit-recommendation/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/review-and-submit-recommendation/show.html.erb
@@ -1,28 +1,34 @@
 <%= render "task_header", task: @task %>
 
-<% has_recommendation = @planning_application.recommendation.present? %>
-<% submitted = @planning_application.may_withdraw_recommendation? %>
-
-<% if has_recommendation %>
-  <p><%= t(".the_following_decision", report_or_notice: report_or_notice?(@planning_application)) %></p>
-  <%= render "planning_applications/decision_notice", planning_application: @planning_application %>
-  <h2><%= t(".submit_recommendation") %></h2>
-  <p><%= t(".if_you_agree", report_or_notice: report_or_notice?(@planning_application)) %></p>
-  <p><%= t(".if_your_reviewer") %></p>
-<% end %>
-
-<p class="govuk-!-margin-top-3">
-  <% unless submitted %>
-    <% if has_recommendation %>
-      <%= govuk_link_to "Edit recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
-    <% else %>
-      <p>No recommendation has been made on this application.</p>
-      <%= govuk_link_to "Make draft recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
-    <% end %>
-  <% end %>
-</p>
-
 <%= form_with model: @form, url: @form.url do |form| %>
+  <%= form.govuk_error_summary %>
+
+  <% has_recommendation = @planning_application.recommendation.present? %>
+  <% submitted = @planning_application.may_withdraw_recommendation? %>
+
+  <% if has_recommendation %>
+    <p>
+      <%= t(".the_following_decision", report_or_notice: report_or_notice?(@planning_application)) %>
+    </p>
+    <%= render "planning_applications/decision_notice", planning_application: @planning_application %>
+    <h2><%= t(".submit_recommendation") %></h2>
+    <p>
+      <%= t(".if_you_agree", report_or_notice: report_or_notice?(@planning_application)) %>
+    </p>
+    <p><%= t(".if_your_reviewer") %></p>
+  <% end %>
+
+  <p class="govuk-!-margin-top-3">
+    <% unless submitted %>
+      <% if has_recommendation %>
+        <%= govuk_link_to "Edit recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
+      <% else %>
+        <p>No recommendation has been made on this application.</p>
+        <%= govuk_link_to "Make draft recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
+      <% end %>
+    <% end %>
+  </p>
+
   <% if submitted %>
     <%= form.govuk_task_button "Withdraw recommendation", action: "withdraw_recommendation", secondary: true %>
   <% elsif has_recommendation %>

--- a/spec/system/tasks/review_and_submit_recommendations_spec.rb
+++ b/spec/system/tasks/review_and_submit_recommendations_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Review and submit recommendation task", type: :system do
       "check-and-assess/complete-assessment/review-and-submit-recommendation"
     )
   end
+
   before do
     create(:decision, :householder_granted)
     create(:decision, :householder_refused)
@@ -93,6 +94,21 @@ RSpec.describe "Review and submit recommendation task", type: :system do
       expect(page).to have_content("Recommendation successfully withdrawn")
       expect(planning_application.reload.status).to eq("in_assessment")
       expect(task.reload).to be_in_progress
+    end
+  end
+
+  context "when there are open post-validation requests" do
+    before do
+      create(:red_line_boundary_change_validation_request, :post_validation, :open, planning_application:)
+
+      within ".bops-sidebar" do
+        click_link "Review and submit recommendation"
+      end
+    end
+
+    it "displays an error message" do
+      click_button "Save and mark as complete"
+      expect(page).to have_content("All post-validation requests must be resolved before submitting")
     end
   end
 end


### PR DESCRIPTION
Catch exception raised when trying to submit a recommendation on an application with open validation requests, show a more user-friendly error message.

https://trello.com/c/2qSnVfF6/1943-500-error-when-trying-to-submit-a-recommendation-for-prior-approval