### PR TITLE
Fix incorrect state transition

### DIFF
--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -78,7 +78,7 @@ module Tasks
         planning_application.update!(decision: decision, public_comment: public_comment)
         save_recommendation(status: :assessment_complete)
         save_committee_decision unless recommend.nil?
-        planning_application.assess!
+        planning_application.assess! unless planning_application.to_be_reviewed?
       end
     end
 

--- a/app/models/concerns/planning_application_status.rb
+++ b/app/models/concerns/planning_application_status.rb
@@ -66,7 +66,8 @@ module PlanningApplicationStatus
       end
 
       event :assess do
-        transitions from: %i[in_assessment assessment_in_progress to_be_reviewed], to: :in_assessment,
+        transitions from: :to_be_reviewed, to: :to_be_reviewed
+        transitions from: %i[in_assessment assessment_in_progress], to: :in_assessment,
           guard: :decision_present?
       end
 
@@ -142,7 +143,7 @@ module PlanningApplicationStatus
       end
 
       event :submit do
-        transitions from: %i[in_assessment in_committee], to: :awaiting_determination,
+        transitions from: %i[in_assessment in_committee to_be_reviewed], to: :awaiting_determination,
           guards: %i[decision_present? no_open_post_validation_requests_excluding_time_extension?] do
           after { recommendation.update!(submitted: true) }
         end


### PR DESCRIPTION
### Description of change

Don't transition from to-be-reviewed to in-assessment when submitting a draft recommendation.

### Story Link

https://trello.com/c/QyiQ33YS/2000-re-submitting-recommendation-after-review-changes-planning-application-status-incorrectly