### PR TITLE
Reorder fields on review-assess-legislation page

### DIFF
--- a/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/edit.html.erb
@@ -29,31 +29,40 @@
 
               <p><%= policy_section.description %></p>
 
-              <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.policy_section.id}][comments_attributes][0][text]",
-                    label: {text: "Add comment", class: "govuk-label govuk-label--s"},
-                    value: policy_section&.last_comment&.text,
-                    class: "govuk-textarea govuk-!-margin-bottom-2",
-                    rows: 2 %>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                    Status
+                  </legend>
 
-              <%= render(
-                    partial: "shared/policy_classes/previous_comments",
-                    locals: {previous_comments: policy_section.previous_comments}
-                  ) %>
-
-              <div class="display-flex">
-                <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
-                  <div class="govuk-radios govuk-radios--small">
-                    <%= form.govuk_radio_button(
-                          "planning_application_policy_sections[#{policy_section.policy_section.id}][status]",
-                          status,
-                          checked: policy_section.status == status,
-                          label: {text: status.humanize},
-                          disabled: true,
-                          class: "govuk-radios__input"
-                        ) %>
+                  <div
+                    class="govuk-radios govuk-radios--inline govuk-radios--small"
+                    data-module="govuk-radios">
+                    <% PlanningApplicationPolicySection.statuses.keys.each do |status| %>
+                      <%= form.govuk_radio_button(
+                            "planning_application_policy_sections[#{policy_section.policy_section.id}][status]",
+                            status,
+                            checked: policy_section.status == status,
+                            label: {text: status.humanize, class: "govuk-!-text-wrap-nowrap"},
+                            disabled: true,
+                            class: "govuk-radios__input"
+                          ) %>
+                    <% end %>
                   </div>
-                <% end %>
+                </fieldset>
               </div>
+
+              <%= govuk_details(summary_text: "Edit comment (optional)", open: policy_section&.last_comment&.text&.present?) do %>
+                <%= form.govuk_text_area "planning_application_policy_sections[#{policy_section.policy_section.id}][comments_attributes][0][text]",
+                      label: {text: "Edit comment",
+                              class: "govuk-label govuk-label--s"},
+                      value: policy_section&.last_comment&.text,
+                      class: "govuk-textarea govuk-!-margin-bottom-2",
+                      rows: 2 %>
+
+                <%= render partial: "shared/policy_classes/previous_comments",
+                      locals: {previous_comments: policy_section.previous_comments} %>
+              <% end %>
             </div>
           <% end %>
         </div>

--- a/spec/system/planning_applications/review/policy_class_spec.rb
+++ b/spec/system/planning_applications/review/policy_class_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Reviewing Policy Class", show_sidebar: false, type: :system do
 
         choose "Agree"
         within("#policy_section_#{policy_section2bii.id}") do
-          fill_in("Add comment", with: "Reviewer comment")
+          fill_in("Edit comment", with: "Reviewer comment")
         end
         click_button("Save and come back later")
 
@@ -86,7 +86,7 @@ RSpec.describe "Reviewing Policy Class", show_sidebar: false, type: :system do
         click_link("Part 1, Class A")
 
         within("#policy_section_#{policy_section2bii.id}") do
-          expect(page).to have_field("Add comment", with: "Reviewer comment")
+          expect(page).to have_field("Edit comment", with: "Reviewer comment")
 
           find("span", text: "Previous comments").click
           expect(page).to have_content("A comment")


### PR DESCRIPTION
### Description of change

Put the comment after the radios, in a dropdown, and fix spacing.

### Story Link

https://trello.com/c/MGO9h4Ey/1929-improve-assess-against-legislation-and-review-area-page

### Screenshots

<img width="1107" height="430" alt="Screenshot 2026-05-08 at 11 59 24" src="https://github.com/user-attachments/assets/29256924-1a22-45da-b7eb-a4dcd6c38676" />
