### PR TITLE
Pause API tokens to hold submissions for manual review

### DIFF
--- a/app/models/api_user.rb
+++ b/app/models/api_user.rb
@@ -28,6 +28,7 @@ class ApiUser < ApplicationRecord
   has_secure_token :token, length: 36
 
   scope :active, -> { where(revoked_at: nil) }
+  scope :paused, -> { where(paused: true) }
   scope :revoked, -> { where.not(revoked_at: nil) }
   scope :by_name, -> { reorder(:name) }
 

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -243,6 +243,10 @@ class LocalAuthority < ApplicationRecord
     subdomain
   end
 
+  def paused_api_users?
+    api_users.active.paused.exists?
+  end
+
   private
 
   def protocol

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -4,6 +4,7 @@ class Submission < ApplicationRecord
   include AASM
 
   belongs_to :local_authority
+  belongs_to :api_user, optional: true
   has_one :case_record, dependent: :nullify
   has_many :documents, dependent: :destroy
 
@@ -21,14 +22,18 @@ class Submission < ApplicationRecord
 
   scope :by_created_at_desc, -> { order(created_at: :desc) }
 
-  aasm column: :status, timestamps: true do
+  aasm column: :status, timestamps: true, whiny_transitions: false do
     state :submitted, initial: true
     state :started
     state :failed
     state :completed
 
     event :start do
-      transitions from: [:failed, :submitted], to: :started
+      transitions from: [:failed, :submitted], to: :started, unless: :api_user_paused?
+
+      after do
+        BopsSubmissions::SubmissionProcessorJob.perform_later(self)
+      end
     end
 
     event :fail do
@@ -64,5 +69,9 @@ class Submission < ApplicationRecord
 
   def odp?
     schema == "odp"
+  end
+
+  def api_user_paused?
+    api_user&.paused?
   end
 end

--- a/db/migrate/20260430154431_add_paused_to_api_users.rb
+++ b/db/migrate/20260430154431_add_paused_to_api_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPausedToApiUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :api_users, :paused, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260430154433_add_api_user_to_submissions.rb
+++ b/db/migrate/20260430154433_add_api_user_to_submissions.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddApiUserToSubmissions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_reference :submissions, :api_user, null: true, index: false
+    add_index :submissions, :api_user_id, algorithm: :concurrently, name: "ix_submissions_on_api_user_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_135314) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_30_154433) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -72,6 +72,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_135314) do
     t.datetime "last_used_at"
     t.bigint "local_authority_id"
     t.string "name", null: false
+    t.boolean "paused", default: false, null: false
     t.string "permissions", array: true
     t.string "product_id"
     t.datetime "revoked_at"
@@ -1265,6 +1266,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_135314) do
   end
 
   create_table "submissions", force: :cascade do |t|
+    t.bigint "api_user_id"
     t.jsonb "application_payload", default: {}, null: false
     t.datetime "completed_at"
     t.datetime "created_at", null: false
@@ -1278,6 +1280,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_135314) do
     t.datetime "started_at"
     t.string "status", default: "submitted", null: false
     t.datetime "updated_at", null: false
+    t.index ["api_user_id"], name: "ix_submissions_on_api_user_id"
     t.index ["external_uuid"], name: "ix_submissions_on_external_uuid", unique: true
     t.index ["local_authority_id"], name: "ix_submissions_on_local_authority_id"
     t.index ["status"], name: "ix_submissions_on_status"

--- a/engines/bops_admin/app/controllers/bops_admin/submissions_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/submissions_controller.rb
@@ -5,7 +5,7 @@ module BopsAdmin
     self.page_key = "submissions"
 
     before_action :set_submissions, only: %i[index]
-    before_action :set_submission, only: %i[show]
+    before_action :set_submission, only: %i[show update]
     before_action :set_planning_application, only: %i[show]
 
     rescue_from Pagy::OverflowError do
@@ -21,6 +21,14 @@ module BopsAdmin
     def show
       respond_to do |format|
         format.html
+      end
+    end
+
+    def update
+      if @submission.start!
+        redirect_to submission_path(@submission), notice: t(".success")
+      else
+        redirect_to submission_path(@submission), alert: t(".not_eligible")
       end
     end
 

--- a/engines/bops_admin/app/controllers/bops_admin/tokens_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/tokens_controller.rb
@@ -77,7 +77,7 @@ module BopsAdmin
     end
 
     def token_attributes
