### PR TITLE
Fix User->PlanningApplication relationship

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,9 @@ class User < ApplicationRecord
   include EmailConfirmable
 
   has_many :case_records, dependent: :nullify
-  has_many :planning_applications, -> { kept }, through: :case_record, dependent: :nullify
+  has_many :planning_applications, -> { kept }, through: :case_records,
+    source: :caseable, source_type: "PlanningApplication",
+    dependent: :nullify
   has_many :audits, dependent: :nullify
   has_many :comments, dependent: :nullify
   belongs_to :local_authority, optional: true


### PR DESCRIPTION
Spotted this when generating an ERD. The `through:` parameter needed to be `case_records`, not singular `case_record`, to match the above `has_many`; but also, because `CaseRecord` doesn't have a `planning_application` relation specifically, it needed to be pointed at the `caseable` source with the correct `caseable_type` (cf. Submission, LocalAuthority.)