### PR TITLE
Add br to permitted tags in rich text

### DIFF
--- a/engines/bops_core/config/initializers/action_text.rb
+++ b/engines/bops_core/config/initializers/action_text.rb
@@ -2,6 +2,6 @@
 
 ActiveSupport.on_load :action_text_content do
   ActionText::ContentHelper.allowed_tags = %w[
-    div h1 blockquote p ol ul li strong em sub sup b i u a figure figcaption img
+    div h1 blockquote p ol ul li strong em sub sup b br i u a figure figcaption img
   ]
 end


### PR DESCRIPTION
### Description of change

Add `br` as a permitted tag in rich text inputs. Without it single line breaks were not rendering correctly once the text field was saved. 

### Story Link

https://trello.com/c/wz6TTs8c/1988-pre-app-report-reformats-planning-considerations-text

