### PR TITLE
Accessibility improvements for 'status' panels

### DIFF
--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -13,15 +13,13 @@
 
   .status-bar {
     max-width: $govuk-page-width;
-    margin-left: auto;
-    margin-right: auto;
+    margin: 1rem auto;
     display: flex;
-    gap: 3rem;
+    gap: 1rem 3rem;
+    flex-wrap: wrap;
 
     .status-panel {
       background-color: govuk-colour("light-grey");
-      margin-top: 1rem;
-      margin-bottom: 1rem;
       display: inline-block;
       padding: 1rem;
 

--- a/app/assets/stylesheets/components/_status_panel.scss
+++ b/app/assets/stylesheets/components/_status_panel.scss
@@ -30,10 +30,6 @@
         border: 5px solid govuk-colour("yellow");
       }
 
-      h3 {
-        margin: 0;
-      }
-
       p {
         margin-bottom: 0;
         margin-top: 0.5em;

--- a/app/views/planning_applications/_status_bar.html.erb
+++ b/app/views/planning_applications/_status_bar.html.erb
@@ -11,7 +11,9 @@
         ) do %>
       <%= link_to public_send(current_tab_route, (filter_enabled_uniquely?(status: "to_be_reviewed") ? {} : {status: [:to_be_reviewed]}).merge(anchor: "tabs")),
             class: "status-filter-link" do %>
-        <h3><%= t "planning_applications.index.reviewer_requests.title" %></h3>
+        <p>
+          <strong><%= t "planning_applications.index.reviewer_requests.title" %></strong>
+        </p>
         <p class="govuk-heading-m"><%= t "planning_applications.index.reviewer_requests", count: search.reviewer_planning_applications.count %></p>
       <% end %>
     <% end %>
@@ -24,7 +26,9 @@
         ) do %>
       <%= link_to public_send(current_tab_route, (filter_enabled_uniquely?(application_type: "prior_approval") ? {} : {application_type: [:prior_approval]}).merge(anchor: "tabs")),
             class: "status-filter-link" do %>
-        <h3><%= t "planning_applications.index.prior_approvals.title" %></h3>
+        <p>
+          <strong><%= t "planning_applications.index.prior_approvals.title" %></strong>
+        </p>
         <p class="govuk-heading-m"><%= t "planning_applications.index.prior_approvals", count: search.unstarted_prior_approvals.count %></p>
       <% end %>
     <% end %>

--- a/app/views/shared/_dates_panel.html.erb
+++ b/app/views/shared/_dates_panel.html.erb
@@ -2,28 +2,34 @@
   <div class="status-bar">
     <div class="status-panel" id="validation-date">
       <p>Valid from</p>
-      <h3>
+      <p>
         <% if @planning_application.valid_from.present? %>
-          <%= @planning_application.valid_from.to_fs(:day_month_year_slashes) %>
+          <strong><%= @planning_application.valid_from.to_fs(:day_month_year_slashes) %></strong>
         <% else %>
-          Not yet valid
+          <strong>Not yet valid</strong>
         <% end %>
-      </h3>
+      </p>
     </div>
     <% if @planning_application.application_type.consultation? %>
       <div class="status-panel" id="consultation-end-date">
         <p>Consultation end</p>
         <% if @planning_application.consultation.present? && @planning_application.consultation.end_date.present? %>
-          <h3><%= @planning_application.consultation.end_date.to_fs(:day_month_year_slashes) %></h3>
+          <p>
+            <strong><%= @planning_application.consultation.end_date.to_fs(:day_month_year_slashes) %></strong>
+          </p>
           <p><span id="edit-consultation-end-date"><%= govuk_link_to "Change", edit_planning_application_consultation_path(@planning_application) %></span></p>
         <% else %>
-          <h3>Not yet started</h3>
+          <p><strong>Not yet started</strong></p>
         <% end %>
       </div>
     <% end %>
     <div class="status-panel" id="expiry-date">
       <p><%= @planning_application.next_date_label %></p>
-      <h3><%= @planning_application.next_date.to_fs(:day_month_year_slashes) %></h3>
+
+      <p>
+        <strong><%= @planning_application.next_date.to_fs(:day_month_year_slashes) %></strong>
+      </p>
+
       <% if @planning_application.in_progress? %>
         <p>
           <% if @planning_application.open_time_extension_requests.any? %>

--- a/app/views/shared/_post_validation_response_banner.html.erb
+++ b/app/views/shared/_post_validation_response_banner.html.erb
@@ -1,16 +1,14 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-three-quarters">
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__content">
-        <svg class="info__icon" fill="#1d70b8" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
-          <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+  <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+    <div class="govuk-notification-banner__content">
+      <svg class="info__icon" fill="#1d70b8" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
         C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path></svg>
-        <p>
-          <strong><%= @planning_application.validation_requests.post_validation.responded.count %> new response<%= (@planning_application.validation_requests.post_validation.responded.count > 1) ? "s" : "" %>
-          </strong> to a request
-        </p>
-        <%= link_to "View all responses", post_validation_requests_planning_application_validation_validation_requests_path(@planning_application), class: "govuk-notification-banner__link" %>
-      </div>
+      <p>
+        <strong><%= @planning_application.validation_requests.post_validation.responded.count %> new response<%= (@planning_application.validation_requests.post_validation.responded.count > 1) ? "s" : "" %>
+        </strong> to a request
+      </p>
+      <%= link_to "View all responses", post_validation_requests_planning_application_validation_validation_requests_path(@planning_application), class: "govuk-notification-banner__link" %>
     </div>
   </div>
 </div>

--- a/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_enforcement.html.erb
+++ b/engines/bops_enforcements/app/views/bops_enforcements/enforcements/_enforcement.html.erb
@@ -44,35 +44,33 @@
         <p class="govuk-body">
           Received
         </p>
-        <h3>
-          <%= @enforcement.received_at.to_date.to_fs %>
-        </h3>
+        <p><strong><%= @enforcement.received_at.to_date.to_fs %></strong></p>
       </div>
       <div class="status-panel" id="started-date">
         <p class="govuk-body">
           Started
         </p>
-        <h3>
+        <p>
           <% if @enforcement.under_investigation? %>
-            <%= @enforcement.under_investigation_at.to_date.to_fs %>
+            <strong><%= @enforcement.under_investigation_at.to_date.to_fs %></strong>
           <% elsif @enforcement.started_at %>
-            <%= @enforcement.started_at.to_date.to_fs %>
+            <strong><%= @enforcement.started_at.to_date.to_fs %></strong>
           <% else %>
             Not yet started
           <% end %>
-        </h3>
+        </p>
       </div>
       <div class="status-panel" id="expiry-date">
         <p class="govuk-body">
           Notice served
         </p>
-        <h3>
+        <p>
           <% if @enforcement.notice_served_at %>
-            <%= @enforcement.notice_served_at_at.to_date.to_fs %>
+            <strong><%= @enforcement.notice_served_at_at.to_date.to_fs %></strong>
           <% else %>
-            None served
+            <strong>None served</strong>
           <% end %>
-        </h3>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Description of change

Using `<strong>` tags instead of inappropriate `<h3>`; enabling flexbox wrapping.

Also a small fix to the validation request banner, which was displaying as 3/4 width; the other banner (sometimes shown immediately below) was full-width, and since the introduction of the sidebar we've tried to avoid the 3/4-width layouts.

### Story Link

https://trello.com/c/7NXHajFA/128-remove-h3-categorisation-from-grey-cards-and-fix-reflow-on-mobile-screens