### PR TITLE
Further assessment statuses after rejection by reviewer

### DIFF
--- a/app/controllers/planning_applications/review/base_controller.rb
+++ b/app/controllers/planning_applications/review/base_controller.rb
@@ -75,6 +75,14 @@ module PlanningApplications
         draft_recommendation_task&.action_required!
         submit_recommendation_task&.action_required!
       end
+
+      def assessment_status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          :complete
+        end
+      end
     end
   end
 end

--- a/app/controllers/planning_applications/review/committee_decisions_controller.rb
+++ b/app/controllers/planning_applications/review/committee_decisions_controller.rb
@@ -45,19 +45,11 @@ module PlanningApplications
             reviews_attributes: {
               reviewed_at: Time.current,
               reviewer: current_user,
-              status:,
+              status: assessment_status,
               review_status:,
               id: @committee_decision.current_review.id
             }
           )
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        elsif mark_as_complete?
-          :complete
-        end
       end
 
       def return_to_officer?

--- a/app/controllers/planning_applications/review/conditions_controller.rb
+++ b/app/controllers/planning_applications/review/conditions_controller.rb
@@ -47,7 +47,15 @@ module PlanningApplications
       def review_params
         params.require(:review_conditions)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current)
+          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
+      end
+
+      def status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          :complete
+        end
       end
 
       def conditions_not_started?

--- a/app/controllers/planning_applications/review/conditions_controller.rb
+++ b/app/controllers/planning_applications/review/conditions_controller.rb
@@ -6,6 +6,7 @@ module PlanningApplications
       before_action :set_condition_set
       before_action :set_conditions
       before_action :set_review
+      before_action :set_task, only: %i[update]
 
       before_action :redirect_to_review_tasks, if: :conditions_not_started?
 
@@ -19,6 +20,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
+              reset_assessment_tasks! if return_to_officer?
+
               redirect_to tasks_url(anchor: "review-conditions", next: true), notice: t(".success")
             else
               render :tasks, alert: t(".failure_html")
@@ -49,6 +52,14 @@ module PlanningApplications
 
       def conditions_not_started?
         @review.not_started?
+      end
+
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/add-conditions")
+      end
+
+      def return_to_officer?
+        params.dig(:review_conditions, :action) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/conditions_controller.rb
+++ b/app/controllers/planning_applications/review/conditions_controller.rb
@@ -47,15 +47,7 @@ module PlanningApplications
       def review_params
         params.require(:review_conditions)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        else
-          :complete
-        end
+          .merge(reviewer: current_user, reviewed_at: Time.current, status: assessment_status)
       end
 
       def conditions_not_started?

--- a/app/controllers/planning_applications/review/considerations_controller.rb
+++ b/app/controllers/planning_applications/review/considerations_controller.rb
@@ -50,15 +50,7 @@ module PlanningApplications
       def review_params
         params.require(:review_considerations)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        else
-          :complete
-        end
+          .merge(reviewer: current_user, reviewed_at: Time.current, status: assessment_status)
       end
 
       def return_to_officer?

--- a/app/controllers/planning_applications/review/informatives_controller.rb
+++ b/app/controllers/planning_applications/review/informatives_controller.rb
@@ -52,15 +52,7 @@ module PlanningApplications
       def review_params
         params.require(:review_informatives)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        else
-          :complete
-        end
+          .merge(reviewer: current_user, reviewed_at: Time.current, status: assessment_status)
       end
 
       def informatives_not_started?

--- a/app/controllers/planning_applications/review/neighbour_responses_controller.rb
+++ b/app/controllers/planning_applications/review/neighbour_responses_controller.rb
@@ -45,16 +45,8 @@ module PlanningApplications
           reviewed_at: Time.current,
           reviewer: current_user,
           review_status: "review_complete",
-          status:
+          status: assessment_status
         )
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        elsif mark_as_complete?
-          :complete
-        end
       end
 
       def consultation_status

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -8,6 +8,7 @@ module PlanningApplications
         before_action :build_form, only: %i[edit update]
         before_action :set_review, only: %i[show edit update]
         before_action :set_policy_sections, only: %i[edit update]
+        before_action :set_task, only: %i[update]
 
         def index
           respond_to do |format|
@@ -31,6 +32,8 @@ module PlanningApplications
           @form.update(policy_section_status_params)
 
           if @planning_application_policy_class.update_review(review_params)
+            reset_assessment_tasks! if return_to_officer?
+
             redirect_to planning_application_review_policy_areas_policy_classes_path(@planning_application, anchor: "review-policy-classes"), notice: t(".success")
           else
             render :edit
