### PR TITLE
Enable sidebar in production for everything

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -121,5 +121,5 @@ Rails.application.configure do
   # nb. only used in staging: production will override
   config.applicants_base_url = "bops-applicants-staging.services"
 
-  config.use_new_sidebar_layout = (Bops.env.staging? || %i[pre_application])
+  config.use_new_sidebar_layout = true
 end


### PR DESCRIPTION
### Description of change

While in some places (e.g. tasks) the sidebar is unconditional, others only display it when specifically enabled (in staging or for preapps); this changes that to be enabled for everything in production.