### PR TITLE
Use action_required state for assessment tasks returned from review

### DIFF
--- a/app/controllers/planning_applications/review/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/review/assessment_details_controller.rb
@@ -4,9 +4,12 @@ module PlanningApplications
   module Review
     class AssessmentDetailsController < BaseController
       before_action :set_assessment_detail
+      before_action :set_task, only: :update
 
       def update
         if @assessment_detail.update(review_assessment_details_params)
+          @task.action_required! if @task && return_to_officer?
+
           redirect_to(
             planning_application_review_tasks_path(@planning_application, anchor: "#{@assessment_detail.category}_section"),
             notice: t(".success", category: @assessment_detail.category.humanize.downcase)
@@ -23,6 +26,10 @@ module PlanningApplications
         @assessment_detail = @planning_application.assessment_details.find(assessment_detail_id)
       end
 
+      def set_task
+        @task = @assessment_detail.task
+      end
+
       def assessment_detail_id
         Integer(params[:id])
       end
@@ -33,6 +40,10 @@ module PlanningApplications
           :entry,
           comment_attributes: [:text]
         ).merge(review_status: :complete)
+      end
+
+      def return_to_officer?
+        params.dig(:assessment_detail, :reviewer_verdict) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/committee_decisions_controller.rb
+++ b/app/controllers/planning_applications/review/committee_decisions_controller.rb
@@ -4,6 +4,7 @@ module PlanningApplications
   module Review
     class CommitteeDecisionsController < BaseController
       before_action :set_committee_decision
+      before_action :set_task, only: :update
 
       def edit
       end
@@ -15,6 +16,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @committee_decision.update(committee_decision_params)
+              @task.action_required! if @task && return_to_officer?
+
               redirect_to planning_application_review_tasks_path(@planning_application, anchor: "recommendation_to_committee_section"), notice: t(".success")
             else
               flash.now[:alert] = @committee_decision.errors.messages.values.flatten.join(", ")
@@ -28,6 +31,10 @@ module PlanningApplications
 
       def set_committee_decision
         @committee_decision = @planning_application.committee_decision
+      end
+
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/make-draft-recommendation")
       end
 
       def committee_decision_params

--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -6,6 +6,7 @@ module PlanningApplications
       before_action :set_consideration_set
       before_action :set_considerations
       before_action :set_review
+      before_action :set_task, only: :update
 
       def edit
         respond_to do |format|
@@ -17,6 +18,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
+              @task.action_required! if @task && return_to_officer?
+
               redirect_to tasks_url(anchor: "review-considerations", next: true), notice: t(".success")
             else
               @show_header_bar = false
@@ -40,10 +43,18 @@ module PlanningApplications
         @review = @consideration_set.current_review
       end
 
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/assessment-summaries/planning-considerations-and-advice")
+      end
+
       def review_params
         params.require(:review_considerations)
           .permit(:action, :comment, :review_status)
           .merge(reviewer: current_user, reviewed_at: Time.current)
+      end
+
+      def return_to_officer?
+        params.dig(:assessment_considerations, :action) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/review/heads_of_terms_controller.rb
@@ -8,6 +8,7 @@ module PlanningApplications
       before_action :set_heads_of_terms
       before_action :set_terms
       before_action :set_review
+      before_action :set_task, only: :update
 
       before_action :redirect_to_review_tasks, if: :heads_of_terms_not_started?
 
@@ -21,6 +22,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
+              @task.action_required! if @task && return_to_officer?
               redirect_to tasks_url(anchor: "review-heads-of-terms", next: true), notice: t(".success")
             else
               render :tasks, alert: t(".failure_html")
@@ -43,6 +45,10 @@ module PlanningApplications
         @review = @heads_of_terms.current_review
       end
 
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/add-heads-of-terms")
+      end
+
       def review_params
         params.require(:review_heads_of_terms)
           .permit(:action, :comment, :review_status)
@@ -55,6 +61,10 @@ module PlanningApplications
 
       def heads_of_terms_not_started?
         @review.not_started?
