### PR TITLE
Add local authority conditions

### DIFF
--- a/app/assets/stylesheets/components/_table.scss
+++ b/app/assets/stylesheets/components/_table.scss
@@ -2,6 +2,13 @@
   overflow-wrap: anywhere;
 }
 
+.line-clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 .redacted-document-table {
   .govuk-form-group {
     margin-bottom: 0;

--- a/app/controllers/conditions_controller.rb
+++ b/app/controllers/conditions_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ConditionsController < AuthenticationController
+  before_action :set_conditions
+
+  rescue_from Pagy::OverflowError do
+    redirect_to conditions_path
+  end
+
+  def index
+    respond_to do |format|
+      format.json
+    end
+  end
+
+  private
+
+  def set_conditions
+    @pagy, @conditions = pagy(current_local_authority.conditions.all_conditions(search_param), limit: 10)
+  end
+
+  def search_param
+    params.fetch(:q, "")
+  end
+end

--- a/app/forms/tasks/add_conditions_form.rb
+++ b/app/forms/tasks/add_conditions_form.rb
@@ -20,6 +20,7 @@ module Tasks
     attr_reader :condition_set, :conditions
 
     with_options on: %i[add_condition update_condition] do
+      validates :title, presence: {message: "Enter title"}
       validates :text, presence: {message: "Enter condition"}
       validates :reason, presence: {message: "Enter a reason for this condition"}
     end

--- a/app/javascript/controllers/condition_form_controller.js
+++ b/app/javascript/controllers/condition_form_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus"
+import Rails from "@rails/ujs"
+import accessibleAutocomplete from "accessible-autocomplete"
+
+export default class extends Controller {
+  static targets = ["container", "titleInput", "textInput", "reasonInput"]
+
+  connect() {
+    const inputId = this.titleInputTarget.id
+    const inputName = this.titleInputTarget.name
+    const inputValue = this.titleInputTarget.value
+
+    accessibleAutocomplete({
+      element: this.containerTarget,
+      id: inputId,
+      name: inputName,
+      defaultValue: inputValue,
+      displayMenu: "overlay",
+      showNoOptionsFound: false,
+      minLength: 3,
+      confirmOnBlur: false,
+      source: (query, populateResults) => {
+        this.source(query, populateResults)
+      },
+      templates: {
+        inputValue: (value) => {
+          return value?.title ? value.title : ""
+        },
+        suggestion: (value) => {
+          return value?.title ? value.title : ""
+        },
+      },
+      onConfirm: (value) => {
+        this.textInputTarget.value = value?.text ? value.text : ""
+        this.reasonInputTarget.value = value?.reason ? value.reason : ""
+      },
+    })
+
+    this.titleInputTarget.remove()
+  }
+
+  source(query, populateResults) {
+    Rails.ajax({
+      type: "GET",
+      url: "/conditions",
+      data: new URLSearchParams({ q: query }).toString(),
+      success: (data) => {
+        populateResults(data)
+      },
+      failure: (_event) => {
+        populateResults([])
+      },
+    })
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -32,6 +32,10 @@ import ConditionsController from "./conditions_controller.js"
 
 application.register("conditions", ConditionsController)
 
+import ConditionFormController from "./condition_form_controller.js"
+
+application.register("condition-form", ConditionFormController)
+
 import ConsiderationFormController from "./consideration_form_controller.js"
 
 application.register("consideration-form", ConsiderationFormController)

--- a/app/models/local_authority.rb
+++ b/app/models/local_authority.rb
@@ -10,6 +10,7 @@ class LocalAuthority < ApplicationRecord
     has_many :constraints
     has_many :contacts
     has_many :informatives
+    has_many :conditions
     has_many :policy_areas
     has_many :policy_guidances
     has_many :policy_references

--- a/app/models/local_authority/condition.rb
+++ b/app/models/local_authority/condition.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class LocalAuthority < ApplicationRecord
+  class Condition < ApplicationRecord
+    belongs_to :local_authority
+
+    validates :title, :text, presence: true
+
+    class << self
+      def all_conditions(query)
+        scope = order(:title)
+
+        if query.blank?
+          scope
+        else
+          scope.where(search_query, search_param(query))
+        end
+      end
+
+      private
+
+      delegate :quote_column_name, to: :connection
+
+      def search_query
+        "#{quoted_table_name}.#{quote_column_name("search")} @@ to_tsquery('simple', ?)"
+      end
+
+      def search_param(query)
+        query.to_s
+          .scan(/[-\w]{3,}/)
+          .map { |word| word.gsub(/^-/, "!") }
+          .map { |word| word.gsub(/-$/, "") }
+          .map { |word| word.gsub(/.+/, "\\0:*") }
+          .join(" & ")
+      end
+    end
+  end
+end

--- a/app/views/conditions/index.json.jbuilder
+++ b/app/views/conditions/index.json.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.array! @conditions do |condition|
+  json.title condition.title
+  json.text condition.text
+  json.reason condition.reason
+end

--- a/app/views/tasks/check-and-assess/complete-assessment/add-conditions/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/add-conditions/show.html.erb
@@ -34,16 +34,27 @@
 <%= govuk_details(summary_text: "Add condition",
       open: @form.conditions.empty?,
       classes: "govuk-details--borderless govuk-!-margin-top-6") do %>
-  <h3>Add a new condition</h3>
-  <%= form_with model: @form, url: @form.url, data: {controller: "reset-text"} do |form| %>
-    <%= form.govuk_error_summary %>
-    <%= form.govuk_text_field :title, label: {text: "Enter title"} %>
-    <%= form.govuk_text_area :text, label: {text: "Enter condition"}, data: {reset_text_target: "destination"} %>
-    <%= form.govuk_text_area :reason, label: {text: "Enter a reason for this condition"}, data: {reset_text_target: "destination"} %>
-    <div class="govuk-button-group">
-      <%= form.govuk_task_button "Add condition to list", action: "add_condition", secondary: true %>
-    </div>
-  <% end %>
+  <div data-controller="condition-form">
+    <h3>Add a new condition</h3>
+    <%= form_with model: @form, url: @form.url, data: {controller: "reset-text"} do |form| %>
+      <%= form.govuk_error_summary %>
+      <%= form.govuk_text_field :title,
+            label: {text: "Enter title"},
+            hint: {text: "Start typing to find an existing condition or create a new one"},
+            form_group: {data: {condition_form_target: "container"}},
+            data: {condition_form_target: "titleInput"} %>
+
+      <%= form.govuk_text_area :text,
+            label: {text: "Enter condition"},
+            data: {reset_text_target: "destination", condition_form_target: "textInput"} %>
+      <%= form.govuk_text_area :reason,
+            label: {text: "Enter a reason for this condition"},
+            data: {reset_text_target: "destination", condition_form_target: "reasonInput"} %>
+      <div class="govuk-button-group">
+        <%= form.govuk_task_button "Add condition to list", action: "add_condition", secondary: true %>
+      </div>
+    <% end %>
+  </div>
 <% end %>
 
 <%= form_with model: @form, url: @form.url do |form| %>

--- a/config/routes/bops.rb
+++ b/config/routes/bops.rb
@@ -56,6 +56,7 @@ local_authority_subdomain do
     get "/policy/guidance", to: "policy_guidances#index"
     get "/policy/references", to: "policy_references#index"
     get "/requirements", to: "requirements#index"
+    get "/conditions", to: "conditions#index"
   end
 
   resources :planning_applications, param: :reference, except: %i[destroy] do

--- a/db/migrate/20260526000000_create_local_authority_conditions.rb
+++ b/db/migrate/20260526000000_create_local_authority_conditions.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class CreateLocalAuthorityConditions < ActiveRecord::Migration[8.0]
+  def change
+    sql = <<~SQL.squish
+      to_tsvector('simple',
+        COALESCE(title, '') || ' ' ||
+        COALESCE(text, '') || ' ' ||
+        COALESCE(reason, '') || ' '
+      )
+    SQL
+
+    create_table :local_authority_conditions do |t|
+      t.references :local_authority
+      t.string :title
+      t.text :text
+      t.text :reason
+      t.boolean :standard, null: false, default: false
+      t.virtual :search, type: :tsvector, as: sql, stored: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_30_154433) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -648,6 +648,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_30_154433) do
     t.string "telephone_number"
     t.datetime "updated_at", null: false
     t.index ["subdomain"], name: "index_local_authorities_on_subdomain", unique: true
+  end
+
+  create_table "local_authority_conditions", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "local_authority_id"
+    t.text "reason"
+    t.virtual "search", type: :tsvector, as: "to_tsvector('simple'::regconfig, ((((((COALESCE(title, ''::character varying))::text || ' '::text) || COALESCE(text, ''::text)) || ' '::text) || COALESCE(reason, ''::text)) || ' '::text))", stored: true
+    t.boolean "standard", default: false, null: false
+    t.text "text"
+    t.string "title"
+    t.datetime "updated_at", null: false
+    t.index ["local_authority_id"], name: "ix_local_authority_conditions_on_local_authority_id"
   end
 
   create_table "local_authority_informatives", force: :cascade do |t|

--- a/engines/bops_admin/app/controllers/bops_admin/conditions_controller.rb
+++ b/engines/bops_admin/app/controllers/bops_admin/conditions_controller.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+module BopsAdmin
+  class ConditionsController < PolicyController
+    before_action :set_conditions, only: %i[index]
+    before_action :build_condition, only: %i[new create]
+    before_action :set_condition, only: %i[edit update destroy]
+
+    rescue_from Pagy::OverflowError do
+      redirect_to conditions_path
+    end
+
+    def index
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def new
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def edit
+      respond_to do |format|
+        format.html
+      end
+    end
+
+    def create
+      respond_to do |format|
+        if @condition.save
+          format.html do
+            redirect_to conditions_path, notice: t(".condition_successfully_created")
+          end
+        else
+          format.html { render :new }
+        end
+      end
+    end
+
+    def update
+      respond_to do |format|
+        if @condition.update(condition_params)
+          format.html do
+            redirect_to conditions_path, notice: t(".condition_successfully_updated")
+          end
+        else
+          format.html { render :edit }
+        end
+      end
+    end
+
+    def destroy
+      respond_to do |format|
+        if @condition.destroy
+          format.html do
+            redirect_to conditions_path, notice: t(".condition_successfully_destroyed")
+          end
+        else
+          format.html do
+            redirect_to conditions_path, alert: t(".condition_unsuccessfully_destroyed")
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_conditions
+      @pagy, @conditions = pagy(current_local_authority.conditions.all_conditions(search_param), limit: 10)
+    end
+
+    def search_param
+      params.fetch(:q, "")
+    end
+
+    def build_condition
+      @condition = current_local_authority.conditions.build(condition_params)
+    end
+
+    def set_condition
+      @condition = current_local_authority.conditions.find(params[:id])
+    end
+
+    def condition_params
+      if action_name == "new"
+        {}
+      else
+        params.require(:condition).permit(*condition_attributes)
+      end
+    end
+
+    def condition_attributes
+      %i[title text reason]
+    end
+  end
+end

--- a/engines/bops_admin/app/views/bops_admin/conditions/_form.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/conditions/_form.html.erb
@@ -1,0 +1,10 @@
+<%= form.govuk_error_summary %>
+<%= form.govuk_fieldset(legend: {text: nil}) do %>
+  <%= form.govuk_text_field :title, label: {text: t(".labels.title")} %>
+  <%= form.govuk_text_area :text, width: "one-half", rows: 10, label: {text: t(".labels.text")} %>
+  <%= form.govuk_text_area :reason, width: "one-half", rows: 10, label: {text: t(".labels.reason")} %>
+<% end %>
+
+<%= form.govuk_submit(t(".submit")) do %>
+<%= back_link %>
+<% end %>

--- a/engines/bops_admin/app/views/bops_admin/conditions/edit.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/conditions/edit.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title do %>
+  <%= t(".edit_condition") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Conditions", conditions_path %>
+
+<% content_for :title, t(".edit_condition") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "side_navigation", current: "conditions" %>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+    <h1>
+      <%= t(".edit_condition") %>
+    </h1>
+
+    <%= form_with model: @condition, url: condition_path(@condition), scope: :condition do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/conditions/index.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/conditions/index.html.erb
@@ -1,0 +1,66 @@
+<% content_for :page_title do %>
+  <%= t(".conditions") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+
+<% content_for :title, t(".conditions") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "side_navigation", current: "conditions" %>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+    <h1>
+      <%= t(".conditions") %>
+    </h1>
+
+    <%= form_with url: conditions_path, class: "govuk-!-margin-bottom-7", method: :get do |form| %>
+      <%= form.govuk_text_field :q, value: params[:q], width: "two-thirds", label: {text: t(".find_conditions"), hidden: true} %>
+      <%= form.govuk_submit t(".find_conditions") do %>
+        <%= govuk_link_to t(".add_condition"), new_condition_path, no_visited_state: true %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_table(id: "conditions") do |table| %>
+      <% table.with_head do |head| %>
+        <% head.with_row do |row| %>
+          <% row.with_cell(text: t("bops_admin.conditions.index.headings.title")) %>
+
+          <% row.with_cell(text: t("bops_admin.conditions.index.headings.text")) %>
+
+          <% row.with_cell(text: t("bops_admin.conditions.index.headings.reason")) %>
+
+          <% row.with_cell(text: t("bops_admin.conditions.index.headings.actions"), classes: %w[govuk-!-text-align-right]) %>
+        <% end %>
+      <% end %>
+
+      <% table.with_body do |body| %>
+        <% if @conditions.present? %>
+          <% @conditions.each do |condition| %>
+            <% body.with_row do |row| %>
+              <% row.with_cell(text: condition.title, header: true) %>
+              <% row.with_cell do %>
+                <span class="line-clamp-3"><%= condition.text %></span>
+              <% end %>
+              <% row.with_cell do %>
+                <span class="line-clamp-3"><%= condition.reason %></span>
+              <% end %>
+              <% row.with_cell(classes: %w[govuk-!-text-align-right govuk-!-text-wrap-nowrap]) do |cell| %>
+                <%= govuk_link_to t("bops_admin.conditions.index.actions.edit"), edit_condition_path(condition), no_visited_state: true, no_underline: true %>
+
+                <%= govuk_link_to t("bops_admin.conditions.index.actions.delete"), condition_path(condition), no_visited_state: true, no_underline: true, class: "govuk-!-margin-left-1", method: :delete, data: {confirm: t("bops_admin.conditions.index.are_you_sure")} %>
+              <% end %>
+            <% end %>
+          <% end %>
+        <% else %>
+          <% body.with_row do |row| %>
+            <% row.with_cell(text: t("bops_admin.conditions.index.no_conditions_found"), colspan: 4) %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
+    <%= govuk_pagination(pagy: @pagy) if @pagy.pages > 1 %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/conditions/new.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/conditions/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title do %>
+  <%= t(".add_condition") %> - <%= t("page_title") %>
+<% end %>
+
+<% add_parent_breadcrumb_link "Home", root_path %>
+<% add_parent_breadcrumb_link "Conditions", conditions_path %>
+
+<% content_for :title, t(".add_condition") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "side_navigation", current: "conditions" %>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+    <h1>
+      <%= t(".add_condition") %>
+    </h1>
+
+    <%= form_with model: @condition, url: conditions_path, scope: :condition do |form| %>
+      <%= render "form", form: form %>
+    <% end %>
+  </div>
+</div>

--- a/engines/bops_admin/app/views/bops_admin/policy/_side_navigation.html.erb
+++ b/engines/bops_admin/app/views/bops_admin/policy/_side_navigation.html.erb
@@ -16,4 +16,8 @@
   <% nav.with_section(title: "Requirements", index: 4) do |section| %>
     <% section.with_navigation_item(text: "Manage requirements", href: requirements_path, current: (current == "requirements")) %>
   <% end %>
+
+    <% nav.with_section(title: "Conditions", index: 5) do |section| %>
+    <% section.with_navigation_item(text: "Manage conditions", href: conditions_path, current: (current == "conditions")) %>
+  <% end %>
 <% end %>

--- a/engines/bops_admin/config/locales/en.yml
+++ b/engines/bops_admin/config/locales/en.yml
@@ -129,6 +129,38 @@ en:
         view_and_or_edit: View and/or edit
       update:
         success: Application profile successfully updated
+    conditions:
+      create:
+        condition_successfully_created: Condition successfully created
+      destroy:
+        condition_successfully_destroyed: Condition successfully deleted
+        condition_unsuccessfully_destroyed: Unable to delete condition - please contact support
+      edit:
+        edit_condition: Edit condition
+      form:
+        labels:
+          reason: Reason for condition
+          text: Condition
+          title: Title
+        submit: Submit
+      index:
+        actions:
+          delete: Delete
+          edit: Edit
+        add_condition: Add condition
+        are_you_sure: Are you sure you want to delete this condition?
+        conditions: Manage conditions
+        find_conditions: Find condition
+        headings:
+          actions: Actions
+          reason: Reason for condition
+          text: Condition
+          title: Title
+        no_conditions_found: No conditions found
+      new:
+        add_condition: Add a new condition
+      update:
+        condition_successfully_updated: Condition successfully updated
     constraints:
       create:
         successfully_created: Constraint successfully created

--- a/engines/bops_admin/config/routes.rb
+++ b/engines/bops_admin/config/routes.rb
@@ -31,6 +31,7 @@ BopsAdmin::Engine.routes.draw do
     resources :informatives
     resources :requirements
     resources :constraints
+    resources :conditions
   end
 
   scope "/policy" do

--- a/engines/bops_admin/spec/system/conditions_spec.rb
+++ b/engines/bops_admin/spec/system/conditions_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Conditions", capybara: true do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:user) { create(:user, :administrator, local_authority:) }
+
+  before do
+    sign_in(user)
+  end
+
+  it "paginates the conditions list" do
+    25.times { create(:local_authority_condition, local_authority:) }
+
+    visit "/admin/conditions"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+    expect(page).to have_selector("tbody tr", count: 10)
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "1")
+      expect(page).to have_no_link("Previous")
+      expect(page).to have_link("Next", href: "/admin/conditions?page=2")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/conditions?page=2")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "2")
+      expect(page).to have_link("Previous", href: "/admin/conditions?page=1")
+      expect(page).to have_link("Next", href: "/admin/conditions?page=3")
+    end
+
+    click_link("Next")
+    expect(page).to have_current_path("/admin/conditions?page=3")
+
+    within ".govuk-pagination" do
+      expect(page).to have_selector("ul li", count: 3)
+      expect(page).to have_selector(".govuk-pagination__item--current", text: "3")
+      expect(page).to have_link("Previous", href: "/admin/conditions?page=2")
+      expect(page).to have_no_link("Next")
+    end
+  end
+
+  it "allows searching for an condition" do
+    25.times { create(:local_authority_condition, local_authority:) }
+    condition = create(:local_authority_condition, local_authority:, title: "Standard condition 1", text: "Standard condition 1 needs applying", reason: "Condition applies to this application type")
+
+    visit "/admin/conditions"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+
+    fill_in "Find condition", with: "Standard condition 1"
+
+    click_button("Find condition")
+    expect(page).to have_selector("tbody tr", count: 1)
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Standard condition 1")
+      expect(page).to have_selector("td:nth-child(2)", text: "Standard condition 1 needs applying")
+      expect(page).to have_selector("td:nth-child(3)", text: "Condition applies to this application type")
+
+      within "td:nth-child(4)" do
+        expect(page).to have_link("Edit", href: "/admin/conditions/#{condition.to_param}/edit")
+        expect(page).to have_link("Delete", href: "/admin/conditions/#{condition.to_param}")
+      end
+    end
+  end
+
+  it "allows adding a condition" do
+    visit "/admin/conditions"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+
+    click_link("Add condition")
+    expect(page).to have_selector("h1", text: "Add a new condition")
+
+    click_button("Submit")
+    expect(page).to have_selector("h2", text: "There is a problem")
+    expect(page).to have_link("Enter Title", href: "#condition-title-field-error")
+    expect(page).to have_link("Enter Text", href: "#condition-text-field-error")
+
+    fill_in "Title", with: "Standard condition 1"
+    fill_in "Condition", with: "Standard condition 1 needs applying"
+    fill_in "Reason for condition", with: "Condition applies to this application type"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/conditions")
+    expect(page).to have_content("Condition successfully created")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Standard condition 1")
+      expect(page).to have_selector("td:nth-child(2)", text: "Standard condition 1 needs applying")
+      expect(page).to have_selector("td:nth-child(3)", text: "Condition applies to this application type")
+    end
+  end
+
+  it "allows editing an condition" do
+    create(:local_authority_condition, local_authority:, title: "Standard condition 1", text: "Standard condition 1 needs applying", reason: "Condition applies to this application type")
+    visit "/admin/conditions"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Standard condition 1")
+      expect(page).to have_selector("td:nth-child(2)", text: "Standard condition 1 needs applying")
+
+      click_link("Edit")
+    end
+
+    expect(page).to have_selector("h1", text: "Edit condition")
+
+    fill_in "Condition", with: "Condition 1 really needs adding"
+
+    click_button("Submit")
+    expect(page).to have_current_path("/admin/conditions")
+    expect(page).to have_content("Condition successfully updated")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Standard condition 1")
+      expect(page).to have_selector("td:nth-child(2)", text: "Condition 1 really needs adding")
+      expect(page).to have_selector("td:nth-child(3)", text: "Condition applies to this application type")
+    end
+  end
+
+  it "allows deleting an condition", :capybara do
+    create(:local_authority_condition, local_authority:, title: "Section 106", text: "Section 106 needs doing")
+
+    visit "/admin/conditions"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+
+    within "tbody tr:nth-child(1)" do
+      expect(page).to have_selector("th:nth-child(1)", text: "Section 106")
+
+      accept_confirm do
+        click_link("Delete")
+      end
+    end
+
+    expect(page).to have_content("Condition successfully deleted")
+    expect(page).to have_selector("tbody tr:nth-child(1)", text: "No conditions found")
+  end
+
+  it "redirects to the first page if the page parameter overflows" do
+    25.times { create(:local_authority_condition, local_authority:) }
+
+    visit "/admin/conditions?page=2"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+    expect(page).to have_current_path("/admin/conditions?page=2")
+
+    visit "/admin/conditions?page=4"
+    expect(page).to have_selector("h1", text: "Manage conditions")
+    expect(page).to have_current_path("/admin/conditions")
+  end
+end

--- a/spec/factories/local_authority_condition.rb
+++ b/spec/factories/local_authority_condition.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :local_authority_condition, class: "LocalAuthority::Condition" do
+    local_authority
+    title { Faker::Lorem.sentence }
+    text { Faker::Lorem.paragraph }
+    reason { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/system/tasks/add_conditions_spec.rb
+++ b/spec/system/tasks/add_conditions_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe "Add conditions task", type: :system do
     end
 
     toggle "Add condition"
+    fill_in "Enter title", with: "Custom title"
     fill_in "Enter condition", with: "New custom condition"
     fill_in "Enter a reason for this condition", with: "Custom reason"
     click_button "Add condition to list"


### PR DESCRIPTION
### Description of change

Add ability to set standard conditions per local authority in local admin. These are them shown as a drop-down when user starts typing in the 'Add conditions' task.

### Story Link

https://trello.com/c/KuFiEVQt/1945-local-admin-allow-standard-conditions-to-be-added

### Screenshots

<img width="1152" height="810" alt="image" src="https://github.com/user-attachments/assets/fb23b2d4-ecbc-4b3a-9e00-fba1a08d6b2e" />
