### PR TITLE
Update status for assess against legislation & policies

### DIFF
--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -139,7 +139,8 @@ module Tasks
     def save_and_complete
       super do
         planning_application_policy_classes.find_each do |policy_class|
-          policy_class.current_review.update!(status: :complete)
+          status = policy_class.current_review&.to_be_reviewed? ? "updated" : "complete"
+          policy_class.current_review.update!(status: status)
         end
       end
     end

--- a/app/forms/tasks/assess_against_policies_and_guidance_form.rb
+++ b/app/forms/tasks/assess_against_policies_and_guidance_form.rb
@@ -40,6 +40,13 @@ module Tasks
       consideration_for_edit.valid?(:assess) && consideration_for_edit.save
     end
 
+    def save_and_complete
+      super do
+        status = review&.to_be_reviewed? ? "updated" : "complete"
+        review&.update!(status: status)
+      end
+    end
+
     def add_consideration
       consideration_params = @params[:consideration]&.permit(
         :policy_area, :assessment, :conclusion,


### PR DESCRIPTION
### Description of change

Update assess against legislation and policies for LDCE to reflect 'Updated' status once assesor has made changes. Missed off earlier PR.

### Story Link

https://trello.com/c/r0xzB7Ha/1967-review-when-a-section-is-resubmitted-observed-with-assess-against-policy-and-guidance-then-reviewers-return-with-comments-radio#comment-6a04891130ed64f24fbe55d8