### PR TITLE
Add reviewer comments to assessment tasks

### DIFF
--- a/app/forms/tasks/check_publicity_form.rb
+++ b/app/forms/tasks/check_publicity_form.rb
@@ -2,14 +2,16 @@
 
 module Tasks
   class CheckPublicityForm < Form
+    def category = "check_publicity"
     self.task_actions = %w[save_and_complete save_draft]
 
     after_initialize do
       @site_notice = planning_application.site_notices.last
       @press_notice = planning_application.press_notice
+      @rejected_assessment_detail = planning_application.rejected_assessment_detail(category:)
     end
 
-    attr_reader :press_notice, :site_notice
+    attr_reader :press_notice, :site_notice, :rejected_assessment_detail
 
     def site_notice_not_required?
       !site_notice&.required? && planning_application.site_notices.any?

--- a/app/forms/tasks/summary_of_neighbour_responses_form.rb
+++ b/app/forms/tasks/summary_of_neighbour_responses_form.rb
@@ -2,6 +2,7 @@
 
 module Tasks
   class SummaryOfNeighbourResponsesForm < Form
+    def category = "neighbour_summary"
     self.task_actions = %w[save_and_complete save_draft]
 
     ALL_TAGS = (NeighbourResponse::TAGS.dup << :untagged).freeze
@@ -12,11 +13,12 @@ module Tasks
 
     after_initialize do
       @assessment_detail = planning_application.assessment_details.find_or_initialize_by(category: "neighbour_summary")
+      @rejected_assessment_detail = planning_application.rejected_assessment_detail(category:)
       @neighbour_responses = planning_application.consultation.neighbour_responses
       populate_from_entry
     end
 
-    attr_reader :assessment_detail, :neighbour_responses
+    attr_reader :assessment_detail, :rejected_assessment_detail, :neighbour_responses
 
     with_options on: :save_and_complete do
       validate :all_summaries_present, if: :neighbour_responses?

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -1,6 +1,6 @@
 <%= bops_task_accordion(id: "review-consultation") do |accordion| %>
   <% accordion.with_heading(text: "Review consultation") %>
-  <%= accordion.with_section(id: "review-neighbour-responses", expanded: @neighbour_review.errors.any?) do |section| %>
+  <%= accordion.with_section(id: "review-neighbour-notifications", expanded: @neighbour_review.errors.any?) do |section| %>
     <% section.with_heading(text: "Check neighbour notifications") %>
 
     <% section.with_status do %>
@@ -10,6 +10,9 @@
             )
           ) %>
     <% end %>
