### PR TITLE
Hide hidden tasks in Enforcement index

### DIFF
--- a/app/components/sidebar_component.rb
+++ b/app/components/sidebar_component.rb
@@ -41,7 +41,7 @@ class SidebarComponent < ViewComponent::Base
   end
 
   def render_section(section, top_level: true)
-    visible_tasks = section.tasks.reject(&:hidden?)
+    visible_tasks = section.tasks.visible
     return if visible_tasks.empty?
 
     elements = []

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,6 +12,8 @@ class Task < ApplicationRecord
   validates :slug, :name, presence: true, strict: true
   validates :status, inclusion: STATUSES
 
+  scope :visible, -> { where(hidden: false) }
+
   aasm column: :status, enum: true, whiny_persistence: true do
     state :not_started, initial: true
     state :in_progress, :completed, :cannot_start_yet, :action_required

--- a/engines/bops_enforcements/app/controllers/bops_enforcements/enforcements_controller.rb
+++ b/engines/bops_enforcements/app/controllers/bops_enforcements/enforcements_controller.rb
@@ -51,7 +51,7 @@ module BopsEnforcements
     end
 
     def set_grouped_tasks
-      @grouped_tasks = @case_record.tasks.group_by(&:section)
+      @grouped_tasks = @case_record.tasks.visible.group_by(&:section)
     end
   end
 end

--- a/engines/bops_enforcements/spec/system/close_spec.rb
+++ b/engines/bops_enforcements/spec/system/close_spec.rb
@@ -52,42 +52,6 @@ RSpec.describe "Enforcement close page", type: :system do
       visit "/cases/#{enforcement.case_record.id}/check-breach-report"
       expect(page).to have_content("You cannot make changes to this case as it has already been closed")
     end
-
-    it "shows the correct grouping of tasks", capybara: true do
-      visit "/enforcements/#{enforcement.case_record.id}/"
-
-      within("#enforcement-tasks") do
-        expect(page).to have_selector("h2", count: 5)
-        expect(page).not_to have_selector("h2", text: "Close case")
-        h2s = all("h2", count: 5)
-
-        expect(h2s[0]).to have_text("Check")
-        within("#Check-section") do
-          lis = all("li", count: 3)
-          expect(lis[0]).to have_text("Check breach report")
-          expect(lis[1]).to have_text(task.name)
-          expect(lis[2]).to have_text(task2.name)
-        end
-
-        expect(h2s[1]).to have_text("Investigate")
-        within("#Investigate-section") do
-          lis = all("li", count: 2)
-          expect(lis[0]).to have_text("Investigate and decide")
-          expect(lis[1]).to have_text(task3.name)
-        end
-
-        expect(h2s[2]).to have_text("Review")
-        within("#Review-section") do
-          expect(page).to have_selector("li", text: "Review recommendation")
-        end
-
-        expect(h2s[4]).to have_text("Appeal")
-        within("#Appeal-section") do
-          lis = all("li", count: 1)
-          expect(lis[0]).to have_text("Process an appeal")
-        end
-      end
-    end
   end
 
   it "sends an email when closing" do

--- a/engines/bops_enforcements/spec/system/close_spec.rb
+++ b/engines/bops_enforcements/spec/system/close_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Enforcement close page", type: :system do
     sign_in(user)
     visit "/enforcements/#{enforcement.case_record.id}/"
 
-    click_link "Close case"
+    click_link "Close the case"
     choose "Other"
     fill_in "Reason", with: "Because I want to"
     fill_in "Reason for closing", with: "Words words words."
@@ -57,8 +57,9 @@ RSpec.describe "Enforcement close page", type: :system do
       visit "/enforcements/#{enforcement.case_record.id}/"
 
       within("#enforcement-tasks") do
-        expect(page).to have_selector("h2", count: 6)
-        h2s = all("h2", count: 6)
+        expect(page).to have_selector("h2", count: 5)
+        expect(page).not_to have_selector("h2", text: "Close case")
+        h2s = all("h2", count: 5)
 
         expect(h2s[0]).to have_text("Check")
         within("#Check-section") do

--- a/engines/bops_enforcements/spec/system/show_spec.rb
+++ b/engines/bops_enforcements/spec/system/show_spec.rb
@@ -119,8 +119,9 @@ RSpec.describe "Enforcement show page", type: :system do
 
   it "shows the correct grouping of tasks", capybara: true do
     within("#enforcement-tasks") do
-      expect(page).to have_selector("h2", count: 6)
-      h2s = all("h2", count: 6)
+      expect(page).to have_selector("h2", count: 5)
+      expect(page).not_to have_selector("h2", text: "Close case")
+      h2s = all("h2", count: 5)
 
       expect(h2s[0]).to have_text("Check")
       within("#Check-section") do

--- a/engines/bops_enforcements/spec/system/show_spec.rb
+++ b/engines/bops_enforcements/spec/system/show_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Enforcement show page", type: :system do
     end
   end
 
-  it "shows the correct grouping of tasks", capybara: true do
+  it "shows the correct grouping of tasks" do
     within("#enforcement-tasks") do
       expect(page).to have_selector("h2", count: 5)
       expect(page).not_to have_selector("h2", text: "Close case")


### PR DESCRIPTION
Although the tasks have been correctly defined as hidden where necessary, the loop creating the index list just shows every task unconditionally. Adding a scope fixes this. 

https://trello.com/c/pLXU9x2P/44-remove-close-from-the-task-list-in-the-cases-landing-page