### PR TITLE
Move recommendation reasons into nested fields

### DIFF
--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -32,6 +32,10 @@ module Tasks
 
     private
 
+    def public_comment
+      @public_comment ||= form_params(params).dig(:public_comment, decision)
+    end
+
     def committee_needed?
       recommend == true
     end
@@ -91,9 +95,9 @@ module Tasks
       params.fetch(param_key, {}).permit(
         :recommend,
         :decision,
-        :public_comment,
         :assessor_comment,
         :other_reason,
+        public_comment: planning_application.application_type.all_decisions.map { it.code.to_sym },
         reasons: []
       )
     end

--- a/app/forms/tasks/make_draft_recommendation_form.rb
+++ b/app/forms/tasks/make_draft_recommendation_form.rb
@@ -30,11 +30,31 @@ module Tasks
       validates :public_comment, presence: true
     end
 
-    private
+    def method_missing(method, *args)
+      return unless method =~ /(.+)_(comment=?)$/
 
-    def public_comment
-      @public_comment ||= form_params(params).dig(:public_comment, decision)
+      user_decision, action = $1, $2
+      return unless user_decision.in?(valid_decisions)
+
+      case action
+      when "comment="
+        if user_decision == decision
+          self.public_comment = args.first
+        end
+      when "comment"
+        if user_decision == decision
+          public_comment
+        end
+      end
     end
+
+    def respond_to_missing?(method, *args)
+      return false unless method =~ /(.+)(_comment=?)$/
+
+      $1.in?(valid_decisions)
+    end
+
+    private
 
     def committee_needed?
       recommend == true
@@ -91,13 +111,21 @@ module Tasks
       end
     end
 
+    def valid_decisions
+      planning_application.application_type.config.all_decision_codes
+    end
+
+    def comment_fields
+      valid_decisions.map { "#{it}_comment" }
+    end
+
     def form_params(params)
       params.fetch(param_key, {}).permit(
         :recommend,
         :decision,
         :assessor_comment,
         :other_reason,
-        public_comment: planning_application.application_type.all_decisions.map { it.code.to_sym },
+        *comment_fields,
         reasons: []
       )
     end

--- a/app/views/tasks/check-and-assess/complete-assessment/make-draft-recommendation/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/make-draft-recommendation/show.html.erb
@@ -74,30 +74,28 @@
   <%= form.govuk_radio_buttons_fieldset(:decision, legend: {text: t(".is_the_use"), size: "s"}) do %>
     <% @planning_application.application_type.all_decisions.each do |d| %>
       <%= form.govuk_radio_button :decision, d.code, label: {text: d.description}, checked: form.object.decision == d.code, disabled: submitted do %>
