### PR TITLE
Refactor task_path logic

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -43,7 +43,7 @@
   <% if show_edit_links && current_user.assessor? %>
     <p class="govuk-body-s">
       <% if task.present? %>
-        <%= helpers.govuk_link_to("Edit constraints", task_path(@planning_application, "check-and-validate/check-application-details/check-constraints", return_to: task_path(@planning_application, task))) %>
+        <%= helpers.govuk_link_to("Edit constraints", task_path(@planning_application, "check-and-validate/check-application-details/check-constraints", return_to: task.url)) %>
       <% else %>
         <%= helpers.govuk_link_to("Edit constraints", planning_application_validation_constraints_path(@planning_application)) %>
       <% end %>
@@ -177,7 +177,7 @@
     <% if show_edit_links && current_user.assessor? %>
       <p class="govuk-body-s">
         <% if task.present? %>
-          <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task_path(@planning_application, task))) %>
+          <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task.url)) %>
         <% else %>
           <%= helpers.govuk_link_to("Edit assessment", edit_planning_application_assessment_considerations_path(@planning_application)) %>
         <% end %>
@@ -229,7 +229,7 @@
       <% if show_edit_links && current_user.assessor? %>
         <p class="govuk-body-s">
           <% if task.present? %>
-            <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task_path(@planning_application, task))) %>
+            <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task.url)) %>
           <% else %>
             <%= helpers.govuk_link_to("Edit assessment", edit_planning_application_assessment_policy_areas_policy_class_path(@planning_application, pa_policy_class)) %>
           <% end %>

--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -27,14 +27,8 @@ class SidebarComponent < ViewComponent::Base
       render_section(task, top_level:)
     else
       is_active = current_task?(task)
-      target = if planning_application.pre_application?
-        BopsPreapps::Engine.routes.url_helpers.task_path(@case_record,
-          slug: task.full_slug, reference: planning_application_reference)
-      else
-        task_path(planning_application_reference, slug: task.full_slug)
-      end
       link_options = is_active ? {"aria-current" => "page"} : {}
-      link = helpers.govuk_link_to(task.name, target, **link_options)
+      link = helpers.govuk_link_to(task.name, task.url, **link_options)
       content = if task.status_hidden?
         safe_join([invisible_status_placeholder, link], " ")
       else
@@ -58,10 +52,7 @@ class SidebarComponent < ViewComponent::Base
           helpers.render("shared/icons/envelope", class: "bops-sidebar__task-icon"),
           "Consultation"
         ]),
-        BopsPreapps::Engine.routes.url_helpers.task_path(
-          planning_application,
-          consultation_task
-        ),
+        consultation_task.url,
         class: "bops-sidebar__link"
       )
 
@@ -74,10 +65,7 @@ class SidebarComponent < ViewComponent::Base
           helpers.render("shared/icons/envelope", class: "bops-sidebar__task-icon"),
           "Assessment"
         ]),
-        BopsPreapps::Engine.routes.url_helpers.task_path(
-          planning_application,
-          assessment_task
-        ),
+        assessment_task.url,
         class: "bops-sidebar__link"
       )
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -28,10 +28,6 @@ class AuthenticationController < ApplicationController
 
     return unless task
 
-    if @planning_application.pre_application?
-      redirect_to BopsPreapps::Engine.routes.url_helpers.task_path(@planning_application, task)
-    else
-      redirect_to task_path(@planning_application, task)
-    end
+    redirect_to task.url
   end
 end

--- a/app/controllers/planning_applications/validation/validation_requests_controller.rb
+++ b/app/controllers/planning_applications/validation/validation_requests_controller.rb
@@ -240,33 +240,13 @@ module PlanningApplications
       end
 
       def check_red_line_boundary_task_path
-        if @planning_application.pre_application?
-          BopsPreapps::Engine.routes.url_helpers.task_path(
-            reference: @planning_application.reference,
-            slug: CaseRecord::CHECK_RED_LINE_BOUNDARY_SLUG
-          )
-        else
-          task_path(
-            planning_application_reference: @planning_application.reference,
-            slug: CaseRecord::CHECK_RED_LINE_BOUNDARY_SLUG
-          )
-        end
+        @planning_application.url_helpers.task_path(@planning_application, slug: CaseRecord::CHECK_RED_LINE_BOUNDARY_SLUG)
       end
 
       def check_and_request_documents_task_path
         return unless redirect_to_check_and_request_documents_task?
 
