### PR TITLE
Improvements to 'assess against legislation'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  pull_request: {}
 
 concurrency:
   group: ${{ github.ref }}

--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -41,6 +41,10 @@ module Tasks
       @assessment_areas ||= planning_application_policy_classes
     end
 
+    def grouped_policy_sections
+      @grouped_policy_sections ||= assessment_area_sections.group_by { |section| section.policy_section.title }.in_order_of(:first, PolicySection::TITLES)
+    end
+
     def assessment_area_ids
       @assessment_area_ids ||= assessment_areas.pluck(:policy_class_id)
     end
@@ -66,7 +70,7 @@ module Tasks
     end
 
     def policy_reference(section, area: assessment_area)
-      "#{area.policy_class.section}.#{section.section}"
+      (area.policy_class.section == section.section) ? section.section : "#{area.policy_class.section}.#{section.section}"
     end
 
     def complies?(area)

--- a/app/views/shared/_consultees_table.html.erb
+++ b/app/views/shared/_consultees_table.html.erb
@@ -14,10 +14,10 @@
   <% end %>
 
   <% table.with_body do |body| %>
-    <% consultees_unassigned = consultation.consultees.unassigned %>
+    <% consultees_unassigned = consultation&.consultees&.unassigned %>
     <% constraints = planning_application.planning_application_constraints %>
 
