### PR TITLE
Update error message assess against legislation

### DIFF
--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -17,6 +17,10 @@ module Tasks
       validates :classes, presence: {message: "Select classes from GPDO Schedule 2"}
     end
 
+    with_options on: :save_and_complete do
+      validate :all_policies_are_determined
+    end
+
     delegate :policy_classes, to: :policy_part
     delegate :planning_application_policy_classes, to: :planning_application
     delegate :planning_application_policy_sections, to: :planning_application
@@ -177,6 +181,13 @@ module Tasks
 
     def policy_part_numbers
       policy_parts.map(&:number)
+    end
+
+    def all_policies_are_determined
+      policies = planning_application_policy_sections
+      return if policies.none?(&:to_be_determined?)
+
+      errors.add(:base, "All policies must be assessed")
     end
   end
 end

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/_default.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/_default.html.erb
@@ -1,11 +1,7 @@
-<% if @planning_application.no_policy_classes_after_assessment? %>
-  <p>No policy classes were added.</p>
+<% if @planning_application.section_55_development? %>
+  <%= render "#{@form.partial_path}/assessment", form: form %>
 <% else %>
-  <% if @planning_application.section_55_development? %>
-    <%= render "#{@form.partial_path}/assessment", form: form %>
-  <% else %>
-    <p>Not required as application has been classed as not being development.</p>
-  <% end %>
+  <p>Not required as application has been classed as not being development.</p>
 <% end %>
 
 <%= render "task_submit_buttons", form: form %>


### PR DESCRIPTION
### Description of change

Update assess against legislation error message to ensure all assessment complete before save and complete.

### Story Link

https://trello.com/c/uzOdRlc2/1984-assess-against-legislation-error-message-does-not-identify-issue

### Screenshots
<img width="1134" height="652" alt="image" src="https://github.com/user-attachments/assets/848215f7-0218-420a-919c-164b97d9fd6d" />