-        if @planning_application.pre_application?
-          BopsPreapps::Engine.routes.url_helpers.task_path(
-            reference: @planning_application.reference,
-            slug: "check-and-validate/check-tag-and-confirm-documents/check-and-request-documents"
-          )
-        else
-          task_path(
-            reference: @planning_application.reference,
-            slug: "check-and-validate/check-tag-and-confirm-documents/check-and-request-documents"
-          )
-        end
+        @planning_application.url_helpers.task_path(@planning_application, slug: "check-and-validate/check-tag-and-confirm-documents/check-and-request-documents")
       end
       helper_method :check_and_request_documents_task_path
 

--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -41,7 +41,7 @@ module ValidationRequestHelper
 
   def show_validation_request_url(application, request, return_to: nil)
     if application.pre_application? && (task_slug = preapps_task_slug_for(request))
-      BopsPreapps::Engine.routes.url_helpers.task_path(
+      application.url_helpers.task_path(
         reference: application.reference,
         slug: task_slug,
         return_to: return_to

--- a/app/models/case_record.rb
+++ b/app/models/case_record.rb
@@ -19,6 +19,7 @@ class CaseRecord < ApplicationRecord
   belongs_to :submission, optional: true
 
   delegate :email, to: :user, prefix: true, allow_nil: true
+  delegate :url_helpers, to: :caseable
 
   after_initialize :generate_uuid
 

--- a/app/models/enforcement.rb
+++ b/app/models/enforcement.rb
@@ -89,6 +89,10 @@ class Enforcement < ApplicationRecord
     model_name.singular
   end
 
+  def url_helpers
+    BopsEnforcements::Engine.routes.url_helpers
+  end
+
   private
 
   def factory

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -1125,6 +1125,14 @@ class PlanningApplication < ApplicationRecord
     find_proposal_detail("What type of pre-application are you applying for?")&.first&.response_values&.first
   end
 
+  def url_helpers
+    if pre_application?
+      BopsPreapps::Engine.routes.url_helpers
+    else
+      Rails.application.routes.url_helpers
+    end
+  end
+
   private
 
   def create_fee_calculation

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -81,6 +81,10 @@ class Task < ApplicationRecord
     tasks.first&.first_child
   end
 
+  def url(**args)
+    @url ||= case_record.url_helpers.task_path(case_record.caseable, self, **args)
+  end
+
   private
 
   def raise_not_saved(transition)

--- a/app/views/planning_applications/validation/additional_document_validation_requests/_form.html.erb
+++ b/app/views/planning_applications/validation/additional_document_validation_requests/_form.html.erb
@@ -5,34 +5,33 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <div data-controller="unsaved-changes"
-         data-action="beforeunload@window->unsaved-changes#handleBeforeUnload">
+    <div
+      data-controller="unsaved-changes"
+      data-action="beforeunload@window->unsaved-changes#handleBeforeUnload">
       <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request,
             data: {unsaved_changes_target: "form", action: "submit->unsaved-changes#handleSubmit"} do |form| %>
-      <%= form.govuk_error_summary %>
+        <%= form.govuk_error_summary %>
 
-      <% return_to = local_assigns[:return_to].presence || params[:return_to].presence %>
-      <% if return_to.nil? && @planning_application.pre_application? %>
-        <% return_to = BopsPreapps::Engine.routes.url_helpers.task_path(
-             reference: @planning_application.reference,
-             slug: "check-and-validate/check-tag-and-confirm-documents/check-and-request-documents"
-           ) %>
-      <% end %>
-      <%= form.hidden_field(:return_to, value: return_to) if return_to.present? %>
+        <% return_to = local_assigns[:return_to].presence || params[:return_to].presence %>
+        <% if return_to.nil? && @planning_application.pre_application? %>
+          <% return_to = @planning_application.url_helpers.task_path(@planning_application.reference, slug: "check-and-validate/check-tag-and-confirm-documents/check-and-request-documents") %>
+        <% end %>
 
-      <%= form.govuk_text_field :document_request_type,
-            label: {size: "m", text: "Please specify the new document type:"},
-            hint: {text: "Eg. Existing floor plans"} %>
+        <%= form.hidden_field(:return_to, value: return_to) if return_to.present? %>
 
-      <%= form.govuk_text_area :reason,
-            label: {size: "m", text: "Please specify the reason you have requested this document?"},
-            rows: 5 %>
+        <%= form.govuk_text_field :document_request_type,
+              label: {size: "m", text: "Please specify the new document type:"},
+              hint: {text: "Eg. Existing floor plans"} %>
 
-      <%= form.hidden_field :type, value: AdditionalDocumentValidationRequest.name %>
+        <%= form.govuk_text_area :reason,
+              label: {size: "m", text: "Please specify the reason you have requested this document?"},
+              rows: 5 %>
 
-      <%= render "shared/planning_guides_link" %>
+        <%= form.hidden_field :type, value: AdditionalDocumentValidationRequest.name %>
 
-      <%= render "shared/validation_request_form_actions", form: form, allow_submit: true %>
+        <%= render "shared/planning_guides_link" %>
+
+        <%= render "shared/validation_request_form_actions", form: form, allow_submit: true %>
       <% end %>
     </div>
   </div>

--- a/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
+++ b/app/views/planning_applications/validation/description_change_validation_requests/_new.html.erb
@@ -3,10 +3,13 @@
 <% end %>
 
 <% add_parent_breadcrumb_link "Home", root_path %>
+
 <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
+
 <% if @planning_application.not_started? %>
   <% add_parent_breadcrumb_link "Validation tasks", planning_application_validation_tasks_path(@planning_application) %>
 <% end %>
+
 <% content_for :title, "Description change" %>
 
 <%= render(
@@ -18,14 +21,12 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @planning_application.application_type.description_change_requires_validation? %>
       <h3 class="govuk-!-margin-top-3">
-       Update the description or suggest a new description to the applicant
+        Update the description or suggest a new description to the applicant
       </h3>
-
     <% else %>
       <h2 class="govuk-!-margin-top-3">
         Update description
       </h2>
-
       <p>
         This will be applied immediately.
       </p>
@@ -38,51 +39,56 @@
       <%= render(FormattedContentComponent.new(text: @planning_application.description)) %>
     </div>
 
-    <div data-controller="unsaved-changes"
-         data-action="beforeunload@window->unsaved-changes#handleBeforeUnload">
+    <div
+      data-controller="unsaved-changes"
+      data-action="beforeunload@window->unsaved-changes#handleBeforeUnload">
       <%= form_with model: [@planning_application, :validation, @validation_request], scope: :validation_request,
             data: {unsaved_changes_target: "form", action: "submit->unsaved-changes#handleSubmit"} do |form| %>
-      <%= form.govuk_error_summary %>
+        <%= form.govuk_error_summary %>
 
-      <% if @planning_application.latest_rejected_description_change.present? %>
-        <p>
-          <strong>
-            Rejected proposed description
-          </strong>
-        </p>
-        <%= render(FormattedContentComponent.new(text: @planning_application.latest_rejected_description_change.proposed_description)) %>
-        <p>
-          <span class="govuk-caption-m">
-            Applicant rejected this description because: <%= @planning_application.latest_rejected_description_change.rejection_reason %>
-          </span>
-        </p>
-      <% end %>
-      <%= form.hidden_field(:type, value: "DescriptionChangeValidationRequest") %>
-      <%= form.govuk_text_area :proposed_description,
-            value: @planning_application.description,
-            label: {size: "s", text: "Enter an amended description"},
-            rows: 5 %>
-      <% if params[:return_to].present? %>
-        <%= form.hidden_field(:return_to, value: params[:return_to]) %>
-      <% elsif @planning_application.pre_application? && @planning_application.not_started? %>
-        <%= form.hidden_field(:return_to, value: BopsPreapps::Engine.routes.url_helpers.task_path(reference: @planning_application.reference, slug: "check-and-validate/check-application-details/check-description")) %>
-      <% elsif @planning_application.not_started? %>
-        <%= form.hidden_field(:return_to, value: planning_application_validation_tasks_path(@planning_application)) %>
-      <% else %>
-        <%= form.hidden_field(:return_to, value: @back_path) %>
-      <% end %>
-      <% if @planning_application.application_type.description_change_requires_validation? %>
-        <div class="display govuk-!-margin-top-3">
-          <%= form.govuk_radio_buttons_fieldset(:skip_applicant_approval, legend: {size: "m", text: "Does this description change require applicant's agreement?"}) do %>
-            <%= form.govuk_radio_button :skip_applicant_approval, false, label: {text: "Yes, applicant agreement needed"} do %>
-              <p>The new description will be sent to the applicant to approve. If the applicant does not respond within 5 days, the amended description will be automatically accepted.</p>
+        <% if @planning_application.latest_rejected_description_change.present? %>
+          <p><strong> Rejected proposed description </strong></p>
+          <%= render(FormattedContentComponent.new(text: @planning_application.latest_rejected_description_change.proposed_description)) %>
+          <p>
+            <span class="govuk-caption-m">
+              Applicant rejected this description because:
+              <%= @planning_application.latest_rejected_description_change.rejection_reason %>
+            </span>
+          </p>
+        <% end %>
+
+        <%= form.hidden_field(:type, value: "DescriptionChangeValidationRequest") %>
+        <%= form.govuk_text_area :proposed_description,
+              value: @planning_application.description,
+              label: {size: "s", text: "Enter an amended description"},
+              rows: 5 %>
+        <% if params[:return_to].present? %>
+          <%= form.hidden_field(:return_to, value: params[:return_to]) %>
+        <% elsif @planning_application.pre_application? && @planning_application.not_started? %>
+          <%= form.hidden_field(:return_to, value: @planning_application.url_helpers.task_path(reference: @planning_application.reference, slug: "check-and-validate/check-application-details/check-description")) %>
+        <% elsif @planning_application.not_started? %>
+          <%= form.hidden_field(:return_to, value: planning_application_validation_tasks_path(@planning_application)) %>
+        <% else %>
+          <%= form.hidden_field(:return_to, value: @back_path) %>
+        <% end %>
+
+        <% if @planning_application.application_type.description_change_requires_validation? %>
+          <div class="display govuk-!-margin-top-3">
+            <%= form.govuk_radio_buttons_fieldset(:skip_applicant_approval, legend: {size: "m", text: "Does this description change require applicant's agreement?"}) do %>
+              <%= form.govuk_radio_button :skip_applicant_approval, false, label: {text: "Yes, applicant agreement needed"} do %>
+                <p>
+                  The new description will be sent to the applicant to approve.
+                  If the applicant does not respond within 5 days, the amended
+                  description will be automatically accepted.
+                </p>
+              <% end %>
+              <%= form.govuk_radio_button :skip_applicant_approval, true, label: {text: "No, update description immediately"} do %>
+                <p>The applicant will be notified of the new description.</p>
+              <% end %>
             <% end %>
-            <%= form.govuk_radio_button :skip_applicant_approval, true, label: {text: "No, update description immediately"} do %>
-              <p>The applicant will be notified of the new description.</p>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
+          </div>
+        <% end %>
+
         <div class="govuk-button-group">
           <%= form.govuk_submit @planning_application.application_type.description_change_requires_validation? ? "Update description" : "Save and mark as complete" %>
           <%= back_link unless @planning_application.pre_application? %>

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
@@ -88,7 +88,7 @@
       <% end %>
 
       <%= form.govuk_task_button "Save assessment", action: "update_assessment" do %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/tasks/check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance/edit.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance/edit.html.erb
@@ -75,7 +75,7 @@
 
       <%= hidden_field_tag :task_action, "update_consideration" %>
       <%= form.govuk_submit "Save consideration" do %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/tasks/check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance/show.html.erb
@@ -12,7 +12,7 @@
           locals: {
             editable: true,
             task_slug: @task.full_slug,
-            return_to: task_path(@planning_application, @task)
+            return_to: @task.url
           } %>
   </ol>
   <p><%= t(".drag_and_drop") %></p>

--- a/app/views/tasks/check-and-assess/check-application/check-site-history/show.html.erb
+++ b/app/views/tasks/check-and-assess/check-application/check-site-history/show.html.erb
@@ -11,7 +11,7 @@
 <%= render "planning_applications/assessment/site_histories/table",
       site_histories: @planning_application.site_histories.all,
       show_action: true,
-      return_to: return_to_or_task_path(@planning_application, @task) %>
+      return_to: return_to_or_task_path(@task) %>
 
 <div data-controller="unsaved-changes"
      data-action="beforeunload@window->unsaved-changes#handleBeforeUnload"><%= govuk_details(summary_text: "Add a new site history", open: @planning_application.site_histories.last&.errors&.any?) do %>

--- a/app/views/tasks/check-and-assess/check-application/permitted-development-rights/show.html.erb
+++ b/app/views/tasks/check-and-assess/check-application/permitted-development-rights/show.html.erb
@@ -19,7 +19,7 @@
 <% end %>
 <%= link_to_if(current_user.assessor?,
       "Edit constraints",
-      task_path(@planning_application, "check-and-validate/check-application-details/check-constraints", return_to: task_path(@planning_application, @task)),
+      task_path(@planning_application, "check-and-validate/check-application-details/check-constraints", return_to: @task.url),
       class: "govuk-link") {} %>
 </section>
 
@@ -28,7 +28,7 @@
 <%= render "planning_applications/assessment/site_histories/table",
       site_histories: @planning_application.site_histories.all,
       show_action: true %>
-<%= govuk_link_to "Edit site history", task_path(@planning_application, "check-and-assess/check-application/check-site-history", return_to: task_path(@planning_application, @task)) %>
+<%= govuk_link_to "Edit site history", task_path(@planning_application, "check-and-assess/check-application/check-site-history", return_to: @task.url) %>
 
 <hr>
 <% if @planning_application.possibly_immune? %>

--- a/app/views/tasks/check-and-assess/complete-assessment/add-conditions/edit.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-conditions/edit.html.erb
@@ -9,7 +9,7 @@
       <%= form.govuk_text_area :reason, value: @form.condition.reason, label: {text: "Enter a reason for this condition"} %>
       <div class="govuk-button-group">
         <%= form.govuk_task_button "Save condition", action: "update_condition" %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/check-and-assess/complete-assessment/add-heads-of-terms/_form.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-heads-of-terms/_form.html.erb
@@ -19,7 +19,7 @@
       <%= form.govuk_task_button "Save", action: "add_term", secondary: true %>
     <% else %>
       <%= form.govuk_task_button "Save", action: "update_term" do %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       <% end %>
     <% end %>
   </fieldset>

--- a/app/views/tasks/check-and-assess/complete-assessment/add-heads-of-terms/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-heads-of-terms/show.html.erb
@@ -20,7 +20,7 @@
           record_controller: "terms",
           record_sortable_url: planning_application_assessment_term_position_path(@planning_application, term),
           edit_record_url: edit_task_component_path(@planning_application, @task, term),
-          remove_record_url: planning_application_assessment_term_path(@planning_application, term, redirect_to: task_path(@planning_application, @task)),
+          remove_record_url: planning_application_assessment_term_path(@planning_application, term, redirect_to: @task.url),
           current_request: term.current_validation_request,
           show_status_tag: !@planning_application.pre_application?
         )) %>

--- a/app/views/tasks/check-and-assess/complete-assessment/add-informatives/edit.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-informatives/edit.html.erb
@@ -8,7 +8,7 @@
       <%= form.govuk_text_area :text, value: @form.informative.text, label: {text: "Enter details of the informative"} %>
       <div class="govuk-button-group">
         <%= form.govuk_task_button "Save informative", action: "update_informative" %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/check-and-assess/complete-assessment/add-pre-commencement-conditions/edit.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-pre-commencement-conditions/edit.html.erb
@@ -9,7 +9,7 @@
       <%= form.govuk_text_area :reason, value: @form.condition.reason, label: {text: "Enter reason"} %>
       <div class="govuk-button-group">
         <%= form.govuk_task_button "Save condition", action: "update_condition" %>
-        <%= govuk_button_link_to "Back", task_path(@planning_application, @task), secondary: true %>
+        <%= govuk_button_link_to "Back", @task.url, secondary: true %>
       </div>
     <% end %>
   </div>

--- a/app/views/tasks/check-and-assess/complete-assessment/review-and-submit-recommendation/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/review-and-submit-recommendation/show.html.erb
@@ -21,10 +21,10 @@
   <p class="govuk-!-margin-top-3">
     <% unless submitted %>
       <% if has_recommendation %>
-        <%= govuk_link_to "Edit recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
+        <%= govuk_link_to "Edit recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: @task.url) %>
       <% else %>
         <p>No recommendation has been made on this application.</p>
-        <%= govuk_link_to "Make draft recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: task_path(@planning_application, @task)) %>
+        <%= govuk_link_to "Make draft recommendation", task_path(@planning_application, "check-and-assess/complete-assessment/make-draft-recommendation", return_to: @task.url) %>
       <% end %>
     <% end %>
   </p>

--- a/app/views/tasks/check-and-assess/complete-assessment/review-documents-for-recommendation/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/review-documents-for-recommendation/show.html.erb
@@ -27,7 +27,7 @@
             <td class="govuk-table__cell">
               <%= govuk_link_to(
                     document.numbers.presence || document.name,
-                    edit_planning_application_document_path(@planning_application, document, route: "review", return_to: task_path(@planning_application, @task))
+                    edit_planning_application_document_path(@planning_application, document, route: "review", return_to: @task.url)
                   ) %>
             </td>
             <td class="govuk-table__cell">

--- a/app/views/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/edit.html.erb
+++ b/app/views/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/edit.html.erb
@@ -1,6 +1,6 @@
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "Application", planning_application_path(@planning_application) %>
-<% add_parent_breadcrumb_link "Review documents", task_path(@planning_application, @task) %>
+<% add_parent_breadcrumb_link "Review documents", @task.url %>
 
 <% if @form.has_open_replacement_request? %>
   <% content_for :title, "Replacement document validation request" %>
@@ -43,7 +43,7 @@
             planning_application: @planning_application,
             validation_request: validation_request,
             include_back_link: false,
-            redirect_to: task_path(@planning_application, @task) %>
+            redirect_to: @task.url %>
     </div>
   </div>
 <% else %>

--- a/app/views/tasks/consultees-neighbours-and-publicity/neighbours/add-and-assign-neighbours/_selected_list.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/neighbours/add-and-assign-neighbours/_selected_list.html.erb
@@ -25,7 +25,7 @@
             <div class="neighbour-action-links" data-edit-form-target="buttons">
               <%= govuk_link_to "Edit", "#", data: {action: "click->edit-form#handleClick"} %>
 
-              <%= govuk_link_to "Remove", planning_application_consultation_neighbour_path(planning_application, neighbour, redirect_to: task_path(planning_application, @task.full_slug)), method: :delete %>
+              <%= govuk_link_to "Remove", planning_application_consultation_neighbour_path(planning_application, neighbour, redirect_to: @task.url), method: :delete %>
             </div>
           </div>
         <% end %>

--- a/engines/bops_core/app/controllers/concerns/bops_core/validation_requests/cancellations_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/validation_requests/cancellations_controller.rb
@@ -70,7 +70,7 @@ module BopsCore
       end
 
       def after_cancel_path
-        task_path(@planning_application, @task)
+        @task.url
       end
 
       def cancellation_form_url

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -138,7 +138,7 @@ module BopsCore
       hidden_field_tag :return_to, params[:return_to]
     end
 
-    def return_to_or_task_path(planning_application, task)
+    def return_to_or_task_path(task)
       params[:return_to].presence || task.url
     end
   end

--- a/engines/bops_core/app/helpers/bops_core/application_helper.rb
+++ b/engines/bops_core/app/helpers/bops_core/application_helper.rb
@@ -139,7 +139,7 @@ module BopsCore
     end
 
     def return_to_or_task_path(planning_application, task)
-      params[:return_to].presence || task_path(planning_application, task)
+      params[:return_to].presence || task.url
     end
   end
 end

--- a/engines/bops_core/app/views/bops_core/tasks/_other_change_validation_request.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/_other_change_validation_request.html.erb
@@ -16,7 +16,7 @@
   <%= render "validation_request_status", validation_request: %>
 
   <td class="govuk-table__cell">
-    <%= govuk_link_to main_app.planning_application_validation_validation_request_path(@planning_application, validation_request, redirect_to: task_path(@planning_application, @task)) do %>
+    <%= govuk_link_to main_app.planning_application_validation_validation_request_path(@planning_application, validation_request, redirect_to: @task.url) do %>
       <%= @planning_application.validated? ? "View" : "View and update" %>
     <% end %>
   </td>

--- a/engines/bops_core/app/views/bops_core/tasks/_task_header.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/_task_header.html.erb
@@ -3,8 +3,8 @@
 <% add_parent_breadcrumb_link "Home", root_path %>
 <% add_parent_breadcrumb_link "Application", main_app.planning_application_path(@planning_application) %>
 
-<% unless current_page?(task_path(@planning_application, task)) %>
-  <% add_parent_breadcrumb_link task.title, task_path(@planning_application, task) %>
+<% unless current_page?(task.url) %>
+  <% add_parent_breadcrumb_link task.title, task.url %>
 <% end %>
 
 <% page_heading = heading || task.title %>

--- a/engines/bops_core/app/views/bops_core/tasks/check-and-validate/other-validation-issues/other-validation-requests/show.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/check-and-validate/other-validation-issues/other-validation-requests/show.html.erb
@@ -18,7 +18,7 @@
         <% @form.each_validation_request do |validation_request| %>
           <% body.with_row do |row| %>
             <% row.with_cell do %>
-              <%= govuk_link_to(main_app.planning_application_validation_validation_request_path(@planning_application, validation_request, redirect_to: task_path(@planning_application, @task))) do %>
+              <%= govuk_link_to(main_app.planning_application_validation_validation_request_path(@planning_application, validation_request, redirect_to: @task.url)) do %>
                 <%= truncate(validation_request.reason, length: 50) %>
               <% end %>
             <% end %>
@@ -39,7 +39,7 @@
 
   <% unless @planning_application.determined? %>
     <p class="govuk-body govuk-!-margin-bottom-9">
-      <%= govuk_link_to "Add other validation request", main_app.new_planning_application_validation_validation_request_path(@planning_application, type: "other_change", redirect_to: task_path(@planning_application, @task)) %>
+      <%= govuk_link_to "Add other validation request", main_app.new_planning_application_validation_validation_request_path(@planning_application, type: "other_change", redirect_to: @task.url) %>
     </p>
   <% end %>
 

--- a/engines/bops_preapps/app/controllers/bops_preapps/consultee_responses_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/consultee_responses_controller.rb
@@ -10,8 +10,6 @@ module BopsPreapps
     before_action :show_sidebar
     before_action :show_header
 
-    helper_method :back_to_task_path
-
     class << self
       private
 
@@ -35,7 +33,7 @@ module BopsPreapps
     def create
       respond_to do |format|
         if @consultee_response.save
-          format.html { redirect_to back_to_task_path, notice: t(".success") }
+          format.html { redirect_to @task.url, notice: t(".success") }
         else
           format.html { render :new, status: :unprocessable_content }
         end
@@ -44,10 +42,6 @@ module BopsPreapps
 
     private
 
-    def back_to_task_path
-      task_path(reference: @planning_application.reference, slug: @task.full_slug)
-    end
-
     def set_consultation
       @consultation = @planning_application.consultation
     end
@@ -55,7 +49,7 @@ module BopsPreapps
     def set_consultee
       @consultee = @consultation.consultees.find(consultee_id)
     rescue ActiveRecord::RecordNotFound
-      redirect_to back_to_task_path, alert: t("bops_preapps.consultee_responses.consultee_not_found")
+      redirect_to @task.url, alert: t("bops_preapps.consultee_responses.consultee_not_found")
     end
 
     def consultee_id

--- a/engines/bops_preapps/app/views/bops_preapps/consultee_responses/index.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/consultee_responses/index.html.erb
@@ -7,7 +7,7 @@
 
     <div class="govuk-button-group govuk-!-margin-top-5">
       <%= govuk_button_link_to "Upload new response", new_consultee_response_path(reference: @planning_application.reference, consultee_id: @consultee.id, task_slug: @task.full_slug), secondary: true %>
-      <%= govuk_button_link_to "Back", back_to_task_path, secondary: true %>
+      <%= govuk_button_link_to "Back", @task.url, secondary: true %>
     </div>
   </div>
 </div>

--- a/engines/bops_preapps/app/views/bops_preapps/consultee_responses/new.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/consultee_responses/new.html.erb
@@ -27,6 +27,6 @@
           t(".save_button"),
           class: "govuk-button govuk-button--primary govuk-!-margin-top-5"
         ) %>