-      %i[name service authentication_type product_id client_id client_secret]
+      %i[name service authentication_type product_id client_id client_secret paused]
     end
 
     def file_downloader_attributes

--- a/engines/bops_admin/app/views/bops_admin/submissions/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/submissions/index.html.erb
@@ -12,6 +12,14 @@
       <%= t(".submissions") %>
     </h1>
 
+    <% if current_local_authority.paused_api_users? %>
+      <%= govuk_notification_banner(title_text: t(".paused_banner.title")) do %>
+        <p class="govuk-body">
+          <%= t(".paused_banner.body_html") %>
+        </p>
+      <% end %>
+    <% end %>
+
     <div class="govuk-inset-text">
       Planning applications with a <strong>Completed</strong> submission status may temporarily show a <strong>Pending</strong> application status before appearing in BOPS.
       Applications pending for more than 10 minutes will trigger an error for the development team to investigate.

--- a/engines/bops_admin/app/views/bops_admin/submissions/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/submissions/show.html.erb
@@ -11,6 +11,14 @@
   <div class="govuk-grid-column-full">
     <h1>Submission</h1>
 
+    <% if @submission.submitted? %>
+      <%= govuk_notification_banner(title_text: t(".awaiting_review.title")) do %>
+        <p class="govuk-notification-banner__heading">
+          <%= t(".awaiting_review.body") %>
+        </p>
+      <% end %>
+    <% end %>
+
     <%= govuk_summary_list(actions: false, classes: "govuk-summary-list--no-border") do |summary_list| %>
       <% {
            "Submission service reference" => @submission.application_reference,
@@ -116,12 +124,24 @@
         and case id:
         <%= @submission.case_record.id + "." %>
       </p>
+    <% elsif @submission.submitted? %>
+      <p><%= t(".awaiting_review.no_application_yet") %></p>
+    <% elsif @submission.started? %>
+      <p><%= t(".processing.body") %></p>
     <% else %>
       <p>There is no case associated with this submission.</p>
     <% end %>
 
-    <div class="govuk-button-group">
-      <%= back_link %>
-    </div>
+    <% if @submission.submitted? %>
+      <%= form_with model: @submission, url: submission_path(@submission), method: :patch do |form| %>
+        <%= form.govuk_submit(t(".submit_button")) do %>
+          <%= back_link %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <div class="govuk-button-group">
+        <%= back_link %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/engines/bops_admin/app/views/bops_admin/tokens/_table.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/_table.html.erb
@@ -5,20 +5,17 @@
       <th scope="col" class="govuk-table__header">Service</th>
       <th scope="col" class="govuk-table__header">Last used at</th>
       <% if revoked %>
-        <th scope="col" class="govuk-table__header">
-          Revoked at
-        </th>
+        <th scope="col" class="govuk-table__header">Revoked at</th>
       <% else %>
-        <th scope="col" class="govuk-table__header govuk-table__header--numeric">
-          &nbsp;
-        </th>
+        <th scope="col" class="govuk-table__header">Status</th>
+        <th scope="col" class="govuk-table__header govuk-table__header--numeric">&nbsp;</th>
       <% end %>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
     <% if tokens.empty? %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell" colspan="4">
+        <td class="govuk-table__cell" colspan="<%= revoked ? 4 : 5 %>">
           <% if revoked %>
             <%= t(".no_revoked_tokens") %>
           <% else %>
@@ -47,6 +44,13 @@
               <%= token.revoked_at.to_fs(:rfc822) %>
             </td>
           <% else %>
+            <td class="govuk-table__cell">
+              <% if token.paused? %>
+                <%= govuk_tag(text: "Paused", colour: "yellow") %>
+              <% else %>
+                <%= govuk_tag(text: "Active", colour: "green") %>
+              <% end %>
+            </td>
             <td class="govuk-table__cell govuk-table__cell--numeric">
               <%= govuk_link_to t(".edit"), edit_token_path(token) %>
             </td>

--- a/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/tokens/edit.html.erb
@@ -43,6 +43,10 @@
         <% end %>
       <% end %>
 
+      <%= form.govuk_check_boxes_fieldset(:paused, multiple: false, legend: {text: t(".legends.paused")}, hint: {text: t(".hints.paused")}) do %>
+        <%= form.govuk_check_box :paused, "1", "0", multiple: false, label: {text: t(".labels.paused")} %>
+      <% end %>
+
       <%= render "file_downloader", form: form, file_downloader: @token.file_downloader %>
 
       <%= form.govuk_submit(t(".submit")) do %>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -607,8 +607,22 @@ en:
         status: Status
       index:
         page_title: BOPS Admin
+        paused_banner:
+          body_html: One or more API tokens are <strong>paused</strong>. New submissions from those tokens are held here until you choose to submit them. Open a submission and click 'Submit application' to create a planning application in BOPS.
+          title: API tokens paused
         submissions: Submissions
       no_submissions_found: No submissions found
+      show:
+        awaiting_review:
+          body: This submission has not been processed yet. Click 'Submit application' to create a planning application in BOPS.
+          no_application_yet: A planning application will be created once you submit this submission.
+          title: Awaiting review
+        processing:
+          body: This submission is being processed. The planning application will appear here shortly.
+        submit_button: Submit application
+      update:
+        not_eligible: This submission cannot be submitted.
+        success: Application submitted - planning application is being created.
     tokens:
       create:
         success: API token successfully created
@@ -621,15 +635,18 @@ en:
         hints:
           authentication_type: If this API token is for Planning Portal choose HMAC digest
           name: A unique name for this token, typically the name of an individual or organisation
+          paused: Incoming submissions from this token will be persisted but no planning application will be created until an administrator submits them manually.
           service: A description for what is using this token - if it's for submission of planning applications it should be the name of the service, e.g. PlanX
         labels:
           bearer_token: Bearer token
           client_id: Client ID
           client_secret: Client secret
           hmac_digest: HMAC digest
+          paused: Hold submissions for manual review
           product_id: Product ID
         legends:
           authentication_type: Select the type of authentication to use
+          paused: Pause this API token
           permissions: Permissions to be granted to this API token
         revoke: Revoke
         submit: Save

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -50,5 +50,5 @@ BopsAdmin::Engine.routes.draw do
     patch :reactivate, on: :member
   end
 
-  resources :submissions, only: %i[index show]
+  resources :submissions, only: %i[index show update]
 end

--- a/engines/bops_admin/spec/system/submissions_spec.rb
+++ b/engines/bops_admin/spec/system/submissions_spec.rb
@@ -264,6 +264,53 @@ RSpec.describe "Submissions", type: :system do
     end
   end
 
+  context "when adding a submission to BOPS manually" do
+    let!(:submission) { create(:submission, :planning_portal, local_authority:) }
+
+    it "shows a Submit application button for a submitted planning portal submission and enqueues the processor job" do
+      visit "/admin/submissions/#{submission.id}"
+
+      expect(page).to have_content("Awaiting review")
+
+      expect {
+        click_button "Submit application"
+      }.to have_enqueued_job(BopsSubmissions::SubmissionProcessorJob).with(submission)
+
+      expect(page).to have_current_path("/admin/submissions/#{submission.id}")
+      expect(page).to have_content("Application submitted")
+      expect(page).not_to have_content("Awaiting review")
+      expect(page).not_to have_button("Submit application")
+      expect(submission.reload.status).to eq("started")
+    end
+
+    it "does not show the button or awaiting-review banner once the submission has started" do
+      submission.start!
+
+      visit "/admin/submissions/#{submission.id}"
+
+      expect(page).not_to have_button("Submit application")
+      expect(page).not_to have_content("Awaiting review")
+    end
+
+    context "when the LPA has a paused API token" do
+      before { create(:api_user, :planning_portal, local_authority:, paused: true) }
+
+      it "shows the paused-tokens banner on the index" do
+        visit "/admin/submissions"
+
+        expect(page).to have_content("API tokens paused")
+      end
+    end
+
+    context "when the LPA has no paused API tokens" do
+      it "does not show the paused-tokens banner on the index" do
+        visit "/admin/submissions"
+
+        expect(page).not_to have_content("API tokens paused")
+      end
+    end
+  end
+
   context "when a submission has been processed into an enforcement case" do
     let!(:submission) { create(:submission, :enforcement, local_authority:) }
 

--- a/engines/bops_admin/spec/system/tokens_spec.rb
+++ b/engines/bops_admin/spec/system/tokens_spec.rb
@@ -29,12 +29,14 @@ RSpec.describe "API Tokens", :capybara do
         expect(page).to have_selector("th:nth-child(1)", text: "Name")
         expect(page).to have_selector("th:nth-child(2)", text: "Service")
         expect(page).to have_selector("th:nth-child(3)", text: "Last used at")
+        expect(page).to have_selector("th:nth-child(4)", text: "Status")
       end
 
       within "tbody tr:nth-child(1)" do
         expect(page).to have_selector("td:nth-child(1)", text: "Active Token")
         expect(page).to have_selector("td:nth-child(2)", text: "PlanX")
         expect(page).to have_selector("td:nth-child(3)", text: "Tue, 15 Oct 2024 11:30:00 +0100")
+        expect(page).to have_selector("td:nth-child(4)", text: "Active")
       end
     end
   end
@@ -93,6 +95,32 @@ RSpec.describe "API Tokens", :capybara do
         expect(page).to have_selector("td:nth-child(1)", text: "Active Token")
         expect(page).to have_selector("td:nth-child(4)", text: "Tue, 22 Oct 2024 11:30:00 +0100")
       end
+    end
+  end
+
+  it "allows a token to be paused and unpaused" do
+    visit "/admin/tokens"
+
+    within "#active table tbody tr:nth-child(1)" do
+      click_link "Edit"
+    end
+
+    expect(page).to have_selector("h1", text: "Edit API token")
+    check "Hold submissions for manual review"
+    click_button "Save"
+
+    expect(page).to have_selector("[role=alert] p", text: "API token successfully updated")
+
+    within "#active table tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(4)", text: "Paused")
+      click_link "Edit"
+    end
+
+    uncheck "Hold submissions for manual review"
+    click_button "Save"
+
+    within "#active table tbody tr:nth-child(1)" do
+      expect(page).to have_selector("td:nth-child(4)", text: "Active")
     end
   end
 

