### PR TITLE
Fix AdditionalService blank names

### DIFF
--- a/db/migrate/20260616101302_check_additional_service_name_not_null.rb
+++ b/db/migrate/20260616101302_check_additional_service_name_not_null.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckAdditionalServiceNameNotNull < ActiveRecord::Migration[8.1]
+  def change
+    add_check_constraint :additional_services, "name IS NOT NULL", name: "additional_services_name_null", validate: false
+  end
+end

--- a/db/migrate/20260616101625_validate_additional_service_name_not_null.rb
+++ b/db/migrate/20260616101625_validate_additional_service_name_not_null.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class ValidateAdditionalServiceNameNotNull < ActiveRecord::Migration[8.1]
+  def up
+    validate_check_constraint :additional_services, name: "additional_services_name_null"
+    change_column_null :additional_services, :name, false
+    remove_check_constraint :additional_services, name: "additional_services_name_null"
+  end
+
+  def down
+    add_check_constraint :additional_services, "name IS NOT NULL", name: "additional_services_name_null", validate: false
+    change_column_null :additional_services, :name, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_16_101625) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pg_catalog.plpgsql"
@@ -56,7 +56,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_26_000000) do
 
   create_table "additional_services", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.string "name"
+    t.string "name", null: false
     t.bigint "planning_application_id", null: false
     t.string "type"
     t.datetime "updated_at", null: false

--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -208,6 +208,8 @@ module BopsApi
           :site_visit
         end
 
+        next if name.blank?
+
         planning_application.additional_services << PreapplicationService.new(name:)
       end
     end

--- a/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
+++ b/engines/bops_api/app/jobs/bops_api/planning_application_dependency_job.rb
@@ -200,7 +200,7 @@ module BopsApi
 
       responses.each do |response|
         name = case response
-        when /written advice/i
+        when /advice/i
           :written_advice
         when /meeting/i
           :meeting


### PR DESCRIPTION
### Description of change

Overly strict matching of inputs led to creation of AdditionalServices with no name, when the proposal detail "Planning Pre-Application Advice Services" included an unrecognised value.

This PR broadens the regex so that all 'advice' is recognised as `written_advice`, then specifically skips any unmatched inputs, and prevents creation of unnamed services.

### Story Link