### PR TITLE
Show 'add other consultees' link even once some have been added

### DIFF
--- a/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_default.html.erb
+++ b/engines/bops_core/app/views/bops_core/tasks/consultees/add-and-assign-consultees/_default.html.erb
@@ -83,11 +83,11 @@
         <% end %>
       <% end %>
     <% end %>
-  <% else %>
-    <p>
-      <%= form.govuk_task_button_link "Add other consultees", action: "edit_consultees" %>
-    </p>
   <% end %>
+
+  <p>
+    <%= form.govuk_task_button_link "Add other consultees", action: "edit_consultees" %>
+  </p>
 
   <%= govuk_section_break(size: "m") %>
 


### PR DESCRIPTION
### Description of change

User may want to add some more.

### Story Link

https://trello.com/c/9ren1vec/2008-once-you-click-add-new-consultees-through-the-link-below-the-table-the-link-disappeared-once-consultees-have-been-added-but-offi