### PR TITLE
Rubocop check for global queries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,11 @@ Style/NoFetchWithLiteralNilDefault:
 Style/UseGovukLinkHelper:
   Enable: true
 
+Safety/NoGlobalQueries:
+  Enable: true
+  Exclude:
+    - 'db/migrate/*'
+
 # We use the strong_migrations gem to catch any schema changes that might affect
 # performance but it can't see what change_table does so don't require its use.
 Rails/BulkChangeTable:

--- a/app/services/planning_applications_creation.rb
+++ b/app/services/planning_applications_creation.rb
@@ -65,12 +65,9 @@ class PlanningApplicationsCreation
   attr_reader(*ATTRIBUTES)
 
   def importer
-    pa = PlanningApplication.find_or_initialize_by(
-      local_authority: planning_application_attributes[:local_authority],
-      reference: reference
-    )
-    pa.update!(case_record: CaseRecord.new(local_authority: planning_application_attributes[:local_authority]),
-               **planning_application_attributes)
+    local_authority = planning_application_attributes[:local_authority]
+    pa = local_authority.planning_applications.find_or_initialize_by(reference: reference)
+    pa.update!(case_record: local_authority.case_records.new, **planning_application_attributes)
   rescue => e
     Rails.logger.debug { "[IMPORT ERROR] #{e.class}: #{e.message}" }
     Rails.logger.debug pa.errors.full_messages.join(", ") if pa

--- a/app/services/site_notices_creation.rb
+++ b/app/services/site_notices_creation.rb
@@ -9,7 +9,9 @@ class SiteNoticesCreation
     required
   ].freeze
 
-  def initialize(**params)
+  def initialize(local_authority:, **params)
+    @local_authority = local_authority
+
     ATTRIBUTES.each do |attribute|
       value = params[attribute]
       value = value.is_a?(String) ? value.strip : value
@@ -23,6 +25,7 @@ class SiteNoticesCreation
 
   private
 
+  attr_reader :local_authority
   attr_reader(*ATTRIBUTES)
 
   def importer
@@ -39,7 +42,7 @@ class SiteNoticesCreation
   end
 
   def find_index(reference)
-    PlanningApplication
+    local_authority.planning_applications
       .where("previous_references @> ARRAY[?]::varchar[]", reference)
       .pick(:id)
   end

--- a/app/services/users_creation.rb
+++ b/app/services/users_creation.rb
@@ -27,9 +27,10 @@ class UsersCreation
 
   def importer
     normalized_email = normalize_email(email)
-    return nil if User.exists?(email: normalized_email)
+    # A global check here because the user email must be unique across all local authorities.
+    return nil if User.exists?(email: normalized_email) # rubocop:disable Safety/NoGlobalQueries
 
-    user = User.new(**user_attributes.merge(email: normalized_email))
+    user = local_authority.users.new(**user_attributes.merge(email: normalized_email))
 
     user.skip_confirmation_notification! if user.deactivated_at.present?
 

--- a/config/initializers/appsignal.rb
+++ b/config/initializers/appsignal.rb
@@ -2,6 +2,6 @@
 
 # Set a gauge for the number of pending applications and trigger an alarm if > 0
 Appsignal::Probes.register(:pending_applications, -> {
-  pending_applications = PlanningApplication.kept.pending.where(created_at: 1.month.ago...5.minutes.ago)
+  pending_applications = PlanningApplication.kept.pending.where(created_at: 1.month.ago...5.minutes.ago) # rubocop:disable Safety/NoGlobalQueries
   Appsignal.set_gauge("pending_applications", pending_applications.count)
 })

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ LocalAuthority.find_each do |lpa|
   end
 end
 
-User.find_or_create_by!(role: "global_administrator") do |user|
+User.find_or_create_by!(role: "global_administrator") do |user| # rubocop:disable Safety/NoGlobalQueries
   user.role = "global_administrator"
   user.password = password[Rails.env]
   user.otp_required_for_login = false