+
+    <% section.with_block(id: "neighbour-notifications") do %>
+      <p>See the table above for a list of <%= govuk_link_to "neighbours contacted", "#neighbours" %>.</p>    <% end %>
 
     <% section.with_footer do %>
       <%= render(

--- a/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
@@ -19,13 +19,7 @@
             <p>Summary: <%= review_immunity_detail.summary %></p>
           <% end %>
           <hr>
-          <% if review_immunity_detail.comment %>
-            <p class="govuk-!-font-weight-bold govuk-!-margin-bottom-0">
-              Reviewer comment
-            </p>
-            <p class="govuk-hint govuk-!-font-size-16 govuk-!-margin-top-1">Sent on <%= review_immunity_detail.created_at.to_fs %> by <%= review_immunity_detail.user.name %></p>
-            <%= render(FormattedContentComponent.new(text: review_immunity_detail.comment, classname: "govuk-body")) %>
-          <% end %>
+          <%= render(ReviewerCommentComponent.new(comment: review_immunity_detail)) %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/check-publicity/show.html.erb
@@ -41,7 +41,7 @@
   </div>
 <% end %>
 
-<%= render(ReviewerCommentComponent.new(comment: @rejected_assessment_detail&.comment)) %>
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
 <div id="site-notice-check">
   <h2><%= t(".check_site_notice") %></h2>
 

--- a/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
@@ -8,6 +8,8 @@
     the assessment of this application.
   </p>
 
+  <%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
   <%= form.govuk_error_summary %>
 
   <%= form.govuk_text_area(:entry, value: @form.assessment_detail.entry, label: nil, rows: 10) %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
@@ -4,6 +4,8 @@
     <%= govuk_link_to t(".view_site_on_map"), map_link(@planning_application.full_address), new_tab: true %>
 </p>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
@@ -27,6 +27,8 @@
   </p>
 <% end %>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
@@ -3,6 +3,9 @@
 <%= render "shared/notification_banner",
       title: "View neighbour responses",
       heading: t("neighbour_responses_by_summary_tag", tag: "neighbour response", count: @form.neighbour_responses.count) %>
+
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
 

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
@@ -2,14 +2,14 @@
 
 <%= govuk_warning_text(text: "This information WILL be made publicly available.") %>
 
+<%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
+
 <% if @form.assessment_detail.present? %>
   <h2>Summary</h2>
   <p>
     <%= render(FormattedContentComponent.new(text: @form.assessment_detail.entry)) %>
   </p>
 <% end %>
-
-<%= render(ReviewerCommentComponent.new(comment: @rejected_assessment_detail&.comment)) %>
 
 <h2><%= @form.assessment_detail.persisted? ? "Edit" : "Add" %> summary</h2>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2152,7 +2152,7 @@ en:
           accept: Accept
           add_a_comment: Add a comment
           add_a_comment_optional: Add a comment (optional)
-          additional_evidence: Summary of additional evidence
+          additional_evidence: Other considerations
           amenity: Amenity assessment
           consultation_summary: Consultation
           edit_review: Edit review
@@ -2619,7 +2619,7 @@ en:
       assess_immunity_detail_permitted_development_right_component:
         immune_permitted_development_rights: Assess immunity
       assessment_detail_component:
-        additional_evidence: Summary of additional evidence
+        additional_evidence: Other considerations
         amenity: Amenity
         check_publicity: Check site notice and press notice
         consultation_summary: Summary of consultation

--- a/spec/system/planning_applications/assessing/additional_evidence_spec.rb
+++ b/spec/system/planning_applications/assessing/additional_evidence_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Additional evidence", show_sidebar: false, type: :system do
 
       within("#assessment-information-tasks") do
         expect(page).to have_content("Not started")
-        click_link "Summary of additional evidence"
+        click_link "Other considerations"
       end
 
       expect(page).to have_current_path(
@@ -39,12 +39,12 @@ RSpec.describe "Additional evidence", show_sidebar: false, type: :system do
       )
     end
 
-    it "I can save and come back later when adding or editing additional evidence" do
+    it "I can save and come back later when adding or editing other considerations" do
       expect(list_item("Check and assess")).to have_content("Not started")
 
       click_link "Check and assess"
       within "#main-content" do
-        click_link "Summary of additional evidence"
+        click_link "Other considerations"
       end
 
       fill_in "assessment_detail[entry]", with: "A draft entry for the additional evidence"
@@ -55,9 +55,8 @@ RSpec.describe "Additional evidence", show_sidebar: false, type: :system do
       within("#assessment-information-tasks") do
         expect(page).to have_content("In progress")
       end
-
       within "#main-content" do
-        click_link "Summary of additional evidence"
+        click_link "Other considerations"
       end
       expect(page).to have_content("Edit additional evidence")
       expect(page).to have_content("A draft entry for the additional evidence")
@@ -77,7 +76,7 @@ RSpec.describe "Additional evidence", show_sidebar: false, type: :system do
     it "I can save and mark as complete when adding additional evidence" do
       click_link "Check and assess"
       within "#main-content" do
-        click_link "Summary of additional evidence"
+        click_link "Other considerations"
       end
 
       fill_in "assessment_detail[entry]", with: "A complete entry for the additional evidence"
@@ -90,7 +89,7 @@ RSpec.describe "Additional evidence", show_sidebar: false, type: :system do
       end
 
       within "#main-content" do
-        click_link "Summary of additional evidence"
+        click_link "Other considerations"
       end
       expect(page).to have_content("A complete entry for the additional evidence")
 

--- a/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
+++ b/spec/system/planning_applications/assessing/assessment_tasks_index_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Assessment tasks", show_sidebar: false, type: :system do
           within("#assessment-information-tasks") do
             expect(page).to have_content("Assessment summaries")
             expect(page).to have_link("Summary of works")
-            expect(page).to have_link("Summary of additional evidence")
+            expect(page).to have_link("Other considerations")
             expect(page).to have_link("Site description")
             expect(page).to have_link("Summary of consultation")
           end
@@ -82,7 +82,7 @@ RSpec.describe "Assessment tasks", show_sidebar: false, type: :system do
           within("#assessment-information-tasks") do
             expect(page).to have_content("Assessment summaries")
             expect(page).to have_link("Summary of works")
-            expect(page).to have_link("Summary of additional evidence")
+            expect(page).to have_link("Other considerations")
             expect(page).to have_link("Site description")
             expect(page).not_to have_link("Summary of consultation")
             expect(page).to have_link("Amenity")

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -168,6 +168,21 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#neighbour_summary_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
         end
+
+        within("#neighbour_summary_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of neighbour summary was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/summary-of-neighbour-responses"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
+        end
       end
 
       it "Summary of works" do
@@ -183,6 +198,21 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
         within("#summary_of_work_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
+
+        within("#summary_of_work_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of summary of work was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/summary-of-works"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
         end
       end
 
@@ -200,6 +230,21 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#consultation_summary_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
         end
+
+        within("#consultation_summary_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of consultation summary was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/summary-of-consultation"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
+        end
       end
 
       it "Site description" do
@@ -216,10 +261,25 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         within("#site_description_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
         end
+
+        within("#site_description_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of site description was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/site-description"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
+        end
       end
 
       it "Additional evidence" do
-        click_button "Summary of additional evidence"
+        click_button "Other considerations"
         within("#additional_evidence_footer") do
           choose "Return with comments"
           click_button("Save and mark as complete")
@@ -231,6 +291,21 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
         within("#additional_evidence_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
+
+        within("#additional_evidence_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of additional evidence was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/other-considerations"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
         end
       end
 
@@ -247,6 +322,21 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
         within("#amenity_footer") do
           expect(page).to have_selector("p.govuk-error-message", text: "You must add a comment")
+        end
+
+        within("#amenity_footer") do
+          fill_in "Add a comment", with: "Summary needs revision"
+          click_button("Save and mark as complete")
+        end
+        expect(page).to have_content("Review of amenity was successfully updated")
+
+        sign_out(reviewer)
+        sign_in(assessor)
+        visit "/planning_applications/#{planning_application.reference}/check-and-assess/assessment-summaries/amenity"
+
+        within(".comment-component") do
+          expect(page).to have_content("Reviewer comment")
+          expect(page).to have_content("Summary needs revision")
         end
       end
     end
@@ -775,11 +865,11 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         expect(page).to have_content("Recommendation was successfully reviewed")
       end
 
-      it "summary of additional evidence" do
+      it "other considerations" do
         task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/other-considerations")
         task.start!
 
-        click_button "Summary of additional evidence"
+        click_button "Other considerations"
         within("#additional_evidence_section") do
           expect(find(".govuk-tag")).to have_content("Not started")
 
@@ -840,9 +930,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
 
         within "#main-content" do
           expect(page).to have_list_item_for(
-            "Summary of additional evidence", with: "To be reviewed"
+            "Other considerations", with: "To be reviewed"
           )
-          click_link("Summary of additional evidence")
+          click_link("Other considerations")
         end
 
         within(".comment-component") do
@@ -859,7 +949,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         expect(page).to have_content("Additional evidence was successfully updated.")
         within "#main-content" do
           expect(page).to have_list_item_for(
-            "Summary of additional evidence", with: "Completed"
+            "Other considerations", with: "Completed"
           )
         end
 

--- a/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
+++ b/spec/system/planning_applications/review/check_neighbour_notifications_spec.rb
@@ -45,14 +45,14 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
       it "you can accept that the assessor has notified the correct people" do
         visit "/planning_applications/#{reference}/review/tasks"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#review-neighbour-responses" do
+        within "#review-neighbour-notifications" do
           choose "Agree"
 
           click_button "Save and mark as complete"
@@ -60,7 +60,7 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
 
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Completed")
         end
       end
@@ -68,7 +68,7 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
       it "you can send it back for assessment", :capybara do
         visit "/planning_applications/#{reference}/review/tasks"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
@@ -76,7 +76,7 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
         click_button "Check neighbour notifications"
         expect(page).to have_selector(:open_review_task, text: "Check neighbour notifications")
 
-        within "#review-neighbour-responses" do
+        within "#review-neighbour-notifications" do
           choose "Return with comments"
           fill_in "Add a comment", with: "Notify more people"
 
@@ -86,7 +86,7 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
         expect(page).to have_current_path("/planning_applications/#{reference}/review/tasks")
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Awaiting changes")
         end
@@ -138,14 +138,14 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
       it "shows errors" do
         visit "/planning_applications/#{reference}/review/tasks"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#review-neighbour-responses" do
+        within "#review-neighbour-notifications" do
           click_button "Save and mark as complete"
         end
 
@@ -154,14 +154,14 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
           expect(page).to have_content("Select an option")
         end
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           choose "Return with comments"
           click_button "Save and mark as complete"
         end
@@ -177,14 +177,14 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
       it "you can accept that the assessor has notified the correct people" do
         visit "/planning_applications/#{reference}/review/tasks"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#review-neighbour-responses" do
+        within "#review-neighbour-notifications" do
           choose "Return with comments"
           fill_in "Add a comment", with: "People need to be consulted"
 
@@ -193,7 +193,7 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
 
         expect(page).to have_content("Review of neighbour responses successfully added")
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Awaiting changes")
         end
@@ -211,14 +211,14 @@ RSpec.describe "Check neighbour notifications", show_sidebar: false, type: :syst
       it "you can't accept or reject the officer's work" do
         visit "/planning_applications/#{reference}/review/tasks"
 
-        within("#review-neighbour-responses") do
+        within("#review-neighbour-notifications") do
           expect(page).to have_content("Check neighbour notifications")
           expect(page).to have_content("Not started")
         end
 
         click_button "Check neighbour notifications"
 
-        within "#review-neighbour-responses" do
+        within "#review-neighbour-notifications" do
           choose "Agree"
           click_button "Save and mark as complete"
         end

--- a/spec/system/tasks/add_conditions_spec.rb
+++ b/spec/system/tasks/add_conditions_spec.rb
@@ -139,4 +139,31 @@ RSpec.describe "Add conditions task", type: :system do
       expect(page).to have_content("Review conditions")
     end
   end
+
+  context "when the reviewer has rejected the conditions" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+
+    let!(:rejected_review) do
+      planning_application.condition_set.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the conditions",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within :sidebar do
+        click_link "Add conditions"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the conditions")
+      end
+    end
+  end
 end

--- a/spec/system/tasks/add_heads_of_terms_spec.rb
+++ b/spec/system/tasks/add_heads_of_terms_spec.rb
@@ -107,4 +107,31 @@ RSpec.describe "Add heads of terms task", type: :system do
     expect(page).to have_content("Successfully updated heads of terms")
     expect(task.reload).to be_in_progress
   end
+
+  context "when the reviewer has rejected the heads of terms" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+
+    let!(:rejected_review) do
+      planning_application.heads_of_term.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the heads of terms",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within :sidebar do
+        click_link "Add heads of terms"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the heads of terms")
+      end
+    end
+  end
 end

--- a/spec/system/tasks/add_informatives_spec.rb
+++ b/spec/system/tasks/add_informatives_spec.rb
@@ -115,6 +115,33 @@ RSpec.describe "Add informatives task", type: :system do
     expect(task.reload).to be_in_progress
   end
 
+  context "when the reviewer has rejected the informatives" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+
+    let!(:rejected_review) do
+      planning_application.informative_set.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the informatives",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within :sidebar do
+        click_link "Add informatives"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the informatives")
+      end
+    end
+  end
+
   context "when changing the list position" do
     let(:informative_set) { planning_application.informative_set }
     let!(:informative_one) { create(:informative, informative_set:, title: "Title 1", text: "Text 1", position: 1) }

--- a/spec/system/tasks/add_pre_commencement_conditions_spec.rb
+++ b/spec/system/tasks/add_pre_commencement_conditions_spec.rb
@@ -265,4 +265,31 @@ RSpec.describe "Add pre-commencement conditions task", type: :system do
       end
     end
   end
+
+  context "when the reviewer has rejected the pre-commencement conditions" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+
+    let!(:rejected_review) do
+      planning_application.pre_commencement_condition_set.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the pre-commencement conditions",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within :sidebar do
+        click_link "Add pre-commencement conditions"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the pre-commencement conditions")
+      end
+    end
+  end
 end

--- a/spec/system/tasks/assess_against_policies_and_guidance_spec.rb
+++ b/spec/system/tasks/assess_against_policies_and_guidance_spec.rb
@@ -103,6 +103,33 @@ RSpec.describe "Assess against policies and guidance task", type: :system, js: t
     expect(task.reload).to be_in_progress
   end
 
+  context "when the reviewer has rejected the policies and guidance assessment" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+
+    let!(:rejected_review) do
+      planning_application.consideration_set.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the policies and guidance assessment",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within ".bops-sidebar" do
+        click_link "Assess against policies and guidance"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the policies and guidance assessment")
+      end
+    end
+  end
+
   context "when a consideration exists" do
     let!(:consideration) do
       create(:consideration,

--- a/spec/system/tasks/make_draft_recommendation_spec.rb
+++ b/spec/system/tasks/make_draft_recommendation_spec.rb
@@ -207,6 +207,34 @@ RSpec.describe "Make draft recommendation task", type: :system do
     end
   end
 
+  context "when the reviewer has rejected the recommendation" do
+    let(:reviewer) { create(:user, :reviewer, local_authority:, name: "Bella Jones") }
+    let!(:committee_decision) { create(:committee_decision, planning_application:) }
+
+    let!(:rejected_review) do
+      committee_decision.reviews.create!(
+        action: "rejected",
+        comment: "Please revise the recommendation",
+        reviewer: reviewer
+      )
+    end
+
+    before do
+      task.complete!
+    end
+
+    it "shows the reviewer comment" do
+      within ".bops-sidebar" do
+        click_link "Make draft recommendation"
+      end
+
+      within(".comment-component") do
+        expect(page).to have_content("Reviewer comment")
+        expect(page).to have_content("Please revise the recommendation")
+      end
+    end
+  end
+
   context "when a return_to param is present" do
     let(:planning_application_path) do
       "/planning_applications/#{planning_application.reference}"


### PR DESCRIPTION
### Description of change

When a reviewer sends an application back to an Assessor with comments ensure that those comments are rendered in the relevant assessment tasks.

### Story Link

https://trello.com/c/nrreVw78/1964-managers-comments-for-an-assessment-summary-task-are-not-showing-observed-on-summary-of-works

### Screenshots

