### PR TITLE
Avoid unnecessary use of `route_for`

### DIFF
--- a/app/forms/tasks/add_conditions_form.rb
+++ b/app/forms/tasks/add_conditions_form.rb
@@ -34,15 +34,15 @@ module Tasks
     end
 
     def condition_url
-      route_for(:task_component, planning_application, slug: task.full_slug, id: condition.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: condition.id)
     end
 
     def edit_condition_url(condition)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: condition.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: condition.id)
     end
 
     def remove_condition_url(condition)
-      route_for(:planning_application_assessment_condition, planning_application, condition, redirect_to: url, only_path: true)
+      planning_application_assessment_condition_path(planning_application, condition, redirect_to: url)
     end
 
     def failure_template

--- a/app/forms/tasks/add_informatives_form.rb
+++ b/app/forms/tasks/add_informatives_form.rb
@@ -28,15 +28,15 @@ module Tasks
     end
 
     def informative_url
-      route_for(:task_component, planning_application, slug: task.full_slug, id: informative.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: informative.id)
     end
 
     def edit_informative_url(informative)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: informative.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: informative.id)
     end
 
     def remove_informative_url(informative)
-      route_for(:planning_application_assessment_informatives_item, planning_application, informative, redirect_to: url, only_path: true)
+      planning_application_assessment_informatives_item_path(planning_application, informative, redirect_to: url)
     end
 
     private

--- a/app/forms/tasks/add_pre_commencement_conditions_form.rb
+++ b/app/forms/tasks/add_pre_commencement_conditions_form.rb
@@ -34,15 +34,15 @@ module Tasks
     end
 
     def condition_url
-      route_for(:task_component, planning_application, slug: task.full_slug, id: condition.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: condition.id)
     end
 
     def edit_condition_url(condition)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: condition.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: condition.id)
     end
 
     def remove_condition_url(condition)
-      route_for(:planning_application_assessment_pre_commencement_condition, planning_application, condition, redirect_to: url, only_path: true)
+      planning_application_assessment_pre_commencement_condition_path(planning_application, condition, redirect_to: url)
     end
 
     def cancel_condition_url(condition)

--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -82,15 +82,15 @@ module Tasks
     end
 
     def assessment_area_url(area = assessment_area)
-      route_for(:task_component, planning_application, slug: task.full_slug, id: area.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: area.id)
     end
 
     def edit_assessment_area_url(area)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: area.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: area.id)
     end
 
     def remove_assessment_area_url(area)
-      route_for(:planning_application_assessment_policy_areas_policy_class, planning_application, area, redirect_to: url, only_path: true)
+      planning_application_assessment_policy_areas_policy_class_path(planning_application, area, redirect_to: url)
     end
 
     def after_success

--- a/app/forms/tasks/check_ownership_certificate_form.rb
+++ b/app/forms/tasks/check_ownership_certificate_form.rb
@@ -37,17 +37,15 @@ module Tasks
     end
 
     def cancel_url
-      route_for(
-        :new_validation_request_cancellation,
+      new_validation_request_cancellation_path(
         planning_application_reference: planning_application.reference,
         validation_request_id: validation_request.id,
-        task_slug: task.full_slug,
-        only_path: true
+        task_slug: task.full_slug
       )
     end
 
     def edit_url
-      route_for(:edit_task, planning_application, task, validation_request_id: validation_request&.id, return_to: return_to, only_path: true)
+      edit_task_path(planning_application, task, validation_request_id: validation_request&.id, return_to: return_to)
     end
 
     def validation_requests

--- a/app/forms/tasks/press_notice_form.rb
+++ b/app/forms/tasks/press_notice_form.rb
@@ -42,15 +42,15 @@ module Tasks
     attr_reader :press_notice, :press_notices
 
     def new_press_notice_url
-      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true, return_to: return_to)
+      task_path(planning_application, slug: task.full_slug, new: true, return_to: return_to)
     end
 
     def press_notice_url
