### PR TITLE
Only mark recommendation review as updated when the answer changed

### DIFF
--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -56,9 +56,10 @@ module Tasks
       decision.update!(reasons: updated_reasons, recommend:)
 
       if decision.current_review.comment.present?
-        # Being resubmitted in response to reviewer feedback
-        # Need to mark updated even if no change.
-        decision.current_review.updated!
+        # Being resubmitted in response to reviewer feedback.
+        # Only mark as updated if the assessor actually changed the answer —
+        # otherwise the existing "Awaiting changes" status carries through.
+        decision.current_review.updated! if decision_changed
       elsif decision.current_review.review_complete? && !decision_changed
         # Resubmitting assessment for other reasons; if no change to decision, mark as complete
         decision.create_review(review_status: :review_complete)

--- a/spec/system/planning_applications/review/review_committee_decision_spec.rb
+++ b/spec/system/planning_applications/review/review_committee_decision_spec.rb
@@ -136,6 +136,63 @@ RSpec.describe "Review committee decision", type: :system do
     end
   end
 
+  context "when resubmitting after the reviewer returned with comments" do
+    before do
+      planning_application.committee_decision.update!(
+        recommend: true,
+        reasons: ["The application is on council owned land"]
+      )
+
+      click_button "Recommendation to committee"
+      within("#recommendation_to_committee_section") do
+        within("#recommendation_to_committee_footer") do
+          choose "Return with comments"
+          fill_in "Add a comment", with: "Please reconsider"
+          click_button "Save and mark as complete"
+        end
+      end
+
+      click_link "Sign off recommendation"
+      choose "No (return the case for assessment)"
+      fill_in "Explain to the officer why the case is being returned", with: "Please reconsider"
+      click_button "Save and mark as complete"
+
+      click_link "Application"
+      click_link "Check and assess"
+      click_link "Make draft recommendation"
+    end
+
+    it "does not show 'Updated' when the assessor resubmits without changing the recommendation" do
+      # Do NOT change the answer — keep the existing recommend value
+      click_button "Save and mark as complete"
+
+      click_link "Review and submit recommendation"
+      click_button "Save and mark as complete"
+
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+      within("#recommendation_to_committee_section") do
+        expect(find(".govuk-tag")).not_to have_content("Updated")
+      end
+    end
+
+    it "shows 'Updated' when the assessor resubmits with a changed recommendation" do
+      within_fieldset("Does this planning application need to be decided by committee?") do
+        choose "No"
+      end
+      click_button "Save and mark as complete"
+
+      click_link "Review and submit recommendation"
+      click_button "Save and mark as complete"
+
+      visit "/planning_applications/#{planning_application.reference}/review/tasks"
+
+      within("#recommendation_to_committee_section") do
+        expect(find(".govuk-tag")).to have_content("Updated")
+      end
+    end
+  end
+
   context "when reviewing other aspects of assessment" do
     before do
       detail = planning_application.assessment_details.find_or_initialize_by(category: :summary_of_work)


### PR DESCRIPTION
### Description of change

Only mark recommendation review as updated when the answer changed

- Previously, once a reviewer had rejected with a comment, any subsequent assessor resubmit flipped the review to `:updated` even if nothing was changed. Gate the `updated!` call on `decision_changed` so the prior "Awaiting changes" state carries through unchanged resubmits.

### Story Link

https://trello.com/c/ru5T9Coy/1966-review-recommendation-to-committee-task-is-shown-as-updated-every-time-an-application-is-submitted-back-to-review-except-for-fir

