### PR TITLE
Update error message for failures add conditions

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2892,12 +2892,16 @@ en:
           success: Successfully removed all neighbour addresses
         success: Addresses have been successfully added
       add-conditions:
-        add_condition: Condition was successfully added
+        add_condition:
+          failure: Unable to add condition
+          success: Condition was successfully added
         delete_condition: Condition was successfully deleted
         failure: Failed to save conditions
         save_draft: Conditions draft was saved
         success: Conditions were successfully saved
-        update_condition: Condition was successfully updated
+        update_condition:
+          failure: Unable to update condition
+          success: Condition was successfully updated
       add-heads-of-terms:
         add_term:
           failure: Failed to add term


### PR DESCRIPTION
### Description of change

Edit error messages for failed methods on add conditions form

### Story Link

https://trello.com/c/wsNxKgR0/2009-non-sensical-error-message-when-adding-a-condition
### Screenshots

<img width="1134" height="226" alt="image" src="https://github.com/user-attachments/assets/bb687241-2569-4658-a478-5a5a4216f870" />
