### PR TITLE
Fix policy review list

### DIFF
--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -128,6 +128,22 @@ module Tasks
       params.fetch(param_key, {}).permit(*permitted_attributes)
     end
 
+    def save_draft
+      super do
+        planning_application_policy_classes.find_each do |policy_class|
+          policy_class.current_review.update!(status: :in_progress)
+        end
+      end
+    end
+
+    def save_and_complete
+      super do
+        planning_application_policy_classes.find_each do |policy_class|
+          policy_class.current_review.update!(status: :complete)
+        end
+      end
+    end
+
     def default
       true
     end

--- a/spec/system/tasks/assess_against_legislation_spec.rb
+++ b/spec/system/tasks/assess_against_legislation_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe "Assess against legislation", type: :system do
   let(:local_authority) { create(:local_authority, :default) }
   let(:api_user) { create(:api_user, :validation_requests_ro, local_authority:) }
   let(:assessor) { create(:user, :assessor, local_authority:) }
+  let(:reviewer) { create(:user, :reviewer, local_authority:) }
   let(:reference) { planning_application.reference }
 
   let!(:schedule) { create(:policy_schedule, number: 2, name: "Permitted development rights") }
@@ -144,6 +145,13 @@ RSpec.describe "Assess against legislation", type: :system do
       expect(page).to have_content("Assessment against legislation successfully saved")
 
       expect(task.reload).to be_completed
+
+      sign_out(assessor)
+      sign_in(reviewer)
+
+      visit "/planning_applications/#{reference}/review/tasks"
+      click_link "Review assessment against legislation"
+      expect(page).to have_content("Review assessment of Part 1, Class B Not started")
     end
   end
 


### PR DESCRIPTION
### Description of change

Review page was hiding all policies, because the review status hadn't been set by the assessment task.

### Story Link

https://trello.com/c/MGO9h4Ey/1929-improve-assess-against-legislation-and-review-area-page