### PR TITLE
Update links in review page to task pages

### DIFF
--- a/app/forms/tasks/press_notice_form.rb
+++ b/app/forms/tasks/press_notice_form.rb
@@ -42,11 +42,11 @@ module Tasks
     attr_reader :press_notice, :press_notices
 
     def new_press_notice_url
-      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true)
+      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true, return_to: return_to)
     end
 
     def press_notice_url
-      route_for(:task, planning_application, slug: task.full_slug, only_path: true)
+      route_for(:task, planning_application, slug: task.full_slug, only_path: true, return_to: return_to)
     end
 
     def edit_press_notice_url(press_notice)

--- a/app/forms/tasks/site_notice_form.rb
+++ b/app/forms/tasks/site_notice_form.rb
@@ -23,24 +23,32 @@ module Tasks
       end
     end
 
+    def redirect_url(options = {})
+      if action == "create_site_notice"
+        task_path(planning_application, task, return_to: return_to, only_path: true)
+      else
+        super
+      end
+    end
+
     def new_site_notice_url
-      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true)
+      task_path(planning_application, task, new: true, return_to: return_to)
     end
 
     def back_url
-      route_for(:task, planning_application, slug: task.full_slug, only_path: true)
+      url(return_to: return_to)
     end
 
     def edit_site_notice_url(site_notice)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: site_notice.id)
     end
 
     def confirm_display_url
-      route_for(:task_component, planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: site_notice.id)
     end
 
     def confirmation_request_url(site_notice)
-      task_component_path(planning_application, slug: task.full_slug, id: site_notice.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: site_notice.id)
     end
 
     attr_reader :site_notice, :site_notices

--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -23,7 +23,9 @@ class AssessmentDetail < ApplicationRecord
   TASK_SLUGS = {
     additional_evidence: "check-and-assess/assessment-summaries/other-considerations",
     amenity: "check-and-assess/assessment-summaries/amenity",
+    assess_immunity: "check-and-assess/assess-immunity/assess-immunity",
     consultation_summary: "check-and-assess/assessment-summaries/summary-of-consultation",
+    evidence_of_immunity: "check-and-assess/assess-immunity/evidence-of-immunity",
     neighbour_summary: "check-and-assess/assessment-summaries/summary-of-neighbour-responses",
     site_description: "check-and-assess/assessment-summaries/site-description",
     summary_of_work: "check-and-assess/assessment-summaries/summary-of-works"

--- a/app/views/planning_applications/review/immunity_enforcements/_details.html.erb
+++ b/app/views/planning_applications/review/immunity_enforcements/_details.html.erb
@@ -4,4 +4,4 @@
   <p>Assessor summary: <strong><%= @planning_application.immunity_detail.current_enforcement_review.summary %></strong></p>
 <% end %>
 
-<%= govuk_link_to "Edit", edit_planning_application_assessment_assess_immunity_detail_permitted_development_right_path(@planning_application) %>
+<%= govuk_link_to "Edit", task_path(@planning_application, slug: "check-and-assess/check-application/permitted-development-rights", return_to: planning_application_review_tasks_path(@planning_application, anchor: "review-conditions-section")) %>

--- a/app/views/planning_applications/review/publicities/_press_notice.html.erb
+++ b/app/views/planning_applications/review/publicities/_press_notice.html.erb
@@ -41,7 +41,7 @@
           </p>
           <ul class="govuk-list">
             <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
-            <li><%= govuk_link_to t(".view_more_documents"), planning_application_press_notice_confirmation_path(@planning_application, @planning_application.press_notice), no_visited_state: true %></li>
+            <li><%= govuk_link_to t(".view_more_documents"), task_path(slug: "consultees-neighbours-and-publicity/publicity/press-notice", return_to: planning_application_review_tasks_path(@planning_application)), no_visited_state: true %></li>
           </ul>
         </div>
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/planning_applications/review/publicities/_site_notice.html.erb
+++ b/app/views/planning_applications/review/publicities/_site_notice.html.erb
@@ -38,7 +38,7 @@
           </p>
           <ul class="govuk-list">
             <li><%= link_to_document(t(".view_in_new_window"), document, no_visited_state: true) %></li>
-            <li><%= govuk_link_to t(".view_more_documents"), planning_application_site_notice_path(@planning_application, @planning_application.site_notice), no_visited_state: true %></li>
+            <li><%= govuk_link_to t(".view_more_documents"), task_path(slug: "consultees-neighbours-and-publicity/publicity/site-notice", return_to: planning_application_review_tasks_path(@planning_application)), no_visited_state: true %></li>
           </ul>
         </div>
         <div class="govuk-grid-column-two-thirds">

--- a/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
@@ -34,7 +34,7 @@
               View neighbour responses: <%= neighbour_responses_summary_text(consultation.neighbour_responses_by_summary_tag) %>
             </p>
             <p>
-              <%= govuk_link_to "View neighbour responses", planning_application_consultation_neighbour_responses_path(@planning_application), new_tab: true %>
+              <%= govuk_link_to "View neighbour responses", task_path(slug: "consultees-neighbours-and-publicity/neighbours/view-neighbour-responses", return_to: planning_application_review_tasks_path(@planning_application)), new_tab: true %>
             </p>
           <% else %>
             <p>
@@ -57,9 +57,9 @@
               )
             ) %>
 