-    <%= govuk_button_link_to t(".back_button"), back_to_task_path, secondary: true, class: "govuk-!-margin-top-5" %>
+    <%= govuk_button_link_to t(".back_button"), @task.url, secondary: true, class: "govuk-!-margin-top-5" %>
   </div>
 <% end %>

--- a/engines/bops_preapps/app/views/bops_preapps/pre_applications/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/pre_applications/show.html.erb
@@ -7,7 +7,7 @@
       <% tasks.each do |task| %>
         <% task_list.with_item(
              title: task.name,
-             href: task_path(@planning_application, task),
+             href: task.url,
              status: task_status_tag(task)
            ) %>
       <% end %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/planning-considerations-and-advice/_form.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/planning-considerations-and-advice/_form.html.erb
@@ -13,7 +13,7 @@
       <div class="govuk-form-group">
         <%= form.hidden_field :draft, value: false %>
         <%= form.hidden_field :policy_area, value: policy_area %>
-        <%= hidden_field_tag :return_to, return_to_or_task_path(@planning_application, @task) %>
+        <%= hidden_field_tag :return_to, return_to_or_task_path(@task) %>
         <%= form.govuk_text_field :proposal, label: {text: "Enter element of proposal"} %>
 
         <%= form.govuk_text_field :policy_references,

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/planning-considerations-and-advice/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/planning-considerations-and-advice/show.html.erb
@@ -6,7 +6,7 @@
       <% if consideration.draft? %>
         <% if considerations.length == 1 %>
           <% card.with_action do %>
