### PR TITLE
Ensure textarea creates valid JSON

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -316,6 +316,10 @@ class Consultation < ApplicationRecord
     end_date >= Time.zone.today
   end
 
+  def polygon_geojson_before_type_cast
+    polygon_geojson.to_json
+  end
+
   def polygon_geojson=(value)
     if value.present?
       parsed = JSON.parse(value)

--- a/spec/models/consultation_spec.rb
+++ b/spec/models/consultation_spec.rb
@@ -275,6 +275,43 @@ RSpec.describe Consultation do
     end
   end
 
+  describe "#polygon_geojson_before_type_cast" do
+    let(:consultation) { create(:consultation) }
+
+    let(:valid_geojson) do
+      {
+        "type" => "FeatureCollection",
+        "features" => [
+          {
+            "type" => "Feature",
+            "properties" => {},
+            "geometry" => {
+              "type" => "Polygon",
+              "coordinates" => [
+                [
+                  [-0.07739927369747812, 51.501345554406896],
+                  [-0.0778893839394212, 51.501002280754676],
+                  [-0.07690508968054104, 51.50102474569704],
+                  [-0.07676672973966252, 51.50128963605792],
+                  [-0.07739927369747812, 51.501345554406896]
+                ]
+              ]
+            }
+          }
+        ]
+      }
+    end
+
+    it "returns a JSON string when the attribute holds a Hash" do
+      consultation.polygon_geojson = valid_geojson.to_json
+
+      result = consultation.polygon_geojson_before_type_cast
+
+      expect(result).to be_a(String)
+      expect(JSON.parse(result)).to eq(valid_geojson)
+    end
+  end
+
   describe "#polygon_search_and_boundary_geojson" do
     let!(:consultation) { create(:consultation, :with_polygon_search, planning_application:) }
 


### PR DESCRIPTION
### Description of change

On the old consultation flows adding neighbours uses `model: consultation`, where the `govuk_text_area` is pre-populating `consultation.polygon_geojson.to_s` resulting in a pre-filled Ruby literal, so even when a neighbour was added manually it was re-submitting this invalid geojson format resulting in a 500 error. 

An earlier PR #3003 removed the `polygon_geojson_before_type_cast` which acted as the guard for this behaviour. I have added it back in.

### Story Link

https://trello.com/c/T9Sjd6Ui/1992-500-error-when-manually-adding-addresses-observed-after-deleting-a-neighbour-with-a-failed-letter-send
