### PR TITLE
Set review status when rejecting

### DIFF
--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -50,11 +50,19 @@ module PlanningApplications
       def review_params
         params.require(:review_considerations)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current)
+          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
+      end
+
+      def status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          :complete
+        end
       end
 
       def return_to_officer?
-        params.dig(:assessment_considerations, :action) == "rejected"
+        params.dig(:review_considerations, :action) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -51,7 +51,15 @@ module PlanningApplications
       def review_params
         params.require(:review_informatives)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current)
+          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
+      end
+
+      def status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          :complete
+        end
       end
 
       def informatives_not_started?
@@ -63,7 +71,7 @@ module PlanningApplications
       end
 
       def return_to_officer?
-        params.dig(:assessment_detail, :reviewer_verdict) == "rejected"
+        params.dig(:review_informatives, :action) == "rejected"
       end
     end
   end

--- a/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/planning_applications/review/assess_against_policies_and_guidance_spec.rb
@@ -241,6 +241,7 @@ RSpec.describe "Reviewing assessment against policies and guidance", :js, show_s
 
       expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks?next=true")
       expect(page).to have_content("Review of assessment against policy and guidance successfully updated")
+      expect(page).to have_content("Review assessment against policies and guidance Awaiting changes")
 
       within("#review-considerations") do
         expect(page).to have_selector(".govuk-tag", text: "Awaiting changes")

--- a/spec/system/planning_applications/review/informatives_spec.rb
+++ b/spec/system/planning_applications/review/informatives_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe "Reviewing informatives", :js, show_sidebar: false, type: :system
           end
 
           expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks?next=true")
+          expect(page).to have_content("Review informatives Awaiting changes")
 
           # The page redirects back to itself so sometimes have_current_path doesn't wait for the redirect
           with_retry do


### PR DESCRIPTION
### Description of change

Make sure `current_review.status` is set back to `to_be_reviewed` when rejecting tasks from the review stage (not just setting the `current_review.review_status`, which will be `complete`).

Follows the pattern from e.g. `CommitteeDecisionsController`.

### Story Link

https://trello.com/c/9a5LA63r/1962-review-when-returned-with-comments-and-status-of-application-is-to-be-reviewed-some-tasks-show-completed-and-some-show-awaiting