-            <%= govuk_link_to("Remove", main_app.planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@planning_application, @task)), method: :delete, data: {confirm: "Are you sure?"}) %>
+            <%= govuk_link_to("Remove", main_app.planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@task)), method: :delete, data: {confirm: "Are you sure?"}) %>
           <% end %>
         <% end %>
       <% else %>
@@ -14,9 +14,9 @@
           <strong class="govuk-body-s"><%= consideration.proposal %></strong>
           <span class="flex-right-align">
             <% unless @planning_application.determined? %>
-              <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@planning_application, @task)) %>
+              <%= govuk_link_to "Edit", main_app.edit_planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@task)) %>
               |
-              <%= govuk_link_to "Remove", main_app.planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@planning_application, @task)), method: :delete, data: {confirm: "Are you sure?"} %>
+              <%= govuk_link_to "Remove", main_app.planning_application_assessment_consideration_guidance_path(@planning_application, consideration, return_to: return_to_or_task_path(@task)), method: :delete, data: {confirm: "Are you sure?"} %>
             <% end %>
           </span>
         </div>
@@ -62,7 +62,7 @@
                 :last, :last, options: {include_blank: true},
                 label: {text: "Select policy area"},
                 data: {consideration_form_target: "policyAreaSelect"} %>
