### PR TITLE
Ensure status is Updated when returned to review

### DIFF
--- a/app/controllers/planning_applications/neighbour_letters_controller.rb
+++ b/app/controllers/planning_applications/neighbour_letters_controller.rb
@@ -146,7 +146,11 @@ module PlanningApplications
     end
 
     def create_review!
-      @consultation.create_neighbour_review! if @consultation.neighbour_review.blank? || @consultation.neighbour_review.to_be_reviewed?
+      if @consultation.neighbour_review.blank?
+        @consultation.create_neighbour_review!
+      elsif @consultation.neighbour_review.to_be_reviewed?
+        @consultation.create_neighbour_review!(status: "updated")
+      end
     end
 
     def redirect_after_rescue(error)

--- a/app/forms/tasks/add_conditions_form.rb
+++ b/app/forms/tasks/add_conditions_form.rb
@@ -77,7 +77,8 @@ module Tasks
 
     def save_and_complete
       super do
-        condition_set.create_or_update_review!("complete")
+        status = condition_set.current_review&.to_be_reviewed? ? "updated" : "complete"
+        condition_set.create_or_update_review!(status)
       end
     end
   end

--- a/app/forms/tasks/add_heads_of_terms_form.rb
+++ b/app/forms/tasks/add_heads_of_terms_form.rb
@@ -34,7 +34,11 @@ module Tasks
 
     def save_and_complete
       super do
-        @heads_of_terms.confirm_pending_requests! unless planning_application.pre_application?
+        if heads_of_terms.current_review&.to_be_reviewed?
+          heads_of_terms.reviews.create!(assessor: Current.user, status: "updated")
+        else
+          heads_of_terms.confirm_pending_requests! unless planning_application.pre_application?
+        end
       end
     end
 

--- a/app/forms/tasks/add_informatives_form.rb
+++ b/app/forms/tasks/add_informatives_form.rb
@@ -41,6 +41,18 @@ module Tasks
 
     private
 
+    def save_draft
+      super do
+        informative_set.update_review(status: "in_progress", assessor: Current.user)
+      end
+    end
+
+    def save_and_complete
+      super do
+        informative_set.update_review(status: "complete", assessor: Current.user)
+      end
+    end
+
     def add_informative
       informative_set.informatives.create!(title:, text:)
       task.start!

--- a/app/forms/tasks/add_pre_commencement_conditions_form.rb
+++ b/app/forms/tasks/add_pre_commencement_conditions_form.rb
@@ -105,7 +105,8 @@ module Tasks
 
     def save_and_complete
       super do
-        condition_set.create_or_update_review!("complete")
+        status = condition_set.current_review&.to_be_reviewed? ? "updated" : "complete"
+        condition_set.create_or_update_review!(status)
       end
     end
   end

--- a/app/forms/tasks/assessment_detail_concern.rb
+++ b/app/forms/tasks/assessment_detail_concern.rb
@@ -17,11 +17,13 @@ module Tasks
       attr_reader :assessment_detail, :category, :rejected_assessment_detail
 
       with_options on: %i[save_and_complete save_draft] do
-        validates :entry, presence: true
+        validates :entry, presence: true, if: :requires_entry?
       end
     end
 
     private
+
+    def requires_entry? = true
 
     def category = nil
 

--- a/app/forms/tasks/check_publicity_form.rb
+++ b/app/forms/tasks/check_publicity_form.rb
@@ -2,16 +2,16 @@
 
 module Tasks
   class CheckPublicityForm < Form
+    include AssessmentDetailConcern
+
     def category = "check_publicity"
-    self.task_actions = %w[save_and_complete save_draft]
 
     after_initialize do
       @site_notice = planning_application.site_notices.last
       @press_notice = planning_application.press_notice
-      @rejected_assessment_detail = planning_application.rejected_assessment_detail(category:)
     end
 
-    attr_reader :press_notice, :site_notice, :rejected_assessment_detail
+    attr_reader :press_notice, :site_notice
 
     def site_notice_not_required?
       !site_notice&.required? && planning_application.site_notices.any?
@@ -28,5 +28,9 @@ module Tasks
     def press_notice_url
       task_path(planning_application, slug: "consultees-neighbours-and-publicity/publicity/press-notice", return_to: task.full_slug)
     end
+
+    private
+
+    def requires_entry? = false
   end
 end

--- a/app/forms/tasks/send_letters_to_neighbours_form.rb
+++ b/app/forms/tasks/send_letters_to_neighbours_form.rb
@@ -53,7 +53,11 @@ module Tasks
     end
 
     def create_review!
-      consultation.create_neighbour_review! if consultation.neighbour_review.blank? || consultation.neighbour_review.to_be_reviewed?
+      if consultation.neighbour_review.blank?
+        consultation.create_neighbour_review!
+      elsif consultation.neighbour_review.to_be_reviewed?
+        consultation.create_neighbour_review!(status: "updated")
+      end
     end
 
     def record_audit_for_letters_sent!

--- a/app/forms/tasks/summary_of_neighbour_responses_form.rb
+++ b/app/forms/tasks/summary_of_neighbour_responses_form.rb
@@ -2,8 +2,9 @@
 
 module Tasks
   class SummaryOfNeighbourResponsesForm < Form