-        <%= govuk_link_to "Edit", edit_planning_application_assessment_assessment_detail_path(
-              @planning_application, assessment_detail, category: assessment_detail.category
-            ) %>
+        <% if (slug = assessment_detail.task_slug) %>
+          <%= govuk_link_to "Edit", task_path(@planning_application, slug: slug, return_to: planning_application_review_tasks_path(@planning_application, anchor: "#{assessment_detail.category}_section")) %>
+        <% end %>
       <% end %>
 
       <% section.with_footer(id: "#{assessment_detail.category}_footer") do %>

--- a/app/views/planning_applications/review/tasks/_review_conditions.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_conditions.html.erb
@@ -31,7 +31,7 @@
         <%= render(
               PlanningApplications::ImmunityDetailsAssessmentComponent.new(planning_application: @planning_application, evidence_groups: @planning_application.immunity_detail.evidence_groups)
             ) %>
-        <%= govuk_link_to "Edit", edit_planning_application_assessment_immunity_detail_path(@planning_application, @planning_application.immunity_detail) %>
+        <%= govuk_link_to "Edit", task_path(slug: "check-and-assess/assess-immunity/evidence-of-immunity", return_to: planning_application_review_tasks_path(@planning_application, anchor: "review-conditions-section")) %>
       <% end %>
 
       <% section.with_footer(id: "review-immunity-details-form") do %>

--- a/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-immunity/assess-immunity/show.html.erb
@@ -28,6 +28,7 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
 
   <%= form.govuk_radio_buttons_fieldset(:immunity, legend: {text: t("planning_applications.assessment.assess_immunity_detail_permitted_development_rights.form.immunity_legend"), size: "m"}) do %>
     <%= form.govuk_radio_button(:immunity, true, label: {text: "Yes, the development is immune"}) do %>

--- a/app/views/tasks/check-and-assess/assess-immunity/evidence-of-immunity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assess-immunity/evidence-of-immunity/show.html.erb
@@ -19,6 +19,7 @@
         ) %>
 
     <% unless @planning_application.determined? || @form.read_only? %>
+      <%= return_to_hidden_field %>
       <div class="govuk-button-group">
         <button type="submit" class="govuk-button" name="task_action" value="save_and_complete" form="immunity-detail-evidence-groups" data-module="govuk-button">
           Save and mark as complete

