### PR TITLE
Fix duplicate DOM IDs

### DIFF
--- a/app/views/planning_applications/review/publicities/_form.html.erb
+++ b/app/views/planning_applications/review/publicities/_form.html.erb
@@ -1,10 +1,19 @@
 <%= form_with scope: :assessment_detail, model: @planning_application.existing_or_new_check_publicity, url: planning_application_review_consultation_publicities_path(@planning_application, @planning_application.consultation) do |form| %>
   <%= form.govuk_error_summary %>
   <%= form.govuk_radio_buttons_fieldset(:action, small: true, legend: nil) do %>
-    <%= form.govuk_radio_button :reviewer_verdict, "accepted", label: {text: "Agree"}, link_errors: true %>
-    <%= form.govuk_radio_button :reviewer_verdict, "rejected", label: {text: "Return with comments"} do %>
+    <%= form.govuk_radio_button :reviewer_verdict,
+          "accepted",
+          id: dom_id(@planning_application.consultation) + "_publicity_reviewer_verdict_accepted",
+          label: {text: "Agree", for: dom_id(@planning_application.consultation) + "_publicity_reviewer_verdict_accepted"},
+          link_errors: true %>
+
+    <%= form.govuk_radio_button :reviewer_verdict, "rejected",
+          id: dom_id(@planning_application.consultation) + "_publicity_reviewer_verdict_rejected",
+          label: {text: "Return with comments", for: dom_id(@planning_application.consultation) + "_publicity_reviewer_verdict_rejected"} do %>
       <%= form.fields_for :comment, @planning_application.existing_or_new_check_publicity.existing_or_new_comment do |ff| %>
-        <%= ff.govuk_text_area :text, label: {text: "Add a comment"} %>
+        <%= ff.govuk_text_area :text,
+              label: {text: "Add a comment", for: dom_id(@planning_application.consultation) + "_publicity_comment_attributes_text_field"},
+              id: dom_id(@planning_application.consultation) + "_publicity_comment_attributes_text_field" %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
+++ b/app/views/planning_applications/review/tasks/_review_assessment_summaries.html.erb
@@ -77,13 +77,15 @@
             <%= form.govuk_radio_button(
                   :reviewer_verdict,
                   :accepted,
-                  label: {text: t(".accept")},
+                  id: dom_id(assessment_detail) + "_reviewer_verdict_accepted",
+                  label: {text: t(".accept"), for: dom_id(assessment_detail) + "_reviewer_verdict_accepted"},
                   aria: {controls: "accepted-comment-#{assessment_detail.id}"}
                 ) %>
             <%= form.govuk_radio_button(
                   :reviewer_verdict,
                   :rejected,
-                  label: {text: t(".return")},
+                  id: dom_id(assessment_detail) + "_reviewer_verdict_rejected",
+                  label: {text: t(".return"), for: dom_id(assessment_detail) + "_reviewer_verdict_rejected"},
                   aria: {controls: "comment-#{assessment_detail.id}"}
                 ) %>
 
@@ -94,12 +96,15 @@
                     <span class="govuk-visually-hidden">Error:</span> <%= form_model.errors["comment.text"].first %>
                   </p>
                 <% end %>
-                <%= form.fields_for :comment, assessment_detail.existing_or_new_comment do |comment_form| %>
+                <%= form.fields_for :comment, assessment_detail.existing_or_new_comment, include_id: false do |comment_form| %>
+                  <%= form.hidden_field "comment_attributes[id]", value: assessment_detail.id, id: dom_id(assessment_detail) + "_comment_attributes_id" %>
+
                   <%= comment_form.govuk_text_area(
                         :text,
                         rows: 3,
                         class: "govuk-textarea #{"govuk-textarea--error" if form_model.errors.any?}",
-                        label: {text: t(".add_a_comment")}
+                        label: {text: t(".add_a_comment"), for: dom_id(assessment_detail) + "_comment_attributes_text_field"},
+                        id: dom_id(assessment_detail) + "_comment_attributes_text_field"
                       ) %>
                 <% end %>
               </div>

