### PR TITLE
Use local authority scope for planning applications

### DIFF
--- a/app/services/planning_applications_creation.rb
+++ b/app/services/planning_applications_creation.rb
@@ -65,7 +65,10 @@ class PlanningApplicationsCreation
   attr_reader(*ATTRIBUTES)
 
   def importer
-    pa = PlanningApplication.find_or_initialize_by(reference: reference)
+    pa = PlanningApplication.find_or_initialize_by(
+      local_authority: planning_application_attributes[:local_authority],
+      reference: reference
+    )
     pa.update!(case_record: CaseRecord.new(local_authority: planning_application_attributes[:local_authority]),
                **planning_application_attributes)
   rescue => e

--- a/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
+++ b/engines/bops_core/app/controllers/concerns/bops_core/tasks_controller.rb
@@ -57,9 +57,9 @@ module BopsCore
 
     def set_case_record
       @case_record = if params[:reference]
-        PlanningApplication.find_by(reference: params[:reference]).case_record
+        current_local_authority.planning_applications.find_by(reference: params[:reference]).case_record
       elsif params[:planning_application_reference]
-        PlanningApplication.find_by(reference: params[:planning_application_reference]).case_record
+        current_local_authority.planning_applications.find_by(reference: params[:planning_application_reference]).case_record
       else
         @current_local_authority.case_records.find(params[:case_id])
       end

--- a/engines/bops_preapps/app/controllers/bops_preapps/pre_applications_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/pre_applications_controller.rb
@@ -25,7 +25,7 @@ module BopsPreapps
     private
 
     def set_planning_application
-      @planning_application = PlanningApplication.find_by(reference: params[:id])
+      @planning_application = current_local_authority.planning_applications.find_by(reference: params[:id])
     end
 
     def set_case_record


### PR DESCRIPTION
### Description of change

Always use `current_local_authority.planning_applications` when looking up a reference, not `PlanningApplications`.

In particular when using `find_by(reference:)`, because references are not globally unique, and `find_by` will return the first if there is more than one (rather than treating it as an error).