### PR TITLE
Add reviewer comments to assessment tasks

### DIFF
--- a/app/forms/tasks/check_publicity_form.rb
+++ b/app/forms/tasks/check_publicity_form.rb
@@ -2,6 +2,9 @@
 
 module Tasks
   class CheckPublicityForm < Form
+    include AssessmentDetailConcern
+
+    def category = "check_publicity"
     self.task_actions = %w[save_and_complete save_draft]
 
     after_initialize do

--- a/app/forms/tasks/summary_of_neighbour_responses_form.rb
+++ b/app/forms/tasks/summary_of_neighbour_responses_form.rb
@@ -2,6 +2,9 @@
 
 module Tasks
   class SummaryOfNeighbourResponsesForm < Form
+    include AssessmentDetailConcern
+
+    def category = "neighbour_summary"
     self.task_actions = %w[save_and_complete save_draft]
 
     ALL_TAGS = (NeighbourResponse::TAGS.dup << :untagged).freeze

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -1,6 +1,6 @@
 <%= bops_task_accordion(id: "review-consultation") do |accordion| %>
   <% accordion.with_heading(text: "Review consultation") %>
-  <%= accordion.with_section(id: "review-neighbour-responses", expanded: @neighbour_review.errors.any?) do |section| %>
+  <%= accordion.with_section(id: "review-neighbour-notifications", expanded: @neighbour_review.errors.any?) do |section| %>
     <% section.with_heading(text: "Check neighbour notifications") %>
 
     <% section.with_status do %>
@@ -10,6 +10,9 @@
             )
           ) %>
     <% end %>
+
+    <% section.with_block(id: "neighbour-notifications") do %>
+      <p>See the table above for a list of <%= govuk_link_to "neighbours contacted", "#neighbours" %>.</p>    <% end %>
 
     <% section.with_footer do %>
       <%= render(

--- a/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
@@ -19,13 +19,7 @@
             <p>Summary: <%= review_immunity_detail.summary %></p>
           <% end %>
           <hr>
-          <% if review_immunity_detail.comment %>
-            <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-              Reviewer comment
-            </p>
-            <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1">Sent on <%= review_immunity_detail.created_at.to_fs %> by <%= review_immunity_detail.user.name %></p>
-            <%= render(FormattedContentComponent.new(text: review_immunity_detail.comment, classname: "govuk-body")) %>
-          <% end %>
+          <%= render(ReviewerCommentComponent.new(comment: review_immunity_detail)) %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 <% end %>
 
-<%= render(ReviewerCommentComponent.new(comment: @rejected_assessment_detail&.comment)) %>
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
 <div id="site-notice-check">
   <h2><%= t(".check_site_notice") %></h2>
 

--- a/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
@@ -8,6 +8,8 @@
     the assessment of this application.
   </p>
 
+  <%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
   <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_area(:entry, value: @form.assessment_detail.entry, label: nil, rows: 10) %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
@@ -4,6 +4,8 @@
     <%= govuk_link_to t(".view_site_on_map"), map_link(@planning_application.full_address), new_tab: true %>
 </p>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
@@ -27,6 +27,8 @@
   </p>
 <% end %>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
@@ -3,6 +3,9 @@
 <%= render "shared/notification_banner",
       title: "View neighbour responses",
       heading: t("neighbour_responses_by_summary_tag", tag: "neighbour response", count: @form.neighbour_responses.count) %>
+
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
 

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
@@ -2,14 +2,14 @@
 
 <%= govuk_warning_text(text: "This information WILL be made publicly available.") %>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <% if @form.assessment_detail.present? %>
   <h2>Summary</h2>
   <p>
     <%= render(FormattedContentComponent.new(text: @form.assessment_detail.entry)) %>
   </p>
 <% end %>
-
-<%= render(ReviewerCommentComponent.new(comment: @rejected_assessment_detail&.comment)) %>
 
 <h2><%= @form.assessment_detail.persisted? ? "Edit" : "Add" %> summary</h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2146,7 +2146,7 @@ en:
           accept: Accept
           add_a_comment: Add a comment
           add_a_comment_optional: Add a comment (optional)
-          additional_evidence: Summary of additional evidence
+          additional_evidence: Other considerations
           amenity: Amenity assessment
           consultation_summary: Consultation
           edit_review: Edit review


### PR DESCRIPTION
### Description of change

When a reviewer submits a comment and sends application back to assessor the comments show in the relevant assessment task.

### Story Link

https://trello.com/c/nrreVw78/1964-managers-comments-for-an-assessment-summary-task-are-not-showing-observed-on-summary-of-works

### Screenshots
