### PR TITLE
Set status when resubmitting unchanged draft decision

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -94,7 +94,7 @@ jobs:
         if: "${{ inputs.want-pdf }}"
         run: |
           sudo apt-get install -y ghostscript poppler-utils imagemagick
-        timeout-minutes: 1
+        timeout-minutes: 5
 
       - name: Install postgres client
         shell: bash

--- a/app/components/status_tags/review_component.rb
+++ b/app/components/status_tags/review_component.rb
@@ -2,9 +2,9 @@
 
 module StatusTags
   class ReviewComponent < StatusTags::BaseComponent
-    def initialize(review_item:, updated: false)
+    def initialize(review_item:, updated: nil)
       @review_item = review_item
-      @updated = updated
+      @updated = updated.nil? ? review_item&.updated? : updated
       super(status:)
     end
 

--- a/app/components/task_list_items/reviewing/conditions_component.rb
+++ b/app/components/task_list_items/reviewing/conditions_component.rb
@@ -29,10 +29,7 @@ module TaskListItems
       end
 
       def status_tag_component
-        StatusTags::ReviewComponent.new(
-          review_item: condition_set.current_review,
-          updated: condition_set.current_review&.status == "updated"
-        )
+        StatusTags::ReviewComponent.new(review_item: condition_set.current_review)
       end
 
       def link_active?

--- a/app/components/task_list_items/reviewing/informatives_component.rb
+++ b/app/components/task_list_items/reviewing/informatives_component.rb
@@ -22,10 +22,7 @@ module TaskListItems
       end
 
       def status_tag_component
-        StatusTags::ReviewComponent.new(
-          review_item: current_review,
-          updated: current_review.updated?
-        )
+        StatusTags::ReviewComponent.new(review_item: current_review)
       end
 
       def link_active?

--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -49,17 +49,13 @@ module Tasks
     end
 
     def save_committee_decision
-      if planning_application.committee_decision.present?
-        planning_application.committee_decision.tap do |cd|
-          cd.update!(reasons: updated_reasons, recommend: recommend)
-          cd.current_review.updated!
-        end
-      else
-        CommitteeDecision.new(
-          planning_application: planning_application,
-          recommend: recommend,
-          reasons: updated_reasons
-        ).save!
+      decision = CommitteeDecision.find_or_create_by!(planning_application:)
+
+      if decision.reasons != updated_reasons || decision.recommend != recommend
+        decision.update!(reasons: updated_reasons, recommend:)
+        decision.current_review.updated!
+      elsif decision.current_review.review_complete?
+        decision.create_review(review_status: :review_complete)
       end
     end
 

--- a/app/models/committee_decision.rb
+++ b/app/models/committee_decision.rb
@@ -119,8 +119,8 @@ class CommitteeDecision < ApplicationRecord
     (reasons_changed? || recommend_changed?) && current_review.to_be_reviewed? && current_review.review_complete?
   end
 
-  def create_review
-    reviews.create!(assessor: Current.user, owner_type: "CommitteeDecision", owner_id: id, status: "complete")
+  def create_review(**params)
+    reviews.create!(assessor: Current.user, owner_type: "CommitteeDecision", owner_id: id, status: "complete", **params)
   end
 
   def ensure_planning_application_not_closed_or_cancelled

--- a/app/views/planning_applications/review/policy_areas/policy_classes/index.html.erb
+++ b/app/views/planning_applications/review/policy_areas/policy_classes/index.html.erb
@@ -25,12 +25,7 @@
 
       <% c.with_tag do %>
         <div class="govuk-task-list__status app-task-list__task-tag">
-        <%= render(
-              StatusTags::ReviewComponent.new(
-                review_item: policy_class.current_review,
-                updated: policy_class.current_review.updated?
-              )
-            ) %>
+          <%= render StatusTags::ReviewComponent.new(review_item: policy_class.current_review) %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/planning_applications/review/tasks/_recommendation_to_committee.html.erb
+++ b/app/views/planning_applications/review/tasks/_recommendation_to_committee.html.erb
@@ -2,7 +2,7 @@
   <% section.with_heading(text: "Recommendation to committee") %>
 
   <% section.with_status do %>
-    <%= render(StatusTags::ReviewComponent.new(review_item: committee_decision.current_review, updated: committee_decision.current_review.updated?)) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: committee_decision.current_review) %>
   <% end %>
 
   <% section.with_block(id: "recommendation_to_committee_block") do %>

--- a/app/views/planning_applications/review/tasks/_review_conditions.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_conditions.html.erb
@@ -20,11 +20,7 @@
       <% section.with_heading(text: "Review evidence of immunity") %>
 
       <% section.with_status do %>
-        <%= render(
-              StatusTags::ReviewComponent.new(
-                review_item: @planning_application.immunity_detail.current_evidence_review
-              )
-            ) %>
+        <%= render StatusTags::ReviewComponent.new(review_item: @planning_application.immunity_detail.current_evidence_review) %>
       <% end %>
 
       <% section.with_block do %>