--- a/engines/bops_submissions/app/controllers/bops_submissions/v2/submissions_controller.rb
+++ b/engines/bops_submissions/app/controllers/bops_submissions/v2/submissions_controller.rb
@@ -8,7 +8,7 @@ module BopsSubmissions
 
       def create
         @submission = creation_service.call
-        SubmissionProcessorJob.perform_later(@submission.id, @current_api_user)
+        @submission.start!
 
         respond_to do |format|
           format.json
@@ -22,6 +22,7 @@ module BopsSubmissions
           params: submission_params,
           headers: request.headers,
           local_authority: current_local_authority,
+          api_user: @current_api_user,
           schema:
         )
       end

--- a/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
+++ b/engines/bops_submissions/app/jobs/bops_submissions/submission_processor_job.rb
@@ -4,22 +4,19 @@ module BopsSubmissions
   class SubmissionProcessorJob < ApplicationJob
     queue_as :submissions
 
-    def perform(submission_id, current_api_user)
-      submission = Submission.find(submission_id)
-      submission.start! if submission.may_start?
-
+    def perform(submission)
       if submission.planning_portal?
         ZipExtractionService.new(submission:).call
         Application::PlanningPortalCreationService.new(submission:).call!
       elsif submission.odp?
         if submission.request_body.dig(:data, :application, :type, :value) == "breach"