-    <% if constraints.none? && consultees_unassigned.none? %>
+    <% if constraints.none? && consultees_unassigned&.none? %>
       <% body.with_row(classes: "govuk-table__row", html_attributes: {data: {consultees_target: "noConsultees"}}) do |row| %>
         <% row.with_cell(
              colspan: 4,
@@ -117,8 +117,7 @@
           <% end %>
         <% end %>
       <% end %>
-
-      <% consultees_unassigned.find_each do |consultee| %>
+      <% consultees_unassigned&.find_each do |consultee| %>
         <% body.with_row do |row| %>
           <% row.with_cell(classes: "consultee-table__constraint", text: "Other") %>
 

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
@@ -7,84 +7,86 @@
     <%= form_with model: @form, url: @form.assessment_area_url do |form| %>
       <%= form.govuk_error_summary %>
 
-      <h2>
-        <%= @form.assessment_area_description %>
-      </h2>
+      <h2><%= @form.assessment_area_description %></h2>
 
       <p>
-        Complete the assessment to show whether the application complies or
-        does not comply with the selected legislative class. You can add comments
-        to provide more information to support your assessment.
+        Complete the assessment to show whether the application complies or does
+        not comply with the selected legislative class. You can add comments to
+        provide more information to support your assessment.
       </p>
 
       <p>
         <%= govuk_link_to @form.assessment_area_legislation_url, new_tab: "" do %>
-          Open the Town and Country Planning (General Permitted Development) (England) Order 2015 in a new window
+          Open the Town and Country Planning (General Permitted Development)
+          (England) Order 2015 in a new window
         <% end %>
       </p>
 
       <%= govuk_section_break(visible: true, size: "l") %>
 
-      <% @form.assessment_area_sections.each do |section| %>
-        <h3 class="govuk-!-margin-bottom-1">
-          <%= @form.policy_reference(section) %>
-        </h3>
+      <% @form.grouped_policy_sections.each do |title, sections| %>
+        <div class="govuk-summary-card" id="<%= title.parameterize %>">
+          <div class="govuk-summary-card__title-wrapper">
+            <h2 class="govuk-summary-card__title"><%= title %></h2>
+          </div>
 
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <p>
-              <%= section.description %>
-            </p>
+          <div class="govuk-summary-card__content">
+            <% sections.each_with_index do |section, index| %>
+              <% if index > 0 %>
+                <%= govuk_section_break(visible: true, size: "l") %>
+              <% end %>
 
-            <% if comment = section.last_comment %>
-              <%= govuk_inset_text(classes: "govuk-!-margin-top-3") do %>
-                <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
+              <h3 class="govuk-!-margin-bottom-1">
+                <%= @form.policy_reference(section) %>
+              </h3>
 
-                <p class="govuk-body-s">
-                  <strong><%= comment.user.name %>, <%= comment.created_at.to_fs %></strong>
-                </p>
+              <p><%= section.description %></p>
 
-                <% if section.previous_comments.any? %>
-                  <%= govuk_details do |details| %>
-                    <% details.with_summary_html do %>
-                      <span class="govuk-!-font-size-16">Previous comments</span>
-                    <% end %>
+              <% if comment = section.last_comment %>
+                <%= govuk_inset_text(classes: "govuk-!-margin-top-3") do %>
+                  <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
 
-                    <ul class="govuk-list">
-                      <% section.previous_comments.reverse_each do |comment| %>
-                        <li>
-                          <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
+                  <p class="govuk-body-s">
+                    <strong><%= comment.user.name %>, <%= comment.created_at.to_fs %></strong>
+                  </p>
 
-                          <p class="govuk-body-s">
-                            <strong><%= comment.user.name %>, <%= comment.created_at.to_fs %></strong>
-                          </p>
-                        </li>
+                  <% if section.previous_comments.any? %>
+                    <%= govuk_details do |details| %>
+                      <% details.with_summary_html do %>
+                        <span class="govuk-!-font-size-16">Previous comments</span>
                       <% end %>
-                    </ul>
+
+                      <ul class="govuk-list">
+                        <% section.previous_comments.reverse_each do |comment| %>
+                          <li>
+                            <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
+
+                            <p class="govuk-body-s">
+                              <strong><%= comment.user.name %>, <%= comment.created_at.to_fs %></strong>
+                            </p>
+                          </li>
+                        <% end %>
+                      </ul>
+                    <% end %>
                   <% end %>
                 <% end %>
+              <% end %>
+
+              <%= form.fields_for :"sections[]", section do |fields| %>
+                <%= fields.govuk_radio_buttons_fieldset :status, inline: true, small: true, legend: {size: "s", text: "Status"} do %>
+                  <%= fields.govuk_radio_button :status, "complies", label: {text: "Complies", class: "govuk-!-text-no-wrap"} %>
+                  <%= fields.govuk_radio_button :status, "does_not_comply", label: {text: "Does not comply", class: "govuk-!-text-wrap-nowrap"} %>
+                  <%= fields.govuk_radio_button :status, "to_be_determined", label: {text: "To be determined", class: "govuk-!-text-wrap-nowrap"} %>
+                <% end %>
+                <%= govuk_details(summary_text: "Add comment (optional)") do
+                      fields.fields_for :comments, section.comments.new do |comment|
+                        comment.govuk_text_area :text, rows: 3, width: "two-thirds", label: {text: "Add comment", size: "s"}
+                      end
+                    end %>
               <% end %>
             <% end %>
           </div>
         </div>
-
-        <%= form.fields_for :"sections[]", section do |fields| %>
-          <%= fields.govuk_radio_buttons_fieldset :status, inline: true, small: true, legend: {size: "s", text: "Status"} do %>
-            <%= fields.govuk_radio_button :status, "complies", label: {text: "Complies", class: "govuk-!-text-no-wrap"} %>
-            <%= fields.govuk_radio_button :status, "does_not_comply", label: {text: "Does not comply", class: "govuk-!-text-wrap-nowrap"} %>
-            <%= fields.govuk_radio_button :status, "to_be_determined", label: {text: "To be determined", class: "govuk-!-text-wrap-nowrap"} %>
-          <% end %>
-
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <%= fields.fields_for :comments, section.comments.new do |comment| %>
-                <%= comment.govuk_text_area :text, rows: 3, width: "two-thirds", label: {text: "Add comment", size: "s"} %>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-
-        <%= govuk_section_break(visible: true, size: "l") %>
       <% end %>
 
       <%= form.govuk_task_button "Save assessment", action: "update_assessment" do %>

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/show.html.erb
@@ -1,9 +1,14 @@
 <%= render "task_header", task: @task %>
 
 <% if @planning_application.section_55_development.nil? %>
-  <%= govuk_warning_text(text: "Proposal not checked if it is development") %>
-  <p>Before assessing against legislation, the proposal must be checked to see whether it is development or not.</p>
-  <p><%= govuk_link_to "Check if proposal is development", task_path(@planning_application, "check-and-assess/assess-against-legislation/check-if-proposal-is-development") %></p>
+  <%= govuk_warning_text(text: "Proposal not checked if it is not development") %>
+  <p>
+    Before assessing against legislation, the proposal must be checked to see
+    whether it is development or not.
+  </p>
+  <p>
+    <%= govuk_link_to "Check if proposal is development", task_path(@planning_application, "check-and-assess/assess-against-legislation/check-if-proposal-is-development") %>
+  </p>
 <% else %>
   <%= form_with model: @form, url: @form.url do |form| %>
     <%= form.govuk_error_summary %>

--- a/spec/system/tasks/assess_against_legislation_spec.rb
+++ b/spec/system/tasks/assess_against_legislation_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Assess against legislation", type: :system do
       click_link "Assess against legislation"
 
       expect(page).to have_selector("h1", text: "Assess against legislation")
-      expect(page).to have_content("Proposal not checked if it is development")
+      expect(page).to have_content("Proposal not checked if it is not development")
     end
 
     it "tells the officer that assessment is not required when it is not development" do


### PR DESCRIPTION
### Description of change

Redesigning the list of assessment areas in the assess-against-legislation task to group them by the section title.

### Story Link

https://trello.com/c/qbonSbyl/1912-improve-assess-against-legislation-and-assessment-area-page

### Screenshots

<img width="1563" height="846" alt="Screenshot 2026-04-29 at 14 55 27" src="https://github.com/user-attachments/assets/7e6e7f78-1ec5-4be9-92a2-64b90e18a23b" />