### PR TITLE
Able to add signature to decision notice

### DIFF
--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -4,6 +4,7 @@ class LocalAuthority < ApplicationRecord
   include StoreModel::NestedAttributes
 
   with_options dependent: :destroy do
+    has_one_attached :signature
     has_many :users
     has_many :planning_applications, -> { kept }
     has_many :constraints

--- a/app/views/planning_applications/_decision_notice.html.erb
+++ b/app/views/planning_applications/_decision_notice.html.erb
@@ -194,7 +194,10 @@
   </h3>
   <p class="govuk-!-margin-bottom-0">
     <%= planning_application.local_authority.signatory_name %><br>
-    <%= planning_application.local_authority.signatory_job_title %>
+    <%= planning_application.local_authority.signatory_job_title %><br>
+    <% if  planning_application.local_authority.signature.present? %>
+      <%= image_tag main_app.url_for(planning_application.local_authority.signature.blob), alt: "Signatory signature", style: "max-width: 150px" %>
+    <% end %>
   </p>
 
   <hr class="govuk-section-break govuk-section-break--m">

--- a/engines/bops_admin/app/controllers/bops_admin/profiles_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/profiles_controller.rb
@@ -26,11 +26,17 @@ module BopsAdmin
       end
     end
 
+    def remove_signature
+      current_local_authority.signature.purge
+      redirect_to edit_profile_path, notice: t(".signature_successfully_removed")
+    end
+
     private
 
     def local_authority_params
       params.require(:local_authority).permit(
         :signatory_name,
+        :signature,
         :signatory_job_title,
         :enquiries_paragraph,
         :engagement_statement,

--- a/engines/bops_admin/app/helpers/bops_admin/file_types_helper.rb
+++ b/engines/bops_admin/app/helpers/bops_admin/file_types_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  module FileTypesHelper
+    def acceptable_file_mime_types
+      FileTypes::ACCEPTED.join(",")
+    end
+  end
+end

--- a/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/_form.html.erb
@@ -16,7 +16,7 @@
               </a>
             <% else %>
               <a href="#">
-                Enter a valid <%= t(current_local_authority.notify_error_status.delete_prefix("bad_")) %> for the configured GOV.UK Notify account
+                Enter a valid <%= t(".#{current_local_authority.notify_error_status.delete_prefix("bad_")}") %> for the configured GOV.UK Notify account
               </a>
             <% end %>
           </li>
@@ -41,6 +41,31 @@
         hint: {text: t(".signatory_job_title_hint")},
         class: "govuk-input--width-30"
       ) %>
