### PR TITLE
Group policy sections in review

### DIFF
--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -7,6 +7,7 @@ module PlanningApplications
         before_action :find_planning_application_policy_class, only: %i[show edit update]
         before_action :build_form, only: %i[edit update]
         before_action :set_review, only: %i[show edit update]
+        before_action :set_policy_sections, only: %i[edit update]
 
         def index
           respond_to do |format|
@@ -63,6 +64,10 @@ module PlanningApplications
 
         def set_review
           @review = @planning_application_policy_class.current_review
+        end
+
+        def set_policy_sections
+          @policy_sections = @planning_application_policy_class.planning_application_policy_sections.group_by { |section| section.title }.in_order_of(:first, PolicySection::TITLES)
         end
       end
     end

--- a/app/models/policy_section.rb
+++ b/app/models/policy_section.rb
@@ -21,7 +21,7 @@ class PolicySection < ApplicationRecord
   validates :title, inclusion: {in: TITLES}
 
   scope :grouped_and_ordered_by_title, -> {
-    group_by(&:title)
+    group_by(&:title).in_order_of(:first, PolicySection::TITLES)
   }
 
   def full_section

--- a/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
@@ -9,56 +9,55 @@
 
 <% if @planning_application_policy_class.policy_class.policy_sections.any? %>
   <%= govuk_error_summary(@review) %>
-
   <%= form_with url: planning_application_review_policy_areas_policy_class_path(@planning_application, @planning_application_policy_class), method: :patch, html: {data: unsaved_changes_data} do |form| %>
-    <%= govuk_table(id: "policy-sections") do |table| %>
-      <% table.with_head do |head| %>
-        <% head.with_row do |row| %>
-          <% row.with_cell(text: "Policy reference") %>
-          <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
-            <% row.with_cell(text: status.humanize) %>
-          <% end %>
-        <% end %>
-      <% end %>
+    <% @policy_sections.each do |title, policy_sections| %>
+      <div class="govuk-summary-card" id="<%= title.parameterize %>">
+        <div class="govuk-summary-card__title-wrapper">
+          <h2 class="govuk-summary-card__title"><%= title %></h2>
+        </div>
 
-      <% table.with_body do |body| %>
-        <% @planning_application_policy_class.planning_application_policy_sections.each do |pa_policy_section| %>
-          <% policy_section = pa_policy_section.policy_section %>
-          <% body.with_row(html_attributes: {id: "policy-section-#{policy_section.id}"}) do |row| %>
-            <% row.with_cell do %>
-              <p><strong><%= @planning_application_policy_class.policy_class.section %>.<%= policy_section.section %></strong></p>
-              <%= render(FormattedContentComponent.new(text: pa_policy_section&.description || policy_section.description)) %>
+        <div class="govuk-summary-card__content">
+          <% policy_sections.each_with_index do |policy_section, index| %>
+            <div id="<%= dom_id(policy_section.policy_section) %>">
+              <% if index > 0 %>
+                <%= govuk_section_break(visible: true, size: "l") %>
+              <% end %>
 
-              <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.id}][comments_attributes][0][text]",
+              <h3 class="govuk-!-margin-bottom-1">
+                <%= policy_section.full_section %>
+              </h3>
+
+              <p><%= policy_section.description %></p>
+
+              <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.policy_section.id}][comments_attributes][0][text]",
                     label: {text: "Add comment", class: "govuk-label govuk-label--s"},
-                    value: pa_policy_section&.last_comment&.text,
+                    value: policy_section&.last_comment&.text,
                     class: "govuk-textarea govuk-!-margin-bottom-2",
                     rows: 2 %>
 
-              <% if pa_policy_section %>
-                <%= render(
-                      partial: "shared/policy_classes/previous_comments",
-                      locals: {previous_comments: pa_policy_section.previous_comments}
-                    ) %>
-              <% end %>
-            <% end %>
-            <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
-              <% row.with_cell do %>
-                <div class="govuk-radios govuk-radios--small">
-                  <%= form.govuk_radio_button(
-                        "planning_application_policy_sections[#{policy_section.id}][status]",
-                        status,
-                        checked: pa_policy_section.status == status,
-                        label: {hidden: true},
-                        disabled: true,
-                        class: "govuk-radios__input"
-                      ) %>
-                </div>
-              <% end %>
-            <% end %>
+              <%= render(
+                    partial: "shared/policy_classes/previous_comments",
+                    locals: {previous_comments: policy_section.previous_comments}
+                  ) %>
+
+              <div class="display-flex">
+                <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
+                  <div class="govuk-radios govuk-radios--small">
+                    <%= form.govuk_radio_button(
+                          "planning_application_policy_sections[#{policy_section.policy_section.id}][status]",
+                          status,
+                          checked: policy_section.status == status,
+                          label: {text: status.humanize},
+                          disabled: true,
+                          class: "govuk-radios__input"
+                        ) %>
+                  </div>
+                <% end %>
+              </div>
+            </div>
           <% end %>
-        <% end %>
-      <% end %>
+        </div>
+      </div>
     <% end %>
 
     <fieldset class="govuk-fieldset govuk-!-padding-bottom-5">

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -68,16 +68,16 @@ RSpec.describe "Reviewing Policy Class", show_sidebar: false, type: :system do
         click_on "Review assessment of Part 1, Class A"
         expect(page).to have_selector("h1", text: "Review - Part 1, Class A")
 
-        expect(page).to have_css("#policy-section-#{policy_section1a.id}")
-        expect(page).to have_css("#policy-section-#{policy_section1b.id}")
-        expect(page).to have_css("#policy-section-#{policy_section2bii.id}")
+        expect(page).to have_css("#policy_section_#{policy_section1a.id}")
+        expect(page).to have_css("#policy_section_#{policy_section1b.id}")
+        expect(page).to have_css("#policy_section_#{policy_section2bii.id}")
 
         expect(page).to have_field("planning-application-policy-sections-#{policy_section1a.id}-status-complies-field", disabled: true)
         expect(page).to have_field("planning-application-policy-sections-#{policy_section1b.id}-status-does-not-comply-field", disabled: true)
         expect(page).to have_field("planning-application-policy-sections-#{policy_section2bii.id}-status-does-not-comply-field", disabled: true)
 
         choose "Agree"
-        within("#policy-section-#{policy_section2bii.id}") do
+        within("#policy_section_#{policy_section2bii.id}") do
           fill_in("Add comment", with: "Reviewer comment")
         end
         click_button("Save and come back later")
@@ -85,7 +85,7 @@ RSpec.describe "Reviewing Policy Class", show_sidebar: false, type: :system do
         expect(list_item("Review assessment of Part 1, Class A")).to have_content("In progress")
         click_link("Part 1, Class A")
 
-        within("#policy-section-#{policy_section2bii.id}") do
+        within("#policy_section_#{policy_section2bii.id}") do
           expect(page).to have_field("Add comment", with: "Reviewer comment")
 
           find("span", text: "Previous comments").click


### PR DESCRIPTION
### Description of change

Show policy sections grouped and ordered by type in the review stage too.

Also apply consistent sort order in global admin (i.e., permitted, not permitted, conditions, interpretation, other.)

### Story Link

https://trello.com/c/MGO9h4Ey/1929-improve-assess-against-legislation-and-review-area-page