### PR TITLE
Move send confirmation action into form

### DIFF
--- a/app/forms/tasks/press_notice_form.rb
+++ b/app/forms/tasks/press_notice_form.rb
@@ -4,7 +4,7 @@ module Tasks
   class PressNoticeForm < Form
     include DateValidateable
 
-    self.task_actions = %w[save_and_complete mark_not_required email_press_notice confirm_publication]
+    self.task_actions = %w[save_and_complete mark_not_required email_press_notice confirm_publication send_confirmation_request]
 
     attribute :required, :boolean
     attribute :reasons, :list, default: []
@@ -51,6 +51,10 @@ module Tasks
 
     def edit_press_notice_url(press_notice)
       route_for(:edit_task_component, planning_application, slug: task.full_slug, id: press_notice.id, only_path: true)
+    end
+
+    def confirmation_request_url(press_notice)
+      task_component_path(planning_application, slug: task.full_slug, id: press_notice.id, only_path: true)
     end
 
     def failure_template
@@ -108,6 +112,12 @@ module Tasks
         )
         SendPressNoticeEmailJob.perform_later(press_notice, Current.user)
         task.in_progress!
+      end
+    end
+
+    def send_confirmation_request
+      transaction do
+        SendPressNoticeConfirmationRequestJob.perform_later(press_notice, Current.user)
       end
     end
   end

--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -2,7 +2,7 @@
 
 module Tasks
   class SiteNoticeForm < Form
-    self.task_actions = %w[save_and_complete create_site_notice email_site_notice mark_not_required confirm_display]
+    self.task_actions = %w[save_and_complete create_site_notice email_site_notice mark_not_required confirm_display send_confirmation_request]
 
     attribute :required, :boolean
     attribute :quantity, :integer, default: 1
