### PR TITLE
Resubmit failed submission

### DIFF
--- a/app/models/assessment_detail.rb
+++ b/app/models/assessment_detail.rb
@@ -107,7 +107,7 @@ class AssessmentDetail < ApplicationRecord
   end
 
   def task
-    planning_application.case_record.find_task_by_slug_path(task_slug)
+    @task ||= planning_application.case_record.find_task_by_slug_path(task_slug)
   end
 
   private

--- a/engines/bops_admin/app/views/bops_admin/submissions/show.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/submissions/show.html.erb
@@ -132,7 +132,7 @@
       <p>There is no case associated with this submission.</p>
     <% end %>
 
-    <% if @submission.submitted? %>
+    <% if @submission.submitted? || @submission.failed? %>
       <%= form_with model: @submission, url: submission_path(@submission), method: :patch do |form| %>
         <%= form.govuk_submit(t(".submit_button")) do %>
           <%= back_link %>

--- a/engines/bops_admin/spec/system/submissions_spec.rb
+++ b/engines/bops_admin/spec/system/submissions_spec.rb
@@ -264,6 +264,31 @@ RSpec.describe "Submissions", type: :system do
     end
   end
 
+  context "when a submission has failed processing" do
+    let!(:submission) { create(:submission, :failed, local_authority:) }
+
+    it "does not show the button or awaiting-review banner once the submission has started" do
+      submission.start!
+
+      visit "/admin/submissions/#{submission.id}"
+
+      expect(page).not_to have_button("Submit application")
+    end
+
+    it "lets the admin manually submit a failed submission" do
+      visit "/admin/submissions/#{submission.id}"
+
+      expect {
+        click_button "Submit application"
+      }.to have_enqueued_job(BopsSubmissions::SubmissionProcessorJob).with(submission)
+
+      expect(page).to have_current_path("/admin/submissions/#{submission.id}")
+      expect(page).to have_content("Application submitted")
+      expect(page).not_to have_button("Submit application")
+      expect(submission.reload.status).to eq("started")
+    end
+  end
+
   context "when adding a submission to BOPS manually" do
     let(:api_user) { create(:api_user, :planning_portal, local_authority:, paused: false) }
     let!(:submission) { create(:submission, :planning_portal, local_authority:, api_user:) }

--- a/engines/bops_admin/spec/system/submissions_spec.rb
+++ b/engines/bops_admin/spec/system/submissions_spec.rb
@@ -265,35 +265,11 @@ RSpec.describe "Submissions", type: :system do
   end
 
   context "when adding a submission to BOPS manually" do
-    let!(:submission) { create(:submission, :planning_portal, local_authority:) }
-
-    it "shows a Submit application button for a submitted planning portal submission and enqueues the processor job" do
-      visit "/admin/submissions/#{submission.id}"
-
-      expect(page).to have_content("Awaiting review")
-
-      expect {
-        click_button "Submit application"
-      }.to have_enqueued_job(BopsSubmissions::SubmissionProcessorJob).with(submission)
-
-      expect(page).to have_current_path("/admin/submissions/#{submission.id}")
-      expect(page).to have_content("Application submitted")
-      expect(page).not_to have_content("Awaiting review")
-      expect(page).not_to have_button("Submit application")
-      expect(submission.reload.status).to eq("started")
-    end
-
-    it "does not show the button or awaiting-review banner once the submission has started" do
-      submission.start!
-
-      visit "/admin/submissions/#{submission.id}"
-
-      expect(page).not_to have_button("Submit application")
-      expect(page).not_to have_content("Awaiting review")
-    end
+    let(:api_user) { create(:api_user, :planning_portal, local_authority:, paused: false) }
+    let!(:submission) { create(:submission, :planning_portal, local_authority:, api_user:) }
 
     context "when the LPA has a paused API token" do
-      let!(:paused_api_user) { create(:api_user, :planning_portal, local_authority:, paused: true) }
+      let(:api_user) { create(:api_user, :planning_portal, local_authority:, paused: true) }
 
       it "shows the paused-tokens banner on the index" do
         visit "/admin/submissions"
@@ -301,16 +277,28 @@ RSpec.describe "Submissions", type: :system do
         expect(page).to have_content("API tokens paused")
       end
 
-      it "lets the admin manually submit a submission held by the paused token" do
-        submission.update!(api_user: paused_api_user)
+      it "does not show the button or awaiting-review banner once the submission has started" do
+        submission.start!
 
         visit "/admin/submissions/#{submission.id}"
+
+        expect(page).not_to have_button("Submit application")
+        expect(page).not_to have_content("Awaiting review")
+      end
+
+      it "lets the admin manually submit a submission held by the paused token" do
+        visit "/admin/submissions/#{submission.id}"
+
+        expect(page).to have_content("Awaiting review")
 
         expect {
           click_button "Submit application"
         }.to have_enqueued_job(BopsSubmissions::SubmissionProcessorJob).with(submission)
 
+        expect(page).to have_current_path("/admin/submissions/#{submission.id}")
         expect(page).to have_content("Application submitted")
+        expect(page).not_to have_content("Awaiting review")
+        expect(page).not_to have_button("Submit application")
         expect(submission.reload.status).to eq("started")
       end
     end


### PR DESCRIPTION
### Description of change

Show the resubmit button for failed as well as paused submissions.

### Story Link

https://trello.com/c/ukP3BNwf/1916-able-to-re-submit-if-bops-fails-to-create-the-application-and-its-our-fault