--- a/app/views/planning_applications/withdraw_or_cancels/show.html.erb
+++ b/app/views/planning_applications/withdraw_or_cancels/show.html.erb
@@ -56,19 +56,19 @@
               <div class="govuk-radios govuk-radios--conditional govuk-!-margin-bottom-4" data-module="govuk-radios">
                 <div class="govuk-radios govuk-radios--small">
                   <div class="govuk-radios__item">
-                    <%= form.radio_button :status, "withdrawn", class: "govuk-radios__input", id: "withdrawn", "aria-controls": "conditional-status-withdrawn-conditional", "aria-expanded": "false" %>
+                    <%= form.radio_button :status, "withdrawn", class: "govuk-radios__input", id: "withdrawn" %>
                     <%= form.label :withdrawn, "Withdrawn by applicant", class: "govuk-label govuk-radios__label", for: "withdrawn" %>
                   </div>
                   <div class="govuk-radios__item">
-                    <%= form.radio_button :status, "returned", class: "govuk-radios__input", id: "returned", "aria-controls": "conditional-status-returned-conditional", "aria-expanded": "false" %>
+                    <%= form.radio_button :status, "returned", class: "govuk-radios__input", id: "returned" %>
                     <%= form.label :returned, "Returned as invalid", class: "govuk-label govuk-radios__label", for: "returned" %>
                   </div>
                   <div class="govuk-radios__item">
-                    <%= form.radio_button :status, "closed", class: "govuk-radios__input", id: "closed", "aria-controls": "conditional-status-closed-conditional", "aria-expanded": "false" %>
+                    <%= form.radio_button :status, "closed", class: "govuk-radios__input", id: "closed" %>
                     <%= form.label :closed, "Cancelled for other reason", class: "govuk-label govuk-radios__label", for: "closed" %>
                   </div>
                   <div class="govuk-radios__item">
-                    <%= form.radio_button :status, "deleted", class: "govuk-radios__input", id: "deleted", "aria-controls": "conditional-status-deleted-conditional", "aria-expanded": "false" %>
+                    <%= form.radio_button :status, "deleted", class: "govuk-radios__input", id: "deleted" %>
                     <%= form.label :deleted, "Deleted entirely (caution!)", class: "govuk-label govuk-radios__label", for: "deleted" %>
                   </div>
                   <div class="govuk-hint">

--- a/spec/system/planning_applications/review/assessment_summaries_spec.rb
+++ b/spec/system/planning_applications/review/assessment_summaries_spec.rb
@@ -364,7 +364,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#neighbour_summary_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -446,7 +446,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("Untagged: A new summary")
           end
           within("#neighbour_summary_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end
@@ -480,7 +480,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#summary_of_work_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -562,7 +562,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("A new summary")
           end
           within("#summary_of_work_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end
@@ -597,7 +597,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#site_description_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -679,7 +679,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("A new summary")
           end
           within("#site_description_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end
@@ -716,7 +716,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#consultation_summary_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -798,7 +798,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("A new summary")
           end
           within("#consultation_summary_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end
@@ -832,7 +832,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#additional_evidence_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -914,7 +914,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("A new summary")
           end
           within("#additional_evidence_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end
@@ -948,7 +948,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
         end
 
         within("#amenity_footer") do
-          choose "Agree"
+          choose "Accept"
           click_button("Save and mark as complete")
         end
 
@@ -1032,7 +1032,7 @@ RSpec.describe "Reviewing assessment summaries", type: :system do
             expect(page).to have_content("A new summary")
           end
           within("#amenity_footer") do
-            choose "Agree"
+            choose "Accept"
             click_button("Save and mark as complete")
           end
         end

--- a/spec/system/tasks/amenity_spec.rb
+++ b/spec/system/tasks/amenity_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Amenity task", :show_sidebar, type: :system do
       end
 
       within("#amenity_footer") do
-        choose "Agree"
+        choose "Accept"
         click_button("Save and mark as complete")
       end
 
@@ -249,7 +249,7 @@ RSpec.describe "Amenity task", :show_sidebar, type: :system do
       end
 
       within("#amenity_footer") do
-        choose "Agree"
+        choose "Accept"
         click_button("Save and mark as complete")
       end
 


### PR DESCRIPTION
### Description of change

ID must be unique but because all assessment details have a radio group instantiated with the same parameters, the generated IDs are the same for each section.

### Story Link

https://trello.com/c/6CdIiC9L/149-review-all-app-types-review-aria-labels