### PR TITLE
Add review workflow e2e test to help ensure consistency

### DIFF
--- a/app/components/concerns/assessment_detailable.rb
+++ b/app/components/concerns/assessment_detailable.rb
@@ -20,8 +20,7 @@ module AssessmentDetailable
     end
 
     def assessment_detail_update_required?(assessment_detail)
-      planning_application.recommendation&.rejected? &&
-        assessment_detail&.update_required?
+      assessment_detail&.update_required?
     end
 
     def rejected_assessment_detail_for_category?(category)

--- a/app/components/status_tags/reviewing/assessment_detail_component.rb
+++ b/app/components/status_tags/reviewing/assessment_detail_component.rb
@@ -4,7 +4,6 @@ module StatusTags
   module Reviewing
     class AssessmentDetailComponent < StatusTags::BaseComponent
       include AssessmentDetailable
-      include Recommendable
 
       def initialize(assessment_detail:, planning_application:)
         @planning_application = planning_application

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -86,6 +86,10 @@ class AssessmentDetail < ApplicationRecord
     comment || build_comment
   end
 
+  def latest_reviewer_comment
+    comment || planning_application.rejected_assessment_detail(category: category)&.comment
+  end
+
   def update_required?
     review_complete? && rejected?
   end

--- a/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
@@ -50,6 +50,8 @@
               )
             ) %>
 
