### PR TITLE
Reset assessment tasks when returning a recommendation for assessment

### DIFF
--- a/app/controllers/planning_applications/review/recommendations_controller.rb
+++ b/app/controllers/planning_applications/review/recommendations_controller.rb
@@ -39,6 +39,8 @@ module PlanningApplications
         respond_to do |format|
           format.html do
             if @recommendation.save_and_review(recommendation_params)
+              reset_assessment_tasks! if return_to_officer?
+
               redirect_to after_save_and_review_location_url, notice: t(".success")
             else
               render :edit
@@ -91,6 +93,10 @@ module PlanningApplications
 
       def committee_overturned_status
         params[:recommendation][:challenged] == "committee_overturned"
+      end
+
+      def return_to_officer?
+        @recommendation.rejected? && !@recommendation.committee_overturned?
       end
 
       def after_save_and_review_location_url

--- a/app/forms/tasks/review_and_submit_recommendation_form.rb
+++ b/app/forms/tasks/review_and_submit_recommendation_form.rb
@@ -4,13 +4,28 @@ module Tasks
   class ReviewAndSubmitRecommendationForm < Form
     self.task_actions = %w[save_and_complete withdraw_recommendation]
 
+    def flash(type, controller)
+      result = case type
+      when :notice
+        "success"
+      when :alert
+        "failure"
+      end
+
+      if result == "failure" && open_post_validation_requests?
+        controller.t(
+          "planning_applications.recommendations.update.has_open_non_validation_requests_html",
+          href: controller.post_validation_requests_planning_application_validation_validation_requests_path(planning_application)
+        )
+      else
+        super
+      end
+    end
+
     private
 
     def save_and_complete
-      if planning_application.open_post_validation_requests?
-        errors.add :base, :invalid, message: "All post-validation requests must be resolved before submitting"
-        return false
-      end
+      return false if open_post_validation_requests?
 
       super do
         if planning_application.can_submit_recommendation?
@@ -19,6 +34,10 @@ module Tasks
       end
     rescue PlanningApplication::SubmitRecommendationError
       false
+    end
+
+    def open_post_validation_requests?
+      !planning_application.no_open_post_validation_requests_excluding_time_extension?
     end
 
     def withdraw_recommendation

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe "post validation requests", type: :system do
 
         click_button("Save and mark as complete")
 
-        pending "Error message incorrect"
         expect(page).to have_content(
           "This application has open non-validation requests."
         )

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         expect(page).to have_title("Planning Application")
       end
 
-      context "when there are open post validation requests", :pending do
+      context "when there are open post validation requests" do
         let(:planning_application) { create(:planning_application, :in_assessment, local_authority: default_local_authority, user: assessor) }
         let!(:red_line_boundary_change_validation_request) { create(:red_line_boundary_change_validation_request, :open, :post_validation, planning_application:) }
 
@@ -373,7 +373,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         end
       end
 
-      context "when there is an open time extension request", :pending do
+      context "when there is an open time extension request" do
         let(:planning_application) { create(:planning_application, :in_assessment, local_authority: default_local_authority, user: assessor) }
         let!(:time_extension_request) { create(:time_extension_validation_request, :open, planning_application:, post_validation: true) }
 