--- a/engines/bops_admin/spec/system/tokens_spec.rb
+++ b/engines/bops_admin/spec/system/tokens_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "API Tokens", :capybara do
   let(:local_authority) { create(:local_authority, :default) }
   let(:user) { create(:user, :administrator, local_authority:) }
-  let(:last_token) { ApiUser.last }
+  let(:last_token) { local_authority.api_users.last }
 
   around do |example|
     travel_to("2024-10-22T10:30:00Z") { example.run }

--- a/engines/bops_admin/spec/system/users_spec.rb
+++ b/engines/bops_admin/spec/system/users_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Users" do
   let(:user) { create(:user, :administrator, local_authority:, name: "Carrie Taylor") }
   let(:last_email) { ActionMailer::Base.deliveries.last }
   let(:secure_password) { PasswordGenerator.call }
-  let(:last_user) { User.last }
+  let(:last_user) { local_authority.users.last }
   let(:last_user_reset_token) { last_user.send_reset_password_instructions }
 
   before do

--- a/engines/bops_api/spec/services/application/creation_service_spec.rb
+++ b/engines/bops_api/spec/services/application/creation_service_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
     end
 
     context "when successfully calling the service with params" do
-      let(:planning_application) { PlanningApplication.last }
+      let(:planning_application) { local_authority.planning_applications.last }
       let(:documents) { planning_application.documents }
       let(:planning_application_constraints) { planning_application.planning_application_constraints }
 
