### PR TITLE
Fix assessment detail review status

### DIFF
--- a/app/components/status_tags/reviewing/assessment_detail_component.rb
+++ b/app/components/status_tags/reviewing/assessment_detail_component.rb
@@ -17,7 +17,7 @@ module StatusTags
       attr_reader :planning_application, :assessment_detail
 
       def status
-        if assessment_detail_update_required?(assessment_detail)
+        if assessment_detail.update_required?
           :awaiting_changes
         elsif updated?
           :updated
@@ -29,8 +29,7 @@ module StatusTags
       end
 
       def updated?
-        recommendation_submitted_and_unchallenged? &&
-          assessment_detail_updated?(assessment_detail)
+        assessment_detail_updated?(assessment_detail)
       end
     end
   end


### PR DESCRIPTION
### Description of change

Update the logic for which status tag to show. This seems to check the overall review state, not just the task state — seems unnecessary.

### Story Link

https://trello.com/c/9a5LA63r/1962-review-when-returned-with-comments-and-status-of-application-is-to-be-reviewed-some-tasks-show-completed-and-some-show-awaiting