### PR TITLE
Improve policy section display

### DIFF
--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -69,10 +69,6 @@ module Tasks
       planning_application_policy_sections.select { |section| section_ids.include?(section.policy_section_id) }
     end
 
-    def policy_reference(section, area: assessment_area)
-      (area.policy_class.section == section.section) ? section.section : "#{area.policy_class.section}.#{section.section}"
-    end
-
     def complies?(area)
       assessment_area_sections(area).all?(&:complies?)
     end

--- a/app/models/planning_application_policy_section.rb
+++ b/app/models/planning_application_policy_section.rb
@@ -27,7 +27,7 @@ class PlanningApplicationPolicySection < ApplicationRecord
     %i[complies does_not_comply to_be_determined].index_with(&:to_s),
     default: :to_be_determined
 
-  delegate :section, :title, to: :policy_section
+  delegate :section, :title, :full_section, to: :policy_section
   delegate :policy_class, to: :policy_section
 
   def set_description

--- a/app/models/policy_section.rb
+++ b/app/models/policy_section.rb
@@ -25,7 +25,7 @@ class PolicySection < ApplicationRecord
   }
 
   def full_section
-    "#{policy_class.section}.#{section}"
+    (policy_class.section == section) ? policy_class.section : "#{policy_class.section}.#{section}"
   end
 
   def planning_application_policy_section

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
@@ -37,7 +37,7 @@
               <% end %>
 
               <h3 class="govuk-!-margin-bottom-1">
-                <%= @form.policy_reference(section) %>
+                <%= section.full_section %>
               </h3>
 
               <p><%= section.description %></p>

--- a/engines/bops_config/app/views/bops_config/gpdo/policy_sections/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/gpdo/policy_sections/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form.govuk_error_summary %>
 
   <%= form.govuk_select(:title, PolicySection::TITLES, label: {text: "Title"}, hint: {text: "Select a title for the section"}) %>
-  <%= form.govuk_text_field :section, label: {text: t(".section_label")}, hint: {text: t(".section_hint")} %>
+  <%= form.govuk_text_field :section, label: {text: t(".section_label")}, hint: {text: t(".section_hint", class: @policy_class.section)} %>
   <%= form.govuk_text_area :description, rows: 10, label: {text: t(".description_label")}, hint: {text: t(".description_hint")} %>
 
   <%= form.govuk_submit(t(".save")) do %>
@@ -12,7 +12,7 @@
             warning: true,
             method: :delete,
             data: {confirm: "Are you sure?"}) %>
-      <% end %>
+    <% end %>
   <% end %>
 
   <%= govuk_button_link_to t("back"), gpdo_policy_schedule_policy_part_policy_class_policy_sections_path(@schedule.number, @part.number, @policy_class.section), secondary: true %>

--- a/engines/bops_config/config/locales/en.yml
+++ b/engines/bops_config/config/locales/en.yml
@@ -370,7 +370,7 @@ en:
           description_label: Description
           remove: Remove
           save: Save
-          section_hint: Enter section number, such as "1a, 1d(ii), 2b(i)(aa)"
+          section_hint: Enter section number, such as "1a, 1d(ii), 2b(i)(aa)", or use class code (i.e., "%{class}") to hide section number
           section_label: Section
           title_hint: Enter section title, such as "Development not permitted, conditions"
           title_label: Title


### PR DESCRIPTION
### Description of change

Show policy section ID as 'A' instead of 'A.A' when it's the same as the class.