### PR TITLE
Prevent policy classes or sections with invalid names

### DIFF
--- a/app/models/policy_class.rb
+++ b/app/models/policy_class.rb
@@ -10,7 +10,7 @@ class PolicyClass < ApplicationRecord
   attr_readonly :section
 
   with_options presence: true do
-    validates :section, uniqueness: {scope: :policy_part}
+    validates :section, uniqueness: {scope: :policy_part}, exclusion: {in: ["."], message: "Class number may not be ‘.’"}
     validates :name
   end
 

--- a/app/models/policy_section.rb
+++ b/app/models/policy_section.rb
@@ -14,7 +14,7 @@ class PolicySection < ApplicationRecord
   has_many :planning_applications, through: :planning_application_policy_sections
 
   with_options presence: true do
-    validates :section, uniqueness: {scope: :policy_class}
+    validates :section, uniqueness: {scope: :policy_class}, exclusion: {in: ["."], message: "Section number may not be ‘.’"}
     validates :description
   end
 

--- a/engines/bops_config/spec/system/gpdo_spec.rb
+++ b/engines/bops_config/spec/system/gpdo_spec.rb
@@ -323,6 +323,16 @@ RSpec.describe "GPDO", type: :system do
       end
     end
 
+    it "cannot create a class with an invalid name" do
+      visit "/gpdo/schedule/2/part/1/class"
+      click_link "Create new class"
+
+      fill_in "Class", with: "."
+      fill_in "Description", with: "invalid class"
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Class number may not be ‘.’")
+    end
+
     it "allows editing the policy class" do
       visit "/gpdo/schedule/2/part/1/class/B/edit"
       within(".govuk-breadcrumbs__list") do
@@ -418,6 +428,16 @@ RSpec.describe "GPDO", type: :system do
           expect(page).to have_content("if the dwellinghouse is located on article 2(3) land")
         end
       end
+    end
+
+    it "cannot create a section with an invalid name" do
+      visit "/gpdo/schedule/2/part/1/class/AA/section"
+      click_link "Create new policy section"
+
+      fill_in "Section", with: "."
+      fill_in "Description", with: "invalid section"
+      click_button "Save"
+      expect(page).to have_selector("[role=alert] li", text: "Section number may not be ‘.’")
     end
 
     it "allows editing the policy section" do


### PR DESCRIPTION
### Description of change

If a policy section (or, presumably, class) is created with the name `.`, it's inaccessible, (presumably) because of Rails' handling of routes (where that is the separator between a parameter and the route format). Since we don't expect valid records ever to have this name, we can just prevent it from being input and give a sensible warning.

If it turned out we did need to allow that, we could revert this and override the route parameter format, which is likely to be fine since we only have html routes anyway; but that's a bit of a weirder fix and we may never need it.

### Story Link

https://trello.com/c/QsW22NGQ/1939-cannot-edit-a-class-when-you-have-set-the-ref-as
