### PR TITLE
Able to edit or delete assessment comments LDC

### DIFF
--- a/app/forms/tasks/assess_against_legislation_form.rb
+++ b/app/forms/tasks/assess_against_legislation_form.rb
@@ -2,11 +2,13 @@
 
 module Tasks
   class AssessAgainstLegislationForm < Form
-    self.task_actions = %w[default save_draft save_and_complete add_part add_classes add_assessment_area update_assessment]
+    self.task_actions = %w[default save_draft save_and_complete add_part add_classes add_assessment_area update_assessment remove_comment edit_comment]
 
     attribute :part, :integer
     attribute :classes, :array, type: :integer, default: -> { [] }
     attribute :sections
+    attribute :comment_id, :integer
+    attribute :comment_text, :string
 
     with_options on: :add_classes do
       validates :part, presence: {message: "Select a part number from GPDO Schedule 2"}
@@ -19,6 +21,10 @@ module Tasks
 
     with_options on: :save_and_complete do
       validate :all_policies_are_determined
+    end
+
+    with_options on: :edit_comment do
+      validates :comment_text, presence: {message: "Enter a comment"}
     end
 
     delegate :policy_classes, to: :policy_part
@@ -95,7 +101,7 @@ module Tasks
 
     def after_success
       case action
-      when "add_assessment_area", "save_draft", "save_and_complete"
+      when "add_assessment_area", "save_draft", "save_and_complete", "remove_comment", "edit_comment"
         "redirect"
       when "remove_assessment_area", "update_assessment"
         "redirect"
@@ -113,6 +119,29 @@ module Tasks
       end
     end
 
+    def redirect_url
+      case action
+      when "remove_comment", "edit_comment"
+        edit_assessment_area_url(assessment_area)
+      else
+        super
+      end
+    end
+
+    def comment
+      return if comment_id.blank?
+
+      @comment ||= Comment.where(commentable: planning_application_policy_sections).find(comment_id)
+    end
+
+    def edit_comment
+      comment.update!(text: comment_text)
+    end
+
+    def remove_comment
+      comment.destroy!
+    end
+
     private
 
     def permitted_attributes
@@ -123,6 +152,10 @@ module Tasks
         [:part, classes: []]
       when "update_assessment"
         [sections: [:id, :status, comments_attributes: [:text]]]
+      when "edit_comment"
+        [:comment_id, :comment_text]
+      when "remove_comment"
+        [:comment_id]
       else
         []
       end

--- a/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
+++ b/app/views/tasks/check-and-assess/assess-against-legislation/assess-against-legislation/edit.html.erb
@@ -4,6 +4,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <% @form.grouped_policy_sections.each do |_title, sections| %>
+      <% sections.each do |section| %>
+        <% if (comment = section.last_comment) %>
+          <%= form_with url: @form.assessment_area_url, method: :patch, id: "remove-comment-form-#{comment.id}", scope: @form.param_key do |f| %>
+            <%= hidden_field_tag :task_action, "remove_comment" %>
+            <%= f.hidden_field :comment_id, value: comment.id %>
+          <% end %>
+          <%= form_with url: @form.assessment_area_url, method: :patch, id: "edit-comment-form-#{comment.id}", scope: @form.param_key do |f| %>
+            <%= hidden_field_tag :task_action, "edit_comment" %>
+            <%= f.hidden_field :comment_id, value: comment.id %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+
     <%= form_with model: @form, url: @form.assessment_area_url do |form| %>
       <%= form.govuk_error_summary %>
 
@@ -44,9 +59,23 @@
 
               <% if comment = section.last_comment %>
                 <%= govuk_inset_text(classes: "govuk-!-margin-top-3") do %>
-                  <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
+                  <div data-controller="show-hide">
+                    <div class="govuk-!-margin-bottom-0" data-show-hide-target="toggleable">
+                      <%= simple_format(comment.text, class: "govuk-!-margin-bottom-1") %>
+                      <button type="button" data-action="click->show-hide#handleEvent" class="button-as-link govuk-!-font-size-16 govuk-!-margin-bottom-0">Edit</button>
+                      <button type="submit" form="remove-comment-form-<%= comment.id %>" class="button-as-link govuk-!-font-size-16 govuk-!-margin-bottom-0">Remove</button>
+                    </div>
+                    <div class="govuk-!-display-none govuk-!-margin-bottom-0" data-show-hide-target="toggleable">
+                      <div class="govuk-form-group">
+                        <%= label_tag "comment_text_#{comment.id}", "Edit comment", class: "govuk-label" %>
+                        <%= text_area_tag "#{@form.param_key}[comment_text]", comment.text, id: "comment_text_#{comment.id}", class: "govuk-textarea", rows: 3, form: "edit-comment-form-#{comment.id}" %>
+                      </div>
+                      <button type="submit" form="edit-comment-form-<%= comment.id %>" class="govuk-button govuk-!-margin-bottom-2">Save</button>
+                      <button type="button" data-action="click->show-hide#handleEvent" class="button-as-link govuk-!-font-size-16 govuk-!-margin-bottom-0">Cancel</button>
+                    </div>
+                  </div>
 