-        <%= tag.div class: class_names("govuk-form-group", {"govuk-form-group--error": form.object.errors[:public_comment].any?}) do %>
-          <%= form.label(:public_comment,
+        <%= tag.div class: class_names("govuk-form-group", {"govuk-form-group--error": form.object.errors[:"#{d.code}_comment"].any?}) do %>
+          <%= form.label(:"#{d.code}_comment",
                          t(".state_the_reason", decision: d.code.humanize.downcase),
-                         for: "tasks_make_draft_recommendation_form_public_comment_#{d.code}",
                          class: "govuk-label govuk-label--s") %>
 
           <div class="govuk-hint"><%= t(".refer_to_the") %></div>
           <%= govuk_warning_text(text: t(".this_information_will")) %>
 
-          <% if form.object.errors[:public_comment].any? %>
-            <%= tag.p id: "recommendation-form-public-comment-field-error", class: "govuk-error-message" do %>
+          <% if form.object.errors[:"#{d.code}_comment"].any? %>
+            <%= tag.p id: "recommendation-form-#{d.code}-comment-field-error", class: "govuk-error-message" do %>
               <%= tag.span class: "govuk-visually-hidden" do %>
                 <%= t(".error") %>
               <% end %>
 
-              <%= form.object.errors[:public_comment].first %>
+              <%= form.object.errors[:"#{d.code}_comment"].first %>
             <% end %>
           <% end %>
 
           <%= form.text_area(
-              :public_comment,
-              id: "tasks_make_draft_recommendation_form_public_comment_#{d.code}",
-              name: "tasks_make_draft_recommendation_form[public_comment][#{d.code}]",
-              class: class_names("govuk-textarea", {"govuk-textarea--error": form.object.errors[:public_comment].any?}),
+              :"#{d.code}_comment",
+              value: form.object.public_send("#{d.code}_comment"),
+              class: class_names("govuk-textarea", {"govuk-textarea--error": form.object.errors[:"#{d.code}_comment"].any?}),
               rows: 9,
               disabled: submitted
           ) %>

--- a/app/views/tasks/check-and-assess/complete-assessment/make-draft-recommendation/show.html.erb
+++ b/app/views/tasks/check-and-assess/complete-assessment/make-draft-recommendation/show.html.erb
@@ -73,41 +73,46 @@
 
   <%= form.govuk_radio_buttons_fieldset(:decision, legend: {text: t(".is_the_use"), size: "s"}) do %>
     <% @planning_application.application_type.all_decisions.each do |d| %>
-      <%= form.govuk_radio_button :decision, d.code, label: {text: d.description}, checked: form.object.decision == d.code, disabled: submitted %>
+      <%= form.govuk_radio_button :decision, d.code, label: {text: d.description}, checked: form.object.decision == d.code, disabled: submitted do %>
+        <%= tag.div class: class_names("govuk-form-group", {"govuk-form-group--error": form.object.errors[:public_comment].any?}) do %>
+          <%= form.label(:public_comment,
+                         t(".state_the_reason", decision: d.code.humanize.downcase),
+                         for: "tasks_make_draft_recommendation_form_public_comment_#{d.code}",
+                         class: "govuk-label govuk-label--s") %>
+
+          <div class="govuk-hint"><%= t(".refer_to_the") %></div>
+          <%= govuk_warning_text(text: t(".this_information_will")) %>
+
+          <% if form.object.errors[:public_comment].any? %>
+            <%= tag.p id: "recommendation-form-public-comment-field-error", class: "govuk-error-message" do %>
+              <%= tag.span class: "govuk-visually-hidden" do %>
+                <%= t(".error") %>
+              <% end %>
+
+              <%= form.object.errors[:public_comment].first %>
+            <% end %>
+          <% end %>
+
+          <%= form.text_area(
+              :public_comment,
+              id: "tasks_make_draft_recommendation_form_public_comment_#{d.code}",
+              name: "tasks_make_draft_recommendation_form[public_comment][#{d.code}]",
+              class: class_names("govuk-textarea", {"govuk-textarea--error": form.object.errors[:public_comment].any?}),
+              rows: 9,
+              disabled: submitted
+          ) %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 
-  <div class="govuk-form-group <%= "govuk-form-group--error" if form.object.errors[:public_comment].any? %>">
-    <%= form.label(:public_comment, t(".state_the_reason"), class: "govuk-label govuk-label--s") %>
-
-    <div class="govuk-hint"><%= t(".refer_to_the") %></div>
-    <%= govuk_warning_text(text: t(".this_information_will")) %>
-
-    <% if form.object.errors[:public_comment].any? %>
-      <p
-        id="recommendation-form-public-comment-field-error"
-        class="govuk-error-message"
-      >
-        <span class="govuk-visually-hidden"><%= t(".error") %></span>
-        <%= form.object.errors[:public_comment].first %>
-      </p>
-    <% end %>
-
-    <%= form.text_area(
-              :public_comment,
-              class: "govuk-textarea #{"govuk-textarea--error" if form.object.errors[:public_comment].any?}",
-              rows: 9,
-              disabled: submitted
-            ) %>
-  </div>
-
   <%= form.govuk_text_area(
-            :assessor_comment,
-            label: {text: t(".please_provide_supporting"), size: "s"},
-            hint: {text: t(".this_information_will_not")},
-            rows: 9,
-            disabled: submitted
-          ) %>
+      :assessor_comment,
+      label: {text: t(".please_provide_supporting"), size: "s"},
+      hint: {text: t(".this_information_will_not")},
+      rows: 9,
+      disabled: submitted
+  ) %>
 
   <% if submitted %>
     <%= form.govuk_task_button "Withdraw recommendation", action: "withdraw_recommendation", secondary: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2374,7 +2374,7 @@ en:
             make_draft_recommendation: Make draft recommendation
             please_provide_supporting: Provide supporting information for the reviewer.
             refer_to_the: Refer to specific development or local plan policies or permitted development legislation to support your recommendation.