+
+  <% if current_local_authority.signature.attached? %>
+    <div class="govuk-form-group">
+      <p class="govuk-label govuk-label--m"><%= t(".current_signature") %></p>
+      <%= image_tag main_app.uploaded_file_url(current_local_authority.signature.blob), alt: "Signatory signature", style: "max-width: 200px" %><br>
+      <%= govuk_button_link_to t(".remove_signature"), remove_signature_profile_path, secondary: true, class: "govuk-!-margin-top-2", method: :delete %>
+    </div>
+  <% end %>
+
+  <div class="govuk-form-group" data-controller="clear-form">
+    <label class="govuk-label govuk-label--m" for="local_authority_signature">
+      <%= t(".signatory_signature") %>
+    </label>
+    <div id="local_authority_signature-hint" class="govuk-hint">
+      <%= t(".signatory_signature_hint") %>
+    </div>
+    <div class="display-flex" style="align-items: center; gap: 1rem; flex-wrap: nowrap;">
+      <%= form.file_field(:signature,
+            class: "govuk-file-upload",
+            multiple: true,
+            accept: acceptable_file_mime_types,
+            "aria-describedby": "local_authority_signature-hint") %>
+      <%= govuk_link_to "clear", "#", no_visited_state: true, data: {action: "click->clear-form#handleClick"} %>
+    </div>
+  </div>
 
   <%= form.govuk_text_field(
         :enquiries_paragraph,

--- a/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/profiles/show.html.erb
@@ -30,7 +30,7 @@
                 </a>
               <% else %>
                 <a href="#">
-                  Enter a valid <%= t(current_local_authority.notify_error_status.delete_prefix("bad_")) %> for the configured GOV.UK Notify account
+                  Enter a valid <%= t(".#{current_local_authority.notify_error_status.delete_prefix("bad_")}") %> for the configured GOV.UK Notify account
                 </a>
               <% end %>
             </li>
@@ -58,6 +58,17 @@
           <div class="govuk-hint govuk-!-margin-bottom-2"><%= t(".signatory_job_title_hint") %></div>
           <p>
             <%= current_local_authority.signatory_job_title %>
+          </p>
+        </li>
+        <li>
+          <h2 class="govuk-!-margin-bottom-2 govuk-!-margin-top-5"><%= t(".signatory_signature") %></h2>
+          <div class="govuk-hint govuk-!-margin-bottom-2"><%= t(".signatory_signature_hint") %></div>
+          <p>
+            <% if current_local_authority.signature.attached? %>
+              <%= image_tag main_app.uploaded_file_url(current_local_authority.signature.blob), alt: "Signatory signature", style: "max-width: 200px" %>
+            <% else %>
+              -
+            <% end %>
           </p>
         </li>
         <li>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -443,6 +443,8 @@ en:
       edit:
         profile: Edit profile
       form:
+        api_key: Notify API key
+        current_signature: Current signature
         document_checklist: Document checklist
         document_checklist_hint: Link to a document checklist that applicants use when submitting applications.
         email_address: Email
@@ -471,12 +473,15 @@ en:
         privacy_policy_url_hint: Link to privacy policy for applicants
         public_register_base_url: Public register url
         public_register_base_url_hint: Enter the Public register url.
+        remove_signature: Remove signature
         reviewer_group_email: BOPS lead email
         reviewer_group_email_hint: This is the email of the person who will be responsible for managing the planning process in BOPS at your council.
         signatory_job_title: Job title
         signatory_job_title_hint: This is the job title of the person whose signature appears at the bottom of decision notices.
         signatory_name: Signatory
         signatory_name_hint: This is the person whose signature appears at the bottom of decision notices.
+        signatory_signature: Signature
+        signatory_signature_hint: Upload an image of the officer's signature. This signature appears at the bottom of decision notices (optional).
         submission_guidance_url: Submission guidance
         submission_guidance_url_hint: This is the web page applicants visit to find out more information about submitting their application.
         submission_url: Application submission
@@ -484,7 +489,10 @@ en:
         submit: Submit
         telephone_number: Contact telephone (optional)
         telephone_number_hint: This is the number that applicants or neighbours can call if they need information in alternative formats.
+      remove_signature:
+        signature_successfully_removed: Signature successfully removed
       show:
+        api_key: Notify API key
         document_checklist: Document checklist
         document_checklist_hint: Link to a document checklist that applicants use when submitting applications.
         email_address: Email
@@ -520,6 +528,8 @@ en:
         signatory_job_title_hint: This is the job title of the person whose signature appears at the bottom of decision notices.
         signatory_name: Signatory
         signatory_name_hint: This is the person whose signature appears at the bottom of decision notices.
+        signatory_signature: Signature
+        signatory_signature_hint: Upload an image of the officer's signature. This signature appears at the bottom of decision notices (optional).
         submission_guidance_url: Submission guidance
         submission_guidance_url_hint: This is the web page applicants visit to find out more information about submitting their application.
         submission_url: Application submission

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -4,7 +4,9 @@ BopsAdmin::Engine.routes.draw do
   root to: redirect("dashboard")
 
   resource :dashboard, only: %i[show]
-  resource :profile, only: %i[show edit update]
+  resource :profile, only: %i[show edit update] do
+    member { delete :remove_signature }
+  end
   resource :accessibility, only: %i[edit update], controller: "accessibility"
   resource :consultation, only: %i[edit update], controller: "consultation"
   resource :site_notices, only: %i[edit update]

--- a/engines/bops_uploads/app/controllers/bops_uploads/files_controller.rb
+++ b/engines/bops_uploads/app/controllers/bops_uploads/files_controller.rb
@@ -26,6 +26,8 @@ module BopsUploads
       case @parent
       when CaseRecord
         @case_record = @parent
+      when LocalAuthority
+        @local_authority = @parent
       when PlanningApplication
         @planning_application = @parent
       when Submission
@@ -36,7 +38,14 @@ module BopsUploads
     end
 
     def local_authority_matches?
-      @parent && @parent.local_authority == current_local_authority
+      return false unless @parent
+
+      case @parent
+      when LocalAuthority
+        @parent == current_local_authority
+      else
+        @parent.local_authority == current_local_authority
+      end
     end
 
     def raise_not_found

--- a/engines/bops_uploads/lib/bops_uploads/engine.rb
+++ b/engines/bops_uploads/lib/bops_uploads/engine.rb
@@ -38,6 +38,8 @@ module BopsUploads
             parent_record(record.consideration_set)
           when Document, ConsiderationSet
             record.parent_record
+          when LocalAuthority
+            record
           else
             raise ArgumentError, "Unexpected record type in chain: #{record.inspect}"
           end


### PR DESCRIPTION
### Description of change

Add optional field to local admin to upload a signature image for decision notice, which is a requirement for some LAs.
The approach also handles removing previously uploaded signatures, and clearing the form before submission.

I have not done any work to remove background of the signature would suggest the user does so on the file itself.

### Story Link

https://trello.com/c/owVMkHND/1905-feedback-support-image-of-hand-drawn-signatures-on-decision-notices-issued-from-bops

### Screenshots

<img width="900" height="320" alt="image" src="https://github.com/user-attachments/assets/b54da856-dc57-4805-9479-eba1da686ce9" />
<img width="2328" height="964" alt="image (2)" src="https://github.com/user-attachments/assets/a74de7e7-21c7-46a9-99a4-3647ac91c905" />
<img width="942" height="309" alt="image" src="https://github.com/user-attachments/assets/e7e686ff-ab05-4b95-bf70-9b9904212302" />