+      end
+
+      def return_to_officer?
+        params.dig(:review_heads_of_terms, :action) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -6,6 +6,7 @@ module PlanningApplications
       before_action :set_informative_set
       before_action :set_informatives
       before_action :set_review
+      before_action :set_task, only: :update
 
       before_action :redirect_to_review_tasks, if: :informatives_not_started?
 
@@ -19,6 +20,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
+              @task.action_required! if @task && return_to_officer?
               redirect_to tasks_url(anchor: "review-informatives", next: true), notice: t(".success")
             else
               @show_header_bar = false
@@ -42,6 +44,10 @@ module PlanningApplications
         @review = @informative_set.current_review
       end
 
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/add-informatives")
+      end
+
       def review_params
         params.require(:review_informatives)
           .permit(:action, :comment, :review_status)
@@ -54,6 +60,10 @@ module PlanningApplications
 
       def sign_off_url
         edit_planning_application_review_recommendation_path(@planning_application, @planning_application.recommendation)
+      end
+
+      def return_to_officer?
+        params.dig(:assessment_detail, :reviewer_verdict) == "rejected"
       end
     end
   end

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -20,6 +20,15 @@ class AssessmentDetail < ApplicationRecord
     check_publicity
   ].freeze
 
+  TASK_SLUGS = {
+    additional_evidence: "check-and-assess/assessment-summaries/other-considerations",
+    amenity: "check-and-assess/assessment-summaries/amenity",
+    consultation_summary: "check-and-assess/assessment-summaries/summary-of-consultation",
+    neighbour_summary: "check-and-assess/assessment-summaries/summary-of-neighbour-responses",
+    site_description: "check-and-assess/assessment-summaries/site-description",
+    summary_of_work: "check-and-assess/assessment-summaries/summary-of-works"
+  }.freeze
+
   enum :review_status, %i[
     in_progress
     complete
@@ -87,6 +96,14 @@ class AssessmentDetail < ApplicationRecord
 
   def to_be_reviewed?
     update_required?
+  end
+
+  def task_slug
+    TASK_SLUGS[category.to_sym]
+  end
+
+  def task
+    planning_application.case_record.find_task_by_slug_path(task_slug)
   end
 
   private

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
+  include AASM
+
   STATUSES = %w[not_started in_progress completed cannot_start_yet action_required]
   enum :status, STATUSES.index_by(&:to_sym)
 
@@ -10,33 +12,30 @@ class Task < ApplicationRecord
   validates :slug, :name, presence: true, strict: true
   validates :status, inclusion: STATUSES
 
+  aasm column: :status, whiny_persistence: true do
+    state :not_started, initial: true
+    state :in_progress, :completed, :cannot_start_yet, :action_required
+
+    event :start do
+      transitions from: :completed, to: :completed
+      transitions from: %i[not_started in_progress], to: :in_progress
+    end
+
+    event :complete do
+      transitions from: %i[not_started in_progress action_required completed], to: :completed
+    end
+
+    event :cannot_start_yet do
+      transitions to: :cannot_start_yet
+    end
+
+    event :action_required do
+      transitions to: :action_required
+    end
+  end
+
   after_initialize do
     self.slug ||= name.to_s.parameterize
-    self.status ||= "not_started"
-  end
-
-  def start
-    completed? || update(status: :in_progress)
-  end
-
-  def start!
-    start || raise_not_saved("start")
-  end
-
-  def complete
-    update(status: :completed)
-  end
-
-  def complete!
-    complete || raise_not_saved("complete")
-  end
-
-  def action_required
-    update(status: :action_required)
-  end
-
-  def action_required!
-    action_required || raise_not_saved("action_required")
   end
 
   def full_slug

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,7 +12,7 @@ class Task < ApplicationRecord
   validates :slug, :name, presence: true, strict: true
   validates :status, inclusion: STATUSES
 
-  aasm column: :status, whiny_persistence: true do
+  aasm column: :status, enum: true, whiny_persistence: true do
     state :not_started, initial: true
     state :in_progress, :completed, :cannot_start_yet, :action_required
 

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe Task, type: :model do
-  let(:local_authority) { create(:local_authority) }
-  let(:enforcement) { create(:enforcement) }
-  let(:case_record) { create(:case_record, caseable: enforcement, local_authority:) }
-
   subject(:task) do
     described_class.new(
       name: "Initial task",
@@ -15,6 +11,10 @@ RSpec.describe Task, type: :model do
       slug: "initial-task"
     )
   end
+
+  let(:local_authority) { create(:local_authority) }
+  let(:enforcement) { create(:enforcement) }
+  let(:case_record) { create(:case_record, caseable: enforcement, local_authority:) }
 
   it "is valid with valid attributes" do
     expect(task).to be_valid
@@ -70,25 +70,11 @@ RSpec.describe Task, type: :model do
     before { task.save! }
 
     it "sets the status to action_required" do
-      expect { task.action_required }.to change(task, :status).from("not_started").to("action_required")
-    end
-
-    it "returns true on success" do
-      expect(task.action_required).to be true
-    end
-  end
-
-  describe "#action_required!" do
-    before { task.save! }
-
-    it "sets the status to action_required" do
       expect { task.action_required! }.to change(task, :status).from("not_started").to("action_required")
     end
 
-    it "raises an error if the update fails" do
-      allow(task).to receive(:update).and_return(false)
-
-      expect { task.action_required! }.to raise_error(ActiveRecord::RecordNotSaved, /Unable to action_required/)
+    it "returns true on success" do
+      expect(task.action_required!).to be true
     end
   end
 
@@ -96,13 +82,13 @@ RSpec.describe Task, type: :model do
     before { task.save! }
 
     it "sets the status to in_progress" do
-      expect { task.start }.to change(task, :status).from("not_started").to("in_progress")
+      expect { task.start! }.to change(task, :status).from("not_started").to("in_progress")
     end
 
     it "does not change the status if already completed" do
       task.update!(status: :completed)
 
-      expect { task.start }.not_to change(task, :status)
+      expect { task.start! }.not_to change(task, :status)
     end
   end
 
@@ -110,7 +96,7 @@ RSpec.describe Task, type: :model do
     before { task.save! }
 
     it "sets the status to completed" do
-      expect { task.complete }.to change(task, :status).from("not_started").to("completed")
+      expect { task.complete! }.to change(task, :status).from("not_started").to("completed")
     end
   end
 end

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -250,6 +250,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "summary of neighbour responses" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/summary-of-neighbour-responses")
+        task.start!
+
         click_button "Summary of neighbour responses"
         within("#neighbour_summary_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
@@ -298,6 +301,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#neighbour_summary_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -376,6 +381,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "summary of works" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/summary-of-works")
+        task.start!
+
         click_button "Summary of works"
         within("#summary_of_work_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
@@ -422,6 +430,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#summary_of_work_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -496,6 +506,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "site description" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/site-description")
+        task.start!
+
         click_button "Site description"
         within("#site_description_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
@@ -543,6 +556,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#site_description_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -621,6 +636,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "summary of consultation" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/summary-of-consultation")
+        task.start!
+
         planning_application.application_type.assessment_details << "consultation_summary"
         planning_application.application_type.save
 
@@ -670,6 +688,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#consultation_summary_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -748,6 +768,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "summary of additional evidence" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/other-considerations")
+        task.start!
+
         click_button "Summary of additional evidence"
         within("#additional_evidence_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
@@ -794,6 +817,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#additional_evidence_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -873,6 +898,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
       end
 
       it "amenity" do
+        task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/amenity")
+        task.start!
+
         click_button "Amenity assessment"
         within("#amenity_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
@@ -919,6 +947,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#amenity_section") do
           expect(find(".govuk-tag")).to have_content("Awaiting changes")
         end
+
+        expect(task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -137,109 +137,117 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
     let!(:supportive_response2) { create(:neighbour_response, neighbour: neighbour3, summary_tag: "supportive") }
     let!(:neutral_response) { create(:neighbour_response, neighbour: neighbour2, summary_tag: "neutral") }
 
-    it "shows validation errors when returning without comments" do
-      visit "/planning_applications/#{planning_application.reference}/review/tasks"
-      expect(page).to have_selector("h2.bops-task-accordion-heading", text: "Review assessment summaries")
-
-      # Neighbour summary
-      click_button "Summary of neighbour responses"
-      within("#neighbour_summary_footer") do
-        click_button("Save and mark as complete")
-      end
-      expect(page).to have_selector("[role=alert] li", text: "Determine whether this is correct")
-      within("#neighbour_summary_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#neighbour_summary_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "Determine whether this is correct")
+    context "shows validation errors when returning without comments" do
+      before do
+        visit "/planning_applications/#{planning_application.reference}/review/tasks"
+        expect(page).to have_selector("h2.bops-task-accordion-heading", text: "Review assessment summaries")
       end
 
-      within("#neighbour_summary_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
+      it "Neighbour summary" do
+        click_button "Summary of neighbour responses"
+        within("#neighbour_summary_footer") do
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_selector("[role=alert] li", text: "Determine whether this is correct")
+        within("#neighbour_summary_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#neighbour_summary_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "Determine whether this is correct")
+        end
+
+        within("#neighbour_summary_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
+
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#neighbour_summary_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#neighbour_summary_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
 
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#neighbour_summary_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#neighbour_summary_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+      it "Summary of works" do
+        click_button "Summary of works"
+        within("#summary_of_work_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
+
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#summary_of_work_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#summary_of_work_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
 
-      # Summary of works
-      click_button "Summary of works"
-      within("#summary_of_work_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
+      it "Consultation" do
+        click_button "Consultation"
+        within("#consultation_summary_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
+
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#consultation_summary_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#consultation_summary_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
 
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#summary_of_work_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#summary_of_work_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+      it "Site description" do
+        click_button "Site description"
+        within("#site_description_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
+
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#site_description_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#site_description_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
 
-      # Consultation
-      click_button "Consultation"
-      within("#consultation_summary_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
+      it "Additional evidence" do
+        click_button "Summary of additional evidence"
+        within("#additional_evidence_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
+
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#additional_evidence_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#additional_evidence_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
 
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#consultation_summary_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#consultation_summary_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
-      end
+      it "Amenity" do
+        click_button "Amenity"
+        within("#amenity_footer") do
+          choose "Return with comments"
+          click_button("Save and mark as complete")
+        end
 
-      # Site description
-      click_button "Site description"
-      within("#site_description_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
-      end
-
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#site_description_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#site_description_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
-      end
-
-      # Additional evidence
-      click_button "Summary of additional evidence"
-      within("#additional_evidence_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
-      end
-
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#additional_evidence_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#additional_evidence_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
-      end
-
-      # Amenity
-      click_button "Amenity"
-      within("#amenity_footer") do
-        choose "Return with comments"
-        click_button("Save and mark as complete")
-      end
-
-      expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
-      within("#amenity_section") do
-        expect(find("button")[:"aria-expanded"]).to eq("true")
-      end
-      within("#amenity_footer") do
-        expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        expect(page).to have_selector("[role=alert] li", text: "You must add a comment")
+        within("#amenity_section") do
+          expect(find("button")[:"aria-expanded"]).to eq("true")
+        end
+        within("#amenity_footer") do
+          expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
       end
     end
 

--- a/spec/system/tasks/add_informatives_spec.rb
+++ b/spec/system/tasks/add_informatives_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Add informatives task", type: :system do
     click_link "Check and assess"
   end
 
-  it "can add a informative", capybara: true do
+  it "can add a informative" do
     within :sidebar do
       click_link "Add informatives"
     end


### PR DESCRIPTION
### Description of change

When the assessment tasks are returned from review, we should update their Task record state to `action_required` so that this is flagged in the UI.

Also ensuring Task status uses AASM for state.

### Story Link

https://trello.com/c/VJiOYzNs/1963-implement-status-symbols-for-each-task-in-the-sidebar-of-assessment-to-show-if-they-need-review