### PR TITLE
Fix validations on make-draft-recommendation

### DIFF
--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -23,7 +23,7 @@ module Tasks
       self.other_reason = Array(committee_decision&.reasons).reject { |r| CommitteeDecision::REASONS.include?(r) }.first
     end
 
-    with_options on: :save_and_complete do
+    with_options on: %i[save_and_complete save_draft] do
       validates :recommend, inclusion: {in: [true, false], message: "Select whether the application needs to be decided by committee."}
       validates :reasons, presence: {message: "Explain why the application needs to be decided by committee"}, if: :committee_needed?
       validates :decision, presence: true

--- a/spec/system/tasks/make_draft_recommendation_spec.rb
+++ b/spec/system/tasks/make_draft_recommendation_spec.rb
@@ -117,13 +117,6 @@ RSpec.describe "Make draft recommendation task", type: :system do
       expect(planning_application.recommendations.last.status).to eq("assessment_in_progress")
       expect(task.reload).to be_in_progress
     end
-
-    it "does not show errors when no decision is given" do
-      click_button "Save changes"
-
-      expect(page).not_to have_content("Select whether the application needs to be decided by committee.")
-      expect(planning_application.reload.status).to eq("in_assessment")
-    end
   end
 
   context "when existing recommendation and committee decision data is present" do


### PR DESCRIPTION
### Description of change

"Make draft recommendations" was only running validations on save-and-complete, not save-draft; but since save-draft tries to save a recommendation record that requires those values, it was failing, but with an unhelpful error message.

If we want to be able to save a partial draft we'll need to change the schema to allow this.

### Story Link

https://trello.com/c/JcynuUZ2/1998-submitting-draft-recommendation-task-without-required-fields-leads-to-generic-error