### PR TITLE
Add print to PDF button on applicant pre-app report

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -1,7 +1,8 @@
 @media print {
   .bops-headers,
   .govuk-notification-banner,
-  .govuk-footer {
+  .govuk-footer,
+  .print-hide {
     display: none;
   }
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -92,6 +92,10 @@ import PolygonSearchController from "./polygon_search_controller.js"
 
 application.register("polygon-search", PolygonSearchController)
 
+import PrintController from "./print_controller.js"
+
+application.register("print", PrintController)
+
 import ResetTextController from "./reset_text_controller.js"
 
 application.register("reset-text", ResetTextController)

--- a/app/javascript/controllers/print_controller.js
+++ b/app/javascript/controllers/print_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  print(event) {
+    event.preventDefault()
+    window.print()
+  }
+}

--- a/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
+++ b/engines/bops_reports/app/views/bops_reports/planning_applications/show.html.erb
@@ -51,6 +51,11 @@
         Date of report: <strong><%= @planning_application.determined_at.to_date.to_fs %></strong><br>
       <% end %>
     </p>
+    <% if applicant_view? %>
+      <%= govuk_button "Print or save as PDF",
+            class: "govuk-button--secondary print-hide",
+            data: {controller: "print", action: "print#print"} %>
+    <% end %>
   </div>
 </div>
 

--- a/engines/bops_reports/spec/system/pre_application_report_spec.rb
+++ b/engines/bops_reports/spec/system/pre_application_report_spec.rb
@@ -109,6 +109,13 @@ RSpec.describe "Pre-application report" do
     end
   end
 
+  it "does not show the print option on the officer view" do
+    within("#planning-application-details") do
+      expect(page).to have_no_button("Print or save as PDF")
+      expect(page).to have_no_link("Print or save as PDF")
+    end
+  end
+
   it "displays the summary of advice outcome section" do
     within("#pre-application-outcome") do
       expect(page).to have_content("Pre-application outcome")
@@ -577,6 +584,8 @@ RSpec.describe "Pre-application report" do
         expect(page).not_to have_link("Edit")
         expect(page).not_to have_css("govuk-breadcrumbs")
         expect(page).not_to have_content("Preview and submit")
+
+        expect(page).to have_button("Print or save as PDF")
       end
     end
 


### PR DESCRIPTION
### Description of change

Add print/save as PDF button to applicant pre-app report

Applicant view of the pre-application report now has a "Print or save
as PDF" button that opens the browser print dialog via a small Stimulus
controller. Button is hidden from the printed output and only shown on
the applicant view.


### Story Link

https://trello.com/c/L8IfbUfu/1471-pre-app-pdf-report