-            state_the_reason: State the reasons for your recommendation.
+            state_the_reason: State the reasons the application is to be %{decision}
             there_are_outstanding_change_requests_html: There are outstanding change requests (last request %{last_request}). <a href="%{href}">View all requests</a>.
             this_information_will: This information will appear on the decision notice and the officer report.
             this_information_will_not: This information will not appear on the decision notice or the public register, but Freedom of Information requests will still apply.

--- a/spec/system/planning_applications/assessing/immunity_spec.rb
+++ b/spec/system/planning_applications/assessing/immunity_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Immunity", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "A public comment"
+      fill_in "State the reasons the application is to be granted", with: "A public comment"
       fill_in "Provide supporting information for the reviewer.", with: "A private comment"
 
       click_button "Save and mark as complete"

--- a/spec/system/planning_applications/post_validation_requests_spec.rb
+++ b/spec/system/planning_applications/post_validation_requests_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "post validation requests", type: :system do
         end
 
         fill_in(
-          "State the reasons for your recommendation.",
+          "State the reasons the application is to be granted",
           with: "GDPO compliant"
         )
 

--- a/spec/system/planning_applications/recommending/recommending_spec.rb
+++ b/spec/system/planning_applications/recommending/recommending_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
       within_fieldset("What is your recommendation?") { choose("Granted") }
 
-      fill_in "State the reasons for your recommendation.", with: "Application valid."
+      fill_in "State the reasons the application is to be granted", with: "Application valid."
       fill_in "Provide supporting information for the reviewer.", with: "Requirements met."
 
       click_button "Save and mark as complete"
@@ -121,7 +121,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
       click_link "Check and assess"
       click_link "Make draft recommendation"
 
-      fill_in "State the reasons for your recommendation.", with: "Amended reason."
+      fill_in "State the reasons the application is to be granted", with: "Amended reason."
 
       click_button "Save and mark as complete"
       click_link "Review and submit recommendation"
@@ -157,7 +157,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "Make draft recommendation"
           within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
           within_fieldset("What is your recommendation?") { choose("Granted") }
-          fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+          fill_in "State the reasons the application is to be granted", with: "This is a public comment"
           fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
           click_button "Save and mark as complete"
           expect(page).to have_content("Draft recommendation successfully saved")
@@ -173,7 +173,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_field("Provide supporting information for the reviewer.", with: "This is a private assessor comment")
 
           within_fieldset("What is your recommendation?") { choose("Refused") }
-          fill_in "State the reasons for your recommendation.", with: "This is a new public comment"
+          fill_in "State the reasons the application is to be refused", with: "This is a new public comment"
           fill_in "Provide supporting information for the reviewer.", with: "Edited private assessor comment"
           click_button "Save and mark as complete"
           expect(page).to have_content("Draft recommendation successfully saved")
@@ -247,7 +247,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
         within_fieldset("What is your recommendation?") { choose("Granted") }
-        fill_in "State the reasons for your recommendation.", with: "This is so granted and GDPO everything"
+        fill_in "State the reasons the application is to be granted", with: "This is so granted and GDPO everything"
         fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
@@ -276,7 +276,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_link "Make draft recommendation"
         within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
         within_fieldset("What is your recommendation?") { choose("Granted") }
-        fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+        fill_in "State the reasons the application is to be granted", with: "This is a public comment"
         fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
@@ -323,7 +323,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_link "Make draft recommendation"
         within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
         within_fieldset("What is your recommendation?") { choose("Granted") }