+    include AssessmentDetailConcern
+
     def category = "neighbour_summary"
-    self.task_actions = %w[save_and_complete save_draft]
 
     ALL_TAGS = (NeighbourResponse::TAGS.dup << :untagged).freeze
     ENTRY_BOUNDARY = /(?=#{ALL_TAGS.map { |t| Regexp.escape("#{t.to_s.humanize}: ") }.join("|")})/
@@ -12,13 +13,11 @@ module Tasks
     attribute :untagged, :string
 
     after_initialize do
-      @assessment_detail = planning_application.assessment_details.find_or_initialize_by(category: "neighbour_summary")
-      @rejected_assessment_detail = planning_application.rejected_assessment_detail(category:)
       @neighbour_responses = planning_application.consultation.neighbour_responses
       populate_from_entry
     end
 
-    attr_reader :assessment_detail, :rejected_assessment_detail, :neighbour_responses
+    attr_reader :neighbour_responses
 
     with_options on: :save_and_complete do
       validate :all_summaries_present, if: :neighbour_responses?
@@ -56,15 +55,15 @@ module Tasks
       end.join
     end
 
-    def save_draft
-      super do
-        @assessment_detail.update!(entry: formatted_entry, assessment_status: :in_progress, user: Current.user)
-      end
-    end
+    def requires_entry? = false
 
-    def save_and_complete
-      super do
-        @assessment_detail.update!(entry: formatted_entry, assessment_status: :complete, user: Current.user)
+    def build_or_update_assessment_detail!(assessment_status:)
+      if @rejected_assessment_detail.present?
+        @assessment_detail = planning_application.assessment_details.create!(
+          category:, entry: formatted_entry, assessment_status:, user: Current.user
+        )
+      else
+        @assessment_detail.update!(entry: formatted_entry, assessment_status:, user: Current.user)
       end
     end
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -382,8 +382,8 @@ class Consultation < ApplicationRecord
     neighbour_reviews.max_by(&:created_at)
   end
 
-  def create_neighbour_review!
-    neighbour_reviews.create!(status: "complete", assessor: Current.user)
+  def create_neighbour_review!(status: "complete")
+    neighbour_reviews.create!(status:, assessor: Current.user)
   end
 
   def consultees_checked?

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -4,9 +4,11 @@
     <% section.with_heading(text: "Check neighbour notifications") %>
 
     <% section.with_status do %>
+      <% neighbour_review = @planning_application.consultation.neighbour_review %>
       <%= render(
             StatusTags::ReviewComponent.new(
-              review_item: @planning_application.consultation.neighbour_review
+              review_item: neighbour_review,
+              updated: neighbour_review&.updated?
             )
           ) %>
     <% end %>
@@ -26,8 +28,9 @@
     <% section.with_heading(text: "Check publicity") %>
     <% section.with_status do %>
       <%= render(
-            StatusTags::ReviewComponent.new(
-              review_item: @planning_application.existing_or_new_check_publicity
+            StatusTags::Reviewing::AssessmentDetailComponent.new(
+              planning_application: @planning_application,
+              assessment_detail: @planning_application.existing_or_new_check_publicity
             )
           ) %>
     <% end %>

--- a/engines/bops_preapps/app/forms/bops_preapps/tasks/summary_of_advice_form.rb
+++ b/engines/bops_preapps/app/forms/bops_preapps/tasks/summary_of_advice_form.rb
@@ -8,11 +8,18 @@ module BopsPreapps
       attribute :summary_tag
       attribute :entry
 
+      after_initialize do
+        @assessment_detail = planning_application.assessment_details.find_or_initialize_by(category: :summary_of_advice)
+      end
+
+      attr_reader :assessment_detail
+
       private
 
       def update_assessment_detail
-        assessment_detail = planning_application.assessment_details.find_or_initialize_by(category: :summary_of_advice)
-        assessment_detail.update!(summary_tag:, entry:) if summary_tag.present? || entry.present?
+        if summary_tag.present? || entry.present?
+          @assessment_detail.update!(summary_tag:, entry:)
+        end
       end
 
       def save_and_complete

--- a/spec/system/planning_applications/review/check_publicity_spec.rb
+++ b/spec/system/planning_applications/review/check_publicity_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe "checking publicity", show_sidebar: false, type: :system do
 
         within("#review-publicities") do
           expect(page).to have_content("Check publicity")
-          expect(page).to have_content("Not started")
+          expect(page).to have_content("Updated")
         end
       end
 
@@ -398,7 +398,7 @@ RSpec.describe "checking publicity", show_sidebar: false, type: :system do
 
       within("#review-publicities") do
         expect(page).to have_content("Check publicity")
-        expect(page).to have_content("Not started")
+        expect(page).to have_content("Updated")
       end
     end
 


### PR DESCRIPTION
### Description of change

When an Assessor has made changes after a Reviewer has returned with comments, and then re-submitted their recommendation, the Reviewer should see the status "Updated" against that task.

### Story Link
(https://trello.com/c/r0xzB7Ha/1967-review-when-a-section-is-resubmitted-observed-with-assess-against-policy-and-guidance-then-reviewers-return-with-comments-radio)