### PR TITLE
Fix map overlay headings

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -595,6 +595,7 @@ body {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
+    z-index: 1000;
   }
 
   .map-data-close {

--- a/app/components/site_map_component.html.erb
+++ b/app/components/site_map_component.html.erb
@@ -43,7 +43,7 @@
       <div class="map-data-tab map-data-constraints govuk-!-display-none">
         <a href="#" class="govuk-back-link" data-action="map#toggleTab" data-map-toggle-param="menu">Back</a><br>
         <div class="map-data-scroll-container">
-          <h3>Constraints</h3>
+          <h2>Constraints</h2>
           <% if planning_application.planning_application_constraints.present? %>
             <ul class="govuk-list govuk-list--spaced">
               <% planning_application.planning_application_constraints.each do |planning_application_constraint| %>
@@ -91,7 +91,7 @@
       <div class="map-data-tab map-data-neighbours govuk-!-display-none">
         <a href="#" class="govuk-back-link" data-action="map#toggleTab" data-map-toggle-param="menu">Back</a><br>
         <div class="map-data-scroll-container">
-          <h3 class="govuk-heading-s" id="neighbour-heading">All neighbours</h3>
+          <h2 id="neighbour-heading">All neighbours</h2>
           <% if planning_application.application_type.consultation? && planning_application.consultation.neighbours.present? %>
             <div class="govuk-checkboxes govuk-checkboxes--small govuk-!-font-size-16" data-module="govuk-checkboxes">
               <% planning_application.consultation.neighbours.each do |neighbour| %>


### PR DESCRIPTION
### Description of change

Map data overlay was using `<h3>` headings with no `<h2>` above, so skipping a level.

Also fixing the z-index.

### Story Link

- https://trello.com/c/PXga0XUJ/162-review-all-apps-update-heading-hierarchy
- https://trello.com/c/sn0N5nmV/127-leaflet-js-map-component-has-an-invisible-show-data-button-which-shows-on-tabbing-screen-readers