### PR TITLE
Wait before enqueuing job

### DIFF
--- a/app/jobs/notify_email_job.rb
+++ b/app/jobs/notify_email_job.rb
@@ -23,6 +23,8 @@ class NotifyEmailJob < ApplicationJob
     SocketError
   ].freeze
 
+  self.enqueue_after_transaction_commit = true
+
   rescue_from NotifyEmailJob::NotConfiguredError do |exception|
     log_exception(exception)
   end


### PR DESCRIPTION
### Description of change

This now gets run within a transaction, which means the consultee emails don't get committed to the database until after the job is enqueued; if the job starts to run before the transaction completes, it will fail.

Configure the jobs to not be enqueued until the transaction has been committed.

### Story Link

https://trello.com/c/QHWVBnea/2005-camden-cant-send-email-to-consultees-on-both-staging-and-production