-          <%= hidden_field_tag :return_to, return_to_or_task_path(@planning_application, @task) %>
+          <%= hidden_field_tag :return_to, return_to_or_task_path(@task) %>
           <%= form.govuk_task_button "Add consideration", action: "add_consideration", secondary: true, class: "govuk-!-margin-bottom-2" %>
         <% end %>
       <% end %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/edit.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/edit.html.erb
@@ -1,3 +1,3 @@
 <%= render "task_header", task: @task %>
 
-<%= render "bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/form", url: main_app.planning_application_assessment_term_path(@planning_application, @term, redirect_to: task_path(@planning_application, @task)) %>
+<%= render "bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/form", url: main_app.planning_application_assessment_term_path(@planning_application, @term, redirect_to: @task.url) %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/show.html.erb
@@ -18,9 +18,9 @@
           position: position,
           record_class: "term",
           record_controller: "terms",
-          record_sortable_url: main_app.planning_application_assessment_term_position_path(@planning_application, term, redirect_to: task_path(@planning_application, @task)),
-          edit_record_url: main_app.edit_planning_application_assessment_term_path(@planning_application, term, redirect_to: task_path(@planning_application, @task)),
-          remove_record_url: main_app.planning_application_assessment_term_path(@planning_application, term, redirect_to: task_path(@planning_application, @task)),
+          record_sortable_url: main_app.planning_application_assessment_term_position_path(@planning_application, term, redirect_to: @task.url),
+          edit_record_url: main_app.edit_planning_application_assessment_term_path(@planning_application, term, redirect_to: @task.url),
+          remove_record_url: main_app.planning_application_assessment_term_path(@planning_application, term, redirect_to: @task.url),
           current_request: term.current_validation_request,
           show_status_tag: !@planning_application.pre_application?
         )) %>
