### PR TITLE
Add planning application discards to audit log

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -44,6 +44,7 @@ class Audit < ApplicationRecord
     started
     withdrawn
     closed
+    deleted
     heads_of_terms_validation_request_sent_post_validation
     heads_of_terms_validation_request_added
     heads_of_terms_validation_request_cancelled_post_validation

--- a/app/models/planning_application.rb
+++ b/app/models/planning_application.rb
@@ -227,6 +227,8 @@ class PlanningApplication < ApplicationRecord
   after_update :address_or_boundary_geojson_updated?
   after_update :update_consultation_status, if: :saved_change_to_consultation_required?
 
+  after_discard { audit!(activity_type: "deleted", audit_comment: "Deleted at #{deleted_at}") }
+
   accepts_nested_attributes_for :recommendations
   accepts_nested_attributes_for :documents, reject_if: proc { |attributes| attributes["file"].blank? }
   accepts_nested_attributes_for :constraints

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -673,6 +673,7 @@ en:
       consultee_response_uploaded: Consultee response uploaded
       consultees_reconsulted: Reconsultation emails sent
       created: Application created by %{args}
+      deleted: Application deleted
       description_change_validation_request_added: 'Added: description change request (description#%{args})'
       description_change_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (description#%{sequence})'

--- a/spec/system/planning_applications/withdraw_or_cancel_spec.rb
+++ b/spec/system/planning_applications/withdraw_or_cancel_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "Withdraw or cancel" do
       planning_application.reload
 
       expect(planning_application.deleted_at).not_to be_nil
+      expect(planning_application.audits.last.activity_type).to eq("deleted")
 
       expect {
         visit "/planning_applications/#{planning_application.reference}"


### PR DESCRIPTION
### Description of change

Record discards in the audit log for visibility.