### PR TITLE
Only show validation requests that aren't pending

### DIFF
--- a/engines/bops_applicants/app/views/bops_applicants/validation_requests/_heads_of_terms_validation_requests.html.erb
+++ b/engines/bops_applicants/app/views/bops_applicants/validation_requests/_heads_of_terms_validation_requests.html.erb
@@ -5,17 +5,19 @@
     </h3>
     <ul class="govuk-task-list">
       <% @validation_requests[:heads_of_terms].each do |validation_request| %>
-        <li class="govuk-task-list__item govuk-task-list__item--with-link">
-          <div class="govuk-task-list__name-and-hint">
-            <% if validation_request.open? %>
-              <%= govuk_link_to validation_request.term_title, edit_heads_of_terms_validation_request_path(validation_request.id, access_control_params) %>
-            <% else %>
-              <%= govuk_link_to validation_request.term_title, heads_of_terms_validation_request_path(validation_request.id, access_control_params) %>
-            <% end %>
-          </div>
+        <% unless validation_request.pending? %>
+          <li class="govuk-task-list__item govuk-task-list__item--with-link">
+            <div class="govuk-task-list__name-and-hint">
+                <% if validation_request.open? %>
+                  <%= govuk_link_to validation_request.term_title, edit_heads_of_terms_validation_request_path(validation_request.id, access_control_params) %>
+                <% else %>
+                  <%= govuk_link_to validation_request.term_title, heads_of_terms_validation_request_path(validation_request.id, access_control_params) %>
+                <% end %>
+            </div>
 
-          <%= render "validation_request_status", validation_request: validation_request %>
-        </li>
+            <%= render "validation_request_status", validation_request: validation_request %>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </li>


### PR DESCRIPTION
### Description of change

Edit bops applicants view to only show heads of terms validation requests that aren't pending.

### Story Link

https://trello.com/c/MlZPUtyU/1983-heads-of-terms-are-shown-to-the-applicant-on-bops-applicant-before-they-have-been-sent-these-show-as-complete-and-the-link-provi