-      route_for(:task, planning_application, slug: task.full_slug, only_path: true, return_to: return_to)
+      task_path(planning_application, slug: task.full_slug, return_to: return_to)
     end
 
     def edit_press_notice_url(press_notice)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: press_notice.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: press_notice.id)
     end
 
     def confirmation_request_url(press_notice)

--- a/app/forms/tasks/view_neighbour_responses_form.rb
+++ b/app/forms/tasks/view_neighbour_responses_form.rb
@@ -51,15 +51,15 @@ module Tasks
     attr_reader :neighbour_response, :neighbour_responses, :consultation
 
     def new_neighbour_response_url
-      route_for(:task, planning_application, slug: task.full_slug, new: true, only_path: true)
+      task_path(planning_application, slug: task.full_slug, new: true)
     end
 
     def edit_neighbour_response_url(neighbour_response)
-      route_for(:edit_task_component, planning_application, slug: task.full_slug, id: neighbour_response.id, only_path: true)
+      edit_task_component_path(planning_application, slug: task.full_slug, id: neighbour_response.id)
     end
 
     def update_neighbour_response_url
-      route_for(:task_component, planning_application, slug: task.full_slug, id: neighbour_response.id, only_path: true)
+      task_component_path(planning_application, slug: task.full_slug, id: neighbour_response.id)
     end
 
     def failure_template

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -82,7 +82,7 @@ class Task < ApplicationRecord
   end
 
   def url(**args)
-    @url ||= case_record.url_helpers.task_path(case_record.caseable, self, **args)
+    case_record.url_helpers.task_path(case_record.caseable, self, **args)
   end
 
   private

--- a/engines/bops_core/app/forms/bops_core/tasks/add_and_assign_consultees_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/add_and_assign_consultees_form.rb
@@ -54,7 +54,7 @@ module BopsCore
       end
 
       def constraint_url(options = {})
-        route_for(:task_component, planning_application, slug: task.full_slug, id: constraint.id, **options.with_defaults(only_path: true))
+        task_component_path(planning_application, slug: task.full_slug, id: constraint.id, **options.with_defaults(only_path: true))
       end
 
       def remove_consultee_url(consultee)
@@ -64,9 +64,9 @@ module BopsCore
         }
 
         if editing_constraint?
-          route_for(:task_component, planning_application, slug: task.full_slug, id: constraint.id, **options.with_defaults(task_action: "remove_constraint_consultee", only_path: true))
+          task_component_path(planning_application, slug: task.full_slug, id: constraint.id, **options.with_defaults(task_action: "remove_constraint_consultee"))
         else
-          route_for(:task, planning_application, slug: task.full_slug, **options.with_defaults(task_action: "remove_consultee", only_path: true))
+          task_path(planning_application, slug: task.full_slug, **options.with_defaults(task_action: "remove_consultee"))
         end
       end
 

--- a/engines/bops_core/app/forms/bops_core/tasks/check_fee_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/check_fee_form.rb
@@ -42,16 +42,14 @@ module BopsCore
       end
 
       def edit_url
-        route_for(:edit_task, planning_application, task, validation_request_id: validation_request&.id, return_to: return_to, only_path: true)
+        edit_task_path(planning_application, task, validation_request_id: validation_request&.id, return_to: return_to)
       end
 
       def cancel_url