@@ -68,6 +71,14 @@ module PlanningApplications
 
         def set_policy_sections
           @policy_sections = @planning_application_policy_class.planning_application_policy_sections.group_by { |section| section.title }.in_order_of(:first, PolicySection::TITLES)
+        end
+
+        def set_task
+          @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/assess-against-legislation/assess-against-legislation")
+        end
+
+        def return_to_officer?
+          params.dig(:review, :action) == "rejected"
         end
       end
     end

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -64,15 +64,7 @@ module PlanningApplications
         def review_params
           params.require(:review)
             .permit(:review_status, :action, :comment)
-            .merge(reviewer: current_user, reviewed_at: Time.current, status:)
-        end
-
-        def status
-          if return_to_officer?
-            :to_be_reviewed
-          else
-            :complete
-          end
+            .merge(reviewer: current_user, reviewed_at: Time.current, status: assessment_status)
         end
 
         def set_review

--- a/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
+++ b/app/controllers/planning_applications/review/policy_areas/policy_classes_controller.rb
@@ -62,7 +62,17 @@ module PlanningApplications
         end
 
         def review_params
-          params.require(:review).permit(:review_status, :action, :comment).merge(reviewer: current_user, reviewed_at: Time.current)
+          params.require(:review)
+            .permit(:review_status, :action, :comment)
+            .merge(reviewer: current_user, reviewed_at: Time.current, status:)
+        end
+
+        def status
+          if return_to_officer?
+            :to_be_reviewed
+          else
+            :complete
+          end
         end
 
         def set_review

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -6,6 +6,7 @@ module PlanningApplications
       before_action :set_condition_set
       before_action :set_conditions
       before_action :set_review
+      before_action :set_task, only: %i[update]
 
       before_action :redirect_to_review_tasks, if: :conditions_not_started?
 
@@ -19,6 +20,7 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @review.update(review_params)
+              reset_assessment_tasks! if return_to_officer?
               redirect_to tasks_url(anchor: "review-pre-commencement-conditions", next: true), notice: t(".success")
             else
               render :tasks, alert: t(".failure_html")
@@ -49,6 +51,14 @@ module PlanningApplications
 
       def conditions_not_started?
         @review.not_started?
+      end
+
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/complete-assessment/add-pre-commencement-conditions")
+      end
+
+      def return_to_officer?
+        params.dig(:review_pre_commencement_conditions, :action) == "rejected"
       end
     end
   end

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -47,15 +47,7 @@ module PlanningApplications
       def review_params
         params.require(:review_pre_commencement_conditions)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
-      end
-
-      def status
-        if return_to_officer?
-          :to_be_reviewed
-        else
-          :complete
-        end
+          .merge(reviewer: current_user, reviewed_at: Time.current, status: assessment_status)
       end
 
       def conditions_not_started?

--- a/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
+++ b/app/controllers/planning_applications/review/pre_commencement_conditions_controller.rb
@@ -21,6 +21,7 @@ module PlanningApplications
           format.html do
             if @review.update(review_params)
               reset_assessment_tasks! if return_to_officer?
+
               redirect_to tasks_url(anchor: "review-pre-commencement-conditions", next: true), notice: t(".success")
             else
               render :tasks, alert: t(".failure_html")
@@ -46,7 +47,15 @@ module PlanningApplications
       def review_params
         params.require(:review_pre_commencement_conditions)
           .permit(:action, :comment, :review_status)
-          .merge(reviewer: current_user, reviewed_at: Time.current)
+          .merge(reviewer: current_user, reviewed_at: Time.current, status:)
+      end
+
+      def status
+        if return_to_officer?
+          :to_be_reviewed
+        else
+          :complete
+        end
       end
 
       def conditions_not_started?

--- a/app/controllers/planning_applications/review/publicities_controller.rb
+++ b/app/controllers/planning_applications/review/publicities_controller.rb
@@ -44,14 +44,6 @@ module PlanningApplications
         ).merge(review_status: :complete, assessment_status:)
       end
 
-      def assessment_status
-        if return_to_officer?
-          :to_be_reviewed
-        elsif mark_as_complete?
-          :complete
-        end
-      end
-
       def return_to_officer?
         params.dig(:review, :action) == "rejected"
       end

--- a/app/controllers/planning_applications/review/publicities_controller.rb
+++ b/app/controllers/planning_applications/review/publicities_controller.rb
@@ -7,11 +7,14 @@ module PlanningApplications
       before_action :set_press_notice
       before_action :set_site_notice
       before_action :set_assessment_detail