-                  <p class="govuk-body-s">
+                  <p class="govuk-body-s govuk-!-margin-top-1">
                     <strong><%= comment.user&.name %>, <%= comment.created_at.to_fs %></strong>
                   </p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2920,7 +2920,9 @@ en:
         success: Amenity assessment was successfully saved
       assess-against-legislation:
         add_assessment_area: Policy class was successfully added
+        edit_comment: Comment successfully updated
         failure: Failed to save assessment against legislation
+        remove_comment: Comment successfully removed
         success: Assessment against legislation successfully saved
         update_assessment: Assessment for policy class successfully saved
       assess-against-policies-and-guidance:

--- a/spec/system/tasks/assess_against_legislation_spec.rb
+++ b/spec/system/tasks/assess_against_legislation_spec.rb
@@ -54,6 +54,84 @@ RSpec.describe "Assess against legislation", type: :system do
       expect(page).to have_content("Not required as application has been classed as not being development")
     end
 
+    context "when editing or removing an existing comment" do
+      let!(:policy_class_record) { create(:planning_application_policy_class, policy_class: policy_classB, planning_application:) }
+      let!(:policy_section_with_comment) { create(:planning_application_policy_section, :with_comments, policy_section: policy_sectionB1b, planning_application:) }
+
+      before do
+        visit "/planning_applications/#{reference}/#{slug}/#{policy_class_record.id}/edit"
+      end
+
+      it "can edit an existing comment", :js do
+        expect(page).to have_content("A comment")
+
+        click_button "Edit"
+        fill_in "Edit comment", with: "Updated comment text"
+        click_button "Save"
+
+        expect(page).to have_content("Comment successfully updated")
+        expect(page).to have_content("Updated comment text")
+        expect(page).not_to have_content("A comment")
+      end
+
+      it "can remove an existing comment", :js do
+        expect(page).to have_content("A comment")
+
+        click_button "Remove"
+
+        expect(page).to have_content("Comment successfully removed")
+        expect(page).not_to have_content("A comment")
+      end
+    end
+
+    context "when multiple sections have comments" do
+      let!(:policy_sectionB2b) { create(:policy_section, section: "2b", description: "description for section B.2b", policy_class: policy_classB) }
+      let!(:policy_class_record) { create(:planning_application_policy_class, policy_class: policy_classB, planning_application:) }
+      let!(:first_section) do
+        section = create(:planning_application_policy_section, policy_section: policy_sectionB1b, planning_application:)
+        create(:comment, text: "First comment", commentable: section, user: assessor)
+        section
+      end
+      let!(:second_section) do
+        section = create(:planning_application_policy_section, policy_section: policy_sectionB2b, planning_application:)
+        create(:comment, text: "Second comment", commentable: section, user: assessor)
+        section
+      end
+
+      before do
+        visit "/planning_applications/#{reference}/#{slug}/#{policy_class_record.id}/edit"
+      end
+
+      it "can edit the first comment without affecting the second", :js do
+        expect(page).to have_content("First comment")
+        expect(page).to have_content("Second comment")
+
+        within(first(".govuk-inset-text")) do
+          click_button "Edit"
+          fill_in "Edit comment", with: "Updated first comment"
+          click_button "Save"
+        end
+
+        expect(page).to have_content("Comment successfully updated")
+        expect(page).to have_content("Updated first comment")
+        expect(page).not_to have_content("First comment")
+        expect(page).to have_content("Second comment")
+      end
+
+      it "can remove the first comment without affecting the second", :js do
+        expect(page).to have_content("First comment")
+        expect(page).to have_content("Second comment")
+
+        within(first(".govuk-inset-text")) do
+          click_button "Remove"
+        end
+
+        expect(page).to have_content("Comment successfully removed")
+        expect(page).not_to have_content("First comment")
+        expect(page).to have_content("Second comment")
+      end
+    end
+
     it "policy classes can be added, removed and assessed" do
       expect(task.reload).not_to be_completed
 


### PR DESCRIPTION
### Description of change

Able to edit and delete comments on assess against legislation for LDCs.
As we are already inside an edit page I have used a JS show/hide approach for a text field and implemented a mini form within the iteration to ensure the correct comment is updated.

### Story Link

https://trello.com/c/UhzU6lgb/1913-allow-editing-deletion-of-saved-comments-on-assessment-against-legislation-for-ldc

