### PR TITLE
Update links check consultees task

### DIFF
--- a/engines/bops_core/app/forms/bops_core/tasks/check_consultees_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/check_consultees_form.rb
@@ -10,11 +10,15 @@ module BopsCore
       end
 
       def add_consultees_task_path
-        task_path(planning_application, "consultees/add-and-assign-consultees")
+        if planning_application.pre_application?
+          task_path(planning_application, "consultees/add-and-assign-consultees", return_to: task.url)
+        else
+          task_path(planning_application, "consultees-neighbours-and-publicity/consultees/add-and-assign-consultees", return_to: task.url)
+        end
       end
 
       def determine_consultation_requirement_task_path
-        task_path(planning_application, "consultees/determine-consultation-requirement")
+        task_path(planning_application, "consultees/determine-consultation-requirement", return_to: task.url)
       end
 
       private

--- a/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_default.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_default.html.erb
@@ -1,6 +1,7 @@
 <%= render "task_header", task: @task %>
 
 <%= form_with model: @form, url: @form.url do |form| %>
+  <%= return_to_hidden_field %>
   <% if @form.constraints.none? %>
     <%= govuk_inset_text do %>
       <p>No planning constraints have been identified. You can still add consultees manually.</p>

--- a/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_edit_consultees.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_edit_consultees.html.erb
@@ -52,6 +52,7 @@
   <% end %>
 
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <%= stimulus_tag("contacts") do %>
       <%= form.govuk_fieldset(legend: {text: "Add another consultee"}) do %>
         <%= form.hidden_field :contact_id, value: nil, data: {contacts_target: "input"} %>
@@ -75,7 +76,7 @@
       <% end %>
     <% end %>
 
-    <%= govuk_button_link_to "Save and return", task_path(@planning_application, @task) %>
+    <%= govuk_button_link_to "Save and return", return_to_or_task_path(@task) %>
   <% end %>
 <% else %>
   <% content_for :page_title do %>
@@ -83,6 +84,7 @@
   <% end %>
 
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <%= stimulus_tag("contacts") do %>
       <%= form.govuk_fieldset(legend: {text: "Add other consultee", tag: "h1", size: "l"}) do %>
         <%= form.hidden_field :contact_id, value: nil, data: {contacts_target: "input"} %>
@@ -105,6 +107,6 @@
       <% end %>
     <% end %>
 
-    <%= govuk_button_link_to "Save and return", task_path(@planning_application, @task) %>
+    <%= govuk_button_link_to "Save and return", return_to_or_task_path(@task) %>
   <% end %>
 <% end %>

--- a/spec/system/tasks/check_consultees_spec.rb
+++ b/spec/system/tasks/check_consultees_spec.rb
@@ -12,6 +12,26 @@ RSpec.describe "Check consultees task", type: :system do
       end
 
       it_behaves_like "check consultees task", application_type
+
+      context "checking page content" do
+        let(:user) { create(:user, local_authority:) }
+
+        before do
+          sign_in(user)
+          visit "/planning_applications/#{planning_application.reference}/check-and-assess/check-application/check-consultees"
+        end
+
+        it "shows the Add consultees link with the correct return path", :capybara do
+          expect(page).to have_link(
+            "Add consultees",
+            href: task_path(
+              planning_application,
+              "consultees-neighbours-and-publicity/consultees/add-and-assign-consultees",
+              return_to: task_path(planning_application, "check-and-assess/check-application/check-consultees")
+            )
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

Update link in Check consultees tasks to handle both pre-app and other applications. The tasks have different slugs based on if they are pre-app or other application types.

### Link to issue

https://trello.com/c/qmaQ80BL/1955-add-consultees-link-from-assessment-task-check-consultees-leads-to-400-error