@@ -36,7 +36,7 @@
     </summary>
 
     <div>
-      <%= render "bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/form", url: main_app.planning_application_assessment_terms_path(@planning_application, redirect_to: task_path(@planning_application, @task)) %>
+      <%= render "bops_preapps/tasks/check-and-assess/assessment-summaries/suggest-heads-of-terms/form", url: main_app.planning_application_assessment_terms_path(@planning_application, redirect_to: @task.url) %>
     </div>
     <hr
       class="

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/check-application/check-site-history/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/check-application/check-site-history/show.html.erb
@@ -11,7 +11,7 @@
 <%= render "planning_applications/assessment/site_histories/table",
       site_histories: @planning_application.site_histories.all,
       show_action: true,
-      return_to: return_to_or_task_path(@planning_application, @task) %>
+      return_to: return_to_or_task_path(@task) %>
 
 <div data-controller="unsaved-changes"
      data-action="beforeunload@window->unsaved-changes#handleBeforeUnload"><%= govuk_details(summary_text: "Add a new site history", open: @planning_application.site_histories.last&.errors&.any?) do %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/complete-assessment/check-and-add-requirements/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-assess/complete-assessment/check-and-add-requirements/show.html.erb
@@ -34,7 +34,7 @@
                   <div class="align-items-center justify-end gap-2">
                     <%= form_with model: @form, url: @form.url do |form| %>
                       <%= form.hidden_field :requirement_id, value: requirement.id %>
