### PR TITLE
Fix cancel replacement document request link

### DIFF
--- a/app/helpers/validation_request_helper.rb
+++ b/app/helpers/validation_request_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ValidationRequestHelper
-  PREAPPS_TASK_SLUGS = {
+  TASK_SLUGS = {
     "FeeChangeValidationRequest" => "check-and-validate/check-application-details/check-fee",
     "DescriptionChangeValidationRequest" => "check-and-validate/check-application-details/check-description",
     "RedLineBoundaryChangeValidationRequest" => "check-and-validate/check-application-details/check-red-line-boundary",
@@ -40,7 +40,7 @@ module ValidationRequestHelper
   end
 
   def show_validation_request_url(application, request, return_to: nil)
-    if application.pre_application? && (task_slug = preapps_task_slug_for(request))
+    if application.pre_application? && (task_slug = task_slug_for(request))
       application.url_helpers.task_path(
         reference: application.reference,
         slug: task_slug,
@@ -53,8 +53,8 @@ module ValidationRequestHelper
     end
   end
 
-  def preapps_task_slug_for(request)
-    PREAPPS_TASK_SLUGS[request.type]
+  def task_slug_for(request)
+    TASK_SLUGS[request.type]
   end
 
   def show_additional_document_validation_request_url(application, request)

--- a/app/views/documents/_active_documents_table.html.erb
+++ b/app/views/documents/_active_documents_table.html.erb
@@ -30,8 +30,13 @@
                 <p class="govuk-!-margin-right-2 govuk-!-text-align-right">
                   <%= govuk_link_to "Edit", main_app.edit_planning_application_document_path(@planning_application, document, redirect_to: redirect_to) %><br>
                   <%= govuk_link_to "Archive", main_app.planning_application_document_archive_path(@planning_application, document, redirect_to: redirect_to) %><br>
-                  <% if document.replacement_document_validation_request %>
-                    <%= govuk_link_to "Cancel replacement request", show_validation_request_url(@planning_application, document.replacement_document_validation_request) %>
+                  <% if (replacement_request = document.replacement_document_validation_request) %>
+                    <%= govuk_link_to "Cancel replacement request",
+                          new_validation_request_cancellation_path(
+                            planning_application_reference: @planning_application.reference,
+                            validation_request_id: replacement_request.id,
+                            task_slug: task_slug_for(replacement_request)
+                          ) %>
                   <% else %>
                     <%= govuk_link_to "Request replacement", main_app.new_planning_application_validation_validation_request_path(planning_application_reference: @planning_application.reference, document: document, type: "replacement_document") %>
                   <% end %>

--- a/app/views/documents/_document_row_image.html.erb
+++ b/app/views/documents/_document_row_image.html.erb
@@ -11,8 +11,13 @@
       <%= govuk_link_to t(".archive"), planning_application_document_archive_path(planning_application, document) %>
     </p>
     <p>
-      <% if document.replacement_document_validation_request %>
-        <%= govuk_link_to "Cancel replacement request", show_validation_request_url(planning_application, document.replacement_document_validation_request) %>
+      <% if (replacement_request = document.replacement_document_validation_request) %>
+        <%= govuk_link_to "Cancel replacement request",
+              new_validation_request_cancellation_path(
+                planning_application_reference: planning_application.reference,
+                validation_request_id: replacement_request.id,
+                task_slug: task_slug_for(replacement_request)
+              ) %>
       <% else %>
         <%= govuk_link_to "Request replacement", new_planning_application_validation_validation_request_path(planning_application_reference: planning_application.reference, document: document, type: "replacement_document") %>
       <% end %>

--- a/engines/bops_preapps/spec/system/tasks/check_and_request_documents_spec.rb
+++ b/engines/bops_preapps/spec/system/tasks/check_and_request_documents_spec.rb
@@ -6,4 +6,43 @@ RSpec.describe "Check and request documents task", type: :system do
   let(:planning_application) { create(:planning_application, :pre_application, :not_started, local_authority:) }
 
   it_behaves_like "check and request documents task", :pre_application
+
+  describe "cancelling a replacement document request" do
+    let(:local_authority) { create(:local_authority, :default) }
+    let(:user) { create(:user, local_authority:) }
+    let(:task) { planning_application.case_record.find_task_by_slug_path!("check-and-validate/check-tag-and-confirm-documents/check-and-request-documents") }
+    let(:planning_application) { create(:planning_application, :pre_application, :invalidated, local_authority:) }
+    let!(:document) { create(:document, :with_tags, planning_application:) }
+    let!(:replacement_request) do
+      create(:replacement_document_validation_request, :open,
+        planning_application:,
+        old_document: document,
+        user:)
+    end
+
+    before do
+      sign_in(user)
+      visit "/planning_applications/#{planning_application.reference}/validation/tasks"
+    end
+
+    it "can cancel the replacement document request from the task page" do
+      within :sidebar do
+        click_link "Check and request documents"
+      end
+
+      within "#all" do
+        click_link "Cancel replacement request"
+      end
+
+      expect(page).to have_content("Cancel validation request")
+
+      expect {
+        fill_in "Explain to the applicant why this request is being cancelled", with: "No longer needed"
+        click_button "Confirm cancellation"
+      }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+      expect(page).to have_content("Document request successfully cancelled")
+      expect(replacement_request.reload).to be_cancelled
+    end
+  end
 end


### PR DESCRIPTION
### Description of change

Fix cancel replacement document request link for pre-applications

### Story Link

https://trello.com/c/v0XiCaIM/1987-unable-to-cancel-validation-request-for-pre-app-in-review-validation-requests-task

