### PR TITLE
Fix list nesting

### DIFF
--- a/engines/bops_core/app/components/bops_core/header_bar_component.html.erb
+++ b/engines/bops_core/app/components/bops_core/header_bar_component.html.erb
@@ -14,24 +14,26 @@
       </li>
     <% end %>
 
-    <div class="bops-header-bar__list--right">
-      <% right_items.each do |item| %>
-        <li class="bops-header-bar__item">
-          <% if item[:href].present? %>
-            <%= helpers.govuk_link_to item[:label].to_s, item[:href],
+    <li class="bops-header-bar__list--right">
+      <ul>
+        <% right_items.each do |item| %>
+          <li class="bops-header-bar__item">
+            <% if item[:href].present? %>
+              <%= helpers.govuk_link_to item[:label].to_s, item[:href],
                   class: class_names(helpers.govuk_link_classes, item[:class]),
                   new_tab: "",
                   method: item[:method],
                   data: item[:data] %>
-          <% else %>
-            <%= button_tag item[:label].to_s,
+            <% else %>
+              <%= button_tag item[:label].to_s,
                   type: item[:type] || "button",
                   class: class_names("button-as-link", helpers.govuk_link_classes, item[:class]),
                   data: item[:data] %>
-          <% end %>
-        </li>
-      <% end %>
-    </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
   </ul>
 
   <% if render_toggle? %>

--- a/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/show.html.erb
+++ b/engines/bops_preapps/app/views/bops_preapps/tasks/check-and-validate/check-tag-and-confirm-documents/review-documents/show.html.erb
@@ -18,9 +18,9 @@
           </span>
         </li>
       <% else %>
-        <div data-download-target="button" class="display-flex">
+        <li data-download-target="button">
           <%= govuk_button_link_to "Download all documents", data: {action: "click->download#submit"}, secondary: true %>
-        </div>
+        </li>
         <%= govuk_table(classes: "govuk-!-margin-top-4") do |table| %>
           <% table.with_head do |head| %>
             <% head.with_row do |row| %>


### PR DESCRIPTION
## Description of change

Some lists are incorrectly nested: e.g., containing elements other than `li`. This shows up in an accessibility scan.

### Story Link

<https://trello.com/c/CHPwhaxn/140-incorrect-use-of-list-elements-in-sidebar>