-        fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+        fill_in "State the reasons the application is to be granted", with: "This is a public comment"
         fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
@@ -337,7 +337,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         click_link "Make draft recommendation"
         within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
         within_fieldset("What is your recommendation?") { choose("Granted") }
-        fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+        fill_in "State the reasons the application is to be granted", with: "This is a public comment"
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
 
@@ -355,7 +355,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "Make draft recommendation"
           within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
           within_fieldset("What is your recommendation?") { choose("Granted") }
-          fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+          fill_in "State the reasons the application is to be granted", with: "This is a public comment"
           fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
           click_button "Save and mark as complete"
           expect(page).to have_content("Draft recommendation successfully saved")
@@ -381,7 +381,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           click_link "Make draft recommendation"
           within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
           within_fieldset("What is your recommendation?") { choose("Granted") }
-          fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+          fill_in "State the reasons the application is to be granted", with: "This is a public comment"
           fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
           click_button "Save and mark as complete"
           expect(page).to have_content("Draft recommendation successfully saved")
@@ -407,7 +407,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         within_fieldset("What is your recommendation?") { choose "Granted" }
 
-        fill_in "State the reasons for your recommendation.", with: "My reason"
+        fill_in "State the reasons the application is to be granted", with: "My reason"
 
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
@@ -443,7 +443,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
         within_fieldset("What is your recommendation?") { choose "Granted" }
 
-        fill_in "State the reasons for your recommendation.", with: "My reason"
+        fill_in "State the reasons the application is to be granted", with: "My reason"
 
         click_button "Save and mark as complete"
         expect(page).to have_content("Draft recommendation successfully saved")
@@ -506,7 +506,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
           within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
 
           within_fieldset("What is your recommendation?") { choose("Granted") }
-          fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+          fill_in "State the reasons the application is to be granted", with: "This is a public comment"
           fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
           click_button "Save changes"
           expect(page).to have_content("Draft recommendation successfully saved")
@@ -543,7 +543,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
 
           within_fieldset("What is your recommendation?") { choose("Granted") }
 
-          fill_in "State the reasons for your recommendation.", with: "Application valid."
+          fill_in "State the reasons for your recommendation", with: "Application valid."
           fill_in "Provide supporting information for the reviewer.", with: "Requirements met."
 
           click_button "Save and mark as complete"
@@ -711,7 +711,7 @@ RSpec.describe "Planning Application Assessment", type: :system do
         within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
         within_fieldset("What is your recommendation?") { choose("Granted") }
 
-        fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+        fill_in "State the reasons for your recommendation", with: "This is a public comment"
         fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
         click_button "Save and mark as complete"
 
@@ -819,11 +819,13 @@ RSpec.describe "Planning Application Assessment", type: :system do
           choose "Prior approval required and approved"
 
           within_fieldset("Does this planning application need to be decided by committee?") { choose("No") }
-          fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+          fill_in "State the reasons the application is to be granted", with: "This is a public comment"
           fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
           click_button "Save and mark as complete"
 
+          expect(page).to have_content("Draft recommendation successfully saved")
           planning_application.reload
+
           expect(planning_application.recommendations.count).to eq(1)
           expect(planning_application.public_comment).to eq("This is a public comment")
           expect(planning_application.recommendations.first.assessor_comment).to eq("This is a private assessor comment")
@@ -841,9 +843,11 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_field("Provide supporting information for the reviewer.",
             with: "This is a private assessor comment")
           choose "Prior approval not required"
-          fill_in "State the reasons for your recommendation.", with: "This is a new public comment"
+          fill_in "State the reasons the application is to be not required", with: "This is a new public comment"
           fill_in "Provide supporting information for the reviewer.", with: "Edited private assessor comment"
           click_button "Save and mark as complete"
+
+          expect(page).to have_content("Draft recommendation successfully saved")
           planning_application.reload
 
           expect(planning_application.recommendations.count).to eq(1)
@@ -863,9 +867,11 @@ RSpec.describe "Planning Application Assessment", type: :system do
           expect(page).to have_field("Provide supporting information for the reviewer.",
             with: "Edited private assessor comment")
           choose "Prior approval required and refused"