@@ -162,7 +162,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
           expect(OwnershipCertificate.last).to have_attributes(
             certificate_type: "b",
-            planning_application_id: PlanningApplication.last.id
+            planning_application_id: local_authority.planning_applications.last.id
           )
 
           expect(LandOwner.last).to have_attributes(
@@ -319,7 +319,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
 
           expect(OwnershipCertificate.last).to have_attributes(
             certificate_type: "a",
-            planning_application_id: PlanningApplication.last.id
+            planning_application_id: local_authority.planning_applications.last.id
           )
         end
 
@@ -411,7 +411,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
           expect(DocumentChecklist.last.document_checklist_items.length).to eq 8
 
           expect(DocumentChecklist.last).to have_attributes(
-            planning_application_id: PlanningApplication.last.id
+            planning_application_id: local_authority.planning_applications.last.id
           )
 
           expect(DocumentChecklist.last.document_checklist_items).to include(
@@ -465,7 +465,7 @@ RSpec.describe BopsApi::Application::CreationService, type: :service do
         it "creates neighbour boundary geojson" do
           create_planning_application
           perform_enqueued_jobs
-          expect(PlanningApplication.last.neighbour_boundary_geojson).not_to be nil
+          expect(local_authority.planning_applications.last.neighbour_boundary_geojson).not_to be_nil
         end
       end
 

--- a/engines/bops_api/spec/services/filters/alternative_reference_filter_spec.rb
+++ b/engines/bops_api/spec/services/filters/alternative_reference_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsApi::Filters::AlternativeReferenceFilter do
   let(:local_authority) { create(:local_authority) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   describe "#applicable?" do

--- a/engines/bops_api/spec/services/filters/application_status_filter_spec.rb
+++ b/engines/bops_api/spec/services/filters/application_status_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsApi::Filters::ApplicationStatusFilter do
   let(:local_authority) { create(:local_authority) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   describe "#applicable?" do

--- a/engines/bops_api/spec/services/filters/application_type_filter_spec.rb
+++ b/engines/bops_api/spec/services/filters/application_type_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsApi::Filters::ApplicationTypeFilter do
   let(:local_authority) { create(:local_authority) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   describe "#applicable?" do

--- a/engines/bops_api/spec/services/filters/council_decision_filter_spec.rb
+++ b/engines/bops_api/spec/services/filters/council_decision_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsApi::Filters::CouncilDecisionFilter do
   let(:local_authority) { create(:local_authority) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   describe "#applicable?" do

--- a/engines/bops_api/spec/services/filters/date_range_filter_spec.rb
+++ b/engines/bops_api/spec/services/filters/date_range_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsApi::Filters::DateRangeFilter do
   let(:local_authority) { create(:local_authority) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
 
   describe "#applicable?" do
     let(:filter) { described_class.new(:receivedAt) }

--- a/engines/bops_api/spec/services/sorting/sorter_spec.rb
+++ b/engines/bops_api/spec/services/sorting/sorter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe BopsApi::Sorting::Sorter do
   describe "#call" do
     context "with default fields" do
       let(:local_authority) { create(:local_authority) }
-      let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+      let(:scope) { local_authority.planning_applications }
       let(:sorter) { described_class.new }
 
       let!(:old_app) do

--- a/engines/bops_config/app/controllers/bops_config/local_authorities_controller.rb
+++ b/engines/bops_config/app/controllers/bops_config/local_authorities_controller.rb
@@ -67,7 +67,7 @@ module BopsConfig
     end
 
     def build_local_authority
-      api_user = ApiUser.find_by!(name: "bops-applicants")
+      api_user = ApiUser.find_by!(name: "bops-applicants") # rubocop:disable Safety/NoGlobalQueries
 
       @local_authority = LocalAuthority.new do |la|
         la.api_users.new(name: "bops-applicants", token: api_user.token, permissions: api_user.permissions)

--- a/engines/bops_config/spec/system/local_authorities_spec.rb
+++ b/engines/bops_config/spec/system/local_authorities_spec.rb
@@ -2,7 +2,7 @@
 
 require "bops_config_helper"
 
-RSpec.describe "Local Authorities", type: :system, capybara: true do
+RSpec.describe "Local Authorities", :capybara, type: :system do
   before do
     local_authority = create(:local_authority, :southwark)
     create(:api_user, :validation_requests_ro, name: "bops-applicants", local_authority:, token: "bops_letmeinpleasethisisabsolutelysecurereally_")
@@ -127,7 +127,7 @@ RSpec.describe "Local Authorities", type: :system, capybara: true do
 
     local_authority = LocalAuthority.find_by!(council_code: "COV")
     administrator = local_authority.users.first!
-    api_user = ApiUser.find_by!(local_authority:, name: "bops-applicants")
+    api_user = local_authority.api_users.find_by!(name: "bops-applicants")
 
     expect(local_authority).to have_attributes(
       short_name: "Coventry",

--- a/engines/bops_config/spec/system/local_authority_users_spec.rb
+++ b/engines/bops_config/spec/system/local_authority_users_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Local authority users", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
   let(:local_authority) { create(:local_authority, :default) }
   let(:last_email) { ActionMailer::Base.deliveries.last }
-  let(:last_user) { User.last }
+  let(:last_user) { local_authority.users.last }
 
   before do
     sign_in(user)

--- a/engines/bops_config/spec/system/users_spec.rb
+++ b/engines/bops_config/spec/system/users_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Users", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
   let(:last_email) { ActionMailer::Base.deliveries.last }
   let(:secure_password) { PasswordGenerator.call }
-  let(:last_user) { User.last }
+  let(:last_user) { User.last } # rubocop:disable Safety/NoGlobalQueries
   let(:last_user_reset_token) { last_user.send_reset_password_instructions }
 
   before do

--- a/engines/bops_core/spec/services/bops_core/filters/application_type_filter_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/application_type_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::ApplicationTypeFilter do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   let!(:application_type_ldc_proposed) { create(:application_type, :ldc_proposed, local_authority:) }

--- a/engines/bops_core/spec/services/bops_core/filters/status_filter_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/status_filter_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::StatusFilter do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   let!(:not_started_app) do

--- a/engines/bops_core/spec/services/bops_core/filters/text_search/address_search_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/text_search/address_search_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::TextSearch::AddressSearch do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
 
   let!(:matching_app) do
     create(:planning_application, local_authority:, address_1: "123 High Street", town: "London")

--- a/engines/bops_core/spec/services/bops_core/filters/text_search/cascading_search_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/text_search/cascading_search_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::TextSearch::CascadingSearch do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
   let(:filter) { described_class.new }
 
   let!(:app_with_reference) do

--- a/engines/bops_core/spec/services/bops_core/filters/text_search/description_search_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/text_search/description_search_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::TextSearch::DescriptionSearch do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
 
   let!(:chimney_application) do
     create(:planning_application, local_authority:, description: "Add a chimney stack to the roof")

--- a/engines/bops_core/spec/services/bops_core/filters/text_search/postcode_search_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/text_search/postcode_search_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::TextSearch::PostcodeSearch do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
 
   let!(:matching_app) do
     create(:planning_application, local_authority:, postcode: "SW1A 1AA")

--- a/engines/bops_core/spec/services/bops_core/filters/text_search/reference_search_spec.rb
+++ b/engines/bops_core/spec/services/bops_core/filters/text_search/reference_search_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe BopsCore::Filters::TextSearch::ReferenceSearch do
   let(:local_authority) { create(:local_authority, :default) }
-  let(:scope) { PlanningApplication.where(local_authority: local_authority) }
+  let(:scope) { local_authority.planning_applications }
 
   let!(:matching_app) do
     create(:planning_application, local_authority:)

--- a/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
+++ b/engines/bops_submissions/spec/jobs/submission_processor_job_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe BopsSubmissions::SubmissionProcessorJob, type: :job do
           described_class.perform_now(submission)
         }.not_to raise_error
 
-        pa = PlanningApplication.last
+        pa = submission.local_authority.planning_applications.last
         expect(pa).to be_present
         expect(pa.case_record.submission_id).to eq(submission.id)
         expect(pa.local_authority_id).to eq(submission.local_authority_id)

--- a/engines/bops_submissions/spec/services/application/planning_portal_creation_service_spec.rb
+++ b/engines/bops_submissions/spec/services/application/planning_portal_creation_service_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
 
       it "creates a new planning application with expected attributes" do
         expect { create_planning_application }.to change(PlanningApplication, :count).by(1)
-        pa = PlanningApplication.last
+        pa = local_authority.planning_applications.last
         expect(pa).to have_attributes(
           status: "not_started",
           description: "\nDH Test Description",
@@ -59,7 +59,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
 
       it "sets application_type to minor" do
         create_planning_application
-        pa = PlanningApplication.last
+        pa = local_authority.planning_applications.last
         expect(pa.application_type.code).to eq("pp.full.minor")
       end
     end
@@ -84,7 +84,7 @@ RSpec.describe BopsSubmissions::Application::PlanningPortalCreationService, type
 
       it "still creates a planning application, leaving missing values" do
         expect { create_planning_application }.to change(PlanningApplication, :count).by(1)
-        pa = PlanningApplication.last
+        pa = local_authority.planning_applications.last
 
         expect(pa.payment_amount).to eq(0.0)
         expect(pa.payment_reference).to be_nil

--- a/lib/bops/cop.rb
+++ b/lib/bops/cop.rb
@@ -5,6 +5,7 @@ module Bops
   end
 end
 
+require_relative "cop/safety/no_global_queries"
 require_relative "cop/style/have_current_path_literal"
 require_relative "cop/style/visit_literal"
 require_relative "cop/style/fetch_literal_nil"

--- a/lib/bops/cop/safety/no_global_queries.rb
+++ b/lib/bops/cop/safety/no_global_queries.rb
@@ -6,7 +6,7 @@ module Bops
       class NoGlobalQueries < RuboCop::Cop::Base
         def on_send(node)
           return unless node.receiver
-          return unless %w[PlanningApplication CaseRecord User ApiUser].include? node.receiver.source
+          return unless %w[PlanningApplication CaseRecord User ApiUser].include?(node.receiver.source) || node.receiver.source.match(/^(::)?(PlanningApplication|CaseRecord|User|ApiUser)\./)
           return unless %i[find_by find_by!
             find_or_create_by find_or_create_by!
             find_or_initialize_by

--- a/lib/bops/cop/safety/no_global_queries.rb
+++ b/lib/bops/cop/safety/no_global_queries.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Bops
+  module Cop
+    module Safety
+      class NoGlobalQueries < RuboCop::Cop::Base
+        def on_send(node)
+          return unless node.receiver
+          return unless node.receiver.source == "PlanningApplication"
+          return unless %i[find_by find_by!
+            find_or_create_by find_or_create_by!
+            find_or_initialize_by
+            find where count first last exists? any? all? none?].include? node.method_name
+
+          add_offense(node.loc.selector, message: "Do not use #{node.method_name} directly on #{node.receiver.source}: scope it to a local authority")
+        end
+      end
+    end
+  end
+end

--- a/lib/bops/cop/safety/no_global_queries.rb
+++ b/lib/bops/cop/safety/no_global_queries.rb
@@ -6,7 +6,7 @@ module Bops
       class NoGlobalQueries < RuboCop::Cop::Base
         def on_send(node)
           return unless node.receiver
-          return unless node.receiver.source == "PlanningApplication"
+          return unless %w[PlanningApplication CaseRecord].include? node.receiver.source
           return unless %i[find_by find_by!
             find_or_create_by find_or_create_by!
             find_or_initialize_by

--- a/lib/bops/cop/safety/no_global_queries.rb
+++ b/lib/bops/cop/safety/no_global_queries.rb
@@ -6,7 +6,7 @@ module Bops
       class NoGlobalQueries < RuboCop::Cop::Base
         def on_send(node)
           return unless node.receiver
-          return unless %w[PlanningApplication CaseRecord].include? node.receiver.source
+          return unless %w[PlanningApplication CaseRecord User ApiUser].include? node.receiver.source
           return unless %i[find_by find_by!
             find_or_create_by find_or_create_by!
             find_or_initialize_by

--- a/lib/tasks/task_model.rake
+++ b/lib/tasks/task_model.rake
@@ -63,10 +63,12 @@ namespace :task_model do
 
     # case records with top-level tasks (sections) but no subtasks
     # i.e. cases created before the tasks were fully defined.
+    # rubocop:disable Safety/NoGlobalQueries
     scope = CaseRecord.left_joins(tasks: :tasks)
       .where(tasks: {parent_type: "CaseRecord"}, tasks_tasks: {id: nil})
       .where.not(tasks: {section: "Review"}) # excluding review, because we expect it to have no subtasks
       .distinct
+    # rubocop:enable Safety/NoGlobalQueries
 
     scope.find_each do |case_record|
       next unless case_record.caseable_type == "PlanningApplication"

--- a/spec/jobs/import_site_notice_job_spec.rb
+++ b/spec/jobs/import_site_notice_job_spec.rb
@@ -3,10 +3,10 @@
 require "rails_helper"
 
 RSpec.describe ImportSiteHistoryJob do
-  let!(:local_authority) { create(:local_authority, :default) }
+  let!(:local_authority) { create(:local_authority) }
   let!(:case_record) { build(:case_record, local_authority:) }
   let!(:application_type) { create(:application_type, :planning_permission) }
-  let!(:planning_application) { create(:planning_application, local_authority: local_authority, case_record: case_record, application_type: application_type, previous_references: ["APP/2025/1234", "OLD/0001"]) }
+  let!(:planning_application) { create(:planning_application, local_authority:, case_record: case_record, application_type: application_type, previous_references: ["APP/2025/1234", "OLD/0001"]) }
   let!(:csv_path) { Rails.root.join("tmp/SiteNoticesBuckinghamshire.csv") }
 
   before do

--- a/spec/mailer/previews/planning_application_mailer_preview.rb
+++ b/spec/mailer/previews/planning_application_mailer_preview.rb
@@ -78,6 +78,6 @@ class PlanningApplicationMailerPreview < ActionMailer::Preview
   private
 
   def planning_application
-    @planning_application ||= PlanningApplication.last
+    @planning_application ||= PlanningApplication.last # rubocop:disable Safety/NoGlobalQueries
   end
 end

--- a/spec/mailer/previews/user_mailer_preview.rb
+++ b/spec/mailer/previews/user_mailer_preview.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Safety/NoGlobalQueries
 class UserMailerPreview < ActionMailer::Preview
   def update_notification_mail
     UserMailer.update_notification_mail(
@@ -12,3 +13,4 @@ class UserMailerPreview < ActionMailer::Preview
     UserMailer.otp_mail(User.last)
   end
 end
+# rubocop:enable Safety/NoGlobalQueries

--- a/spec/requests/api/oas3_spec.rb
+++ b/spec/requests/api/oas3_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "The Open API Specification document" do
   let!(:local_authority) { create(:local_authority, :default) }
   let!(:api_user) { create(:api_user, permissions: %w[validation_request:read planning_application:read], local_authority:) }
   let!(:application_type) { create(:application_type, :ldc_proposed) }
-  let(:result) { PlanningApplication.last }
+  let(:result) { local_authority.planning_applications.last }
 
   before do
     stub_planx_api_response_for("POLYGON ((-0.07716178894042969 51.50094238217541, -0.07645905017852783 51.50053497847238, -0.07615327835083008 51.50115276135022, -0.07716178894042969 51.50094238217541))").to_return(

--- a/spec/services/planning_applications_creation_spec.rb
+++ b/spec/services/planning_applications_creation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe PlanningApplicationsCreation do
         described_class.new(**params).perform
       }.to change(PlanningApplication, :count).by(1)
 
-      pa = PlanningApplication.find_by(uprn: "10000000001")
+      pa = local_authority.planning_applications.find_by(uprn: "10000000001")
       expect(pa).to have_attributes(
         address_1: "1 High Street",
         agent_first_name: "Alice",
@@ -153,7 +153,7 @@ RSpec.describe PlanningApplicationsCreation do
         described_class.new(**params).perform
       }.to change(PlanningApplication, :count).by(1)
 
-      pa = PlanningApplication.find_by(uprn: "10000000001")
+      pa = local_authority.planning_applications.find_by(uprn: "10000000001")
       expect(pa).to have_attributes(
         address_1: "1 High Street",
         agent_first_name: "Alice",

--- a/spec/services/site_notices_creation_spec.rb
+++ b/spec/services/site_notices_creation_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe SiteNoticesCreation do
       {
         reference: reference,
         displayed_at: Date.new(2025, 8, 1),
-        expiry_date: Date.new(2025, 8, 15)
+        expiry_date: Date.new(2025, 8, 15),
+        local_authority:
       }
     end
 
@@ -40,7 +41,8 @@ RSpec.describe SiteNoticesCreation do
       {
         reference: "APP/9999/0000",
         displayed_at: Date.new(2025, 8, 1),
-        expiry_date: Date.new(2025, 8, 15)
+        expiry_date: Date.new(2025, 8, 15),
+        local_authority:
       }
     end
 

--- a/spec/services/users_creation_spec.rb
+++ b/spec/services/users_creation_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UsersCreation do
         described_class.new(**params).perform
       }.to change(User, :count).by(1)
 
-      u = User.find_by(email: "alice.planner@example.com")
+      u = User.find_by(email: "alice.planner@example.com") # rubocop:disable Safety/NoGlobalQueries
       expect(u).to have_attributes(
         name: "Alice Planner",
         email: "alice.planner@example.com",
@@ -48,7 +48,7 @@ RSpec.describe UsersCreation do
         described_class.new(**params).perform
       }.to change(User, :count).by(1)
 
-      u = User.find_by(email: "bob.planner@example.com")
+      u = User.find_by(email: "bob.planner@example.com") # rubocop:disable Safety/NoGlobalQueries
       expect(u).to have_attributes(
         name: "Bob Planner",
         email: "bob.planner@example.com",

--- a/spec/system/planning_applications/index_spec.rb
+++ b/spec/system/planning_applications/index_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Planning Application index page", type: :system do
 
       context "when one gets marked as started" do
         before do
-          app = PlanningApplication.prior_approvals.not_started.last
+          app = local_authority.planning_applications.prior_approvals.not_started.last
           app.update!(validated_at: Time.zone.today)
           app.start
           app.save!

--- a/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
+++ b/spec/system/planning_applications/review/send_notifications_to_neighbours_of_committee_spec.rb
@@ -3,19 +3,19 @@
 require "rails_helper"
 
 RSpec.describe "Send notification to neighbours of committee" do
-  let!(:default_local_authority) { create(:local_authority, :default) }
+  let!(:local_authority) { create(:local_authority, :default) }
   let!(:reviewer) do
     create(:user,
       :reviewer,
-      local_authority: default_local_authority)
+      local_authority:)
   end
   let!(:assessor) do
     create(:user,
       :assessor,
-      local_authority: default_local_authority)
+      local_authority:)
   end
   let!(:planning_application) do
-    create(:planning_application, :planning_permission, :awaiting_determination, :with_recommendation, local_authority: default_local_authority, user: assessor)
+    create(:planning_application, :planning_permission, :awaiting_determination, :with_recommendation, local_authority:, user: assessor)
   end
 
   before do
@@ -28,7 +28,7 @@ RSpec.describe "Send notification to neighbours of committee" do
 
   context "when the assessor has not recommended the application go to committee" do
     it "does not show the option to send to committee" do
-      visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
+      visit "/planning_applications/#{local_authority.planning_applications.last.id}/review/tasks"
 
       expect(page).to have_content("Review and sign-off")
 
@@ -44,7 +44,7 @@ RSpec.describe "Send notification to neighbours of committee" do
     end
 
     it "does not show the option to send to committee" do
-      visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
+      visit "/planning_applications/#{local_authority.planning_applications.last.id}/review/tasks"
 
       expect(page).to have_content("Review and sign-off")
 
@@ -80,7 +80,7 @@ RSpec.describe "Send notification to neighbours of committee" do
     end
 
     it "can send notifications to neighbours who have commented" do
-      visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
+      visit "/planning_applications/#{local_authority.planning_applications.last.id}/review/tasks"
 
       click_link "Notify neighbours of committee meeting"
 
@@ -137,7 +137,7 @@ RSpec.describe "Send notification to neighbours of committee" do
     end
 
     it "shows errors" do
-      visit "/planning_applications/#{PlanningApplication.last.id}/review/tasks"
+      visit "/planning_applications/#{local_authority.planning_applications.last.id}/review/tasks"
 
       click_link "Notify neighbours of committee meeting"
 


### PR DESCRIPTION
### Description of change

Warn about 'global' queries for planning applications, i.e., `PlanningApplication.find_by` and similar, rather than `local_authority.planning_applications.find_by`.

Detect the kind of error fixed in #3087.

A couple of details: firstly, there are clearly some false positives. For example I haven't tried to distinguish when the code is manually scoped to the local authority, e.g., `.where(local_authority: local_authority)`. It's easier just to make sure we always use the scope and then consider `PlanningApplication.where` to be a code smell. (This also avoids potential issues with the `kept`/`discarded` scopes being ignored.)

Second, I haven't included an autocorrect. Writing one was more complicated than seemed justified for the small number of cases; most of them were handled by a global find-and-replace, and the remainder could be easily manually corrected.