### PR TITLE
Fix application-type select

### DIFF
--- a/app/models/application_type/config.rb
+++ b/app/models/application_type/config.rb
@@ -151,15 +151,14 @@ class ApplicationType < ApplicationRecord
         in_order_of(:name, NAME_ORDER).order(:name, :code)
       end
 
-      def code_menu
+      def code_menu(current:)
         existing_codes = not_retired.pluck(:code)
 
-        ODP_APPLICATION_TYPES.each_with_object([]) do |item, memo|
-          next memo if existing_codes.include?(item.first)
-          next memo unless CURRENT_APPLICATION_TYPES.include?(item.first)
+        existing_codes -= [current&.code] if current
 
-          memo << item.reverse
-        end
+        ODP_APPLICATION_TYPES.select {
+          CURRENT_APPLICATION_TYPES.include?(it) && !existing_codes.include?(it)
+        }.map(&:reverse)
       end
 
       def reporting_type_used?(codes)

--- a/engines/bops_config/app/views/bops_config/application_types/_form.html.erb
+++ b/engines/bops_config/app/views/bops_config/application_types/_form.html.erb
@@ -2,7 +2,7 @@
   <%= form.govuk_error_summary %>
 
   <div data-controller="autocomplete-select">
-    <%= form.govuk_select :code, ApplicationType::Config.code_menu,
+    <%= form.govuk_select :code, ApplicationType::Config.code_menu(current: @application_type),
           label: {text: t(".code_label"), tag: "h2", size: "m"},
           hint: {text: t(".code_hint")},
           options: {include_blank: true} %>

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -2,7 +2,7 @@
 
 require "bops_config_helper"
 
-RSpec.describe "Application Types", :capybara, type: :system do
+RSpec.describe "Application Types", type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
 
   before do
@@ -10,7 +10,7 @@ RSpec.describe "Application Types", :capybara, type: :system do
     visit "/"
   end
 
-  it "allows adding a new application type" do
+  it "allows adding a new application type", :capybara do
     create(:legislation, title: "Town and Country Planning Act 1990")
 
     create(:reporting_type, :major_dwellings)
@@ -183,7 +183,7 @@ RSpec.describe "Application Types", :capybara, type: :system do
     expect(page).to have_selector("li", text: "Assess policies and guidance (considerations)")
   end
 
-  it "allows editing of an inactive application type" do
+  it "allows editing of an inactive application type", :capybara do
     application_type = create(:application_type_config, :configured, :ldc_proposed, status: "inactive")
 
     visit "/application_types/#{application_type.id}"
@@ -204,7 +204,7 @@ RSpec.describe "Application Types", :capybara, type: :system do
     expect(page).to have_selector("dl div:nth-child(2) dd", text: "LDCE")
   end
 
-  it "prevents editing of an active application type" do
+  it "prevents editing of an active application type", :capybara do
     application_type = create(:application_type_config, :ldc_proposed, status: "active")
 
     visit "/application_types/#{application_type.id}"
@@ -229,7 +229,7 @@ RSpec.describe "Application Types", :capybara, type: :system do
     expect(page).to have_selector("[role=alert] li", text: "The suffix can't be changed when the application type is active")
   end
 
-  it "prevents editing of a retired application type" do
+  it "prevents editing of a retired application type", :capybara do
     application_type = create(:application_type_config, :ldc_proposed, status: "retired")
 
     visit "/application_types/#{application_type.id}"

--- a/engines/bops_config/spec/system/application_types_spec.rb
+++ b/engines/bops_config/spec/system/application_types_spec.rb
@@ -2,7 +2,7 @@
 
 require "bops_config_helper"
 
-RSpec.describe "Application Types", type: :system, capybara: true do
+RSpec.describe "Application Types", :capybara, type: :system do
   let(:user) { create(:user, :global_administrator, name: "Clark Kent", local_authority: nil) }
 
   before do
@@ -393,6 +393,33 @@ RSpec.describe "Application Types", type: :system, capybara: true do
 
     expect(page).to have_selector("h1", text: "Review the application type")
     expect(page).to have_selector("dl div:nth-child(12) dd", text: "Active")
+  end
+
+  it "allows editing of the suffix" do
+    application_type = create(:application_type_config, :configured, :ldc_proposed, status: "inactive")
+
+    visit "/application_types/#{application_type.id}"
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(2)" do
+      expect(page).to have_selector("dt", text: "Suffix")
+      expect(page).to have_selector("dd:nth-child(2)", text: /^LDCP$/)
+
+      click_link "Change"
+    end
+
+    expect(page).to have_selector("h1", text: "Application profile")
+
+    fill_in "Suffix", with: "LDC"
+    click_button "Continue"
+
+    expect(page).to have_content("Application profile successfully updated")
+    expect(page).to have_selector("h1", text: "Review the application type")
+
+    within "dl div:nth-child(2)" do
+      expect(page).to have_selector("dt", text: "Suffix")
+      expect(page).to have_selector("dd:nth-child(2)", text: /^LDC$/)
+    end
   end
 
   it "allows editing of the category" do


### PR DESCRIPTION
### Description of change

Include current application type in config menu when editing

Because the current application type is, by definition, 'existing', it always gets excluded from the list of types — but that makes it impossible to leave the value unchanged when editing. So, for an existing type, the current type's code should always be included as a valid option.

### Story Link

https://trello.com/c/CW5Hqn7w/9-cannot-update-the-suffix-for-an-application-type-once-it-has-been-created-as-the-form-requires-the-name-to-be-selected-but-cant