-        route_for(
-          :new_validation_request_cancellation,
+        new_validation_request_cancellation_path(
           reference_param_name => planning_application.reference,
           :validation_request_id => validation_request.id,
-          :task_slug => task.full_slug,
-          :only_path => true
+          :task_slug => task.full_slug
         )
       end
 

--- a/engines/bops_core/app/forms/bops_core/tasks/check_red_line_boundary_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/check_red_line_boundary_form.rb
@@ -55,8 +55,7 @@ module BopsCore
       end
 
       def cancel_url
-        route_for(
-          :new_validation_request_cancellation,
+        new_validation_request_cancellation_path(
           reference_param_name => planning_application.reference,
           :validation_request_id => validation_request.id,
           :task_slug => task.full_slug,

--- a/engines/bops_core/app/forms/bops_core/tasks/form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/form.rb
@@ -71,13 +71,11 @@ module BopsCore
       end
 
       def url(options = {})
-        route_for(:task, planning_application, task, **options.with_defaults(only_path: true))
+        task.url(**options)
       end
 
       def redirect_url(options = {})
-        return return_to if return_to.present?
-
-        route_for(:task, planning_application, task, **options.with_defaults(only_path: true))
+        return_to.presence || task.url(**options)
       end
 
       def permitted_fields(params)

--- a/engines/bops_core/app/forms/bops_core/tasks/site_visit_form.rb
+++ b/engines/bops_core/app/forms/bops_core/tasks/site_visit_form.rb
@@ -72,7 +72,7 @@ module BopsCore
       end
 
       def edit_url
-        route_for(:edit_task, planning_application, task, site_visit_id: planning_application.site_visits.find(site_visit_id), only_path: true)
+        edit_task_path(planning_application, task, site_visit_id: planning_application.site_visits.find(site_visit_id))
       end
 
       def failure_template

--- a/engines/bops_core/app/views/bops_core/tasks/site-visit/_show.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/site-visit/_show.html.erb
@@ -45,7 +45,7 @@
                 </p>
               <% end %>
             <td class="govuk-table__cell govuk-table__cell--numeric">
-              <%= govuk_link_to "Edit", @form.route_for(:edit_task, @planning_application, @task, site_visit_id: site_visit.id, only_path: true) %>
+              <%= govuk_link_to "Edit", edit_task_path(@planning_application, @task, site_visit_id: site_visit.id) %>
               <%= form.govuk_task_button "Remove", action: "remove_site_visit", class: "button-as-link" %>
             </td>
           </tr>

--- a/engines/bops_preapps/app/controllers/bops_preapps/assign_constraints_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/assign_constraints_controller.rb
@@ -7,10 +7,9 @@ module BopsPreapps
 
     def create
       if planning_application_constraint.update(assignment_params)
-        redirect_to route_for(:task, @planning_application, @task)
+        redirect_to @task.url
       else
-        redirect_to route_for(:task, @planning_application, @task),
-          alert: t(".failure")
+        redirect_to @task.url, alert: t(".failure")
       end
     end
 

--- a/engines/bops_preapps/app/controllers/bops_preapps/constraint_consultees_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/constraint_consultees_controller.rb
@@ -8,8 +8,7 @@ module BopsPreapps
     def destroy
       constraint_consultee.destroy!
 
-      redirect_to route_for(:task, @planning_application, @task),
-        notice: t(".success")
+      redirect_to @task.url, notice: t(".success")
     end
 
     private

--- a/engines/bops_preapps/app/controllers/bops_preapps/consultees_controller.rb
+++ b/engines/bops_preapps/app/controllers/bops_preapps/consultees_controller.rb
@@ -23,8 +23,7 @@ module BopsPreapps
 
     def create
       if @constraint.update(consultee_params)
-        redirect_to route_for(:task, @planning_application, @task),
-          notice: t(".success")
+        redirect_to @task.url, notice: t(".success")
       else
         @consultees = @consultation.consultees
         render :new, status: :unprocessable_content

--- a/engines/bops_preapps/app/views/bops_preapps/consultees/new.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/consultees/new.html.erb
@@ -18,6 +18,6 @@
 
   <div class="govuk-button-group">
     <%= form.submit "Assign consultees", class: "govuk-button", data: {module: "govuk-button"} %>
-    <%= govuk_button_link_to "Back", route_for(:task, @planning_application, @task), secondary: true %>
+    <%= govuk_button_link_to "Back", @task.url, secondary: true %>
   </div>
 <% end %>


### PR DESCRIPTION
### Description of change

`route_for` probably isn't needed if the first parameter is a literal symbol, since in that case there's an equivalent helper method (e.g. `route_for(:task, ...)` is the same as `task_url(...)` or `task_path(...)`).