@@ -37,6 +37,10 @@ module Tasks
 
     def confirm_display_url
       route_for(:task_component, planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
+    end
+
+    def confirmation_request_url(site_notice)
+      task_component_path(planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
     end
 
     attr_reader :site_notice, :site_notices
@@ -141,6 +145,12 @@ module Tasks
         displayed_at: displayed_at,
         documents: documents
       )
+    end
+
+    def send_confirmation_request
+      transaction do
+        SendSiteNoticeConfirmationRequestJob.perform_later(site_notice, Current.user)
+      end
     end
   end
 end

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/_table.html.erb
@@ -1,4 +1,11 @@
 <%= govuk_summary_card(title: "Press notice #{index + 1}", html_attributes: {class: "govuk-!-margin-top-6"}) do |card| %>
+  <% unless press_notice.published_at? %>
+    <% card.with_action do %>
+      <%= form_with model: @form, url: @form.confirmation_request_url(press_notice) do |form| %>
+        <%= form.govuk_task_button_link "Send reminder", action: "send_confirmation_request" %>
+      <% end %>
+    <% end %>
+  <% end %>
   <% card.with_summary_list do |summary_list| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Reasons" } %>
@@ -35,9 +42,6 @@
         <% else %>
           <strong class="govuk-tag govuk-tag--blue">Requested</strong>
         <% end %>
-      <% end %>
-      <% unless press_notice.published_at? %>
-        <% row.with_action(text: "Send reminder", href: planning_application_press_notice_confirmation_requests_path(@planning_application, press_notice), visually_hidden_text: "for press notice #{index + 1}") %>
       <% end %>
     <% end %>
 

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/_table.html.erb
@@ -1,4 +1,11 @@
 <%= govuk_summary_card(title: "Site notice #{index + 1}", html_attributes: {class: "govuk-!-margin-top-6"}) do |card| %>
+    <% unless site_notice.displayed_at? %>
+      <% card.with_action do %>
+        <%= form_with model: @form, url: @form.confirmation_request_url(site_notice) do |form| %>
+          <%= form.govuk_task_button_link "Send reminder", action: "send_confirmation_request" %>
+        <% end %>
+      <% end %>
+  <% end %>
   <% card.with_summary_list do |summary_list| %>
     <% summary_list.with_row do |row| %>
       <% row.with_key { "Quantity" } %>
@@ -56,9 +63,6 @@
         <% else %>
           <strong class="govuk-tag govuk-tag--blue">Sent</strong>
         <% end %>
-      <% end %>
-      <% unless site_notice.displayed_at? && site_notice.documents.any? %>
-        <% row.with_action(text: "Send reminder", href: planning_application_site_notice_confirmation_requests_path(@planning_application, site_notice), visually_hidden_text: "for site notice #{index + 1}") %>
       <% end %>
     <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2971,6 +2971,9 @@ en:
           failure: Unable to send press notice email
           success: Successfully sent press notice email
         failure: Failed to save press notice requirement
+        send_confirmation_request:
+          failure: Failed to send press notice reminder
+          success: Successfully sent press notice reminder
         success: Successfully saved press notice requirement
       review-and-submit-recommendation:
         failure: Failed to submit recommendation
@@ -3017,6 +3020,9 @@ en:
         mark_not_required:
           failure: Unable to mark site notice as not required
           success: Successfully marked site notice as not required
+        send_confirmation_request:
+          failure: Failed to send site notice reminder
+          success: Successfully sent site notice reminder
         success: Successfully saved site notice task
       site-visit:
         add_site_visit:

--- a/spec/system/tasks/press_notice_spec.rb
+++ b/spec/system/tasks/press_notice_spec.rb
@@ -144,8 +144,48 @@ RSpec.describe "Press notice task", js: true do
     end
   end
 
+  describe "sending a reminder for a press notice" do
+    let!(:press_notice) do
+      create(:press_notice, :required,
+        planning_application:,
+        created_at: 2.hours.ago)
+    end
+
+    before do
+      within :sidebar do
+        click_link "Press notice"
+      end
+    end
+
+    it "enqueues a confirmation request job for the correct press notice and shows a success message" do
+      expect do
+        within(".govuk-summary-card") { click_button "Send reminder" }
+        expect(page).to have_content("Successfully sent press notice reminder")
+      end.to have_enqueued_job(SendPressNoticeConfirmationRequestJob).with(press_notice, assessor).exactly(:once)
+    end
+
+    context "with multiple press notices" do
+      let!(:newer_press_notice) do
+        create(:press_notice, :required,
+          planning_application:,
+          reasons: %w[major_development],
+          created_at: 1.hour.ago)
+      end
+
+      it "enqueues the job only for the press notice whose reminder was clicked" do
+        expect do
+          within(".govuk-summary-card", text: "An environmental statement accompanies this application") do
+            click_button "Send reminder"
+          end
+          expect(page).to have_content("Successfully sent press notice reminder")
+        end.to have_enqueued_job(SendPressNoticeConfirmationRequestJob)
+          .with(press_notice, assessor)
+          .exactly(:once)
+      end
+    end
+  end
+
   describe "adding multiple press notices" do
-    # Use factories with different created_at values to ensure deterministic ordering
     let!(:older_press_notice) do
       create(:press_notice,
         planning_application:,

--- a/spec/system/tasks/site_notice_spec.rb
+++ b/spec/system/tasks/site_notice_spec.rb
@@ -152,6 +152,44 @@ RSpec.describe "Site notice task", js: true do
     end
   end
 
+  describe "sending a reminder for a site notice" do
+    let!(:site_notice) do
+      create(:site_notice,
+        planning_application:,
+        created_at: 2.hours.ago)
+    end
+
+    before do
+      within :sidebar do
+        click_link "Site notice"
+      end
+    end
+
+    it "enqueues a confirmation request job for the correct site notice and shows a success message" do
+      expect do
+        within(".govuk-summary-card") { click_button "Send reminder" }
+        expect(page).to have_content("Successfully sent site notice reminder")
+      end.to have_enqueued_job(SendSiteNoticeConfirmationRequestJob).with(site_notice, assessor).exactly(:once)
+    end
+
+    context "with multiple site notices" do
+      let!(:newer_site_notice) do
+        create(:site_notice,
+          planning_application:,
+          created_at: 1.hour.ago)
+      end
+
+      it "enqueues the job only for the site notice whose reminder was clicked" do
+        expect do
+          click_button "Send reminder"
+          expect(page).to have_content("Successfully sent site notice reminder")
+        end.to have_enqueued_job(SendSiteNoticeConfirmationRequestJob)
+          .with(site_notice, assessor)
+          .exactly(:once)
+      end
+    end
+  end
+
   describe "adding multiple site notices" do
     before do
       within :sidebar do


### PR DESCRIPTION
### Description of change

Move send reminder actions for Press Notice and Site Notice into respective forms and outside of old controllers. 

### Story Link

<img width="1112" height="644" alt="image" src="https://github.com/user-attachments/assets/d54f96b9-7a12-4672-8b71-d5efb0cf9b59" />

### Screenshots

If you have made changes to the frontend please add screenshots

### Decisions 
Due to format of summary card the link had to be moved out of the individual rows and into the header row.
