### PR TITLE
Preview officer report

### DIFF
--- a/app/components/planning_applications/assessment/assessment_report_component.html.erb
+++ b/app/components/planning_applications/assessment/assessment_report_component.html.erb
@@ -219,7 +219,7 @@
 
     <% if show_edit_links && current_user.assessor? %>
       <p class="govuk-body-s">
-        <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task.url)) %>
+        <%= helpers.govuk_link_to("Edit assessment", task_path(@planning_application, "check-and-assess/assess-against-policies-and-guidance/assess-against-policies-and-guidance", return_to: task&.url)) %>
       </p>
     <% end %>
   </section>

--- a/app/controllers/planning_applications/recommendations_controller.rb
+++ b/app/controllers/planning_applications/recommendations_controller.rb
@@ -20,10 +20,9 @@ module PlanningApplications
           @assessor_name = @planning_application.recommendation.assessor.name
           @recommended_date = @planning_application.recommendation.created_at.to_date.to_fs
 
-          format.html
-        else
-          format.html { redirect_to planning_application_assessment_path(@planning_application) }
         end
+
+        format.html
       end
     end
 

--- a/app/views/planning_applications/recommendations/show.html.erb
+++ b/app/views/planning_applications/recommendations/show.html.erb
@@ -3,24 +3,36 @@
 <% end %>
 
 <%= render "shared/assessment_dashboard" do %>
-  <h2>
-    View recommendation
-  </h2>
-
-  <p>
-    Recommendations submitted by <%= @assessor_name %> on
-    <%= @recommended_date %>
-  </p>
-
-  <%= render "planning_applications/decision_notice", planning_application: @planning_application %>
-
-  <div class="govuk-button-group govuk-!-padding-top-3">
-    <%= form_with model: @planning_application, url: planning_application_recommendation_path(@planning_application), method: :delete do |form| %>
-      <% if @planning_application.may_withdraw_recommendation? %>
-        <%= form.submit "Withdraw recommendation", data: {confirm: "Are you sure you want to withdraw this recommendation?"}, class: "govuk-button govuk-button--secondary" %>
+  <% if @planning_application.awaiting_determination? || @planning_application.closed_or_cancelled? %>
+    <%= govuk_accordion do |accordion| %>
+      <% accordion.with_section(heading_text: "Assessment report details") do %>
+        <%= render PlanningApplications::Assessment::AssessmentReportComponent.new(planning_application: @planning_application) %>
       <% end %>
-
-      <%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>
     <% end %>
-  </div>
+
+    <h2>
+      View recommendation
+    </h2>
+
+    <p>
+      Recommendations submitted by <%= @assessor_name %> on
+      <%= @recommended_date %>
+    </p>
+
+    <%= render "planning_applications/decision_notice", planning_application: @planning_application %>
+
+    <div class="govuk-button-group govuk-!-padding-top-3">
+      <%= form_with model: @planning_application, url: planning_application_recommendation_path(@planning_application), method: :delete do |form| %>
+        <% if @planning_application.may_withdraw_recommendation? %>
+          <%= form.submit "Withdraw recommendation", data: {confirm: "Are you sure you want to withdraw this recommendation?"}, class: "govuk-button govuk-button--secondary" %>
+        <% end %>
+
+        <%= govuk_button_link_to "Back", planning_application_path(@planning_application), secondary: true %>
+      <% end %>
+    </div>
+  <% else %>
+    <h2>Assessment report details</h2>
+
+    <%= render PlanningApplications::Assessment::AssessmentReportComponent.new(planning_application: @planning_application) %>
+  <% end %>
 <% end %>

--- a/app/views/planning_applications/steps/_review.html.erb
+++ b/app/views/planning_applications/steps/_review.html.erb
@@ -33,15 +33,21 @@
         <% item.with_status(text: render(StatusTags::Reviewing::RecommendationComponent.new(planning_application: @planning_application, user: current_user))) %>
       <% end %>
     <% else %>
-      <% task_list.with_item(
-           title: "View recommendation",
-           href: (@planning_application.awaiting_determination? || @planning_application.closed_or_cancelled?) && planning_application_recommendation_path(@planning_application),
-           html_attributes: {aria: {describedby: "review_assessment-completed"}}
-         ) do |item| %>
-        <% if @planning_application.awaiting_determination? || @planning_application.closed_or_cancelled? %>
+      <% if @planning_application.awaiting_determination? || @planning_application.closed_or_cancelled? %>
+        <%= task_list.with_item(
+              title: "View recommendation",
+              href: planning_application_recommendation_path(@planning_application),
+              html_attributes: {aria: {describedby: "review_assessment-completed"}}
+            ) do |item| %>
           <% item.with_status(text: render(StatusTags::Reviewing::RecommendationComponent.new(planning_application: @planning_application, user: current_user))) %>