@@ -45,11 +41,7 @@
       <% section.with_heading(text: "Review assessment of immunity") %>
 
       <% section.with_status do %>
-        <%= render(
-              StatusTags::ReviewComponent.new(
-                review_item: @planning_application.immunity_detail.current_enforcement_review
-              )
-            ) %>
+        <%= render StatusTags::ReviewComponent.new(review_item: @planning_application.immunity_detail.current_enforcement_review) %>
       <% end %>
 
       <% section.with_block do %>
@@ -67,12 +59,7 @@
     <% accordion.with_section(id: "review-permitted-development-rights", expanded: @permitted_development_right.errors.any?) do |section| %>
       <%= section.with_heading(text: "Review permitted development rights") %>
       <% section.with_status do %>
-        <%= render(
-              StatusTags::ReviewComponent.new(
-                review_item: @permitted_development_right,
-                updated: @permitted_development_right.status == "updated"
-              )
-            ) %>
+        <%= render StatusTags::ReviewComponent.new(review_item: @permitted_development_right) %>
       <% end %>
       <% section.with_block do %>
         <%= render(partial: "planning_applications/review/permitted_development_rights/summary") %>

--- a/app/views/planning_applications/review/tasks/_review_consultation.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_consultation.html.erb
@@ -4,13 +4,7 @@
     <% section.with_heading(text: "Check neighbour notifications") %>
 
     <% section.with_status do %>
-      <% neighbour_review = @planning_application.consultation.neighbour_review %>
-      <%= render(
-            StatusTags::ReviewComponent.new(
-              review_item: neighbour_review,
-              updated: neighbour_review&.updated?
-            )
-          ) %>
+      <%= render StatusTags::ReviewComponent.new(review_item: @planning_application.consultation.neighbour_review) %>
     <% end %>
 
     <% section.with_block(id: "neighbour-notifications") do %>

--- a/app/views/planning_applications/review/tasks/summaries/_conditions.html.erb
+++ b/app/views/planning_applications/review/tasks/summaries/_conditions.html.erb
@@ -2,12 +2,7 @@
   <% section.with_heading(text: "Review conditions") %>
 
   <% section.with_status do %>
-    <%= render(
-          StatusTags::ReviewComponent.new(
-            review_item: current_review,
-            updated: current_review.updated?
-          )
-        ) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: current_review) %>
   <% end %>
 
   <% section.with_block do %>

--- a/app/views/planning_applications/review/tasks/summaries/_considerations.html.erb
+++ b/app/views/planning_applications/review/tasks/summaries/_considerations.html.erb
@@ -2,12 +2,7 @@
   <% section.with_heading(text: "Review assessment against policies and guidance") %>
 
   <% section.with_status do %>
-    <%= render(
-          StatusTags::ReviewComponent.new(
-            review_item: current_review,
-            updated: current_review.updated?
-          )
-        ) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: current_review) %>
   <% end %>
 
   <% section.with_block do %>

--- a/app/views/planning_applications/review/tasks/summaries/_heads_of_terms.html.erb
+++ b/app/views/planning_applications/review/tasks/summaries/_heads_of_terms.html.erb
@@ -2,12 +2,7 @@
   <% section.with_heading(text: "Review heads of terms") %>
 
   <% section.with_status do %>
-    <%= render(
-          StatusTags::ReviewComponent.new(
-            review_item: current_review,
-            updated: current_review.updated?
-          )
-        ) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: current_review) %>
   <% end %>
 
   <% section.with_block do %>

--- a/app/views/planning_applications/review/tasks/summaries/_informatives.html.erb
+++ b/app/views/planning_applications/review/tasks/summaries/_informatives.html.erb
@@ -2,12 +2,7 @@
   <% section.with_heading(text: "Review informatives") %>
 
   <% section.with_status do %>
-    <%= render(
-          StatusTags::ReviewComponent.new(
-            review_item: current_review,
-            updated: current_review.updated?
-          )
-        ) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: current_review) %>
   <% end %>
 
   <% section.with_block do %>

--- a/app/views/planning_applications/review/tasks/summaries/_pre_commencement_conditions.html.erb
+++ b/app/views/planning_applications/review/tasks/summaries/_pre_commencement_conditions.html.erb
@@ -2,12 +2,7 @@
   <% section.with_heading(text: "Review pre-commencement conditions") %>
 
   <% section.with_status do %>
-    <%= render(
-          StatusTags::ReviewComponent.new(
-            review_item: current_review,
-            updated: current_review.updated?
-          )
-        ) %>
+    <%= render StatusTags::ReviewComponent.new(review_item: current_review) %>
   <% end %>
 
   <% section.with_block do %>


### PR DESCRIPTION
### Description of change

When resubmitting a draft decision without change, don't warn the reviewer that it's been updated (because it hasn't); instead go straight to complete.

Also some simplification of ReviewComponent.

### Story Link

https://trello.com/c/ru5T9Coy/1966-review-recommendation-to-committee-task-is-shown-as-updated-every-time-an-application-is-submitted-back-to-review-except-for-fir