-                      <%= govuk_link_to("Edit", main_app.edit_planning_application_assessment_requirement_path(@planning_application, requirement, redirect_to: task_path(@planning_application, @task)), no_visited_state: true, no_underline: true) %>
+                      <%= govuk_link_to("Edit", main_app.edit_planning_application_assessment_requirement_path(@planning_application, requirement, redirect_to: @task.url), no_visited_state: true, no_underline: true) %>
                       <span>|</span>
 
                       <%= form.govuk_task_button "Remove", action: "remove_requirement", class: "button-as-link",

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/show.html.erb
@@ -36,7 +36,7 @@
                      ) do |row| %>
                 <%= row.with_cell do %>
                   <p>
-                    <%= govuk_link_to(truncate(document.reference_or_name, length: 50), document_link_path(document, redirect_to: task_path(@planning_application, @task))) %>
+                    <%= govuk_link_to(truncate(document.reference_or_name, length: 50), document_link_path(document, redirect_to: @task.url)) %>
                   </p>
 
                   <% if document.tags.present? %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/show.html.erb
@@ -4,7 +4,7 @@
   <% @task.tasks.each do |task| %>
     <%= task_list.with_item(
           title: task.name,
-          href: task_path(@planning_application, task),
+          href: task.url,
           status: task_status_tag(task)
         ) %>
   <% end %>


### PR DESCRIPTION
Refactor repeated logic around `task_path`: e.g., we always need an extra parameter (though we always know it'll be the parent application), and in several places need to do the same `pre_application?` check to pick the right helper.