-        <% else %>
-          <% item.with_status(text: "Cannot start yet", cannot_start_yet: true) %>
+        <% end %>
+      <% else %>
+        <%= task_list.with_item(
+              title: "Preview recommendation",
+              href: planning_application_recommendation_path(@planning_application),
+              html_attributes: {aria: {describedby: "review_assessment-completed"}}
+            ) do |item| %>
+          <% item.with_status(text: render(StatusTags::Reviewing::RecommendationComponent.new(planning_application: @planning_application, user: current_user))) %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/system/planning_applications/task_list_spec.rb
+++ b/spec/system/planning_applications/task_list_spec.rb
@@ -3,9 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Planning Application show page", type: :system do
-  let(:default_local_authority) { create(:local_authority, :default) }
-  let(:reviewer) { create(:user, :reviewer, local_authority: default_local_authority) }
-  let(:assessor) { create(:user, :assessor, local_authority: default_local_authority) }
+  let(:local_authority) { create(:local_authority, :default) }
+  let(:reviewer) { create(:user, :reviewer, local_authority:) }
+  let(:assessor) { create(:user, :assessor, local_authority:) }
 
   context "as a reviewer" do
     before do
@@ -13,7 +13,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for not_started" do
-      planning_application = create(:planning_application, :not_started, local_authority: default_local_authority)
+      planning_application = create(:planning_application, :not_started, local_authority:)
       visit "/planning_applications/#{planning_application.reference}"
 
       within "#validation-section" do
@@ -27,7 +27,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it has been validated but no proposal has been made" do
-      planning_application = create(:planning_application, local_authority: default_local_authority)
+      planning_application = create(:planning_application, local_authority:)
       visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
         expect(page).to have_link("Check and validate")
@@ -40,8 +40,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it is awaiting determination" do
-      planning_application = create(:planning_application, :awaiting_determination,
-        local_authority: default_local_authority)
+      planning_application = create(:planning_application, :awaiting_determination, local_authority:)
       create(:recommendation, planning_application:)
       visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
@@ -58,8 +57,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed", :capybara do
-      planning_application = create(:planning_application, :awaiting_determination,
-        local_authority: default_local_authority)
+      planning_application = create(:planning_application, :awaiting_determination, local_authority:)
       create(:recommendation, :reviewed, planning_application:, challenged: false)
       visit "/planning_applications/#{planning_application.reference}"
 
@@ -74,8 +72,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it is to be reviewed and no re-proposal has been made" do
-      planning_application = create(:planning_application, :to_be_reviewed,
-        local_authority: default_local_authority)
+      planning_application = create(:planning_application, :to_be_reviewed, local_authority:)
 
       create(
         :recommendation,
@@ -93,8 +90,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it is to be reviewed and a re-proposal has been made" do
-      planning_application = create(:planning_application, :to_be_reviewed,
-        local_authority: default_local_authority)
+      planning_application = create(:planning_application, :to_be_reviewed, local_authority:)
       create(:recommendation, :reviewed, planning_application:, challenged: false)
       create(:recommendation, planning_application:, submitted: true)
       visit "/planning_applications/#{planning_application.reference}"
@@ -115,9 +111,8 @@ RSpec.describe "Planning Application show page", type: :system do
       sign_in assessor
     end
 
-    it "makes valid task list for when it is awaiting determination" do
-      planning_application = create(:planning_application, :awaiting_determination,
-        local_authority: default_local_authority)
+    it "makes valid task list for when it is in assessment" do
+      planning_application = create(:planning_application, :in_assessment, local_authority:)
       create(:recommendation, planning_application:)
       visit "/planning_applications/#{planning_application.reference}"
       within "#validation-section" do
@@ -130,6 +125,27 @@ RSpec.describe "Planning Application show page", type: :system do
 
       within "#review-section" do
         expect(page).not_to have_link("Review and sign-off")
+        expect(page).to have_link("Preview recommendation")
+        expect(page).not_to have_link("View recommendation")
+        expect(page).not_to have_content("Completed")
+      end
+    end
+
+    it "makes valid task list for when it is awaiting determination" do
+      planning_application = create(:planning_application, :awaiting_determination, local_authority:)
+      create(:recommendation, planning_application:)
+      visit "/planning_applications/#{planning_application.reference}"
+      within "#validation-section" do
+        expect(page).to have_content("Completed")
+      end
+
+      within "#assess-section" do
+        expect(page).to have_content("In progress")
+      end
+
+      within "#review-section" do
+        expect(page).not_to have_link("Review and sign-off")
+        expect(page).not_to have_link("Preview recommendation")
         expect(page).to have_link("View recommendation")
         expect(page).not_to have_content("Completed")
 
@@ -139,8 +155,7 @@ RSpec.describe "Planning Application show page", type: :system do
     end
 
     it "makes valid task list for when it is awaiting determination and recommendation has been reviewed" do
-      planning_application = create(:planning_application, :awaiting_determination,
-        local_authority: default_local_authority)
+      planning_application = create(:planning_application, :awaiting_determination, local_authority:)
       create(:recommendation, :reviewed, planning_application:, challenged: false)
       visit "/planning_applications/#{planning_application.reference}"
 


### PR DESCRIPTION
Enable officers to preview details going into the report. Achieving this by adding them to the show-recommendation page and making that accessible before a recommendation has been made.

### Story Link

<https://trello.com/c/DA2w0dpR/26-the-officer-report-can-be-previewed-and-downloaded-during-assessment-and-also-when-reviewing>