-          fill_in "State the reasons for your recommendation.", with: "This is a new public comment"
+          fill_in "State the reasons the application is to be refused", with: "This is a new public comment"
           fill_in "Provide supporting information for the reviewer.", with: "Edited private assessor comment"
           click_button "Save and mark as complete"
+
+          expect(page).to have_content("Draft recommendation successfully saved")
           planning_application.reload
 
           expect(planning_application.recommendations.count).to eq(1)

--- a/spec/system/tasks/make_draft_recommendation_spec.rb
+++ b/spec/system/tasks/make_draft_recommendation_spec.rb
@@ -53,10 +53,12 @@ RSpec.describe "Make draft recommendation task", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "The proposal meets all policy requirements."
+      fill_in "State the reasons the application is to be granted", with: "The proposal meets all policy requirements."
       fill_in "Provide supporting information for the reviewer.", with: "No issues identified."
 
       click_button "Save and mark as complete"
+
+      expect(page).to have_content "successfully saved"
 
       planning_application.reload
       expect(planning_application.decision).to eq("granted")
@@ -82,7 +84,7 @@ RSpec.describe "Make draft recommendation task", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "Public comment"
+      fill_in "State the reasons the application is to be granted", with: "Public comment"
 
       click_button "Save and mark as complete"
 
@@ -106,10 +108,12 @@ RSpec.describe "Make draft recommendation task", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "This is a public comment"
+      fill_in "State the reasons the application is to be granted", with: "This is a public comment"
       fill_in "Provide supporting information for the reviewer.", with: "This is a private assessor comment"
 
       click_button "Save changes"
+
+      expect(page).to have_content "successfully saved"
 
       planning_application.reload
       expect(planning_application.public_comment).to eq("This is a public comment")
@@ -158,7 +162,7 @@ RSpec.describe "Make draft recommendation task", type: :system do
       end
 
       expect(page).to have_field(
-        "State the reasons for your recommendation.",
+        "State the reasons the application is to be granted",
         with: "Existing public comment"
       )
       expect(page).to have_field(
@@ -188,9 +192,11 @@ RSpec.describe "Make draft recommendation task", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "Public comment"
+      fill_in "State the reasons the application is to be granted", with: "Public comment"
 
       click_button "Save and mark as complete"
+
+      expect(page).to have_content "successfully saved"
 
       committee_decision = planning_application.reload.committee_decision
       expect(committee_decision.recommend).to be(true)
@@ -244,7 +250,7 @@ RSpec.describe "Make draft recommendation task", type: :system do
         choose "Granted"
       end
 
-      fill_in "State the reasons for your recommendation.", with: "Public comment"
+      fill_in "State the reasons the application is to be granted", with: "Public comment"
 
       click_button "Save and mark as complete"
 

--- a/spec/system/tasks/return_for_assessment_spec.rb
+++ b/spec/system/tasks/return_for_assessment_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Returning a recommendation for assessment", type: :system do
     within_fieldset("What is your recommendation?") do
       choose "Granted"
     end
-    fill_in "State the reasons for your recommendation.", with: "Meets policy requirements."
+    fill_in "State the reasons the application is to be granted", with: "Meets policy requirements."
     click_button "Save and mark as complete"
 
     within :sidebar do
@@ -83,7 +83,7 @@ RSpec.describe "Returning a recommendation for assessment", type: :system do
     within_fieldset("What is your recommendation?") do
       choose "Granted"
     end
-    fill_in "State the reasons for your recommendation.", with: "Meets policy requirements."
+    fill_in "State the reasons the application is to be granted", with: "Meets policy requirements."
     click_button "Save and mark as complete"
 
     expect(planning_application.reload).to be_to_be_reviewed


### PR DESCRIPTION
### Description of change

Show the reason for an application decision as a field nested under each decision option, not as a separate field.

### Story Link

https://trello.com/c/ourG1Klr/27-when-deciding-an-application-reasons-for-recommendations-should-be-shown-as-revealed-text-boxes-for-each-radio-button-reading-re