--- a/spec/system/tasks/return_for_assessment_spec.rb
+++ b/spec/system/tasks/return_for_assessment_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Returning a recommendation for assessment", type: :system do
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:assessor) { create(:user, :assessor, local_authority:) }
+  let(:reviewer) { create(:user, :reviewer, local_authority:) }
+  let(:planning_application) do
+    create(:planning_application, :planning_permission, :in_assessment, local_authority:,
+      decision: nil, public_comment: nil)
+  end
+
+  let(:make_draft_task) do
+    planning_application.case_record.find_task_by_slug_path!(
+      "check-and-assess/complete-assessment/make-draft-recommendation"
+    )
+  end
+
+  let(:submit_task) do
+    planning_application.case_record.find_task_by_slug_path!(
+      "check-and-assess/complete-assessment/review-and-submit-recommendation"
+    )
+  end
+
+  before do
+    create(:decision, :householder_granted)
+    create(:decision, :householder_refused)
+  end
+
+  it "resets the assessment task statuses and keeps the case 'to be reviewed'" do
+    sign_in assessor
+    visit "/planning_applications/#{planning_application.reference}"
+    click_link "Check and assess"
+
+    within :sidebar do
+      click_link "Make draft recommendation"
+    end
+    within_fieldset("Does this planning application need to be decided by committee?") do
+      choose "No"
+    end
+    within_fieldset("What is your recommendation?") do
+      choose "Granted"
+    end
+    fill_in "State the reasons for your recommendation.", with: "Meets policy requirements."
+    click_button "Save and mark as complete"
+
+    within :sidebar do
+      click_link "Review and submit recommendation"
+    end
+    click_button "Save and mark as complete"
+
+    expect(planning_application.reload).to be_awaiting_determination
+    expect(make_draft_task.reload).to be_completed
+    expect(submit_task.reload).to be_completed
+
+    switch_user(reviewer)
+    visit "/planning_applications/#{planning_application.reference}/review/tasks"
+    click_link "Sign off recommendation"
+    choose "No (return the case for assessment)"
+    fill_in "Explain to the officer why the case is being returned", with: "Please revise"
+    click_button "Save and mark as complete"
+
+    expect(planning_application.reload).to be_to_be_reviewed
+    expect(make_draft_task.reload).to be_action_required
+    expect(submit_task.reload).to be_action_required
+
+    switch_user(assessor)
+    visit "/planning_applications/#{planning_application.reference}"
+    click_link "Check and assess"
+
+    within :sidebar do
+      expect(page).to have_selector(:action_required_sidebar_task, "Make draft recommendation")
+      expect(page).to have_selector(:action_required_sidebar_task, "Review and submit recommendation")
+    end
+
+    within :sidebar do
+      click_link "Make draft recommendation"
+    end
+    within_fieldset("Does this planning application need to be decided by committee?") do
+      choose "No"
+    end
+    within_fieldset("What is your recommendation?") do
+      choose "Granted"
+    end
+    fill_in "State the reasons for your recommendation.", with: "Meets policy requirements."
+    click_button "Save and mark as complete"
+
+    expect(planning_application.reload).to be_to_be_reviewed
+
+    within :sidebar do
+      click_link "Review and submit recommendation"
+    end
+    click_button "Save and mark as complete"
+
+    expect(planning_application.reload).to be_awaiting_determination
+    expect(submit_task.reload).to be_completed
+  end
+end

--- a/spec/system/tasks/review_and_submit_recommendations_spec.rb
+++ b/spec/system/tasks/review_and_submit_recommendations_spec.rb
@@ -108,7 +108,11 @@ RSpec.describe "Review and submit recommendation task", type: :system do
 
     it "displays an error message" do
       click_button "Save and mark as complete"
-      expect(page).to have_content("All post-validation requests must be resolved before submitting")
+
+      within(".govuk-notification-banner--alert") do
+        expect(page).to have_content("This application has open non-validation requests. Please review open requests and resolve them before submitting the application for review.")
+        expect(page).to have_link("review open requests", href: post_validation_requests_planning_application_validation_validation_requests_path(planning_application))
+      end
     end
   end
 end


### PR DESCRIPTION
### Description of change

Reset assessment tasks when returning a recommendation for assessment

When a reviewer rejected a recommendation on sign-off, the application correctly moved back to `to_be_reviewed`, but the "Make draft recommendation" and "Review and submit recommendation" tasks stayed `completed`, so the assessor saw no action-required prompt in the sidebar.

Every other review controller calls `reset_assessment_tasks!` on rejection; the sign-off `RecommendationsController#update` did not. Add the same call, guarded by `return_to_officer?` (rejected and not committee-overturned), to mirror when `Recommendation#review!` triggers `request_correction!`.

Adds a system spec covering the full return-for-assessment flow.

### Story Link

https://trello.com/c/xVetW0Gn/2002-submitting-recommendation-doesnt-give-clear-error-when-there-are-open-validation-requests
https://trello.com/c/wfjiymqd/1999-returning-recommendation-from-review-fails-to-reset-the-task-statuses-intermittently