-          Enforcement::CreationService.new(submission:, user: current_api_user).call!
+          Enforcement::CreationService.new(submission:, user: submission.api_user).call!
         else
           send_email = false # TODO where do we set this from?
           Application::PlanxCreationService.new(
             local_authority: submission.local_authority,
             submission:,
-            user: current_api_user,
+            user: submission.api_user,
             params: submission.request_body,
             email_sending_permitted: send_email
           ).call!

--- a/engines/bops_submissions/app/services/bops_submissions/application/planx_creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/application/planx_creation_service.rb
@@ -3,7 +3,7 @@
 module BopsSubmissions
   module Application
     class PlanxCreationService
-      def initialize(local_authority: nil, user: nil, params: nil, submission: nil, email_sending_permitted: false)
+      def initialize(user:, local_authority: nil, params: nil, submission: nil, email_sending_permitted: false)
         @local_authority = local_authority
         @user = user
         @params = params

--- a/engines/bops_submissions/app/services/bops_submissions/creation_service.rb
+++ b/engines/bops_submissions/app/services/bops_submissions/creation_service.rb
@@ -13,19 +13,21 @@ module BopsSubmissions
       Referer
     ].freeze
 
-    def initialize(params:, headers:, local_authority:, schema: nil)
+    def initialize(params:, headers:, local_authority:, api_user:, schema: nil)
       @params = params
       @headers = headers
       @local_authority = local_authority
