### PR TITLE
Set draft-recommendation and submit-recommendation task statuses when rejecting

### DIFF
--- a/app/controllers/planning_applications/review/assessment_details_controller.rb
+++ b/app/controllers/planning_applications/review/assessment_details_controller.rb
@@ -8,7 +8,7 @@ module PlanningApplications
 
       def update
         if @assessment_detail.update(review_assessment_details_params)
-          @task.action_required! if @task && return_to_officer?
+          reset_assessment_tasks! if return_to_officer?
 
           redirect_to(
             planning_application_review_tasks_path(@planning_application, anchor: "#{@assessment_detail.category}_section"),

--- a/app/controllers/planning_applications/review/base_controller.rb
+++ b/app/controllers/planning_applications/review/base_controller.rb
@@ -61,6 +61,20 @@ module PlanningApplications
       def tasks_url(options = {})
         planning_application_review_tasks_url(@planning_application, options)
       end
+
+      def draft_recommendation_task
+        @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/make-draft-recommendation")
+      end
+
+      def submit_recommendation_task
+        @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/review-and-submit-recommendation")
+      end
+
+      def reset_assessment_tasks!
+        @task&.action_required!
+        draft_recommendation_task&.action_required!
+        submit_recommendation_task&.action_required!
+      end
     end
   end
 end

--- a/app/controllers/planning_applications/review/committee_decisions_controller.rb
+++ b/app/controllers/planning_applications/review/committee_decisions_controller.rb
@@ -16,7 +16,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @committee_decision.update(committee_decision_params)
-              @task.action_required! if @task && return_to_officer?
+              reset_assessment_tasks! if return_to_officer?
 
               redirect_to planning_application_review_tasks_path(@planning_application, anchor: "recommendation_to_committee_section"), notice: t(".success")
             else

--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -18,7 +18,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              @task.action_required! if @task && return_to_officer?
+              reset_assessment_tasks! if return_to_officer?
 
               redirect_to tasks_url(anchor: "review-considerations", next: true), notice: t(".success")
             else

--- a/app/controllers/planning_applications/review/heads_of_terms_controller.rb
+++ b/app/controllers/planning_applications/review/heads_of_terms_controller.rb
@@ -22,7 +22,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              @task.action_required! if @task && return_to_officer?
+              reset_assessment_tasks! if return_to_officer?
+
               redirect_to tasks_url(anchor: "review-heads-of-terms", next: true), notice: t(".success")
             else
               render :tasks, alert: t(".failure_html")

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -20,7 +20,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
-              @task.action_required! if @task && return_to_officer?
+              reset_assessment_tasks! if return_to_officer?
+
               redirect_to tasks_url(anchor: "review-informatives", next: true), notice: t(".success")
             else
               @show_header_bar = false


### PR DESCRIPTION
### Description of change

When any negative review response is submitted, also set the draft-recommendation and submit-recommendation task statuses to `action_required` so they show up as needing attention.

### Story Link

https://trello.com/c/8nbUacUI/1965-make-draft-recommendation-and-review-and-submit-recommendation-status-in-sidebar-should-be-changed-from-complete-to-to-be-review