### PR TITLE
Fix missing validation request audits

### DIFF
--- a/app/models/audit.rb
+++ b/app/models/audit.rb
@@ -86,6 +86,7 @@ class Audit < ApplicationRecord
     ownership_certificate_validation_request_sent
     ownership_certificate_validation_request_cancelled
     ownership_certificate_validation_request_sent_post_validation
+    ownership_certificate_validation_request_cancelled_post_validation
     validation_requests_sent
     additional_document_validation_request_cancelled
     additional_document_validation_request_cancelled_post_validation
@@ -106,6 +107,12 @@ class Audit < ApplicationRecord
     time_extension_validation_request_cancelled
     time_extension_validation_request_cancelled_post_validation
     time_extension_validation_request_sent
+    fee_change_validation_request_cancelled_post_validation
+    heads_of_terms_validation_request_cancelled
+    heads_of_terms_validation_request_sent
+    other_change_validation_request_cancelled_post_validation
+    pre_commencement_condition_validation_request_cancelled
+    pre_commencement_condition_validation_request_sent
     constraints_checked
     neighbour_letters_sent
     neighbour_letter_copy_mail_sent

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -688,12 +688,15 @@ en:
       document_received_at_changed: "%{args} received at date was modified"
       fee_change_validation_request_added: 'Added: validation request (fee validation#%{args})'
       fee_change_validation_request_cancelled: 'Cancelled: validation request (fee change from applicant#%{args})'
+      fee_change_validation_request_cancelled_post_validation: 'Cancelled: validation request (fee change from applicant#%{args})'
       fee_change_validation_request_received: 'Received: request for change (fee validation#%{args})'
       fee_change_validation_request_sent: 'Sent: validation request (fee validation#%{args})'
       fee_change_validation_request_sent_post_validation: 'Sent: Post-validation request (fee validation#%{args})'
       heads_of_terms_validation_request_added: 'Added: request (heads of terms#%{args})'
+      heads_of_terms_validation_request_cancelled: 'Cancelled: request (heads of terms#%{args})'
       heads_of_terms_validation_request_cancelled_post_validation: 'Cancelled: request (heads of terms#%{args})'
       heads_of_terms_validation_request_received: 'Received: validation request for heads of terms #%{args}'
+      heads_of_terms_validation_request_sent: 'Sent: request (heads of terms#%{args})'
       heads_of_terms_validation_request_sent_post_validation: 'Sent: request (heads of terms#%{args})'
       invalidated: Application invalidated
       legislation_checked: Legislative requirements checked
@@ -705,11 +708,13 @@ en:
         assigned: Application unassigned
       other_change_validation_request_added: 'Added: validation request (other validation#%{args})'
       other_change_validation_request_cancelled: 'Cancelled: validation request (other change from applicant#%{args})'
+      other_change_validation_request_cancelled_post_validation: 'Cancelled: validation request (other change from applicant#%{args})'
       other_change_validation_request_received: 'Received: request for change (other validation#%{args})'
       other_change_validation_request_sent: 'Sent: validation request (other validation#%{args})'
       other_change_validation_request_sent_post_validation: 'Sent: Post-validation request (other validation#%{args})'
       ownership_certificate_validation_request_added: 'Added: validation request (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_cancelled: 'Cancelled: validation request (ownership certificate validation#%{args})'
+      ownership_certificate_validation_request_cancelled_post_validation: 'Cancelled: validation request (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_received: 'Received: request for change (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_sent: 'Sent: request for change (ownership certificate validation#%{args})'
       ownership_certificate_validation_request_sent_post_validation: 'Sent: request for change (ownership certificate validation#%{args})'
@@ -717,8 +722,10 @@ en:
       pre_commencement_condition_validation_request_added: 'Added: validation request for pre-commencement condition #%{args}'
       pre_commencement_condition_validation_request_auto_closed:
         auto_closed_validation: 'Auto-closed: validation request (pre-commencement condition)'
+      pre_commencement_condition_validation_request_cancelled: 'Cancelled: validation request (pre-commencement condition validation#%{args})'
       pre_commencement_condition_validation_request_cancelled_post_validation: 'Cancelled: validation request (pre-commencement condition validation#%{args})'
       pre_commencement_condition_validation_request_received: 'Received: validation request for pre-commencement condition #%{args}'
+      pre_commencement_condition_validation_request_sent: 'Sent: pre-commencement conditions for applicant''s approval (#%{args})'
       pre_commencement_condition_validation_request_sent_post_validation: 'Sent: pre-commencement conditions for applicant''s approval (#%{args})'
       press_notice: Press notice response added
       press_notice_mail: Request made for press notice


### PR DESCRIPTION
Add missing audit types

Specifically `ownership_certificate_validation_request_cancelled_post_validation` showed up as missing. However, from an inspection of the `ValidationRequest` model, it seems like any of the validation request types can potentially show up with any of the events `added`, `sent`, and `cancelled`, plus `sent_post_validation` and `cancelled_post_validation`; so I've added all of those.

It may be that some of them will never occur in practice but it seems safer to make sure they all exist, unless we actively prevent certain combinations from being generated.

[Showed up](https://appsignal.com/southwark-bops/sites/63efadfcd2a5e42c27a8518c/exceptions/incidents/1347/samples/timestamp/2026-06-03T14:41:13Z) when UATing #3080 but I don't think it's introduced by that; it seems left over from adding ownership certificates.

https://trello.com/c/JFCointV/1823-remove-the-old-assessment-controllers-once-sidebar-is-enabled-in-production