+      @api_user = api_user
       @schema = schema
     end
 
-    attr_reader :params, :headers, :local_authority, :schema
+    attr_reader :params, :headers, :local_authority, :api_user, :schema
 
     def call
       submission = local_authority.submissions.create!(
         request_headers: filtered_request_headers,
         request_body: params,
+        api_user: api_user,
         schema:
       )
 

--- a/engines/bops_submissions/spec/controllers/v2/submissions_controller_spec.rb
+++ b/engines/bops_submissions/spec/controllers/v2/submissions_controller_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe BopsSubmissions::V2::SubmissionsController, type: :controller do
         expect(response).to have_http_status(:ok)
         expect(response).to render_template("bops_submissions/v2/submissions/create")
       end
+
+      it "stamps the authenticated api_user onto the submission" do
+        post :create, as: :json, body: body.to_json
+
+        perform_enqueued_jobs
+
+        expect(Submission.last.api_user).to eq(local_authority.api_users.first)
+      end
     end
 
     context "without the correct schema parameter" do
@@ -107,6 +115,29 @@ RSpec.describe BopsSubmissions::V2::SubmissionsController, type: :controller do
         }.not_to change(Submission, :count)
 
         expect(response).to have_http_status(:internal_server_error)
+      end
+    end
+
+    context "when the API token is paused" do
+      let(:body) { json_data.merge(schema: "planning-portal") }
+      let(:api_user) { local_authority.api_users.first }
+
+      before do
+        api_user.update!(paused: true)
+        expect(BopsSubmissions::Application::PlanningPortalCreationService).not_to receive(:new)
+      end
+
+      it "persists the submission but does not enqueue the processor job" do
+        expect {
+          post :create, as: :json, body: body.to_json
+        }.to change(Submission, :count).by(1)
+
+        expect(BopsSubmissions::SubmissionProcessorJob)
+          .not_to have_been_enqueued
+
+        expect(response).to have_http_status(:ok)
+        expect(Submission.last.status).to eq("submitted")
+        expect(Submission.last.api_user).to eq(api_user)
       end
     end
   end

--- a/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
+++ b/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
@@ -3,18 +3,11 @@
 require "rails_helper"
 
 RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
-  let!(:submission) { create(:submission, :planning_portal, status: "submitted") }
-
-  before do
-    allow(Submission)
-      .to receive(:find)
-      .with(submission.id)
-      .and_return(submission)
-  end
+  let!(:submission) { create(:submission, :planning_portal, status: "started") }
 
   describe "#perform" do
     context "when everything succeeds" do
-      it "starts, processes, and completes the submission in order" do
+      it "processes and completes the submission in order" do
         extractor = instance_double(BopsSubmissions::ZipExtractionService)
         allow(BopsSubmissions::ZipExtractionService)
           .to receive(:new)
@@ -29,12 +22,11 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
           .and_return(creator)
         allow(creator).to receive(:call!)
 
-        expect(submission).to receive(:start!).ordered
         expect(extractor).to receive(:call).ordered
         expect(creator).to receive(:call!).ordered
         expect(submission).to receive(:complete!).ordered
 
-        described_class.perform_now(submission.id, current_api_user: nil)
+        described_class.perform_now(submission)
       end
     end
 
@@ -50,31 +42,12 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
       end
 
       it "calls start!, then fail!, updates the error, and re-raises" do
-        expect(submission).to receive(:start!).ordered.and_call_original
-        expect(submission).to receive(:fail!).ordered.and_call_original
-        expect(submission).to receive(:update!).with(error_message: "An error!").ordered.and_call_original
-
         expect {
-          described_class.perform_now(submission.id, current_api_user: nil)
+          described_class.perform_now(submission)
         }.to raise_error(StandardError, "An error!")
 
         expect(submission.reload.status).to eq("failed")
         expect(submission.error_message).to eq("An error!")