--- a/app/views/tasks/check-and-assess/assessment-summaries/amenity/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/amenity/show.html.erb
@@ -13,6 +13,7 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
 
   <%= form.govuk_text_area(:entry, value: @form.assessment_detail.entry, rows: 10, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>
     <p><%= t(".guidance") %></p>

--- a/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/other-considerations/show.html.erb
@@ -11,6 +11,7 @@
   <%= render(ReviewerCommentComponent.new(comment: @form.rejected_assessment_detail&.comment)) %>
 
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
 
   <%= form.govuk_text_area(:entry, value: @form.assessment_detail.entry, label: nil, rows: 10) %>
 

--- a/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/site-description/show.html.erb
@@ -8,6 +8,8 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
+
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>
 
     <% if @planning_application.publishable? %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-consultation/show.html.erb
@@ -31,6 +31,8 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
+
   <%= form.govuk_text_area(:entry, rows: 10, value: @form.assessment_detail.entry, label: {text: t(".heading"), tag: "h2", size: "m"}) do %>
 
     <% if @planning_application.publishable? %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-neighbour-responses/show.html.erb
@@ -8,6 +8,7 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
 
   <% NeighbourResponse::TAGS.select { |tag| @form.neighbour_responses.any? { |r| r.tags.include?(tag.to_s) } }.each do |tag| %>
     <%= govuk_accordion(html_attributes: {id: "neighbour-response-accordion-#{tag}"}) do |accordion| %>

--- a/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
+++ b/app/views/tasks/check-and-assess/assessment-summaries/summary-of-works/show.html.erb
@@ -46,6 +46,7 @@
 
 <%= form_with model: @form, url: @form.url do |form| %>
   <%= form.govuk_error_summary %>
+  <%= return_to_hidden_field %>
 
   <%= form.govuk_text_area(:entry, value: @form.assessment_detail.entry, label: nil, rows: 10) %>
 

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/press-notice/show.html.erb
@@ -36,6 +36,7 @@
     <%= render "tasks/consultees-neighbours-and-publicity/publicity/press-notice/table", press_notice: press_notice, index: index %>
   <% end %>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group" id="press-notice-form-actions">
       <%= render "task_submit_buttons", form: form, save_draft: false %>
       <%= govuk_button_link_to "Add another press notice", @form.new_press_notice_url, secondary: true, class: "govuk-!-margin-left-3" %>
@@ -45,6 +46,7 @@
 <% elsif @form.press_notices.where.not(id: nil).empty? %>
   <p class="govuk-body govuk-!-margin-top-4"> No press notices have been created for this application</p>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group" id="press-notice-form-actions">
       <%= govuk_button_link_to "Create press notice", @form.new_press_notice_url %>
       <%= form.govuk_task_button "Mark as not required", action: "mark_not_required", secondary: true %>
@@ -55,6 +57,7 @@
     Press notices are not required for this application
   </div>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group" id="press-notice-form-actions">
       <%= govuk_button_link_to "Create press notice", @form.new_press_notice_url %>
     </div>

--- a/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/show.html.erb
+++ b/app/views/tasks/consultees-neighbours-and-publicity/publicity/site-notice/show.html.erb
@@ -47,6 +47,7 @@
       <%= render "tasks/consultees-neighbours-and-publicity/publicity/site-notice/table", site_notice: site_notice, index: index %>
   <% end %>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group">
       <%= render "task_submit_buttons", form: form, save_draft: false %>
       <%= govuk_button_link_to "Add another site notice", @form.new_site_notice_url, secondary: true, class: "govuk-!-margin-left-3" %>
@@ -55,6 +56,7 @@
 <% elsif @form.site_notices.where.not(id: nil).empty? %>
   <p class="govuk-body govuk-!-margin-top-4"> No site notices have been created for this application</p>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group" id="site-notice-form-actions">
       <%= govuk_button_link_to "Create site notice", @form.new_site_notice_url %>
       <%= form.govuk_task_button "Mark as not required", action: "mark_not_required", secondary: true %>
@@ -65,6 +67,7 @@
     Site notices are not required for this application
   </div>
   <%= form_with model: @form, url: @form.url do |form| %>
+    <%= return_to_hidden_field %>
     <div class="govuk-button-group" id="site-notice-form-actions">
       <%= govuk_button_link_to "Create site notice", @form.new_site_notice_url %>
       <%= form.govuk_task_button "Mark as not required", action: "mark_not_required", secondary: true %>

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -350,7 +350,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
         visit "/planning_applications/#{planning_application.reference}/review/tasks"
       end
 
-      it "summary of neighbour responses" do
+      it "summary of neighbour responses", capubara: true do
         task = planning_application.case_record.find_task_by_slug_path!("check-and-assess/assessment-summaries/summary-of-neighbour-responses")
         task.start!
 
@@ -364,7 +364,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_content("neighbour summary")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{neighbour_summary.id}/edit?category=neighbour_summary"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/summary-of-neighbour-responses", return_to: planning_application_review_tasks_path(planning_application, anchor: "neighbour_summary_section"))
             )
           end
         end
@@ -495,7 +495,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_content("summary of works assessment")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{summary_of_work.id}/edit?category=summary_of_work"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/summary-of-works", return_to: planning_application_review_tasks_path(planning_application, anchor: "summary_of_work_section"))
             )
           end
         end
@@ -623,7 +623,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_link("View site on Google Maps (opens in new tab)")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{site_description.id}/edit?category=site_description"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/site-description", return_to: planning_application_review_tasks_path(planning_application, anchor: "site_description_section"))
             )
           end
         end
@@ -757,7 +757,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_content("consultation summary")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{consultation_summary.id}/edit?category=consultation_summary"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/summary-of-consultation", return_to: planning_application_review_tasks_path(planning_application, anchor: "consultation_summary_section"))
             )
           end
         end
@@ -888,7 +888,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_content("additional evidence")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{additional_evidence.id}/edit?category=additional_evidence"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/other-considerations", return_to: planning_application_review_tasks_path(planning_application, anchor: "additional_evidence_section"))
             )
           end
         end
@@ -1020,7 +1020,7 @@ RSpec.describe "Reviewing assessment summaries", show_sidebar: false, type: :sys
             expect(page).to have_content("amenity")
             expect(page).to have_link(
               "Edit",
-              href: "/planning_applications/#{planning_application.reference}/assessment/assessment_details/#{amenity.id}/edit?category=amenity"
+              href: task_path(planning_application, "check-and-assess/assessment-summaries/amenity", return_to: planning_application_review_tasks_path(planning_application, anchor: "amenity_section"))
             )
           end
         end


### PR DESCRIPTION
### Description of change

Update all relevant links on review page to direct to new task pages.

### Story Link

https://trello.com/c/bnT4qafv/1971-update-links-in-review-step-to-direct-back-to-task-pages-rather-than-old-pages

