### PR TITLE
Enable Devise paranoid mode

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -41,6 +41,8 @@ Devise.setup do |config|
 
   config.otp_allowed_drift = 300
 
+  config.paranoid = true
+
   # ==> Warden configuration
 
   # Scope the lookup to the local authority when restoring the user from the session

--- a/spec/system/log_in_spec.rb
+++ b/spec/system/log_in_spec.rb
@@ -491,7 +491,7 @@ RSpec.describe "Sign in" do
       fill_in("user[email]", with: assessor.email)
 
       click_button("Send me reset password instructions")
-      expect(page).to have_content("You will receive an email with instructions on how to reset your password in a few minutes.")
+      expect(page).to have_content("If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.")
 
       email = ActionMailer::Base.deliveries.last
       url = email.body.encoded.match(%r{https?://[^/]+(/\S+)})[1]
@@ -521,7 +521,7 @@ RSpec.describe "Sign in" do
     fill_in("user[email]", with: assessor.email)
 
     click_button("Send me reset password instructions")
-    expect(page).to have_content("You will receive an email with instructions on how to reset your password in a few minutes.")
+    expect(page).to have_content("If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes.")
 
     email = ActionMailer::Base.deliveries.last
     url = email.body.encoded.match(%r{https?://[^/]+(/\S+)})[1]


### PR DESCRIPTION
### Description of change

Enable 'paranoid mode', which overrides the error messages so as not to reveal whether an account exists or not.

### Story Link

https://trello.com/c/v6Gmmp7X/115-prevent-username-enumeration