+      before_action :set_task, only: %i[update]
 
       def update
         respond_to do |format|
           format.html do
             if @assessment_detail.update(assessment_detail_params)
+              reset_assessment_tasks! if return_to_officer?
+
               redirect_to planning_application_review_tasks_path(@planning_application, anchor: "review-publicities"), notice: t(".success")
             else
               flash.now[:alert] = @assessment_detail.errors.messages.values.flatten.join(", ")
@@ -58,6 +61,10 @@ module PlanningApplications
 
       def set_press_notice
         @press_notice = @planning_application.press_notice
+      end
+
+      def set_task
+        @task = @planning_application.case_record.find_task_by_slug_path("check-and-assess/assessment-summaries/check-publicity")
       end
     end
   end

--- a/app/forms/tasks/add_conditions_form.rb
+++ b/app/forms/tasks/add_conditions_form.rb
@@ -56,15 +56,13 @@ module Tasks
     private
 
     def add_condition
-      condition_set.conditions.create!(title:, text:, reason:, standard: false).tap do
-        task.start! unless task.in_progress?
-      end
+      condition_set.conditions.create!(title:, text:, reason:, standard: false)
+      task.start!
     end
 
     def update_condition
-      condition.update!(title:, text:, reason:).tap do
-        task.start! unless task.in_progress?
-      end
+      condition.update!(title:, text:, reason:)
+      task.start!
     end
 
     def delete_condition

--- a/app/forms/tasks/add_pre_commencement_conditions_form.rb
+++ b/app/forms/tasks/add_pre_commencement_conditions_form.rb
@@ -79,15 +79,13 @@ module Tasks
     private
 
     def add_condition
-      condition_set.conditions.create!(title:, text:, reason:).tap do
-        task.start! unless task.in_progress?
-      end
+      condition_set.conditions.create!(title:, text:, reason:)
+      task.start!
     end
 
     def update_condition
-      condition.update!(title:, text:, reason:).tap do
-        task.start! unless task.in_progress?
-      end
+      condition.update!(title:, text:, reason:)
+      task.start!
     end
 
     def delete_condition
@@ -95,9 +93,8 @@ module Tasks
     end
 
     def confirm_and_send
-      condition_set.confirm_pending_requests!.tap do
-        task.start! unless task.in_progress?
-      end
+      condition_set.confirm_pending_requests!
+      task.start!
     end
 
     def save_draft

--- a/app/models/planning_application_policy_class.rb
+++ b/app/models/planning_application_policy_class.rb
@@ -29,12 +29,12 @@ class PlanningApplicationPolicyClass < ApplicationRecord
 
   def update_review(params)
     status = params[:status] || params[:review_status]
-    case status
+    case status.to_s
     when "complete"
       mark_as_complete(params)
     when "in_progress"
       mark_as_in_progress(params)
-    when "review_complete", "review_in_progress"
+    when "review_complete", "review_in_progress", "to_be_reviewed"
       update_current_review(params)
     else
       raise ArgumentError, "Unexpected review status: #{status.inspect}"

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -342,6 +342,9 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
     end
 
     context "when reviewer submits their review" do
+      let(:draft_recommendation_task) { planning_application.case_record.find_task_by_slug_path!("check-and-assess/complete-assessment/make-draft-recommendation") }
+      let(:submit_recommendation_task) { planning_application.case_record.find_task_by_slug_path!("check-and-assess/complete-assessment/review-and-submit-recommendation") }
+
       before do
         travel_to(Time.zone.local(2024, 11, 28, 12, 30))
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
@@ -401,6 +404,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -530,6 +535,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -656,6 +663,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -788,6 +797,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -917,6 +928,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day
@@ -1047,6 +1060,8 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         end
 
         expect(task.reload).to be_action_required
+        expect(draft_recommendation_task.reload).to be_action_required
+        expect(submit_recommendation_task.reload).to be_action_required
 
         sign_out(reviewer)
         travel 1.day


### PR DESCRIPTION
### Description of change

Some fixes and overlooked tasks

### Story Link

https://trello.com/c/VJiOYzNs/1963-implement-status-symbols-for-each-task-in-the-sidebar-of-assessment-to-show-if-they-need-review
https://trello.com/c/8nbUacUI/1965-make-draft-recommendation-and-review-and-submit-recommendation-status-in-sidebar-should-be-changed-from-complete-to-to-be-review