+        <%= render(ReviewerCommentComponent.new(comment: assessment_detail.latest_reviewer_comment)) %>
+
         <%= render(
               Reviewing::AssessmentDetails::PreviousSummariesComponent.new(
                 planning_application: planning_application,

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -79,6 +79,11 @@ module SystemSpecHelpers
     end
   end
 
+  def switch_user(user)
+    sign_out :user
+    sign_in user
+  end
+
   def on_subdomain(subdomain)
     previous_app_host = Capybara.app_host
     Capybara.app_host = "http://#{subdomain}.bops.services"

--- a/spec/system/planning_applications/review/review_workflow_spec.rb
+++ b/spec/system/planning_applications/review/review_workflow_spec.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Review workflow consistency", show_sidebar: false, type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority:, name: "Alice Smith") }
+  let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+  let(:reference) { planning_application.reference }
+  let(:comment_text) { "Please revise this" }
+
+  let(:assessor_task_slug) { nil }
+  let(:assessor_task_label) { nil }
+  let(:revised_entry) { nil }
+
+  shared_examples "a consistent review task" do
+    it "rejects, returns to assessor with visible comment, and accepts" do
+      sign_in(reviewer)
+      visit "/planning_applications/#{reference}/review/tasks"
+      within("##{section_id}") { expect(page).to have_content("Not started") }
+
+      click_button expand_button
+      within("##{section_id}") do
+        choose "Return with comments"
+        fill_in "Add a comment", with: comment_text
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Awaiting changes")
+        expect(page).to have_css(".comment-component", text: comment_text)
+      end
+
+      click_link "Sign off recommendation"
+      choose "No (return the case for assessment)"
+      fill_in "Explain to the officer why the case is being returned", with: "Returned for rework"
+      click_button "Save and mark as complete"
+      expect(planning_application.reload.status).to eq("to_be_reviewed")
+
+      if assessor_task_slug
+        switch_user(assessor)
+
+        if assessor_task_label
+          visit "/planning_applications/#{reference}/assessment/tasks"
+          expect(page).to have_list_item_for(assessor_task_label, with: "To be reviewed")
+        end
+
+        visit "/planning_applications/#{reference}/#{assessor_task_slug}"
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content(comment_text)
+        end
+
+        if revised_entry
+          find("textarea").set(revised_entry)
+          click_button "Save and mark as complete"
+        end
+
+        switch_user(reviewer)
+        visit "/planning_applications/#{reference}/review/tasks"
+
+        if revised_entry
+          within("##{section_id}") { expect(page).to have_content("Updated") }
+        end
+      end
+
+      click_button expand_button
+      within("##{section_id}") do
+        choose accept_label
+        click_button "Save and mark as complete"
+
+        expect(page).to have_content("Completed")
+      end
+    end
+  end
+
+  context "for a planning permission application" do
+    let(:planning_application) do
+      create(:planning_application, :awaiting_determination, :planning_permission,
+        local_authority:, decision: :granted, user: assessor)
+    end
+
+    before { create(:recommendation, status: "assessment_complete", planning_application:) }
+
+    describe "summary of works" do
+      let(:section_id) { "summary_of_work_section" }
+      let(:expand_button) { "Summary of works" }
+      let(:accept_label) { "Accept" }
+      let(:assessor_task_slug) { "check-and-assess/assessment-summaries/summary-of-works" }
+      let(:assessor_task_label) { "Summary of works" }
+      let(:revised_entry) { "Updated summary" }
+
+      let!(:detail) do
+        create(:assessment_detail, :summary_of_work,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original summary")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "site description" do
+      let(:section_id) { "site_description_section" }
+      let(:expand_button) { "Site description" }
+      let(:accept_label) { "Accept" }
+      let(:assessor_task_slug) { "check-and-assess/assessment-summaries/site-description" }
+      let(:revised_entry) { "Updated site description" }
+
+      let!(:detail) do
+        create(:assessment_detail, :site_description,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original site description")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "additional evidence", :pending do
+      let(:section_id) { "additional_evidence_section" }
+      let(:expand_button) { "Summary of additional evidence" }
+      let(:accept_label) { "Accept" }
+      let(:assessor_task_slug) { "check-and-assess/assessment-summaries/other-considerations" }
+
+      let!(:detail) do
+        create(:assessment_detail, :additional_evidence,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original additional evidence")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "consultation summary" do
+      let(:section_id) { "consultation_summary_section" }
+      let(:expand_button) { "Consultation" }
+      let(:accept_label) { "Accept" }
+      let(:assessor_task_slug) { "check-and-assess/assessment-summaries/summary-of-consultation" }
+      let(:revised_entry) { "Updated consultation summary" }
+
+      let!(:detail) do
+        create(:assessment_detail, :consultation_summary,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original consultation summary")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "neighbour summary" do
+      let(:section_id) { "neighbour_summary_section" }
+      let(:expand_button) { "Summary of neighbour responses" }
+      let(:accept_label) { "Accept" }
+      let(:assessor_task_slug) { "check-and-assess/assessment-summaries/summary-of-neighbour-responses" }
+
+      let!(:neighbour) { create(:neighbour, consultation: planning_application.consultation) }
+      let!(:response) { create(:neighbour_response, neighbour:, summary_tag: "objection") }
+      let!(:detail) do
+        create(:assessment_detail, :neighbour_summary,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original neighbour summary")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "amenity" do
+      let(:section_id) { "amenity_section" }
+      let(:expand_button) { "Amenity assessment" }
+      let(:accept_label) { "Accept" }
+
+      let!(:detail) do
+        create(:assessment_detail, :amenity,
+          assessment_status: :complete, planning_application:, user: assessor,
+          entry: "Original amenity assessment")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "considerations", :pending do
+      let(:section_id) { "review-considerations" }
+      let(:expand_button) { "Review assessment against policies and guidance" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance" }
+
+      let!(:consideration_set) { planning_application.consideration_set || create(:consideration_set, planning_application:) }
+      let!(:consideration) { create(:consideration, consideration_set:) }
+
+      before { consideration_set.update_review(status: "complete") }
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "conditions", :pending do
+      let(:section_id) { "review-conditions" }
+      let(:expand_button) { "Review conditions" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/complete-assessment/add-conditions" }
+
+      let!(:condition_set) { planning_application.condition_set }
+      let!(:condition) { create(:condition, condition_set:) }
+
+      before { condition_set.current_review.complete! }
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "pre-commencement conditions", :pending do
+      let(:section_id) { "review-pre-commencement-conditions" }
+      let(:expand_button) { "Review pre-commencement conditions" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/complete-assessment/add-pre-commencement-conditions" }
+
+      let!(:pcc_set) { planning_application.pre_commencement_condition_set }
+      let!(:pcc) { Current.set(user: assessor) { create(:condition, condition_set: pcc_set) } }
+
+      before { pcc_set.current_review.complete! }
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "informatives", :pending do
+      let(:section_id) { "review-informatives" }
+      let(:expand_button) { "Review informatives" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/complete-assessment/add-informatives" }
+
+      let!(:informative_set) { planning_application.informative_set }
+      let!(:informative) { create(:informative, informative_set:) }
+
+      before { informative_set.current_review.update!(status: :complete) }
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "heads of terms", :pending do
+      let(:section_id) { "review-heads-of-terms" }
+      let(:expand_button) { "Review heads of terms" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/complete-assessment/add-heads-of-terms" }
+
+      let!(:heads_of_term) { planning_application.heads_of_term }
+      let!(:term) { Current.set(user: assessor) { create(:term, heads_of_term:) } }
+
+      before { heads_of_term.current_review.complete! }
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "check neighbour notifications", :pending do
+      let(:section_id) { "review-neighbour-responses" }
+      let(:expand_button) { "Check neighbour notifications" }
+      let(:accept_label) { "Agree" }
+
+      before do
+        create(:neighbour, consultation: planning_application.consultation)
+        Current.set(user: assessor) { planning_application.consultation.create_neighbour_review! }
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+
+    describe "check publicity", :pending do
+      let(:section_id) { "review-publicities" }
+      let(:expand_button) { "Check publicity" }
+      let(:accept_label) { "Agree" }
+
+      let!(:site_notice) { create(:site_notice, planning_application:) }
+      let!(:press_notice) { create(:press_notice, planning_application:) }
+
+      it_behaves_like "a consistent review task"
+    end
+  end
+
+  context "for a prior approval application" do
+    let(:planning_application) do
+      create(:planning_application, :awaiting_determination, :prior_approval,
+        local_authority:, decision: :granted, user: assessor)
+    end
+
+    before { create(:recommendation, status: "assessment_complete", planning_application:) }
+
+    describe "permitted development rights", :pending do
+      let(:section_id) { "review-permitted-development-rights" }
+      let(:expand_button) { "Review permitted development rights" }
+      let(:accept_label) { "Agree" }
+      let(:assessor_task_slug) { "check-and-assess/check-application/permitted-development-rights" }
+
+      let!(:permitted_development_right) do
+        create(:permitted_development_right, planning_application:,
+          status: :in_progress, removed: true, removed_reason: "Removal reason")
+      end
+
+      it_behaves_like "a consistent review task"
+    end
+  end
+end


### PR DESCRIPTION
### Description of change

- Add a reviewer workflow consistency spec as a shared example across all the review tasks. This is just to check the high level interactions and status changes.
- Surface rejection state on assessment-details review page

### Story Link

https://trello.com/c/Tw37OooK/1968-create-full-e2e-test-for-review-stage