-      end
-    end
-
-    context "when the submission cannot be found" do
-      before do
-        allow(Submission).to receive(:find).with(1).and_raise(ActiveRecord::RecordNotFound.new("not found"))
-        allow(Appsignal).to receive(:report_error)
-      end
-
-      it "reports the RecordNotFound to AppSignal and re-raises" do
-        expect(Appsignal).to receive(:report_error).with(instance_of(ActiveRecord::RecordNotFound))
-
-        expect {
-          described_class.perform_now(1, current_api_user: nil)
-        }.to raise_error(ActiveRecord::RecordNotFound, "not found")
       end
     end
 
@@ -97,14 +70,8 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
           .and_return(creator)
         allow(creator).to receive(:call!).and_raise(ArgumentError, "Submission has no JSON")
 
-        expect(submission).to receive(:start!).ordered
-        expect(extractor).to receive(:call).ordered
-        expect(creator).to receive(:call!).ordered
-        expect(submission).to receive(:fail!).ordered.and_call_original
-        expect(submission).to receive(:update!).with(error_message: "Submission has no JSON").ordered.and_call_original
-
         expect {
-          described_class.perform_now(submission.id, current_api_user: nil)
+          described_class.perform_now(submission)
         }.to raise_error(ArgumentError, "Submission has no JSON")
 
         expect(submission.reload.status).to eq("failed")
@@ -130,13 +97,31 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
         create(:application_type, :minor)
 
         expect {
-          described_class.perform_now(submission.id, current_api_user: nil)
+          described_class.perform_now(submission)
         }.not_to raise_error
 
         pa = PlanningApplication.last
         expect(pa).to be_present
         expect(pa.case_record.submission_id).to eq(submission.id)
         expect(pa.local_authority_id).to eq(submission.local_authority_id)
+      end
+    end
+
+    context "when the submission has an api_user (odp PlanX flow)" do
+      let!(:api_user) { create(:api_user, :planx) }
+      let!(:odp_submission) do
+        create(:submission, status: "started", api_user: api_user, local_authority: api_user.local_authority)
+      end
+
+      it "passes submission.api_user as the user to PlanxCreationService" do
+        creator = instance_double(BopsSubmissions::Application::PlanxCreationService)
+        expect(BopsSubmissions::Application::PlanxCreationService)
+          .to receive(:new)
+          .with(hash_including(submission: odp_submission, user: api_user))
+          .and_return(creator)
+        allow(creator).to receive(:call!)
+
+        described_class.perform_now(odp_submission)
       end
     end
   end

--- a/engines/bops_submissions/spec/services/bops_submissions/creation_service_spec.rb
+++ b/engines/bops_submissions/spec/services/bops_submissions/creation_service_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe BopsSubmissions::CreationService, type: :service do
     )
   end
 
-  subject(:service) { described_class.new(params:, headers:, local_authority:) }
+  let(:api_user) { create(:api_user, :planx, local_authority:) }
+  subject(:service) { described_class.new(params:, headers:, local_authority:, api_user:) }
 
   it "creates a submission with filtered headers and permitted params" do
     expect {
@@ -47,5 +48,12 @@ RSpec.describe BopsSubmissions::CreationService, type: :service do
     headers.env["Authorization"] = "xxxxxx"
     submission = service.call
     expect(submission.request_headers).not_to have_key("Authorization")
+  end
+
+  it "associates the submission with the supplied api_user" do
+    api_user = create(:api_user, :planx, local_authority:)
+    submission = described_class.new(params:, headers:, local_authority:, api_user:).call
+
+    expect(submission.api_user).to eq(api_user)
   end
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -134,20 +134,20 @@ RSpec.describe Submission do
     context "event guards" do
       it "won't complete before start" do
         expect(submission.may_complete?).to be_falsey
-        expect { submission.complete! }.to raise_error(AASM::InvalidTransition)
+        expect(submission.complete!).to be(false)
       end
 
       it "won't fail after completion" do
         submission.start!
         submission.complete!
         expect(submission.may_fail?).to be_falsey
-        expect { submission.fail! }.to raise_error(AASM::InvalidTransition)
+        expect(submission.fail!).to be(false)
       end
 
       it "won't start twice" do
         submission.start!
         expect(submission.may_start?).to be_falsey
-        expect { submission.start! }.to raise_error(AASM::InvalidTransition)
+        expect(submission.start!).to be(false)
       end
 
       it "allows fail from started" do


### PR DESCRIPTION
### Description of change

Pause API tokens to hold submissions for manual review

### Story Link

https://trello.com/c/B9ELI8wV/1724-enable-selective-addition-of-planning-portal-submissions


